### PR TITLE
I've refactored the Atlassian settings to a nested structure.

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,9 +1,3 @@
-CONFLUENCE_API_KEY=""
-CONFLUENCE_ENABLED="True"
-CONFLUENCE_URL=""
-CONFLUENCE_USERNAME=""
-# Comma-separated list of Confluence space keys to index
-CONFLUENCE_SPACE_KEYS=""
 FASTAPI_RELOAD=""
 FERNET_KEY=""
 # Set to true to initialize the vector database on startup
@@ -19,6 +13,24 @@ GITHUB_TOKEN=""
 GITHUB_REPOS=""
 # Set to true to enable GitHub repository indexing on startup
 GITHUB_ENABLED="true"
+
+# Atlassian Settings
+ATLASSIAN_API_KEY=""
+ATLASSIAN_USERNAME=""
+ATLASSIAN_URL=""
+ATLASSIAN_ENABLED="False"
+
+# Atlassian Confluence Settings
+ATLASSIAN_CONFLUENCE_ENABLED="False"
+# Comma-separated list of Confluence space keys to index
+ATLASSIAN_CONFLUENCE_SPACE_KEYS=""
+
+# Atlassian Jira Settings
+ATLASSIAN_JIRA_ENABLED="False"
+# JQL query to select issues, e.g., 'project in (PROJA, PROJB)'
+ATLASSIAN_JIRA_JQL_QUERY=""
+ATLASSIAN_JIRA_FETCH_BATCH_SIZE="50"
+
 HF_ACCESS_TOKEN=""
 LANGCHAIN_API_KEY=""
 LANGCHAIN_TRACING_V2="true"

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -61,6 +61,41 @@ class OllamaSettings(BaseSettings):
     class Config:
         env_prefix = ""
 
+
+class AtlassianSettings(BaseSettings):
+    """Atlassian base settings"""
+    atlassian_api_key: Optional[str] = Field(None, env="ATLASSIAN_API_KEY")
+    atlassian_username: Optional[str] = Field(None, env="ATLASSIAN_USERNAME")
+    atlassian_url: Optional[str] = Field(None, env="ATLASSIAN_URL")
+    atlassian_enabled: bool = Field(False, env="ATLASSIAN_ENABLED")
+
+    # Nested settings for Confluence and Jira
+    confluence: ConfluenceSettings = ConfluenceSettings()
+    jira: JiraSettings = JiraSettings()
+
+    class Config:
+        env_prefix = ""
+
+
+class ConfluenceSettings(BaseSettings):
+    """Confluence specific settings"""
+    confluence_space_keys: Optional[str] = Field(None, env="CONFLUENCE_SPACE_KEYS")
+    confluence_enabled: bool = Field(False, env="CONFLUENCE_ENABLED")
+
+    class Config:
+        env_prefix = ""
+
+
+class JiraSettings(BaseSettings):
+    """Jira specific settings"""
+    jira_jql_query: Optional[str] = Field(None, env="JIRA_JQL_QUERY")
+    jira_fetch_batch_size: int = Field(50, env="JIRA_FETCH_BATCH_SIZE")
+    jira_enabled: bool = Field(False, env="JIRA_ENABLED")
+
+    class Config:
+        env_prefix = ""
+
+
 class QdrantSettings(BaseSettings):
     """Qdrant settings"""
     qdrant_host: str = Field("qdrant", env="QDRANT_HOST")
@@ -89,6 +124,7 @@ class AppSettings(BaseSettings):
     google_drive: GoogleDriveSettings = GoogleDriveSettings()
     qdrant: QdrantSettings = QdrantSettings()
     rag: RAGSettings = RAGSettings()
+    atlassian: AtlassianSettings = AtlassianSettings()
 
     # Default providers and models
     default_chat_provider: str = Field("google", env="DEFAULT_CHAT_PROVIDER")
@@ -108,20 +144,6 @@ class AppSettings(BaseSettings):
     vector_store_collection_name: str = Field("moonmind", env="VECTOR_STORE_COLLECTION_NAME")
 
     # Other settings
