### PR TITLE
Fix settings status check

### DIFF
--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -1,19 +1,19 @@
 import uuid
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, AliasChoices
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UserProfileBaseSchema(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     google_api_key: Optional[str] = Field(
         default=None,
-        validation_alias=AliasChoices("google_api_key", "google_api_key_encrypted"),
+        alias="google_api_key_encrypted",
     )
     openai_api_key: Optional[str] = Field(
         default=None,
-        validation_alias=AliasChoices("openai_api_key", "openai_api_key_encrypted"),
+        alias="openai_api_key_encrypted",
     )
     # Add other profile fields here as they are defined in the UserProfile model
 

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -1,14 +1,20 @@
 import uuid
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, AliasChoices
 
 
 class UserProfileBaseSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    google_api_key: Optional[str] = None
-    openai_api_key: Optional[str] = None
+    google_api_key: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("google_api_key", "google_api_key_encrypted"),
+    )
+    openai_api_key: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("openai_api_key", "openai_api_key_encrypted"),
+    )
     # Add other profile fields here as they are defined in the UserProfile model
 
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1,8 +1,8 @@
 from pathlib import Path  # Added Path
 from typing import Optional  # Keep one Optional import
 
-from pydantic import (  # Ensure AliasChoices is imported if not already
-    AliasChoices, Field, field_validator)
+from pydantic import (
+    Field, field_validator)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -191,7 +191,8 @@ class LocalDataSettings(BaseSettings):
     """Settings for local data indexing"""
 
     local_data_path: Optional[str] = Field(
-        None, validation_alias=AliasChoices("LocalData", "LOCAL_DATA_PATH")
+        None,
+        env=["LocalData", "LOCAL_DATA_PATH"],
     )
     # Add local_data_enabled if we want a separate boolean flag, but for now, path presence implies enabled.
     # local_data_enabled: bool = Field(False, env="LOCAL_DATA_ENABLED")

--- a/tests/unit/services/test_profile_service.py
+++ b/tests/unit/services/test_profile_service.py
@@ -26,3 +26,20 @@ async def test_update_profile_enforces_ownership():
         )
 
     assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_userprofile_read_populates_from_encrypted():
+    profile = UserProfile(
+        id=1,
+        user_id=uuid.uuid4(),
+        openai_api_key_encrypted="secret-openai",
+        google_api_key_encrypted="secret-google",
+    )
+
+    from api_service.api.schemas import UserProfileRead
+
+    read_schema = UserProfileRead.model_validate(profile)
+
+    assert read_schema.openai_api_key == "secret-openai"
+    assert read_schema.google_api_key == "secret-google"


### PR DESCRIPTION
## Summary
- map profile schema fields to encrypted db columns
- ensure UserProfileRead populates API keys from encrypted fields
- test schema mapping

## Testing
- `pytest tests/unit/services/test_profile_service.py -q`
- `pytest tests/unit/api/test_profile.py::test_get_profile_management_page_success -q`
- `python tools/get_action_status.py`

------
https://chatgpt.com/codex/tasks/task_b_6865c25c868c8331b136aa15608eaec9