### PR TITLE
Fix runtime dropdown and orchestrator create UI options

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -82,7 +82,10 @@ def status_maps() -> dict[str, dict[str, str]]:
 
 
 def _build_supported_task_runtimes() -> list[str]:
-    return ["codex", "gemini", "claude"]
+    supported: list[str] = ["codex", "gemini"]
+    if settings.claude_runtime_gate.enabled:
+        supported.append("claude")
+    return supported
 
 
 def build_runtime_config(initial_path: str) -> dict[str, Any]:

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -227,6 +227,16 @@
     [ORCHESTRATOR_RUNTIME]: "Orchestrator",
   };
 
+  const buildSubmitRuntimeOptions = (workerRuntimes = []) => {
+    const normalized = normalizeRuntimeOptions(workerRuntimes);
+    if (!normalized.includes(ORCHESTRATOR_RUNTIME)) {
+      normalized.push(ORCHESTRATOR_RUNTIME);
+    }
+    return normalized;
+  };
+
+  const submitRuntimeOptions = buildSubmitRuntimeOptions(supportedTaskRuntimes);
+
   const formatRuntimeLabel = (runtimeValue) => {
     const normalized = String(runtimeValue || "").trim().toLowerCase();
     if (!normalized) {
@@ -2515,7 +2525,7 @@
       setView(
         "Orchestrator Runs",
         "Recent orchestrator runs.",
-        `<div class="actions"><a href="/tasks/new?runtime=orchestrator"><button type="button">New Orchestrator Run</button></a></div>${renderRowsTable(rows)}`,
+        `<div class="actions"><a href="/tasks/new?runtime=orchestrator"><button type="button" class="queue-submit-primary">New Orchestrator Run</button></a></div>${renderRowsTable(rows)}`,
         { showAutoRefreshControls: true },
       );
     };
@@ -2571,7 +2581,7 @@
       : [];
 
     const runtimeOptions = renderRuntimeOptions(
-      [...supportedTaskRuntimes, ORCHESTRATOR_RUNTIME],
+      submitRuntimeOptions,
       selectedWorkerRuntime,
     );
     const repositoryFallback = queueDraftRepository || defaultRepository;
@@ -3960,7 +3970,7 @@
         `<div class="notice error">Unsupported runtime value: <code>${escapeHtml(
           String(presetRuntime),
         )}</code>. Use one of: <code>${escapeHtml(
-          [...supportedTaskRuntimes, ORCHESTRATOR_RUNTIME].join(", "),
+          submitRuntimeOptions.join(", "),
         )}</code>.</div>`,
       );
       return;
@@ -4021,7 +4031,7 @@
           )}</textarea>
         </label>
         <div class="actions">
-          <button type="submit">Create Orchestrator Run</button>
+          <button type="submit" class="queue-submit-primary">Create Orchestrator Run</button>
           <a href="/tasks/orchestrator"><button class="secondary" type="button">Cancel</button></a>
         </div>
         <p class="small" id="orchestrator-submit-message"></p>

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1114,7 +1114,12 @@ class GoogleSettings(BaseSettings):
 class AnthropicSettings(BaseSettings):
     """Anthropic API settings"""
 
-    anthropic_api_key: Optional[str] = Field(None, env="ANTHROPIC_API_KEY")
+    anthropic_api_key: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices(
+            "anthropic_api_key", "ANTHROPIC_API_KEY", "CLAUDE_API_KEY"
+        ),
+    )
     anthropic_chat_model: str = Field("claude-sonnet-4-6", env="ANTHROPIC_CHAT_MODEL")
     anthropic_enabled: bool = Field(True, env="ANTHROPIC_ENABLED")
 

--- a/tests/task_dashboard/test_queue_layouts.js
+++ b/tests/task_dashboard/test_queue_layouts.js
@@ -144,6 +144,15 @@ const {
   assert(html.includes("status-running"));
 })();
 
