### PR TITLE
Update docs for provider key precedence

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -49,7 +49,7 @@ VLLM_DTYPE="float16"
 VLLM_GPU_MEMORY_UTILIZATION="0.90"
 VLLM_MODEL_NAME="ByteDance-Seed/UI-TARS-1.5-7B"
 
-# Profile Settings
+# Provider Keys (also populate the default profile when AUTH_PROVIDER=disabled)
 ANTHROPIC_API_KEY=""
 ANTHROPIC_CHAT_MODEL="claude-sonnet-4-20250514"
 ANTHROPIC_ENABLED="true"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This section guides you through a one-click deployment of MoonMind using Docker 
 
 3.  **Accessing the UI:** Once the services are up and running (this might take a few minutes the first time as images are downloaded and built), you can access the Open-WebUI by navigating to `http://localhost:8080` in your web browser.
 
-4.  **Initializing the Vector Database (Optional but Recommended):**
+4.  **Manage API Keys:** When `AUTH_PROVIDER` is left as `disabled` (the default for local setups), any provider keys you place in `.env` are copied to the default user profile on startup. Visit `http://localhost:8080/settings` to view or change these values.
+5.  **Initializing the Vector Database (Optional but Recommended):**
     If you want to load initial data into the Qdrant vector database (e.g., from local files or other sources configured in `config.toml`), you can trigger the initialization process.
     Set the `INIT_DATABASE` variable in your `.env` file to `true`:
     ```env
@@ -425,6 +426,17 @@ GOOGLE_API_KEY="your_google_api_key_here"
 OPENAI_API_KEY="your_openai_api_key_here"
 # OPENAI_CHAT_MODEL="gpt-4o" # Optional
 ```
+
+### Provider Key Precedence
+
+MoonMind checks user profile settings first when looking up API keys. If a key is not stored in the profile, the value from the environment is used. The default `disabled` auth mode automatically seeds the default profile with keys from `.env` so they can be managed via the UI.
+
+| Auth mode | Key lookup order |
+|-----------|-----------------|
+| `disabled` | user profile → environment variable |
+| `keycloak` | user profile → environment variable |
+
+You can view or change keys at `http://localhost:8080/settings`.
 
 ## Roadmap
 MoonMind now supports:

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -5,4 +5,4 @@ MoonMind background jobs run using the default user account.
 - **User ID:** `00000000-0000-0000-0000-000000000000`
 - **Email:** `default@example.com`
 
-Keys for model providers (e.g. Google and OpenAI) are read from this user's profile whenever jobs execute. Disable global provider keys in the environment to verify jobs fail until a key is stored on this user.
+Keys for model providers (e.g. Google and OpenAI) are read from this user's profile whenever jobs execute. In `disabled` auth mode, the values from `.env` seed this profile on startup. Remove them from the environment to verify jobs fail until a key is stored on this user.


### PR DESCRIPTION
## Summary
- document that provider keys populate the default profile when auth is disabled
- add API key precedence table to README
- mention the `/settings` page in the Quick Start guide
- clarify provider key seeding in ops runbook
- update env template comment

## Testing
- `pip install -e .`
- `pytest tests/unit -q` *(fails: ModuleNotFoundError)*
- `sphinx-build -b html docs docs/_build` *(fails: config directory doesn't contain a conf.py file)*

------
https://chatgpt.com/codex/tasks/task_b_686465379224833196727770edd6f84b