### PR TITLE
Fix: Migrate from deprecated ServiceContext to Settings in llama_index

### DIFF
--- a/fastapi/api/dependencies.py
+++ b/fastapi/api/dependencies.py
@@ -17,4 +17,5 @@ def get_storage_context(request: Request):
     return request.app.state.storage_context
 
 def get_service_context(request: Request):
-    return request.app.state.service_context
+    # Return the global Settings object instead of ServiceContext
+    return request.app.state.settings

--- a/fastapi/api/routers/documents.py
+++ b/fastapi/api/routers/documents.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Optional
 
-from llama_index.core import ServiceContext, StorageContext
+from llama_index.core import Settings, StorageContext
 from pydantic import BaseModel
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 async def load_confluence_documents(
     request: ConfluenceLoadRequest,
     storage_context: StorageContext = Depends(get_storage_context),
-    service_context: ServiceContext = Depends(get_service_context)
+    service_context: Settings = Depends(get_service_context)
 ):
     if not settings.confluence.confluence_enabled:
         raise HTTPException(status_code=500, detail="Confluence is not enabled")
@@ -68,7 +68,7 @@ async def load_confluence_documents(
 async def load_github_repo(
     request: GitHubLoadRequest,
     storage_context: StorageContext = Depends(get_storage_context),
-    service_context: ServiceContext = Depends(get_service_context)
+    service_context: Settings = Depends(get_service_context)
 ):
     """Load documents from a GitHub repository."""
     try:
@@ -110,7 +110,7 @@ async def load_github_repo(
 async def load_google_drive_documents(
     request: GoogleDriveLoadRequest,
     storage_context: StorageContext = Depends(get_storage_context),
-    service_context: ServiceContext = Depends(get_service_context)
+    service_context: Settings = Depends(get_service_context)
 ):
     """Load documents from Google Drive."""
     try:

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -65,7 +65,8 @@ async def setup():
         app.state.embed_model, app.state.embed_dimensions = build_embed_model(settings)
         app.state.vector_store = build_vector_store(settings, app.state.embed_model, app.state.embed_dimensions)
         app.state.storage_context = build_storage_context(settings, app.state.vector_store)
-        app.state.service_context = build_service_context(settings, app.state.embed_model)
+        # Configure global Settings instead of using ServiceContext
+        app.state.settings = build_service_context(settings, app.state.embed_model)
 
         # Setup routers
         app.include_router(chat_router)

--- a/moonmind/factories/service_context_factory.py
+++ b/moonmind/factories/service_context_factory.py
@@ -1,7 +1,14 @@
-from llama_index.core import ServiceContext
+from llama_index.core import Settings
 
 from ..config.settings import AppSettings
 
 
 def build_service_context(settings: AppSettings, embed_model):
-    return ServiceContext.from_defaults(embedding=embed_model)
+    """
+    Configure and return global Settings with the provided embedding model.
+    """
+    # Configure global settings
+    Settings.embed_model = embed_model
+    
+    # Return the configured Settings object
+    return Settings

--- a/moonmind/factories/vector_store_factory.py
+++ b/moonmind/factories/vector_store_factory.py
@@ -1,4 +1,4 @@
-from llama_index.core import ServiceContext, StorageContext
+from llama_index.core import Settings, StorageContext
 from llama_index.vector_stores.qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
 from qdrant_client.http.exceptions import UnexpectedResponse
@@ -20,9 +20,8 @@ def build_vector_store(settings: AppSettings, embed_model, embed_dimensions: int
 
 def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1):
     """
-    Builds and returns a Qdrant-based vector store, along with a ServiceContext
-    for embeddings. Allows the user to configure different embed models by passing
-    `embed_model` directly into this function.
+    Builds and returns a Qdrant-based vector store. Allows the user to configure 
+    different embed models by passing `embed_model` directly into this function.
     """
 
     client = QdrantClient(

--- a/moonmind/indexers/confluence_indexer.py
+++ b/moonmind/indexers/confluence_indexer.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Union
 
-from llama_index.core import (ServiceContext, StorageContext, VectorStoreIndex,
+from llama_index.core import (Settings, StorageContext, VectorStoreIndex,
                               load_index_from_storage)
 from llama_index.core.base.embeddings.base import BaseEmbedding
 from llama_index.core.schema import TextNode
@@ -43,7 +43,7 @@ class ConfluenceIndexer:
         self,
         space_key: str,
         storage_context: StorageContext,
-        service_context: ServiceContext,
+        service_context: Settings,
         page_ids: Optional[List[str]] = None,
         confluence_fetch_batch_size: int = 100
     ) -> Dict[str, Union[VectorStoreIndex, int]]:
@@ -53,14 +53,15 @@ class ConfluenceIndexer:
         the provided storage and service contexts.
         """
         # Initialize an empty index (with no initial documents)
+        # Use the embed_model from Settings instead of passing service_context
         index = VectorStoreIndex.from_documents(
             [],
             storage_context=storage_context,
-            service_context=service_context
+            embed_model=service_context.embed_model
         )
         total_nodes_indexed = 0
 
-        # Use the node parser from the service context if provided; otherwise create a default parser.
+        # Use the node parser from the Settings if provided; otherwise create a default parser.
         try:
             node_parser = service_context.node_parser
         except AttributeError:

--- a/moonmind/indexers/github_indexer.py
+++ b/moonmind/indexers/github_indexer.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Dict, List, Optional, Union
 
-from llama_index.core import ServiceContext, StorageContext, VectorStoreIndex
+from llama_index.core import Settings, StorageContext, VectorStoreIndex
 from llama_index.core.node_parser import \
     SimpleNodeParser  # Default node parser
 from llama_index.readers.github import GithubRepositoryReader
@@ -26,7 +26,7 @@ class GitHubIndexer:
         branch: str,
         filter_extensions: Optional[List[str]],
         storage_context: StorageContext,
-        service_context: ServiceContext,
+        service_context: Settings,
     ) -> Dict[str, Union[VectorStoreIndex, int]]:
         self.logger.info(f"Starting GitHub indexing for repo: {repo_full_name} on branch: {branch}")
 
@@ -78,7 +78,7 @@ class GitHubIndexer:
         index = VectorStoreIndex.from_documents(
             [], # No initial documents
             storage_context=storage_context,
-            service_context=service_context
+            embed_model=service_context.embed_model
         )
         total_nodes_indexed = 0
 

--- a/moonmind/indexers/google_drive_indexer.py
+++ b/moonmind/indexers/google_drive_indexer.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Optional, Dict, Union
 
-from llama_index.core import VectorStoreIndex, ServiceContext, StorageContext
+from llama_index.core import VectorStoreIndex, Settings, StorageContext
 from llama_index.readers.google import GoogleDriveReader
 from llama_index.core.node_parser import SimpleNodeParser
 from fastapi import HTTPException
@@ -20,7 +20,7 @@ class GoogleDriveIndexer:
     def index(
         self,
         storage_context: StorageContext,
-        service_context: ServiceContext,
+        service_context: Settings,
         folder_id: Optional[str] = None,
         file_ids: Optional[List[str]] = None,
         # recursive: bool = False, # LlamaIndex GoogleDriveReader loads all files from a folder_id.
@@ -60,7 +60,7 @@ class GoogleDriveIndexer:
         index = VectorStoreIndex.from_documents(
             [], # No initial documents
             storage_context=storage_context,
-            service_context=service_context
+            embed_model=service_context.embed_model
         )
         total_nodes_indexed = 0
 


### PR DESCRIPTION
## Description
This PR fixes the API container startup issue by migrating from the deprecated `ServiceContext` to the new `Settings` approach in llama_index.

## Changes
- Updated service_context_factory.py to use Settings instead of ServiceContext
- Updated main.py to store the Settings object in app.state.settings instead of app.state.service_context
- Updated dependencies.py to return the Settings object instead of ServiceContext
- Updated all indexers (confluence_indexer.py, github_indexer.py, google_drive_indexer.py) to:
  - Import Settings instead of ServiceContext
  - Accept Settings instead of ServiceContext in their index methods
  - Use embed_model from Settings instead of passing service_context to VectorStoreIndex.from_documents
- Updated vector_store_factory.py to import Settings instead of ServiceContext
- Updated documents.py to use Settings instead of ServiceContext in all route handlers

## Error Fixed
This fixes the following error during API container startup:
```
ValueError: ServiceContext is deprecated. Use llama_index.settings.Settings instead, or pass in modules to local functions/methods/interfaces.
See the docs for updated usage/migration:
https://docs.llamaindex.ai/en/stable/module_guides/supporting_modules/service_context_migration/
```

## Testing
The API container should now start up correctly without the ServiceContext deprecation error.