-    confluence_api_key: Optional[str] = Field(None, env="CONFLUENCE_API_KEY")
-    confluence_enabled: bool = Field(True, env="CONFLUENCE_ENABLED")
-    confluence_url: Optional[str] = Field(None, env="CONFLUENCE_URL")
-    confluence_username: Optional[str] = Field(None, env="CONFLUENCE_USERNAME")
-    confluence_space_keys: Optional[str] = Field(None, env="CONFLUENCE_SPACE_KEYS")
-
-    # Jira Settings
-    jira_enabled: bool = Field(False, env="JIRA_ENABLED")
-    jira_url: Optional[str] = Field(None, env="JIRA_URL", description="Jira instance URL, e.g., your-domain.atlassian.net")
-    jira_username: Optional[str] = Field(None, env="JIRA_USERNAME", description="Jira username (usually email)")
-    jira_api_token: Optional[str] = Field(None, env="JIRA_API_TOKEN")
-    jira_jql_query: Optional[str] = Field(None, env="JIRA_JQL_QUERY", description="JQL query to select issues, e.g., 'project in (PROJA, PROJB)'")
-    jira_fetch_batch_size: int = Field(50, env="JIRA_FETCH_BATCH_SIZE", description="Number of issues to fetch per API call")
-
     fastapi_reload: bool = Field(False, env="FASTAPI_RELOAD")
     fernet_key: Optional[str] = Field(None, env="FERNET_KEY")
     hf_access_token: Optional[str] = Field(None, env="HF_ACCESS_TOKEN")

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class GoogleSettings(BaseSettings):
@@ -13,9 +13,7 @@ class GoogleSettings(BaseSettings):
     google_enabled: bool = Field(True, env="GOOGLE_ENABLED")
     # google_application_credentials has been moved to GoogleDriveSettings as per requirements
 
-
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class GitHubSettings(BaseSettings):
@@ -24,8 +22,7 @@ class GitHubSettings(BaseSettings):
     github_repos: Optional[str] = Field(None, env="GITHUB_REPOS") # Comma-delimited string of repositories
     github_enabled: bool = Field(True, env="GITHUB_ENABLED")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class GoogleDriveSettings(BaseSettings):
@@ -34,8 +31,7 @@ class GoogleDriveSettings(BaseSettings):
     google_drive_folder_id: Optional[str] = Field(None, env="GOOGLE_DRIVE_FOLDER_ID")
     google_application_credentials: Optional[str] = Field(None, env="GOOGLE_APPLICATION_CREDENTIALS")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class OpenAISettings(BaseSettings):
@@ -44,8 +40,7 @@ class OpenAISettings(BaseSettings):
     openai_chat_model: str = Field("gpt-3.5-turbo", env="OPENAI_CHAT_MODEL")
     openai_enabled: bool = Field(True, env="OPENAI_ENABLED")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class OllamaSettings(BaseSettings):
@@ -58,8 +53,7 @@ class OllamaSettings(BaseSettings):
     ollama_modes: str = Field("chat", env="OLLAMA_MODES")
     ollama_enabled: bool = Field(True, env="OLLAMA_ENABLED")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class ConfluenceSettings(BaseSettings):
@@ -67,8 +61,7 @@ class ConfluenceSettings(BaseSettings):
     confluence_space_keys: Optional[str] = Field(None, env="ATLASSIAN_CONFLUENCE_SPACE_KEYS")
     confluence_enabled: bool = Field(False, env="ATLASSIAN_CONFLUENCE_ENABLED")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class JiraSettings(BaseSettings):
@@ -77,8 +70,7 @@ class JiraSettings(BaseSettings):
     jira_fetch_batch_size: int = Field(50, env="ATLASSIAN_JIRA_FETCH_BATCH_SIZE")
     jira_enabled: bool = Field(False, env="ATLASSIAN_JIRA_ENABLED")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class AtlassianSettings(BaseSettings):
@@ -92,8 +84,7 @@ class AtlassianSettings(BaseSettings):
     confluence: ConfluenceSettings = ConfluenceSettings()
     jira: JiraSettings = JiraSettings()
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class QdrantSettings(BaseSettings):
@@ -102,6 +93,7 @@ class QdrantSettings(BaseSettings):
     qdrant_port: int = Field(6333, env="QDRANT_PORT")
     qdrant_api_key: Optional[str] = Field(None, env="QDRANT_API_KEY")
     qdrant_enabled: bool = Field(True, env="QDRANT_ENABLED")
