### PR TITLE
feat: Add Google Text Embedding 004 and Confluence init container

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -15,6 +15,12 @@ GOOGLE_EMBEDDINGS_MODEL="models/text-embedding-004"
 # Overrides the default Google embeddings dimensions
 GOOGLE_EMBEDDINGS_DIMENSIONS=768
 GOOGLE_ENABLED="true"
+# Personal Access Token for GitHub API access, required for indexing private repos or increasing rate limits.
+GITHUB_TOKEN=""
+# Comma-separated list of GitHub repositories to index, e.g., owner1/repoA,owner2/repoB
+GITHUB_REPOS=""
+# Set to true to enable GitHub repository indexing on startup
+GITHUB_ENABLED="true"
 HF_ACCESS_TOKEN=""
 LANGCHAIN_API_KEY=""
 LANGCHAIN_TRACING_V2="true"

--- a/.env-template
+++ b/.env-template
@@ -7,7 +7,7 @@ CONFLUENCE_SPACE_KEYS=""
 FASTAPI_RELOAD=""
 FERNET_KEY=""
 # Set to true to initialize the vector database on startup
-INIT_DATABASE=false
+INIT_DATABASE="false"
 GOOGLE_API_KEY=""
 GOOGLE_CHAT_MODEL="gemini-2.5-pro-exp-03-25"
 # Overrides the default Google embeddings model

--- a/.env-template
+++ b/.env-template
@@ -2,11 +2,18 @@ CONFLUENCE_API_KEY=""
 CONFLUENCE_ENABLED="True"
 CONFLUENCE_URL=""
 CONFLUENCE_USERNAME=""
-CONFLUENCE_DEFAULT_SPACE_KEY=""
+# Comma-separated list of Confluence space keys to index
+CONFLUENCE_SPACE_KEYS=""
 FASTAPI_RELOAD=""
 FERNET_KEY=""
+# Set to true to initialize the vector database on startup
+INIT_DATABASE=false
 GOOGLE_API_KEY=""
 GOOGLE_CHAT_MODEL="gemini-2.5-pro-exp-03-25"
+# Overrides the default Google embeddings model
+GOOGLE_EMBEDDINGS_MODEL="models/text-embedding-004"
+# Overrides the default Google embeddings dimensions
+GOOGLE_EMBEDDINGS_DIMENSIONS=768
 GOOGLE_ENABLED="true"
 HF_ACCESS_TOKEN=""
 LANGCHAIN_API_KEY=""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,31 @@ services:
       - "ai.model.context.protocol.version=0.1"
       - "ai.model.context.protocol.endpoint=/context"
 
