### PR TITLE
Add manifest schema models

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,3 +511,14 @@ To execute the Confluence integration tests, run the following command from the 
 .\tools\test-integration.ps1
 ```
 The tests will be skipped if the required Confluence environment variables (`CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `TEST_CONFLUENCE_SPACE_KEY`) are not found in the `.env` file.
+
+## Manifests
+
+Reader configurations can be validated using the `Manifest` schema. For example:
+
+```python
+from moonmind.schemas import Manifest
+manifest = Manifest.model_validate_yaml("samples/github_manifest.yaml")
+```
+
+The JSON Schema can be exported with `export_schema("manifest.schema.json")`.

--- a/manifest.schema.json
+++ b/manifest.schema.json
@@ -1,0 +1,164 @@
+{
+  "$defs": {
+    "AuthItem": {
+      "properties": {
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value"
+        },
+        "secretRef": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SecretRef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "AuthItem",
+      "type": "object"
+    },
+    "Defaults": {
+      "additionalProperties": true,
+      "title": "Defaults",
+      "type": "object"
+    },
+    "Reader": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        },
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "init": {
+          "additionalProperties": true,
+          "title": "Init",
+          "type": "object"
+        },
+        "load_data": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Load Data",
+          "type": "array"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "title": "Reader",
+      "type": "object"
+    },
+    "SecretRef": {
+      "properties": {
+        "provider": {
+          "title": "Provider",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "extra": {
+          "additionalProperties": true,
+          "title": "Extra",
+          "type": "object"
+        }
+      },
+      "required": [
+        "provider",
+        "key"
+      ],
+      "title": "SecretRef",
+      "type": "object"
+    },
+    "Spec": {
+      "properties": {
+        "defaults": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Defaults"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "auth": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AuthItem"
+          },
+          "title": "Auth",
+          "type": "object"
+        },
+        "readers": {
+          "items": {
+            "$ref": "#/$defs/Reader"
+          },
+          "title": "Readers",
+          "type": "array"
+        }
+      },
+      "required": [
+        "readers"
+      ],
+      "title": "Spec",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "apiVersion": {
+      "title": "Apiversion",
+      "type": "string"
+    },
+    "kind": {
+      "title": "Kind",
+      "type": "string"
+    },
+    "metadata": {
+      "additionalProperties": true,
+      "title": "Metadata",
+      "type": "object"
+    },
+    "spec": {
+      "$ref": "#/$defs/Spec"
+    }
+  },
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec"
+  ],
+  "title": "Manifest",
+  "type": "object"
+}

--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -1,10 +1,10 @@
 from .manifest_models import (
-    SecretRef,
     AuthItem,
     Defaults,
-    Reader,
-    Spec,
     Manifest,
+    Reader,
+    SecretRef,
+    Spec,
     export_schema,
 )
 

--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -1,0 +1,19 @@
+from .manifest_models import (
+    SecretRef,
+    AuthItem,
+    Defaults,
+    Reader,
+    Spec,
+    Manifest,
+    export_schema,
+)
+
+__all__ = [
+    "SecretRef",
+    "AuthItem",
+    "Defaults",
+    "Reader",
+    "Spec",
+    "Manifest",
+    "export_schema",
+]

--- a/moonmind/schemas/manifest_models.py
+++ b/moonmind/schemas/manifest_models.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+from os import PathLike
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+
+class SecretRef(BaseModel):
+    provider: str
+    key: str
+    extra: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AuthItem(BaseModel):
+    value: Optional[str] = None
+    secretRef: Optional[SecretRef] = None
+
+    @model_validator(mode="after")
+    def check_xor(cls, values):  # type: ignore[override]
+        if (values.value is None) == (values.secretRef is None):
+            raise ValueError("Exactly one of value or secretRef must be provided")
+        return values
+
+
+from pydantic import RootModel
+
+
+class Defaults(RootModel[Dict[str, Any]]):
+    root: Dict[str, Any] = Field(default_factory=dict)
+
+
+class Reader(BaseModel):
+    name: Optional[str] = None
+    type: str
+    enabled: bool = True
+    init: Dict[str, Any] = Field(default_factory=dict)
+    load_data: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class Spec(BaseModel):
+    defaults: Optional[Defaults] = None
+    auth: Dict[str, AuthItem] = Field(default_factory=dict)
+    readers: List[Reader]
+
+
+class Manifest(BaseModel):
+    apiVersion: str
+    kind: str
+    metadata: Dict[str, Any]
+    spec: Spec
+
+    @classmethod
+    def model_validate_yaml(cls, data: PathLike | str) -> "Manifest":
+        if isinstance(data, (str, Path)) and not isinstance(data, bytes):
+            if isinstance(data, (str, Path)) and Path(str(data)).exists():
+                content = Path(str(data)).read_text()
+            else:
+                content = data
+        else:
+            raise TypeError("model_validate_yaml expects a path or YAML string")
+        parsed = yaml.safe_load(content)
+        return cls.model_validate(parsed)
+
+
+def export_schema(path: PathLike) -> None:
+    path = Path(path)
+    import json
+
+    schema = Manifest.model_json_schema()
+    path.write_text(json.dumps(schema, indent=2))

--- a/moonmind/schemas/manifest_models.py
+++ b/moonmind/schemas/manifest_models.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, RootModel, model_validator
 
 
 class SecretRef(BaseModel):
@@ -19,13 +19,10 @@ class AuthItem(BaseModel):
     secretRef: Optional[SecretRef] = None
 
     @model_validator(mode="after")
-    def check_xor(cls, values):  # type: ignore[override]
-        if (values.value is None) == (values.secretRef is None):
+    def check_xor(cls, model: "AuthItem") -> "AuthItem":  # type: ignore[override]
+        if (model.value is None) == (model.secretRef is None):
             raise ValueError("Exactly one of value or secretRef must be provided")
