### PR TITLE
Add YAML manifest interpolation

### DIFF
--- a/moonmind/manifest/__init__.py
+++ b/moonmind/manifest/__init__.py
@@ -1,4 +1,4 @@
-from .loader import ManifestLoader
 from .interpolation import InterpolationError, interpolate
+from .loader import ManifestLoader
 
 __all__ = ["ManifestLoader", "interpolate", "InterpolationError"]

--- a/moonmind/manifest/__init__.py
+++ b/moonmind/manifest/__init__.py
@@ -1,3 +1,4 @@
 from .loader import ManifestLoader
+from .interpolation import InterpolationError, interpolate
 
-__all__ = ["ManifestLoader"]
+__all__ = ["ManifestLoader", "interpolate", "InterpolationError"]

--- a/moonmind/manifest/interpolation.py
+++ b/moonmind/manifest/interpolation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from moonmind.schemas import Manifest, AuthItem
+
+
+class InterpolationError(Exception):
+    """Raised when an interpolation reference cannot be resolved."""
+
+
+_PATTERN = re.compile(r"^\$\{([^}]+)\}$")
+_ALLOWED_ROOTS = {"auth", "defaults", "env"}
+
+
+def interpolate(model: Manifest, env: Mapping[str, str]) -> Manifest:
+    """Return a new Manifest with ${...} references resolved."""
+
+    data = model.model_dump()
+    resolved = _apply(data, model, env)
+    return Manifest.model_validate(resolved)
+
+
+def _apply(value: Any, model: Manifest, env: Mapping[str, str]) -> Any:
+    if isinstance(value, str):
+        match = _PATTERN.fullmatch(value)
+        if match:
+            return _resolve(match.group(1), model, env)
+        return value
+    if isinstance(value, list):
+        return [_apply(v, model, env) for v in value]
+    if isinstance(value, dict):
+        return {k: _apply(v, model, env) for k, v in value.items()}
+    return value
+
+
+def _resolve(path: str, model: Manifest, env: Mapping[str, str]) -> Any:
+    parts = path.split(".")
+    if not parts:
+        raise InterpolationError("empty interpolation path")
+
+    root = parts.pop(0)
+    if root not in _ALLOWED_ROOTS:
+        raise InterpolationError(f"invalid root '{root}' in '{path}'")
+
+    if root == "env":
+        if not parts:
+            raise InterpolationError(f"invalid env reference '{path}'")
+        key = parts[0]
+        if key in env:
+            return env[key]
+        raise InterpolationError(f"env variable not found: {key}")
+
+    if root == "defaults":
+        cur: Any = model.spec.defaults.model_dump() if model.spec.defaults else {}
+        for part in parts:
+            if isinstance(cur, Mapping) and part in cur:
+                cur = cur[part]
+            else:
+                raise InterpolationError(f"unresolved path '{path}'")
+        return cur
+
+    # root == "auth"
+    if not parts:
+        raise InterpolationError(f"invalid auth reference '{path}'")
+    key = parts.pop(0)
+    item = model.spec.auth.get(key)
+    if item is None:
+        raise InterpolationError(f"unknown auth key '{key}'")
+    cur = _resolve_auth_item(item, env)
+    for part in parts:
+        if isinstance(cur, Mapping) and part in cur:
+            cur = cur[part]
+        else:
+            raise InterpolationError(f"unresolved path '{path}'")
+    return cur
+
+
+def _resolve_auth_item(item: AuthItem, env: Mapping[str, str]) -> Any:
+    if item.value is not None:
+        return item.value
+
+    provider = item.secretRef.provider
+    key = item.secretRef.key
+    if provider == "env":
+        if key in env:
+            return env[key]
+        raise InterpolationError(f"env variable not found: {key}")
+
+    raise InterpolationError(f"unsupported auth provider '{provider}'")

--- a/moonmind/manifest/interpolation.py
+++ b/moonmind/manifest/interpolation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Mapping
 
