### PR TITLE
Add Jira planning HTML form

### DIFF
--- a/api_service/api/routers/planning.py
+++ b/api_service/api/routers/planning.py
@@ -1,13 +1,20 @@
+import json
 import logging
+import os
 from typing import List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 from moonmind.planning import (JiraStoryPlanner, JiraStoryPlannerError,
                                StoryDraft)
 
 router = APIRouter()
+
+TEMPLATES_DIR = "api_service/templates"
+templates = Jinja2Templates(directory=TEMPLATES_DIR)
 
 
 class JiraPlanRequest(BaseModel):
@@ -30,3 +37,46 @@ async def plan_jira_stories(request: JiraPlanRequest):
         logging.getLogger(__name__).exception("Jira planning failed: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc))
 
+
+@router.get("/jira/ui", response_class=HTMLResponse, name="jira_planner_ui")
+async def get_jira_planner_page(request: Request):
+    """Render the Jira planning form."""
+    return templates.TemplateResponse(
+        "planning.html", {"request": request, "result": None, "message": None}
+    )
+
+
+@router.post("/jira/ui", response_class=HTMLResponse, name="jira_planner_submit")
+async def handle_jira_planner_form(request: Request):
+    """Handle Jira planning form submission."""
+    form_data = await request.form()
+    plan_text = form_data.get("plan_text", "")
+    jira_project_key = form_data.get("jira_project_key", "")
+    dry_run = form_data.get("dry_run") not in (None, "", "false", "off")
+
+    for var in ("ATLASSIAN_API_KEY", "ATLASSIAN_USERNAME", "ATLASSIAN_URL"):
+        val = form_data.get(var)
+        if val:
+            os.environ[var] = val
+
+    message = None
+    result = None
+
+    if not plan_text or not jira_project_key:
+        message = "plan_text and jira_project_key are required."
+    else:
+        planner = JiraStoryPlanner(
+            plan_text=plan_text, jira_project_key=jira_project_key, dry_run=dry_run
+        )
+        try:
+            drafts = planner.plan()
+            result = json.dumps([d.model_dump() for d in drafts], indent=2)
+            message = "Planning successful."
+        except JiraStoryPlannerError as exc:
+            logging.getLogger(__name__).exception("Jira planning failed: %s", exc)
+            message = f"Planning failed: {exc}"
+
+    return templates.TemplateResponse(
+        "planning.html",
+        {"request": request, "result": result, "message": message},
+    )

--- a/api_service/templates/planning.html
+++ b/api_service/templates/planning.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jira Planner</title>
+    <style>
+        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
+        .container { background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); max-width: 600px; margin: auto; }
+        textarea, input[type="text"], input[type="password"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 15px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        label { display: block; margin-bottom: 5px; font-weight: bold; }
+        button { background-color: #007bff; color: white; padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        button:hover { background-color: #0056b3; }
+        pre { background-color: #eee; padding: 10px; border-radius: 4px; overflow-x: auto; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Plan Jira Stories</h1>
+        <form method="POST" action="{{ request.url_for('jira_planner_submit') }}">
+            <label for="plan_text">Plan Text</label>
+            <textarea id="plan_text" name="plan_text" rows="8" placeholder="Describe the work to plan"></textarea>
+            <label for="jira_project_key">Jira Project Key</label>
+            <input type="text" id="jira_project_key" name="jira_project_key" placeholder="PROJECT">
+            <label><input type="checkbox" name="dry_run" checked> Dry Run</label>
+            <h2>Jira Settings</h2>
+            <label for="ATLASSIAN_API_KEY">ATLASSIAN_API_KEY</label>
+            <input type="password" id="ATLASSIAN_API_KEY" name="ATLASSIAN_API_KEY" placeholder="ATLASSIAN_API_KEY">
+            <label for="ATLASSIAN_USERNAME">ATLASSIAN_USERNAME</label>
+            <input type="text" id="ATLASSIAN_USERNAME" name="ATLASSIAN_USERNAME" placeholder="ATLASSIAN_USERNAME">
+            <label for="ATLASSIAN_URL">ATLASSIAN_URL</label>
+            <input type="text" id="ATLASSIAN_URL" name="ATLASSIAN_URL" placeholder="https://jira.example.com">
+            <button type="submit">Submit</button>
+        </form>
+        {% if message %}
+            <p>{{ message }}</p>
+        {% endif %}
+        {% if result %}
+            <h2>Result</h2>
+            <pre>{{ result }}</pre>
+        {% endif %}
+    </div>
+</body>
+</html>

--- a/tests/unit/api/test_planning_ui.py
+++ b/tests/unit/api/test_planning_ui.py
@@ -1,0 +1,53 @@
+import json
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api_service.api.routers import planning as planning_router
+from moonmind.planning import StoryDraft
+
+app = FastAPI()
+app.include_router(planning_router.router, prefix="/v1/planning")
+client = TestClient(app)
+
+# Mock templates like in profile tests
+mock_templates = AsyncMock()
+
+def template_side_effect(name, context, status_code=200, headers=None):
+    return planning_router.HTMLResponse(
+        content=f"<html>{name}</html>", status_code=status_code, headers=headers
+    )
+
+mock_templates.TemplateResponse = MagicMock(side_effect=template_side_effect)
+planning_router.templates = mock_templates
+
+
+def test_get_planner_page():
+    response = client.get("/v1/planning/jira/ui")
+    assert response.status_code == 200
+    mock_templates.TemplateResponse.assert_called_once()
+    args, kwargs = mock_templates.TemplateResponse.call_args
+    assert args[0] == "planning.html"
+    context = args[1]
+    assert context["result"] is None
+
+
+def test_post_planner_page_success():
+    draft = StoryDraft(summary="s", description="d", issue_type="Task")
+    planner_instance = MagicMock()
+    planner_instance.plan.return_value = [draft]
+    with patch("api_service.api.routers.planning.JiraStoryPlanner", return_value=planner_instance):
+        response = client.post(
+            "/v1/planning/jira/ui",
+            data={
+                "plan_text": "do work",
+                "jira_project_key": "PROJ",
+                "dry_run": "on",
+                "ATLASSIAN_API_KEY": "k",
+                "ATLASSIAN_USERNAME": "u",
+                "ATLASSIAN_URL": "http://j",
+            },
+        )
+    assert response.status_code == 200
+    mock_templates.TemplateResponse.assert_called()
+    planner_instance.plan.assert_called_once()


### PR DESCRIPTION
### **User description**
## Summary
- add `planning.html` template for Jira planning form
- extend planning router with HTML endpoints
- test the new planner UI

## Testing
- `pytest tests/unit/api/test_planning_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68708b5528ec8331824bfe46faf4a85c


___

### **PR Type**
Enhancement


___

### **Description**
- Add HTML form UI for Jira story planning

- Extend planning router with GET/POST endpoints

- Include form validation and error handling

- Add comprehensive unit tests for UI functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User"] --> B["GET /jira/ui"]
  B --> C["planning.html form"]
  C --> D["POST /jira/ui"]
  D --> E["JiraStoryPlanner"]
  E --> F["JSON results display"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planning.py</strong><dd><code>Add HTML endpoints for planning form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/api/routers/planning.py

<li>Add Jinja2Templates setup and HTML response imports<br> <li> Create GET endpoint for rendering planning form<br> <li> Add POST endpoint for form submission with validation<br> <li> Include environment variable handling for Atlassian credentials


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/124/files#diff-b384e849ee5482ebe9704695ecde46c0768aeb8ce6549ba400447b120e9cfd66">+51/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>planning.html</strong><dd><code>Create Jira planning HTML template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/templates/planning.html

<li>Create complete HTML form with styling<br> <li> Include fields for plan text and Jira configuration<br> <li> Add result display area with JSON formatting<br> <li> Implement responsive design with CSS styling


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/124/files#diff-761f286ee2a104a47ed03a7c176393fd8d951916df3c03d8f3da1dc7b8194fe9">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_planning_ui.py</strong><dd><code>Add unit tests for planning UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/api/test_planning_ui.py

<li>Create comprehensive test suite for UI endpoints<br> <li> Mock templates and JiraStoryPlanner dependencies<br> <li> Test both GET form rendering and POST form submission<br> <li> Verify proper context passing and planner integration


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/124/files#diff-b0d39f54f66acb73b597a94f91cc7bcbdaeb3804ec77f3a95bbb97eb2981f8f2">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>