### PR TITLE
Fix: Correctly parse Atlassian URL with extra https schema

### DIFF
--- a/build/lib/moonmind/config/settings.py
+++ b/build/lib/moonmind/config/settings.py
@@ -90,6 +90,8 @@ class AtlassianSettings(BaseSettings):
 
     def __init__(self, **data):
         super().__init__(**data)
+        if self.atlassian_url and self.atlassian_url.startswith("https://https://"):
+            self.atlassian_url = self.atlassian_url[8:]
         # Manually load environment variables for nested settings
         if os.environ.get("ATLASSIAN_CONFLUENCE_ENABLED") == "True":
             self.confluence.confluence_enabled = True

--- a/build/lib/moonmind/factories/vector_store_factory.py
+++ b/build/lib/moonmind/factories/vector_store_factory.py
@@ -34,7 +34,7 @@ def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1)
         # Use a public API method to determine embedding dimensions
         test_vector = embed_model.embed_query("test")
         embed_dimensions = len(test_vector)
-        logger.info(f"Embedding dimensions set to: {embed_dimensions}")
+        print(f"Embedding dimensions set to: {embed_dimensions}")
 
     desired_distance = Distance.COSINE
     try:

--- a/moonmind.egg-info/PKG-INFO
+++ b/moonmind.egg-info/PKG-INFO
@@ -48,6 +48,7 @@ Requires-Dist: llama-index-readers-google<1.0,>=0.6
 Requires-Dist: llama-index-readers-jira<1.0,>=0.4
 Requires-Dist: llama-index-vector-stores-qdrant<1.0,>=0.6
 Requires-Dist: qdrant-client<2.0,>=1.14
+Requires-Dist: PyGithub<2.0,>=1.59
 Requires-Dist: google-generativeai<1.0,>=0.8
 Requires-Dist: openai<2.0,>=1.86
 Requires-Dist: ollama<1.0,>=0.5

--- a/moonmind.egg-info/requires.txt
+++ b/moonmind.egg-info/requires.txt
@@ -20,6 +20,7 @@ llama-index-readers-google<1.0,>=0.6
 llama-index-readers-jira<1.0,>=0.4
 llama-index-vector-stores-qdrant<1.0,>=0.6
 qdrant-client<2.0,>=1.14
+PyGithub<2.0,>=1.59
 google-generativeai<1.0,>=0.8
 openai<2.0,>=1.86
 ollama<1.0,>=0.5

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -90,6 +90,8 @@ class AtlassianSettings(BaseSettings):
 
     def __init__(self, **data):
         super().__init__(**data)
+        if self.atlassian_url and self.atlassian_url.startswith("https://https://"):
+            self.atlassian_url = self.atlassian_url[8:]
         # Manually load environment variables for nested settings
         if os.environ.get("ATLASSIAN_CONFLUENCE_ENABLED") == "True":
             self.confluence.confluence_enabled = True

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -3,12 +3,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-# Assuming AppSettings is in moonmind.config.settings
-import os # Added for environment variable manipulation
-from unittest.mock import patch
-
-# Adjust the import path if necessary based on your project structure
-from moonmind.config.settings import (AppSettings, AtlassianSettings, # Added AtlassianSettings
+from moonmind.config.settings import (AppSettings, AtlassianSettings,
                                       GoogleSettings, OllamaSettings,
                                       OpenAISettings)
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -4,9 +4,13 @@ import pytest
 from pydantic import ValidationError
 
 # Assuming AppSettings is in moonmind.config.settings
+import os # Added for environment variable manipulation
+from unittest.mock import patch
+
 # Adjust the import path if necessary based on your project structure
-from moonmind.config.settings import (AppSettings, GoogleSettings,
-                                      OllamaSettings, OpenAISettings)
+from moonmind.config.settings import (AppSettings, AtlassianSettings, # Added AtlassianSettings
+                                      GoogleSettings, OllamaSettings,
+                                      OpenAISettings)
 
 
 # Fixture for default settings, can be customized in tests
@@ -51,3 +55,39 @@ def test_default_model_fields_removed(app_settings_defaults):
     settings = AppSettings(**app_settings_defaults)
     assert not hasattr(settings, "default_chat_model")
     assert not hasattr(settings, "default_embed_model")
+
+
+class TestAtlassianSettings:
+    def test_atlassian_url_correction(self, monkeypatch):
+        # Test case 1: URL with "https://https://"
+        monkeypatch.setenv("ATLASSIAN_URL", "https://https://example.atlassian.net")
+        settings = AtlassianSettings()
+        assert settings.atlassian_url == "https://example.atlassian.net"
+
+        # Test case 2: Correct HTTPS URL
+        monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+        settings2 = AtlassianSettings()
+        assert settings2.atlassian_url == "https://example.atlassian.net"
+
+        # Test case 3: HTTP URL (should remain unchanged)
+        monkeypatch.setenv("ATLASSIAN_URL", "http://example.atlassian.net")
+        settings3 = AtlassianSettings()
+        assert settings3.atlassian_url == "http://example.atlassian.net"
+
+        # Test case 4: Empty URL (should remain None or empty)
+        monkeypatch.delenv("ATLASSIAN_URL", raising=False)
+        settings4 = AtlassianSettings()
+        assert settings4.atlassian_url is None
+
+        # Test case 5: URL that only starts with "https://" once
+        monkeypatch.setenv("ATLASSIAN_URL", "https://another.example.com")
+        settings5 = AtlassianSettings()
+        assert settings5.atlassian_url == "https://another.example.com"
+
+        # Test case 6: URL with no scheme
+        monkeypatch.setenv("ATLASSIAN_URL", "example.atlassian.net")
+        settings6 = AtlassianSettings()
+        assert settings6.atlassian_url == "example.atlassian.net"
+
+        # Clean up environment variable
+        monkeypatch.delenv("ATLASSIAN_URL", raising=False)


### PR DESCRIPTION
The `ATLASSIAN_URL` environment variable was being set incorrectly, causing an extra "https://" prefix. This commit updates the `AtlassianSettings` class to detect and remove this extra prefix, ensuring the Jira URL is always correctly formatted.

I added a unit test to verify the URL correction logic for various scenarios, including correctly formed URLs and URLs with the extra prefix.