### PR TITLE
Add YAML manifest loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ The API container is powered by FastAPI and LangChain, employing Dependency Inje
 
 ## Apps
 
-Apps are higher-level workflows built on top of MoonMind. They can be invoked from the CLI or other tools using the Model Context Protocol. When started with a manifest file, the application loads reader definitions and default settings from YAML, merging them with the existing environment-based configuration.
+Apps are higher-level workflows built on top of MoonMind. They can be invoked from the CLI or other tools using the Model Context Protocol. When started with a manifest file, the application uses `ManifestLoader` to read reader definitions and defaults from YAML, returning a new settings instance that merges the manifest values with the environment configuration.
 
 ## Running the VLLM Service
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,10 @@ If using the default Ollama container, an NVIDIA GPU with appropriate drivers is
 
 The API container is powered by FastAPI and LangChain, employing Dependency Injection with abstract interfaces to enable modular service selection. It supports both OpenAI-compatible endpoints and the Model Context Protocol, making it versatile for different client applications and AI agents.
 
+## Apps
+
+Apps are higher-level workflows built on top of MoonMind. They can be invoked from the CLI or other tools using the Model Context Protocol. When started with a manifest file, the application loads reader definitions and default settings from YAML, merging them with the existing environment-based configuration.
+
 ## Running the VLLM Service
 
 This project includes a Docker Compose configuration to run a VLLM (Very Large Language Model) service with GPU acceleration, providing an OpenAI-compatible API endpoint.

--- a/moonmind/manifest/__init__.py
+++ b/moonmind/manifest/__init__.py
@@ -1,0 +1,3 @@
+from .loader import ManifestLoader
+
+__all__ = ["ManifestLoader"]

--- a/moonmind/manifest/loader.py
+++ b/moonmind/manifest/loader.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
+
+import yaml
+from pydantic import ValidationError
 
 import moonmind.config as settings_module
 from moonmind.config.settings import AppSettings
@@ -14,22 +17,29 @@ class ManifestLoader:
     def __init__(self, path: str | None = None) -> None:
         self.path = path
 
-    def load(self) -> Optional[Manifest]:
-        """Return the parsed Manifest and apply defaults if present."""
+    def load(self) -> Tuple[Optional[Manifest], AppSettings]:
+        """Return the parsed Manifest and merged settings."""
+        current_settings = settings_module.settings
+
         if not self.path:
-            return None
+            return None, current_settings
 
         manifest_path = Path(self.path)
         if not manifest_path.exists():
             raise FileNotFoundError(f"Manifest not found: {manifest_path}")
 
-        manifest = Manifest.model_validate_yaml(manifest_path)
+        try:
+            manifest = Manifest.model_validate_yaml(manifest_path)
+        except (yaml.YAMLError, ValidationError) as exc:
+            raise ValueError(f"Failed to parse manifest: {exc}") from exc
 
         if manifest.spec.defaults is not None:
             merged = {
-                **settings_module.settings.model_dump(),
-                **manifest.spec.defaults.root,
+                **current_settings.model_dump(),
+                **manifest.spec.defaults.model_dump(),
             }
-            settings_module.settings = AppSettings.model_validate(merged)
+            new_settings = AppSettings.model_validate(merged)
+        else:
+            new_settings = current_settings
 
-        return manifest
+        return manifest, new_settings

--- a/moonmind/manifest/loader.py
+++ b/moonmind/manifest/loader.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import moonmind.config.settings as settings_module
+from moonmind.config.settings import AppSettings
+from moonmind.schemas import Manifest
+
+
+class ManifestLoader:
+    """Load a YAML manifest and merge defaults with application settings."""
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = path
+
+    def load(self) -> Optional[Manifest]:
+        """Return the parsed Manifest and apply defaults if present."""
+        if not self.path:
+            return None
+
+        manifest_path = Path(self.path)
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+        manifest = Manifest.model_validate_yaml(manifest_path)
+
+        if manifest.spec.defaults is not None:
+            merged = {
+                **settings_module.settings.model_dump(),
+                **manifest.spec.defaults.root,
+            }
+            settings_module.settings = AppSettings.model_validate(merged)
+
+        return manifest