+
+(function testRenderQueueTableEscapesTitleLabel() {
+  const html = renderQueueTable([
+    createQueueRow({ title: '<img src=x onerror=alert(1)>' }),
+  ]);
+  assert(html.includes('&lt;img src=x onerror=alert(1)&gt;'));
+  assert(!html.includes('<img src=x onerror=alert(1)>'));
+})();
+
 (function testQueueDefinitionOrderMatchesTableHeaders() {
   const html = renderQueueTable([createQueueRow()]);
   const headerOrder = Array.from(html.matchAll(/<th data-field="([^"]+)"/g)).map(

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -32,7 +32,11 @@ def test_status_maps_returns_copy() -> None:
     assert status_maps()["queue"]["queued"] == "queued"
 
 
-def test_build_runtime_config_contains_expected_keys() -> None:
+def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
+    monkeypatch.setattr(settings.anthropic, "anthropic_api_key", None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+
     config = build_runtime_config("/tasks")
     assert config["initialPath"] == "/tasks"
     assert config["pollIntervalsMs"]["list"] > 0
@@ -97,7 +101,7 @@ def test_build_runtime_config_contains_expected_keys() -> None:
     assert config["system"]["defaultTaskEffortByRuntime"]["codex"]
     assert config["system"]["queueEnv"] == "MOONMIND_QUEUE"
     assert config["system"]["workerRuntimeEnv"] == "MOONMIND_WORKER_RUNTIME"
-    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini", "claude"]
+    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini"]
     assert "claude" in config["system"]["supportedWorkerRuntimes"]
     assert "taskTemplateCatalog" in config["system"]
     assert "enabled" in config["system"]["taskTemplateCatalog"]
@@ -119,6 +123,8 @@ def test_build_runtime_config_uses_runtime_env_for_task_default(monkeypatch) -> 
 
 def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
     monkeypatch.setenv("MOONMIND_WORKER_RUNTIME", "claude")
+    monkeypatch.setattr(settings.anthropic, "anthropic_api_key", "test-key")
+
     config = build_runtime_config("/tasks")
 
     assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini", "claude"]

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -123,7 +123,7 @@ def test_build_runtime_config_uses_runtime_env_for_task_default(monkeypatch) -> 
 
 def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
     monkeypatch.setenv("MOONMIND_WORKER_RUNTIME", "claude")
-    monkeypatch.setattr(settings.anthropic, "anthropic_api_key", "test-key")
+    monkeypatch.setenv("CLAUDE_API_KEY", "enabled")
 
     config = build_runtime_config("/tasks")
 
@@ -148,7 +148,7 @@ def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
 
 
 def test_build_runtime_config_includes_claude_when_api_key_set(monkeypatch) -> None:
-    monkeypatch.setattr(settings.anthropic, "anthropic_api_key", "test-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "enabled")
 
     config = build_runtime_config("/tasks")
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -829,6 +829,16 @@ class TestAppSettingsRuntimeValidation:
         settings = AppSettings(**defaults)
         assert settings.spec_workflow.default_task_runtime == "claude"
 
+    def test_app_settings_maps_claude_alias_to_anthropic_api_key(
+        self, app_settings_defaults, monkeypatch
+    ):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLAUDE_API_KEY", "enabled")
+
+        settings = AppSettings(**dict(app_settings_defaults))
+
+        assert settings.anthropic.anthropic_api_key == "enabled"
+
     def test_app_settings_allows_claude_default_with_claude_alias_key(
         self, app_settings_defaults, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- Fixed runtime support list to be conditional on Claude availability: default runtimes are now only `codex` and `gemini`, with `claude` appended when the Claude runtime gate is enabled.
- Updated task submit runtime dropdown to always include `orchestrator` as an option while preserving worker runtime options.
- Added primary button styling to orchestrator create actions (`New Orchestrator Run` and `Create Orchestrator Run`) for consistency with queue create flow.
- Updated runtime config unit tests to reflect the new conditional Claude behavior while keeping coverage for explicit runtime env settings.

## Testing
- Not run in this session.
