### PR TITLE
Fix: Ensure case-insensitive boolean parsing for Atlassian settings

### DIFF
--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -93,11 +93,11 @@ class AtlassianSettings(BaseSettings):
         if self.atlassian_url and self.atlassian_url.startswith("https://https://"):
             self.atlassian_url = self.atlassian_url[8:]
         # Manually load environment variables for nested settings
-        if os.environ.get("ATLASSIAN_CONFLUENCE_ENABLED") == "True":
+        if os.environ.get("ATLASSIAN_CONFLUENCE_ENABLED", "").lower() == "true":
             self.confluence.confluence_enabled = True
         if os.environ.get("ATLASSIAN_CONFLUENCE_SPACE_KEYS"):
             self.confluence.confluence_space_keys = os.environ.get("ATLASSIAN_CONFLUENCE_SPACE_KEYS")
-        if os.environ.get("ATLASSIAN_JIRA_ENABLED") == "True":
+        if os.environ.get("ATLASSIAN_JIRA_ENABLED", "").lower() == "true":
             self.jira.jira_enabled = True
         if os.environ.get("ATLASSIAN_JIRA_JQL_QUERY"):
             self.jira.jira_jql_query = os.environ.get("ATLASSIAN_JIRA_JQL_QUERY")

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,0 +1,55 @@
+import os
+import pytest
+
+from moonmind.config.settings import AtlassianSettings
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("TRUE", True),
+        ("tRuE", True),
+        ("False", False),
+        ("false", False),
+        ("FALSE", False),
+        ("fAlSe", False),
+        ("", False),  # Default to False if empty
+        ("other", False), # Default to False if not a valid boolean string
+    ],
+)
+def test_atlassian_confluence_enabled_parsing(monkeypatch, env_value, expected):
+    monkeypatch.setenv("ATLASSIAN_CONFLUENCE_ENABLED", env_value)
+    # We also need to set other required env vars for AtlassianSettings if any,
+    # or ensure the model allows them to be None for this test.
+    # For now, assuming other fields can be None or have defaults.
+    settings = AtlassianSettings()
+    assert settings.confluence.confluence_enabled == expected
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("TRUE", True),
+        ("tRuE", True),
+        ("False", False),
+        ("false", False),
+        ("FALSE", False),
+        ("fAlSe", False),
+        ("", False),
+        ("other", False),
+    ],
+)
+def test_atlassian_jira_enabled_parsing(monkeypatch, env_value, expected):
+    monkeypatch.setenv("ATLASSIAN_JIRA_ENABLED", env_value)
+    settings = AtlassianSettings()
+    assert settings.jira.jira_enabled == expected
+
+def test_atlassian_settings_init_no_env_vars(monkeypatch):
+    # Ensure that if the env vars are not set, the defaults (False) are used.
+    monkeypatch.delenv("ATLASSIAN_CONFLUENCE_ENABLED", raising=False)
+    monkeypatch.delenv("ATLASSIAN_JIRA_ENABLED", raising=False)
+    settings = AtlassianSettings()
+    assert settings.confluence.confluence_enabled is False
+    assert settings.jira.jira_enabled is False


### PR DESCRIPTION
I modified the `__init__` method in `AtlassianSettings` to correctly parse `ATLASSIAN_CONFLUENCE_ENABLED` and `ATLASSIAN_JIRA_ENABLED` environment variables in a case-insensitive manner.

Previously, these settings were checked using a direct string comparison (e.g., `os.environ.get("VAR") == "True"`), which would fail if the environment variable was set to "true" or "TRUE". This change updates the logic to use `.lower() == "true"` for robust boolean parsing.

I added unit tests to `tests/config/test_settings.py` to cover various capitalizations for these boolean environment variables, ensuring they are parsed as expected. The tests also verify the default behavior when the environment variables are not set.