### PR TITLE
🧹 [code health] Remove dead code from test_ollama_embeddings.py

### DIFF
--- a/tests/integration/test_ollama_embeddings.py
+++ b/tests/integration/test_ollama_embeddings.py
@@ -109,27 +109,6 @@ def test_ollama_embeddings_instance_creation(ollama_embeddings_instance):
     assert isinstance(ollama_embeddings_instance, OllamaEmbedding)
 
 
-# def test_ollama_embeddings_confluence_document(ollama_embeddings_instance):
-#     """Test embedding a Confluence document."""
-#     loader = ConfluenceLoader(
-#         url=settings.confluence.confluence_url,
-#         api_key=settings.confluence.confluence_api_key,
-#         username=settings.confluence.confluence_username,
-#         space_key=settings.confluence.confluence_default_space_key,
-#         include_attachments=False,
-#         limit=50
-#     )
-#     documents = loader.load()
-#     logger.info(f"Loaded {len(documents)} documents from Confluence.") # Should now see this log
-
-#     embeddings = ollama_embeddings_instance.get_text_embedding_batch([doc.page_content for doc in documents])
-#     assert isinstance(embeddings, list)
-#     assert len(embeddings) == len(documents)
-#     for embedding in embeddings:
-#         assert isinstance(embedding, list)
-#         assert all(isinstance(e, float) for e in embedding), "Embeddings should be a list of floats."
-
-
 def test_ollama_embeddings_confluence_document(ollama_embeddings_instance):
     """Test embedding a Confluence document."""
     loader = ConfluenceLoader(


### PR DESCRIPTION
🎯 **What:** Removed commented out code block for `test_ollama_embeddings_confluence_document` in `tests/integration/test_ollama_embeddings.py`.
💡 **Why:** The commented-out code was a duplicate implementation, left as dead code directly above the active implementation of the same function. Removing it improves readability and maintainability.
✅ **Verification:** Verified that the test file is correct and passes by running `pytest` with `PYTHONPATH=. poetry run pytest tests/integration/test_ollama_embeddings.py -c /dev/null`. Additionally, verified no regression bugs exist by running the complete unit test suite `bash -c 'poetry run ./tools/test_unit.sh'`.
✨ **Result:** Improved codebase maintainability without changing logic or test functionality.

---
*PR created automatically by Jules for task [8844626881576421416](https://jules.google.com/task/8844626881576421416) started by @nsticco*