### PR TITLE
Update Jira planning prompt instructions

### DIFF
--- a/moonmind/planning/jira_story_planner.py
+++ b/moonmind/planning/jira_story_planner.py
@@ -98,6 +98,9 @@ class JiraStoryPlanner:
         ----------
         plan_text : str
             The raw text describing the plan to convert into Jira stories.
+            If the plan already lists individual stories, those entries should
+            be treated as the issues to create with any available context
+            appended.
 
         Returns
         -------
@@ -120,6 +123,8 @@ class JiraStoryPlanner:
 
         system_prompt = (
             "You are a Jira planning assistant. "
+            "If the plan already includes specific stories, use those as the "
+            "issues to create and simply add any provided context to each. "
             "Return ONLY a JSON array of issues using the fields "
             f"{field_list}."
         )

--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -40,9 +40,11 @@ def test_build_prompt(monkeypatch):
     from moonmind.schemas.chat_models import Message
 
     expected_system = (
-        "You are a Jira planning assistant. Return ONLY a JSON array of issues "
-        "using the fields 'summary', 'description', 'issue_type', 'story_points', "
-        "and 'labels'."
+        "You are a Jira planning assistant. "
+        "If the plan already includes specific stories, use those as the "
+        "issues to create and simply add any provided context to each. "
+        "Return ONLY a JSON array of issues using the fields "
+        "'summary', 'description', 'issue_type', 'story_points', and 'labels'."
     )
 
     assert messages == [
@@ -64,7 +66,13 @@ def test_build_prompt_no_story_points(monkeypatch):
 
     from moonmind.schemas.chat_models import Message
 
-    expected_system = "You are a Jira planning assistant. Return ONLY a JSON array of issues using the fields 'summary', 'description', 'issue_type', 'labels'."
+    expected_system = (
+        "You are a Jira planning assistant. "
+        "If the plan already includes specific stories, use those as the "
+        "issues to create and simply add any provided context to each. "
+        "Return ONLY a JSON array of issues using the fields "
+        "'summary', 'description', 'issue_type', 'labels'."
+    )
 
     assert messages == [
         Message(role="system", content=expected_system),


### PR DESCRIPTION
### **User description**
## Summary
- clarify docstring in JiraStoryPlanner about how to handle pre-defined stories
- mention existing stories in system prompt

## Testing
- `ruff check moonmind/planning/jira_story_planner.py`
- `pytest -q tests/test_jira_story_planner.py`

------
https://chatgpt.com/codex/tasks/task_b_68858f64e2c08331add1fac9d0409c83


___

### **PR Type**
Documentation


___

### **Description**
- Enhanced docstring to clarify handling of pre-defined stories

- Updated system prompt to mention existing stories processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docstring"] -- "clarify handling" --> B["Pre-defined Stories"]
  C["System Prompt"] -- "mention processing" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jira_story_planner.py</strong><dd><code>Enhanced prompt instructions for existing stories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/planning/jira_story_planner.py

<ul><li>Added clarification in <code>_build_prompt</code> docstring about handling <br>pre-defined stories<br> <li> Updated system prompt to mention processing existing stories from plan</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/135/files#diff-41d33e9005803e9207cf82284f85579393fea61ddc83fa7776130e48e68d4f86">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

