### PR TITLE
🔒 Fix hardcoded default security secrets

### DIFF
--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1372,12 +1372,8 @@ class AppSpecWorkflowSettings(SpecWorkflowSettings):
 class SecuritySettings(BaseSettings):
     """Security settings"""
 
-    JWT_SECRET_KEY: Optional[str] = Field(
-        None, env="JWT_SECRET_KEY"
-    )
-    ENCRYPTION_MASTER_KEY: Optional[str] = Field(
-        None, env="ENCRYPTION_MASTER_KEY"
-    )
+    JWT_SECRET_KEY: Optional[str] = Field(None, env="JWT_SECRET_KEY")
+    ENCRYPTION_MASTER_KEY: Optional[str] = Field(None, env="ENCRYPTION_MASTER_KEY")
 
     model_config = SettingsConfigDict(env_prefix="")
 

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1373,11 +1373,11 @@ class SecuritySettings(BaseSettings):
     """Security settings"""
 
     JWT_SECRET_KEY: Optional[str] = Field(
-        "test_jwt_secret_key", env="JWT_SECRET_KEY"
-    )  # Made Optional and added default
+        None, env="JWT_SECRET_KEY"
+    )
     ENCRYPTION_MASTER_KEY: Optional[str] = Field(
-        "test_encryption_master_key", env="ENCRYPTION_MASTER_KEY"
-    )  # Made Optional and added default
+        None, env="ENCRYPTION_MASTER_KEY"
+    )
 
     model_config = SettingsConfigDict(env_prefix="")
 


### PR DESCRIPTION
🎯 **What:** The `JWT_SECRET_KEY` and `ENCRYPTION_MASTER_KEY` variables in `moonmind/config/settings.py` were defined with hardcoded default fallback values.
⚠️ **Risk:** If the application were deployed to a production environment without explicitly setting these environment variables, it would silently fallback to using these globally known, hardcoded dummy secrets. This could allow attackers to trivially forge authorization tokens or decrypt sensitive information encrypted at rest using the leaked master key.
🛡️ **Solution:** The default values have been changed from hardcoded test strings to `None`. This guarantees that if the variables are not explicitly provided in the environment, the application will fail safely and visibly (e.g., throwing exceptions when cryptographic functions attempt to use missing keys) rather than failing open with compromised secrets.

---
*PR created automatically by Jules for task [10257530201854082883](https://jules.google.com/task/10257530201854082883) started by @nsticco*