### PR TITLE
🔒 Add missing timeout parameters to requests calls

### DIFF
--- a/examples/context_protocol_client.py
+++ b/examples/context_protocol_client.py
@@ -11,6 +11,7 @@ import requests
 
 # Default to localhost, but allow override via environment variable
 API_BASE_URL = os.environ.get("MOONMIND_API_URL", "http://localhost:5000")
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30
 
 
 def send_context_request(messages, model="gemini-pro"):
@@ -36,7 +37,12 @@ def send_context_request(messages, model="gemini-pro"):
 
     headers = {"Content-Type": "application/json"}
 
-    response = requests.post(url, json=payload, headers=headers, timeout=30)
+    response = requests.post(
+        url,
+        json=payload,
+        headers=headers,
+        timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    )
 
     if response.status_code != 200:
         print(f"Error: {response.status_code}")

--- a/examples/context_protocol_client.py
+++ b/examples/context_protocol_client.py
@@ -36,7 +36,7 @@ def send_context_request(messages, model="gemini-pro"):
 
     headers = {"Content-Type": "application/json"}
 
-    response = requests.post(url, json=payload, headers=headers)
+    response = requests.post(url, json=payload, headers=headers, timeout=30)
 
     if response.status_code != 200:
         print(f"Error: {response.status_code}")

--- a/tests/integration/test_ollama_embeddings.py
+++ b/tests/integration/test_ollama_embeddings.py
@@ -33,7 +33,7 @@ logger.addHandler(ch)
 def ollama_running():
     """Fixture to check if Ollama is running at the specified URL."""
     try:
-        response = requests.get(settings.ollama.ollama_base_url + "/api/tags")
+        response = requests.get(settings.ollama.ollama_base_url + "/api/tags", timeout=30)
         if response.status_code == 200:
             return True
     except requests.ConnectionError:

--- a/tests/integration/test_ollama_embeddings.py
+++ b/tests/integration/test_ollama_embeddings.py
@@ -27,6 +27,7 @@ ch.setLevel(logging.DEBUG)  # Set handler level
 
 # Add the handler to your logger
 logger.addHandler(ch)
+OLLAMA_API_TIMEOUT_SECONDS = 30
 
 
 @pytest.fixture(scope="session")
@@ -34,11 +35,12 @@ def ollama_running():
     """Fixture to check if Ollama is running at the specified URL."""
     try:
         response = requests.get(
-            settings.ollama.ollama_base_url + "/api/tags", timeout=30
+            settings.ollama.ollama_base_url + "/api/tags",
+            timeout=OLLAMA_API_TIMEOUT_SECONDS,
         )
         if response.status_code == 200:
             return True
-    except requests.ConnectionError:
+    except requests.RequestException:
         pass
     return False
 

--- a/tests/integration/test_ollama_embeddings.py
+++ b/tests/integration/test_ollama_embeddings.py
@@ -41,7 +41,11 @@ def ollama_running():
         if response.status_code == 200:
             return True
     except requests.RequestException:
-        pass
+        logger.warning(
+            "Ollama health probe failed for %s/api/tags; treating service as unavailable.",
+            settings.ollama.ollama_base_url,
+            exc_info=True,
+        )
     return False
 
 

--- a/tests/integration/test_ollama_embeddings.py
+++ b/tests/integration/test_ollama_embeddings.py
@@ -33,7 +33,9 @@ logger.addHandler(ch)
 def ollama_running():
     """Fixture to check if Ollama is running at the specified URL."""
     try:
-        response = requests.get(settings.ollama.ollama_base_url + "/api/tags", timeout=30)
+        response = requests.get(
+            settings.ollama.ollama_base_url + "/api/tags", timeout=30
+        )
         if response.status_code == 200:
             return True
     except requests.ConnectionError:


### PR DESCRIPTION
🎯 **What:** The `requests.post` and `requests.get` calls in `examples/context_protocol_client.py` and `tests/integration/test_ollama_embeddings.py` lacked timeout parameters.
⚠️ **Risk:** Without timeouts, HTTP requests can hang indefinitely if the server is unresponsive or deliberately holds the connection open. This could lead to thread exhaustion, denial of service (DoS), or unresponsiveness.
🛡️ **Solution:** Added a default `timeout=30` to the vulnerable `requests` calls to ensure they fail gracefully if a response is not received within 30 seconds.

(Note: I checked `moonmind/agents/cli/task_templates.py` but it already contained a `timeout=self.timeout_seconds` implementation).

---
*PR created automatically by Jules for task [13528091541248602943](https://jules.google.com/task/13528091541248602943) started by @nsticco*