### PR TITLE
Implement manifest sync feature

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -3,6 +3,7 @@ from sqlalchemy import (  # Added Uuid, String, UniqueConstraint
     Column,
     ForeignKey,
     Integer,
+    DateTime,
     String,
     Text,
     UniqueConstraint,
@@ -66,3 +67,14 @@ class UserProfile(Base):
     # Add other provider keys here as needed
 
     user = relationship("User", back_populates="user_profile")
+
+
+class ManifestRecord(Base):
+    __tablename__ = "manifest"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), unique=True, nullable=False)
+    content = Column(Text, nullable=False)
+    content_hash = Column(String(64), nullable=False)
+    last_indexed_at = Column(DateTime(timezone=True), nullable=True)
+

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1,9 +1,9 @@
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy import (  # Added Uuid, String, UniqueConstraint
     Column,
+    DateTime,
     ForeignKey,
     Integer,
-    DateTime,
     String,
     Text,
     UniqueConstraint,
@@ -77,4 +77,3 @@ class ManifestRecord(Base):
     content = Column(Text, nullable=False)
     content_hash = Column(String(64), nullable=False)
     last_indexed_at = Column(DateTime(timezone=True), nullable=True)
-

--- a/api_service/migrations/versions/cb32e6509d1a_add_manifest_table.py
+++ b/api_service/migrations/versions/cb32e6509d1a_add_manifest_table.py
@@ -1,0 +1,33 @@
+"""add_manifest_table
+
+Revision ID: cb32e6509d1a
+Revises: 909263807406
+Create Date: 2025-07-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "cb32e6509d1a"
+down_revision: Union[str, None] = "909263807406"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "manifest",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("last_indexed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("name"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("manifest")

--- a/api_service/services/manifest_sync_service.py
+++ b/api_service/services/manifest_sync_service.py
@@ -7,17 +7,23 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from moonmind.manifest import ManifestRunner, ManifestChange, compute_content_hash, detect_change
-from moonmind.schemas import Manifest
-
 from api_service.db.models import ManifestRecord
+from moonmind.manifest import (
+    ManifestChange,
+    ManifestRunner,
+    compute_content_hash,
+    detect_change,
+)
+from moonmind.schemas import Manifest
 
 
 class ManifestSyncService:
     def __init__(self, logger: Optional[logging.Logger] = None) -> None:
         self.logger = logger or logging.getLogger(__name__)
 
-    async def sync_manifest(self, db_session: AsyncSession, name: str, content: str) -> ManifestChange:
+    async def sync_manifest(
+        self, db_session: AsyncSession, name: str, content: str
+    ) -> ManifestChange:
         """Sync a single manifest by name."""
         manifest = Manifest.model_validate_yaml(content)
 

--- a/api_service/services/manifest_sync_service.py
+++ b/api_service/services/manifest_sync_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from moonmind.manifest import ManifestRunner, ManifestChange, compute_content_hash, detect_change
+from moonmind.schemas import Manifest
+
+from api_service.db.models import ManifestRecord
+
+
+class ManifestSyncService:
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+
+    async def sync_manifest(self, db_session: AsyncSession, name: str, content: str) -> ManifestChange:
+        """Sync a single manifest by name."""
+        manifest = Manifest.model_validate_yaml(content)
+
+        result = await db_session.execute(
+            select(ManifestRecord).where(ManifestRecord.name == name)
+        )
+        record = result.scalars().first()
+        stored_hash = record.content_hash if record else None
+
+        status = detect_change(stored_hash, manifest)
+
+        if status in {ManifestChange.NEW, ManifestChange.MODIFIED}:
+            self.logger.info("Running readers for manifest %s", name)
+            runner = ManifestRunner(manifest, logger=self.logger)
+            runner.run()
+
+            now = datetime.now(timezone.utc)
+            new_hash = compute_content_hash(manifest)
+
+            if record is None:
+                record = ManifestRecord(
+                    name=name,
+                    content=content,
+                    content_hash=new_hash,
+                    last_indexed_at=now,
+                )
+                db_session.add(record)
+            else:
+                record.content = content
+                record.content_hash = new_hash
+                record.last_indexed_at = now
+            await db_session.commit()
+
+        return status

--- a/moonmind/manifest/__init__.py
+++ b/moonmind/manifest/__init__.py
@@ -1,5 +1,14 @@
 from .interpolation import InterpolationError, interpolate
 from .loader import ManifestLoader
 from .runner import ManifestRunner
+from .sync import ManifestChange, compute_content_hash, detect_change
 
-__all__ = ["ManifestLoader", "interpolate", "InterpolationError", "ManifestRunner"]
+__all__ = [
+    "ManifestLoader",
+    "interpolate",
+    "InterpolationError",
+    "ManifestRunner",
+    "compute_content_hash",
+    "detect_change",
+    "ManifestChange",
+]

--- a/moonmind/manifest/sync.py
+++ b/moonmind/manifest/sync.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+from enum import Enum
+from typing import Optional
+
+import yaml
+
+from moonmind.schemas import Manifest
+
+
+class ManifestChange(str, Enum):
+    NEW = "new"
+    UNCHANGED = "unchanged"
+    MODIFIED = "modified"
+
+
+def compute_content_hash(manifest: Manifest) -> str:
+    """Return SHA256 hash of the manifest spec."""
+    dumped = yaml.safe_dump(manifest.spec.model_dump(), sort_keys=True)
+    return hashlib.sha256(dumped.encode("utf-8")).hexdigest()
+
+
+def detect_change(stored_hash: Optional[str], manifest: Manifest) -> ManifestChange:
+    """Return change status compared to the stored hash."""
+    new_hash = compute_content_hash(manifest)
+    if stored_hash is None:
+        return ManifestChange.NEW
+    if stored_hash == new_hash:
+        return ManifestChange.UNCHANGED
+    return ManifestChange.MODIFIED

--- a/tests/unit/manifest/test_sync.py
+++ b/tests/unit/manifest/test_sync.py
@@ -1,0 +1,25 @@
+from moonmind.manifest.sync import compute_content_hash, detect_change, ManifestChange
+from moonmind.schemas import Manifest
+
+
+YAML1 = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  readers:
+    - type: Dummy
+"""
+
+YAML2 = YAML1.replace("Dummy", "Other")
+
+
+def test_detect_change_states():
+    m1 = Manifest.model_validate_yaml(YAML1)
+    m2 = Manifest.model_validate_yaml(YAML2)
+
+    assert detect_change(None, m1) is ManifestChange.NEW
+
+    h1 = compute_content_hash(m1)
+    assert detect_change(h1, m1) is ManifestChange.UNCHANGED
+    assert detect_change(h1, m2) is ManifestChange.MODIFIED

--- a/tests/unit/manifest/test_sync.py
+++ b/tests/unit/manifest/test_sync.py
@@ -1,6 +1,5 @@
-from moonmind.manifest.sync import compute_content_hash, detect_change, ManifestChange
+from moonmind.manifest.sync import ManifestChange, compute_content_hash, detect_change
 from moonmind.schemas import Manifest
-
 
 YAML1 = """
 apiVersion: moonmind/v1

--- a/tests/unit/services/test_manifest_sync_service.py
+++ b/tests/unit/services/test_manifest_sync_service.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import sessionmaker
 from api_service.db.models import Base
 from api_service.services.manifest_sync_service import ManifestSyncService
 
-
 MANIFEST_YAML = """
 apiVersion: moonmind/v1
 kind: Readers
@@ -26,7 +25,9 @@ MANIFEST_YAML_MOD = MANIFEST_YAML.replace("token: 1", "token: 2")
 @pytest.mark.asyncio
 async def test_manifest_sync_detects_changes(tmp_path):
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
-    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async_session_maker = sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/tests/unit/services/test_manifest_sync_service.py
+++ b/tests/unit/services/test_manifest_sync_service.py
@@ -1,0 +1,54 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import Base
+from api_service.services.manifest_sync_service import ManifestSyncService
+
+
+MANIFEST_YAML = """
+apiVersion: moonmind/v1
+kind: Readers
+metadata: {}
+spec:
+  readers:
+    - type: DummyReader
+      init:
+        token: 1
+"""
+
+MANIFEST_YAML_MOD = MANIFEST_YAML.replace("token: 1", "token: 2")
+
+
+@pytest.mark.asyncio
+async def test_manifest_sync_detects_changes(tmp_path):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    service = ManifestSyncService(logger=logging.getLogger("test"))
+
+    with patch("api_service.services.manifest_sync_service.ManifestRunner") as MR:
+        MR.return_value.run.return_value = {}
+        async with async_session_maker() as session:
+            status1 = await service.sync_manifest(session, "test", MANIFEST_YAML)
+        MR.assert_called_once()
+    assert status1.name.lower() == "new"
+
+    with patch("api_service.services.manifest_sync_service.ManifestRunner") as MR:
+        MR.return_value.run.return_value = {}
+        async with async_session_maker() as session:
+            status2 = await service.sync_manifest(session, "test", MANIFEST_YAML)
+        MR.assert_not_called()
+    assert status2.name.lower() == "unchanged"
+
+    with patch("api_service.services.manifest_sync_service.ManifestRunner") as MR:
+        MR.return_value.run.return_value = {}
+        async with async_session_maker() as session:
+            status3 = await service.sync_manifest(session, "test", MANIFEST_YAML_MOD)
+        MR.assert_called_once()
+    assert status3.name.lower() == "modified"


### PR DESCRIPTION
### **User description**
## Summary
- add `ManifestRecord` database model and migration
- create manifest sync utilities
- add `ManifestSyncService` for detecting manifest changes and running readers
- export new utilities from the manifest package
- test manifest syncing and change detection

## Testing
- `pytest -q`
- `python tools/get_action_status.py --branch work`

------
https://chatgpt.com/codex/tasks/task_b_6886d2e1f12883318553a7396aa45338


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ManifestRecord` database model for tracking manifest state

- Implement `ManifestSyncService` for detecting and processing manifest changes

- Create manifest sync utilities with hash-based change detection

- Add comprehensive test coverage for sync functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manifest Content"] --> B["ManifestSyncService"]
  B --> C["detect_change()"]
  C --> D["ManifestRecord DB"]
  C --> E["ManifestRunner"]
  E --> F["Process Changes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add ManifestRecord database model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/db/models.py

<ul><li>Add <code>DateTime</code> import for timestamp support<br> <li> Create <code>ManifestRecord</code> model with name, content, hash, and timestamp <br>fields</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-ddde5d2377b0146f217c31df6b090756ffe0262a1216e7d603fc47519b9f0dc8">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cb32e6509d1a_add_manifest_table.py</strong><dd><code>Add manifest table migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/migrations/versions/cb32e6509d1a_add_manifest_table.py

<ul><li>Create database migration for manifest table<br> <li> Define table schema with unique name constraint<br> <li> Include upgrade and downgrade functions</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-48e6ac30baee7f632ddff28627dd3952343e80fcc123451ae1f33020d8337ea1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>manifest_sync_service.py</strong><dd><code>Create ManifestSyncService for sync operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api_service/services/manifest_sync_service.py

<ul><li>Implement <code>ManifestSyncService</code> class for manifest synchronization<br> <li> Add <code>sync_manifest</code> method with change detection and runner execution<br> <li> Handle database record creation and updates with timestamps</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-7f33ef2a61f03e250ee3050d86c5b54839463601293879bf726d3212b8926edd">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export manifest sync utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/__init__.py

<ul><li>Export new sync utilities: <code>compute_content_hash</code>, <code>detect_change</code>, <br><code>ManifestChange</code><br> <li> Update <code>__all__</code> list with new exports</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-79ed2c23abff8f90f6ff15cfe3b205cb99fe89a9da7e5de51f826357b0996c98">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Add manifest sync utilities and change detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

moonmind/manifest/sync.py

<ul><li>Define <code>ManifestChange</code> enum for change states<br> <li> Implement <code>compute_content_hash</code> using SHA256 of manifest spec<br> <li> Create <code>detect_change</code> function for comparing stored and current hashes</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-e87415e2bc2c69f10da37a0bc4da944c004db6b86257791eb1ff17caf06e6e30">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Add unit tests for sync utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/manifest/test_sync.py

<ul><li>Test change detection states: NEW, UNCHANGED, MODIFIED<br> <li> Verify hash computation and comparison logic</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-7c0ddc66d040594cf791a7df03a344323395c23fd9c2ddb3c8bed6cf1c1ba4aa">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_manifest_sync_service.py</strong><dd><code>Add integration tests for ManifestSyncService</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/services/test_manifest_sync_service.py

<ul><li>Test <code>ManifestSyncService</code> with in-memory SQLite database<br> <li> Verify change detection workflow and runner execution<br> <li> Mock <code>ManifestRunner</code> to test service behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/MoonLadderStudios/MoonMind/pull/140/files#diff-d664fac5a0294a388b27d3a8eea84da14f5c5a2955fe14901deadbec6cfbbc49">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