+    model_config = SettingsConfigDict(env_prefix="")
 
 class RAGSettings(BaseSettings):
     """RAG (Retrieval-Augmented Generation) settings"""
@@ -109,8 +101,7 @@ class RAGSettings(BaseSettings):
     similarity_top_k: int = Field(5, env="RAG_SIMILARITY_TOP_K")
     max_context_length_chars: int = Field(8000, env="RAG_MAX_CONTEXT_LENGTH_CHARS")
 
-    class Config:
-        env_prefix = ""
+    model_config = SettingsConfigDict(env_prefix="")
 
 
 class AppSettings(BaseSettings):
@@ -202,9 +193,7 @@ class AppSettings(BaseSettings):
         else:
             return False
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra='ignore')
 
 
 # Create a global settings instance

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -61,7 +61,7 @@ class ConfluenceSettings(BaseSettings):
     confluence_space_keys: Optional[str] = Field(None, env="ATLASSIAN_CONFLUENCE_SPACE_KEYS")
     confluence_enabled: bool = Field(False, env="ATLASSIAN_CONFLUENCE_ENABLED")
 
-    model_config = SettingsConfigDict(env_prefix="")
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env", env_file_encoding="utf-8")
 
 
 class JiraSettings(BaseSettings):
@@ -70,7 +70,7 @@ class JiraSettings(BaseSettings):
     jira_fetch_batch_size: int = Field(50, env="ATLASSIAN_JIRA_FETCH_BATCH_SIZE")
     jira_enabled: bool = Field(False, env="ATLASSIAN_JIRA_ENABLED")
 
-    model_config = SettingsConfigDict(env_prefix="")
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env", env_file_encoding="utf-8")
 
 
 class AtlassianSettings(BaseSettings):
@@ -81,10 +81,24 @@ class AtlassianSettings(BaseSettings):
     atlassian_enabled: bool = Field(False, env="ATLASSIAN_ENABLED")
 
     # Nested settings for Confluence and Jira
-    confluence: ConfluenceSettings = ConfluenceSettings()
-    jira: JiraSettings = JiraSettings()
+    confluence: ConfluenceSettings = Field(default_factory=ConfluenceSettings)
+    jira: JiraSettings = Field(default_factory=JiraSettings)
 
-    model_config = SettingsConfigDict(env_prefix="")
+    model_config = SettingsConfigDict(env_prefix="", env_file=".env", env_file_encoding="utf-8")
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        # Manually load environment variables for nested settings
+        if os.environ.get("ATLASSIAN_CONFLUENCE_ENABLED") == "True":
+            self.confluence.confluence_enabled = True
+        if os.environ.get("ATLASSIAN_CONFLUENCE_SPACE_KEYS"):
+            self.confluence.confluence_space_keys = os.environ.get("ATLASSIAN_CONFLUENCE_SPACE_KEYS")
+        if os.environ.get("ATLASSIAN_JIRA_ENABLED") == "True":
+            self.jira.jira_enabled = True
+        if os.environ.get("ATLASSIAN_JIRA_JQL_QUERY"):
+            self.jira.jira_jql_query = os.environ.get("ATLASSIAN_JIRA_JQL_QUERY")
+        if os.environ.get("ATLASSIAN_JIRA_FETCH_BATCH_SIZE"):
+            self.jira.jira_fetch_batch_size = int(os.environ.get("ATLASSIAN_JIRA_FETCH_BATCH_SIZE"))
 
 
 class QdrantSettings(BaseSettings):
@@ -108,13 +122,13 @@ class AppSettings(BaseSettings):
     """Main application settings"""
 
     # Sub-settings
-    google: GoogleSettings = GoogleSettings()
-    openai: OpenAISettings = OpenAISettings()
-    ollama: OllamaSettings = OllamaSettings()
-    github: GitHubSettings = GitHubSettings()
-    google_drive: GoogleDriveSettings = GoogleDriveSettings()
-    qdrant: QdrantSettings = QdrantSettings()
-    rag: RAGSettings = RAGSettings()
+    google: GoogleSettings = Field(default_factory=GoogleSettings)
+    openai: OpenAISettings = Field(default_factory=OpenAISettings)
+    ollama: OllamaSettings = Field(default_factory=OllamaSettings)
+    github: GitHubSettings = Field(default_factory=GitHubSettings)
+    google_drive: GoogleDriveSettings = Field(default_factory=GoogleDriveSettings)
+    qdrant: QdrantSettings = Field(default_factory=QdrantSettings)
+    rag: RAGSettings = Field(default_factory=RAGSettings)
     atlassian: AtlassianSettings = Field(default_factory=AtlassianSettings)
 
     # Default providers and models

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -62,6 +62,25 @@ class OllamaSettings(BaseSettings):
         env_prefix = ""
 
 
