### PR TITLE
Run jobs as default user

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -304,7 +304,9 @@ async def startup_event():
                                     f"Created profile for default user {default_user.email} (Profile ID: {profile.id}) from env keys."
                                 )
                             from moonmind.models_cache import refresh_model_cache_for_user
-                            await refresh_model_cache_for_user(default_user, db_session)
+                            import asyncio
+                            loop = asyncio.get_running_loop()
+                            await loop.run_in_executor(None, refresh_model_cache_for_user, default_user, db_session)
                         else:
                             logger.error("Failed to get or create default user on startup.")
                 except ValueError as ve:

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -303,6 +303,8 @@ async def startup_event():
                                 logger.info(
                                     f"Created profile for default user {default_user.email} (Profile ID: {profile.id}) from env keys."
                                 )
+                            from moonmind.models_cache import refresh_model_cache_for_user
+                            await refresh_model_cache_for_user(default_user, db_session)
                         else:
                             logger.error("Failed to get or create default user on startup.")
                 except ValueError as ve:

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -1,0 +1,8 @@
+# Operations Runbook
+
+MoonMind background jobs run using the default user account.
+
+- **User ID:** `00000000-0000-0000-0000-000000000000`
+- **Email:** `default@example.com`
+
+Keys for model providers (e.g. Google and OpenAI) are read from this user's profile whenever jobs execute. Disable global provider keys in the environment to verify jobs fail until a key is stored on this user.

--- a/moonmind/factories/embed_model_factory.py
+++ b/moonmind/factories/embed_model_factory.py
@@ -4,7 +4,7 @@ from llama_index.embeddings.ollama import OllamaEmbedding
 from ..config.settings import AppSettings
 
 
-def build_embed_model(settings: AppSettings):
+def build_embed_model(settings: AppSettings, google_api_key: str | None = None):
     provider = (
         settings.default_embedding_provider.lower()
         if settings.default_embedding_provider
@@ -17,12 +17,17 @@ def build_embed_model(settings: AppSettings):
             model_name=settings.ollama.ollama_embedding_model,
         ), settings.ollama.ollama_embeddings_dimensions
     elif provider == "google":
-        if not settings.google.google_api_key:
+        key_to_use = google_api_key if google_api_key else settings.google.google_api_key
+        if not key_to_use:
             raise ValueError("Google API key is not configured for Google embeddings.")
-        return GoogleGenAIEmbedding(
-            model_name=settings.google.google_embedding_model,
-            google_embed_batch_size=settings.google.google_embed_batch_size,
-        ), settings.google.google_embedding_dimensions
+        return (
+            GoogleGenAIEmbedding(
+                model_name=settings.google.google_embedding_model,
+                google_embed_batch_size=settings.google.google_embed_batch_size,
+                api_key=key_to_use,
+            ),
+            settings.google.google_embedding_dimensions,
+        )
     # Add other providers here if they become default options
     # TODO: OpenAI
     else:

--- a/moonmind/factories/google_factory.py
+++ b/moonmind/factories/google_factory.py
@@ -7,14 +7,15 @@ from moonmind.config.settings import settings
 logger = logging.getLogger(__name__)
 
 
-def list_google_models():
-    if not settings.google.google_api_key:
+def list_google_models(api_key: str | None = None):
+    key_to_use = api_key if api_key else settings.google.google_api_key
+    if not key_to_use:
         logger.warning(
             "Google models are not available because the API key is not set in settings"
         )
         return []
 
-    genai.configure(api_key=settings.google.google_api_key)
+    genai.configure(api_key=key_to_use)
     return genai.list_models()
 
 

--- a/moonmind/factories/openai_factory.py
+++ b/moonmind/factories/openai_factory.py
@@ -5,14 +5,15 @@ from moonmind.config.settings import settings
 logger = logging.getLogger(__name__)
 
 
-def list_openai_models():
-    if not settings.openai.openai_api_key:
+def list_openai_models(api_key: str | None = None):
+    key_to_use = api_key if api_key else settings.openai.openai_api_key
+    if not key_to_use:
         logger.warning(
             "OpenAI models are not available because the API key is not set in settings"
         )
         return []
 
-    openai.api_key = settings.openai.openai_api_key
+    openai.api_key = key_to_use
     try:
         models = openai.Model.list()
         # Filter for models that support chat completions, or adjust as needed


### PR DESCRIPTION
## Summary
- add optional API key parameters to model helper factories
- store provider keys in `ModelCache` and refresh using a user profile
- update startup flow to refresh model cache using the default user
- allow initialization and summarizer jobs to fetch keys via the default user
- document which user runs jobs

## Testing
- `pytest -q` *(fails: ImportError during collection)*
- `python tools/get_action_status.py --branch work`

------
https://chatgpt.com/codex/tasks/task_b_68645f96efc4833199d2071baaf4b0fa