### PR TITLE
Fix gemini prompt formatting

### DIFF
--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -383,7 +383,8 @@ class JiraStoryPlanner:
                             except Exception:
                                 pass
                         self.logger.warning(error_msg)
-                        break # Exit retry loop to fallback
+                        # Re-raise as a planner error to ensure callers can handle it
+                        raise JiraStoryPlannerError(error_msg) from e
 
             if bulk_resp is None:
                 # Fall back to creating issues one-by-one if bulk failed or was skipped

--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -353,10 +353,13 @@ class JiraStoryPlanner:
             # Attempt bulk creation with retries on 429. Some Jira clients
             # expose `issue_create_bulk` while others use `create_issues`.
             bulk_method = None
-            if hasattr(jira, "issue_create_bulk"):
-                bulk_method = jira.issue_create_bulk
-            elif hasattr(jira, "create_issues"):
-                bulk_method = jira.create_issues
+            candidate = getattr(jira, "issue_create_bulk", None)
+            if callable(candidate):
+                bulk_method = candidate
+            else:
+                candidate = getattr(jira, "create_issues", None)
+                if callable(candidate):
+                    bulk_method = candidate
 
             attempts = 0
             while True:

--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -365,7 +365,9 @@ class JiraStoryPlanner:
                         bulk_resp = bulk_method(issue_updates)
                     else:
                         # Fall back to creating issues one-by-one
-                        bulk_resp = [jira.create_issue(fields=u["fields"]) for u in issue_updates]
+                        bulk_resp = [
+                            jira.create_issue(fields=u["fields"]) for u in issue_updates
+                        ]
                     break
                 except Exception as e:  # pragma: no cover - network errors
                     if (
@@ -376,7 +378,8 @@ class JiraStoryPlanner:
                         time.sleep(2**attempts)
                         attempts += 1
                         continue
-                    raise
+                    self.logger.exception("Failed to create issues: %s", e)
+                    raise JiraStoryPlannerError(f"Failed to create issues: {e}") from e
 
             bulk_issues = []
             if isinstance(bulk_resp, dict):

--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -353,13 +353,10 @@ class JiraStoryPlanner:
             # Attempt bulk creation with retries on 429. Some Jira clients
             # expose `issue_create_bulk` while others use `create_issues`.
             bulk_method = None
-            candidate = getattr(jira, "issue_create_bulk", None)
-            if callable(candidate):
-                bulk_method = candidate
-            else:
-                candidate = getattr(jira, "create_issues", None)
-                if callable(candidate):
-                    bulk_method = candidate
+            if hasattr(jira, "issue_create_bulk"):
+                bulk_method = jira.issue_create_bulk
+            elif hasattr(jira, "create_issues"):
+                bulk_method = jira.create_issues
 
             attempts = 0
             bulk_resp: Any = None

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -282,6 +282,31 @@ def test_create_issues_bulk_success(monkeypatch):
     fake_jira.issue_create_bulk.assert_called_once()
 
 
+def test_create_issues_create_issues_fallback(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=False)
+    drafts = [
+        StoryDraft(summary="A", description="da", issue_type="Task"),
+        StoryDraft(summary="B", description="db", issue_type="Task"),
+    ]
+
+    fake_jira = MagicMock(spec=["create_issues", "create_issue"])
+    fake_jira.create_issues.return_value = {
+        "issues": [{"key": "PROJ-1"}, {"key": "PROJ-2"}]
+    }
+
+    with patch.object(planner, "_get_jira_client", return_value=fake_jira):
+        with patch.object(planner, "_resolve_story_points_field", return_value="sp"):
+            result = planner._create_issues(drafts)
+
+    assert [d.key for d in result] == ["PROJ-1", "PROJ-2"]
+    fake_jira.create_issues.assert_called_once()
+    fake_jira.create_issue.assert_not_called()
+
+
 def test_create_issues_bulk_partial_failure(monkeypatch):
     monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
     monkeypatch.setenv("ATLASSIAN_USERNAME", "user")

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -340,7 +340,7 @@ def test_create_issues_http_error(monkeypatch):
     planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=False)
     drafts = [StoryDraft(summary="s", description="d", issue_type="Task")]
 
-    fake_jira = MagicMock()
+    fake_jira = MagicMock(spec=["create_issues", "create_issue"])
     fake_jira.create_issues.side_effect = HTTPError("400: bad request")
 
     with patch.object(planner, "_get_jira_client", return_value=fake_jira):

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -2,6 +2,7 @@ import logging
 import hashlib
 import pytest
 from unittest.mock import MagicMock, patch
+from requests.exceptions import HTTPError
 
 from moonmind.planning import (
     JiraStoryPlanner,
@@ -329,6 +330,23 @@ def test_create_issues_bulk_partial_failure(monkeypatch):
     assert [d.key for d in result] == ["PROJ-1", "PROJ-2"]
     fake_jira.issue_create_bulk.assert_called_once()
     fake_jira.create_issue.assert_called_once()
+
+
+def test_create_issues_http_error(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ", dry_run=False)
+    drafts = [StoryDraft(summary="s", description="d", issue_type="Task")]
+
+    fake_jira = MagicMock()
+    fake_jira.create_issues.side_effect = HTTPError("400: bad request")
+
+    with patch.object(planner, "_get_jira_client", return_value=fake_jira):
+        with patch.object(planner, "_resolve_story_points_field", return_value="sp"):
+            with pytest.raises(JiraStoryPlannerError):
+                planner._create_issues(drafts)
 
 
 def test_plan_logs_metrics(monkeypatch, caplog):


### PR DESCRIPTION
### **User description**
## Summary
- convert planning messages to Gemini-compatible format in `_call_llm`
- parse JSON responses inside code blocks
- test JSON extraction from code-fenced replies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'readmeai')*
- `python tools/get_action_status.py --branch main`

------
https://chatgpt.com/codex/tasks/task_b_6869db30ab2883318993d5cee33f1616


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix Gemini prompt formatting by converting message roles

- Add JSON extraction from code blocks in LLM responses

- Improve error handling for malformed JSON responses

- Add comprehensive test coverage for JSON parsing


___

### **Changes diagram**

```mermaid
flowchart LR
  A["LLM Prompt"] --> B["Role Conversion"]
  B --> C["Gemini API Call"]
  C --> D["Raw Response"]
  D --> E["JSON Extraction"]
  E --> F["Story Validation"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_story_planner.py</strong><dd><code>Enhanced LLM integration with robust JSON parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/planning/jira_story_planner.py

<li>Convert prompt message roles to Gemini-compatible format<br> <li> Add <code>_extract_json</code> method to parse JSON from code blocks<br> <li> Replace direct JSON parsing with robust extraction logic<br> <li> Handle role mapping for assistant->model conversion


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/121/files#diff-41d33e9005803e9207cf82284f85579393fea61ddc83fa7776130e48e68d4f86">+46/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jira_story_planner.py</strong><dd><code>Add test coverage for JSON code block parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/planning/test_jira_story_planner.py

<li>Add test for JSON extraction from code-fenced blocks<br> <li> Verify proper parsing of JSON wrapped in markdown code blocks<br> <li> Test story validation with extracted JSON data


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/121/files#diff-de92bffe1bc4ea2119117670757f6ed448cac835865c129e610aa95c0558f945">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>