### PR TITLE
🔒 Fix SSRF via DNS Rebinding Vulnerability

### DIFF
--- a/moonmind/workflows/skills/materializer.py
+++ b/moonmind/workflows/skills/materializer.py
@@ -6,6 +6,7 @@ import hashlib
 import http.client
 import ipaddress
 import os
+import re
 import shutil
 import socket
 import stat
@@ -18,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
-from urllib.request import HTTPHandler, HTTPSHandler, Request, build_opener
+from urllib.request import HTTPHandler, HTTPSHandler, ProxyHandler, Request, build_opener
 
 from .resolver import ResolvedSkill, RunSkillSelection, validate_skill_name
 from .workspace_links import (
@@ -38,6 +39,15 @@ class SkillMaterializationError(RuntimeError):
 
 _SKILL_NAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
 _DOWNLOAD_TIMEOUT_SECONDS = 30
+_PUBLIC_ADDRESS_REJECTION_PROPERTIES = (
+    "is_private",
+    "is_loopback",
+    "is_link_local",
+    "is_multicast",
+    "is_reserved",
+    "is_unspecified",
+)
+_GIT_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443, "ssh": 22, "git": 9418}
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,8 +155,6 @@ def _validate_skill_name(skill_name: str) -> None:
             "invalid_skill_name",
             f"Skill name '{skill_name}' cannot contain '..'",
         )
-    import re
-
     if not re.fullmatch(_SKILL_NAME_PATTERN, skill_name):
         raise SkillMaterializationError(
             "invalid_skill_name",
@@ -245,14 +253,7 @@ def _safe_create_connection(
                 f"Unable to parse resolved bundle host IP for '{host}'",
             ) from exc
 
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
+        if any(getattr(ip, property_name) for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES):
             raise SkillMaterializationError(
                 "bundle_fetch_failed",
                 f"Skill bundle source host resolves to a non-public address: {host} ({ip})",
@@ -310,6 +311,37 @@ class _SafeHTTPSHandler(HTTPSHandler):
         return self.do_open(_SafeHTTPSConnection, req, context=self._context)
 
 
+def _validate_public_host(
+    hostname: str,
+    port: int,
+    *,
+    error_code: str,
+    source_label: str,
+) -> None:
+    try:
+        addresses = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
+    except OSError as exc:
+        raise SkillMaterializationError(
+            error_code,
+            f"Unable to resolve {source_label} host '{hostname}': {exc}",
+        ) from exc
+
+    for addrinfo in addresses:
+        try:
+            ip = ipaddress.ip_address(addrinfo[4][0])
+        except ValueError as exc:
+            raise SkillMaterializationError(
+                error_code,
+                f"Unable to parse resolved {source_label} host IP for '{hostname}'",
+            ) from exc
+
+        if any(getattr(ip, property_name) for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES):
+            raise SkillMaterializationError(
+                error_code,
+                f"{source_label} host resolves to a non-public address: {hostname}",
+            )
+
+
 def _validate_public_remote_host(source_uri: str) -> None:
     parsed = urlparse(source_uri)
     hostname = parsed.hostname
@@ -320,40 +352,63 @@ def _validate_public_remote_host(source_uri: str) -> None:
         )
 
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    try:
-        addresses = socket.getaddrinfo(hostname, port, type=socket.SOCK_STREAM)
-    except OSError as exc:
-        raise SkillMaterializationError(
-            "bundle_fetch_failed",
-            f"Unable to resolve skill bundle host '{hostname}': {exc}",
-        ) from exc
+    _validate_public_host(
+        hostname,
+        port,
+        error_code="bundle_fetch_failed",
+        source_label="Skill bundle source",
+    )
 
-    for addrinfo in addresses:
-        try:
-            ip = ipaddress.ip_address(addrinfo[4][0])
-        except ValueError as exc:
+
+def _validate_git_source_uri(repo_uri: str) -> None:
+    parsed = urlparse(repo_uri)
+    scheme = parsed.scheme.lower()
+
+    if scheme == "ext":
+        raise SkillMaterializationError(
+            "git_fetch_failed",
+            "Unsupported git source transport 'ext' for skill materialization",
+        )
+
+    if scheme:
+        if scheme not in _GIT_SCHEME_DEFAULT_PORTS:
             raise SkillMaterializationError(
-                "bundle_fetch_failed",
-                f"Unable to parse resolved bundle host IP for '{hostname}'",
-            ) from exc
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
-            or ip.is_unspecified
-        ):
-            raise SkillMaterializationError(
-                "bundle_fetch_failed",
-                f"Skill bundle source host resolves to a non-public address: {hostname}",
+                "git_fetch_failed",
+                f"Unsupported git source URI scheme '{scheme}' for skill materialization",
             )
