### PR TITLE
Add Model Context Protocol server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ The API will return appropriate error messages for issues like missing `folder_i
 
 MoonMind uses a modular microservices architecture with the following containers:
 
-- **API**: A FastAPI service that provides an OpenAI-compatible REST API for Retrieval-Augmented Generation
+- **API**: A FastAPI service that provides:
+  - An OpenAI-compatible REST API for Retrieval-Augmented Generation
+  - A Model Context Protocol server for agent interactions
 - **UI**: An Open-WebUI container that provides a UI for Retrieval-Augmented Generation
 - **Qdrant**: A Qdrant container that provides a vector database
 - **Ollama**: An Ollama container that handles local LLM inference (optional)
@@ -186,7 +188,7 @@ It is possible to run inference with Ollama, with third-party AI providers, or w
 
 If using the default Ollama container, an NVIDIA GPU with appropriate drivers is required.
 
-The API container is an OpenAI-compatible REST API, powered by FastAPI andLangChain, employing Dependency Injection with abstract interfaces to enable modular service selection.
+The API container is powered by FastAPI and LangChain, employing Dependency Injection with abstract interfaces to enable modular service selection. It supports both OpenAI-compatible endpoints and the Model Context Protocol, making it versatile for different client applications and AI agents.
 
 ## Component Definitions
 
@@ -197,9 +199,26 @@ Vector Store:
 Storage Context:
 Service Context:
 
+## Model Context Protocol Support
+
+MoonMind now supports the Model Context Protocol, allowing it to act as a server that OpenHands and other agents can make client requests to. This provides a standardized way for AI agents to communicate with language models through MoonMind.
+
+The Model Context Protocol is exposed via the `/context` endpoint, which accepts POST requests with messages and other parameters. For detailed information about the protocol implementation, see [Model Context Protocol Documentation](docs/model_context_protocol.md).
+
+### Example Client
+
+An example client is provided in `/examples/context_protocol_client.py` to demonstrate how to interact with the Model Context Protocol endpoint:
+
+```bash
+# Run with default model (gemini-pro)
+python examples/context_protocol_client.py
+
+# Run with a specific model
+python examples/context_protocol_client.py gemini-pro-vision
+```
+
 ## Roadmap
 In the future, we will support:
-- mcp protocol and server mode
 - multiple chat models available without redeployment
 - multiple embedding models available without redeployment, e.g. a code embedding model and a general purpose embedding model
 - the ability to change many settings at runtime

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,9 @@ services:
       - LOG_LEVEL=DEBUG
       - PYTHONUNBUFFERED=1
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-0}
+      - MODEL_CONTEXT_PROTOCOL_ENABLED=true
+      - MODEL_CONTEXT_PROTOCOL_PORT=8000
+      - MODEL_CONTEXT_PROTOCOL_HOST=0.0.0.0
     env_file:
       - .env
     volumes:
@@ -42,6 +45,9 @@ services:
       fi"
     networks:
       - local-network
+    labels:
+      - "ai.model.context.protocol.version=0.1"
+      - "ai.model.context.protocol.endpoint=/context"
 
 volumes:
   open-webui:

--- a/docs/model_context_protocol.md
+++ b/docs/model_context_protocol.md
@@ -1,0 +1,112 @@
+# Model Context Protocol in MoonMind
+
+This document describes how MoonMind implements the Model Context Protocol, allowing it to act as a server that OpenHands and other agents can make client requests to.
+
+## Overview
+
+The Model Context Protocol is a standardized way for AI agents to communicate with language models. MoonMind implements this protocol to provide a consistent interface for agents to interact with various language models supported by MoonMind.
+
+## API Endpoint
+
+The Model Context Protocol is exposed via the `/context` endpoint. This endpoint accepts POST requests with a JSON payload containing messages and other parameters.
+
+## Request Format
+
+```json
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a helpful AI assistant."
+    },
+    {
+      "role": "user",
+      "content": "What are the key features of the Model Context Protocol?"
+    }
+  ],
+  "model": "gemini-pro",
+  "temperature": 0.7,
+  "max_tokens": 1000,
+  "stream": false,
+  "metadata": {
+    "source": "example_client"
+  }
+}
+```
+
+### Request Parameters
+
+- `messages`: An array of message objects, each with a `role` and `content`. Roles can be "system", "user", or "assistant".
+- `model`: The model to use for generation (e.g., "gemini-pro").
+- `temperature`: Controls the randomness of the output. Higher values (e.g., 0.8) make the output more random, while lower values (e.g., 0.2) make it more deterministic.
+- `max_tokens`: The maximum number of tokens to generate.
+- `stream`: Whether to stream the response (not currently implemented).
+- `metadata`: Additional metadata to include with the request.
+
+## Response Format
+
+```json
+{
+  "id": "ctx-1234567890abcdef",
+  "content": "The Model Context Protocol is a standardized interface...",
+  "model": "gemini-pro",
+  "created_at": 1621234567,
+  "metadata": {
+    "usage": {
+      "prompt_tokens": 42,
+      "completion_tokens": 128,
+      "total_tokens": 170
+    }
+  }
+}
+```
+
+### Response Parameters
+
+- `id`: A unique identifier for the response.
+- `content`: The generated text.
+- `model`: The model used for generation.
+- `created_at`: The timestamp when the response was created.
+- `metadata`: Additional metadata, including token usage information.
+
+## Docker Configuration
+
+The MoonMind API container is configured to act as a Model Context Protocol server with the following settings in `docker-compose.yaml`:
+
+```yaml
+environment:
+  - MODEL_CONTEXT_PROTOCOL_ENABLED=true
+  - MODEL_CONTEXT_PROTOCOL_PORT=8000
+  - MODEL_CONTEXT_PROTOCOL_HOST=0.0.0.0
+labels:
+  - "ai.model.context.protocol.version=0.1"
+  - "ai.model.context.protocol.endpoint=/context"
+```
+
+## Example Client
+
+An example client is provided in `/examples/context_protocol_client.py` to demonstrate how to interact with the Model Context Protocol endpoint.
+
+To use the example client:
+
+```bash
+# Run with default model (gemini-pro)
+python examples/context_protocol_client.py
+
+# Run with a specific model
+python examples/context_protocol_client.py gemini-pro-vision
+```
+
+## Using with OpenHands
+
+OpenHands and other agents can connect to MoonMind's Model Context Protocol server by configuring their client to point to the MoonMind API endpoint:
+
+```
+http://api:8000/context
+```
+
+If accessing from outside the Docker network, use:
+
+```
+http://localhost:8000/context
+```

--- a/examples/context_protocol_client.py
+++ b/examples/context_protocol_client.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Example client for the Model Context Protocol implementation in MoonMind.
+This demonstrates how an agent like OpenHands could interact with the MoonMind API.
+"""
+
+import requests
+import json
+import sys
+import os
+
+# Default to localhost, but allow override via environment variable
+API_BASE_URL = os.environ.get("MOONMIND_API_URL", "http://localhost:8000")
+
+def send_context_request(messages, model="gemini-pro"):
+    """
+    Send a request to the Model Context Protocol endpoint.
+    
+    Args:
+        messages: List of message objects with role and content
+        model: The model to use for generation
+        
+    Returns:
+        The response from the API
+    """
+    url = f"{API_BASE_URL}/context"
+    
+    payload = {
+        "messages": messages,
+        "model": model,
+        "temperature": 0.7,
+        "max_tokens": 1000,
+        "metadata": {
+            "source": "example_client"
+        }
+    }
+    
+    headers = {
+        "Content-Type": "application/json"
+    }
+    
+    response = requests.post(url, json=payload, headers=headers)
+    
+    if response.status_code != 200:
+        print(f"Error: {response.status_code}")
+        print(response.text)
+        return None
+    
+    return response.json()
+
+def main():
+    # Example conversation
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful AI assistant."
+        },
+        {
+            "role": "user",
+            "content": "What are the key features of the Model Context Protocol?"
+        }
+    ]
+    
+    # Specify model if provided as command line argument
+    model = "gemini-pro"
+    if len(sys.argv) > 1:
+        model = sys.argv[1]
+    
+    print(f"Sending request to {API_BASE_URL}/context using model {model}...")
+    response = send_context_request(messages, model)
+    
+    if response:
+        print("\nResponse:")
+        print(f"ID: {response['id']}")
+        print(f"Model: {response['model']}")
+        print(f"Created at: {response['created_at']}")
+        print("\nContent:")
+        print(response['content'])
+        
+        if 'metadata' in response and 'usage' in response['metadata']:
+            usage = response['metadata']['usage']
+            print("\nToken Usage:")
+            print(f"Prompt tokens: {usage.get('prompt_tokens', 'N/A')}")
+            print(f"Completion tokens: {usage.get('completion_tokens', 'N/A')}")
+            print(f"Total tokens: {usage.get('total_tokens', 'N/A')}")
+
+if __name__ == "__main__":
+    main()

--- a/fastapi/api/routers/context_protocol.py
+++ b/fastapi/api/routers/context_protocol.py
@@ -1,0 +1,92 @@
+import logging
+import time
+from typing import Dict, List, Optional, Any
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, Request, Depends
+from pydantic import BaseModel, Field
+
+from moonmind.factories.google_factory import get_google_model
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Model Context Protocol Schema Definitions
+class ContextMessage(BaseModel):
+    role: str
+    content: str
+    name: Optional[str] = None
+
+class ContextRequest(BaseModel):
+    messages: List[ContextMessage]
+    model: str
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = 0.7
+    stream: Optional[bool] = False
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+class ContextResponse(BaseModel):
+    id: str
+    content: str
+    model: str
+    created_at: int
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+@router.post("/context", response_model=ContextResponse)
+async def process_context(request: ContextRequest):
+    try:
+        # Convert Context Protocol messages to Google LLM format
+        contents = []
+        for msg in request.messages:
+            if msg.role in {"system", "user", "assistant"}:
+                contents.append({"role": msg.role, "parts": [msg.content]})
+            else:
+                raise HTTPException(status_code=400, detail=f"Invalid message role: {msg.role}")
+
+        logger.info(f"Context Protocol request for model: {request.model}")
+
+        # Fetch the Google LLM and generate content
+        chat_model = get_google_model(request.model)
+        
+        # Set generation parameters if provided
+        generation_config = {}
+        if request.max_tokens:
+            generation_config["max_output_tokens"] = request.max_tokens
+        if request.temperature is not None:
+            generation_config["temperature"] = request.temperature
+            
+        # Generate response
+        response_gemini = chat_model.generate_content(
+            contents,
+            generation_config=generation_config
+        )
+
+        # Extract the response from the Google LLM
+        if not response_gemini.candidates or not response_gemini.candidates[0].content.parts:
+            raise HTTPException(status_code=500, detail="Invalid response from Google LLM")
+
+        ai_message = response_gemini.candidates[0].content.parts[0].text
+
+        # Construct the Context Protocol response
+        response = ContextResponse(
+            id=f"ctx-{uuid4().hex}",
+            content=ai_message,
+            model=request.model,
+            created_at=int(time.time()),
+            metadata={
+                "usage": {
+                    "prompt_tokens": len(contents),  # Placeholder
+                    "completion_tokens": len(ai_message.split()),  # Estimate
+                    "total_tokens": len(contents) + len(ai_message.split()),
+                }
+            }
+        )
+
+        return response
+
+    except Exception as e:
+        logger.exception(f"Error in context protocol: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"An internal error occurred: {str(e)}"
+        )

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 from api.routers.chat import router as chat_router
 from api.routers.documents import router as documents_router
 from api.routers.models import router as models_router
+from api.routers.context_protocol import router as context_protocol_router
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -67,6 +68,7 @@ async def setup():
         app.include_router(chat_router)
         app.include_router(documents_router)
         app.include_router(models_router)
+        app.include_router(context_protocol_router)
 
     except Exception as e:
         logger.error(f"Failed to initialize providers: {str(e)}")

--- a/tests/api/test_context_protocol.py
+++ b/tests/api/test_context_protocol.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from api.routers.context_protocol import ContextRequest, ContextMessage
+from main import app
+
+client = TestClient(app)
+
+@pytest.fixture
+def mock_google_model():
+    with patch("api.routers.context_protocol.get_google_model") as mock:
+        model_mock = MagicMock()
+        response_mock = MagicMock()
+        candidate_mock = MagicMock()
+        content_mock = MagicMock()
+        part_mock = MagicMock()
+        
+        part_mock.text = "This is a test response from the model."
+        content_mock.parts = [part_mock]
+        candidate_mock.content = content_mock
+        response_mock.candidates = [candidate_mock]
+        model_mock.generate_content.return_value = response_mock
+        
+        mock.return_value = model_mock
+        yield mock
+
+def test_context_protocol_endpoint(mock_google_model):
+    """Test the context protocol endpoint with a mocked Google model."""
+    request_data = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the Model Context Protocol?"}
+        ],
+        "model": "gemini-pro",
+        "temperature": 0.7,
+        "max_tokens": 100
+    }
+    
+    response = client.post("/context", json=request_data)
+    
+    assert response.status_code == 200
+    data = response.json()
+    
+    # Check that the response has the expected structure
+    assert "id" in data
+    assert "content" in data
+    assert "model" in data
+    assert "created_at" in data
+    assert "metadata" in data
+    
+    # Check that the model was called with the correct parameters
+    mock_google_model.assert_called_once_with("gemini-pro")
+    
+    # Check that the content matches our mock
+    assert data["content"] == "This is a test response from the model."
+    assert data["model"] == "gemini-pro"
+    
+    # Check that metadata contains usage information
+    assert "usage" in data["metadata"]
+    assert "prompt_tokens" in data["metadata"]["usage"]
+    assert "completion_tokens" in data["metadata"]["usage"]
+    assert "total_tokens" in data["metadata"]["usage"]
+
+def test_context_protocol_invalid_role():
+    """Test the context protocol endpoint with an invalid role."""
+    request_data = {
+        "messages": [
+            {"role": "invalid_role", "content": "This should fail."},
+            {"role": "user", "content": "What is the Model Context Protocol?"}
+        ],
+        "model": "gemini-pro"
+    }
+    
+    response = client.post("/context", json=request_data)
+    
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert "Invalid message role" in data["detail"]


### PR DESCRIPTION
## Description
This PR adds support for the Model Context Protocol to the MoonMind API container, allowing it to act as a server that OpenHands and other agents can make client requests to.

## Changes
- Added a new `/context` endpoint that implements the Model Context Protocol
- Updated the docker-compose.yaml file to configure the API container as a Model Context Protocol server
- Added environment variables and Docker labels for Model Context Protocol configuration
- Created an example client script to demonstrate how to interact with the Model Context Protocol
- Added comprehensive documentation for the Model Context Protocol implementation
- Added unit tests for the Model Context Protocol endpoint
- Updated the README.md to include information about the Model Context Protocol support

## Testing
Unit tests have been added to verify the functionality of the Model Context Protocol endpoint. The implementation has been designed to work with the existing Google model factory.