### PR TITLE
Add integration fixtures and auth tests

### DIFF
--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -37,29 +37,29 @@ jobs:
       run: |
         python -m pytest tests/unit
 
-  integration:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    - name: Cache pip dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install readmeai~=0.6.0
-    - name: Run integration tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        python -m pytest tests/integration
+  # integration:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Check out code
+  #     uses: actions/checkout@v3
+  #   - name: Set up Python
+  #     uses: actions/setup-python@v4
+  #     with:
+  #       python-version: '3.12'
+  #   - name: Cache pip dependencies
+  #     uses: actions/cache@v3
+  #     with:
+  #       path: ~/.cache/pip
+  #       key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+  #       restore-keys: |
+  #         ${{ runner.os }}-pip-
+  #   - name: Install dependencies
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       python -m pip install -e .
+  #       python -m pip install readmeai~=0.6.0
+  #   - name: Run integration tests
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     run: |
+  #       python -m pytest tests/integration

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -33,3 +33,30 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         python -m pytest tests/unit
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        python -m pip install readmeai~=0.6.0
+    - name: Run integration tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        python -m pytest tests/integration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from moonmind.config.settings import settings
+from api_service.auth import _DEFAULT_USER_ID
+
+@pytest.fixture
+def disabled_env_keys(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled", raising=False)
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", _DEFAULT_USER_ID, raising=False)
+    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_EMAIL", "seed@example.com", raising=False)
+    monkeypatch.setattr(settings.openai, "openai_api_key", "sk-test", raising=False)
+    monkeypatch.setattr(settings.google, "google_api_key", "g-test", raising=False)
+    yield
+
+@pytest.fixture
+def keycloak_mode(monkeypatch):
+    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "keycloak", raising=False)
+    yield

--- a/tests/integration/test_profile_chat_flow.py
+++ b/tests/integration/test_profile_chat_flow.py
@@ -1,0 +1,97 @@
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.main import app, startup_event
+from api_service.db import base as db_base
+from api_service.db.models import Base, User
+from api_service.services.profile_service import ProfileService
+from api_service.api.schemas import UserProfileUpdate
+from moonmind.config.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_ui_keys_used_in_chat(disabled_env_keys, tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    db_base.DATABASE_URL = db_url
+    db_base.engine = create_async_engine(db_url, future=True)
+    db_base.async_session_maker = sessionmaker(
+        db_base.engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with db_base.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    with (
+        patch("api_service.main._initialize_embedding_model"),
+        patch("api_service.main._initialize_vector_store"),
+        patch("api_service.main._initialize_contexts"),
+        patch("api_service.main._load_or_create_vector_index"),
+        patch("api_service.main._initialize_oidc_provider"),
+    ):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        service = ProfileService()
+        user = await session.get(User, uuid.UUID(settings.oidc.DEFAULT_USER_ID))
+        await service.update_profile(
+            db_session=session,
+            user_id=user.id,
+            profile_data=UserProfileUpdate(openai_api_key="user-key"),
+        )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        with (
+            patch("api_service.api.routers.chat.model_cache.get_model_provider", return_value="OpenAI"),
+            patch("api_service.api.routers.chat.AsyncOpenAI") as mock_ai,
+        ):
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=type("Resp", (), {"choices": [type("C", (), {"message": type("M", (), {"content": "ok"})()})], "model": "gpt", "usage": None})()
+            )
+            mock_ai.return_value = mock_client
+            payload = {
+                "model": "gpt",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 10,
+            }
+            resp = await client.post("/v1/chat/completions", json=payload)
+            assert resp.status_code == 200
+            mock_ai.assert_called_with(api_key="user-key")
+
+
+@pytest.mark.asyncio
+async def test_keycloak_user_profile_empty(keycloak_mode, tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    db_base.DATABASE_URL = db_url
+    db_base.engine = create_async_engine(db_url, future=True)
+    db_base.async_session_maker = sessionmaker(
+        db_base.engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with db_base.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    with (
+        patch("api_service.main._initialize_embedding_model"),
+        patch("api_service.main._initialize_vector_store"),
+        patch("api_service.main._initialize_contexts"),
+        patch("api_service.main._load_or_create_vector_index"),
+        patch("api_service.main._initialize_oidc_provider"),
+    ):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        user = User(id=uuid.uuid4(), email="k@example.com")
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        service = ProfileService()
+        profile = await service.get_or_create_profile(session, user.id)
+        assert profile.openai_api_key is None
+        assert profile.google_api_key is None
+        assert getattr(profile, "openai_api_key_encrypted", None) is None
+        assert getattr(profile, "google_api_key_encrypted", None) is None

--- a/tests/integration/test_profile_chat_flow.py
+++ b/tests/integration/test_profile_chat_flow.py
@@ -2,15 +2,15 @@ import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
-from api_service.main import app, startup_event
+from api_service.api.schemas import UserProfileUpdate
 from api_service.db import base as db_base
 from api_service.db.models import Base, User
+from api_service.main import app, startup_event
 from api_service.services.profile_service import ProfileService
-from api_service.api.schemas import UserProfileUpdate
 from moonmind.config.settings import settings
 
 
@@ -25,6 +25,7 @@ async def test_ui_keys_used_in_chat(disabled_env_keys, tmp_path):
     async with db_base.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
+    app.state.settings = settings
     with (
         patch("api_service.main._initialize_embedding_model"),
         patch("api_service.main._initialize_vector_store"),
@@ -75,6 +76,7 @@ async def test_keycloak_user_profile_empty(keycloak_mode, tmp_path):
     async with db_base.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
+    app.state.settings = settings
     with (
         patch("api_service.main._initialize_embedding_model"),
         patch("api_service.main._initialize_vector_store"),

--- a/tests/integration/test_startup_profile_seeding.py
+++ b/tests/integration/test_startup_profile_seeding.py
@@ -15,7 +15,7 @@ from moonmind.config.settings import settings
 
 
 @pytest.mark.asyncio
-async def test_startup_profile_seeding(monkeypatch, tmp_path):
+async def test_startup_profile_seeding(disabled_env_keys, tmp_path):
     db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
     db_base.DATABASE_URL = db_url
     db_base.engine = create_async_engine(db_url, future=True)
@@ -25,11 +25,7 @@ async def test_startup_profile_seeding(monkeypatch, tmp_path):
     async with db_base.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    monkeypatch.setattr(settings.oidc, "AUTH_PROVIDER", "disabled", raising=False)
-    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_ID", _DEFAULT_USER_ID, raising=False)
-    monkeypatch.setattr(settings.oidc, "DEFAULT_USER_EMAIL", "seed@example.com", raising=False)
-    monkeypatch.setattr(settings.openai, "openai_api_key", "sk-test", raising=False)
-    monkeypatch.setattr(settings.google, "google_api_key", "g-test", raising=False)
+
 
     with patch("api_service.main._initialize_embedding_model"), \
          patch("api_service.main._initialize_vector_store"), \


### PR DESCRIPTION
## Summary
- add reusable auth fixtures
- run integration test job in CI
- cover profile startup seeding with fixtures
- test key updates used in chat
- validate empty profiles in keycloak mode

## Testing
- `pytest tests/integration/test_startup_profile_seeding.py -k test_startup_profile_seeding -q`
- `pytest tests/integration/test_profile_chat_flow.py::test_ui_keys_used_in_chat -q` *(fails: AttributeError)*
- `pytest -q` *(fails: 2 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68646a02c6188331a41c63eca3f45754