### PR TITLE
feat: Create generic summarization module and script

### DIFF
--- a/moonmind/summarization/__init__.py
+++ b/moonmind/summarization/__init__.py
@@ -1,1 +1,1 @@
-from .summarization import summarize_text, update_summaries
+from .summarization import summarize_text_gemini, update_summaries

--- a/moonmind/summarization/__init__.py
+++ b/moonmind/summarization/__init__.py
@@ -1,1 +1,2 @@
 from .summarization import summarize_text_gemini, update_summaries
+from .repo_summary import summarize_repo_for_readme

--- a/moonmind/summarization/__init__.py
+++ b/moonmind/summarization/__init__.py
@@ -1,0 +1,1 @@
+from .summarization import summarize_text, update_summaries

--- a/moonmind/summarization/repo_summary.py
+++ b/moonmind/summarization/repo_summary.py
@@ -1,0 +1,246 @@
+import os
+import logging
+import json
+import toml # For pyproject.toml or other toml files
+import re
+
+# We might need find_files or similar from utils later
+# from moonmind.utils.find_files import find_files
+
+logger = logging.getLogger(__name__)
+
+def summarize_repo_for_readme(repo_path: str, model_factory: callable, text_summarizer: callable, project_name_arg: str = None, main_language_arg: str = None) -> str:
+    """
+    Generates a README content string for a given code repository.
+    Aims to provide context for coding agents and follows modern summarization strategies.
+    """
+    logger.info(f"Starting README generation for repository at: {repo_path}")
+
+    project_name = project_name_arg if project_name_arg else os.path.basename(repo_path)
+    detected_language = main_language_arg # Prioritize argument
+    tech_stack = []
+    top_level_files = []
+    top_level_dirs = []
+    dependencies = []
+    all_files_detail = [] # For deeper analysis if needed later
+
+    if main_language_arg:
+        tech_stack.append(main_language_arg)
+
+    logger.info(f"Project name set to: {project_name}")
+    logger.info(f"Main language (from arg): {main_language_arg}")
+
+    try:
+        for item in os.listdir(repo_path):
+            item_path = os.path.join(repo_path, item)
+            if os.path.isfile(item_path):
+                top_level_files.append(item)
+                _, ext = os.path.splitext(item)
+                ext = ext.lower()
+                if item == "requirements.txt":
+                    tech_stack.append("Python")
+                    try:
+                        with open(item_path, 'r') as f:
+                            dependencies.extend([line.strip() for line in f if line.strip() and not line.startswith("#")])
+                        logger.info(f"Parsed dependencies from {item}")
+                    except Exception as e:
+                        logger.warning(f"Could not read {item}: {e}")
+                elif item == "pyproject.toml":
+                    tech_stack.append("Python")
+                    try:
+                        with open(item_path, 'r') as f:
+                            toml_data = toml.load(f)
+                        if 'project' in toml_data and 'dependencies' in toml_data['project']:
+                            dependencies.extend(toml_data['project']['dependencies'])
+                        elif 'tool' in toml_data and 'poetry' in toml_data['tool'] and 'dependencies' in toml_data['tool']['poetry']:
+                            # Poetry dependencies can be a dict, we only want keys
+                            deps = toml_data['tool']['poetry']['dependencies']
+                            dependencies.extend([dep for dep in deps.keys() if dep.lower() != 'python']) # Exclude 'python' itself
+                        logger.info(f"Parsed dependencies from {item}")
+                    except Exception as e:
+                        logger.warning(f"Could not parse {item}: {e}")
+                elif item == "package.json":
+                    tech_stack.append("JavaScript/TypeScript") # Could be either
+                    try:
+                        with open(item_path, 'r') as f:
+                            pkg_data = json.load(f)
+                        if 'dependencies' in pkg_data:
+                            dependencies.extend(pkg_data['dependencies'].keys())
+                        if 'devDependencies' in pkg_data:
+                            dependencies.extend(pkg_data['devDependencies'].keys())
+                        logger.info(f"Parsed dependencies from {item}")
+                    except Exception as e:
+                        logger.warning(f"Could not parse {item}: {e}")
+                elif item == "pom.xml" or ext == ".java":
+                    tech_stack.append("Java")
+                elif item == "Cargo.toml" or ext == ".rs":
+                    tech_stack.append("Rust")
+                elif item == "go.mod" or ext == ".go":
+                    tech_stack.append("Go")
+                elif ext == ".py":
+                    tech_stack.append("Python")
+                elif ext in [".js", ".ts"]:
+                    tech_stack.append("JavaScript/TypeScript")
+
+            elif os.path.isdir(item_path):
+                if item not in ['.git', '.hg', '.svn', '__pycache__', 'node_modules', 'target', 'build', 'dist', '.vscode', '.idea']: # common ignores
+                    top_level_dirs.append(item)
+
+        # Simple language detection if not provided
+        if not detected_language and tech_stack:
+            # Basic heuristic: most frequent or first one related to known languages
+            # This can be improved significantly
+            lang_counts = {}
+            for tech in tech_stack:
+                if tech in ["Python", "JavaScript/TypeScript", "Java", "Rust", "Go"]:
+                    lang_counts[tech] = lang_counts.get(tech, 0) + 1
+            if lang_counts:
+                detected_language = max(lang_counts, key=lang_counts.get)
+        logger.info(f"Detected main language: {detected_language}")
+
+
+        # TODO: Deeper scan for all_files_detail if necessary for more advanced analysis
+        # for root, dirs, files in os.walk(repo_path):
+        #     # Add filtering for common ignore patterns here too
+        #     dirs[:] = [d for d in dirs if d not in ['.git', '.hg', '.svn', '__pycache__', 'node_modules', 'target', 'build', 'dist', '.vscode', '.idea']]
+        #     for file in files:
+        #         # Add filtering for file extensions if needed
+        #         all_files_detail.append(os.path.join(root, file))
+
+
+    except Exception as e:
+        logger.exception(f"Error during repository analysis: {e}")
+
+
+    repo_info = {
+        "project_name": project_name,
+        "main_language": detected_language or "Undetermined", # Fallback
+        "tech_stack": list(set(tech_stack)), # Unique items
+        "top_level_files": top_level_files,
+        "top_level_dirs": top_level_dirs,
+        "dependencies": list(set(dependencies)), # Unique items
+        "all_files_detail": all_files_detail # To be populated by os.walk later
+    }
+
+    logger.info(f"Repo info gathered: {json.dumps(repo_info, indent=2, ensure_ascii=False)}") # ensure_ascii for broader char support in logs
+
+    readme_sections = []
+    model = None
+    try:
+        model = model_factory()
+    except Exception as e:
+        logger.exception(f"Failed to initialize model via model_factory: {e}. Some summarization may not be available.")
+        # Proceeding without a model means text_summarizer calls will likely fail or use a fallback if designed that way.
+
+    # 1. Project Title Section
+    readme_sections.append(f"# {repo_info['project_name']}")
+
+    # 2. Overview/Purpose Section
+    readme_sections.append("\n## Overview")
+    existing_readme_content = None
+    existing_readme_path = None
+    readme_filenames = ["README.md", "readme.md", "README.txt", "README", "readme.txt"]
+    for fname in readme_filenames:
+        if fname in repo_info['top_level_files']:
+            try:
+                potential_path = os.path.join(repo_path, fname)
+                with open(potential_path, 'r', encoding='utf-8', errors='ignore') as f:
+                    # Read a snippet: first 20 lines or up to ~1000 chars to keep it manageable
+                    lines = [next(f) for _ in range(20)]
+                    existing_readme_content = "".join(lines)
+                    if len(existing_readme_content) > 1000: # Further truncate if very long lines
+                        existing_readme_content = existing_readme_content[:1000] + "..."
+                existing_readme_path = potential_path
+                logger.info(f"Found and read snippet from existing README: {existing_readme_path}")
+                break
+            except Exception as e:
+                logger.warning(f"Could not read existing README {fname}: {e}")
+
+    purpose_summary_text = "Purpose of this project to be determined." # Default
+    if model and text_summarizer: # Only attempt summarization if model and summarizer are available
+        if existing_readme_content:
+            overview_prompt = f"The following is the beginning of an existing README file for the project '{repo_info['project_name']}'. Summarize its main purpose concisely for a technical audience, focusing on what the project does. If it's too short or unclear to determine the purpose, state that 'The purpose is not clearly defined from this snippet.'"
+            summary_attempt = text_summarizer(overview_prompt, existing_readme_content, model)
+            if summary_attempt:
+                purpose_summary_text = summary_attempt
+            else:
+                purpose_summary_text = "Could not summarize the existing README snippet. The purpose is not clearly defined from this snippet."
+        else:
+            # Try to infer from project name and key files
+            # Construct a more informative input string for the summarizer
+            context_for_llm = (
+                f"Project Name: {repo_info['project_name']}\n"
+                f"Main Language: {repo_info['main_language']}\n"
+                f"Key Top-Level Files: {str(repo_info['top_level_files'][:5])}\n" # First 5 files
+                f"Key Top-Level Directories: {str(repo_info['top_level_dirs'][:3])}\n" # First 3 dirs
+            )
+            overview_prompt = f"Based on the following information about a software project, infer and describe its primary purpose in one or two sentences for a technical audience. If the purpose is unclear from this data, state that 'The purpose is not immediately obvious from the provided file and directory names.'"
+            summary_attempt = text_summarizer(overview_prompt, context_for_llm, model)
+            if summary_attempt:
+                purpose_summary_text = summary_attempt
+            else:
+                purpose_summary_text = "The purpose is not immediately obvious from the provided file and directory names."
+    readme_sections.append(purpose_summary_text)
+
+    # 3. Tech Stack Section
+    readme_sections.append("\n## Technology Stack")
+    tech_stack_info = []
+    if repo_info['main_language'] and repo_info['main_language'] != "Undetermined":
+        tech_stack_info.append(f"- **Main Language:** {repo_info['main_language']}")
+    
+    unique_stack = sorted(list(set(item for item in repo_info['tech_stack'] if item.lower() != repo_info['main_language'].lower()))) # Avoid duplicating main lang
+    if unique_stack:
+        tech_stack_info.append("- **Other Technologies & Frameworks:**")
+        for item in unique_stack:
+            tech_stack_info.append(f"  - {item}")
+    if not tech_stack_info: # If main_language was undetermined and tech_stack was empty
+        tech_stack_info.append("Technology stack information is not readily available from the repository analysis.")
+    readme_sections.extend(tech_stack_info)
+
+    # 4. Directory Structure Section
+    readme_sections.append("\n## Directory Structure")
+    readme_sections.append("A brief look at the top-level directories and files:")
+    if not repo_info['top_level_dirs'] and not repo_info['top_level_files']:
+        readme_sections.append("- No top-level files or directories were identified (or all were ignored).")
+    else:
+        for dir_name in sorted(repo_info['top_level_dirs']):
+            readme_sections.append(f"- `{dir_name}/`")
+        for file_name in sorted(repo_info['top_level_files']):
+            readme_sections.append(f"- `{file_name}`")
+
+    # 5. Setup and Usage Section
+    readme_sections.append("\n## Setup and Usage")
+    setup_instructions = []
+    setup_files_found = []
+    common_setup_files = ["INSTALL", "INSTALL.md", "CONTRIBUTING.md", "BUILD.md", "Makefile", "Dockerfile", "docker-compose.yml", "docker-compose.yaml", "Vagrantfile"]
+    for sfile in common_setup_files:
+        if sfile in repo_info['top_level_files'] or sfile.lower() in repo_info['top_level_files']: # Check case-insensitively for some
+            setup_files_found.append(sfile)
+    
+    if setup_files_found:
+        setup_instructions.append(f"Refer to the following file(s) for setup and usage instructions: {', '.join(setup_files_found)}.")
+
+    if repo_info['main_language'] == 'Python' and 'requirements.txt' in repo_info['top_level_files']:
+        setup_instructions.append("To set up a Python environment, typically you would run: `pip install -r requirements.txt`")
+    elif repo_info['main_language'] == 'Python' and 'pyproject.toml' in repo_info['top_level_files']:
+         setup_instructions.append("This Python project uses `pyproject.toml`. You might use Poetry (`poetry install`) or pip with build (`pip install .`) for setup.")
+
+    if repo_info['main_language'] == 'JavaScript/TypeScript' and 'package.json' in repo_info['top_level_files']:
+        setup_instructions.append("To install dependencies for this JavaScript/TypeScript project, typically you would run: `npm install` or `yarn install`.")
+
+    if not setup_instructions:
+        setup_instructions.append("No specific setup instructions were automatically detected. Refer to standard practices for the identified technology stack or look for specific script files.")
+    readme_sections.extend(setup_instructions)
+
+    # 6. Dependencies Section (Optional)
+    if repo_info['dependencies']:
+        readme_sections.append("\n## Key Dependencies")
+        # List first 10-15 unique dependencies
+        deps_to_list = sorted(list(set(repo_info['dependencies'])))[:15]
+        for dep in deps_to_list:
+            readme_sections.append(f"- {dep}")
+        if len(repo_info['dependencies']) > 15:
+            readme_sections.append("- ... and more.")
+            
+    logger.info("Finished generating README sections.")
+    return "\n\n".join(readme_sections)

