### PR TITLE
Refactor: Use atlassian_username for Confluence settings

### DIFF
--- a/scripts/init_vector_db.py
+++ b/scripts/init_vector_db.py
@@ -83,8 +83,8 @@ if __name__ == "__main__":
             missing_confluence_settings = []
             if not settings.atlassian.atlassian_url:
                 missing_confluence_settings.append("ATLASSIAN_URL")
-            if not settings.atlassian.confluence.confluence_username:
-                missing_confluence_settings.append("ATLASSIAN_CONFLUENCE_USERNAME")
+            if not settings.atlassian.atlassian_username:
+                missing_confluence_settings.append("ATLASSIAN_USERNAME")
             if not settings.atlassian.confluence.confluence_space_keys:
                 missing_confluence_settings.append("ATLASSIAN_CONFLUENCE_SPACE_KEYS")
 
@@ -109,7 +109,7 @@ if __name__ == "__main__":
                 try:
                     confluence_indexer = ConfluenceIndexer(
                         base_url=settings.atlassian.atlassian_url,
-                        user_name=settings.atlassian.confluence.confluence_username,
+                        user_name=settings.atlassian.atlassian_username,
                         api_token=settings.atlassian.confluence.confluence_api_key,
                         logger=logger
                     )


### PR DESCRIPTION
I replaced all instances of `settings.atlassian.confluence.confluence_username` with `settings.atlassian.atlassian_username` in `scripts/init_vector_db.py`. This aligns Confluence username configuration with the general Atlassian settings structure, resolving an AttributeError that occurred due to `confluence_username` no longer being an attribute of `ConfluenceSettings`.

The `ConfluenceIndexer` itself was unaffected as it accepts `user_name` as a parameter; the change involved passing the correct setting value to it. The error message for missing configuration in `init_vector_db.py` was also updated to reflect the new setting name (`ATLASSIAN_USERNAME` instead of `ATLASSIAN_CONFLUENCE_USERNAME`).