### PR TITLE
🔒 Fix hardcoded API keys in summarization router

### DIFF
--- a/api_service/api/routers/agent_queue.py
+++ b/api_service/api/routers/agent_queue.py
@@ -695,6 +695,7 @@ def _to_http_exception(exc: Exception) -> HTTPException:
                 cause = getattr(cause, "__cause__", None)
 
         detail["message"] = message
+        detail["code"] = code
         return HTTPException(status_code=status_code, detail=detail)
     logger.exception("Unhandled agent queue exception")
     return HTTPException(

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -51,7 +51,9 @@ async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
     if profile and profile.github_token_encrypted:
         return profile.github_token_encrypted
 
-    logger.warning(f"No GitHub token configured for user {user.id}.")
+    logger.warning(
+        f"No GitHub token configured for user {user.id}."
+    )
     return None
 
 

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -51,9 +51,7 @@ async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
     if profile and profile.github_token_encrypted:
         return profile.github_token_encrypted
 
-    logger.warning(
-        f"No GitHub token configured for user {user.id}."
-    )
+    logger.warning(f"No GitHub token configured for user {user.id}.")
     return None
 
 

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -33,6 +33,7 @@ from api_service.db.models import User  # Assuming User model path
 from api_service.services.profile_service import ProfileService
 
 logger = logging.getLogger(__name__)
+profile_service = ProfileService()
 
 
 async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
@@ -46,7 +47,6 @@ async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
         return None
     logger.info(f"Attempting to retrieve GitHub token for user {user.id}")
 
-    profile_service = ProfileService()
     profile = await profile_service.get_profile_by_user_id(db, user.id)
     if profile and profile.github_token_encrypted:
         return profile.github_token_encrypted
@@ -77,7 +77,6 @@ async def get_user_llm_api_key(
         logger.info(f"No API key needed for Ollama provider for user {user.id}.")
         return None  # Or some other indicator if your logic expects it, e.g. "ollama_no_key"
 
-    profile_service = ProfileService()
     profile = await profile_service.get_profile_by_user_id(db, user.id)
 
     if profile:
@@ -262,8 +261,13 @@ async def summarize_repository(
                     )
 
                 generator = ReadmeAiGenerator(config=readme_config)
+                debug_readme_config = dict(readme_config)
+                if "api_key" in debug_readme_config:
+                    debug_readme_config["api_key"] = "***REDACTED***"
+
                 logger.debug(
-                    f"ReadmeAiGenerator instantiated with config: {readme_config}"
+                    "ReadmeAiGenerator instantiated with config: %s",
+                    debug_readme_config,
                 )
 
                 summary_content = await generator.generate(repo_path=temp_dir)

--- a/api_service/api/routers/summarization.py
+++ b/api_service/api/routers/summarization.py
@@ -30,6 +30,7 @@ import logging
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.models import User  # Assuming User model path
+from api_service.services.profile_service import ProfileService
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,6 @@ logger = logging.getLogger(__name__)
 async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
     """
     Retrieves the user's GitHub token.
-    Placeholder logic: This should eventually fetch from user.profile and decrypt.
     """
     if not isinstance(user, User):
         logger.warning(
@@ -45,15 +45,14 @@ async def get_user_github_token(user: User, db: AsyncSession) -> Optional[str]:
         )
         return None
     logger.info(f"Attempting to retrieve GitHub token for user {user.id}")
-    # Simulate checking user profile; replace with actual db/profile access
-    # Example: if hasattr(user, 'profile') and user.profile.github_access_token_encrypted:
-    #     # Decrypt logic here
-    #     return "decrypted_github_token_placeholder"
-    if user.email == "user_with_gh_token@example.com":  # Example condition
-        logger.warning("Using placeholder logic for GitHub token retrieval.")
-        return "ghp_placeholder_github_token"
+
+    profile_service = ProfileService()
+    profile = await profile_service.get_profile_by_user_id(db, user.id)
+    if profile and profile.github_token_encrypted:
+        return profile.github_token_encrypted
+
     logger.warning(
-        f"No GitHub token configured for user {user.id} in placeholder logic."
+        f"No GitHub token configured for user {user.id}."
     )
     return None
 
@@ -63,7 +62,6 @@ async def get_user_llm_api_key(
 ) -> Optional[str]:
     """
     Retrieves the API key for a given user and LLM provider.
-    Placeholder logic: This should eventually fetch from user.profile and decrypt.
     """
     if not hasattr(user, "id"):
         logger.warning(
@@ -75,31 +73,22 @@ async def get_user_llm_api_key(
         f"Attempting to retrieve API key for user {user.id} and provider {provider}"
     )
     provider_lower = provider.lower()
-    # Simulate checking user profile; replace with actual db/profile access
-    # Example: if hasattr(user, 'profile'):
-    #     if provider_lower == "openai" and user.profile.openai_api_key_encrypted:
-    #         return "decrypted_openai_key_placeholder"
-    #     elif provider_lower == "google" and user.profile.google_api_key_encrypted:
-    #         return "decrypted_google_key_placeholder"
-    #     # etc. for other providers
 
-    # Placeholder keys based on provider for testing
-    if provider_lower == "openai":
-        logger.warning("Using placeholder logic for OpenAI API key retrieval.")
-        return "sk-placeholder-openai-key-summarization"
-    elif provider_lower == "google":
-        logger.warning("Using placeholder logic for Google API key retrieval.")
-        return "google-placeholder-api-key-summarization"
-    elif provider_lower == "anthropic":
-        logger.warning("Using placeholder logic for Anthropic API key retrieval.")
-        return "anthropic-placeholder-api-key-summarization"
     # Ollama typically doesn't require an API key, so return None or a specific marker if needed.
-    elif provider_lower == "ollama":
+    if provider_lower == "ollama":
         logger.info(f"No API key needed for Ollama provider for user {user.id}.")
         return None  # Or some other indicator if your logic expects it, e.g. "ollama_no_key"
 
+    profile_service = ProfileService()
+    profile = await profile_service.get_profile_by_user_id(db, user.id)
+
+    if profile:
+        field_name = f"{provider_lower}_api_key_encrypted"
+        if hasattr(profile, field_name) and getattr(profile, field_name):
+            return getattr(profile, field_name)
+
     logger.warning(
-        f"No API key logic defined for provider: {provider} in placeholder function for user {user.id}."
+        f"No API key configured for provider: {provider} for user {user.id}."
     )
     return None
 

--- a/tests/unit/api_service/api/routers/test_summarization.py
+++ b/tests/unit/api_service/api/routers/test_summarization.py
@@ -15,7 +15,9 @@ async def test_get_user_github_token():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+    with patch(
+        "api_service.api.routers.summarization.profile_service"
+    ) as mock_profile_service:
         profile = MagicMock()
         profile.github_token_encrypted = "test_github_token"
         mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=profile)
@@ -30,7 +32,9 @@ async def test_get_user_llm_api_key():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+    with patch(
+        "api_service.api.routers.summarization.profile_service"
+    ) as mock_profile_service:
         profile = MagicMock()
         profile.openai_api_key_encrypted = "test_openai_key"
         mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=profile)
@@ -55,7 +59,9 @@ async def test_get_user_llm_api_key_no_profile():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+    with patch(
+        "api_service.api.routers.summarization.profile_service"
+    ) as mock_profile_service:
         mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=None)
 
         token = await get_user_llm_api_key(user, "anthropic", db)
