### PR TITLE
Fix Gemini worker tool access and import noise (v2)

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ Auto-generated from all feature plans. Last updated: 2025-11-23
 - Python 3.11+ (matches existing `api_service` and workers) (008-gemini-cli-worker)
 - Docker named volume (`gemini_auth_volume`) for auth persistence (008-gemini-cli-worker)
 
-- Node.js 20+ (for CLI runtime), Python 3.11 (existing service) + `@google/gemini-cli` (npm package) (006-add-gemini-cli)
+- Node.js 20+ (for CLI runtime), Python 3.11 (existing service) + Gemini CLI npm package (`@google` scope, `gemini-cli` name) (006-add-gemini-cli)
 
 ## Project Structure
 
@@ -19,7 +19,7 @@ tests/
 
 ## Commands
 
-- npm install -g @google/gemini-cli
+- npm install -g [Gemini CLI npm package under the `@google` scope]
 - gemini --version
 
 ## Code Style
@@ -30,7 +30,7 @@ Node.js 20+ (for CLI runtime), Python 3.11 (existing service): Follow standard c
 - 008-gemini-cli-worker: Added Python 3.11+ (matches existing `api_service` and workers)
 - 007-scalable-codex-worker: Added Python 3.11 + Celery (Work Queue), Docker (Containerization), Codex CLI (Tooling)
 
-- 006-add-gemini-cli: Added Node.js 20+ (for CLI runtime), Python 3.11 (existing service) + `@google/gemini-cli` (npm package)
+- 006-add-gemini-cli: Added Node.js 20+ (for CLI runtime), Python 3.11 (existing service) + Gemini CLI npm package (`@google` scope, `gemini-cli` name)
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -338,6 +338,7 @@ class CodexWorkerConfig:
     default_claude_effort: str | None = None
     gemini_binary: str = "gemini"
     gemini_cli_auth_mode: str = "api_key"
+    gemini_approval_mode: str = "yolo"
     claude_binary: str = "claude"
     worker_capabilities: tuple[str, ...] = ("codex", "git", "gh")
     docker_binary: str = "docker"
@@ -580,6 +581,15 @@ class CodexWorkerConfig:
         if gemini_cli_auth_mode not in {"api_key", "oauth"}:
             raise ValueError(
                 "MOONMIND_GEMINI_CLI_AUTH_MODE must be one of: api_key, oauth"
+            )
+        gemini_approval_mode = (
+            str(source.get("MOONMIND_GEMINI_APPROVAL_MODE", "yolo")).strip().lower()
+            or "yolo"
+        )
+        if gemini_approval_mode not in {"default", "auto_edit", "yolo", "plan"}:
+            raise ValueError(
+                "MOONMIND_GEMINI_APPROVAL_MODE must be one of: "
+                "default, auto_edit, yolo, plan"
             )
         claude_binary = (
             str(source.get("MOONMIND_CLAUDE_BINARY", "claude")).strip() or "claude"
@@ -880,6 +890,7 @@ class CodexWorkerConfig:
             default_claude_effort=default_claude_effort,
             gemini_binary=gemini_binary,
             gemini_cli_auth_mode=gemini_cli_auth_mode,
+            gemini_approval_mode=gemini_approval_mode,
             claude_binary=claude_binary,
             worker_capabilities=worker_capabilities,
             docker_binary=docker_binary,
@@ -7750,7 +7761,13 @@ class CodexWorker:
         effort: str | None,
     ) -> list[str]:
         if runtime_mode == "gemini":
-            command = [self._config.gemini_binary, "--prompt", instruction]
+            command = [
+                self._config.gemini_binary,
+                "--approval-mode",
+                self._config.gemini_approval_mode,
+                "--prompt",
+                instruction,
+            ]
         elif runtime_mode == "claude":
             command = [self._config.claude_binary, "--print", instruction]
         else:

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -586,10 +586,11 @@ class CodexWorkerConfig:
             str(source.get("MOONMIND_GEMINI_APPROVAL_MODE", "yolo")).strip().lower()
             or "yolo"
         )
