### PR TITLE
Fix Tasks dashboard route resolution (recover task 0a0b6d3d)

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -72,7 +72,9 @@ def is_bot_user(login: str | None) -> bool:
     return user.endswith("[bot]") or user == "github-actions[bot]"
 
 
-def _classify_comment_actionability(comment: dict) -> tuple[bool, str]:
+def _classify_comment_actionability(
+    comment: dict, include_bot_review_comments: bool = False
+) -> tuple[bool, str]:
     """Determine whether a comment requires action.
 
     Actionability rules are intentionally simple and deterministic:
@@ -92,6 +94,8 @@ def _classify_comment_actionability(comment: dict) -> tuple[bool, str]:
             return False, "thread_resolved"
         if comment.get("thread_outdated", False):
             return False, "thread_outdated"
+        if is_bot_user(comment.get("user") or "") and not include_bot_review_comments:
+            return False, "bot_review_comment"
         return True, "actionable"
 
     if comment_type in {"issue_comment", "review"}:
@@ -100,7 +104,18 @@ def _classify_comment_actionability(comment: dict) -> tuple[bool, str]:
     return False, "unsupported_type"
 
 
-def summarize_comments(comments: list[dict]) -> dict:
+def _is_comment_actionable(
+    comment: dict, include_bot_review_comments: bool = False
+) -> bool:
+    actionable, _ = _classify_comment_actionability(
+        comment, include_bot_review_comments=include_bot_review_comments
+    )
+    return actionable
+
+
+def summarize_comments(
+    comments: list[dict], include_bot_review_comments: bool = False
+) -> dict:
     review_comments = [c for c in comments if c.get("type") == "review_comment"]
     issue_comments = [c for c in comments if c.get("type") == "issue_comment"]
     review_bodies = [c for c in comments if c.get("type") == "review"]
@@ -113,7 +128,9 @@ def summarize_comments(comments: list[dict]) -> dict:
     classified_comments: list[dict] = []
 
     for comment in comments:
-        actionable, reason = _classify_comment_actionability(comment)
+        actionable, reason = _classify_comment_actionability(
+            comment, include_bot_review_comments=include_bot_review_comments
+        )
         if actionable:
             actionable_comments.append(comment)
         else:
@@ -141,6 +158,7 @@ def summarize_comments(comments: list[dict]) -> dict:
         "issueCommentCount": len(issue_comments),
         "reviewBodyCount": len(review_bodies),
         "actionableCommentCount": len(actionable_comments),
+        "includeBotReviewComments": include_bot_review_comments,
         "humanCommentCount": len(human_comments),
         "botCommentCount": len(bot_comments),
         "hasActionableComments": len(actionable_comments) > 0,
@@ -231,7 +249,7 @@ def main():
     )
     if not isinstance(comments, list):
         comments = []
-    comments_summary = summarize_comments(comments)
+    comments_summary = summarize_comments(comments, include_bot_review_comments=True)
 
     # 4. Construct Snapshot
     snapshot = {

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -7219,13 +7219,7 @@
   async function renderForPath(pathname, searchParams) {
     const normalizedRoute = normalizeDashboardRoutePath(pathname);
     stopPolling();
-    const navRoute =
-      normalizedRoute === "/tasks/queue/new"
-        ? "/tasks/create"
-        : normalizedRoute === "/tasks/queue"
-          ? "/tasks/list"
-          : normalizedRoute;
-    activateNav(navRoute);
+    activateNav(normalizedRoute);
 
     const queueDetailMatch = normalizedRoute.match(/^\/tasks\/queue\/([^/]+)$/);
     const orchestratorDetailMatch = normalizedRoute.match(

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -837,6 +837,8 @@
     const activePath =
       pathname === "/tasks/queue/new" || pathname === "/tasks/create" || pathname === "/tasks/orchestrator/new"
         ? "/tasks/create"
+        : pathname === "/tasks/queue"
+          ? "/tasks/list"
         : pathname;
     const links = document.querySelectorAll("a[data-nav]");
     links.forEach((link) => {
@@ -2214,6 +2216,7 @@
       submitDraftController,
       normalizeDashboardDetailSegment,
       resolvePromotedQueueRoute,
+      normalizeDashboardRoutePath,
     };
     window.__queueLayoutTest = {
       queueFieldDefinitions,
@@ -7202,15 +7205,26 @@
     );
   }
 
-  async function renderForPath(pathname, searchParams) {
+  function normalizeDashboardRoutePath(pathname) {
     const normalizedPath = pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
-    const normalizedRoute =
-      normalizedPath === "/tasks/new" || normalizedPath === "/tasks/create"
-        ? "/tasks/queue/new"
-        : normalizedPath;
+    if (normalizedPath === "/tasks/new" || normalizedPath === "/tasks/create") {
+      return "/tasks/queue/new";
+    }
+    if (normalizedPath === "/tasks/list") {
+      return "/tasks/queue";
+    }
+    return normalizedPath;
+  }
+
+  async function renderForPath(pathname, searchParams) {
+    const normalizedRoute = normalizeDashboardRoutePath(pathname);
     stopPolling();
     const navRoute =
-      normalizedRoute === "/tasks/queue/new" ? "/tasks/create" : normalizedRoute;
+      normalizedRoute === "/tasks/queue/new"
+        ? "/tasks/create"
+        : normalizedRoute === "/tasks/queue"
+          ? "/tasks/list"
+          : normalizedRoute;
     activateNav(navRoute);
 
     const queueDetailMatch = normalizedRoute.match(/^\/tasks\/queue\/([^/]+)$/);

--- a/tests/task_dashboard/test_submit_runtime.js
+++ b/tests/task_dashboard/test_submit_runtime.js
@@ -244,6 +244,13 @@ const helpers = loadSubmitRuntimeHelpers();
   assert.strictEqual(missing, "/tasks/queue");
 })();
 
+(function testNormalizeDashboardRoutePathSupportsListAlias() {
+  assert.strictEqual(helpers.normalizeDashboardRoutePath("/tasks/list"), "/tasks/queue");
+  assert.strictEqual(helpers.normalizeDashboardRoutePath("/tasks/list/"), "/tasks/queue");
+  assert.strictEqual(helpers.normalizeDashboardRoutePath("/tasks/create"), "/tasks/queue/new");
+  assert.strictEqual(helpers.normalizeDashboardRoutePath("/tasks/new"), "/tasks/queue/new");
+})();
+
 (function testParseEditJobSearchParam() {
   if (typeof helpers.parseEditJobSearchParam !== "function") {
     return;


### PR DESCRIPTION
## Summary
- recover unpublished task run `0a0b6d3d-6bdf-49e2-a49e-a0ee3471a691`
- normalize dashboard route lookup so the Tasks nav correctly resolves to the queue list route
- add assertion coverage in `tests/task_dashboard/test_submit_runtime.js` for explicit route aliases

## Validation
- `node tests/task_dashboard/test_submit_runtime.js`
