### PR TITLE
Add option to disable story points

### DIFF
--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -112,7 +112,11 @@ class JiraStoryPlanner:
             fields.append("story_points")
         fields.append("labels")
 
-        field_list = ", ".join(f"'{f}'" for f in fields)
+        if self.include_story_points:
+            field_list = ", ".join(f"'{f}'" for f in fields[:-1])
+            field_list += f", and '{fields[-1]}'"
+        else:
+            field_list = ", ".join(f"'{f}'" for f in fields)
 
         system_prompt = (
             "You are a Jira planning assistant. "


### PR DESCRIPTION
### **User description**
## Summary
- add `include_story_points` option to JiraStoryPlanner
- support omitted story points in prompts and Jira issue creation
- test planner behaviour when story points are disabled

## Testing
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'readmeai')*

------
https://chatgpt.com/codex/tasks/task_b_6870b050fb8c833190a7bd7f31d04398


___

### **PR Type**
Enhancement


___

### **Description**
- Add `include_story_points` parameter to JiraStoryPlanner

- Modify prompt generation to conditionally include story points

- Update issue creation logic to skip story points when disabled

- Add comprehensive tests for story points disabled functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["JiraStoryPlanner"] --> B["include_story_points parameter"]
  B --> C["Conditional prompt generation"]
  B --> D["Conditional issue creation"]
  C --> E["Modified system prompt"]
  D --> F["Skip story points field"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_story_planner.py</strong><dd><code>Add configurable story points support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/planning/jira_story_planner.py

<li>Add <code>include_story_points</code> parameter to constructor with default True<br> <li> Modify <code>_build_prompt</code> to conditionally include story points in field <br>list<br> <li> Update <code>_create_issues</code> to skip story points field resolution and <br>assignment when disabled<br> <li> Add conditional logic in error handling for story points field issues


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/126/files#diff-41d33e9005803e9207cf82284f85579393fea61ddc83fa7776130e48e68d4f86">+23/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jira_story_planner.py</strong><dd><code>Add tests for disabled story points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/planning/test_jira_story_planner.py

<li>Add <code>test_build_prompt_no_story_points</code> to verify prompt generation <br>without story points<br> <li> Add <code>test_create_issues_skip_story_points</code> to verify issue creation <br>skips story points resolution<br> <li> Test that story points field resolver is not called when disabled


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/126/files#diff-de92bffe1bc4ea2119117670757f6ed448cac835865c129e610aa95c0558f945">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>