### PR TITLE
Ignore worker runtime scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ build/
 dist/
 *.egg-info/
 uv.lock
+
+# Worker runtime scratch outputs
+var/worker/
+var/worker-relative/


### PR DESCRIPTION
## Summary
- ignore worker runtime scratch outputs under `var/worker/` and `var/worker-relative/`
- prevent accidental commits of local worker logs, patches, and cloned repos
- keep tracked artifact anchor `var/artifacts/spec_workflows/.gitkeep` unchanged

## Validation
- verified `var/worker*` entries are no longer tracked after unstage/ignore cleanup
