### PR TITLE
Flatten queue submit step UI on mobile

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -2018,19 +2018,17 @@
       `Create a typed Task job. Jobs are consumed from the shared queue ${defaultQueueName}.`,
       `
       <form id="queue-submit-form">
+        <section class="queue-steps-section stack">
+          <strong>Steps</strong>
+          <span class="small">At least one step is required to submit. You can remove all steps while editing, but submit stays disabled by validation until a step is added back.</span>
+          <div id="queue-steps-list" class="stack"></div>
+        </section>
+        ${templateControlsHtml}
         <label>Runtime
           <select name="runtime">
             ${runtimeOptions}
           </select>
         </label>
-        <div class="card">
-          <div class="actions">
-            <strong>Steps</strong>
-          </div>
-          <span class="small">At least one step is required to submit. You can remove all steps while editing, but submit stays disabled by validation until a step is added back.</span>
-          <div id="queue-steps-list"></div>
-        </div>
-        ${templateControlsHtml}
         <datalist id="queue-skill-options">
           <option value="auto"></option>
         </datalist>
@@ -2130,7 +2128,6 @@
     }
     const createStepStateEntry = (overrides = {}) => ({
       id: "",
-      title: "",
       instructions: "",
       skillId: "",
       skillArgs: "",
@@ -2167,7 +2164,7 @@
             ? "Primary step skill values are forwarded to <span class=\"inline-code\">task.skill</span>."
             : "Leave skill blank to inherit primary step defaults.";
           return `
-            <div class="card" data-step-index="${index}">
+            <section class="queue-step-section stack" data-step-index="${index}">
               <div class="queue-step-header">
                 <strong>Step ${index + 1}${stepLabel}</strong>
                 <div class="queue-step-controls" role="group" aria-label="Step ${index + 1} controls">
@@ -2215,9 +2212,6 @@
                   </button>
                 </div>
               </div>
-              <label>Title (optional)
-                <input data-step-field="title" data-step-index="${index}" value="${escapeHtml(step.title)}" placeholder="Short label" />
-              </label>
               <label>${instructionsLabel}
                 <textarea class="queue-step-instructions" data-step-field="instructions" data-step-index="${index}" placeholder="${escapeHtml(
                   instructionsPlaceholder,
@@ -2244,7 +2238,7 @@
                   step.skillArgs,
                 )}</textarea>
               </label>
-            </div>
+            </section>
           `;
         })
         .join("");
@@ -2670,7 +2664,6 @@
       const instructions = String(step?.instructions || "").trim();
       return createStepStateEntry({
         id: stepId,
-        title: String(step?.title || "").trim(),
         instructions,
         skillId: String(skill?.id || "").trim(),
         skillArgs: args,
@@ -2682,7 +2675,6 @@
 
     const isEmptyStepStateEntry = (step) =>
       !String(step?.id || "").trim() &&
-      !String(step?.title || "").trim() &&
       !String(step?.instructions || "").trim() &&
       !String(step?.skillId || "").trim() &&
       !String(step?.skillArgs || "").trim() &&
@@ -2835,7 +2827,6 @@
             return null;
           }
           const blueprint = {
-            ...(String(step.title || "").trim() ? { title: String(step.title).trim() } : {}),
             instructions,
           };
           const skillId = String(step.skillId || "").trim();
@@ -3051,18 +3042,15 @@
       const effort = String(formData.get("effort") || "").trim() || null;
       const startingBranch = String(formData.get("startingBranch") || "").trim() || null;
       const newBranch = String(formData.get("newBranch") || "").trim() || null;
-      const primaryStepTitle = String(primaryStep.title || "").trim();
       const additionalSteps = [];
       const stepSkillRequiredCapabilities = [];
       for (let index = 1; index < stepState.length; index += 1) {
         const rawStep = stepState[index] || {};
-        const stepTitle = String(rawStep.title || "").trim();
         const stepInstructions = String(rawStep.instructions || "").trim();
         const stepSkillId = String(rawStep.skillId || "").trim();
         const stepSkillArgsRaw = String(rawStep.skillArgs || "").trim();
         const stepSkillCaps = parseCapabilitiesCsv(rawStep.skillRequiredCapabilities || "");
         const hasStepContent =
-          Boolean(stepTitle) ||
           Boolean(stepInstructions) ||
           Boolean(stepSkillId) ||
           Boolean(stepSkillArgsRaw) ||
@@ -3085,9 +3073,6 @@
           }
         }
         const stepPayload = {};
-        if (stepTitle) {
-          stepPayload.title = stepTitle;
-        }
         if (stepInstructions) {
           stepPayload.instructions = stepInstructions;
         }
@@ -3109,7 +3094,6 @@
       const hasTemplateBoundStep = stepState.some((step) => Boolean(String(step?.id || "").trim()));
       const includeExplicitSteps =
         additionalSteps.length > 0 ||
-        Boolean(primaryStepTitle) ||
         includePrimaryStepForObjectiveOverride ||
         hasTemplateBoundStep;
       const normalizedStepEntries = includeExplicitSteps
@@ -3117,7 +3101,6 @@
             {
               sourceIndex: 0,
               payload: {
-                ...(primaryStepTitle ? { title: primaryStepTitle } : {}),
                 instructions,
               },
             },


### PR DESCRIPTION
## Summary\n- flatten the queue submit steps UI by removing nested step cards\n- move the runtime selector below preset controls and above model/effort\n- remove per-step title inputs from the submit form and stop sending step titles in task payloads\n\n## Scope\n- api_service/static/task_dashboard/dashboard.js\n\n## Notes\n- preserves existing step ordering, controls, and submission behavior\n- focuses on mobile readability by reducing card nesting depth