### PR TITLE
Fix: Prevent init_vector_db.py from deleting collection by default

### DIFF
--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -46,18 +46,6 @@ if __name__ == "__main__":
             logger.info(f"Using vector store collection name: {settings.vector_store_collection_name}")
             logger.info(f"Using dynamic embeddings dimensions for Qdrant: {embed_dimensions}")
 
-            if init_db:
-                logger.info(f"INIT_DATABASE is true. Attempting to delete collection '{settings.vector_store_collection_name}' if it exists, to ensure a clean start.")
-                try:
-                    client.delete_collection(collection_name=settings.vector_store_collection_name)
-                    logger.info(f"Successfully deleted collection '{settings.vector_store_collection_name}'.")
-                except qdrant_client.http.exceptions.UnexpectedResponse as e:
-                    # Handle cases where the collection does not exist or other expected Qdrant-specific issues
-                    logger.info(f"Could not delete collection '{settings.vector_store_collection_name}' due to an unexpected response: {e}")
-                except Exception as e:
-                    # Handle any other unexpected errors
-                    logger.error(f"An unexpected error occurred while attempting to delete collection '{settings.vector_store_collection_name}': {e}", exc_info=True)
-
             vector_store = QdrantVectorStore(
                 client=client,
                 collection_name=settings.vector_store_collection_name,


### PR DESCRIPTION
The script `scripts/init_vector_db.py` no longer deletes the Qdrant collection when `INIT_DATABASE` is set to true. This change makes the script safer to run repeatedly, preventing accidental data loss.

The underlying Qdrant client behavior for adding documents with existing IDs is to upsert (update) them, which handles the desired outcome of overwriting data when re-indexing the same content. The script will still create the collection if it does not exist.