### PR TITLE
Add JiraStoryPlanner skeleton

### DIFF
--- a/moonmind/planning/__init__.py
+++ b/moonmind/planning/__init__.py
@@ -1,0 +1,5 @@
+"""Planning utilities for generating Jira stories."""
+
+from .jira_story_planner import JiraStoryPlanner
+
+__all__ = ["JiraStoryPlanner"]

--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -1,0 +1,59 @@
+"""Skeleton for planning Jira stories from high level text."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from moonmind.config.settings import AppSettings
+
+
+class JiraStoryPlanner:
+    """Convert a plan description into Jira issues.
+
+    Parameters
+    ----------
+    plan_text : str
+        Text describing the overall plan or feature to implement.
+    jira_project_key : str
+        Key of the Jira project where issues should be created.
+    dry_run : bool, optional
+        If ``True``, no changes will be made in Jira. Defaults to ``True``.
+    llm_model : Any, optional
+        Language model used for text processing.
+    logger : logging.Logger, optional
+        Logger for debug and progress messages.
+    **jira_kwargs : Any
+        Additional arguments forwarded to the Jira client when implemented.
+    """
+
+    def __init__(
+        self,
+        plan_text: str,
+        jira_project_key: str,
+        dry_run: bool = True,
+        llm_model: Optional[Any] = None,
+        logger: Optional[logging.Logger] = None,
+        **jira_kwargs: Any,
+    ) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+
+        if not plan_text:
+            raise ValueError("plan_text is required")
+        if not jira_project_key:
+            raise ValueError("jira_project_key is required")
+
+        self.plan_text = plan_text
+        self.jira_project_key = jira_project_key
+        self.dry_run = dry_run
+        self.llm_model = llm_model
+        self.jira_kwargs = jira_kwargs
+
+        # Load Jira credentials from application settings
+        settings = AppSettings()
+        self.jira_url = settings.atlassian.atlassian_url
+        self.jira_username = settings.atlassian.atlassian_username
+        self.jira_api_key = settings.atlassian.atlassian_api_key
+
+        # Placeholder for future Jira client
+        self.jira_client = None

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -1,0 +1,24 @@
+import logging
+import pytest
+
+from moonmind.planning import JiraStoryPlanner
+
+
+def test_init_requires_mandatory_fields():
+    with pytest.raises(ValueError):
+        JiraStoryPlanner(plan_text="", jira_project_key="PROJ")
+    with pytest.raises(ValueError):
+        JiraStoryPlanner(plan_text="plan", jira_project_key="")
+
+
+def test_init_loads_credentials(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+
+    assert planner.jira_api_key == "key"
+    assert planner.jira_username == "user"
+    assert planner.jira_url == "https://example.atlassian.net"
+


### PR DESCRIPTION
## Summary
- add planning package with JiraStoryPlanner placeholder
- expose JiraStoryPlanner for `from moonmind.planning import JiraStoryPlanner`
- test that the planner imports settings and validates input

## Testing
- `pytest tests/unit/planning/test_jira_story_planner.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686849f046148331b3419e6367f9b154