+class ConfluenceSettings(BaseSettings):
+    """Confluence specific settings"""
+    confluence_space_keys: Optional[str] = Field(None, env="ATLASSIAN_CONFLUENCE_SPACE_KEYS")
+    confluence_enabled: bool = Field(False, env="ATLASSIAN_CONFLUENCE_ENABLED")
+
+    class Config:
+        env_prefix = ""
+
+
+class JiraSettings(BaseSettings):
+    """Jira specific settings"""
+    jira_jql_query: Optional[str] = Field(None, env="ATLASSIAN_JIRA_JQL_QUERY")
+    jira_fetch_batch_size: int = Field(50, env="ATLASSIAN_JIRA_FETCH_BATCH_SIZE")
+    jira_enabled: bool = Field(False, env="ATLASSIAN_JIRA_ENABLED")
+
+    class Config:
+        env_prefix = ""
+
+
 class AtlassianSettings(BaseSettings):
     """Atlassian base settings"""
     atlassian_api_key: Optional[str] = Field(None, env="ATLASSIAN_API_KEY")
@@ -72,25 +91,6 @@ class AtlassianSettings(BaseSettings):
     # Nested settings for Confluence and Jira
     confluence: ConfluenceSettings = ConfluenceSettings()
     jira: JiraSettings = JiraSettings()
-
-    class Config:
-        env_prefix = ""
-
-
-class ConfluenceSettings(BaseSettings):
-    """Confluence specific settings"""
-    confluence_space_keys: Optional[str] = Field(None, env="CONFLUENCE_SPACE_KEYS")
-    confluence_enabled: bool = Field(False, env="CONFLUENCE_ENABLED")
-
-    class Config:
-        env_prefix = ""
-
-
-class JiraSettings(BaseSettings):
-    """Jira specific settings"""
-    jira_jql_query: Optional[str] = Field(None, env="JIRA_JQL_QUERY")
-    jira_fetch_batch_size: int = Field(50, env="JIRA_FETCH_BATCH_SIZE")
-    jira_enabled: bool = Field(False, env="JIRA_ENABLED")
 
     class Config:
         env_prefix = ""

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -115,7 +115,7 @@ class AppSettings(BaseSettings):
     google_drive: GoogleDriveSettings = GoogleDriveSettings()
     qdrant: QdrantSettings = QdrantSettings()
     rag: RAGSettings = RAGSettings()
-    atlassian: AtlassianSettings = AtlassianSettings()
+    atlassian: AtlassianSettings = Field(default_factory=AtlassianSettings)
 
     # Default providers and models
     default_chat_provider: str = Field("google", env="DEFAULT_CHAT_PROVIDER")

--- a/moonmind/factories/indexers_factory.py
+++ b/moonmind/factories/indexers_factory.py
@@ -8,29 +8,33 @@ from moonmind.indexers.jira_indexer import JiraIndexer # New import
 def build_indexers(settings: AppSettings):
     indexers = {}
 
-    if settings.confluence_enabled:
-        # Ensure required Confluence settings are present
-        if settings.confluence_url and settings.confluence_username and settings.confluence_api_key:
+    # Confluence Indexer
+    if settings.atlassian.atlassian_enabled and settings.atlassian.confluence.confluence_enabled:
+        if settings.atlassian.atlassian_url and \
+           settings.atlassian.atlassian_username and \
+           settings.atlassian.atlassian_api_key:
             indexers["confluence"] = ConfluenceIndexer(
-                base_url=settings.confluence_url,
-                user_name=settings.confluence_username,
-                api_token=settings.confluence_api_key
+                base_url=settings.atlassian.atlassian_url,
+                user_name=settings.atlassian.atlassian_username,
+                api_token=settings.atlassian.atlassian_api_key
                 # cloud=True is the default in ConfluenceIndexer
             )
         else:
