### PR TITLE
Implement manifest runner

### DIFF
--- a/moonmind/manifest/__init__.py
+++ b/moonmind/manifest/__init__.py
@@ -1,4 +1,5 @@
 from .interpolation import InterpolationError, interpolate
 from .loader import ManifestLoader
+from .runner import ManifestRunner
 
-__all__ = ["ManifestLoader", "interpolate", "InterpolationError"]
+__all__ = ["ManifestLoader", "interpolate", "InterpolationError", "ManifestRunner"]

--- a/moonmind/manifest/runner.py
+++ b/moonmind/manifest/runner.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+from typing import Any, Dict, List, Optional
+
+from llama_index.core import download_loader
+
+from moonmind.schemas import Manifest
+
+
+class ManifestRunner:
+    """Run readers defined in a Manifest."""
+
+    def __init__(self, manifest: Manifest, logger: Optional[logging.Logger] = None) -> None:
+        self.manifest = manifest
+        self.logger = logger or logging.getLogger(__name__)
+
+    def run(self) -> Dict[str, List[Any]]:
+        """Instantiate and run each enabled reader.
+
+        Returns a mapping of reader name/type to the list of loaded data results.
+        """
+        results: Dict[str, List[Any]] = {}
+        for reader in self.manifest.spec.readers:
+            name = reader.name or reader.type
+            if not reader.enabled:
+                self.logger.info("Reader %s is disabled; skipping", name)
+                continue
+            try:
+                cls = self._load_reader_class(reader.type)
+                instance = cls(**reader.init)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.logger.exception("Failed to initialize reader %s: %s", name, exc)
+                continue
+
+            reader_results: List[Any] = []
+            for load_args in reader.load_data or [{}]:
+                try:
+                    data = instance.load_data(**load_args)
+                    reader_results.append(data)
+                except Exception as exc:  # pragma: no cover - defensive
+                    self.logger.exception(
+                        "Error loading data with reader %s: %s", name, exc
+                    )
+            results[name] = reader_results
+        return results
+
+    def _load_reader_class(self, type_name: str):
+        """Return the reader class for the given type name."""
+        try:
+            return download_loader(type_name)
+        except Exception:
+            # Fallback to importing from llama_index.readers package
+            try:
+                module = import_module(f"llama_index.readers.{type_name.lower()}")
+                return getattr(module, type_name)
+            except Exception:
+                module = import_module("llama_index.readers")
+                return getattr(module, type_name)
+

--- a/moonmind/manifest/runner.py
+++ b/moonmind/manifest/runner.py
@@ -12,7 +12,9 @@ from moonmind.schemas import Manifest
 class ManifestRunner:
     """Run readers defined in a Manifest."""
 
-    def __init__(self, manifest: Manifest, logger: Optional[logging.Logger] = None) -> None:
+    def __init__(
+        self, manifest: Manifest, logger: Optional[logging.Logger] = None
+    ) -> None:
         self.manifest = manifest
         self.logger = logger or logging.getLogger(__name__)
 
@@ -58,4 +60,3 @@ class ManifestRunner:
             except Exception:
                 module = import_module("llama_index.readers")
                 return getattr(module, type_name)
-

