### PR TITLE
Add planning router

### DIFF
--- a/api_service/api/routers/planning.py
+++ b/api_service/api/routers/planning.py
@@ -1,0 +1,31 @@
+import logging
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from moonmind.planning import JiraStoryPlanner, JiraStoryPlannerError, StoryDraft
+
+router = APIRouter()
+
+
+class JiraPlanRequest(BaseModel):
+    plan_text: str = Field(..., description="Description of the work to plan")
+    jira_project_key: str = Field(..., description="Jira project key")
+    dry_run: bool = Field(True, description="If true, do not create issues")
+
+
+@router.post("/jira", response_model=List[StoryDraft])
+async def plan_jira_stories(request: JiraPlanRequest):
+    """Generate Jira stories from plan text using the JiraStoryPlanner."""
+    planner = JiraStoryPlanner(
+        plan_text=request.plan_text,
+        jira_project_key=request.jira_project_key,
+        dry_run=request.dry_run,
+    )
+    try:
+        return planner.plan()
+    except JiraStoryPlannerError as exc:
+        logging.getLogger(__name__).exception("Jira planning failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc))
+

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -29,6 +29,7 @@ from api_service.api.routers.context_protocol import \
 from api_service.api.routers.documents import router as documents_router
 from api_service.api.routers.models import router as models_router
 from api_service.api.routers.profile import router as profile_router
+from api_service.api.routers.planning import router as planning_router
 from api_service.api.schemas import UserProfileUpdate
 # Auth imports
 from api_service.auth import (UserCreate, UserRead, UserUpdate, auth_backend,
@@ -228,6 +229,7 @@ app.include_router(
     prefix="/summarization",
     tags=["Summarization"],
 )  # Added summarization router
+app.include_router(planning_router, prefix="/v1/planning", tags=["Planning"])
 app.include_router(context_protocol_router, tags=["Context Protocol"])  # Removed prefix="/context"
 app.include_router(profile_router, prefix="", tags=["Profile"])  # Include profile router
 

--- a/tests/unit/api/test_planning.py
+++ b/tests/unit/api/test_planning.py
@@ -1,0 +1,38 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch
+
+from api_service.api.routers.planning import router as planning_router
+from moonmind.planning import StoryDraft, JiraStoryPlannerError
+
+app = FastAPI()
+app.include_router(planning_router, prefix="/v1/planning")
+client = TestClient(app)
+
+
+def test_plan_jira_stories_success():
+    draft = StoryDraft(summary="s", description="d", issue_type="Task")
+    planner_instance = MagicMock()
+    planner_instance.plan.return_value = [draft]
+    with patch("api_service.api.routers.planning.JiraStoryPlanner", return_value=planner_instance) as mock_cls:
+        response = client.post(
+            "/v1/planning/jira",
+            json={"plan_text": "do work", "jira_project_key": "PROJ", "dry_run": True},
+        )
+    assert response.status_code == 200
+    assert response.json() == [draft.model_dump()]
+    mock_cls.assert_called_once_with(plan_text="do work", jira_project_key="PROJ", dry_run=True)
+    planner_instance.plan.assert_called_once()
+
+
+def test_plan_jira_stories_error():
+    planner_instance = MagicMock()
+    planner_instance.plan.side_effect = JiraStoryPlannerError("boom")
+    with patch("api_service.api.routers.planning.JiraStoryPlanner", return_value=planner_instance):
+        response = client.post(
+            "/v1/planning/jira",
+            json={"plan_text": "do work", "jira_project_key": "PROJ", "dry_run": False},
+        )
+    assert response.status_code == 500
+    assert "boom" in response.json()["detail"]


### PR DESCRIPTION
### **User description**
## Summary
- add planning router with JiraStoryPlanner endpoint
- include planning router in FastAPI application
- test planning router

## Testing
- `pytest -q tests/unit/api/test_planning.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'readmeai')*


------
https://chatgpt.com/codex/tasks/task_b_6869b4d26e1c83319c7e030cf8007101


___

### **PR Type**
Enhancement


___

### **Description**
- Add planning router with Jira story planner endpoint

- Include planning router in FastAPI application

- Add comprehensive unit tests for planning functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Planning Router"] --> B["Jira Story Planner"]
  B --> C["FastAPI Application"]
  A --> D["Unit Tests"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planning.py</strong><dd><code>Create planning router with Jira endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/api/routers/planning.py

<li>Create new planning router with <code>/jira</code> endpoint<br> <li> Define <code>JiraPlanRequest</code> model with validation fields<br> <li> Implement error handling for <code>JiraStoryPlannerError</code><br> <li> Return list of <code>StoryDraft</code> objects as response


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/117/files#diff-b384e849ee5482ebe9704695ecde46c0768aeb8ce6549ba400447b120e9cfd66">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Register planning router in main application</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/main.py

<li>Import planning router module<br> <li> Include planning router in FastAPI app with <code>/v1/planning</code> prefix<br> <li> Add "Planning" tag for API documentation


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/117/files#diff-992287f42f167ab442781b4871fdd4be342978c1bfe7820972abcca09773a764">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_planning.py</strong><dd><code>Add unit tests for planning router</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/api/test_planning.py

<li>Create test client with planning router<br> <li> Test successful Jira story planning with mocked planner<br> <li> Test error handling for <code>JiraStoryPlannerError</code><br> <li> Verify API response format and status codes


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/117/files#diff-b4589d9051b2fa7087b7e68cfefed131e0d1a78b1b86ad9c70c2be5c9f3b0362">+38/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>