### PR TITLE
Fix: Prevent API from creating Qdrant collection

### DIFF
--- a/moonmind/factories/vector_store_factory.py
+++ b/moonmind/factories/vector_store_factory.py
@@ -52,7 +52,7 @@ def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1)
                 f"a different distance metric: {existing_distance} vs {desired_distance}"
             )
     except UnexpectedResponse as e:
-        if e.status_code == 404:
+        if "404" in str(e):
             raise RuntimeError(
                 f"Qdrant collection '{settings.vector_store_collection_name}' not found. "
                 "Please ensure it is initialized by running the init_vector_db.py script "

--- a/moonmind/factories/vector_store_factory.py
+++ b/moonmind/factories/vector_store_factory.py
@@ -52,7 +52,7 @@ def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1)
                 f"a different distance metric: {existing_distance} vs {desired_distance}"
             )
     except UnexpectedResponse as e:
-        if "404" in str(e):
+        if e.status_code == 404:
             raise RuntimeError(
                 f"Qdrant collection '{settings.vector_store_collection_name}' not found. "
                 "Please ensure it is initialized by running the init_vector_db.py script "

--- a/moonmind/factories/vector_store_factory.py
+++ b/moonmind/factories/vector_store_factory.py
@@ -53,13 +53,10 @@ def build_qdrant(settings: AppSettings, embed_model, embed_dimensions: int = -1)
             )
     except UnexpectedResponse as e:
         if "404" in str(e):
-            print(f"Collection '{settings.vector_store_collection_name}' does not exist. Creating...")
-            client.create_collection(
-                collection_name=settings.vector_store_collection_name,
-                vectors_config=VectorParams(
-                    size=embed_dimensions,
-                    distance=desired_distance
-                )
+            raise RuntimeError(
+                f"Qdrant collection '{settings.vector_store_collection_name}' not found. "
+                "Please ensure it is initialized by running the init_vector_db.py script "
+                "before starting the API service."
             )
         else:
             raise e

--- a/tests/unit/api/test_context_protocol.py
+++ b/tests/unit/api/test_context_protocol.py
@@ -43,15 +43,12 @@ def mock_qdrant_client_autouse():
     with patch("moonmind.factories.vector_store_factory.QdrantClient") as mock_qdrant:
         mock_client_instance = MagicMock()
         
-        # Simulate QdrantClient.get_collection raising UnexpectedResponse
-        # The TypeError indicated missing: 'reason_phrase', 'content', and 'headers'
-        # Assuming the order is status_code, reason_phrase, content, headers
-        mock_client_instance.get_collection.side_effect = UnexpectedResponse(
-            status_code=404,
-            reason_phrase=b"Not Found", # httpx.Response uses bytes for reason_phrase
-            content=b'{"status": {"error": "Collection not found"}}',
-            headers={} # Example: empty headers
-        )
+        # Mock a CollectionInfo object
+        mock_collection_info = MagicMock()
+        mock_collection_info.config.params.vectors.size = 100 # Match dimension from client fixture
+        mock_collection_info.config.params.vectors.distance = Distance.COSINE # Match expected distance
+
+        mock_client_instance.get_collection.return_value = mock_collection_info
         
         mock_qdrant.return_value = mock_client_instance
         yield mock_qdrant


### PR DESCRIPTION
Previously, the API service (`api_service/main.py`) via `vector_store_factory.build_qdrant` would proactively create an empty Qdrant collection if it didn't find one during startup. This could lead to issues if the API started before the `init_vector_db.py` script had populated the collection, causing the API to work with an empty or incorrect index.

This commit modifies `moonmind/factories/vector_store_factory.py` so that the `build_qdrant` function no longer creates the Qdrant collection if it's not found (HTTP 404). Instead, it now raises a RuntimeError, ensuring that the API service will only start if the collection has been previously initialized by `init_vector_db.py`.

The `init_vector_db.py` script is already responsible for creating the collection with the correct parameters (embedding dimensions, distance metric) if it doesn't exist.

Operational Note:
It is crucial that the `init_vector_db.py` script (or the batch job/process that executes it) is run and completes successfully *before* the API service is started. This ensures the Qdrant collection is properly initialized and populated, preventing the API from failing to load the index.