-from moonmind.schemas import Manifest, AuthItem
+from moonmind.schemas import AuthItem, Manifest
 
 
 class InterpolationError(Exception):

--- a/tests/unit/manifest/test_interpolation.py
+++ b/tests/unit/manifest/test_interpolation.py
@@ -1,0 +1,53 @@
+import pytest
+
+from moonmind.schemas import Manifest
+from moonmind.manifest import interpolate, InterpolationError
+
+
+def test_interpolate_success():
+    yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  defaults:
+    verbose: true
+    api_url: http://example.com
+  auth:
+    github_token:
+      value: abc123
+  readers:
+    - type: Dummy
+      enabled: true
+      init:
+        token: "${auth.github_token}"
+        url: "${defaults.api_url}"
+        home: "${env.HOME_VAR}"
+"""
+    env = {"HOME_VAR": "/tmp"}
+    manifest = Manifest.model_validate_yaml(yaml_str)
+    result = interpolate(manifest, env)
+    init = result.spec.readers[0].init
+    assert init["token"] == "abc123"
+    assert init["url"] == "http://example.com"
+    assert init["home"] == "/tmp"
+
+
+def test_interpolate_unresolved():
+    yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  auth:
+    token:
+      value: secret
+  readers:
+    - type: Dummy
+      enabled: true
+      init:
+        token: "${auth.missing}"
+"""
+    manifest = Manifest.model_validate_yaml(yaml_str)
+    with pytest.raises(InterpolationError):
+        interpolate(manifest, {})

--- a/tests/unit/manifest/test_interpolation.py
+++ b/tests/unit/manifest/test_interpolation.py
@@ -1,7 +1,7 @@
 import pytest
 
+from moonmind.manifest import InterpolationError, interpolate
 from moonmind.schemas import Manifest
-from moonmind.manifest import interpolate, InterpolationError
 
 
 def test_interpolate_success():


### PR DESCRIPTION
### **User description**
## Summary
- add interpolation utilities and export them
- implement strict resolver for ${auth}, ${defaults} and ${env}
- test successful and failing interpolation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68740a0b894c833187392f1867facce3


___

### **PR Type**
Enhancement


___

### **Description**
- Add YAML manifest interpolation engine with strict resolver

- Support ${auth}, ${defaults}, and ${env} variable references

- Include comprehensive error handling for unresolved paths

- Export interpolation utilities from manifest module


___

### **Changes diagram**

```mermaid
flowchart LR
  A["YAML Manifest"] --> B["Interpolation Engine"]
  B --> C["Resolve ${auth}"]
  B --> D["Resolve ${defaults}"]
  B --> E["Resolve ${env}"]
  C --> F["Interpolated Manifest"]
  D --> F
  E --> F
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export interpolation utilities from manifest module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/__init__.py

<li>Export <code>interpolate</code> function and <code>InterpolationError</code> class<br> <li> Update <code>__all__</code> list to include new interpolation utilities


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/132/files#diff-79ed2c23abff8f90f6ff15cfe3b205cb99fe89a9da7e5de51f826357b0996c98">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>interpolation.py</strong><dd><code>Add complete interpolation engine with strict resolver</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/interpolation.py

<li>Implement <code>interpolate()</code> function for resolving ${...} references<br> <li> Add strict resolver supporting auth, defaults, and env roots<br> <li> Include <code>InterpolationError</code> exception for unresolved references<br> <li> Handle nested path resolution with comprehensive error checking


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/132/files#diff-a85d00ac4307c40c3de8ef23d111634e74b893d330922743eda7866253545388">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_interpolation.py</strong><dd><code>Add comprehensive interpolation engine tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_interpolation.py

<li>Test successful interpolation of auth, defaults, and env variables<br> <li> Test error handling for unresolved interpolation references<br> <li> Validate interpolated manifest structure and values


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/132/files#diff-8cfcc690602b187ab9abb1a7dddfbf6538e9a6338a79240e91bff33544a03c66">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>