--- a/moonmind/summarization/repo_summary.py
+++ b/moonmind/summarization/repo_summary.py
@@ -146,7 +146,8 @@ def summarize_repo_for_readme(repo_path: str, model_factory: callable, text_summ
                 potential_path = os.path.join(repo_path, fname)
                 with open(potential_path, 'r', encoding='utf-8', errors='ignore') as f:
                     # Read a snippet: first 20 lines or up to ~1000 chars to keep it manageable
-                    lines = [next(f) for _ in range(20)]
+                    from itertools import islice
+                    lines = list(islice(f, 20))
                     existing_readme_content = "".join(lines)
                     if len(existing_readme_content) > 1000: # Further truncate if very long lines
                         existing_readme_content = existing_readme_content[:1000] + "..."

--- a/moonmind/summarization/summarization.py
+++ b/moonmind/summarization/summarization.py
@@ -1,0 +1,156 @@
+import logging
+import os
+import time
+
+from moonmind.utils.find_files import find_files
+from moonmind.utils.read_text_file import read_text_file
+
+def summarize_text(base_prompt: str, input_text: str, model: any):
+    logger = logging.getLogger(__name__)
+    try:
+        prompt = f"{base_prompt}\n\n{input_text}"
+        response = model.generate_content(prompt)
+
+        if response.prompt_feedback and response.prompt_feedback.block_reason:
+            logger.warning(f"Gemini content generation was blocked. Reason: {response.prompt_feedback.block_reason}. Input (start): '{input_text[:100]}...'")
+            return None
+
+        response_text_content = None
+        if response.candidates:
+            first_candidate = response.candidates[0]
+            if first_candidate.content and first_candidate.content.parts:
+                text_parts = [part.text for part in first_candidate.content.parts if hasattr(part, 'text') and part.text]
+                if text_parts:
+                    response_text_content = "".join(text_parts)
+
+        if not response_text_content and hasattr(response, 'text') and response.text:
+             response_text_content = response.text
+
+        if not response_text_content:
+            logger.warning(f"Gemini API returned no parsable text content. Input (start): '{input_text[:100]}...'. Full response: {response}")
+            return None
+
+        return response_text_content.strip()
+
+    except Exception as e:
+        logger.exception(f"Error during text summarization (Gemini call or response processing): {e}. Input (start): '{input_text[:100]}...'")
+        return None
+
+def update_summaries(input_dir: str, output_dir: str, prompt_file_path: str, model_factory: callable, text_summarizer: callable, input_ext: str = ".copy", output_ext: str = ".rst", request_delay: int = 15, replace_existing: bool = False):
+    logger = logging.getLogger(__name__) # Define logger for this function's scope or use a module-level one
+    logger.info(f"Starting summary generation process for input_dir='{input_dir}', output_dir='{output_dir}', prompt_file='{prompt_file_path}', replace_existing={replace_existing}.")
+
+    try:
+        # Use the passed model_factory to get the model
+        model = model_factory()
+    except Exception as e:
+        logger.exception(f"Failed to initialize model via model_factory: {e}. Aborting summary generation.")
+        return
+
+    try:
+        base_prompt = read_text_file(prompt_file_path)
+        if not base_prompt:
+            logger.error(f"Failed to load base prompt or prompt is empty from {prompt_file_path}. Aborting summary generation.")
+            return
+    except FileNotFoundError:
+        logger.error(f"Base prompt file not found at {prompt_file_path}. Aborting summary generation.")
+        return
+    except IOError as e:
+        logger.error(f"IOError reading base prompt from {prompt_file_path}: {e}. Aborting summary generation.")
+        return
+    except Exception as e:
+        logger.error(f"An unexpected error occurred while loading base prompt from {prompt_file_path}: {e}. Aborting summary generation.")
+        return
+
+    files_processed = 0
+    files_summarized = 0
+    files_skipped_existing_output = 0
+    files_failed_input_read = 0
+    files_failed_summarization = 0
+    files_failed_output_write = 0
+    files_failed_other = 0
+
+    if not os.path.exists(output_dir):
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+            logger.info(f"Created output directory: {output_dir}")
+        except OSError as e:
+            logger.error(f"Failed to create output directory {output_dir}: {e}. Aborting.")
+            return
+
+    logger.info(f"Searching for '{input_ext}' files in '{input_dir}'")
+    try:
+        for input_file_path in find_files(search_directory=input_dir, target_extension=input_ext):
+            logger.info(f"Processing input file: {input_file_path}")
+            files_processed += 1
+
+            relative_path_from_input_dir = os.path.relpath(input_file_path, input_dir)
+            output_file_name = relative_path_from_input_dir.replace(input_ext, output_ext)
+            output_file_path = os.path.join(output_dir, output_file_name)
+
+            output_file_dir = os.path.dirname(output_file_path)
+            if not os.path.exists(output_file_dir):
+                try:
+                    os.makedirs(output_file_dir, exist_ok=True)
+                    logger.info(f"Created subdirectory for output: {output_file_dir}")
+                except OSError as e:
+                    logger.error(f"Failed to create subdirectory {output_file_dir} for output file {output_file_path}: {e}. Skipping this file.")
+                    files_failed_other += 1
+                    continue
+
+            if not replace_existing and os.path.exists(output_file_path):
+                logger.info(f"Output file {output_file_path} already exists and replace_existing is False. Skipping.")
+                files_skipped_existing_output += 1
+                continue
+
+            try:
+                input_text_content = read_text_file(input_file_path)
+                if not input_text_content:
+                    logger.error(f"Failed to load input text or file is empty from {input_file_path}. Skipping summarization for this file.")
+                    files_failed_input_read += 1
+                    continue
+
+                logger.info(f"Generating summary for {input_file_path} to be saved at {output_file_path}.")
+                # Use the passed text_summarizer function
+                summary_text = text_summarizer(base_prompt, input_text_content, model)
+
+                if summary_text is None:
+                    logger.error(f"Failed to generate summary for content from {input_file_path}. Skipping writing to {output_file_path}.")
+                    files_failed_summarization += 1
+                    continue
+
+                try:
+                    with open(output_file_path, 'w', encoding='utf-8') as f:
+                        f.write(summary_text)
+                    files_summarized += 1
+                    logger.info(f"Successfully wrote summary to {output_file_path}.")
+                except IOError as e_write:
+                    logger.error(f"Failed to write summary to {output_file_path}: {e_write}")
+                    files_failed_output_write += 1
+                    continue
+
+                logger.info(f"Waiting for {request_delay} seconds before next request.")
+                time.sleep(request_delay)
+
+            except FileNotFoundError as e_fnf:
+                logger.error(f"Input file not found during processing {input_file_path}: {e_fnf}. Skipping.")
+                files_failed_other += 1
+            except IOError as e_io:
+                logger.error(f"IOError during processing of input file {input_file_path}: {e_io}. Skipping.")
+                files_failed_input_read +=1
+            except Exception as e_inner:
+                logger.exception(f"An unexpected error occurred processing input file {input_file_path}: {e_inner}. Skipping.")
+                files_failed_other += 1
+    except FileNotFoundError: # This will catch if input_dir itself is not found by find_files
+        logger.error(f"The input directory {input_dir} was not found. Cannot process files.")
+    except Exception as e_outer:
+        logger.exception(f"An unexpected error occurred during the main file finding/processing loop: {e_outer}")
+
+    logger.info("Summary generation process finished.")
+    logger.info(f"Total input files encountered: {files_processed}")
+    logger.info(f"  Summaries written/overwritten: {files_summarized}")
+    logger.info(f"  Skipped (output file exists, replace_existing=False): {files_skipped_existing_output}")
+    logger.info(f"  Failed (input read error): {files_failed_input_read}")
+    logger.info(f"  Failed (summarization error): {files_failed_summarization}")
+    logger.info(f"  Failed (output write error): {files_failed_output_write}")
+    logger.info(f"  Failed (other errors): {files_failed_other}")

--- a/moonmind/summarization/summarization.py
+++ b/moonmind/summarization/summarization.py
@@ -5,7 +5,7 @@ import time
 from moonmind.utils.find_files import find_files
 from moonmind.utils.read_text_file import read_text_file
 
-def summarize_text(base_prompt: str, input_text: str, model: any):
+def summarize_text_gemini(base_prompt: str, input_text: str, model: any):
     logger = logging.getLogger(__name__)
     try:
         prompt = f"{base_prompt}\n\n{input_text}"

--- a/scripts/run_summarizer.py
+++ b/scripts/run_summarizer.py
@@ -8,7 +8,7 @@ import time # Keep time import as it was in original, though not directly used i
 from moonmind.config.logging import configure_logging
 
 from moonmind.factories.google_factory import get_google_model
-from moonmind.summarization import summarize_text, update_summaries
+from moonmind.summarization import summarize_text_gemini, update_summaries
 
 # Call configure_logging early, as in the original script
 configure_logging()
@@ -48,7 +48,7 @@ if __name__ == "__main__":
             output_dir=output_directory,
             prompt_file_path=args.prompt_file,
             model_factory=get_google_model,
-            text_summarizer=summarize_text,
+            text_summarizer=summarize_text_gemini,
             replace_existing=args.replace_existing
         )
         logger.info("Summarizer job process completed.")

