### PR TITLE
fix(tasks): List tasks by creation time descending in Mission Control

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -868,6 +868,10 @@ async def list_executions(
                 query_parts.append(f'mm_integration="{escape_val(integration)}"')
 
             query_str = " AND ".join(query_parts) if query_parts else ""
+            if query_str:
+                query_str += " ORDER BY StartTime DESC"
+            else:
+                query_str = "ORDER BY StartTime DESC"
 
             items = []
             async for wf in client.list_workflows(query=query_str):

--- a/moonmind/workflows/tasks/compatibility.py
+++ b/moonmind/workflows/tasks/compatibility.py
@@ -261,7 +261,7 @@ class TaskCompatibilityService:
             rows.extend(temporal_rows)
             total_count += temporal_count
         rows.sort(
-            key=lambda row: (row.updated_at, row.created_at, row.task_id),
+            key=lambda row: (row.created_at, row.updated_at, row.task_id),
             reverse=True,
         )
         return rows[:window_end], total_count
@@ -295,8 +295,8 @@ class TaskCompatibilityService:
 
         count_stmt = select(func.count()).select_from(stmt.subquery())
         stmt = stmt.order_by(
-            queue_models.AgentJob.updated_at.desc(),
             queue_models.AgentJob.created_at.desc(),
+            queue_models.AgentJob.updated_at.desc(),
             queue_models.AgentJob.id.desc(),
         ).limit(limit)
         jobs = list((await self._session.execute(stmt)).scalars().all())
@@ -327,8 +327,8 @@ class TaskCompatibilityService:
             )
         count_stmt = select(func.count()).select_from(stmt.subquery())
         stmt = stmt.order_by(
-            db_models.OrchestratorRun.updated_at.desc(),
             db_models.OrchestratorRun.queued_at.desc(),
+            db_models.OrchestratorRun.updated_at.desc(),
             db_models.OrchestratorRun.id.desc(),
         ).limit(limit)
         runs = list((await self._session.execute(stmt)).scalars().all())
@@ -378,8 +378,8 @@ class TaskCompatibilityService:
             )
         count_stmt = select(func.count()).select_from(stmt.subquery())
         stmt = stmt.order_by(
-            db_models.TemporalExecutionRecord.updated_at.desc(),
             db_models.TemporalExecutionRecord.started_at.desc(),
+            db_models.TemporalExecutionRecord.updated_at.desc(),
             db_models.TemporalExecutionRecord.workflow_id.desc(),
         ).limit(limit)
         records = list((await self._session.execute(stmt)).scalars().all())

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -401,7 +401,7 @@ class TemporalExecutionService:
             integration=integration,
         )
         stmt = stmt.order_by(
-            TemporalExecutionCanonicalRecord.updated_at.desc(),
+            TemporalExecutionCanonicalRecord.started_at.desc(),
             TemporalExecutionCanonicalRecord.workflow_id.desc(),
         )
         stmt = stmt.offset(offset).limit(page_size + 1)


### PR DESCRIPTION
Tasks and executions in Mission Control are now sorted from most recently created to least recently created instead of most recently updated. This aligns the Temporal Execution listings, task compatibility endpoints, and API queries with user expectations.
