### PR TITLE
Add prompt builder

### DIFF
--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -57,3 +57,31 @@ class JiraStoryPlanner:
 
         # Placeholder for future Jira client
         self.jira_client = None
+
+    def _build_prompt(self, plan_text: str) -> list:
+        """Build LLM prompt messages from raw plan text.
+
+        Parameters
+        ----------
+        plan_text : str
+            The raw text describing the plan to convert into Jira stories.
+
+        Returns
+        -------
+        list of Message
+            A list containing the system and user messages ready for an LLM
+            chat completion request.
+        """
+        from moonmind.schemas.chat_models import Message
+
+        system_prompt = (
+            "You are a Jira planning assistant. "
+            "Return ONLY a JSON array of issues using the fields "
+            "'summary', 'description', 'issue_type', 'story_points', and "
+            "'labels'."
+        )
+
+        return [
+            Message(role="system", content=system_prompt),
+            Message(role="user", content=plan_text),
+        ]

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -22,3 +22,27 @@ def test_init_loads_credentials(monkeypatch):
     assert planner.jira_username == "user"
     assert planner.jira_url == "https://example.atlassian.net"
 
+
+def test_build_prompt(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    sample_plan = "Implement login and registration"
+    planner = JiraStoryPlanner(plan_text=sample_plan, jira_project_key="PROJ")
+
+    messages = planner._build_prompt(sample_plan)
+
+    from moonmind.schemas.chat_models import Message
+
+    expected_system = (
+        "You are a Jira planning assistant. Return ONLY a JSON array of issues "
+        "using the fields 'summary', 'description', 'issue_type', 'story_points', "
+        "and 'labels'."
+    )
+
+    assert messages == [
+        Message(role="system", content=expected_system),
+        Message(role="user", content=sample_plan),
+    ]
+


### PR DESCRIPTION
## Summary
- implement _build_prompt in JiraStoryPlanner to generate LLM chat messages
- add test for prompt creation

## Testing
- `pytest tests/unit/planning/test_jira_story_planner.py::test_build_prompt -q`
- `pytest tests/unit/planning/test_jira_story_planner.py -q`

------
https://chatgpt.com/codex/tasks/task_b_686853bf79308331bdfa0fa5f55b49bd