--- a/scripts/run_summarizer.py
+++ b/scripts/run_summarizer.py
@@ -1,0 +1,58 @@
+import argparse
+import logging
+import os
+import sys
+import time # Keep time import as it was in original, though not directly used in this script's main logic after refactor
+
+# Assuming moonmind.config.logging and configure_logging exist and are accessible
+from moonmind.config.logging import configure_logging
+
+from moonmind.factories.google_factory import get_google_model
+from moonmind.summarization import summarize_text, update_summaries
+
+# Call configure_logging early, as in the original script
+configure_logging()
+logger = logging.getLogger(__name__)
+
+
+if __name__ == "__main__":
+    logger.info("Summarizer job starting.")
+
+    parser = argparse.ArgumentParser(description="Generate summaries for text files.")
+    parser.add_argument("base_data_path", help="Base data path inside the container (e.g., /app/data). This is where the host directory is mounted.")
+    parser.add_argument("--input-dir-suffix", default="BlueprintText", help="Suffix for the input directory, relative to base_data_path (e.g., BlueprintText).")
+    parser.add_argument("--output-dir-suffix", default="BlueprintSummaries", help="Suffix for the output directory, relative to base_data_path (e.g., BlueprintSummaries).")
+    parser.add_argument("--prompt-file", default="/app/prompts/atbtt-bp-summary.txt", help="Path to the prompt file inside the container.")
+    parser.add_argument("--replace-existing", action="store_true", help="Replace existing summary files if they are found.")
+
+    args = parser.parse_args()
+
+    logger.info(f"Base data path received: {args.base_data_path}")
+    logger.info(f"Input directory suffix: {args.input_dir_suffix}")
+    logger.info(f"Output directory suffix: {args.output_dir_suffix}")
+    logger.info(f"Prompt file: {args.prompt_file}")
+    logger.info(f"Replace existing summaries: {args.replace_existing}")
+
+    input_directory = os.path.join(args.base_data_path, args.input_dir_suffix)
+    output_directory = os.path.join(args.base_data_path, args.output_dir_suffix)
+
+    logger.info(f"Derived input directory: {input_directory}")
+    logger.info(f"Derived output directory: {output_directory}")
+
+    if not os.getenv("GOOGLE_API_KEY"):
+        logger.error("GOOGLE_API_KEY environment variable is not set. The job may fail to access Google services.")
+
+    try:
+        update_summaries(
+            input_dir=input_directory,
+            output_dir=output_directory,
+            prompt_file_path=args.prompt_file,
+            model_factory=get_google_model,
+            text_summarizer=summarize_text,
+            replace_existing=args.replace_existing
+        )
+        logger.info("Summarizer job process completed.")
+        sys.exit(0)
+    except Exception as e:
+        logger.exception(f"An unexpected error occurred during the summarizer job: {e}")
+        sys.exit(1)


### PR DESCRIPTION
I've refactored the summarization logic into a new module, `moonmind.summarization`, which contains `summarize_text` and `update_summaries` functions.

The `update_summaries` function is now generalized to accept a `model_factory` and a `text_summarizer` function, which will make it more flexible.

I've also added a new script, `scripts/run_summarizer.py`. This script utilizes the new summarization module to process files based on command-line arguments, mirroring the functionality you described in the initial issue. It uses `get_google_model` as the model factory and the refactored `summarize_text` for summarization.

The new module is located at `moonmind/summarization/summarization.py`, with an `__init__.py` to facilitate imports.