### PR TITLE
Recover PR-resolution validation hardening (task f84900bf)

### DIFF
--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -4678,7 +4678,9 @@ class CodexWorker:
 
         snapshot_path = prepared.repo_dir / "artifacts" / "pr_resolver_snapshot.json"
         result_path = prepared.repo_dir / "artifacts" / "pr_resolver_result.json"
-        report_path = prepared.artifacts_dir / "reports" / "pr_resolution_validation.json"
+        report_path = (
+            prepared.artifacts_dir / "reports" / "pr_resolution_validation.json"
+        )
         report_path.parent.mkdir(parents=True, exist_ok=True)
 
         failure_reason: str | None = None
@@ -4701,12 +4703,16 @@ class CodexWorker:
                     snapshot_payload = dict(parsed_snapshot)
 
         if snapshot_error is not None:
-            failure_reason = f"pr-resolution final state validation failed: {snapshot_error}"
+            failure_reason = (
+                f"pr-resolution final state validation failed: {snapshot_error}"
+            )
         else:
             pr_node = snapshot_payload.get("pr")
             pr = pr_node if isinstance(pr_node, Mapping) else {}
             comments_node = snapshot_payload.get("commentsSummary")
-            comments_summary = comments_node if isinstance(comments_node, Mapping) else {}
+            comments_summary = (
+                comments_node if isinstance(comments_node, Mapping) else {}
+            )
 
             merge_state = str(pr.get("mergeStateStatus") or "").strip().upper()
             mergeable_raw = pr.get("mergeable")
@@ -4727,7 +4733,9 @@ class CodexWorker:
             actionable_count = self._coerce_non_negative_int(
                 comments_summary.get("actionableCommentCount")
             )
-            has_actionable_comments = bool(comments_summary.get("hasActionableComments"))
+            has_actionable_comments = bool(
+                comments_summary.get("hasActionableComments")
+            )
             if actionable_count is None:
                 actionable_count = 1 if has_actionable_comments else 0
             elif actionable_count == 0 and has_actionable_comments:

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -169,12 +169,27 @@ _VERIFICATION_COMMAND_PATTERNS = (
     ),
 )
 _VERIFICATION_COMMAND_LOG_PREFIX = "[command] $ "
+_RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
+    r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
+    re.IGNORECASE,
+)
+_CONFLICTING_MERGE_STATES = frozenset({"DIRTY", "CONFLICTING"})
+_CONFLICTING_MERGEABLE_VALUES = frozenset({"CONFLICTING", "DIRTY", "FALSE"})
 
 
 def _normalize_instruction_text_for_comparison(value: str | None) -> str:
     """Normalize instruction text for objective/step deduplication checks."""
 
     return re.sub(r"\s+", " ", str(value or "").strip())
+
+
+def _is_resolve_pr_objective_text(value: str | None) -> bool:
+    """Return True when instructions target pull-request resolution."""
+
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return _RESOLVE_PR_OBJECTIVE_PATTERN.search(text) is not None
 
 
 def _normalize_proposal_tags(values: object) -> list[str]:
@@ -4633,6 +4648,167 @@ class CodexWorker:
             encoding="utf-8",
         )
 