+        if not parsed.hostname:
+            raise SkillMaterializationError(
+                "git_fetch_failed",
+                f"Git skill source URI is missing a hostname: {repo_uri}",
+            )
+        _validate_public_host(
+            parsed.hostname,
+            parsed.port or _GIT_SCHEME_DEFAULT_PORTS[scheme],
+            error_code="git_fetch_failed",
+            source_label="Git skill source",
+        )
+        return
+
+    scp_like = re.match(r"^[^@:/\s]+@([^:/\s]+):.+$", repo_uri)
+    if not scp_like:
+        raise SkillMaterializationError(
+            "git_fetch_failed",
+            "Unsupported git source URI format for skill materialization",
+        )
+
+    _validate_public_host(
+        scp_like.group(1),
+        _GIT_SCHEME_DEFAULT_PORTS["ssh"],
+        error_code="git_fetch_failed",
+        source_label="Git skill source",
+    )
 
 
 def _download_remote_bundle(source_uri: str, destination: Path) -> Path:
     _validate_public_remote_host(source_uri)
     request = Request(source_uri, method="GET")
-    opener = build_opener(_SafeHTTPHandler(), _SafeHTTPSHandler())
+    # Prevent environment/system proxy settings from bypassing host IP validation.
+    opener = build_opener(ProxyHandler({}), _SafeHTTPHandler(), _SafeHTTPSHandler())
     try:
         with opener.open(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
             final_url = response.geturl()
@@ -388,6 +443,12 @@ def _resolve_source_root(entry: ResolvedSkill, scratch_dir: Path) -> Path:
 
     if source_uri.startswith("git+"):
         repo_uri = source_uri[len("git+") :].strip()
+        if not repo_uri:
+            raise SkillMaterializationError(
+                "git_fetch_failed",
+                f"Git skill source URI is missing repository value for {skill_name}",
+            )
+        _validate_git_source_uri(repo_uri)
         destination = scratch_dir / f"git-{skill_name}"
         try:
             subprocess.run(

--- a/moonmind/workflows/skills/materializer.py
+++ b/moonmind/workflows/skills/materializer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import ipaddress
 import os
 import shutil
@@ -15,10 +16,9 @@ import uuid
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-import http.client
-from typing import Optional, Tuple, Any
+from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
-from urllib.request import Request, HTTPHandler, HTTPSHandler, build_opener
+from urllib.request import HTTPHandler, HTTPSHandler, Request, build_opener
 
 from .resolver import ResolvedSkill, RunSkillSelection, validate_skill_name
 from .workspace_links import (

--- a/moonmind/workflows/skills/materializer.py
+++ b/moonmind/workflows/skills/materializer.py
@@ -15,8 +15,10 @@ import uuid
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
+import http.client
+from typing import Optional, Tuple, Any
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
+from urllib.request import Request, HTTPHandler, HTTPSHandler, build_opener
 
 from .resolver import ResolvedSkill, RunSkillSelection, validate_skill_name
 from .workspace_links import (
@@ -218,6 +220,96 @@ def _extract_archive(archive: Path, destination: Path) -> Path:
         ) from exc
 
 
+def _safe_create_connection(
+    address: Tuple[str, int],
+    timeout: float = socket._GLOBAL_DEFAULT_TIMEOUT,  # type: ignore
+    source_address: Optional[Tuple[str, int]] = None,
+) -> socket.socket:
+    host, port = address
+    err = None
+    try:
+        addresses = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+    except OSError as exc:
+        raise SkillMaterializationError(
+            "bundle_fetch_failed",
+            f"Unable to resolve skill bundle host '{host}': {exc}",
+        ) from exc
+
+    for res in addresses:
+        af, socktype, proto, canonname, sa = res
+        try:
+            ip = ipaddress.ip_address(sa[0])
+        except ValueError as exc:
+            raise SkillMaterializationError(
+                "bundle_fetch_failed",
+                f"Unable to parse resolved bundle host IP for '{host}'",
+            ) from exc
+
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            raise SkillMaterializationError(
+                "bundle_fetch_failed",
+                f"Skill bundle source host resolves to a non-public address: {host} ({ip})",
+            )
+
+        sock = None
+        try:
+            sock = socket.socket(af, socktype, proto)
+            if timeout is not socket._GLOBAL_DEFAULT_TIMEOUT:  # type: ignore
+                sock.settimeout(timeout)
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sa)
+            return sock
+        except OSError as _:
+            err = _
+            if sock is not None:
+                sock.close()
+
+    if err is not None:
+        raise err
+    raise OSError("getaddrinfo returns an empty list")
+
+
+class _SafeHTTPConnection(http.client.HTTPConnection):
+    def connect(self) -> None:
+        self.sock = _safe_create_connection(
+            (self.host, self.port), self.timeout, self.source_address
+        )
+
+
+class _SafeHTTPSConnection(http.client.HTTPSConnection):
+    def connect(self) -> None:
+        self.sock = _safe_create_connection(
+            (self.host, self.port), self.timeout, self.source_address
+        )
+        if self._tunnel_host:
+            server_hostname = self._tunnel_host
+            self._tunnel()  # type: ignore
+        else:
+            server_hostname = self.host
+
+        self.sock = self._context.wrap_socket(
+            self.sock, server_hostname=server_hostname
+        )
+
+
+class _SafeHTTPHandler(HTTPHandler):
+    def http_open(self, req: Request) -> Any:
+        return self.do_open(_SafeHTTPConnection, req)
+
+
+class _SafeHTTPSHandler(HTTPSHandler):
+    def https_open(self, req: Request) -> Any:
+        return self.do_open(_SafeHTTPSConnection, req, context=self._context)
+
+
 def _validate_public_remote_host(source_uri: str) -> None:
     parsed = urlparse(source_uri)
     hostname = parsed.hostname
@@ -261,8 +353,9 @@ def _validate_public_remote_host(source_uri: str) -> None:
 def _download_remote_bundle(source_uri: str, destination: Path) -> Path:
     _validate_public_remote_host(source_uri)
     request = Request(source_uri, method="GET")
+    opener = build_opener(_SafeHTTPHandler(), _SafeHTTPSHandler())
     try:
-        with urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        with opener.open(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
             final_url = response.geturl()
             _validate_public_remote_host(final_url)
             with destination.open("wb") as output:

--- a/moonmind/workflows/skills/materializer.py
+++ b/moonmind/workflows/skills/materializer.py
@@ -19,7 +19,13 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Optional, Tuple
 from urllib.parse import urlparse
-from urllib.request import HTTPHandler, HTTPSHandler, ProxyHandler, Request, build_opener
+from urllib.request import (
+    HTTPHandler,
+    HTTPSHandler,
+    ProxyHandler,
+    Request,
+    build_opener,
+)
 
 from .resolver import ResolvedSkill, RunSkillSelection, validate_skill_name
 from .workspace_links import (
@@ -253,7 +259,10 @@ def _safe_create_connection(
                 f"Unable to parse resolved bundle host IP for '{host}'",
             ) from exc
 
-        if any(getattr(ip, property_name) for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES):
+        if any(
+            getattr(ip, property_name)
+            for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES
+        ):
             raise SkillMaterializationError(
                 "bundle_fetch_failed",
                 f"Skill bundle source host resolves to a non-public address: {host} ({ip})",
@@ -335,7 +344,10 @@ def _validate_public_host(
                 f"Unable to parse resolved {source_label} host IP for '{hostname}'",
             ) from exc
 
-        if any(getattr(ip, property_name) for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES):
+        if any(
+            getattr(ip, property_name)
+            for property_name in _PUBLIC_ADDRESS_REJECTION_PROPERTIES
+        ):
             raise SkillMaterializationError(
                 error_code,
                 f"{source_label} host resolves to a non-public address: {hostname}",

--- a/tests/unit/workflows/test_skills_materializer.py
+++ b/tests/unit/workflows/test_skills_materializer.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import pytest
 
 from moonmind.workflows.skills.materializer import (
-    _download_remote_bundle,
     SkillMaterializationError,
+    _download_remote_bundle,
     _extract_archive,
     _resolve_source_root,
     _validate_public_remote_host,
@@ -254,7 +254,6 @@ def test_extract_archive_rejects_tar_path_traversal(tmp_path):
     assert not (tmp_path / "evil.txt").exists()
 
 
-
 def test_validate_public_remote_host_rejects_private_ip(monkeypatch):
     monkeypatch.setattr(
         "moonmind.workflows.skills.materializer.socket.getaddrinfo",
@@ -272,6 +271,7 @@ def test_validate_public_remote_host_rejects_private_ip(monkeypatch):
 def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path):
     # Setup mock to first return a valid public IP, then a private IP (for the redirect)
     call_count = 0
+
     def mock_getaddrinfo(host, port, *args, **kwargs):
         nonlocal call_count
         call_count += 1
@@ -282,8 +282,7 @@ def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path)
         return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", port))]
 
     monkeypatch.setattr(
-        "moonmind.workflows.skills.materializer.socket.getaddrinfo",
-        mock_getaddrinfo
+        "moonmind.workflows.skills.materializer.socket.getaddrinfo", mock_getaddrinfo
     )
 
     # We mock opener.open to simulate what happens during the actual urllib call
@@ -295,12 +294,22 @@ def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path)
 
     # Let's mock socket.socket so it doesn't actually connect
     class MockSocket:
-        def settimeout(self, t): pass
-        def bind(self, a): pass
-        def connect(self, a): pass
-        def close(self): pass
+        def settimeout(self, t):
+            pass
 
-    monkeypatch.setattr("moonmind.workflows.skills.materializer.socket.socket", lambda *args, **kwargs: MockSocket())
+        def bind(self, a):
+            pass
+
+        def connect(self, a):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer.socket.socket",
+        lambda *args, **kwargs: MockSocket(),
+    )
 
     with pytest.raises(SkillMaterializationError, match="non-public address") as exc:
         # We need the first validation to pass, and the second connection to fail.
@@ -312,7 +321,6 @@ def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path)
 
     assert exc.value.code == "bundle_fetch_failed"
     assert "resolves to a non-public address: example.com" in str(exc.value)
-
 
 
 def test_resolve_source_root_uses_git_clone_end_of_options_separator(

--- a/tests/unit/workflows/test_skills_materializer.py
+++ b/tests/unit/workflows/test_skills_materializer.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from moonmind.workflows.skills.materializer import (
+    _download_remote_bundle,
     SkillMaterializationError,
     _extract_archive,
     _resolve_source_root,
@@ -253,6 +254,7 @@ def test_extract_archive_rejects_tar_path_traversal(tmp_path):
     assert not (tmp_path / "evil.txt").exists()
 
 
+
 def test_validate_public_remote_host_rejects_private_ip(monkeypatch):
     monkeypatch.setattr(
         "moonmind.workflows.skills.materializer.socket.getaddrinfo",
@@ -265,6 +267,52 @@ def test_validate_public_remote_host_rejects_private_ip(monkeypatch):
         _validate_public_remote_host("https://example.com/skill.zip")
 
     assert exc.value.code == "bundle_fetch_failed"
+
+
+def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path):
+    # Setup mock to first return a valid public IP, then a private IP (for the redirect)
+    call_count = 0
+    def mock_getaddrinfo(host, port, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call (e.g. for example.com) -> Public IP
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("8.8.8.8", port))]
+        # Subsequent call (e.g. for the redirect target) -> Private IP
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", port))]
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer.socket.getaddrinfo",
+        mock_getaddrinfo
+    )
+
+    # We mock opener.open to simulate what happens during the actual urllib call
+    # when it creates a connection. We don't actually want to hit the network,
+    # but we want it to trigger the _safe_create_connection.
+
+    # We can just test _safe_create_connection directly, or we can mock
+    # socket.socket and trigger _download_remote_bundle.
+
+    # Let's mock socket.socket so it doesn't actually connect
+    class MockSocket:
+        def settimeout(self, t): pass
+        def bind(self, a): pass
+        def connect(self, a): pass
+        def close(self): pass
+
+    monkeypatch.setattr("moonmind.workflows.skills.materializer.socket.socket", lambda *args, **kwargs: MockSocket())
+
+    with pytest.raises(SkillMaterializationError, match="non-public address") as exc:
+        # We need the first validation to pass, and the second connection to fail.
+        # However, _download_remote_bundle does a _validate_public_remote_host first,
+        # which will consume call_count = 1.
+        # Then it does opener.open(), which will trigger _safe_create_connection and consume call_count = 2,
+        # hitting the private IP rejection!
+        _download_remote_bundle("http://example.com/bundle.zip", tmp_path / "dest.zip")
+
+    assert exc.value.code == "bundle_fetch_failed"
+    assert "resolves to a non-public address: example.com" in str(exc.value)
+
 
 
 def test_resolve_source_root_uses_git_clone_end_of_options_separator(

--- a/tests/unit/workflows/test_skills_materializer.py
+++ b/tests/unit/workflows/test_skills_materializer.py
@@ -8,6 +8,7 @@ import tarfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
+from urllib.request import ProxyHandler
 
 import pytest
 
@@ -323,6 +324,47 @@ def test_download_remote_bundle_rejects_ssrf_via_redirect(monkeypatch, tmp_path)
     assert "resolves to a non-public address: example.com" in str(exc.value)
 
 
+def test_download_remote_bundle_disables_proxy_usage(monkeypatch, tmp_path):
+    handlers: list[object] = []
+
+    class FakeResponse(BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            return False
+
+        def geturl(self):
+            return "https://example.com/bundle.zip"
+
+    class FakeOpener:
+        def open(self, _request, timeout):
+            assert timeout > 0
+            return FakeResponse(b"bundle-bytes")
+
+    def fake_build_opener(*opener_handlers):
+        handlers.extend(opener_handlers)
+        return FakeOpener()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer._validate_public_remote_host",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer.build_opener",
+        fake_build_opener,
+    )
+
+    output = tmp_path / "bundle.zip"
+    _download_remote_bundle("https://example.com/bundle.zip", output)
+
+    proxy_handlers = [handler for handler in handlers if isinstance(handler, ProxyHandler)]
+    assert proxy_handlers
+    assert proxy_handlers[0].proxies == {}
+    assert output.read_bytes() == b"bundle-bytes"
+
+
 def test_resolve_source_root_uses_git_clone_end_of_options_separator(
     tmp_path, monkeypatch
 ):
@@ -336,6 +378,12 @@ def test_resolve_source_root_uses_git_clone_end_of_options_separator(
         "moonmind.workflows.skills.materializer.subprocess.run",
         fake_run,
     )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 443))
+        ],
+    )
 
     entry = ResolvedSkill(
         skill_name="speckit",
@@ -347,3 +395,37 @@ def test_resolve_source_root_uses_git_clone_end_of_options_separator(
 
     assert calls
     assert calls[0][:5] == ["git", "clone", "--depth", "1", "--"]
+
+
+def test_resolve_source_root_rejects_git_ext_transport(tmp_path):
+    entry = ResolvedSkill(
+        skill_name="speckit",
+        version="1.0.0",
+        source_uri="git+ext::sh -c echo pwned",
+    )
+
+    with pytest.raises(
+        SkillMaterializationError, match="Unsupported git source transport 'ext'"
+    ) as exc:
+        _resolve_source_root(entry, tmp_path)
+
+    assert exc.value.code == "git_fetch_failed"
+
+
+def test_resolve_source_root_rejects_git_private_host(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.materializer.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("127.0.0.1", 443))
+        ],
+    )
+    entry = ResolvedSkill(
+        skill_name="speckit",
+        version="1.0.0",
+        source_uri="git+https://internal.example/repo.git",
+    )
+
+    with pytest.raises(SkillMaterializationError, match="non-public address") as exc:
+        _resolve_source_root(entry, tmp_path)
+
+    assert exc.value.code == "git_fetch_failed"

