### PR TITLE
I've optimized pip caching in your GitHub Actions workflow.

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r api_service/requirements.txt
-        python -m pip install pytest
         python -m pip install -e .
     - name: Run pytest unit tests
       run: |


### PR DESCRIPTION
- I removed a redundant `pip install pytest` in the pytest-unit-tests workflow. Since `pytest` is already listed in `api_service/requirements.txt`, it will be installed as part of that step. This makes the separate installation unnecessary and ensures it's covered by the pip cache more effectively.

- I also verified that dependencies from `pyproject.toml` are largely consistent with `api_service/requirements.txt`. This ensures that `pip install -e .` can leverage the cache populated by installing `requirements.txt`.