### PR TITLE
feat: Implement API endpoint for repository summarization

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e .
+        python -m pip install readmeai~=0.6.0
     - name: Run pytest unit tests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -12,7 +12,6 @@ class RepositorySummarizationResponse(BaseModel):
 
 # Imports for helper functions and upcoming endpoint
 import logging
-from typing import Optional # Already imported, but good to ensure it's here for context
 from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.db.models import User # Assuming User model path
 

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -1,6 +1,9 @@
-from typing import Optional
-from pydantic import BaseModel, Field
 from enum import Enum
+from typing import Optional
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+
 
 class SummaryType(str, Enum):
     README = "readme"
@@ -16,8 +19,10 @@ class RepositorySummarizationResponse(BaseModel):
 
 # Imports for helper functions and upcoming endpoint
 import logging
+
 from sqlalchemy.ext.asyncio import AsyncSession
-from api_service.db.models import User # Assuming User model path
+
+from api_service.db.models import User  # Assuming User model path
 
 logger = logging.getLogger(__name__)
 
@@ -70,18 +75,18 @@ async def get_user_llm_api_key(user: User, provider: str, db: AsyncSession) -> O
     logger.warning(f"No API key logic defined for provider: {provider} in placeholder function for user {user.id}.")
     return None
 
+import tempfile
+
+import git  # GitPython
 # FastAPI and other necessary imports for the router
 from fastapi import APIRouter, Depends, HTTPException
-import tempfile
-import git # GitPython
 
+from api_service.auth import current_active_user
+from api_service.db.base import get_async_session
 # MoonMind specific imports
 from moonmind.config.settings import settings
 from moonmind.models_cache import model_cache
 from moonmind.summarization.readme_generator import ReadmeAiGenerator
-from api_service.auth import current_active_user
-from api_service.db.base import get_async_session
-
 
 router = APIRouter()
 