--- a/tests/unit/manifest/test_runner.py
+++ b/tests/unit/manifest/test_runner.py
@@ -1,0 +1,55 @@
+import logging
+from unittest.mock import patch
+
+from moonmind.manifest.runner import ManifestRunner
+from moonmind.schemas import Manifest
+
+
+yaml_str = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  readers:
+    - type: DummyReader
+      enabled: true
+      init:
+        token: 123
+      load_data:
+        - foo: bar
+"""
+
+
+class DummyReader:
+    def __init__(self, token: str):
+        self.token = token
+
+    def load_data(self, foo: str):
+        return [f"{self.token}-{foo}"]
+
+
+def test_runner_instantiates_and_runs():
+    manifest = Manifest.model_validate_yaml(yaml_str)
+
+    with patch("moonmind.manifest.runner.download_loader", return_value=DummyReader) as dl:
+        runner = ManifestRunner(manifest, logger=logging.getLogger("test"))
+        results = runner.run()
+
+    dl.assert_called_once_with("DummyReader")
+    assert results["DummyReader"][0] == ["123-bar"]
+
+
+def test_runner_handles_errors():
+    class BadReader(DummyReader):
+        def load_data(self, foo: str):
+            raise RuntimeError("boom")
+
+    manifest = Manifest.model_validate_yaml(yaml_str)
+
+    with patch("moonmind.manifest.runner.download_loader", return_value=BadReader):
+        runner = ManifestRunner(manifest, logger=logging.getLogger("test"))
+        results = runner.run()
+
+    # Error during load_data should result in empty list for the reader
+    assert results["DummyReader"] == []
+

--- a/tests/unit/manifest/test_runner.py
+++ b/tests/unit/manifest/test_runner.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from moonmind.manifest.runner import ManifestRunner
 from moonmind.schemas import Manifest
 
-
 yaml_str = """
 apiVersion: moonmind/v1
 kind: Readers
@@ -31,7 +30,9 @@ class DummyReader:
 def test_runner_instantiates_and_runs():
     manifest = Manifest.model_validate_yaml(yaml_str)
 
-    with patch("moonmind.manifest.runner.download_loader", return_value=DummyReader) as dl:
+    with patch(
+        "moonmind.manifest.runner.download_loader", return_value=DummyReader
+    ) as dl:
         runner = ManifestRunner(manifest, logger=logging.getLogger("test"))
         results = runner.run()
 
@@ -52,4 +53,3 @@ def test_runner_handles_errors():
 
     # Error during load_data should result in empty list for the reader
     assert results["DummyReader"] == []
-


### PR DESCRIPTION
### **User description**
## Summary
- implement `ManifestRunner` for dynamic reader instantiation
- expose runner from `moonmind.manifest`
- test runner logic

## Testing
- `pytest tests/unit/manifest/test_runner.py -q`
- `pytest -q`
- `python tools/get_action_status.py`

------
https://chatgpt.com/codex/tasks/task_b_68866b30b2748331803e4d08a9f9f28d


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ManifestRunner` class for dynamic reader instantiation

- Support loading readers via `download_loader` with fallback imports

- Handle reader initialization and data loading with error handling

- Expose runner through `moonmind.manifest` module interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manifest"] --> B["ManifestRunner"]
  B --> C["Load Reader Class"]
  C --> D["Instantiate Reader"]
  D --> E["Execute load_data"]
  E --> F["Return Results"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export ManifestRunner from manifest module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/__init__.py

<ul><li>Import and expose <code>ManifestRunner</code> class<br> <li> Add <code>ManifestRunner</code> to <code>__all__</code> exports</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/137/files#diff-79ed2c23abff8f90f6ff15cfe3b205cb99fe89a9da7e5de51f826357b0996c98">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runner.py</strong><dd><code>Add ManifestRunner class for dynamic reader execution</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/runner.py

<ul><li>Implement <code>ManifestRunner</code> class with manifest-based reader execution<br> <li> Add <code>run()</code> method to instantiate and execute enabled readers<br> <li> Include <code>_load_reader_class()</code> with fallback import strategies<br> <li> Provide comprehensive error handling and logging</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/137/files#diff-4117b2b42ad8506060eac21668cb0bd8f8c0956fe4d6a285c5e3b1d2ae271bb0">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_runner.py</strong><dd><code>Add comprehensive tests for ManifestRunner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_runner.py

<ul><li>Add unit tests for <code>ManifestRunner</code> functionality<br> <li> Test successful reader instantiation and execution<br> <li> Test error handling during data loading<br> <li> Mock external dependencies for isolated testing</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/137/files#diff-e8659bd25bfdbd50842f813da0c5bfbdb4abd349efb7d0e6cad83bfef8860ea5">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

