### PR TITLE
I've fixed the Python import errors in the `api` and `init-vector-db`…

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -8,10 +8,10 @@ from moonmind.config.logging import configure_logging
 configure_logging()
 logger = logging.getLogger(__name__)
 
-from .api.routers.chat import router as chat_router
-from .api.routers.context_protocol import router as context_protocol_router
-from .api.routers.documents import router as documents_router
-from .api.routers.models import router as models_router
+from api.routers.chat import router as chat_router
+from api.routers.context_protocol import router as context_protocol_router
+from api.routers.documents import router as documents_router
+from api.routers.models import router as models_router
 from llama_index.core import VectorStoreIndex, load_index_from_storage
 
 from fastapi import FastAPI, Request

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -8,10 +8,10 @@ from moonmind.config.logging import configure_logging
 configure_logging()
 logger = logging.getLogger(__name__)
 
-from api.routers.chat import router as chat_router
-from api.routers.context_protocol import router as context_protocol_router
-from api.routers.documents import router as documents_router
-from api.routers.models import router as models_router
+from api_service.api.routers.chat import router as chat_router
+from api_service.api.routers.context_protocol import router as context_protocol_router
+from api_service.api.routers.documents import router as documents_router
+from api_service.api.routers.models import router as models_router
 from llama_index.core import VectorStoreIndex, load_index_from_storage
 
 from fastapi import FastAPI, Request

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,7 @@ services:
       context: .
       dockerfile: ./api_service/Dockerfile
     environment:
+      - PYTHONPATH=/app
       - LOG_LEVEL=INFO
       - PYTHONUNBUFFERED=1
       - QDRANT_URL=http://qdrant:6333

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      - PYTHONPATH=/app
       - LOG_LEVEL=DEBUG
       - PYTHONUNBUFFERED=1
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-0}


### PR DESCRIPTION
… services. Here's what I did:

- In `api_service/main.py`, I changed the imports to be absolute (e.g., `from api.routers...`) instead of relative (`from .api.routers...`). This takes care of the `ImportError: attempted relative import with no known parent package` that was happening when you run the FastAPI application with uvicorn. This is because `main.py` runs from the `/app` directory, which also contains the `api` module.

- I updated the `docker-compose.yaml` file to add `PYTHONPATH: /app` to the environment variables for the `init-vector-db` service. This makes sure that the `moonmind` package, which is located at `/app/moonmind`, can be found when `/app/scripts/init_vector_db.py` is executed. This resolves the `ModuleNotFoundError: No module named 'moonmind'`.