### PR TITLE
Update API port references and adjust VLLM mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ To build (if necessary) and start the VLLM service, run:
 docker-compose --profile vllm up -d
 ```
 
-The VLLM OpenAI-compatible API will be available at `http://localhost:8001/v1`. (Note: The service is mapped to port `8001` on the host to avoid conflicts with other services that might use port `8000`).
+The VLLM OpenAI-compatible API will be available at `http://localhost:8000/v1`.
 
 ### Accessing Logs
 

--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -28,6 +28,6 @@ COPY api_service /app/api_service/
 RUN chmod +x /app/api_service/entrypoint.sh && \
     sed -i 's/\r$//' /app/api_service/entrypoint.sh
 
-EXPOSE 8000
+EXPOSE 5000
 
 CMD ["/app/api_service/entrypoint.sh"]

--- a/api_service/entrypoint.sh
+++ b/api_service/entrypoint.sh
@@ -5,7 +5,7 @@ export GIT_PYTHON_REFRESH=quiet
 
 echo "Starting Uvicorn server..."
 if [ "$FASTAPI_RELOAD" = "true" ]; then
-    exec uvicorn api_service.main:app --host 0.0.0.0 --port 8000 --reload
+    exec uvicorn api_service.main:app --host 0.0.0.0 --port 5000 --reload
 else
-    exec uvicorn api_service.main:app --host 0.0.0.0 --port 8000
+    exec uvicorn api_service.main:app --host 0.0.0.0 --port 5000
 fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - OPENAI_API_BASE_URL=${OPENAI_API_BASE_URL:-http://api:8000/v1}
+      - OPENAI_API_BASE_URL=${OPENAI_API_BASE_URL:-http://api:5000/v1}
       - WEBUI_AUTH=${WEBUI_AUTH:-false}
       # - WEBUI_FORWARD_AUTH_HEADER=${WEBUI_FORWARD_AUTH_HEADER:-true} # Keep or remove based on final setup with OIDC
       - ENABLE_OLLAMA_API=false
@@ -66,14 +66,14 @@ services:
       dockerfile: ./api_service/Dockerfile
     image: ghcr.io/moonladderstudios/moonmind:latest
     ports:
-      - "8000:8000"
+      - "5000:5000"
     environment:
       - PYTHONPATH=/app
       - LOG_LEVEL=${LOG_LEVEL:-DEBUG}
       - PYTHONUNBUFFERED=1
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-false}
       - MODEL_CONTEXT_PROTOCOL_ENABLED=true
-      - MODEL_CONTEXT_PROTOCOL_PORT=8000
+      - MODEL_CONTEXT_PROTOCOL_PORT=5000
       - MODEL_CONTEXT_PROTOCOL_HOST=0.0.0.0
       - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
       # OIDC specific variables for API service
@@ -214,7 +214,7 @@ services:
       - ./model_data:/root/.cache/huggingface/hub
       - ./tools/entrypoint-vllm.sh:/entrypoint-vllm.sh:ro
     ports:
-      - "8001:8000"
+      - "8000:8000"
     environment:
       - MODEL_NAME=${VLLM_MODEL_NAME:-ByteDance-Seed/UI-TARS-1.5-7B}
       - DTYPE=${VLLM_DTYPE:-float16}

--- a/docs/model_context_protocol.md
+++ b/docs/model_context_protocol.md
@@ -76,7 +76,7 @@ The MoonMind API container is configured to act as a Model Context Protocol serv
 ```yaml
 environment:
   - MODEL_CONTEXT_PROTOCOL_ENABLED=true
-  - MODEL_CONTEXT_PROTOCOL_PORT=8000
+  - MODEL_CONTEXT_PROTOCOL_PORT=5000
   - MODEL_CONTEXT_PROTOCOL_HOST=0.0.0.0
 labels:
   - "ai.model.context.protocol.version=0.1"
@@ -105,11 +105,11 @@ python examples/context_protocol_client.py gpt-4o
 OpenHands and other agents can connect to MoonMind's Model Context Protocol server by configuring their client to point to the MoonMind API endpoint:
 
 ```
-http://api:8000/context
+http://api:5000/context
 ```
 
 If accessing from outside the Docker network, use:
 
 ```
-http://localhost:8000/context
+http://localhost:5000/context
 ```

--- a/examples/context_protocol_client.py
+++ b/examples/context_protocol_client.py
@@ -9,7 +9,7 @@ import sys
 import os
 
 # Default to localhost, but allow override via environment variable
-API_BASE_URL = os.environ.get("MOONMIND_API_URL", "http://localhost:8000")
+API_BASE_URL = os.environ.get("MOONMIND_API_URL", "http://localhost:5000")
 
 
 def send_context_request(messages, model="gemini-pro"):


### PR DESCRIPTION
## Summary
- update API service to run on port 5000
- adjust Model Context Protocol docs and example client for new port
- switch VLLM mapping to port 8000

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_b_68671772747c83319d124aa8b4152bcc