+  init-vector-db:
+    build:
+      context: .
+      dockerfile: ./fastapi/Dockerfile
+    environment:
+      - LOG_LEVEL=INFO
+      - PYTHONUNBUFFERED=1
+    env_file:
+      - .env
+    volumes:
+      - ./moonmind:/app/moonmind:ro
+      - ./scripts:/app/scripts:ro
+      - ./models:/app/models:ro
+    command: >
+      sh -c "
+      if [ \"$$INIT_DATABASE\" = \"true\" ]; then
+        echo 'Attempting to initialize vector database...'
+        python /app/scripts/init_vector_db.py;
+      else
+        echo 'INIT_DATABASE not set to true, skipping vector DB initialization.';
+      fi"
+    networks:
+      - local-network
+    restart: "no"
+
 volumes:
   open-webui:
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -8,6 +8,8 @@ class GoogleSettings(BaseSettings):
     """Google/Gemini API settings"""
     google_api_key: Optional[str] = Field(None, env="GOOGLE_API_KEY")
     google_chat_model: str = Field("gemini-2.5-pro-exp-03-25", env="GOOGLE_CHAT_MODEL")
+    google_embeddings_model: str = Field("models/text-embedding-004", env="GOOGLE_EMBEDDINGS_MODEL")
+    google_embeddings_dimensions: int = Field(768, env="GOOGLE_EMBEDDINGS_DIMENSIONS")
     google_enabled: bool = Field(True, env="GOOGLE_ENABLED")
     
     class Config:
@@ -48,7 +50,7 @@ class AppSettings(BaseSettings):
     
     # Default providers and models
     default_chat_provider: str = Field("google", env="DEFAULT_CHAT_PROVIDER")
-    default_embed_provider: str = Field("ollama", env="DEFAULT_EMBED_PROVIDER")
+    default_embed_provider: str = Field("google", env="DEFAULT_EMBED_PROVIDER")
     default_chat_model: Optional[str] = Field(None, env="DEFAULT_CHAT_MODEL")
     default_embed_model: Optional[str] = Field(None, env="DEFAULT_EMBED_MODEL")
     
@@ -69,7 +71,7 @@ class AppSettings(BaseSettings):
     confluence_enabled: bool = Field(True, env="CONFLUENCE_ENABLED")
     confluence_url: Optional[str] = Field(None, env="CONFLUENCE_URL")
     confluence_username: Optional[str] = Field(None, env="CONFLUENCE_USERNAME")
-    confluence_default_space_key: Optional[str] = Field(None, env="CONFLUENCE_DEFAULT_SPACE_KEY")
+    confluence_space_keys: Optional[str] = Field(None, env="CONFLUENCE_SPACE_KEYS")
     
     fastapi_reload: bool = Field(False, env="FASTAPI_RELOAD")
     fernet_key: Optional[str] = Field(None, env="FERNET_KEY")

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -16,6 +16,16 @@ class GoogleSettings(BaseSettings):
         env_prefix = ""
 
 
+class GitHubSettings(BaseSettings):
+    """GitHub settings"""
+    github_token: Optional[str] = Field(None, env="GITHUB_TOKEN")
+    github_repos: Optional[str] = Field(None, env="GITHUB_REPOS") # Comma-delimited string of repositories
+    github_enabled: bool = Field(True, env="GITHUB_ENABLED")
+
+    class Config:
+        env_prefix = ""
+
+
 class OpenAISettings(BaseSettings):
     """OpenAI API settings"""
     openai_api_key: Optional[str] = Field(None, env="OPENAI_API_KEY")
@@ -47,6 +57,7 @@ class AppSettings(BaseSettings):
     google: GoogleSettings = GoogleSettings()
     openai: OpenAISettings = OpenAISettings()
     ollama: OllamaSettings = OllamaSettings()
+    github: GitHubSettings = GitHubSettings()
     
     # Default providers and models
     default_chat_provider: str = Field("google", env="DEFAULT_CHAT_PROVIDER")

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import logging
+import qdrant_client
+from moonmind.indexers.confluence_indexer import ConfluenceIndexer
+from moonmind.config.settings import settings
+from llama_index.core import StorageContext, ServiceContext
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from llama_index.embeddings.google import GoogleGenerativeAiEmbedding
+
+# Set up basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    logger.info("Starting vector database initialization script.")
+
+    init_db = os.getenv("INIT_DATABASE", "false").lower() == "true"
+    if not init_db:
+        logger.info("INIT_DATABASE environment variable is not set to 'true', exiting.")
+        sys.exit()
+
+    logger.info("INIT_DATABASE is 'true', proceeding with database initialization.")
+
+    try:
+        # 1. Confluence Configuration Check
+        logger.info("Checking Confluence configuration...")
+        if not settings.confluence.confluence_enabled:
+            logger.error("Confluence is not enabled in settings. Exiting.")
+            sys.exit()
+        if not settings.confluence.confluence_url:
+            logger.error("Confluence URL is not configured. Exiting.")
+            sys.exit()
+        if not settings.confluence.confluence_username:
+            logger.error("Confluence username is not configured. Exiting.")
+            sys.exit()
+        if not settings.confluence.confluence_api_key:
+            logger.error("Confluence API key is not configured. Exiting.")
+            sys.exit()
+        if not settings.confluence.confluence_space_keys:
+            logger.error("No Confluence space keys configured (CONFLUENCE_SPACE_KEYS). Exiting.")
+            sys.exit()
+        logger.info("Confluence configuration check passed.")
+
+        # 2. Parse Confluence Space Keys
+        space_keys_str = settings.confluence.confluence_space_keys
+        space_keys = [key.strip() for key in space_keys_str.split(',') if key.strip()]
+        if not space_keys:
+            logger.error("No valid Confluence space keys found after parsing. Exiting.")
+            sys.exit()
+        logger.info(f"Found Confluence space keys to process: {space_keys}")
+
+        # 3. Set up Qdrant client and VectorStore
+        logger.info(f"Initializing Qdrant client for host: {settings.qdrant_host}, port: {settings.qdrant_port}")
+        client = qdrant_client.QdrantClient(host=settings.qdrant_host, port=settings.qdrant_port)
+        
+        logger.info(f"Using vector store collection name: {settings.vector_store_collection_name}")
+        logger.info(f"Using Google embeddings dimensions for Qdrant: {settings.google.google_embeddings_dimensions}")
+        vector_store = QdrantVectorStore(
+            client=client,
+            collection_name=settings.vector_store_collection_name,
+            embed_dim=settings.google.google_embeddings_dimensions  # Using Google's dimensions
+        )
+        logger.info("Qdrant client and vector store initialized successfully.")
+
+        # 4. Set up StorageContext
+        storage_context = StorageContext.from_defaults(vector_store=vector_store)
+        logger.info("StorageContext initialized successfully.")
+
+        # 5. Set up Embedding Model (Google)
+        logger.info(f"Initializing Google Embeddings model: {settings.google.google_embeddings_model}")
+        if not settings.google.google_api_key:
+            logger.error("Google API key (GOOGLE_API_KEY) is not configured for embeddings. Exiting.")
+            sys.exit()
+            
+        embed_model = GoogleGenerativeAiEmbedding(
+            model_name=settings.google.google_embeddings_model,
+            api_key=settings.google.google_api_key
+        )
+        logger.info("Google Embedding model initialized successfully.")
+
+        # 6. Set up ServiceContext
+        # LLM is set to None as we are only performing indexing operations.
+        service_context = ServiceContext.from_defaults(embed_model=embed_model, llm=None)
+        logger.info("ServiceContext initialized successfully (LLM is None for indexing).")
+
+        # 7. Instantiate ConfluenceIndexer
+        logger.info("Initializing ConfluenceIndexer...")
+        confluence_indexer = ConfluenceIndexer(
+            base_url=settings.confluence.confluence_url,
+            user_name=settings.confluence.confluence_username,
+            api_token=settings.confluence.confluence_api_key,
+            logger=logger  # Pass the logger instance
+        )
+        logger.info("ConfluenceIndexer initialized successfully.")
+
+        # 8. Loop through space keys and index
+        logger.info(f"Starting to process {len(space_keys)} Confluence space(s).")
+        for space_key in space_keys:
+            logger.info(f"Processing Confluence space: {space_key}")
+            try:
+                # The ConfluenceIndexer's index method is expected to handle the actual indexing
+                # process, including fetching documents and adding them to the vector store
+                # via the provided storage_context and service_context.
+                index_result = confluence_indexer.index(
+                    space_key=space_key,
+                    storage_context=storage_context,
+                    service_context=service_context
+                    # Assuming `index` method does not require page_ids or include_attachments by default
+                    # or handles them internally based on some logic or further configuration.
+                    # If these are mandatory, the ConfluenceIndexer logic or this call needs adjustment.
+                )
+                total_nodes_indexed = 0
+                if index_result and isinstance(index_result, dict) and 'total_nodes_indexed' in index_result:
+                    total_nodes_indexed = index_result.get('total_nodes_indexed', 0)
+
+                logger.info(f"Successfully processed space {space_key}. Nodes indexed: {total_nodes_indexed}.")
+            except Exception as e:
+                logger.error(f"Error indexing space {space_key}: {e}", exc_info=True)
+        
+        logger.info("Finished processing all Confluence spaces.")
+
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during vector database initialization: {e}", exc_info=True)
+        sys.exit(1)
+
+    logger.info("Vector database initialization script finished successfully.")

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -115,8 +115,10 @@ if __name__ == "__main__":
                     total_nodes_indexed = index_result.get('total_nodes_indexed', 0)
 
                 logger.info(f"Successfully processed space {space_key}. Nodes indexed: {total_nodes_indexed}.")
+            except (ValueError, KeyError, ConnectionError) as e:
+                logger.error(f"Known error occurred while indexing space {space_key}: {e}", exc_info=True)
             except Exception as e:
-                logger.error(f"Error indexing space {space_key}: {e}", exc_info=True)
+                logger.error(f"Unexpected error occurred while indexing space {space_key}: {e}", exc_info=True)
         
         logger.info("Finished processing all Confluence spaces.")
 

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     init_db = os.getenv("INIT_DATABASE", "false").lower() == "true"
     if not init_db:
         logger.info("INIT_DATABASE environment variable is not set to 'true', exiting.")
-        sys.exit()
+        sys.exit(1)
 
     logger.info("INIT_DATABASE is 'true', proceeding with database initialization.")
 

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
                     github_indexer = GitHubIndexer(github_token=settings.github.github_token, logger=logger)
                     logger.info("GitHubIndexer initialized.")
 
-                    default_branch = "main" # Or "master", or make this configurable later
+                    default_branch = settings.github.default_branch or "main"
                     for repo_full_name in github_repo_list:
                         logger.info(f"Processing GitHub repository: {repo_full_name} (branch: {default_branch})")
                         try:

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     init_db = os.getenv("INIT_DATABASE", "false").lower() == "true"
     if not init_db:
         logger.info("INIT_DATABASE environment variable is not set to 'true', exiting.")
-        sys.exit()
+        sys.exit(1)
 
     logger.info("INIT_DATABASE is 'true', proceeding with database initialization.")
 


### PR DESCRIPTION
This commit introduces several enhancements:

1.  **Google Text Embedding 004 as Default:**
    *   Sets `models/text-embedding-004` as the default Google embeddings model (`google_embeddings_model`) in `GoogleSettings`.
    *   Sets the corresponding `google_embeddings_dimensions` to 768.
    *   Changes the `default_embed_provider` in `AppSettings` to "google".

2.  **Confluence Multi-Space Initialization:**
    *   Replaces `confluence_default_space_key` with `confluence_space_keys` in `AppSettings` to support a comma-delimited list of Confluence space keys.
    *   Introduces an initialization script `scripts/init_vector_db.py` that loads documents from the specified Confluence spaces into the Qdrant vector database. This script uses the configured Google embedding model.
    *   Adds an `init-vector-db` service to `docker-compose.yaml`. This service runs the `init_vector_db.py` script if the `INIT_DATABASE` environment variable is set to "true".

3.  **Configuration Updates:**
    *   Updates `.env-template` to include `INIT_DATABASE` and `CONFLUENCE_SPACE_KEYS`, and reflects the new Google embedding model variables.

The existing Confluence API endpoint in `fastapi/api/routers/documents.py` remains unaffected as it already required a `space_key` in the request.