### PR TITLE
Implement disabled auth mode with default user

### DIFF
--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -98,7 +98,7 @@ async def get_or_create_default_user(
             # Ideally, ID should be authoritative.
             if user_by_email.id != default_user_uuid:
                 # Log a warning about ID mismatch if logging is available
-                logger.warning(f"Default user email {default_email} exists with ID {user_by_email.id}, but expected ID {default_user_uuid}.")
+                print(f"Warning: Default user email {default_email} exists with ID {user_by_email.id}, but expected ID {default_user_uuid}.")
                 # Potentially update the existing user's ID if that's desired and feasible,
                 # or raise an error. For now, we'll return the user found by email.
                 pass # Or handle more robustly
@@ -171,7 +171,7 @@ async def get_or_create_default_user(
     except Exception as e:
         await db_session.rollback()
         # Log error details here
-        logger.error(f"Error creating default user: {e}")
+        print(f"Error creating default user: {e}")
         raise HTTPException(status_code=500, detail=f"Could not create default user: {e}")
 
 

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -52,6 +52,128 @@ async def get_user_db(session: get_async_session = Depends(get_async_session)):
 async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)):
     yield UserManager(user_db)
 
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def get_user_manager_context(db_session: AsyncSession) -> AsyncGenerator[UserManager, None]:
+    """Context manager for UserManager."""
+    # Create a SQLAlchemyUserDatabase instance for the current session
+    user_db = SQLAlchemyUserDatabase(db_session, User)
+    # Yield a UserManager instance
+    yield UserManager(user_db)
+    # No specific cleanup needed for UserManager itself here, session is managed outside.
+
+
+async def get_or_create_default_user(
+    db_session: AsyncSession, user_manager: UserManager
+) -> User:
+    """
+    Retrieves or creates the default user if AUTH_PROVIDER is 'disabled'.
+    Uses DEFAULT_USER_ID, DEFAULT_USER_EMAIL, and DEFAULT_USER_PASSWORD from settings.
+    """
+    if not settings.oidc.DEFAULT_USER_ID or not settings.oidc.DEFAULT_USER_EMAIL:
+        raise ValueError(
+            "DEFAULT_USER_ID and DEFAULT_USER_EMAIL must be set in settings for default user functionality."
+        )
+
+    default_user_uuid = uuid.UUID(settings.oidc.DEFAULT_USER_ID)
+    default_email = settings.oidc.DEFAULT_USER_EMAIL
+    default_password = settings.oidc.DEFAULT_USER_PASSWORD # Can be None if not set, UserManager handles it
+
+    try:
+        # Attempt to get user by ID first
+        user = await user_manager.get(default_user_uuid)
+        if user:
+            return user
+    except Exception: # Catch potential errors if user_manager.get fails for non-existent user (though it usually returns None)
+        pass # User not found by ID, proceed to check by email or create
+
+    # Attempt to get user by email if not found by ID
+    # This handles cases where ID might change or not be the primary lookup for creation path
+    try:
+        user_by_email = await user_manager.get_by_email(default_email)
+        if user_by_email:
+            # If user exists by email but ID doesn't match, this is a conflict.
+            # For simplicity, we'll assume if email matches, it's the intended default user.
+            # Ideally, ID should be authoritative.
+            if user_by_email.id != default_user_uuid:
+                # Log a warning about ID mismatch if logging is available
+                print(f"Warning: Default user email {default_email} exists with ID {user_by_email.id}, but expected ID {default_user_uuid}.")
+                # Potentially update the existing user's ID if that's desired and feasible,
+                # or raise an error. For now, we'll return the user found by email.
+                pass # Or handle more robustly
+            return user_by_email
+    except Exception:
+        pass # User not found by email, proceed to create
+
+    # If user not found by ID or email, create them
+    user_create_data = {
+        "email": default_email,
+        "password": default_password,
+        "is_active": True,
+        "is_verified": True,
+        # We are setting the ID directly in the User model instance before adding to DB
+        # as UserCreate schema might not support 'id'.
+        # This requires careful handling with user_manager or direct DB interaction.
+    }
+
+    # UserManager.create typically expects a UserCreate schema object.
+    # We need to ensure the ID is set correctly.
+    # One way is to create the user object directly if UserManager allows it,
+    # or use a transaction with direct DB interaction for the ID part.
+
+    # Revised approach: Create with UserManager, then update ID if necessary, or ensure ID is part of UserCreate if allowed.
+    # FastAPI-Users UserCreate does not allow specifying 'id'.
+    # The UserManager will generate an ID.
+    # This means we cannot pre-determine the ID as settings.oidc.DEFAULT_USER_ID
+    # unless we modify how UserManager works or directly interact with the DB.
+
+    # Let's try a more direct DB interaction approach for default user setup
+    # to enforce the DEFAULT_USER_ID.
+
+    # Check if user with default_user_uuid exists (again, to be safe in direct DB context)
+    user = await db_session.get(User, default_user_uuid)
+    if user:
+        # If user somehow got created between earlier checks and now, return them
+        return user
+
+    # Check if user with default_email exists
+    existing_user_by_email = await user_manager.get_by_email(default_email)
+    if existing_user_by_email and existing_user_by_email.id != default_user_uuid:
+        raise ValueError(
+            f"A user with email {default_email} already exists but with a different ID ({existing_user_by_email.id}) than the configured DEFAULT_USER_ID ({default_user_uuid})."
+        )
+    elif existing_user_by_email and existing_user_by_email.id == default_user_uuid:
+        return existing_user_by_email # Should have been caught by user_manager.get(default_user_uuid)
+
+    # Create the user directly with the specified ID
+    # Note: Hashing the password should be handled by UserManager or a utility.
+    # For simplicity in this step, we assume user_manager.password_helper.hash can be used.
+    # If not, we might need to adjust.
+    hashed_password = user_manager.password_helper.hash(default_password)
+
+    user = User(
+        id=default_user_uuid,
+        email=default_email,
+        hashed_password=hashed_password,
+        is_active=True,
+        is_superuser=False, # Default user is not superuser unless specified
+        is_verified=True,
+        # oidc_provider and oidc_subject can be null or set to 'disabled_auth_default'
+        oidc_provider="default",
+        oidc_subject=str(default_user_uuid)
+    )
+    db_session.add(user)
+    try:
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+    except Exception as e:
+        await db_session.rollback()
+        # Log error details here
+        print(f"Error creating default user: {e}")
+        raise HTTPException(status_code=500, detail=f"Could not create default user: {e}")
+
 
 bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
 

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -98,7 +98,7 @@ async def get_or_create_default_user(
             # Ideally, ID should be authoritative.
             if user_by_email.id != default_user_uuid:
                 # Log a warning about ID mismatch if logging is available
-                print(f"Warning: Default user email {default_email} exists with ID {user_by_email.id}, but expected ID {default_user_uuid}.")
+                logger.warning(f"Default user email {default_email} exists with ID {user_by_email.id}, but expected ID {default_user_uuid}.")
                 # Potentially update the existing user's ID if that's desired and feasible,
                 # or raise an error. For now, we'll return the user found by email.
                 pass # Or handle more robustly

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -1,17 +1,15 @@
 import uuid
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
-from fastapi import Depends, Request
-from fastapi_users import BaseUserManager, FastAPIUsers, schemas, UUIDIDMixin
-from fastapi_users.authentication import (
-    AuthenticationBackend,
-    BearerTransport,
-    JWTStrategy,
-)
+from fastapi import Depends, HTTPException, Request
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin, schemas
+from fastapi_users.authentication import (AuthenticationBackend,
+                                          BearerTransport, JWTStrategy)
 from fastapi_users.db import SQLAlchemyUserDatabase
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from api_service.db.models import User
 from api_service.db.base import get_async_session
+from api_service.db.models import User
 from moonmind.config.settings import settings
 
 
@@ -53,6 +51,7 @@ async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db
     yield UserManager(user_db)
 
 from contextlib import asynccontextmanager
+
 
 @asynccontextmanager
 async def get_user_manager_context(db_session: AsyncSession) -> AsyncGenerator[UserManager, None]:

--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -171,7 +171,7 @@ async def get_or_create_default_user(
     except Exception as e:
         await db_session.rollback()
         # Log error details here
-        print(f"Error creating default user: {e}")
+        logger.error(f"Error creating default user: {e}")
         raise HTTPException(status_code=500, detail=f"Could not create default user: {e}")
 
 

--- a/api_service/db/base.py
+++ b/api_service/db/base.py
@@ -9,6 +9,30 @@ engine = create_async_engine(DATABASE_URL)
 async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
+from contextlib import asynccontextmanager
+
 async def get_async_session() -> AsyncSession:
     async with async_session_maker() as session:
         yield session
+
+@asynccontextmanager
+async def get_async_session_context() -> AsyncGenerator[AsyncSession, None]:
+    """Context manager for an async database session.
+    The caller is responsible for commit/rollback based on operations.
+    """
+    async with async_session_maker() as session:
+        try:
+            yield session
+            # Caller should explicitly commit if operations within the 'with' block succeeded
+            # For example, by calling session.commit() before the block ends.
+            # However, for services that manage their own commits, this outer commit might be unnecessary
+            # or could interfere if not handled carefully.
+            # For the startup logic, since get_or_create_default_user and get_or_create_profile
+            # already commit, an outer commit here is likely not needed.
+        except Exception:
+            # Rollback might be too broad here if services already rolled back.
+            # But if an error happens before service commit, this is useful.
+            await session.rollback() # Ensure rollback on error within the context
+            raise
+        finally:
+            await session.close()

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -212,8 +212,9 @@ class OIDCSettings(BaseSettings):
     OIDC_ISSUER_URL: Optional[str] = Field(None, env="OIDC_ISSUER_URL", description="URL of the OIDC provider, e.g., Keycloak.")
     OIDC_CLIENT_ID: Optional[str] = Field(None, env="OIDC_CLIENT_ID")
     OIDC_CLIENT_SECRET: Optional[str] = Field(None, env="OIDC_CLIENT_SECRET")
-    DEFAULT_USER_ID: Optional[str] = Field(None, env="DEFAULT_USER_ID")
-    DEFAULT_USER_EMAIL: Optional[str] = Field(None, env="DEFAULT_USER_EMAIL")
+    DEFAULT_USER_ID: Optional[str] = Field(None, env="DEFAULT_USER_ID", description="Default user ID for 'disabled' auth_provider mode.")
+    DEFAULT_USER_EMAIL: Optional[str] = Field(None, env="DEFAULT_USER_EMAIL", description="Default user email for 'disabled' auth_provider mode.")
+    DEFAULT_USER_PASSWORD: Optional[str] = Field("default_password_please_change", env="DEFAULT_USER_PASSWORD", description="Default user password for 'disabled' auth_provider mode. Used for user creation if needed.")
 
     model_config = SettingsConfigDict(env_prefix="")
 


### PR DESCRIPTION
Features:
- B-1: When AUTH_PROVIDER='disabled', a default user is created/fetched based on DEFAULT_USER_ID and DEFAULT_USER_EMAIL environment variables.
- B-2: The default user's profile is automatically created on application startup if it doesn't exist.
- B-3: Allows Open-WebUI to operate with WEBUI_AUTH=false against the API without login prompts, using the default user context.

Implementation Details:
- Added DEFAULT_USER_PASSWORD to OIDCSettings.
- Implemented `get_or_create_default_user` in `api_service/auth.py` to handle default user logic, including direct DB interaction to set a specific ID.
- Modified `get_current_user` dependency in `api_service/auth_providers.py` to use the default user logic when auth is disabled.
- Updated application startup event in `api_service/main.py` to ensure the default user and their profile are created.
- Added necessary DB/UserManager context managers.