@@ -135,8 +140,9 @@ async def summarize_repository(
                 if github_token:
                     # Construct authenticated URL: https://oauth2:{token}@github.com/owner/repo.git
                     # This format is common for GitHub. Other providers might vary.
-                    if "github.com/" in request.repo_url:
-                        repo_part = request.repo_url.split("github.com/")[-1]
+                    parsed_url = urlparse(request.repo_url)
+                    if parsed_url.hostname == "github.com":
+                        repo_part = parsed_url.path.lstrip("/")
                         authenticated_url = f"https://oauth2:{github_token}@github.com/{repo_part}"
                         logger.info(f"Attempting to clone with authenticated URL: {authenticated_url.replace(github_token, '***TOKEN***')}")
                         try:

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -1,14 +1,18 @@
 from typing import Optional
 from pydantic import BaseModel, Field
+from enum import Enum
+
+class SummaryType(str, Enum):
+    README = "readme"
 
 class RepositorySummarizationRequest(BaseModel):
     repo_url: str
-    summary_type: str = Field(default="readme", description="The type of summary to generate.")
+    summary_type: SummaryType = Field(default=SummaryType.README, description="The type of summary to generate.")
     model: Optional[str] = Field(default=None, description="The language model to use for generation.")
 
 class RepositorySummarizationResponse(BaseModel):
     summary_content: str
-    summary_type: str
+    summary_type: SummaryType
 
 # Imports for helper functions and upcoming endpoint
 import logging

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -1,0 +1,195 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class RepositorySummarizationRequest(BaseModel):
+    repo_url: str
+    summary_type: str = Field(default="readme", description="The type of summary to generate.")
+    model: Optional[str] = Field(default=None, description="The language model to use for generation.")
+
+class RepositorySummarizationResponse(BaseModel):
+    summary_content: str
+    summary_type: str
+
+# Imports for helper functions and upcoming endpoint
+import logging
+from typing import Optional # Already imported, but good to ensure it's here for context
+from sqlalchemy.ext.asyncio import AsyncSession
+from api_service.db.models import User # Assuming User model path
+
+logger = logging.getLogger(__name__)
+
+async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
+    """
+    Retrieves the user's GitHub token.
+    Placeholder logic: This should eventually fetch from user.profile and decrypt.
+    """
+    logger.info(f"Attempting to retrieve GitHub token for user {user.id}")
+    # Simulate checking user profile; replace with actual db/profile access
+    # Example: if hasattr(user, 'profile') and user.profile.github_access_token_encrypted:
+    #     # Decrypt logic here
+    #     return "decrypted_github_token_placeholder"
+    if user.email == "user_with_gh_token@example.com": # Example condition
+        logger.warning("Using placeholder logic for GitHub token retrieval.")
+        return "ghp_placeholder_github_token"
+    logger.warning(f"No GitHub token configured for user {user.id} in placeholder logic.")
+    return None
+
+async def get_user_llm_api_key(user: User, provider: str, db: AsyncSession) -> Optional[str]:
+    """
+    Retrieves the API key for a given user and LLM provider.
+    Placeholder logic: This should eventually fetch from user.profile and decrypt.
+    """
+    logger.info(f"Attempting to retrieve API key for user {user.id} and provider {provider}")
+    provider_lower = provider.lower()
+    # Simulate checking user profile; replace with actual db/profile access
+    # Example: if hasattr(user, 'profile'):
+    #     if provider_lower == "openai" and user.profile.openai_api_key_encrypted:
+    #         return "decrypted_openai_key_placeholder"
+    #     elif provider_lower == "google" and user.profile.google_api_key_encrypted:
+    #         return "decrypted_google_key_placeholder"
+    #     # etc. for other providers
+
+    # Placeholder keys based on provider for testing
+    if provider_lower == "openai":
+        logger.warning("Using placeholder logic for OpenAI API key retrieval.")
+        return "sk-placeholder-openai-key-summarization"
+    elif provider_lower == "google":
+        logger.warning("Using placeholder logic for Google API key retrieval.")
+        return "google-placeholder-api-key-summarization"
+    elif provider_lower == "anthropic":
+        logger.warning("Using placeholder logic for Anthropic API key retrieval.")
+        return "anthropic-placeholder-api-key-summarization"
+    # Ollama typically doesn't require an API key, so return None or a specific marker if needed.
+    elif provider_lower == "ollama":
+        logger.info(f"No API key needed for Ollama provider for user {user.id}.")
+        return None # Or some other indicator if your logic expects it, e.g. "ollama_no_key"
+
+    logger.warning(f"No API key logic defined for provider: {provider} in placeholder function for user {user.id}.")
+    return None
+
+# FastAPI and other necessary imports for the router
+from fastapi import APIRouter, Depends, HTTPException
+import tempfile
+import git # GitPython
+
+# MoonMind specific imports
+from moonmind.config.settings import settings
+from moonmind.models_cache import model_cache
+from moonmind.summarization.readme_generator import ReadmeAiGenerator
+from api_service.auth import current_active_user
+from api_service.db.base import get_async_session
+
+
+router = APIRouter()
+
+@router.post("/repository", response_model=RepositorySummarizationResponse)
+async def summarize_repository(
+    request: RepositorySummarizationRequest,
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """
+    Summarizes a code repository.
+    Currently supports generating a README.md file.
+    """
+    logger.info(f"Received repository summarization request for URL: {request.repo_url}, type: {request.summary_type}, model: {request.model} by user {user.id}")
+
+    # 1. Model and Provider Resolution
+    model_to_use = request.model or settings.get_default_chat_model()
+    logger.info(f"Model to use (after considering default): {model_to_use}")
+
+    provider = model_cache.get_model_provider(model_to_use)
+    if not provider:
+        logger.warning(f"Provider not found for model {model_to_use} in cache. Refreshing cache.")
+        model_cache.refresh_models_sync() # Consider if async refresh is available/needed
+        provider = model_cache.get_model_provider(model_to_use)
+        if not provider:
+            logger.error(f"Provider still not found for model {model_to_use} after cache refresh.")
+            raise HTTPException(status_code=404, detail=f"Model '{model_to_use}' not found or provider unknown.")
+    logger.info(f"Resolved provider: {provider} for model {model_to_use}")
+
+    user_llm_api_key = await get_user_llm_api_key(user, provider, db)
+    if not user_llm_api_key and provider.lower() != "ollama": # Ollama might not need a key
+        logger.error(f"API key for provider {provider} not found for user {user.id}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"API key for {provider} not found in your profile. Please add it to use this model.",
+        )
+
+    # 2. Temporary Directory and Cloning
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            logger.info(f"Created temporary directory: {temp_dir}")
+            cloned_successfully = False
+            try:
+                logger.info(f"Attempting to clone {request.repo_url} into {temp_dir}")
+                git.Repo.clone_from(request.repo_url, temp_dir)
+                logger.info(f"Successfully cloned {request.repo_url} anonymously.")
+                cloned_successfully = True
+            except git.exc.GitCommandError as e_clone:
+                logger.warning(f"Anonymous clone failed for {request.repo_url}: {e_clone}. Attempting with token.")
+                github_token = await get_user_github_token(user, db)
+                if github_token:
+                    # Construct authenticated URL: https://oauth2:{token}@github.com/owner/repo.git
+                    # This format is common for GitHub. Other providers might vary.
+                    if "github.com/" in request.repo_url:
+                        repo_part = request.repo_url.split("github.com/")[-1]
+                        authenticated_url = f"https://oauth2:{github_token}@github.com/{repo_part}"
+                        logger.info(f"Attempting to clone with authenticated URL: {authenticated_url.replace(github_token, '***TOKEN***')}")
+                        try:
+                            git.Repo.clone_from(authenticated_url, temp_dir)
+                            logger.info(f"Successfully cloned {request.repo_url} using user's GitHub token.")
+                            cloned_successfully = True
+                        except git.exc.GitCommandError as e_auth_clone:
+                            logger.error(f"Authenticated clone failed for {request.repo_url}: {e_auth_clone}")
+                            raise HTTPException(status_code=400, detail=f"Failed to clone repository (even with authentication): {e_auth_clone}")
+                    else:
+                        logger.warning("Cannot construct authenticated URL for non-GitHub repo automatically.")
+                        raise HTTPException(status_code=400, detail=f"Failed to clone repository. Non-GitHub URL, cannot use token auth automatically: {e_clone}")
+                else:
+                    logger.error(f"Anonymous clone failed and no GitHub token found for user {user.id}.")
+                    raise HTTPException(status_code=400, detail=f"Failed to clone repository. Anonymous access failed and no GitHub token available: {e_clone}")
+
+            if not cloned_successfully: # Should be caught by exceptions above, but as a safeguard
+                raise HTTPException(status_code=500, detail="Repository cloning process failed unexpectedly.")
+
+            # 3. Summarization
+            summary_content = None
+            if request.summary_type == "readme":
+                logger.info(f"Preparing to generate README for repository in {temp_dir}")
+                readme_config = {
+                    "provider": provider.lower(), # readme-ai expects lowercase
+                    "model": model_to_use,
+                }
+                if user_llm_api_key: # Only add api_key if it exists (e.g. not for Ollama)
+                    readme_config["api_key"] = user_llm_api_key
+
+                # Potentially add other readme-ai specific settings from a global config or request if needed
+                # readme_config["badge_style"] = "flat-square"
+
+                generator = ReadmeAiGenerator(config=readme_config)
+                logger.debug(f"ReadmeAiGenerator instantiated with config: {readme_config}")
+
+                summary_content = await generator.generate(repo_path=temp_dir)
+                if summary_content is None:
+                    logger.error(f"README.md generation failed for {request.repo_url} in {temp_dir}")
+                    raise HTTPException(status_code=500, detail="Failed to generate README.md summary.")
+                logger.info(f"Successfully generated README.md for {request.repo_url}")
+            else:
+                logger.error(f"Unsupported summary_type requested: {request.summary_type}")
+                raise HTTPException(status_code=400, detail=f"Unsupported summary_type: {request.summary_type}")
+
+            # 4. Response
+            return RepositorySummarizationResponse(
+                summary_content=summary_content,
+                summary_type=request.summary_type
+            )
+    except HTTPException: # Re-raise HTTPExceptions directly
+        raise
+    except git.exc.GitCommandError as e: # Catch specific git errors not handled above
+        logger.exception(f"A GitCommandError occurred during repository operation for {request.repo_url}: {e}")
+        raise HTTPException(status_code=500, detail=f"A Git error occurred: {e}")
+    except Exception as e:
+        logger.exception(f"An unexpected error occurred while summarizing repository {request.repo_url}: {e}")
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+    # Temporary directory 'temp_dir' is automatically cleaned up here due to 'with' statement

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -13,6 +13,7 @@ from api_service.api.routers.context_protocol import router as context_protocol_
 from api_service.api.routers.documents import router as documents_router
 from api_service.api.routers.models import router as models_router
 from api_service.api.routers.profile import router as profile_router
+from api_service.api.routers import summarization as summarization_router # Added import for summarization router
 from llama_index.core import VectorStoreIndex, load_index_from_storage
 
 from fastapi import FastAPI, Request, Depends
@@ -111,6 +112,7 @@ app = FastAPI(
 app.include_router(chat_router, prefix="/v1/chat")
 app.include_router(models_router, prefix="/v1/models")
 app.include_router(documents_router, prefix="/v1/documents")
+app.include_router(summarization_router.router, prefix="/summarization", tags=["Summarization"]) # Added summarization router
 app.include_router(context_protocol_router)  # Removed prefix="/context"
 app.include_router(
     profile_router, prefix="/api/v1/profile", tags=["profile"]

--- a/moonmind/summarization/readme_generator.py
+++ b/moonmind/summarization/readme_generator.py
@@ -58,8 +58,25 @@ class ReadmeAiGenerator:
 
             # Add any custom configurations
             # For example: --badge-style flat-square
+            # Specific handling for model, provider, and api_key
+            if "model" in self.config and self.config["model"]:
+                args.extend(["--model", str(self.config["model"])])
+
+            # 'provider' in config corresponds to '--llm-provider' for readme-ai CLI
+            if "provider" in self.config and self.config["provider"]:
+                args.extend(["--llm-provider", str(self.config["provider"])]) # Changed from --provider to --llm-provider
+
+            if "api_key" in self.config and self.config["api_key"]:
+                args.extend(["--api-key", str(self.config["api_key"])])
+
+            # Add other configurations from self.config, avoiding duplication
+            # of already handled keys (model, provider, api_key).
+            other_config_keys = ["model", "provider", "api_key"]
             for key, value in self.config.items():
-                args.extend([f"--{key.replace('_', '-')}", str(value)])
+                if key not in other_config_keys and value is not None:
+                    args.extend([f"--{key.replace('_', '-')}", str(value)])
+
+            logger.debug(f"readme-ai arguments: {args}")
 
             # Invoke the readme-ai CLI's entrypoint function
             # readme_cli is not an async function, it's synchronous.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
     "sqlalchemy-utils~=0.41.2",
     "cryptography~=45.0.4",
     "psycopg2-binary~=2.9.0",
-    "gitpython~=3.1.42"
+    "gitpython~=3.1.42",
+    "toml~=0.10.2"
 ]
 
 # This tells setuptools where to find packages when building.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "alembic~=1.16.2",
     "sqlalchemy-utils~=0.41.2",
     "cryptography~=45.0.4",
-    "psycopg2-binary~=2.9.0"
+    "psycopg2-binary~=2.9.0",
+    "gitpython~=3.1.42"
 ]
 
 # This tells setuptools where to find packages when building.


### PR DESCRIPTION
Implements a new POST /summarization/repository endpoint that allows users to submit a Git repository URL and generate a summary (initially README.md).

Key features:
- Accepts `repo_url`, `summary_type` (optional, default: "readme"), and `model` (optional).
- Uses application default model if not specified.
- Clones public repositories anonymously.
- Attempts to use a user-specific GitHub token for private repositories (placeholder token logic).
- Resolves LLM provider and API key based on the selected model (placeholder key logic).
- Uses `ReadmeAiGenerator` for README generation, passing necessary configurations (model, provider, API key).
- Cleans up temporary cloned repositories.
- Adds `GitPython` dependency.
- Integrates the new router into the main FastAPI application.