-            # logger.warning("Confluence is enabled but missing required settings (URL, Username, API Key).")
+            # logger.warning("Confluence is enabled but missing required Atlassian settings (URL, Username, API Key).")
             pass # ConfluenceIndexer raises ValueError for missing essential params
 
-    if settings.jira_enabled:
-        # Ensure required Jira settings are present
-        if settings.jira_url and settings.jira_username and settings.jira_api_token:
+    # Jira Indexer
+    if settings.atlassian.atlassian_enabled and settings.atlassian.jira.jira_enabled:
+        if settings.atlassian.atlassian_url and \
+           settings.atlassian.atlassian_username and \
+           settings.atlassian.atlassian_api_key:
             indexers["jira"] = JiraIndexer(
-                jira_url=settings.jira_url,
-                username=settings.jira_username,
-                api_token=settings.jira_api_token
+                jira_url=settings.atlassian.atlassian_url,
+                username=settings.atlassian.atlassian_username,
+                api_token=settings.atlassian.atlassian_api_key
             )
         else:
-            # logger.warning("Jira is enabled but missing required settings (URL, Username, API Token).")
+            # logger.warning("Jira is enabled but missing required Atlassian settings (URL, Username, API Token).")
             pass # JiraIndexer raises ValueError for missing essential params
 
     return indexers

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -28,25 +28,25 @@ if __name__ == "__main__":
     try:
         # 1. Confluence Configuration Check
         logger.info("Checking Confluence configuration...")
-        if not settings.confluence.confluence_enabled:
-            logger.error("Confluence is not enabled in settings. Exiting.")
+        if not (settings.atlassian.atlassian_enabled and settings.atlassian.confluence.confluence_enabled):
+            logger.error("Confluence is not enabled via Atlassian settings. Exiting.")
             sys.exit()
-        if not settings.confluence.confluence_url:
-            logger.error("Confluence URL is not configured. Exiting.")
+        if not settings.atlassian.atlassian_url:
+            logger.error("Atlassian URL is not configured. Exiting.")
             sys.exit()
-        if not settings.confluence.confluence_username:
-            logger.error("Confluence username is not configured. Exiting.")
+        if not settings.atlassian.atlassian_username:
+            logger.error("Atlassian username is not configured. Exiting.")
             sys.exit()
-        if not settings.confluence.confluence_api_key:
-            logger.error("Confluence API key is not configured. Exiting.")
+        if not settings.atlassian.atlassian_api_key:
+            logger.error("Atlassian API key is not configured. Exiting.")
             sys.exit()
-        if not settings.confluence.confluence_space_keys:
-            logger.error("No Confluence space keys configured (CONFLUENCE_SPACE_KEYS). Exiting.")
+        if not settings.atlassian.confluence.confluence_space_keys:
+            logger.error("No Confluence space keys configured (ATLASSIAN_CONFLUENCE_SPACE_KEYS). Exiting.")
             sys.exit()
         logger.info("Confluence configuration check passed.")
 
         # 2. Parse Confluence Space Keys
-        space_keys_str = settings.confluence.confluence_space_keys
+        space_keys_str = settings.atlassian.confluence.confluence_space_keys
         space_keys = [key.strip() for key in space_keys_str.split(',') if key.strip()]
         if not space_keys:
             logger.error("No valid Confluence space keys found after parsing. Exiting.")
@@ -90,9 +90,9 @@ if __name__ == "__main__":
         # 7. Instantiate ConfluenceIndexer
         logger.info("Initializing ConfluenceIndexer...")
         confluence_indexer = ConfluenceIndexer(
-            base_url=settings.confluence.confluence_url,
-            user_name=settings.confluence.confluence_username,
-            api_token=settings.confluence.confluence_api_key,
+            base_url=settings.atlassian.atlassian_url,
+            user_name=settings.atlassian.atlassian_username,
+            api_token=settings.atlassian.atlassian_api_key,
             logger=logger  # Pass the logger instance
         )
         logger.info("ConfluenceIndexer initialized successfully.")
@@ -214,47 +214,47 @@ if __name__ == "__main__":
         # 11. Jira Indexing
         logger.info("Starting Jira indexing process...")
         jira_skipped = True # Assume skipped until success
