### PR TITLE
Real default user dependency

### DIFF
--- a/api_service/auth_providers.py
+++ b/api_service/auth_providers.py
@@ -1,33 +1,43 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+import uuid
 
-from api_service.auth import (UserCreate, UserRead, auth_backend,
-                              current_active_user, fastapi_users)
+from api_service.auth import (
+    UserCreate,
+    UserRead,
+    auth_backend,
+    current_active_user,
+    fastapi_users,
+)
 from api_service.db.models import User
+from api_service.db.base import get_async_session
 from moonmind.config.settings import settings
 
 
-class MockUser:
+async def get_default_user_from_db(
+    session: AsyncSession = Depends(get_async_session),
+) -> User:
+    """Retrieve the default user from the database."""
+    user_id_str = settings.oidc.DEFAULT_USER_ID
+    if not user_id_str:
+        raise HTTPException(status_code=500, detail="DEFAULT_USER_ID not configured")
 
-    def __init__(self, id, email, is_active=True, is_superuser=False, is_verified=True):
-        self.id = id
-        self.email = email
-        self.is_active = is_active
-        self.is_superuser = is_superuser
-        self.is_verified = is_verified
+    try:
+        user_uuid = uuid.UUID(user_id_str)
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="Invalid DEFAULT_USER_ID") from exc
 
-    def __call__(self):
-        return self
+    user = await session.get(User, user_uuid)
+    if user is None:
+        raise HTTPException(status_code=500, detail="Default user not found")
+    return user
 
 
 def get_current_user():
     if settings.oidc.AUTH_PROVIDER == "disabled":
-        # When auth is disabled, we return a mock user object.
-        # This allows endpoints to function without requiring a real user session.
-        # The default user is created in the database if it doesn't exist.
-        return MockUser(
-            id="00000000-0000-0000-0000-000000000000", email="default@example.com")
+        return get_default_user_from_db
     else:
-        return Depends(current_active_user)
+        return current_active_user
 
 
 def get_auth_router():

--- a/tests/unit/api/test_auth_providers.py
+++ b/tests/unit/api/test_auth_providers.py
@@ -1,0 +1,37 @@
+import uuid
+import pytest
+from fastapi import HTTPException
+from unittest.mock import AsyncMock
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.auth_providers import get_default_user_from_db
+from api_service.db.models import User
+from moonmind.config.settings import settings
+
+@pytest.mark.asyncio
+async def test_get_default_user_happy_path(monkeypatch):
+    user_id = str(uuid.uuid4())
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", user_id)
+    default_user = User(
+        id=uuid.UUID(user_id),
+        email="default@example.com",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        hashed_password="x",
+    )
+    mock_session = AsyncMock(spec=AsyncSession)
+    mock_session.get.return_value = default_user
+
+    result = await get_default_user_from_db(mock_session)
+
+    assert result.id == uuid.UUID(user_id)
+    mock_session.get.assert_called_once_with(User, uuid.UUID(user_id))
+
+@pytest.mark.asyncio
+async def test_get_default_user_invalid_id(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", None)
+    mock_session = AsyncMock(spec=AsyncSession)
+    with pytest.raises(HTTPException) as exc:
+        await get_default_user_from_db(mock_session)
+    assert exc.value.status_code == 500


### PR DESCRIPTION
## Summary
- implement `get_default_user_from_db` and replace `MockUser`
- add unit tests for default user retrieval

## Testing
- `pytest tests/unit/api/test_auth_providers.py::test_get_default_user_happy_path -q`
- `pytest tests/unit/api/test_auth_providers.py::test_get_default_user_invalid_id -q`
- `pytest tests/unit/api/test_auth_providers.py -q`


------
https://chatgpt.com/codex/tasks/task_b_686390e92ebc8331883bb6c52565ce63