### PR TITLE
Add Jira planner integration tests

### DIFF
--- a/tests/test_jira_story_planner.py
+++ b/tests/test_jira_story_planner.py
@@ -1,0 +1,66 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from moonmind.planning import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft
+
+
+@pytest.fixture(autouse=True)
+def patch_env(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+
+def test_plan_valid_flow(monkeypatch):
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=False)
+    draft = StoryDraft(summary="A", description="da", issue_type="Task")
+
+    with patch.object(planner, "_call_llm", return_value=[draft]) as mock_llm, \
+         patch.object(planner, "_create_issues", return_value=[draft]) as mock_create:
+        result = planner.plan()
+
+    assert result == [draft]
+    mock_llm.assert_called_once()
+    mock_create.assert_called_once_with([draft])
+
+
+def test_plan_invalid_json(monkeypatch):
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+
+    with patch.object(planner, "_call_llm", side_effect=JiraStoryPlannerError("invalid json")):
+        with pytest.raises(JiraStoryPlannerError):
+            planner.plan()
+
+
+def test_plan_auth_error(monkeypatch):
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=False)
+    draft = StoryDraft(summary="s", description="d", issue_type="Task")
+
+    with patch.object(planner, "_call_llm", return_value=[draft]), \
+         patch.object(planner, "_get_jira_client", side_effect=JiraStoryPlannerError("auth")):
+        with pytest.raises(JiraStoryPlannerError):
+            planner.plan()
+
+
+def test_plan_duplicate_summaries(monkeypatch):
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+    draft1 = StoryDraft(summary="A", description="d1", issue_type="Task")
+    draft2 = StoryDraft(summary="A", description="d2", issue_type="Task")
+
+    with patch.object(planner, "_call_llm", return_value=[draft1, draft2]):
+        with patch.object(planner, "_create_issues", return_value=[draft1, draft2]):
+            result = planner.plan()
+
+    assert result == [draft1, draft2]
+
+
+def test_plan_dry_run(monkeypatch):
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=True)
+    draft = StoryDraft(summary="A", description="d", issue_type="Task")
+
+    with patch.object(planner, "_call_llm", return_value=[draft]) as mock_llm, \
+         patch.object(planner, "_get_jira_client", side_effect=AssertionError("should not auth")):
+        result = planner.plan()
+
+    assert result == [draft]
+    mock_llm.assert_called_once()


### PR DESCRIPTION
### **User description**
## Summary
- add integration tests for JiraStoryPlanner covering core scenarios

## Testing
- `coverage run -m pytest tests/test_jira_story_planner.py tests/unit/planning/test_jira_story_planner.py -q`
- `coverage report -m`

------
https://chatgpt.com/codex/tasks/task_b_6869ae640d7c83319cbfc47bb6d7d969


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive integration tests for JiraStoryPlanner

- Cover valid flow, error handling, and dry-run scenarios

- Test authentication errors and duplicate summaries


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Test Suite"] --> B["Valid Flow Test"]
  A --> C["Error Handling Tests"]
  A --> D["Dry Run Test"]
  B --> E["Mock LLM & Jira"]
  C --> F["JSON/Auth Errors"]
  D --> G["Skip Jira Creation"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jira_story_planner.py</strong><dd><code>Add JiraStoryPlanner integration test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_jira_story_planner.py

<li>Add 6 integration test cases for JiraStoryPlanner<br> <li> Mock environment variables and external dependencies<br> <li> Test valid flow, error scenarios, and dry-run mode<br> <li> Cover authentication errors and duplicate summaries


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/116/files#diff-c66c7f24e0f5c41718f3d094cc524e5bc01a643e2c826ff4684d4805d953f6d8">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>