### PR TITLE
Implement secret provider system

### DIFF
--- a/moonmind/manifest/interpolation.py
+++ b/moonmind/manifest/interpolation.py
@@ -4,6 +4,7 @@ import re
 from typing import Any, Mapping, Optional
 
 from moonmind.schemas import AuthItem, Manifest
+
 from .secret_providers import (
     EnvSecretProvider,
     ProfileSecretProvider,
@@ -111,4 +112,3 @@ def _resolve_auth_item(item: AuthItem, manager: SecretProviderManager) -> Any:
         return manager.get_secret(provider, key)
     except ValueError as exc:
         raise InterpolationError(str(exc)) from exc
-

--- a/moonmind/manifest/secret_providers.py
+++ b/moonmind/manifest/secret_providers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Mapping, Optional, Protocol
+
+
+
+class SecretProvider(Protocol):
+    """Protocol for synchronous secret providers."""
+
+    def get_secret(self, key: str) -> Optional[str]:
+        ...
+
+
+class EnvSecretProvider:
+    def __init__(self, env: Mapping[str, str]):
+        self.env = env
+
+    def get_secret(self, key: str) -> Optional[str]:
+        return self.env.get(key)
+
+
+class ProfileSecretProvider:
+    def __init__(self, profile: Mapping[str, str]):
+        self.profile = profile
+
+    def get_secret(self, key: str) -> Optional[str]:
+        return self.profile.get(key)
+
+
+class SecretProviderManager:
+    def __init__(
+        self,
+        *,
+        profile_provider: SecretProvider | None = None,
+        env_provider: SecretProvider | None = None,
+        extra_providers: Mapping[str, SecretProvider] | None = None,
+    ) -> None:
+        self.profile_provider = profile_provider
+        self.env_provider = env_provider
+        self.providers = {k.lower(): v for k, v in (extra_providers or {}).items()}
+
+    def get_secret(self, provider: str, key: str) -> str:
+        provider_lc = provider.lower()
+        if provider_lc == "profile":
+            if self.profile_provider:
+                value = self.profile_provider.get_secret(key)
+                if value is not None:
+                    return value
+            if self.env_provider:
+                value = self.env_provider.get_secret(key)
+                if value is not None:
+                    return value
+            raise ValueError(f"secret not found: {key}")
+
+        if provider_lc == "env":
+            if not self.env_provider:
+                raise ValueError("env provider not configured")
+            value = self.env_provider.get_secret(key)
+            if value is None:
+                raise ValueError(f"env variable not found: {key}")
+            return value
+
+        provider_obj = self.providers.get(provider_lc)
+        if provider_obj is not None:
+            value = provider_obj.get_secret(key)
+            if value is None:
+                raise ValueError(f"secret not found: {key}")
+            return value
+        raise ValueError(f"unsupported auth provider '{provider}'")
+

--- a/moonmind/manifest/secret_providers.py
+++ b/moonmind/manifest/secret_providers.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 from typing import Mapping, Optional, Protocol
 
 
-
 class SecretProvider(Protocol):
     """Protocol for synchronous secret providers."""
 
-    def get_secret(self, key: str) -> Optional[str]:
-        ...
+    def get_secret(self, key: str) -> Optional[str]: ...
 
 
 class EnvSecretProvider:
@@ -67,4 +65,3 @@ class SecretProviderManager:
                 raise ValueError(f"secret not found: {key}")
             return value
         raise ValueError(f"unsupported auth provider '{provider}'")
-

--- a/tests/unit/manifest/test_interpolation.py
+++ b/tests/unit/manifest/test_interpolation.py
@@ -121,4 +121,3 @@ spec:
     manifest = Manifest.model_validate_yaml(yaml_str)
     with pytest.raises(InterpolationError):
         interpolate(manifest, {})
-

--- a/tests/unit/manifest/test_interpolation.py
+++ b/tests/unit/manifest/test_interpolation.py
@@ -51,3 +51,74 @@ spec:
     manifest = Manifest.model_validate_yaml(yaml_str)
     with pytest.raises(InterpolationError):
         interpolate(manifest, {})
+
+
+def test_secretref_profile_provider_with_env_fallback():
+    yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  auth:
+    token:
+      secretRef:
+        provider: profile
+        key: MY_TOKEN
+  readers:
+    - type: Dummy
+      enabled: true
+      init:
+        token: "${auth.token}"
+"""
+    manifest = Manifest.model_validate_yaml(yaml_str)
+    env = {"MY_TOKEN": "envtok"}
+    profile = {"MY_TOKEN": "profiletok"}
+    result = interpolate(manifest, env, profile)
+    init = result.spec.readers[0].init
+    assert init["token"] == "profiletok"
+
+
+def test_secretref_env_provider():
+    yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  auth:
+    token:
+      secretRef:
+        provider: env
+        key: ENV_ONLY
+  readers:
+    - type: Dummy
+      enabled: true
+      init:
+        token: "${auth.token}"
+"""
+    manifest = Manifest.model_validate_yaml(yaml_str)
+    env = {"ENV_ONLY": "envtok"}
+    result = interpolate(manifest, env)
+    assert result.spec.readers[0].init["token"] == "envtok"
+
+
+def test_secretref_unsupported_provider():
+    yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  auth:
+    token:
+      secretRef:
+        provider: unknown
+        key: X
+  readers:
+    - type: Dummy
+      enabled: true
+      init:
+        token: "${auth.token}"
+"""
+    manifest = Manifest.model_validate_yaml(yaml_str)
+    with pytest.raises(InterpolationError):
+        interpolate(manifest, {})
+


### PR DESCRIPTION
### **User description**
## Summary
- add a generic secret provider manager for manifest interpolation
- support profile and env providers with fallback logic
- update interpolation to use provider manager
- test secret reference resolution with profile and env providers

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6885eb5c5ed883319dc5f6d4daf0a5f9


___

### **PR Type**
Enhancement


___

### **Description**
- Implement flexible secret provider system for manifest interpolation

- Add profile provider with environment fallback logic

- Support extensible provider architecture with manager

- Add comprehensive test coverage for provider resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manifest"] --> B["SecretProviderManager"]
  B --> C["ProfileSecretProvider"]
  B --> D["EnvSecretProvider"]
  C --> E["Profile Secrets"]
  D --> F["Environment Variables"]
  E --> G["Resolved Values"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interpolation.py</strong><dd><code>Integrate secret provider manager into interpolation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/interpolation.py

<ul><li>Add <code>SecretProviderManager</code> integration to interpolation system<br> <li> Update <code>interpolate()</code> function to accept optional profile parameter<br> <li> Replace direct environment variable access with provider manager<br> <li> Modify <code>_resolve_auth_item()</code> to use provider manager for secret <br>resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/136/files#diff-a85d00ac4307c40c3de8ef23d111634e74b893d330922743eda7866253545388">+38/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>secret_providers.py</strong><dd><code>Add secret provider system with manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/secret_providers.py

<ul><li>Create <code>SecretProvider</code> protocol for extensible provider system<br> <li> Implement <code>EnvSecretProvider</code> for environment variable access<br> <li> Implement <code>ProfileSecretProvider</code> for profile-based secrets<br> <li> Add <code>SecretProviderManager</code> with fallback logic and provider <br>registration</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/136/files#diff-4931bfb9fa565eff4b760ac50160debc9a62895862821bb7ace6a82e7db0a831">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_interpolation.py</strong><dd><code>Add comprehensive secret provider tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_interpolation.py

<ul><li>Add test for profile provider with environment fallback<br> <li> Add test for environment-only provider resolution<br> <li> Add test for unsupported provider error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/136/files#diff-8cfcc690602b187ab9abb1a7dddfbf6538e9a6338a79240e91bff33544a03c66">+71/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

