### PR TITLE
🧪 test: add unit tests for retrieval gateway authorization

### DIFF
--- a/api_service/api/routers/agent_queue.py
+++ b/api_service/api/routers/agent_queue.py
@@ -648,11 +648,6 @@ def _to_http_exception(exc: Exception) -> HTTPException:
         code = "invalid_queue_payload"
         message = "Queue request payload is invalid."
         raw_message = str(exc).strip()
-        detail: dict[str, Any] = {
-            "code": code,
-            "message": message,
-            "debugMessage": raw_message,
-        }
         lowered = str(exc).lower()
         if "targetruntime=claude requires anthropic_api_key" in lowered:
             return HTTPException(
@@ -690,11 +685,14 @@ def _to_http_exception(exc: Exception) -> HTTPException:
                 if isinstance(cause, ManifestContractError):
                     # Surface actionable manifest contract failures to API clients.
                     message = raw_message
-                    detail["message"] = message
                     break
                 cause = getattr(cause, "__cause__", None)
 
-        detail["message"] = message
+        detail: dict[str, Any] = {
+            "code": code,
+            "message": message,
+            "debugMessage": raw_message,
+        }
         return HTTPException(status_code=status_code, detail=detail)
     logger.exception("Unhandled agent queue exception")
     return HTTPException(

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -145,6 +145,47 @@ async def test_authorize_with_bearer_token() -> None:
 
 
 @pytest.mark.asyncio
+async def test_authorize_prefers_worker_token_over_bearer() -> None:
+    policy = SimpleNamespace(
+        auth_source="worker_token",
+        allowed_repositories=("repo4",),
+        capabilities=("rag",),
+    )
+    service = MockQueueService(policy=policy)
+
+    result = await authorize_retrieval_request(
+        worker_token_header="worker_token_abc",
+        authorization_header="Bearer bearer_token_xyz",
+        queue_service=service,  # type: ignore
+        user=None,
+    )
+
+    assert result.auth_source == "worker_token"
+    assert service.called_with_token == "worker_token_abc"
+
+
+@pytest.mark.asyncio
+async def test_authorize_prefers_token_over_user() -> None:
+    policy = SimpleNamespace(
+        auth_source="worker_token",
+        allowed_repositories=("repo5",),
+        capabilities=("rag",),
+    )
+    service = MockQueueService(policy=policy)
+    user = SimpleNamespace(id="user_1")
+
+    result = await authorize_retrieval_request(
+        worker_token_header=None,
+        authorization_header="Bearer bearer_token_456",
+        queue_service=service,  # type: ignore
+        user=user,  # type: ignore
+    )
+
+    assert result.auth_source == "worker_token"
+    assert service.called_with_token == "bearer_token_456"
+
+
+@pytest.mark.asyncio
 async def test_authorize_invalid_worker_token() -> None:
     service = MockQueueService(error=AgentQueueAuthenticationError("invalid"))
 

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from fastapi import FastAPI
+import pytest
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from api_service.api.routers.retrieval_gateway import (
@@ -12,6 +13,7 @@ from api_service.api.routers.retrieval_gateway import (
     router,
 )
 from moonmind.rag.context_pack import ContextItem, build_context_pack
+from moonmind.workflows.agent_queue.service import AgentQueueAuthenticationError
 
 
 class StubService:
@@ -83,3 +85,130 @@ def test_context_returns_gateway_transport_for_authorized_request() -> None:
 
     assert response.status_code == 200
     assert response.json()["transport"] == "gateway"
+
+
+class MockQueueService:
+    def __init__(self, policy=None, error=None) -> None:
+        self.policy = policy
+        self.error = error
+        self.called_with_token = None
+
+    async def resolve_worker_token(self, token: str):
+        self.called_with_token = token
+        if self.error:
+            raise self.error
+        return self.policy
+
+
+@pytest.mark.asyncio
+async def test_authorize_with_worker_token_header() -> None:
+    policy = SimpleNamespace(
+        auth_source="worker_token",
+        allowed_repositories=("repo1",),
+        capabilities=("rag",),
+    )
+    service = MockQueueService(policy=policy)
+
+    result = await authorize_retrieval_request(
+        worker_token_header="token_abc",
+        authorization_header=None,
+        queue_service=service,  # type: ignore
+        user=None,
+    )
+
+    assert result.auth_source == "worker_token"
+    assert result.allowed_repositories == ("repo1",)
+    assert result.capabilities == ("rag",)
+    assert service.called_with_token == "token_abc"
+
+
+@pytest.mark.asyncio
+async def test_authorize_with_bearer_token() -> None:
+    policy = SimpleNamespace(
+        auth_source="worker_token",
+        allowed_repositories=("repo2",),
+        capabilities=("gateway",),
+    )
+    service = MockQueueService(policy=policy)
+
+    result = await authorize_retrieval_request(
+        worker_token_header=None,
+        authorization_header="Bearer token_xyz",
+        queue_service=service,  # type: ignore
+        user=None,
+    )
+
+    assert result.auth_source == "worker_token"
+    assert result.allowed_repositories == ("repo2",)
+    assert result.capabilities == ("gateway",)
+    assert service.called_with_token == "token_xyz"
+
+
+@pytest.mark.asyncio
+async def test_authorize_invalid_worker_token() -> None:
+    service = MockQueueService(error=AgentQueueAuthenticationError("invalid"))
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorize_retrieval_request(
+            worker_token_header="invalid_token",
+            authorization_header=None,
+            queue_service=service,  # type: ignore
+            user=None,
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Invalid worker token."
+
+
+@pytest.mark.asyncio
+async def test_authorize_missing_capability() -> None:
+    policy = SimpleNamespace(
+        auth_source="worker_token",
+        allowed_repositories=("repo3",),
+        capabilities=("other_capability",),
+    )
+    service = MockQueueService(policy=policy)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorize_retrieval_request(
+            worker_token_header="token_123",
+            authorization_header=None,
+            queue_service=service,  # type: ignore
+            user=None,
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Worker token does not have RAG retrieval capability."
+
+
+@pytest.mark.asyncio
+async def test_authorize_with_valid_user() -> None:
+    user = SimpleNamespace(id="user_1")
+    service = MockQueueService()
+
+    result = await authorize_retrieval_request(
+        worker_token_header=None,
+        authorization_header=None,
+        queue_service=service,  # type: ignore
+        user=user,  # type: ignore
+    )
+
+    assert result.auth_source == "oidc"
+    assert result.allowed_repositories == ()
+    assert result.capabilities == ("rag",)
+
+
+@pytest.mark.asyncio
+async def test_authorize_unauthorized() -> None:
+    service = MockQueueService()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await authorize_retrieval_request(
+            worker_token_header=None,
+            authorization_header=None,
+            queue_service=service,  # type: ignore
+            user=None,
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.detail == "Retrieval authentication is required."

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -178,7 +178,9 @@ async def test_authorize_missing_capability() -> None:
         )
 
     assert excinfo.value.status_code == 403
-    assert excinfo.value.detail == "Worker token does not have RAG retrieval capability."
+    assert (
+        excinfo.value.detail == "Worker token does not have RAG retrieval capability."
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/routers/test_retrieval_gateway.py
+++ b/tests/unit/api/routers/test_retrieval_gateway.py
@@ -178,9 +178,7 @@ async def test_authorize_missing_capability() -> None:
         )
 
     assert excinfo.value.status_code == 403
-    assert (
-        excinfo.value.detail == "Worker token does not have RAG retrieval capability."
-    )
+    assert excinfo.value.detail == "Worker token does not have RAG retrieval capability."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
🎯 **What:** The testing gap for `authorize_retrieval_request` in `api_service/api/routers/retrieval_gateway.py` has been addressed.
📊 **Coverage:** Scenarios for happy paths (worker token, bearer token, valid user) and error conditions (invalid token, missing capabilities, complete unauthorization) are now tested. The `AgentQueueService` mock correctly verifies the extraction of the token by asserting against the `called_with_token`.
✨ **Result:** A significant improvement in test coverage, achieving the requested verification logic.

---
*PR created automatically by Jules for task [5431175238429873399](https://jules.google.com/task/5431175238429873399) started by @nsticco*