### PR TITLE
Implement reader type uniqueness validation

### DIFF
--- a/moonmind/manifest/loader.py
+++ b/moonmind/manifest/loader.py
@@ -33,6 +33,13 @@ class ManifestLoader:
         except (yaml.YAMLError, ValidationError) as exc:
             raise ValueError(f"Failed to parse manifest: {exc}") from exc
 
+        # Validate unique reader types
+        types = [r.type for r in manifest.spec.readers]
+        duplicates = sorted({t for t in types if types.count(t) > 1})
+        if duplicates:
+            joined = ", ".join(duplicates)
+            raise ValueError(f"Duplicate reader type(s) found: {joined}")
+
         if manifest.spec.defaults is not None:
             merged = {
                 **current_settings.model_dump(),

--- a/moonmind/manifest/loader.py
+++ b/moonmind/manifest/loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -35,7 +36,8 @@ class ManifestLoader:
 
         # Validate unique reader types
         types = [r.type for r in manifest.spec.readers]
-        duplicates = sorted({t for t in types if types.count(t) > 1})
+        counts = Counter(types)
+        duplicates = sorted([t for t, count in counts.items() if count > 1])
         if duplicates:
             joined = ", ".join(duplicates)
             raise ValueError(f"Duplicate reader type(s) found: {joined}")

--- a/tests/unit/manifest/test_loader.py
+++ b/tests/unit/manifest/test_loader.py
@@ -51,3 +51,21 @@ def test_manifest_loader_validation_error(tmp_path):
     loader = ManifestLoader(str(manifest_path))
     with pytest.raises(ValueError):
         loader.load()
+
+
+def test_manifest_loader_duplicate_reader_types(tmp_path):
+    manifest_content = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  readers:
+    - type: Dummy
+    - type: Dummy
+"""
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(manifest_content)
+
+    loader = ManifestLoader(str(manifest_path))
+    with pytest.raises(ValueError, match="Duplicate reader type"):
+        loader.load()


### PR DESCRIPTION
### **User description**
## Summary
- validate that each manifest specifies unique reader types
- test loader duplicate type validation

## Testing
- `poetry run pytest -q tests/unit/manifest/test_loader.py::test_manifest_loader_duplicate_reader_types`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886a726ad90833185b79f3d159198e4


___

### **PR Type**
Enhancement


___

### **Description**
- Add validation for unique reader types in manifest

- Prevent duplicate reader type configurations

- Include comprehensive test coverage for validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manifest Loading"] --> B["Parse YAML"]
  B --> C["Validate Reader Types"]
  C --> D["Check for Duplicates"]
  D --> E["Raise Error if Found"]
  D --> F["Continue Processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>loader.py</strong><dd><code>Add duplicate reader type validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/loader.py

<ul><li>Add validation logic to check for duplicate reader types<br> <li> Extract reader types and identify duplicates using count<br> <li> Raise ValueError with descriptive message for duplicates</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/139/files#diff-19541e22e66cd2acd593baaea852541bc1782beb10ddbe99f1e1ec63803ee5c0">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_loader.py</strong><dd><code>Add test for duplicate reader validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_loader.py

<ul><li>Add test case for duplicate reader type validation<br> <li> Create manifest with duplicate "Dummy" reader types<br> <li> Verify ValueError is raised with appropriate message</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/139/files#diff-21b967013bf58eab195dd3b916968938f1afbed00980bcd3810598d957f2abd8">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

