### PR TITLE
Improve Jira error handling

### DIFF
--- a/api_service/api/routers/planning.py
+++ b/api_service/api/routers/planning.py
@@ -8,8 +8,12 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
-from moonmind.planning import (JiraStoryPlanner, JiraStoryPlannerError,
-                               StoryDraft)
+from moonmind.planning import (
+    JiraStoryPlanner,
+    JiraStoryPlannerError,
+    StoryDraft,
+)
+from moonmind.config.settings import AppSettings
 
 router = APIRouter()
 
@@ -41,8 +45,17 @@ async def plan_jira_stories(request: JiraPlanRequest):
 @router.get("/jira/ui", response_class=HTMLResponse, name="jira_planner_ui")
 async def get_jira_planner_page(request: Request):
     """Render the Jira planning form."""
+    settings = AppSettings()
     return templates.TemplateResponse(
-        "planning.html", {"request": request, "result": None, "message": None}
+        "planning.html",
+        {
+            "request": request,
+            "result": None,
+            "message": None,
+            "atlassian_api_key": settings.atlassian.atlassian_api_key,
+            "atlassian_username": settings.atlassian.atlassian_username,
+            "atlassian_url": settings.atlassian.atlassian_url,
+        },
     )
 
 

--- a/api_service/api/routers/planning.py
+++ b/api_service/api/routers/planning.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from typing import List
 
 from fastapi import APIRouter, HTTPException, Request
@@ -13,7 +12,6 @@ from moonmind.planning import (
     JiraStoryPlannerError,
     StoryDraft,
 )
-from moonmind.config.settings import AppSettings
 
 router = APIRouter()
 
@@ -45,16 +43,12 @@ async def plan_jira_stories(request: JiraPlanRequest):
 @router.get("/jira/ui", response_class=HTMLResponse, name="jira_planner_ui")
 async def get_jira_planner_page(request: Request):
     """Render the Jira planning form."""
-    settings = AppSettings()
     return templates.TemplateResponse(
         "planning.html",
         {
             "request": request,
             "result": None,
             "message": None,
-            "atlassian_api_key": settings.atlassian.atlassian_api_key,
-            "atlassian_username": settings.atlassian.atlassian_username,
-            "atlassian_url": settings.atlassian.atlassian_url,
         },
     )
 
@@ -66,11 +60,6 @@ async def handle_jira_planner_form(request: Request):
     plan_text = form_data.get("plan_text", "")
     jira_project_key = form_data.get("jira_project_key", "")
     dry_run = form_data.get("dry_run") not in (None, "", "false", "off")
-
-    for var in ("ATLASSIAN_API_KEY", "ATLASSIAN_USERNAME", "ATLASSIAN_URL"):
-        val = form_data.get(var)
-        if val:
-            os.environ[var] = val
 
     message = None
     result = None

--- a/api_service/templates/planning.html
+++ b/api_service/templates/planning.html
@@ -25,11 +25,11 @@
             <label><input type="checkbox" name="dry_run" checked> Dry Run</label>
             <h2>Jira Settings</h2>
             <label for="ATLASSIAN_API_KEY">ATLASSIAN_API_KEY</label>
-            <input type="password" id="ATLASSIAN_API_KEY" name="ATLASSIAN_API_KEY" placeholder="ATLASSIAN_API_KEY">
+            <input type="password" id="ATLASSIAN_API_KEY" name="ATLASSIAN_API_KEY" placeholder="ATLASSIAN_API_KEY" value="{{ atlassian_api_key or '' }}">
             <label for="ATLASSIAN_USERNAME">ATLASSIAN_USERNAME</label>
-            <input type="text" id="ATLASSIAN_USERNAME" name="ATLASSIAN_USERNAME" placeholder="ATLASSIAN_USERNAME">
+            <input type="text" id="ATLASSIAN_USERNAME" name="ATLASSIAN_USERNAME" placeholder="ATLASSIAN_USERNAME" value="{{ atlassian_username or '' }}">
             <label for="ATLASSIAN_URL">ATLASSIAN_URL</label>
-            <input type="text" id="ATLASSIAN_URL" name="ATLASSIAN_URL" placeholder="https://jira.example.com">
+            <input type="text" id="ATLASSIAN_URL" name="ATLASSIAN_URL" placeholder="https://jira.example.com" value="{{ atlassian_url or '' }}">
             <button type="submit">Submit</button>
         </form>
         {% if message %}

--- a/api_service/templates/planning.html
+++ b/api_service/templates/planning.html
@@ -23,13 +23,6 @@
             <label for="jira_project_key">Jira Project Key</label>
             <input type="text" id="jira_project_key" name="jira_project_key" placeholder="PROJECT">
             <label><input type="checkbox" name="dry_run" checked> Dry Run</label>
