### PR TITLE
Refactor: Rename root 'models' directory to 'model_data'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 __pycache__/
-models/
+model_data/
 outputs/
 temp/
 data/

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -34,7 +34,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./models:/app/models
+      - ./model_data:/app/model_data
       - ./api_service/api:/app/api:ro
       - ./api_service/main.py:/app/main.py:ro
       - ./moonmind:/app/moonmind:ro
@@ -63,7 +63,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./scripts:/app/scripts:ro
-      - ./models:/app/models:ro
+      - ./model_data:/app/model_data:ro
     command: >
       sh -c "
       if [ \"$$INIT_DATABASE\" = \"true\" ]; then

--- a/docker-compose.downloader.yaml
+++ b/docker-compose.downloader.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       - PYTHONPATH=/app
     volumes:
-      - ./models:/app/models
+      - ./model_data:/app/model_data
       - ./moonmind:/app/moonmind
       - ./scripts:/app/scripts
     working_dir: /app

--- a/docker-compose.job.yaml
+++ b/docker-compose.job.yaml
@@ -13,7 +13,7 @@ services:
       - .env
     volumes:
       - ./jobs:/app/jobs
-      - ./models:/app/models
+      - ./model_data:/app/model_data
       - ./moonmind:/app/moonmind:ro
       - ./prompts:/app/prompts
       # - ${DATA_MOUNT_SOURCE:-./data}:${DATA_MOUNT_TARGET:-/app/data}

--- a/docker-compose.ollama.yaml
+++ b/docker-compose.ollama.yaml
@@ -13,7 +13,7 @@ services:
               count: all
               capabilities: [gpu]
     volumes:
-      - ./models:/root/.ollama/models
+      - ./model_data:/root/.ollama/models
       - ./scripts/entrypoint-ollama.sh:/entrypoint-ollama.sh:ro
     entrypoint: ["/bin/sh", "/entrypoint-ollama.sh"]
     networks:

--- a/docker-compose.vllm.yaml
+++ b/docker-compose.vllm.yaml
@@ -11,7 +11,7 @@ services:
               count: all
               capabilities: [gpu]
     volumes:
-      - ./models:/root/.cache/huggingface/hub
+      - ./model_data:/root/.cache/huggingface/hub
       - ./scripts/entrypoint-vllm.sh:/entrypoint-vllm.sh:ro # Added this line
     ports:
       - "8001:8000" # Exposing on 8001 to avoid conflict with existing api service on 8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./models:/app/models
+      - ./model_data:/app/model_data
       - ./api_service/api:/app/api:ro
       - ./api_service/main.py:/app/main.py:ro
       - ./moonmind:/app/moonmind:ro
@@ -69,7 +69,7 @@ services:
     volumes:
       - ./moonmind:/app/moonmind:ro
       - ./scripts:/app/scripts:ro
-      - ./models:/app/models:ro
+      - ./model_data:/app/model_data:ro
     command: >
       sh -c "
       if [ "$INIT_DATABASE" = "true" ]; then

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -122,7 +122,7 @@ class AppSettings(BaseSettings):
     langchain_tracing_v2: str = Field("true", env="LANGCHAIN_TRACING_V2")
     langchain_project: str = Field("MoonMind", env="LANGCHAIN_PROJECT")
 
-    model_directory: str = Field("/app/models", env="MODEL_DIRECTORY")
+    model_directory: str = Field("/app/model_data", env="MODEL_DIRECTORY")
 
     # OpenHands settings
     openhands_llm_api_key: Optional[str] = Field(None, env="OPENHANDS__LLM__API_KEY")


### PR DESCRIPTION
This commit updates all references to the root-level 'models' directory to 'model_data'.

Changes include:
- Updated .gitignore to ignore 'model_data/' instead of 'models/'.
- Modified volume mounts in docker-compose.dev.yaml, docker-compose.downloader.yaml, docker-compose.job.yaml, docker-compose.ollama.yaml, docker-compose.vllm.yaml, and docker-compose.yaml to use './model_data' on the host and '/app/model_data' or other relevant paths (like '/root/.ollama/models' or '/root/.cache/huggingface/hub') within the containers.
- Updated 'model_directory' in moonmind/config/settings.py to '/app/model_data'.

This change ensures consistency in naming for the directory intended for stateful model storage, distinguishing it from the 'moonmind/models' Python package.