### PR TITLE
Implement dynamic provider settings UI

### DIFF
--- a/api_service/api/constants.py
+++ b/api_service/api/constants.py
@@ -1,0 +1,1 @@
+MANAGED_PROVIDERS = ["openai", "google", "anthropic"]

--- a/api_service/templates/profile.html
+++ b/api_service/templates/profile.html
@@ -28,31 +28,19 @@
             <div class="alert {% if 'success' in message.lower() %}alert-success{% else %}alert-danger{% endif %}">{{ message }}</div>
         {% endif %}
 
-        <form method="POST" action="{{ request.url_for('profile_ui') }}">
+        <form method="POST" action="{{ request.url_for('update_settings_ui') }}">
+            {% for provider in provider_list %}
             <div>
-                <label for="openai_api_key">OpenAI API Key</label>
-                {% if keys_status.openai_api_key_set %}
-                    <div class="key-status status-set">OpenAI API Key is SET.</div>
+                <label for="{{ provider }}_api_key">{{ provider|capitalize }} API Key</label>
+                {% if keys_status[provider + '_api_key_set'] %}
+                    <div class="key-status status-set">{{ provider|capitalize }} API Key is SET.</div>
                     <p><em>To change it, enter a new key below. Otherwise, leave blank to keep the current key.</em></p>
                 {% else %}
-                    <div class="key-status status-not-set">OpenAI API Key is NOT SET.</div>
+                    <div class="key-status status-not-set">{{ provider|capitalize }} API Key is NOT SET.</div>
                 {% endif %}
-                <input type="password" name="openai_api_key" id="openai_api_key" placeholder="Enter new OpenAI API Key (optional)">
+                <input type="password" name="{{ provider }}_api_key" id="{{ provider }}_api_key" placeholder="Enter new {{ provider|capitalize }} API Key (optional)">
             </div>
-
-            <!-- Add fields for other API keys as needed, following the pattern above -->
-            <!-- For example:
-            <div>
-                <label for="anthropic_api_key">Anthropic API Key</label>
-                {% if keys_status.anthropic_api_key_set %}
-                    <div class="key-status status-set">Anthropic API Key is SET.</div>
-                    <p><em>To change it, enter a new key below. Otherwise, leave blank to keep the current key.</em></p>
-                {% else %}
-                    <div class="key-status status-not-set">Anthropic API Key is NOT SET.</div>
-                {% endif %}
-                <input type="password" name="anthropic_api_key" id="anthropic_api_key" placeholder="Enter new Anthropic API Key (optional)">
-            </div>
-            -->
+            {% endfor %}
 
             <button type="submit">Save API Keys</button>
         </form>

--- a/tests/e2e/test_settings_ui_browser.py
+++ b/tests/e2e/test_settings_ui_browser.py
@@ -1,0 +1,61 @@
+import threading
+import time
+
+import pytest
+import uvicorn
+from playwright.sync_api import sync_playwright
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.main import app as main_app
+from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
+from api_service.api.routers.profile import get_profile_service
+from api_service.db.models import User
+
+
+class DummyProfileService:
+    def __init__(self):
+        self.update_called_with = None
+
+    async def get_or_create_profile(self, db_session: AsyncSession, user_id):
+        class Obj:
+            openai_api_key = None
+            google_api_key = None
+
+        return Obj()
+
+    async def update_profile(self, db_session: AsyncSession, user_id, profile_data):
+        self.update_called_with = profile_data
+        return None
+
+
+@pytest.fixture(scope="module")
+def server():
+    test_user = User(id=__import__("uuid").uuid4(), email="test@example.com")
+    dummy_service = DummyProfileService()
+
+    main_app.dependency_overrides[get_current_user()] = lambda: test_user
+    main_app.dependency_overrides[get_async_session] = lambda: AsyncSession
+    main_app.dependency_overrides[get_profile_service] = lambda: dummy_service
+
+    config = uvicorn.Config(main_app, host="127.0.0.1", port=8001, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    time.sleep(1)
+    yield dummy_service
+    server.should_exit = True
+    thread.join()
+
+
+def test_submit_key(server):
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto("http://127.0.0.1:8001/settings")
+        page.fill("input[name='openai_api_key']", "browser-key")
+        page.click("button[type='submit']")
+        page.wait_for_load_state("networkidle")
+        browser.close()
+
+    assert server.update_called_with is not None

--- a/tests/e2e/test_settings_ui_browser.py
+++ b/tests/e2e/test_settings_ui_browser.py
@@ -35,7 +35,10 @@ def server():
     dummy_service = DummyProfileService()
 
     main_app.dependency_overrides[get_current_user] = lambda: test_user
-    main_app.dependency_overrides[get_async_session] = lambda: AsyncSession
+    from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async_session_maker = async_sessionmaker(bind=engine, expire_on_commit=False)
+    main_app.dependency_overrides[get_async_session] = lambda: async_session_maker()
     main_app.dependency_overrides[get_profile_service] = lambda: dummy_service
 
     config = uvicorn.Config(main_app, host="127.0.0.1", port=8001, log_level="warning")

--- a/tests/e2e/test_settings_ui_browser.py
+++ b/tests/e2e/test_settings_ui_browser.py
@@ -34,7 +34,7 @@ def server():
     test_user = User(id=__import__("uuid").uuid4(), email="test@example.com")
     dummy_service = DummyProfileService()
 
-    main_app.dependency_overrides[get_current_user()] = lambda: test_user
+    main_app.dependency_overrides[get_current_user] = lambda: test_user
     main_app.dependency_overrides[get_async_session] = lambda: AsyncSession
     main_app.dependency_overrides[get_profile_service] = lambda: dummy_service
 

--- a/tests/unit/api/test_profile.py
+++ b/tests/unit/api/test_profile.py
@@ -466,7 +466,7 @@ async def test_handle_profile_update_form_service_error(
                 "openai_api_key_set": bool(MOCK_PROFILE_READ_SCHEMA.openai_api_key)
             },
             "provider_list": [
-                p for p in MANAGED_PROVIDERS if p in ["openai", "google"]
+                p for p in MANAGED_PROVIDERS if hasattr(MOCK_PROFILE_READ_SCHEMA, f"{p}_api_key")
             ],
             "message": f"Error updating API keys: {error_message}",
         },


### PR DESCRIPTION
## Summary
- expose MANAGED_PROVIDERS constant
- build keys_status dynamically using MANAGED_PROVIDERS
- post form to `update_settings_ui` and iterate provider list in template
- add Playwright test to exercise settings form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'readmeai')*

------
https://chatgpt.com/codex/tasks/task_b_68644f103f6c83318fd8d22ee4b5efb7