-        return values
-
-
-from pydantic import RootModel
+        return model
 
 
 class Defaults(RootModel[Dict[str, Any]]):

--- a/moonmind/schemas/manifest_models.py
+++ b/moonmind/schemas/manifest_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 from os import PathLike
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml

--- a/samples/github_manifest.yaml
+++ b/samples/github_manifest.yaml
@@ -1,0 +1,36 @@
+apiVersion: moonmind/v1
+kind: Readers
+metadata:
+  name: moonmind-example
+  description: Example collection of data readers for MoonMind
+spec:
+  readers:
+    - type: GithubRepositoryReader
+      enabled: true
+      init:
+        github_client:
+          _type: llama_index.readers.github.github_client.GithubClient
+          _init:
+            github_token:
+              secretRef:
+                provider: profile
+                key: GITHUB_TOKEN
+            verbose: true
+            concurrent_requests: 10
+            timeout: 5
+            retries: 3
+        owner: MoonLadderStudios
+        repo: MoonMind
+        use_parser: true
+        verbose: true
+        concurrent_requests: 10
+        timeout: 5
+        retries: 3
+        filter_directories:
+          - ["tests"]
+          - "EXCLUDE"
+        filter_file_extensions:
+          - [".md", ".py", ".yaml"]
+          - "INCLUDE"
+      load_data:
+        - branch: main

--- a/tests/schemas/test_manifest_models.py
+++ b/tests/schemas/test_manifest_models.py
@@ -6,7 +6,6 @@ from pydantic import ValidationError
 
 from moonmind.schemas import Manifest, export_schema
 
-
 SAMPLE_PATH = Path("samples/github_manifest.yaml")
 
 

--- a/tests/schemas/test_manifest_models.py
+++ b/tests/schemas/test_manifest_models.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas import Manifest, export_schema
+
+
+SAMPLE_PATH = Path("samples/github_manifest.yaml")
+
+
+def test_happy_path():
+    manifest = Manifest.model_validate_yaml(SAMPLE_PATH)
+    assert manifest.spec.readers[0].type == "GithubRepositoryReader"
+
+
+def test_missing_readers():
+    bad_yaml = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec: {}
+"""
+    with pytest.raises(ValidationError):
+        Manifest.model_validate_yaml(bad_yaml)
+
+
+def test_auth_xor_rule():
+    bad_yaml = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  auth:
+    token:
+      value: abc
+      secretRef:
+        provider: env
+        key: TOKEN
+  readers: []
+"""
+    with pytest.raises(ValidationError):
+        Manifest.model_validate_yaml(bad_yaml)
+
+
+def test_export_schema(tmp_path):
+    out = tmp_path / "out.json"
+    export_schema(out)
+    data = json.loads(out.read_text())
+    assert data.get("title") == "Manifest"


### PR DESCRIPTION
### **User description**
## Summary
- define manifest models and schema export
- include sample manifest
- expose manifest models from schemas package
- add unit tests for manifest schema
- document manifest usage in README

## Testing
- `pytest -q tests/schemas/test_manifest_models.py`

------
https://chatgpt.com/codex/tasks/task_b_68735d4ce2c48331b2d218e21fab1426


___

### **PR Type**
Enhancement


___

### **Description**
- Add Pydantic models for manifest schema validation

- Include JSON schema export functionality

- Add comprehensive unit tests for validation

- Document manifest usage in README


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Manifest Models"] --> B["Schema Export"]
  A --> C["YAML Validation"]
  A --> D["Unit Tests"]
  B --> E["JSON Schema File"]
  C --> F["Sample Manifest"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Initialize schemas package with exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/schemas/__init__.py

<li>Export all manifest model classes and functions<br> <li> Define package public API with <code>__all__</code>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-8db2ee90d0278183870473a201900e75066bf9c7a786238a53f03a6462603f59">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifest.schema.json</strong><dd><code>Generated JSON schema file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest.schema.json

<li>Generated JSON schema for manifest validation<br> <li> Includes all model definitions and constraints


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-172a5c54b45d9ba109c2bf7d8d2bad6c8ac390e65801ede13ad2953dd6421124">+164/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest_models.py</strong><dd><code>Core manifest schema models implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/schemas/manifest_models.py

<li>Define Pydantic models for manifest structure (<code>SecretRef</code>, <code>AuthItem</code>, <br><code>Defaults</code>, <code>Reader</code>, <code>Spec</code>, <code>Manifest</code>)<br> <li> Add YAML validation with <code>model_validate_yaml</code> method<br> <li> Include XOR validation for <code>AuthItem</code> (value or secretRef)<br> <li> Implement <code>export_schema</code> function for JSON schema generation


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-8bc8699edc6066b533861398d1a2c5155aa0237af7d081724e9c58791299f60c">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_manifest_models.py</strong><dd><code>Comprehensive manifest validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/schemas/test_manifest_models.py

<li>Test happy path YAML validation<br> <li> Test validation errors for missing required fields<br> <li> Test XOR constraint enforcement for auth items<br> <li> Test schema export functionality


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-8ce11e621aba3f9775d1d7f697e06fc8f199c81cf255bd3b9a5f9e5cc9c3bab2">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document manifest schema usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Add manifest usage documentation section<br> <li> Show example of YAML validation<br> <li> Document schema export functionality


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github_manifest.yaml</strong><dd><code>Sample GitHub manifest configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

samples/github_manifest.yaml

<li>Sample manifest configuration for GitHub reader<br> <li> Demonstrates auth with secret references<br> <li> Shows reader configuration structure


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/130/files#diff-145df32bdb855f56ab85cf5cc6d13637980f41c54602a64dee581b3de278dfc7">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>