### PR TITLE
Fix default user initialization

### DIFF
--- a/api_service/auth.py
+++ b/api_service/auth.py
@@ -93,11 +93,13 @@ async def get_or_create_default_user(
     db_session: AsyncSession, user_manager: UserManager
 ) -> User:
     """
-    Retrieves or creates the default user if AUTH_PROVIDER is 'disabled'.
-    Uses hardcoded values for the user's ID and email.
+    Retrieves or creates the default user if AUTH_PROVIDER is "disabled".
+    Falls back to built-in default ID and email unless overridden in settings.
     """
-    default_user_uuid = uuid.UUID(_DEFAULT_USER_ID)
-    default_email = _DEFAULT_USER_EMAIL
+    default_user_uuid = uuid.UUID(
+        settings.oidc.DEFAULT_USER_ID or _DEFAULT_USER_ID
+    )
+    default_email = settings.oidc.DEFAULT_USER_EMAIL or _DEFAULT_USER_EMAIL
     default_password = settings.oidc.DEFAULT_USER_PASSWORD # Can be None if not set, UserManager handles it
 
     try:

--- a/api_service/auth_providers.py
+++ b/api_service/auth_providers.py
@@ -8,6 +8,7 @@ from api_service.auth import (
     auth_backend,
     current_active_user,
     fastapi_users,
+    _DEFAULT_USER_ID,
 )
 from api_service.db.models import User
 from api_service.db.base import get_async_session
@@ -18,10 +19,7 @@ async def get_default_user_from_db(
     session: AsyncSession = Depends(get_async_session),
 ) -> User:
     """Retrieve the default user from the database."""
-    user_id_str = settings.oidc.DEFAULT_USER_ID
-    if not user_id_str:
-        raise HTTPException(status_code=500, detail="DEFAULT_USER_ID not configured")
-
+    user_id_str = settings.oidc.DEFAULT_USER_ID or _DEFAULT_USER_ID
     try:
         user_uuid = uuid.UUID(user_id_str)
     except ValueError as exc:


### PR DESCRIPTION
## Summary
- remove DEFAULT_USER entries from `.env-template`
- simplify setup docs and note defaults
- fall back to hard-coded default user id/email in the API
- log when built-in defaults are used during startup

## Testing
- `pip install -e .` *(success)*
- `pytest -k "chat_completions_google_no_api_key_with_cache" -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_686718b87c60833195fcf151162b4be1