-        if not settings.jira_enabled: # Direct access for jira_enabled
-            logger.info("Jira integration is not enabled via settings. Skipping Jira indexing.")
-        elif not settings.jira_url: # Direct access
-            logger.warning("JIRA_URL is not configured. Skipping Jira indexing.")
-        elif not settings.jira_username: # Direct access
-            logger.warning("JIRA_USERNAME is not configured. Skipping Jira indexing.")
-        elif not settings.jira_api_token: # Direct access
-            logger.warning("JIRA_API_TOKEN is not configured. Skipping Jira indexing.")
-        elif not settings.jira_jql_query: # Direct access
-            logger.warning("JIRA_JQL_QUERY is not configured. Skipping Jira indexing.")
+        if not (settings.atlassian.atlassian_enabled and settings.atlassian.jira.jira_enabled):
+            logger.info("Jira integration is not enabled via Atlassian settings. Skipping Jira indexing.")
+        elif not settings.atlassian.atlassian_url:
+            logger.warning("Atlassian URL (for Jira) is not configured. Skipping Jira indexing.")
+        elif not settings.atlassian.atlassian_username:
+            logger.warning("Atlassian username (for Jira) is not configured. Skipping Jira indexing.")
+        elif not settings.atlassian.atlassian_api_key:
+            logger.warning("Atlassian API key (for Jira) is not configured. Skipping Jira indexing.")
+        elif not settings.atlassian.jira.jira_jql_query:
+            logger.warning("Jira JQL query (ATLASSIAN_JIRA_JQL_QUERY) is not configured. Skipping Jira indexing.")
         else:
             jira_skipped = False # Enabled and all basic settings seem present
-            logger.info(f"Found Jira JQL query to process: {settings.jira_jql_query}")
+            logger.info(f"Found Jira JQL query to process: {settings.atlassian.jira.jira_jql_query}")
             logger.info("Initializing JiraIndexer...")
             try:
                 jira_indexer = JiraIndexer(
-                    jira_url=settings.jira_url,
-                    username=settings.jira_username,
-                    api_token=settings.jira_api_token,
+                    jira_url=settings.atlassian.atlassian_url,
+                    username=settings.atlassian.atlassian_username,
+                    api_token=settings.atlassian.atlassian_api_key,
                     logger=logger
                 )
                 logger.info("JiraIndexer initialized.")
 
-                logger.info(f"Processing Jira query: {settings.jira_jql_query}")
+                logger.info(f"Processing Jira query: {settings.atlassian.jira.jira_jql_query}")
                 # The existing storage_context and service_context should be reused
                 index_result = jira_indexer.index(
-                    jql_query=settings.jira_jql_query,
+                    jql_query=settings.atlassian.jira.jira_jql_query,
                     storage_context=storage_context,
                     service_context=service_context, # This is LlamaIndex ServiceContext
-                    jira_fetch_batch_size=settings.jira_fetch_batch_size
+                    jira_fetch_batch_size=settings.atlassian.jira.jira_fetch_batch_size
                 )
                 nodes_indexed_count = 0
                 if isinstance(index_result, dict) and 'total_nodes_indexed' in index_result:
                     nodes_indexed_count = index_result.get('total_nodes_indexed', 0)
-                logger.info(f"Successfully indexed {nodes_indexed_count} nodes from Jira for query: {settings.jira_jql_query}.")
+                logger.info(f"Successfully indexed {nodes_indexed_count} nodes from Jira for query: {settings.atlassian.jira.jira_jql_query}.")
             except Exception as e:
-                logger.error(f"Error indexing Jira query {settings.jira_jql_query}: {e}", exc_info=True)
+                logger.error(f"Error indexing Jira query {settings.atlassian.jira.jira_jql_query}: {e}", exc_info=True)
                 jira_skipped = True # Mark as skipped due to error
 
         # Check if any indexing was attempted
