### PR TITLE
Fix: Resolve multiple startup errors in API and DB initialization

### DIFF
--- a/moonmind/factories/vector_store_factory.py
+++ b/moonmind/factories/vector_store_factory.py
@@ -26,7 +26,8 @@ def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1)
 
     client = QdrantClient(
         host=settings.qdrant.qdrant_host, # Corrected access
-        port=settings.qdrant.qdrant_port   # Corrected access
+        port=settings.qdrant.qdrant_port,  # Corrected access
+        check_compatibility=False # Add this line
     )
 
     if embed_dimensions == -1:

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
             logger.info(f"Using vector store collection name: {settings.vector_store_collection_name}")
             logger.info(f"Using dynamic embeddings dimensions for Qdrant: {embed_dimensions}")
 
-            if init_db: # init_db is already defined from os.getenv("INIT_DATABASE")
+            if init_db:
                 logger.info(f"INIT_DATABASE is true. Attempting to delete collection '{settings.vector_store_collection_name}' if it exists, to ensure a clean start.")
                 try:
                     client.delete_collection(collection_name=settings.vector_store_collection_name)

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -51,12 +51,12 @@ if __name__ == "__main__":
                 try:
                     client.delete_collection(collection_name=settings.vector_store_collection_name)
                     logger.info(f"Successfully deleted collection '{settings.vector_store_collection_name}'.")
+                except qdrant_client.http.exceptions.UnexpectedResponse as e:
+                    # Handle cases where the collection does not exist or other expected Qdrant-specific issues
+                    logger.info(f"Could not delete collection '{settings.vector_store_collection_name}' due to an unexpected response: {e}")
                 except Exception as e:
-                    # Handle cases where collection doesn't exist (common) or other errors
-                    # Qdrant client might raise different exceptions depending on the scenario,
-                    # e.g., if the collection does not exist, it might raise an UnexpectedResponse with 404 or similar.
-                    # For simplicity, we'll log a general message if deletion fails, as creation will be attempted next.
-                    logger.info(f"Could not delete collection '{settings.vector_store_collection_name}' (it might not exist or another issue occurred): {e}")
+                    # Handle any other unexpected errors
+                    logger.error(f"An unexpected error occurred while attempting to delete collection '{settings.vector_store_collection_name}': {e}", exc_info=True)
 
             vector_store = QdrantVectorStore(
                 client=client,


### PR DESCRIPTION
This commit addresses several errors encountered during the startup of the api and init-vector-db services:

1.  **Corrected Qdrant Host/Port Access:** Modified `scripts/init_vector_db.py` to correctly access Qdrant host and port from nested settings (`settings.qdrant.qdrant_host` and `settings.qdrant.qdrant_port`), resolving an `AttributeError`.

2.  **Ensured Clean Qdrant Collection Initialization:** Updated `scripts/init_vector_db.py` to delete the existing Qdrant collection if `INIT_DATABASE` is true. This prevents dimension mismatch errors if an old collection exists with different embedding dimensions.

3.  **Suppressed Qdrant Version Mismatch Warning:** Modified `moonmind/factories/vector_store_factory.py` to initialize `QdrantClient` with `check_compatibility=False`. This temporarily suppresses warnings about client/server version mismatches.

4.  **Improved API Service Startup Error Handling:** Refactored the `setup()` function in `api_service/main.py` to:
    - Initialize application state variables (`storage_context`, etc.) to `None`.
    - Ensure `vector_store` is built before attempting to build `storage_context`.
    - Implement more robust error catching: if `build_vector_store` fails, the application will log a critical error and not start.
    - Prevent `AttributeError` for `storage_context` in exception handling paths by ensuring it's valid before use or by failing fast.