-        if gemini_approval_mode not in {"default", "auto_edit", "yolo", "plan"}:
+        allowed_approval_modes = {"default", "auto_edit", "yolo", "plan"}
+        if gemini_approval_mode not in allowed_approval_modes:
             raise ValueError(
                 "MOONMIND_GEMINI_APPROVAL_MODE must be one of: "
-                "default, auto_edit, yolo, plan"
+                f"{', '.join(sorted(allowed_approval_modes))}"
             )
         claude_binary = (
             str(source.get("MOONMIND_CLAUDE_BINARY", "claude")).strip() or "claude"

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -4756,6 +4756,7 @@ async def test_config_from_env_defaults_and_overrides(monkeypatch) -> None:
     monkeypatch.setenv("MOONMIND_ARTIFACT_UPLOAD_INCREMENTAL", "false")
     monkeypatch.setenv("MOONMIND_STEP_LOG_MAX_BYTES", "2097152")
     monkeypatch.setenv("MOONMIND_SKILL_POLICY_MODE", "allowlist")
+    monkeypatch.setenv("MOONMIND_GEMINI_APPROVAL_MODE", "auto_edit")
     monkeypatch.setenv("MOONMIND_GIT_USER_NAME", "Nate Sticco")
     monkeypatch.setenv("MOONMIND_GIT_USER_EMAIL", "nsticco@gmail.com")
 
@@ -4777,6 +4778,7 @@ async def test_config_from_env_defaults_and_overrides(monkeypatch) -> None:
     assert config.stage_command_timeout_seconds == 2400
     assert config.artifact_upload_incremental is False
     assert config.step_log_max_bytes == 2097152
+    assert config.gemini_approval_mode == "auto_edit"
     assert config.git_user_name == "Nate Sticco"
     assert config.git_user_email == "nsticco@gmail.com"
 
@@ -4915,6 +4917,20 @@ async def test_config_from_env_uses_defaults(monkeypatch) -> None:
     assert config.stage_command_timeout_seconds == 3600
     assert config.artifact_upload_incremental is True
     assert config.step_log_max_bytes == 1024 * 1024
+    assert config.gemini_approval_mode == "yolo"
+
+
+async def test_config_from_env_rejects_invalid_gemini_approval_mode(monkeypatch) -> None:
+    """Gemini approval mode should fail fast on unsupported values."""
+
+    monkeypatch.setenv("MOONMIND_URL", "http://localhost:5000")
+    monkeypatch.setenv("MOONMIND_GEMINI_APPROVAL_MODE", "unsafe")
+
+    with pytest.raises(
+        ValueError,
+        match="MOONMIND_GEMINI_APPROVAL_MODE must be one of",
+    ):
+        CodexWorkerConfig.from_env()
 
 
 async def test_config_from_env_enables_task_proposals(monkeypatch) -> None:
@@ -5083,6 +5099,48 @@ async def test_runtime_override_precedence_prefers_task_then_worker_defaults(
     )
     assert model_override == "gemini-2.5-pro"
     assert effort_override == "high"
+
+
+async def test_build_non_codex_runtime_command_uses_gemini_approval_mode(
+    tmp_path: Path,
+) -> None:
+    """Gemini runtime command should include explicit non-interactive approval mode."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+        worker_runtime="gemini",
+        gemini_binary="gemini",
+        gemini_approval_mode="yolo",
+    )
+    queue = FakeQueueClient(jobs=[])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    command = worker._build_non_codex_runtime_command(
+        runtime_mode="gemini",
+        instruction="Apply patch and run tests.",
+        model="gemini-2.5-pro",
+        effort="high",
+    )
+
+    assert command == [
+        "gemini",
+        "--approval-mode",
+        "yolo",
+        "--prompt",
+        "Apply patch and run tests.",
+        "--model",
+        "gemini-2.5-pro",
+        "--effort",
+        "high",
+    ]
 
 
 @pytest.fixture

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -4920,7 +4920,9 @@ async def test_config_from_env_uses_defaults(monkeypatch) -> None:
     assert config.gemini_approval_mode == "yolo"
 
 
-async def test_config_from_env_rejects_invalid_gemini_approval_mode(monkeypatch) -> None:
+async def test_config_from_env_rejects_invalid_gemini_approval_mode(
+    monkeypatch,
+) -> None:
     """Gemini approval mode should fail fast on unsupported values."""
 
     monkeypatch.setenv("MOONMIND_URL", "http://localhost:5000")


### PR DESCRIPTION
## Summary
- add explicit Gemini headless approval mode support to worker config (`MOONMIND_GEMINI_APPROVAL_MODE`, default `yolo`)
- pass `--approval-mode <mode>` on Gemini runtime execution so non-interactive runs can use edit/shell tools
- remove `google/gemini-cli` token patterns from `GEMINI.md` to stop Gemini ImportProcessor ENOENT noise
- add unit tests for config parsing/validation and Gemini command construction

## Validation
- ran `./tools/test_unit.sh`
  - result: `873 passed`