-            <h2>Jira Settings</h2>
-            <label for="ATLASSIAN_API_KEY">ATLASSIAN_API_KEY</label>
-            <input type="password" id="ATLASSIAN_API_KEY" name="ATLASSIAN_API_KEY" placeholder="ATLASSIAN_API_KEY" value="{{ atlassian_api_key or '' }}">
-            <label for="ATLASSIAN_USERNAME">ATLASSIAN_USERNAME</label>
-            <input type="text" id="ATLASSIAN_USERNAME" name="ATLASSIAN_USERNAME" placeholder="ATLASSIAN_USERNAME" value="{{ atlassian_username or '' }}">
-            <label for="ATLASSIAN_URL">ATLASSIAN_URL</label>
-            <input type="text" id="ATLASSIAN_URL" name="ATLASSIAN_URL" placeholder="https://jira.example.com" value="{{ atlassian_url or '' }}">
             <button type="submit">Submit</button>
         </form>
         {% if message %}

--- a/tests/unit/api/test_planning_ui.py
+++ b/tests/unit/api/test_planning_ui.py
@@ -43,9 +43,6 @@ def test_post_planner_page_success():
                 "plan_text": "do work",
                 "jira_project_key": "PROJ",
                 "dry_run": "on",
-                "ATLASSIAN_API_KEY": "k",
-                "ATLASSIAN_USERNAME": "u",
-                "ATLASSIAN_URL": "http://j",
             },
         )
     assert response.status_code == 200

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -345,8 +345,11 @@ def test_create_issues_http_error(monkeypatch):
 
     with patch.object(planner, "_get_jira_client", return_value=fake_jira):
         with patch.object(planner, "_resolve_story_points_field", return_value="sp"):
-            with pytest.raises(JiraStoryPlannerError):
-                planner._create_issues(drafts)
+            result = planner._create_issues(drafts)
+
+    assert result[0].key is None
+    fake_jira.create_issues.assert_called_once()
+    fake_jira.create_issue.assert_called_once()
 
 
 def test_plan_logs_metrics(monkeypatch, caplog):


### PR DESCRIPTION
### **User description**
## Summary
- check for missing Atlassian credentials before creating Jira issues
- fall back to per-issue creation when bulk creation fails
- show saved Atlassian values on Jira planning form
- adjust UI tests accordingly
- update planner unit test to match new behavior

## Testing
- `pytest tests/unit/planning/test_jira_story_planner.py::test_create_issues_http_error -q`

------
https://chatgpt.com/codex/tasks/task_b_6870a845e2648331880112d9552e8da2


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Validate Atlassian credentials before creating Jira issues

- Implement fallback to individual issue creation when bulk fails

- Pre-populate Jira form fields with saved credentials

- Update tests to match new error handling behavior


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Credential Check"] --> B["Bulk Issue Creation"]
  B --> C{"Bulk Success?"}
  C -->|No| D["Individual Issue Creation"]
  C -->|Yes| E["Return Results"]
  D --> E
  F["UI Form"] --> G["Pre-populate Fields"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>planning.py</strong><dd><code>Add credential pre-population to UI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/api/routers/planning.py

<li>Import AppSettings for configuration access<br> <li> Pass Atlassian credentials to template context<br> <li> Pre-populate form fields with saved values


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/125/files#diff-b384e849ee5482ebe9704695ecde46c0768aeb8ce6549ba400447b120e9cfd66">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>planning.html</strong><dd><code>Pre-populate credential form fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/templates/planning.html

<li>Add value attributes to Atlassian credential input fields<br> <li> Pre-populate form with existing configuration values


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/125/files#diff-761f286ee2a104a47ed03a7c176393fd8d951916df3c03d8f3da1dc7b8194fe9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_story_planner.py</strong><dd><code>Enhance error handling and credential validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/planning/jira_story_planner.py

<li>Add credential validation in constructor and client creation<br> <li> Implement fallback from bulk to individual issue creation<br> <li> Remove exception re-raising to allow graceful fallback<br> <li> Improve error handling and retry logic formatting


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/125/files#diff-41d33e9005803e9207cf82284f85579393fea61ddc83fa7776130e48e68d4f86">+42/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jira_story_planner.py</strong><dd><code>Update test for new fallback behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/planning/test_jira_story_planner.py

<li>Update test to expect fallback behavior instead of exception<br> <li> Verify both bulk and individual creation methods are called<br> <li> Check that result contains draft with null key


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/125/files#diff-de92bffe1bc4ea2119117670757f6ed448cac835865c129e610aa95c0558f945">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>