-        confluence_skipped = not (settings.confluence.confluence_enabled and settings.confluence.confluence_space_keys) # This line still uses .confluence. which is likely a bug in existing code
+        confluence_skipped = not (settings.atlassian.atlassian_enabled and settings.atlassian.confluence.confluence_enabled and settings.atlassian.confluence.confluence_space_keys)
         github_skipped = not (settings.github.github_enabled and settings.github.github_token and settings.github.github_repos)
         # google_drive_skipped is already set
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,88 @@
+import os
+import unittest
+from unittest.mock import patch
+
+# Assuming AppSettings can be imported like this.
+# Adjust if the path or import method is different.
+from moonmind.config.settings import AppSettings, AtlassianSettings, ConfluenceSettings, JiraSettings
+
+class TestAtlassianSettings(unittest.TestCase):
+
+    @patch.dict(os.environ, {
+        "ATLASSIAN_API_KEY": "test_api_key",
+        "ATLASSIAN_USERNAME": "test_user",
+        "ATLASSIAN_URL": "https://test.atlassian.net",
+        "ATLASSIAN_ENABLED": "True",
+        "ATLASSIAN_CONFLUENCE_ENABLED": "True",
+        "ATLASSIAN_CONFLUENCE_SPACE_KEYS": "TEST_SPACE_1,TEST_SPACE_2",
+        "ATLASSIAN_JIRA_ENABLED": "True",
+        "ATLASSIAN_JIRA_JQL_QUERY": "project=TEST",
+        "ATLASSIAN_JIRA_FETCH_BATCH_SIZE": "100"
+    })
+    def test_load_atlassian_settings_from_env(self):
+        settings = AppSettings()
+        self.assertTrue(settings.atlassian.atlassian_enabled)
+        self.assertEqual(settings.atlassian.atlassian_api_key, "test_api_key")
+        self.assertEqual(settings.atlassian.atlassian_username, "test_user")
+        self.assertEqual(settings.atlassian.atlassian_url, "https://test.atlassian.net")
+
+        self.assertTrue(settings.atlassian.confluence.confluence_enabled)
+        self.assertEqual(settings.atlassian.confluence.confluence_space_keys, "TEST_SPACE_1,TEST_SPACE_2")
+
+        self.assertTrue(settings.atlassian.jira.jira_enabled)
+        self.assertEqual(settings.atlassian.jira.jira_jql_query, "project=TEST")
+        self.assertEqual(settings.atlassian.jira.jira_fetch_batch_size, 100) # Pydantic converts "100" to int
+
+    @patch.dict(os.environ, {}, clear=True) # Clear all env vars for this test method
+    def test_atlassian_settings_defaults(self):
+        # Keys relevant to Atlassian settings that might have been set by other tests or globally
+        # We want to ensure these are not present for this default testing scenario.
+        atlassian_env_keys = [
+            "ATLASSIAN_API_KEY", "ATLASSIAN_USERNAME", "ATLASSIAN_URL", "ATLASSIAN_ENABLED",
+            "ATLASSIAN_CONFLUENCE_ENABLED", "ATLASSIAN_CONFLUENCE_SPACE_KEYS",
+            "ATLASSIAN_JIRA_ENABLED", "ATLASSIAN_JIRA_JQL_QUERY", "ATLASSIAN_JIRA_FETCH_BATCH_SIZE"
+        ]
+        
+        # Construct a dictionary for patch.dict to ensure these keys are removed from os.environ
+        # if they were somehow set before this test method's @patch.dict(clear=True) took effect
+        # or if they were set by a broader scope patch.
+        vars_to_ensure_removed = {k: "" for k in atlassian_env_keys if k in os.environ}
+
+        with patch.dict(os.environ, vars_to_ensure_removed, clear=True):
+            # Instantiating AppSettings here will read from the (now modified for this context) os.environ
+            temp_settings = AppSettings()
+
+            # Check default values (as defined in Pydantic models)
+            self.assertFalse(temp_settings.atlassian.atlassian_enabled) # Default is False
+            self.assertIsNone(temp_settings.atlassian.atlassian_api_key)
+            self.assertIsNone(temp_settings.atlassian.atlassian_username)
+            self.assertIsNone(temp_settings.atlassian.atlassian_url)
+
+            self.assertFalse(temp_settings.atlassian.confluence.confluence_enabled) # Default is False
+            self.assertIsNone(temp_settings.atlassian.confluence.confluence_space_keys)
+
+            self.assertFalse(temp_settings.atlassian.jira.jira_enabled) # Default is False
+            self.assertIsNone(temp_settings.atlassian.jira.jira_jql_query)
+            self.assertEqual(temp_settings.atlassian.jira.jira_fetch_batch_size, 50) # Default is 50
+
+
+    def test_atlassian_settings_types(self):
+        # Instantiate with whatever environment is currently active; type checks are independent of values.
+        settings = AppSettings() 
+        self.assertIsInstance(settings.atlassian, AtlassianSettings)
+        self.assertIsInstance(settings.atlassian.confluence, ConfluenceSettings)
+        self.assertIsInstance(settings.atlassian.jira, JiraSettings)
+        
+        # Field type checks
+        self.assertIsInstance(settings.atlassian.atlassian_enabled, bool)
+        # Optional fields can be None or str, but after Pydantic processing, they should be str if set.
+        # If not set, they are None. Type check against Pydantic model field types might be more robust.
+        # However, for enabled flags, they are bool. For batch_size, it's int.
+        
+        self.assertIsInstance(settings.atlassian.confluence.confluence_enabled, bool)
+        
+        self.assertIsInstance(settings.atlassian.jira.jira_enabled, bool)
+        self.assertIsInstance(settings.atlassian.jira.jira_fetch_batch_size, int)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -20,18 +20,22 @@ class TestAtlassianSettings(unittest.TestCase):
         "ATLASSIAN_JIRA_FETCH_BATCH_SIZE": "100"
     })
     def test_load_atlassian_settings_from_env(self):