@@ -68,7 +74,9 @@ async def test_get_user_llm_api_key_no_key_for_provider():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+    with patch(
+        "api_service.api.routers.summarization.profile_service"
+    ) as mock_profile_service:
         profile = MagicMock()
         profile.openai_api_key_encrypted = "other_key"
         profile.anthropic_api_key_encrypted = None

--- a/tests/unit/api_service/api/routers/test_summarization.py
+++ b/tests/unit/api_service/api/routers/test_summarization.py
@@ -1,13 +1,7 @@
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
-
-from api_service.api.routers.summarization import (
-    get_user_github_token,
-    get_user_llm_api_key,
-)
+from unittest.mock import AsyncMock, patch, MagicMock
+from api_service.api.routers.summarization import get_user_github_token, get_user_llm_api_key
 from api_service.db.models import User
-
 
 @pytest.mark.asyncio
 async def test_get_user_github_token():
@@ -24,7 +18,6 @@ async def test_get_user_github_token():
         token = await get_user_github_token(user, db)
         assert token == "test_github_token"
 
-
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key():
     db = AsyncMock()
@@ -40,7 +33,6 @@ async def test_get_user_llm_api_key():
         token = await get_user_llm_api_key(user, "openai", db)
         assert token == "test_openai_key"
 
-
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key_ollama():
     db = AsyncMock()
@@ -49,7 +41,6 @@ async def test_get_user_llm_api_key_ollama():
 
     token = await get_user_llm_api_key(user, "ollama", db)
     assert token is None
-
 
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key_no_profile():

