### PR TITLE
Support nested init in manifest runner

### DIFF
--- a/moonmind/manifest/runner.py
+++ b/moonmind/manifest/runner.py
@@ -79,7 +79,8 @@ class ManifestRunner:
             if "_type" in value:
                 cls = self._load_class(value["_type"])
                 init_params = {
-                    k: self._construct_value(v) for k, v in value.get("_init", {}).items()
+                    k: self._construct_value(v)
+                    for k, v in value.get("_init", {}).items()
                 }
                 return cls(**init_params)
             return {k: self._construct_value(v) for k, v in value.items()}

--- a/tests/unit/manifest/test_runner.py
+++ b/tests/unit/manifest/test_runner.py
@@ -53,3 +53,45 @@ def test_runner_handles_errors():
 
     # Error during load_data should result in empty list for the reader
     assert results["DummyReader"] == []
+
+
+class DummyChild:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class ParentReader:
+    def __init__(self, child: DummyChild):
+        self.child = child
+
+    def load_data(self):
+        return [self.child.value]
+
+
+def test_runner_recursive_initialization():
+    yaml_nested = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  readers:
+    - type: ParentReader
+      enabled: true
+      init:
+        child:
+          _type: tests.unit.manifest.test_runner.DummyChild
+          _init:
+            value: hello
+      load_data:
+        - {}
+"""
+
+    manifest = Manifest.model_validate_yaml(yaml_nested)
+
+    with patch(
+        "moonmind.manifest.runner.download_loader", return_value=ParentReader
+    ):
+        runner = ManifestRunner(manifest, logger=logging.getLogger("test"))
+        results = runner.run()
+
+    assert results["ParentReader"][0] == ["hello"]

--- a/tests/unit/manifest/test_runner.py
+++ b/tests/unit/manifest/test_runner.py
@@ -88,9 +88,7 @@ spec:
 
     manifest = Manifest.model_validate_yaml(yaml_nested)
 
-    with patch(
-        "moonmind.manifest.runner.download_loader", return_value=ParentReader
-    ):
+    with patch("moonmind.manifest.runner.download_loader", return_value=ParentReader):
         runner = ManifestRunner(manifest, logger=logging.getLogger("test"))
         results = runner.run()
 


### PR DESCRIPTION
### **User description**
## Summary
- recursively instantiate nested objects in `ManifestRunner`
- add unit test covering nested initialization logic

## Testing
- `pytest tests/unit/manifest/test_runner.py::test_runner_recursive_initialization -q`
- `pytest tests/unit/manifest -q`

------
https://chatgpt.com/codex/tasks/task_b_68867dc32cf88331a546b8420ecd90fd


___

### **PR Type**
Enhancement


___

### **Description**
- Add recursive object instantiation in ManifestRunner

- Support nested `_type`/`_init` blocks in configuration

- Process both reader initialization and load_data arguments

- Include comprehensive unit tests for nested initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Configuration with _type/_init"] --> B["_construct_value method"]
  B --> C["Recursive processing"]
  C --> D["Class instantiation"]
  D --> E["Nested object creation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runner.py</strong><dd><code>Implement recursive object instantiation in ManifestRunner</code></dd></summary>
<hr>

moonmind/manifest/runner.py

<ul><li>Add <code>_construct_value</code> method for recursive object instantiation<br> <li> Add <code>_load_class</code> helper for importing classes by fully qualified name<br> <li> Update <code>run</code> method to process init args and load_data args recursively<br> <li> Support <code>_type</code>/<code>_init</code> blocks in configuration dictionaries</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/138/files#diff-4117b2b42ad8506060eac21668cb0bd8f8c0956fe4d6a285c5e3b1d2ae271bb0">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_runner.py</strong><dd><code>Add unit tests for recursive initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_runner.py

<ul><li>Add <code>DummyChild</code> and <code>ParentReader</code> test classes<br> <li> Add <code>test_runner_recursive_initialization</code> test function<br> <li> Test nested object creation with <code>_type</code>/<code>_init</code> configuration<br> <li> Verify recursive instantiation works end-to-end</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/138/files#diff-e8659bd25bfdbd50842f813da0c5bfbdb4abd349efb7d0e6cad83bfef8860ea5">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