+        # Create the main settings
         settings = AppSettings()
+        
+        # Verify the main Atlassian settings
         self.assertTrue(settings.atlassian.atlassian_enabled)
         self.assertEqual(settings.atlassian.atlassian_api_key, "test_api_key")
         self.assertEqual(settings.atlassian.atlassian_username, "test_user")
         self.assertEqual(settings.atlassian.atlassian_url, "https://test.atlassian.net")
-
+        
+        # Verify the nested settings in the main settings
         self.assertTrue(settings.atlassian.confluence.confluence_enabled)
         self.assertEqual(settings.atlassian.confluence.confluence_space_keys, "TEST_SPACE_1,TEST_SPACE_2")
-
+        
         self.assertTrue(settings.atlassian.jira.jira_enabled)
         self.assertEqual(settings.atlassian.jira.jira_jql_query, "project=TEST")
-        self.assertEqual(settings.atlassian.jira.jira_fetch_batch_size, 100) # Pydantic converts "100" to int
+        self.assertEqual(settings.atlassian.jira.jira_fetch_batch_size, 100)
 
     @patch.dict(os.environ, {}, clear=True) # Clear all env vars for this test method
     def test_atlassian_settings_defaults(self):


### PR DESCRIPTION
This commit introduces a new nested structure for Atlassian settings (Jira and Confluence) within your application's configuration.

Key changes include:

1.  **Defined new Pydantic Models:**
    *   I created `AtlassianSettings` in `moonmind/config/settings.py` for shared settings like API key, username, URL, and a general enabled flag.
    *   I created `ConfluenceSettings` and `JiraSettings` to hold service-specific configurations (e.g., `confluence_space_keys`, `jira_jql_query`).

2.  **Integrated into AppSettings:**
    *   The `AtlassianSettings` model is now part of `AppSettings`.
    *   `ConfluenceSettings` and `JiraSettings` are nested under `AppSettings.atlassian`.

3.  **Removed Old Settings:**
    *   I deleted the previous standalone Confluence and Jira fields from `AppSettings` to avoid redundancy.

4.  **Updated .env-template:**
    *   I modified `.env-template` to reflect the new environment variable names (e.g., `ATLASSIAN_API_KEY`, `ATLASSIAN_CONFLUENCE_SPACE_KEYS`).

5.  **Updated Code References:**
    *   I modified `moonmind/factories/indexers_factory.py` to use the new settings structure when instantiating `ConfluenceIndexer` and `JiraIndexer`.
    *   I updated `scripts/init_vector_db.py` to correctly access the new nested settings for enabling features, passing credentials, and configuring service-specific parameters like space keys and JQL queries.

**Further Work:**
My next step was to add unit tests to verify the new settings structure, including loading from environment variables and default value application. I wasn't able to complete this due to reaching the current operational limit.