### PR TITLE
Fix: Fetch default branch dynamically from GitHub

### DIFF
--- a/moonmind/indexers/github_indexer.py
+++ b/moonmind/indexers/github_indexer.py
@@ -24,10 +24,10 @@ class GitHubIndexer:
     def index(
         self,
         repo_full_name: str,  # e.g., "owner/repo_name"
-        branch: Optional[str] = None,
-        filter_extensions: Optional[List[str]],
         storage_context: StorageContext,
         service_context: Settings,
+        filter_extensions: Optional[List[str]] = None,
+        branch: Optional[str] = None,
     ) -> Dict[str, Union[VectorStoreIndex, int]]:
         self.logger.info(f"Starting GitHub indexing for repo: {repo_full_name} on branch: {branch or 'default'}")
 

--- a/moonmind/indexers/github_indexer.py
+++ b/moonmind/indexers/github_indexer.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Dict, List, Optional, Union
 
+from github import Github
 from llama_index.core import Settings, StorageContext, VectorStoreIndex
 from llama_index.core.node_parser import \
     SimpleNodeParser  # Default node parser
@@ -23,12 +24,12 @@ class GitHubIndexer:
     def index(
         self,
         repo_full_name: str,  # e.g., "owner/repo_name"
-        branch: str,
+        branch: Optional[str] = None,
         filter_extensions: Optional[List[str]],
         storage_context: StorageContext,
         service_context: Settings,
     ) -> Dict[str, Union[VectorStoreIndex, int]]:
-        self.logger.info(f"Starting GitHub indexing for repo: {repo_full_name} on branch: {branch}")
+        self.logger.info(f"Starting GitHub indexing for repo: {repo_full_name} on branch: {branch or 'default'}")
 
         try:
             owner, repo_name = repo_full_name.split('/')
@@ -37,6 +38,21 @@ class GitHubIndexer:
         except ValueError as e:
             self.logger.error(f"Invalid repo_full_name format: {repo_full_name}. Expected 'owner/repo_name'. Error: {e}")
             raise ValueError(f"Invalid repo_full_name format: {repo_full_name}. Expected 'owner/repo_name'. Error: {e}")
+
+        # Determine the branch to use
+        if not branch:
+            self.logger.info(f"No branch specified for {repo_full_name}. Attempting to fetch default branch.")
+            try:
+                g = Github(self.github_token)
+                repo = g.get_repo(f"{owner}/{repo_name}")
+                branch = repo.default_branch
+                self.logger.info(f"Default branch for {repo_full_name} is '{branch}'.")
+            except Exception as e:
+                self.logger.warning(f"Failed to fetch default branch for {repo_full_name}: {e}. Falling back to 'main'.")
+                branch = "main"
+        else:
+            self.logger.info(f"Using specified branch '{branch}' for {repo_full_name}.")
+
 
         reader_filter_extensions_tuple = None
         if filter_extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "llama-index-readers-jira>=0.4,<1.0",
     "llama-index-vector-stores-qdrant>=0.6,<1.0",
     "qdrant-client>=1.14,<2.0",
+    "PyGithub>=1.59,<2.0",
     "google-generativeai>=0.8,<1.0",
     "openai>=1.86,<2.0",
     "ollama>=0.5,<1.0",

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -163,13 +163,12 @@ if __name__ == "__main__":
                     github_indexer = GitHubIndexer(github_token=settings.github.github_token, logger=logger)
                     logger.info("GitHubIndexer initialized.")
 
-                    default_branch = settings.github.default_branch if settings.github.default_branch else "main"
                     for repo_full_name in github_repo_list:
-                        logger.info(f"Processing GitHub repository: {repo_full_name} (branch: {default_branch})")
+                        logger.info(f"Processing GitHub repository: {repo_full_name} (using default branch)")
                         try:
                             index_result = github_indexer.index(
                                 repo_full_name=repo_full_name,
-                                branch=default_branch,
+                                branch=None, # Let the indexer determine the default branch
                                 storage_context=storage_context,
                                 filter_extensions=None
                             )

--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -168,9 +168,10 @@ if __name__ == "__main__":
                         try:
                             index_result = github_indexer.index(
                                 repo_full_name=repo_full_name,
-                                branch=None, # Let the indexer determine the default branch
                                 storage_context=storage_context,
-                                filter_extensions=None
+                                service_context=Settings,  # Pass the global Settings object
+                                filter_extensions=None, # Explicitly None
+                                branch=None # Let the indexer determine the default branch
                             )
                             nodes_indexed_count = 0
                             if isinstance(index_result, dict) and 'total_nodes_indexed' in index_result:


### PR DESCRIPTION
Previously, the system relied on a `default_branch` setting in `GitHubSettings`, which was not always present and caused an AttributeError during the vector database initialization if not set.

This commit modifies the `GitHubIndexer` to:
- Dynamically fetch the default branch of a repository using the GitHub API if no specific branch is provided for indexing.
- Fall back to "main" if fetching the default branch fails (e.g., due to repository not being found, network issues, or permissions).
- Log appropriate messages regarding branch usage.

The `init_vector_db.py` script has been updated to:
- Remove the reliance on the non-existent `settings.github.default_branch`.
- Call the `GitHubIndexer` in a way that allows it to use the new dynamic default branch fetching mechanism.

This change makes the GitHub indexing process more robust by removing the need for a manual default branch configuration per repository source and instead relying on the actual default branch defined in GitHub.