### PR TITLE
Implement env-based profile seeding

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -28,6 +28,7 @@ from api_service.api.routers.context_protocol import \
 from api_service.api.routers.documents import router as documents_router
 from api_service.api.routers.models import router as models_router
 from api_service.api.routers.profile import router as profile_router
+from api_service.api.schemas import UserProfileUpdate
 # Auth imports
 from api_service.auth import (UserCreate, UserRead, UserUpdate, auth_backend,
                               fastapi_users)
@@ -271,19 +272,48 @@ async def startup_event():
                     if not settings.oidc.DEFAULT_USER_ID or not settings.oidc.DEFAULT_USER_EMAIL:
                         logger.warning("DEFAULT_USER_ID or DEFAULT_USER_EMAIL not set. Skipping default user/profile creation on startup.")
                     else:
-                        logger.info(f"Attempting to get/create default user ID: {settings.oidc.DEFAULT_USER_ID} on startup.")
-                        default_user = await get_or_create_default_user(db_session=db_session, user_manager=user_manager)
+                        logger.info(
+                            f"Attempting to get/create default user ID: {settings.oidc.DEFAULT_USER_ID} on startup."
+                        )
+                        default_user = await get_or_create_default_user(
+                            db_session=db_session, user_manager=user_manager
+                        )
                         if default_user:
-                            logger.info(f"Default user {default_user.email} (ID: {default_user.id}) ensured.")
+                            logger.info(
+                                f"Default user {default_user.email} (ID: {default_user.id}) ensured."
+                            )
                             profile_service = ProfileService()
-                            profile = await profile_service.get_or_create_profile(db_session=db_session, user_id=default_user.id)
-                            logger.info(f"Profile for default user {default_user.email} ensured (Profile ID: {profile.id}).")
+                            existing_profile = await profile_service.get_profile_by_user_id(
+                                db_session=db_session, user_id=default_user.id
+                            )
+                            if existing_profile:
+                                logger.info(
+                                    f"Profile for default user {default_user.email} already exists (Profile ID: {existing_profile.id})."
+                                )
+                            else:
+                                profile_update = UserProfileUpdate(
+                                    google_api_key=settings.google.google_api_key,
+                                    openai_api_key=settings.openai.openai_api_key,
+                                )
+                                profile = await profile_service.update_profile(
+                                    db_session=db_session,
+                                    user_id=default_user.id,
+                                    profile_data=profile_update,
+                                )
+                                logger.info(
+                                    f"Created profile for default user {default_user.email} (Profile ID: {profile.id}) from env keys."
+                                )
                         else:
                             logger.error("Failed to get or create default user on startup.")
                 except ValueError as ve:
-                    logger.error(f"Configuration error during default user setup on startup: {ve}")
+                    logger.error(
+                        f"Configuration error during default user setup on startup: {ve}"
+                    )
                 except Exception as e:
-                    logger.error(f"Error ensuring default user/profile on startup: {e}", exc_info=True)
+                    logger.error(
+                        f"Error ensuring default user/profile on startup: {e}",
+                        exc_info=True,
+                    )
     else:
         logger.info(f"Auth provider is '{settings.oidc.AUTH_PROVIDER}'. Skipping default user creation on startup.")
 

--- a/tests/integration/test_startup_profile_seeding.py
+++ b/tests/integration/test_startup_profile_seeding.py
@@ -1,0 +1,48 @@
+import asyncio
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.main import app, startup_event
+from api_service.auth import _DEFAULT_USER_ID
+from api_service.db import base as db_base
+from api_service.db.models import Base, UserProfile
+from moonmind.config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_startup_profile_seeding(monkeypatch, tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    db_base.DATABASE_URL = db_url
+    db_base.engine = create_async_engine(db_url, future=True)
+    db_base.async_session_maker = sessionmaker(
+        db_base.engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with db_base.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled", raising=False)
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", _DEFAULT_USER_ID, raising=False)
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_EMAIL", "seed@example.com", raising=False)
+    monkeypatch.setattr(settings.openai, "openai_api_key", "sk-test", raising=False)
+    monkeypatch.setattr(settings.google, "google_api_key", "g-test", raising=False)
+
+    with patch("api_service.main._initialize_embedding_model"), \
+         patch("api_service.main._initialize_vector_store"), \
+         patch("api_service.main._initialize_contexts"), \
+         patch("api_service.main._load_or_create_vector_index"), \
+         patch("api_service.main._initialize_oidc_provider"):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(
+            select(UserProfile).where(UserProfile.user_id == uuid.UUID(_DEFAULT_USER_ID))
+        )
+        profile = result.scalars().first()
+        assert profile is not None
+        assert profile.openai_api_key_encrypted is not None
+        assert profile.google_api_key_encrypted is not None


### PR DESCRIPTION
## Summary
- seed default user profile from env on first startup when auth is disabled
- add integration test verifying startup profile seeding

## Testing
- `pytest -q tests/integration/test_startup_profile_seeding.py`
- `pytest -q` *(fails: tests/unit/config/test_settings.py import mismatch)*

------
https://chatgpt.com/codex/tasks/task_b_6864114e4ee083318466b99cdc38a4a7