+    @staticmethod
+    def _coerce_non_negative_int(value: object) -> int | None:
+        """Best-effort conversion for non-negative integer fields."""
+
+        try:
+            converted = int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return converted if converted >= 0 else None
+
+    def _validate_pr_resolution_final_state(
+        self,
+        *,
+        canonical_payload: Mapping[str, Any],
+        resolved_steps: Sequence[ResolvedTaskStep],
+        prepared: PreparedTaskWorkspace,
+    ) -> StepGateResult:
+        """Fail resolve-PR runs when final PR state remains unresolved."""
+
+        task_node = canonical_payload.get("task")
+        task = task_node if isinstance(task_node, Mapping) else {}
+        objective = str(task.get("instructions") or "").strip()
+        is_pr_resolution_task = _is_resolve_pr_objective_text(objective) or any(
+            step.effective_skill_id == _PR_RESOLVER_SKILL_ID for step in resolved_steps
+        )
+        if not is_pr_resolution_task:
+            return StepGateResult(passed=True)
+
+        snapshot_path = prepared.repo_dir / "artifacts" / "pr_resolver_snapshot.json"
+        result_path = prepared.repo_dir / "artifacts" / "pr_resolver_result.json"
+        report_path = prepared.artifacts_dir / "reports" / "pr_resolution_validation.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+
+        failure_reason: str | None = None
+        unresolved_signals: list[str] = []
+        snapshot_payload: dict[str, Any] = {}
+        snapshot_error: str | None = None
+        if not snapshot_path.exists():
+            snapshot_error = "missing artifacts/pr_resolver_snapshot.json"
+        else:
+            try:
+                parsed_snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                snapshot_error = "artifacts/pr_resolver_snapshot.json is not valid JSON"
+            else:
+                if not isinstance(parsed_snapshot, Mapping):
+                    snapshot_error = (
+                        "artifacts/pr_resolver_snapshot.json must be a JSON object"
+                    )
+                else:
+                    snapshot_payload = dict(parsed_snapshot)
+
+        if snapshot_error is not None:
+            failure_reason = f"pr-resolution final state validation failed: {snapshot_error}"
+        else:
+            pr_node = snapshot_payload.get("pr")
+            pr = pr_node if isinstance(pr_node, Mapping) else {}
+            comments_node = snapshot_payload.get("commentsSummary")
+            comments_summary = comments_node if isinstance(comments_node, Mapping) else {}
+
+            merge_state = str(pr.get("mergeStateStatus") or "").strip().upper()
+            mergeable_raw = pr.get("mergeable")
+            if merge_state in _CONFLICTING_MERGE_STATES:
+                unresolved_signals.append(f"mergeStateStatus={merge_state}")
+
+            mergeable_conflicting = False
+            if isinstance(mergeable_raw, bool):
+                mergeable_conflicting = not mergeable_raw
+            else:
+                mergeable_conflicting = (
+                    str(mergeable_raw or "").strip().upper()
+                    in _CONFLICTING_MERGEABLE_VALUES
+                )
+            if mergeable_conflicting:
+                unresolved_signals.append(f"mergeable={mergeable_raw}")
+
+            actionable_count = self._coerce_non_negative_int(
+                comments_summary.get("actionableCommentCount")
+            )
+            has_actionable_comments = bool(comments_summary.get("hasActionableComments"))
+            if actionable_count is None:
+                actionable_count = 1 if has_actionable_comments else 0
+            elif actionable_count == 0 and has_actionable_comments:
+                actionable_count = 1
+            if actionable_count > 0:
+                unresolved_signals.append(f"actionableCommentCount={actionable_count}")
+
+            if unresolved_signals:
+                failure_reason = "pr-resolution final state unresolved: " + "; ".join(
+                    unresolved_signals
+                )
+
+        result_payload: dict[str, Any] | None = None
+        if result_path.exists():
+            try:
+                parsed_result = json.loads(result_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                result_payload = None
+            else:
+                if isinstance(parsed_result, Mapping):
+                    result_payload = dict(parsed_result)
+
+        passed = failure_reason is None
+        report_payload = {
+            "schemaVersion": "v1",
+            "status": "PASS" if passed else "FAIL",
+            "reason": failure_reason or "pr-resolution final state is resolved",
+            "objective": objective,
+            "sources": {
+                "snapshotPath": "artifacts/pr_resolver_snapshot.json",
+                "resultPath": "artifacts/pr_resolver_result.json",
+            },
+            "snapshot": {
+                "available": bool(snapshot_payload),
+                "pr": (
+                    snapshot_payload.get("pr")
+                    if isinstance(snapshot_payload.get("pr"), Mapping)
+                    else {}
+                ),
+                "commentsSummary": (
+                    snapshot_payload.get("commentsSummary")
+                    if isinstance(snapshot_payload.get("commentsSummary"), Mapping)
+                    else {}
+                ),
+            },
+            "result": {
+                "available": bool(result_payload),
+                "mergeOutcome": (
+                    str(result_payload.get("merge_outcome") or "").strip()
+                    if isinstance(result_payload, Mapping)
+                    else None
+                ),
+                "reason": (
+                    str(result_payload.get("reason") or "").strip()
+                    if isinstance(result_payload, Mapping)
+                    else None
+                ),
+            },
+            "signals": {"unresolved": unresolved_signals},
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        redacted = self._redact_payload(report_payload)
+        serialized_report = redacted if isinstance(redacted, dict) else report_payload
+        report_path.write_text(
+            json.dumps(serialized_report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        return StepGateResult(
+            passed=passed,
+            message=failure_reason,
+            artifacts=(
+                ArtifactUpload(
+                    path=report_path,
+                    name="reports/pr_resolution_validation.json",
+                    content_type="application/json",
+                    required=False,
+                ),
+            ),
+        )
+
     def _evaluate_step_gate(
         self,
         *,
@@ -6325,6 +6501,24 @@ class CodexWorker:
             step_artifacts.append(final_patch_artifact)
             if artifact_callback is not None:
                 await artifact_callback((final_patch_artifact,))
+
+        pr_resolution_state = self._validate_pr_resolution_final_state(
+            canonical_payload=canonical_payload,
+            resolved_steps=resolved_steps,
+            prepared=prepared,
+        )
+        if pr_resolution_state.artifacts:
+            pr_resolution_artifacts = list(pr_resolution_state.artifacts)
+            step_artifacts.extend(pr_resolution_artifacts)
+            if artifact_callback is not None:
+                await artifact_callback(pr_resolution_artifacts)
+        if not pr_resolution_state.passed:
+            return WorkerExecutionResult(
+                succeeded=False,
+                summary=None,
+                error_message=pr_resolution_state.message,
+                artifacts=tuple(step_artifacts),
+            )
 
         return WorkerExecutionResult(
             succeeded=True,

--- a/moonmind/workflows/agent_queue/task_contract.py
+++ b/moonmind/workflows/agent_queue/task_contract.py
@@ -34,6 +34,14 @@ _CONTAINER_RESERVED_ENV_KEYS = frozenset({"ARTIFACT_DIR", "JOB_ID", "REPOSITORY"
 _PROPOSAL_POLICY_TARGETS = ("project", "moonmind")
 _PROPOSAL_SEVERITIES = ("low", "medium", "high", "critical")
 _SELF_MANAGED_PUBLISH_SKILLS = frozenset({"pr-resolver"})
+_RESOLVE_PR_OBJECTIVE_PATTERN = re.compile(
+    r"\bresolve(?:d|s|ing)?\s+(?:an?\s+|the\s+)?(?:pr|pull\s+request)\b",
+    re.IGNORECASE,
+)
+_NO_COMMIT_PUSH_PATTERN = re.compile(
+    r"\bdo\s+not\s+commit(?:\s+or\s+push|/push)\b",
+    re.IGNORECASE,
+)
 
 
 class TaskContractError(ValueError):
@@ -80,6 +88,24 @@ def _normalize_publish_mode(value: object) -> str:
         supported = ", ".join(sorted(SUPPORTED_PUBLISH_MODES))
         raise TaskContractError(f"publish.mode must be one of: {supported}")
     return candidate
+
+
+def _is_resolve_pr_objective(value: object) -> bool:
+    """Return True when task instructions target PR resolution behavior."""
+
+    text = _clean_optional_str(value)
+    if not text:
+        return False
+    return _RESOLVE_PR_OBJECTIVE_PATTERN.search(text) is not None
+
+
+def _contains_no_commit_push_constraint(value: object) -> bool:
+    """Return True when text instructs the runtime not to commit/push."""
+
+    text = _clean_optional_str(value)
+    if not text:
+        return False
+    return _NO_COMMIT_PUSH_PATTERN.search(text) is not None
 
 
 def _normalize_capabilities(values: list[object] | tuple[object, ...]) -> list[str]:
@@ -615,6 +641,40 @@ class TaskExecutionSpec(BaseModel):
             raise TaskContractError(
                 "task.publish.mode must be 'none' when using skill 'pr-resolver'"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_resolve_pr_constraints(self) -> "TaskExecutionSpec":
+        """Reject conflicting constraints for resolve-PR task objectives."""
+
+        if not _is_resolve_pr_objective(self.instructions):
+            return self
+
+        skill_ids: set[str] = {str(self.skill.id or "").strip().lower()}
+        instruction_chunks: list[str] = [self.instructions]
+        for step in self.steps:
+            if step.skill is not None:
+                skill_ids.add(str(step.skill.id or "").strip().lower())
+            if step.instructions:
+                instruction_chunks.append(step.instructions)
+
+        if (
+            self.publish.mode == "none"
+            and "pr-resolver" not in skill_ids
+        ):
+            raise TaskContractError(
+                "resolve-PR objectives with task.publish.mode='none' require "
+                "skill 'pr-resolver' so commit/push/merge can be handled directly"
+            )
+
+        if any(
+            _contains_no_commit_push_constraint(chunk)
+            for chunk in instruction_chunks
+        ):
+            raise TaskContractError(
+                "resolve-PR objectives cannot include 'Do NOT commit or push' constraints"
+            )
+
         return self
 
 

--- a/moonmind/workflows/agent_queue/task_contract.py
+++ b/moonmind/workflows/agent_queue/task_contract.py
@@ -658,18 +658,14 @@ class TaskExecutionSpec(BaseModel):
             if step.instructions:
                 instruction_chunks.append(step.instructions)
 
-        if (
-            self.publish.mode == "none"
-            and "pr-resolver" not in skill_ids
-        ):
+        if self.publish.mode == "none" and "pr-resolver" not in skill_ids:
             raise TaskContractError(
                 "resolve-PR objectives with task.publish.mode='none' require "
                 "skill 'pr-resolver' so commit/push/merge can be handled directly"
             )
 
         if any(
-            _contains_no_commit_push_constraint(chunk)
-            for chunk in instruction_chunks
+            _contains_no_commit_push_constraint(chunk) for chunk in instruction_chunks
         ):
             raise TaskContractError(
                 "resolve-PR objectives cannot include 'Do NOT commit or push' constraints"

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -3047,7 +3047,10 @@ async def test_run_once_rejects_resolve_pr_publish_none_without_pr_resolver(
     assert processed is True
     assert queue.completed == []
     assert len(queue.failed) == 1
-    assert "resolve-PR objectives with task.publish.mode='none' require skill 'pr-resolver'" in queue.failed[0]
+    assert (
+        "resolve-PR objectives with task.publish.mode='none' require skill 'pr-resolver'"
+        in queue.failed[0]
+    )
     assert handler.calls == []
 
 
@@ -3095,7 +3098,11 @@ async def test_run_once_fails_resolve_pr_when_final_state_unresolved(
             output_chunk_callback=None,
         ):
             snapshot_path = (
-                tmp_path / str(job_id) / "repo" / "artifacts" / "pr_resolver_snapshot.json"
+                tmp_path
+                / str(job_id)
+                / "repo"
+                / "artifacts"
+                / "pr_resolver_snapshot.json"
             )
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
             snapshot_path.write_text(
@@ -3200,7 +3207,11 @@ async def test_run_once_allows_resolve_pr_when_final_state_is_resolved(
             output_chunk_callback=None,
         ):
             snapshot_path = (
-                tmp_path / str(job_id) / "repo" / "artifacts" / "pr_resolver_snapshot.json"
+                tmp_path
+                / str(job_id)
+                / "repo"
+                / "artifacts"
+                / "pr_resolver_snapshot.json"
             )
             snapshot_path.parent.mkdir(parents=True, exist_ok=True)
             snapshot_path.write_text(

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -3008,6 +3008,253 @@ async def test_run_once_rejects_when_required_capabilities_missing(
     assert handler.calls == []
 
 
+async def test_run_once_rejects_resolve_pr_publish_none_without_pr_resolver(
+    tmp_path: Path,
+) -> None:
+    """Contract validation should reject resolve-PR tasks that cannot self-publish."""
+
+    job = ClaimedJob(
+        id=uuid4(),
+        type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex",
+            "task": {
+                "instructions": "Resolve PR #777",
+                "skill": {"id": "auto", "args": {}},
+                "runtime": {"mode": "codex"},
+                "git": {"startingBranch": "feature/resolve-pr", "newBranch": None},
+                "publish": {"mode": "none"},
+            },
+        },
+    )
+    queue = FakeQueueClient(jobs=[job])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    processed = await worker.run_once()
+
+    assert processed is True
+    assert queue.completed == []
+    assert len(queue.failed) == 1
+    assert "resolve-PR objectives with task.publish.mode='none' require skill 'pr-resolver'" in queue.failed[0]
+    assert handler.calls == []
+
+
+async def test_run_once_fails_resolve_pr_when_final_state_unresolved(
+    tmp_path: Path,
+) -> None:
+    """resolve-PR runs must fail when final snapshot remains unresolved."""
+
+    step_log = tmp_path / "resolve-pr.log"
+    step_log.write_text("step", encoding="utf-8")
+
+    job = ClaimedJob(
+        id=uuid4(),
+        type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex",
+            "task": {
+                "instructions": "Resolve PR #321",
+                "skill": {"id": "auto", "args": {}},
+                "runtime": {"mode": "codex"},
+                "git": {"startingBranch": "feature/resolve-pr", "newBranch": None},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "resolve",
+                        "instructions": "Follow pr-resolver workflow",
+                        "skill": {"id": "pr-resolver", "args": {"pr": "321"}},
+                    }
+                ],
+            },
+        },
+    )
+    queue = FakeQueueClient(jobs=[job])
+
+    class _UnresolvedPrStateHandler(FakeHandler):
+        async def handle_skill(
+            self,
+            *,
+            job_id,
+            payload,
+            selected_skill,
+            fallback=False,
+            cancel_event=None,
+            output_chunk_callback=None,
+        ):
+            snapshot_path = (
+                tmp_path / str(job_id) / "repo" / "artifacts" / "pr_resolver_snapshot.json"
+            )
+            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_path.write_text(
+                json.dumps(
+                    {
+                        "pr": {
+                            "number": 321,
+                            "mergeable": "CONFLICTING",
+                            "mergeStateStatus": "DIRTY",
+                        },
+                        "commentsSummary": {
+                            "hasActionableComments": True,
+                            "actionableCommentCount": 2,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return await super().handle_skill(
+                job_id=job_id,
+                payload=payload,
+                selected_skill=selected_skill,
+                fallback=fallback,
+                cancel_event=cancel_event,
+                output_chunk_callback=output_chunk_callback,
+            )
+
+    handler = _UnresolvedPrStateHandler(
+        WorkerExecutionResult(
+            succeeded=True,
+            summary="resolver completed",
+            error_message=None,
+            artifacts=(ArtifactUpload(path=step_log, name="logs/codex_exec.log"),),
+        )
+    )
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    processed = await worker.run_once()
+
+    assert processed is True
+    assert queue.completed == []
+    assert len(queue.failed) == 1
+    assert "pr-resolution final state unresolved" in queue.failed[0]
+    assert "reports/pr_resolution_validation.json" in queue.uploaded
+    assert queue.failed_finish_payloads[0]["finishOutcomeStage"] == "execute"
+    assert queue.failed_finish_payloads[0]["finishOutcomeCode"] == "FAILED"
+    assert not any(
+        event["message"] == "moonmind.task.publish" for event in queue.events
+    )
+    assert handler.calls == ["codex_skill:pr-resolver:True"]
+
+
+async def test_run_once_allows_resolve_pr_when_final_state_is_resolved(
+    tmp_path: Path,
+) -> None:
+    """resolve-PR runs should complete when final snapshot has no unresolved signals."""
+
+    step_log = tmp_path / "resolve-pr-ok.log"
+    step_log.write_text("step", encoding="utf-8")
+
+    job = ClaimedJob(
+        id=uuid4(),
+        type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex",
+            "task": {
+                "instructions": "Resolve PR #654",
+                "skill": {"id": "auto", "args": {}},
+                "runtime": {"mode": "codex"},
+                "git": {"startingBranch": "feature/resolve-pr", "newBranch": None},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "resolve",
+                        "instructions": "Follow pr-resolver workflow",
+                        "skill": {"id": "pr-resolver", "args": {"pr": "654"}},
+                    }
+                ],
+            },
+        },
+    )
+    queue = FakeQueueClient(jobs=[job])
+
+    class _ResolvedPrStateHandler(FakeHandler):
+        async def handle_skill(
+            self,
+            *,
+            job_id,
+            payload,
+            selected_skill,
+            fallback=False,
+            cancel_event=None,
+            output_chunk_callback=None,
+        ):
+            snapshot_path = (
+                tmp_path / str(job_id) / "repo" / "artifacts" / "pr_resolver_snapshot.json"
+            )
+            snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+            snapshot_path.write_text(
+                json.dumps(
+                    {
+                        "pr": {
+                            "number": 654,
+                            "mergeable": "MERGEABLE",
+                            "mergeStateStatus": "CLEAN",
+                        },
+                        "commentsSummary": {
+                            "hasActionableComments": False,
+                            "actionableCommentCount": 0,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            return await super().handle_skill(
+                job_id=job_id,
+                payload=payload,
+                selected_skill=selected_skill,
+                fallback=fallback,
+                cancel_event=cancel_event,
+                output_chunk_callback=output_chunk_callback,
+            )
+
+    handler = _ResolvedPrStateHandler(
+        WorkerExecutionResult(
+            succeeded=True,
+            summary="resolver completed",
+            error_message=None,
+            artifacts=(ArtifactUpload(path=step_log, name="logs/codex_exec.log"),),
+        )
+    )
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    processed = await worker.run_once()
+
+    assert processed is True
+    assert queue.failed == []
+    assert len(queue.completed) == 1
+    assert "reports/pr_resolution_validation.json" in queue.uploaded
+    assert handler.calls == ["codex_skill:pr-resolver:True"]
+
+
 async def test_run_once_universal_worker_executes_gemini_task(tmp_path: Path) -> None:
     """Universal worker mode should execute non-codex runtime tasks."""
 

--- a/tests/unit/workflows/agent_queue/test_task_contract.py
+++ b/tests/unit/workflows/agent_queue/test_task_contract.py
@@ -79,6 +79,50 @@ def test_normalize_task_payload_rejects_pr_resolver_without_publish_none() -> No
         )
 
 
+def test_normalize_task_payload_rejects_resolve_pr_without_pr_resolver() -> None:
+    """resolve-PR objectives with publish mode none require `pr-resolver`."""
+
+    with pytest.raises(
+        TaskContractError,
+        match="resolve-PR objectives with task.publish.mode='none' require skill 'pr-resolver'",
+    ):
+        normalize_queue_job_payload(
+            job_type="task",
+            payload={
+                "repository": "Moon/Mind",
+                "task": {
+                    "instructions": "Resolve PR #456",
+                    "skill": {"id": "auto", "args": {}},
+                    "runtime": {"mode": "codex"},
+                    "git": {"startingBranch": "feature/example", "newBranch": None},
+                    "publish": {"mode": "none"},
+                },
+            },
+        )
+
+
+def test_normalize_task_payload_rejects_resolve_pr_no_commit_push_constraint() -> None:
+    """resolve-PR objectives must not include no-commit/push constraints."""
+
+    with pytest.raises(
+        TaskContractError,
+        match="resolve-PR objectives cannot include 'Do NOT commit or push' constraints",
+    ):
+        normalize_queue_job_payload(
+            job_type="task",
+            payload={
+                "repository": "Moon/Mind",
+                "task": {
+                    "instructions": "Resolve PR #456. Do NOT commit or push.",
+                    "skill": {"id": "pr-resolver", "args": {"pr": "456"}},
+                    "runtime": {"mode": "codex"},
+                    "git": {"startingBranch": "feature/example", "newBranch": None},
+                    "publish": {"mode": "none"},
+                },
+            },
+        )
+
+
 def test_normalize_task_payload_respects_default_publish_mode_override(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- recover unpublished task run `f84900bf-8bae-4559-a1e2-7335a7b1f153`
- fail fast when PR-resolver style objectives conflict with `publish.mode=none` and disallowed commit/push requirements
- enforce unresolved-PR detection in final outcome mapping (e.g. dirty/conflicting merge state or actionable comments remaining)
- add/expand contract and worker tests for constraint mismatch and unresolved state handling

## Validation
- `./tools/test_unit.sh`
  - Result on this branch: `3 failed, 918 passed`
  - The 3 failures are in `tests/unit/test_pr_resolver_tools.py` and are unrelated to files changed in this PR.
