### PR TITLE
Fix Gemini worker proposal hook pathing and worker runtime prerequisites

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -312,9 +312,9 @@ RUN touch /app/moonmind/__init__.py /app/api_service/__init__.py
 
 # Install dependencies first (this layer will be cached as long as pyproject.toml doesn't change)
 RUN pip install -e .
-RUN pip install readmeai~=0.6.3 --no-deps
-# Keep test runners available in all worker images (codex/gemini/claude).
-RUN pip install pytest pytest-xdist
+RUN pip install readmeai~=0.6.3 --no-deps && \
+    # Keep test runners available in all worker images (codex/gemini/claude).
+    pip install pytest pytest-xdist
 
 # Install test extras when requested so compose-driven test runs have pytest and
 # related dependencies baked into the image, avoiding runtime network installs.

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -1476,21 +1476,21 @@ class QueueApiClient:
                     f"artifact upload failed for job {job_id}: {exc}"
                 ) from exc
 
-    async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
+    async def _request_json(
+        self, method: str, path: str, *, json: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
-            response = await self._client.post(path, json=json)
+            response = await self._client.request(method, path, json=json)
             response.raise_for_status()
             return dict(response.json()) if response.content else {}
         except httpx.HTTPError as exc:
             raise QueueClientError(f"queue API request failed: {path}: {exc}") from exc
 
+    async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        return await self._request_json("POST", path, json=json)
+
     async def _put_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
-        try:
-            response = await self._client.put(path, json=json)
-            response.raise_for_status()
-            return dict(response.json()) if response.content else {}
-        except httpx.HTTPError as exc:
-            raise QueueClientError(f"queue API request failed: {path}: {exc}") from exc
+        return await self._request_json("PUT", path, json=json)
 
     async def create_task_proposal(self, *, proposal: dict[str, Any]) -> dict[str, Any]:
         """Submit a task proposal to the MoonMind API."""
@@ -6777,17 +6777,27 @@ class CodexWorker:
 
         source_task_context = prepared.artifacts_dir / "task_context.json"
         mirrored_task_context = evidence_root / "task_context.json"
-        if source_task_context.exists():
-            shutil.copy2(source_task_context, mirrored_task_context)
+        if source_task_context.is_file() and not source_task_context.is_symlink():
+            shutil.copy2(
+                source_task_context, mirrored_task_context, follow_symlinks=False
+            )
         else:
             mirrored_task_context.write_text("{}\n", encoding="utf-8")
 
         source_logs_dir = prepared.artifacts_dir / "logs"
         mirrored_logs_dir = evidence_root / "logs"
         if mirrored_logs_dir.exists():
-            shutil.rmtree(mirrored_logs_dir)
-        if source_logs_dir.exists():
-            shutil.copytree(source_logs_dir, mirrored_logs_dir)
+            if mirrored_logs_dir.is_symlink() or mirrored_logs_dir.is_file():
+                mirrored_logs_dir.unlink()
+            else:
+                shutil.rmtree(mirrored_logs_dir)
+        if source_logs_dir.is_dir() and not source_logs_dir.is_symlink():
+            shutil.copytree(
+                source_logs_dir,
+                mirrored_logs_dir,
+                symlinks=True,
+                ignore_dangling_symlinks=True,
+            )
         else:
             mirrored_logs_dir.mkdir(parents=True, exist_ok=True)
 
@@ -6857,7 +6867,7 @@ class CodexWorker:
             task_context_path, artifacts_path = (
                 self._prepare_post_task_proposal_evidence_paths(prepared=prepared)
             )
-        except OSError:
+        except (OSError, shutil.Error):
             logger.warning(
                 "Failed to mirror proposal evidence into repo workspace for job %s; "
                 "falling back to worker artifact paths.",

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -6,6 +6,7 @@ import asyncio
 import gzip
 import json
 import logging
+import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Sequence
@@ -222,14 +223,16 @@ async def test_parse_positive_int_field_rejects_invalid_values() -> None:
         )
 
 
-class _RecordingPutClient:
-    """Minimal async HTTP client stub capturing PUT calls."""
+class _RecordingRequestClient:
+    """Minimal async HTTP client stub capturing JSON request calls."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.calls: list[tuple[str, str, dict[str, object]]] = []
 
-    async def put(self, path: str, *, json: dict[str, object]) -> object:
-        self.calls.append((path, dict(json)))
+    async def request(
+        self, method: str, path: str, *, json: dict[str, object]
+    ) -> object:
+        self.calls.append((method, path, dict(json)))
         return _QueueApiResponseStub()
 
 
@@ -254,7 +257,7 @@ async def test_replace_worker_runtime_capabilities_uses_put(
         base_url="http://moonmind.test",
         worker_token="token",
     )
-    recorder = _RecordingPutClient()
+    recorder = _RecordingRequestClient()
     monkeypatch.setattr(client, "_client", recorder)
     runtime_caps = {"gemini": {"models": ["gemini-3-pro"], "efforts": []}}
 
@@ -264,6 +267,7 @@ async def test_replace_worker_runtime_capabilities_uses_put(
 
     assert recorder.calls == [
         (
+            "PUT",
             "/api/queue/workers/tokens/capabilities",
             {"runtimeCapabilities": runtime_caps},
         )
@@ -441,6 +445,93 @@ def _build_execute_stage_workspace(*, tmp_path: Path, job_id) -> PreparedTaskWor
         repo_command_env=None,
         publish_command_env=None,
     )
+
+
+def test_prepare_post_task_proposal_evidence_paths_rejects_symlink_sources(
+    tmp_path: Path,
+) -> None:
+    """Mirroring should not read symlinked task context/log sources."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+        ),
+    )
+    prepared = _build_execute_stage_workspace(tmp_path=tmp_path, job_id=uuid4())
+
+    source_task_context = prepared.artifacts_dir / "task_context.json"
+    source_logs_dir = prepared.artifacts_dir / "logs"
+    secret_context = tmp_path / "secret-task-context.json"
+    secret_context.write_text('{"secret":"value"}\n', encoding="utf-8")
+    source_task_context.symlink_to(secret_context)
+    shutil.rmtree(source_logs_dir)
+    external_logs = tmp_path / "external-logs"
+    external_logs.mkdir(parents=True, exist_ok=True)
+    (external_logs / "sensitive.log").write_text("sensitive\n", encoding="utf-8")
+    source_logs_dir.symlink_to(external_logs, target_is_directory=True)
+
+    mirrored_task_context_path, mirrored_artifacts_path = (
+        worker._prepare_post_task_proposal_evidence_paths(prepared=prepared)
+    )
+    mirrored_task_context = Path(mirrored_task_context_path)
+    mirrored_logs_dir = Path(mirrored_artifacts_path) / "logs"
+
+    assert mirrored_task_context.read_text(encoding="utf-8") == "{}\n"
+    assert mirrored_logs_dir.is_dir()
+    assert list(mirrored_logs_dir.iterdir()) == []
+
+
+def test_prepare_post_task_proposal_evidence_paths_preserves_log_symlinks(
+    tmp_path: Path,
+) -> None:
+    """Mirroring should keep symlink entries as symlinks instead of dereferencing."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(
+        config=config,
+        queue_client=FakeQueueClient(),
+        codex_exec_handler=FakeHandler(
+            WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+        ),
+    )
+    prepared = _build_execute_stage_workspace(tmp_path=tmp_path, job_id=uuid4())
+
+    source_task_context = prepared.artifacts_dir / "task_context.json"
+    source_logs_dir = prepared.artifacts_dir / "logs"
+    source_task_context.write_text('{"task":"ok"}\n', encoding="utf-8")
+    (source_logs_dir / "worker.log").write_text("worker\n", encoding="utf-8")
+    external_log = tmp_path / "outside.log"
+    external_log.write_text("outside\n", encoding="utf-8")
+    (source_logs_dir / "external.log").symlink_to(external_log)
+
+    mirrored_task_context_path, mirrored_artifacts_path = (
+        worker._prepare_post_task_proposal_evidence_paths(prepared=prepared)
+    )
+    mirrored_task_context = Path(mirrored_task_context_path)
+    mirrored_logs_dir = Path(mirrored_artifacts_path) / "logs"
+    mirrored_external = mirrored_logs_dir / "external.log"
+
+    assert mirrored_task_context.read_text(encoding="utf-8") == '{"task":"ok"}\n'
+    assert (mirrored_logs_dir / "worker.log").read_text(encoding="utf-8") == "worker\n"
+    assert mirrored_external.is_symlink()
+    assert mirrored_external.resolve() == external_log.resolve()
 
 
 def _build_resolved_step(


### PR DESCRIPTION
## Summary
- fix queue capability sync to use `PUT /api/queue/workers/tokens/capabilities` so worker startup no longer gets 405
- mirror post-run proposal evidence into repo-local `.artifacts/proposal_inputs` so Gemini proposal hooks can read required logs/context within workspace constraints
- add `procps` to worker image so `pgrep` is available during CLI tool execution
- install `pytest` and `pytest-xdist` in all worker images by default for consistent future test execution
- add a unit regression test verifying runtime capability sync uses PUT

## Validation
- `./tools/test_unit.sh` (passes)
