### PR TITLE
Implement profile ownership guard and migration

### DIFF
--- a/api_service/migrations/versions/909263807406_fix_oidc_encryption_and_password.py
+++ b/api_service/migrations/versions/909263807406_fix_oidc_encryption_and_password.py
@@ -1,0 +1,62 @@
+"""ensure oidc constraint and encrypted columns"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+revision: str = "909263807406"
+down_revision: Union[str, None] = '9e9bd65e1b9e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'user',
+        'hashed_password',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        nullable=True,
+    )
+
+    op.alter_column(
+        'user_profile',
+        'google_api_key_encrypted',
+        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'user_profile',
+        'openai_api_key_encrypted',
+        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
+        existing_nullable=True,
+    )
+
+    op.drop_constraint('uq_oidc_identity', 'user', type_='unique')
+    op.create_unique_constraint('uq_oidc_identity', 'user', ['oidc_provider', 'oidc_subject'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_oidc_identity', 'user', type_='unique')
+    op.create_unique_constraint('uq_oidc_identity', 'user', ['oidc_provider', 'oidc_subject'])
+    op.alter_column(
+        'user_profile',
+        'openai_api_key_encrypted',
+        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'user_profile',
+        'google_api_key_encrypted',
+        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'user',
+        'hashed_password',
+        existing_type=sa.Text(),
+        type_=sa.Text(),
+        nullable=True,
+    )

--- a/api_service/migrations/versions/909263807406_fix_oidc_encryption_and_password.py
+++ b/api_service/migrations/versions/909263807406_fix_oidc_encryption_and_password.py
@@ -39,24 +39,29 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Restore unique constraint to its previous definition
     op.drop_constraint('uq_oidc_identity', 'user', type_='unique')
-    op.create_unique_constraint('uq_oidc_identity', 'user', ['oidc_provider', 'oidc_subject'])
+    op.create_unique_constraint('uq_oidc_identity', 'user', ['oidc_identity'])
+
+    # Revert encrypted columns to their original types and nullability
     op.alter_column(
         'user_profile',
         'openai_api_key_encrypted',
-        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
-        existing_nullable=True,
+        type_=sa.Text(),
+        existing_nullable=False,
     )
     op.alter_column(
         'user_profile',
         'google_api_key_encrypted',
-        type_=sqlalchemy_utils.types.encrypted.encrypted_type.EncryptedType(sa.Text),
-        existing_nullable=True,
+        type_=sa.Text(),
+        existing_nullable=False,
     )
+
+    # Revert hashed_password to non-nullable state
     op.alter_column(
         'user',
         'hashed_password',
         existing_type=sa.Text(),
         type_=sa.Text(),
-        nullable=True,
+        nullable=False,
     )

--- a/api_service/services/profile_service.py
+++ b/api_service/services/profile_service.py
@@ -106,6 +106,12 @@ class ProfileService:
         profile = await self.get_profile_by_user_id(db_session, user_id)
         update_data = profile_data.dict(exclude_unset=True)
 
+        if profile and profile.user_id != user_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Cannot update another user's profile.",
+            )
+
         if not profile:
             user_exists = await db_session.get(User, user_id)
             if not user_exists:

--- a/api_service/services/profile_service.py
+++ b/api_service/services/profile_service.py
@@ -106,6 +106,10 @@ class ProfileService:
         profile = await self.get_profile_by_user_id(db_session, user_id)
         update_data = profile_data.dict(exclude_unset=True)
 
+        # Safety check: `get_profile_by_user_id` should return a profile for the
+        # provided user_id. This guard protects against potential data
+        # inconsistencies where a profile might be associated with a different
+        # user.
         if profile and profile.user_id != user_id:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/tests/unit/services/test_profile_service.py
+++ b/tests/unit/services/test_profile_service.py
@@ -1,0 +1,28 @@
+import uuid
+import pytest
+from unittest.mock import AsyncMock
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.services.profile_service import ProfileService
+from api_service.db.models import UserProfile
+from api_service.api.schemas import UserProfileUpdate
+
+
+@pytest.mark.asyncio
+async def test_update_profile_enforces_ownership():
+    service = ProfileService()
+    db_session = AsyncMock(spec=AsyncSession)
+
+    existing_profile = UserProfile(user_id=uuid.uuid4())
+    service.get_profile_by_user_id = AsyncMock(return_value=existing_profile)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.update_profile(
+            db_session=db_session,
+            user_id=uuid.uuid4(),
+            profile_data=UserProfileUpdate(openai_api_key="new"),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
## Summary
- enforce ownership check in `ProfileService.update_profile`
- add migration for nullable hashed password and OIDC constraint
- cover the guard with a negative unit test

## Testing
- `pytest tests/unit/services/test_profile_service.py -q` *(fails: ModuleNotFoundError: No module named 'distutils')*

------
https://chatgpt.com/codex/tasks/task_b_6862fa614d5883318a7e8ce30c19ff62