### PR TITLE
Fix: Resolve AttributeError for github.default_branch

### DIFF
--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
                     github_indexer = GitHubIndexer(github_token=settings.github.github_token, logger=logger)
                     logger.info("GitHubIndexer initialized.")
 
-                    default_branch = settings.github.default_branch or "main"
+                    default_branch = "main"
                     for repo_full_name in github_repo_list:
                         logger.info(f"Processing GitHub repository: {repo_full_name} (branch: {default_branch})")
                         try:


### PR DESCRIPTION
The script `scripts/init_vector_db.py` attempted to access `settings.github.default_branch`, which is not defined in the `GitHubSettings` model or the `.env-template` file.

This commit resolves the `AttributeError: 'GitHubSettings' object has no attribute 'default_branch'` by hardcoding the `default_branch` for GitHub repositories to "main" within the `init_vector_db.py` script.

The Confluence and Jira 'disabled' messages in the logs are correct as per their environment variable settings (e.g., ATLASSIAN_CONFLUENCE_ENABLED=false). This commit does not alter that behavior, only the GitHub error.