--- a/moonmind/manifest/loader.py
+++ b/moonmind/manifest/loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-import moonmind.config.settings as settings_module
+import moonmind.config as settings_module
 from moonmind.config.settings import AppSettings
 from moonmind.schemas import Manifest
 

--- a/moonmind/utils/env_bool.py
+++ b/moonmind/utils/env_bool.py
@@ -1,4 +1,7 @@
-from distutils.util import strtobool
+try:  # Python < 3.12
+    from distutils.util import strtobool  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback for Python >= 3.12
+    from setuptools._distutils.util import strtobool
 from typing import Any, Optional
 
 

--- a/tests/unit/manifest/test_loader.py
+++ b/tests/unit/manifest/test_loader.py
@@ -1,6 +1,4 @@
-
-
-import moonmind.config.settings as settings_module
+import moonmind.config as config_module
 from moonmind.config.settings import AppSettings
 from moonmind.manifest.loader import ManifestLoader
 from moonmind.schemas import Manifest
@@ -20,10 +18,10 @@ spec:
     manifest_path = tmp_path / "manifest.yaml"
     manifest_path.write_text(manifest_content)
 
-    monkeypatch.setattr(settings_module, "settings", AppSettings())
+    monkeypatch.setattr(config_module, "settings", AppSettings())
 
     loader = ManifestLoader(str(manifest_path))
     manifest = loader.load()
 
     assert isinstance(manifest, Manifest)
-    assert settings_module.settings.openai.openai_enabled is False
+    assert config_module.settings.openai.openai_enabled is False

--- a/tests/unit/manifest/test_loader.py
+++ b/tests/unit/manifest/test_loader.py
@@ -1,0 +1,29 @@
+
+
+import moonmind.config.settings as settings_module
+from moonmind.config.settings import AppSettings
+from moonmind.manifest.loader import ManifestLoader
+from moonmind.schemas import Manifest
+
+
+def test_manifest_loader_merges_defaults(tmp_path, monkeypatch):
+    manifest_content = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  defaults:
+    openai:
+      openai_enabled: false
+  readers: []
+"""
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(manifest_content)
+
+    monkeypatch.setattr(settings_module, "settings", AppSettings())
+
+    loader = ManifestLoader(str(manifest_path))
+    manifest = loader.load()
+
+    assert isinstance(manifest, Manifest)
+    assert settings_module.settings.openai.openai_enabled is False


### PR DESCRIPTION
### **User description**
## Summary
- create `ManifestLoader` class to import YAML manifests and merge with Pydantic settings
- document new Apps concept in README
- test merging defaults via the loader

## Testing
- `pre-commit run --files README.md moonmind/manifest/__init__.py moonmind/manifest/loader.py tests/unit/manifest/test_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'readmeai')*

------
https://chatgpt.com/codex/tasks/task_b_6873f321b82c8331b1d68bf4176cceb1


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ManifestLoader` class for YAML manifest processing

- Implement settings merging with Pydantic configuration

- Document new Apps concept in README

- Add unit tests for manifest loading functionality


___

### **Changes diagram**

```mermaid
flowchart LR
  A["YAML Manifest"] --> B["ManifestLoader"]
  B --> C["Parsed Manifest"]
  B --> D["Settings Merge"]
  D --> E["Updated AppSettings"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Initialize manifest module exports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/__init__.py

- Export `ManifestLoader` class from module


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/131/files#diff-79ed2c23abff8f90f6ff15cfe3b205cb99fe89a9da7e5de51f826357b0996c98">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loader.py</strong><dd><code>Implement YAML manifest loader with settings merge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/loader.py

<li>Create <code>ManifestLoader</code> class with YAML loading capability<br> <li> Implement settings merging with manifest defaults<br> <li> Add file existence validation and error handling


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/131/files#diff-19541e22e66cd2acd593baaea852541bc1782beb10ddbe99f1e1ec63803ee5c0">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_loader.py</strong><dd><code>Add unit tests for manifest loader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_loader.py

<li>Add test for manifest loading and settings merging<br> <li> Verify OpenAI settings override functionality


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/131/files#diff-21b967013bf58eab195dd3b916968938f1afbed00980bcd3810598d957f2abd8">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Apps concept and manifest usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Document new Apps concept and workflow capabilities<br> <li> Explain manifest-based configuration loading


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/131/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>