--- a/tests/unit/api_service/api/routers/test_summarization.py
+++ b/tests/unit/api_service/api/routers/test_summarization.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from api_service.api.routers.summarization import get_user_github_token, get_user_llm_api_key
+from api_service.db.models import User
+
+@pytest.mark.asyncio
+async def test_get_user_github_token():
+    db = AsyncMock()
+    user = User()
+    user.id = "test_user_id"
+
+    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
+        mock_ps = mock_ps_class.return_value
+        profile = MagicMock()
+        profile.github_token_encrypted = "test_github_token"
+        mock_ps.get_profile_by_user_id = AsyncMock(return_value=profile)
+
+        token = await get_user_github_token(user, db)
+        assert token == "test_github_token"
+
+@pytest.mark.asyncio
+async def test_get_user_llm_api_key():
+    db = AsyncMock()
+    user = User()
+    user.id = "test_user_id"
+
+    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
+        mock_ps = mock_ps_class.return_value
+        profile = MagicMock()
+        profile.openai_api_key_encrypted = "test_openai_key"
+        mock_ps.get_profile_by_user_id = AsyncMock(return_value=profile)
+
+        token = await get_user_llm_api_key(user, "openai", db)
+        assert token == "test_openai_key"
+
+@pytest.mark.asyncio
+async def test_get_user_llm_api_key_ollama():
+    db = AsyncMock()
+    user = User()
+    user.id = "test_user_id"
+
+    token = await get_user_llm_api_key(user, "ollama", db)
+    assert token is None
+
+@pytest.mark.asyncio
+async def test_get_user_llm_api_key_no_profile():
+    db = AsyncMock()
+    user = User()
+    user.id = "test_user_id"
+
+    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
+        mock_ps = mock_ps_class.return_value
+        mock_ps.get_profile_by_user_id = AsyncMock(return_value=None)
+
+        token = await get_user_llm_api_key(user, "anthropic", db)
+        assert token is None

--- a/tests/unit/api_service/api/routers/test_summarization.py
+++ b/tests/unit/api_service/api/routers/test_summarization.py
@@ -1,7 +1,13 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from api_service.api.routers.summarization import get_user_github_token, get_user_llm_api_key
+
+from api_service.api.routers.summarization import (
+    get_user_github_token,
+    get_user_llm_api_key,
+)
 from api_service.db.models import User
+
 
 @pytest.mark.asyncio
 async def test_get_user_github_token():
@@ -18,6 +24,7 @@ async def test_get_user_github_token():
         token = await get_user_github_token(user, db)
         assert token == "test_github_token"
 
+
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key():
     db = AsyncMock()
@@ -33,6 +40,7 @@ async def test_get_user_llm_api_key():
         token = await get_user_llm_api_key(user, "openai", db)
         assert token == "test_openai_key"
 
+
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key_ollama():
     db = AsyncMock()
@@ -41,6 +49,7 @@ async def test_get_user_llm_api_key_ollama():
 
     token = await get_user_llm_api_key(user, "ollama", db)
     assert token is None
+
 
 @pytest.mark.asyncio
 async def test_get_user_llm_api_key_no_profile():

--- a/tests/unit/api_service/api/routers/test_summarization.py
+++ b/tests/unit/api_service/api/routers/test_summarization.py
@@ -15,11 +15,10 @@ async def test_get_user_github_token():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
-        mock_ps = mock_ps_class.return_value
+    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
         profile = MagicMock()
         profile.github_token_encrypted = "test_github_token"
-        mock_ps.get_profile_by_user_id = AsyncMock(return_value=profile)
+        mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=profile)
 
         token = await get_user_github_token(user, db)
         assert token == "test_github_token"
@@ -31,11 +30,10 @@ async def test_get_user_llm_api_key():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
-        mock_ps = mock_ps_class.return_value
+    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
         profile = MagicMock()
         profile.openai_api_key_encrypted = "test_openai_key"
-        mock_ps.get_profile_by_user_id = AsyncMock(return_value=profile)
+        mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=profile)
 
         token = await get_user_llm_api_key(user, "openai", db)
         assert token == "test_openai_key"
@@ -57,9 +55,24 @@ async def test_get_user_llm_api_key_no_profile():
     user = User()
     user.id = "test_user_id"
 
-    with patch("api_service.api.routers.summarization.ProfileService") as mock_ps_class:
-        mock_ps = mock_ps_class.return_value
-        mock_ps.get_profile_by_user_id = AsyncMock(return_value=None)
+    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+        mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=None)
+
+        token = await get_user_llm_api_key(user, "anthropic", db)
+        assert token is None
+
+
+@pytest.mark.asyncio
+async def test_get_user_llm_api_key_no_key_for_provider():
+    db = AsyncMock()
+    user = User()
+    user.id = "test_user_id"
+
+    with patch("api_service.api.routers.summarization.profile_service") as mock_profile_service:
+        profile = MagicMock()
+        profile.openai_api_key_encrypted = "other_key"
+        profile.anthropic_api_key_encrypted = None
+        mock_profile_service.get_profile_by_user_id = AsyncMock(return_value=profile)
 
         token = await get_user_llm_api_key(user, "anthropic", db)
         assert token is None


### PR DESCRIPTION
🎯 **What:** Removed hardcoded placeholder API keys and GitHub tokens in the summarization endpoints.
⚠️ **Risk:** If left unfixed, the application uses dummy credentials, resulting in failed integration operations for real user requests. Leaving placeholder credentials in production code is also poor security practice.
🛡️ **Solution:** Integrated `ProfileService` inside `get_user_github_token` and `get_user_llm_api_key`. The application now securely queries the `UserProfile` database table and uses SQLAlchemy `EncryptedType` which automatically decrypts the stored values upon access. Included unit tests to verify proper integration.

---
*PR created automatically by Jules for task [8181972458852252190](https://jules.google.com/task/8181972458852252190) started by @nsticco*