--- a/tests/unit/workflows/test_skills_materializer.py
+++ b/tests/unit/workflows/test_skills_materializer.py
@@ -359,7 +359,9 @@ def test_download_remote_bundle_disables_proxy_usage(monkeypatch, tmp_path):
     output = tmp_path / "bundle.zip"
     _download_remote_bundle("https://example.com/bundle.zip", output)
 
-    proxy_handlers = [handler for handler in handlers if isinstance(handler, ProxyHandler)]
+    proxy_handlers = [
+        handler for handler in handlers if isinstance(handler, ProxyHandler)
+    ]
     assert proxy_handlers
     assert proxy_handlers[0].proxies == {}
     assert output.read_bytes() == b"bundle-bytes"


### PR DESCRIPTION
🎯 **What:** Fixed an SSRF vulnerability caused by a DNS rebinding race condition in `_download_remote_bundle`.

⚠️ **Risk:** The previous implementation validated the URL host first and then let `urllib` resolve it a second time. This allowed a malicious DNS server to pass the initial validation check with a public IP, but resolve to an internal/private IP during the actual connection. This would allow an attacker to probe internal networks or reach internal services. Furthermore, redirects could be abused to target private IPs.

🛡️ **Solution:** Implemented custom connection classes (`_SafeHTTPConnection`, `_SafeHTTPSConnection`, `_SafeHTTPHandler`, `_SafeHTTPSHandler`) and a `_safe_create_connection` function that wraps `socket.getaddrinfo`. This forces IP validation immediately after DNS resolution and strictly connects only to the validated IP, effectively mitigating the race condition. Also ensured SNI hostname checking (`self._tunnel_host`) correctly passes proxy settings for HTTPS connections.

---
*PR created automatically by Jules for task [17241870681965277511](https://jules.google.com/task/17241870681965277511) started by @nsticco*