### PR TITLE
feat(auth): bring Claude auth volume script to Codex/Gemini parity

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -285,6 +285,13 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "post": "/api/system/worker-pause",
                 "pollIntervalMs": 5000,
             },
+            "authProfiles": {
+                "list": "/api/v1/auth-profiles",
+                "create": "/api/v1/auth-profiles",
+                "detail": "/api/v1/auth-profiles/{profileId}",
+                "update": "/api/v1/auth-profiles/{profileId}",
+                "delete": "/api/v1/auth-profiles/{profileId}",
+            },
             "attachmentPolicy": {
                 "enabled": bool(settings.workflow.agent_job_attachment_enabled),
                 **_build_default_attachment_policy(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -8,6 +8,7 @@ configure_logging()
 logger = logging.getLogger(__name__)  # Get logger after configuration
 
 import os  # For path operations
+import time
 
 # Now proceed with other imports
 from uuid import uuid4
@@ -15,11 +16,13 @@ from uuid import uuid4
 import httpx
 from fastapi import APIRouter, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from llama_index.core import VectorStoreIndex, load_index_from_storage
+from sqlalchemy import text
 
+from api_service.db.base import get_async_session_context
 from api_service.api.routers import retrieval_gateway as retrieval_router
 from api_service.api.routers import (
     summarization as summarization_router,  # Added import for summarization router
@@ -263,10 +266,22 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 # Healthz router
 health_router = APIRouter()
 
+_api_start_time = time.monotonic()
+
 
 @health_router.get("/healthz")
 async def health_check():
-    return {"status": "ok"}
+    """Health endpoint with database connectivity probe."""
+    uptime = int(time.monotonic() - _api_start_time)
+    try:
+        async with get_async_session_context() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok", "db": "connected", "uptime_seconds": uptime}
+    except Exception:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "degraded", "db": "unreachable", "uptime_seconds": uptime},
+        )
 
 
 @app.get("/", include_in_schema=False)

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -555,6 +555,18 @@
       ? systemConfig.workerPause
       : null;
   const workerPauseTransport = createWorkerPauseTransport(workerPauseConfig);
+  const authProfileEndpoints =
+    systemConfig.authProfiles &&
+      typeof systemConfig.authProfiles === "object" &&
+      !Array.isArray(systemConfig.authProfiles)
+      ? {
+        list: String(systemConfig.authProfiles.list || "/api/v1/auth-profiles"),
+        create: String(systemConfig.authProfiles.create || "/api/v1/auth-profiles"),
+        detail: String(systemConfig.authProfiles.detail || "/api/v1/auth-profiles/{profileId}"),
+        update: String(systemConfig.authProfiles.update || "/api/v1/auth-profiles/{profileId}"),
+        delete: String(systemConfig.authProfiles.delete || "/api/v1/auth-profiles/{profileId}"),
+      }
+      : null;
   const taskTemplateEndpoints = {
     list: String(queueSourceConfig.taskStepTemplates || "/api/task-step-templates"),
     detail: String(
@@ -10314,6 +10326,73 @@
           </form>
         </section>
       `;
+      const authProfilesMarkup = authProfileEndpoints ? `
+        <section class="card system-settings-auth-profiles">
+          <h3>Auth Profiles</h3>
+          <p class="form-caption">
+            Manage authentication profiles for managed agent runtimes.
+          </p>
+          <div data-auth-profiles-table>
+            <p class="loading">Loading profiles...</p>
+          </div>
+          <details class="auth-profile-create-toggle">
+            <summary>Create New Profile</summary>
+            <form data-auth-profile-form="create" class="stack">
+              <fieldset>
+                <legend>New Auth Profile</legend>
+                <label>
+                  Profile ID
+                  <input type="text" name="profile_id" maxlength="80" required
+                         placeholder="e.g. gemini_oauth_user_a" />
+                </label>
+                <label>
+                  Runtime ID
+                  <input type="text" name="runtime_id" maxlength="80"
+                         placeholder="e.g. gemini_pro_runtime" />
+                </label>
+                <label>
+                  Auth Mode
+                  <select name="auth_mode" required>
+                    <option value="oauth" selected>OAuth</option>
+                    <option value="api_key">API Key</option>
+                  </select>
+                </label>
+                <label>
+                  Volume Ref
+                  <input type="text" name="volume_ref" maxlength="120"
+                         placeholder="e.g. gemini_auth_volume" />
+                </label>
+                <label>
+                  API Key Ref
+                  <input type="text" name="api_key_ref" maxlength="120"
+                         placeholder="Secret reference (API key mode only)" />
+                </label>
+                <label>
+                  Max Parallel Runs
+                  <input type="number" name="max_parallel_runs" min="0" value="1" />
+                </label>
+                <label>
+                  Cooldown After 429 (seconds)
+                  <input type="number" name="cooldown_after_429_seconds" min="0" value="60" />
+                </label>
+                <label>
+                  Rate Limit Policy
+                  <select name="rate_limit_policy">
+                    <option value="backoff" selected>Backoff</option>
+                    <option value="queue">Queue</option>
+                    <option value="reject">Reject</option>
+                  </select>
+                </label>
+                <label>
+                  <input type="checkbox" name="enabled" checked />
+                  Enabled
+                </label>
+                <button type="submit">Create Profile</button>
+              </fieldset>
+            </form>
+          </details>
+        </section>
+      ` : "";
       const layout = `
         <div data-system-settings-notice>${noticeHtml}</div>
         <div class="system-settings">
@@ -10327,6 +10406,7 @@
               <div data-system-settings-audit></div>
             </section>
           </div>
+          ${authProfilesMarkup}
         </div>
       `;
       setView(
@@ -10478,6 +10558,161 @@
       });
     }
 
+    function buildProfileTableMarkup(profiles) {
+      if (!Array.isArray(profiles) || profiles.length === 0) {
+        return "<p class='small'>No auth profiles configured.</p>";
+      }
+      return `
+        <table class="auth-profiles-table">
+          <thead>
+            <tr>
+              <th>Profile ID</th>
+              <th>Runtime</th>
+              <th>Auth Mode</th>
+              <th>Max Runs</th>
+              <th>Cooldown</th>
+              <th>Enabled</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${profiles.map((p) => `
+              <tr data-profile-id="${escapeHtml(p.profile_id)}">
+                <td>${escapeHtml(p.profile_id)}</td>
+                <td>${escapeHtml(p.runtime_id || "-")}</td>
+                <td>${escapeHtml(p.auth_mode || "-")}</td>
+                <td>${p.max_parallel_runs ?? "-"}</td>
+                <td>${p.cooldown_after_429_seconds ?? "-"}s</td>
+                <td>${p.enabled ? "✅" : "❌"}</td>
+                <td>
+                  <button class="btn-small" data-profile-toggle="${escapeHtml(p.profile_id)}">
+                    ${p.enabled ? "Disable" : "Enable"}
+                  </button>
+                  <button class="btn-small btn-danger" data-profile-delete="${escapeHtml(p.profile_id)}">
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      `;
+    }
+
+    async function loadAuthProfiles() {
+      if (!authProfileEndpoints) {
+        return;
+      }
+      const tableNode = document.querySelector("[data-auth-profiles-table]");
+      if (!tableNode) {
+        return;
+      }
+      try {
+        const response = await fetch(authProfileEndpoints.list, {
+          credentials: "include",
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          tableNode.innerHTML = "<p class='small'>Failed to load auth profiles.</p>";
+          return;
+        }
+        const profiles = await response.json();
+        tableNode.innerHTML = buildProfileTableMarkup(profiles);
+        attachProfileHandlers();
+      } catch (error) {
+        console.error("auth profiles load failed", error);
+        tableNode.innerHTML = "<p class='small'>Error loading auth profiles.</p>";
+      }
+    }
+
+    function attachProfileHandlers() {
+      document.querySelectorAll("[data-profile-toggle]").forEach((btn) => {
+        btn.addEventListener("click", async () => {
+          const profileId = btn.dataset.profileToggle;
+          const isCurrentlyEnabled = btn.textContent.trim() === "Disable";
+          const endpoint = authProfileEndpoints.update.replace("{profileId}", profileId);
+          try {
+            await fetch(endpoint, {
+              method: "PATCH",
+              credentials: "include",
+              headers: { "Content-Type": "application/json", Accept: "application/json" },
+              body: JSON.stringify({ enabled: !isCurrentlyEnabled }),
+            });
+            await loadAuthProfiles();
+          } catch (error) {
+            console.error("toggle profile failed", error);
+          }
+        });
+      });
+
+      document.querySelectorAll("[data-profile-delete]").forEach((btn) => {
+        btn.addEventListener("click", async () => {
+          const profileId = btn.dataset.profileDelete;
+          if (!window.confirm(`Delete auth profile "${profileId}"?`)) {
+            return;
+          }
+          const endpoint = authProfileEndpoints.delete.replace("{profileId}", profileId);
+          try {
+            await fetch(endpoint, {
+              method: "DELETE",
+              credentials: "include",
+            });
+            await loadAuthProfiles();
+          } catch (error) {
+            console.error("delete profile failed", error);
+          }
+        });
+      });
+
+      const createForm = document.querySelector('[data-auth-profile-form="create"]');
+      createForm?.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const formData = new FormData(createForm);
+        const payload = {
+          profile_id: String(formData.get("profile_id") || "").trim(),
+          runtime_id: String(formData.get("runtime_id") || "").trim() || undefined,
+          auth_mode: String(formData.get("auth_mode") || "oauth"),
+          volume_ref: String(formData.get("volume_ref") || "").trim() || undefined,
+          api_key_ref: String(formData.get("api_key_ref") || "").trim() || undefined,
+          max_parallel_runs: Number(formData.get("max_parallel_runs")) || 1,
+          cooldown_after_429_seconds: Number(formData.get("cooldown_after_429_seconds")) || 60,
+          rate_limit_policy: String(formData.get("rate_limit_policy") || "backoff"),
+          enabled: Boolean(formData.get("enabled")),
+        };
+        if (!payload.profile_id) {
+          setNotice("error", "Profile ID is required.");
+          syncDynamicView();
+          return;
+        }
+        try {
+          const response = await fetch(authProfileEndpoints.create, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json", Accept: "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (response.status === 409) {
+            setNotice("error", `Profile "${payload.profile_id}" already exists.`);
+            syncDynamicView();
+            return;
+          }
+          if (!response.ok) {
+            setNotice("error", "Failed to create auth profile.");
+            syncDynamicView();
+            return;
+          }
+          setNotice("ok", `Profile "${payload.profile_id}" created.`);
+          createForm.reset();
+          await loadAuthProfiles();
+          syncDynamicView();
+        } catch (error) {
+          console.error("create profile failed", error);
+          setNotice("error", "Failed to create auth profile.");
+          syncDynamicView();
+        }
+      });
+    }
+
     const load = async (silent = false) => {
       try {
         state.snapshot = await workerPauseTransport.fetchState();
@@ -10496,14 +10731,16 @@
       }
       if (silent && hasRendered) {
         syncDynamicView();
+        loadAuthProfiles();
         return;
       }
       renderView();
+      loadAuthProfiles();
     };
 
     setView(
       "System Settings",
-      "Pause or resume worker processing.",
+      "Manage worker pause controls and auth profiles.",
       "<p class='loading'>Loading system controls...</p>",
       { showAutoRefreshControls: true },
     );

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,6 +66,12 @@ services:
     command: sh /app/api_service/entrypoint.sh
     networks:
       - local-network
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     labels:
       - "ai.model.context.protocol.version=0.1"
       - "ai.model.context.protocol.endpoint=/context"
@@ -251,6 +257,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started
@@ -289,6 +301,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started
@@ -328,6 +346,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started
@@ -383,6 +407,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started
@@ -446,6 +476,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started
@@ -490,6 +526,12 @@ services:
     entrypoint:
       - /bin/sh
       - /app/services/temporal/scripts/start-worker.sh
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     depends_on:
       temporal:
         condition: service_started

--- a/docs/ManagedAgents/ManagedAgentsAuthentication.md
+++ b/docs/ManagedAgents/ManagedAgentsAuthentication.md
@@ -71,9 +71,9 @@ Auth credentials are provisioned into volumes via scripts in `tools/`:
 |--------|---------|-------|
 | `tools/auth-gemini-volume.sh` | Gemini CLI | `--sync` (copy host creds), `--login` (interactive), `--check` (verify) |
 | `tools/auth-codex-volume.sh` | Codex CLI | Interactive `codex login --device-auth` |
-| `tools/auth-claude-volume.sh` | Claude Code | Interactive `claude login` |
+| `tools/auth-claude-volume.sh` | Claude Code | `--sync` (copy host creds), `--login` (interactive), `--check` (verify) |
 
-The `--sync` mode (Gemini) copies the host user's local `~/.gemini` credentials into the Docker volume, preserving the account's subscription tier claims (e.g. Gemini Ultra). The `--login` modes authenticate interactively inside a container.
+The `--sync` mode (Gemini, Claude) copies the host user's local credential directory (`~/.gemini` or `~/.claude`) into the Docker volume, preserving the account's subscription tier claims. The `--login` modes authenticate interactively inside a container.
 
 ---
 

--- a/moonmind/workflows/temporal/worker_healthcheck.py
+++ b/moonmind/workflows/temporal/worker_healthcheck.py
@@ -1,0 +1,110 @@
+"""Lightweight HTTP health-check server for Temporal workers.
+
+Runs as a background asyncio task alongside the Temporal worker polling loop
+so Docker Compose healthcheck probes can verify the process is responsive.
+
+Uses only the Python standard library (``asyncio.start_server``) to avoid
+adding external dependencies.
+
+Environment variables:
+    WORKER_HEALTHCHECK_PORT     Port to listen on (default 8080).
+    WORKER_HEALTHCHECK_ENABLED  Set to "false" to disable (default "true").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 8080
+
+_start_time: float = time.monotonic()
+
+
+def _is_enabled() -> bool:
+    return os.environ.get("WORKER_HEALTHCHECK_ENABLED", "true").lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+
+def _port() -> int:
+    raw = os.environ.get("WORKER_HEALTHCHECK_PORT", "")
+    if raw.strip().isdigit():
+        return int(raw.strip())
+    return _DEFAULT_PORT
+
+
+def _build_response_body() -> bytes:
+    """Build the JSON health response payload."""
+    fleet = os.environ.get("TEMPORAL_WORKER_FLEET", "unknown")
+    uptime = int(time.monotonic() - _start_time)
+
+    body: dict[str, Any] = {
+        "status": "ok",
+        "fleet": fleet,
+        "uptime_seconds": uptime,
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+async def _handle_connection(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    """Handle a single HTTP connection — respond to any request with health JSON."""
+    try:
+        # Read request line (we don't need the full request)
+        await asyncio.wait_for(reader.readline(), timeout=5.0)
+
+        # Consume remaining headers
+        while True:
+            line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            if line in (b"\r\n", b"\n", b""):
+                break
+
+        payload = _build_response_body()
+
+        response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Connection: close\r\n"
+            b"Content-Length: " + str(len(payload)).encode() + b"\r\n"
+            b"\r\n" + payload
+        )
+        writer.write(response)
+        await writer.drain()
+    except (asyncio.TimeoutError, ConnectionError, OSError):
+        pass
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except (ConnectionError, OSError):
+            pass
+
+
+async def start_healthcheck_server() -> asyncio.Server | None:
+    """Start the health-check HTTP server as a background asyncio task.
+
+    Returns the ``asyncio.Server`` so callers can close it on shutdown,
+    or ``None`` if the server is disabled via environment variable.
+    """
+    if not _is_enabled():
+        logger.info("Worker healthcheck server disabled via WORKER_HEALTHCHECK_ENABLED")
+        return None
+
+    global _start_time
+    _start_time = time.monotonic()
+
+    port = _port()
+    server = await asyncio.start_server(_handle_connection, "0.0.0.0", port)
+    logger.info("Worker healthcheck server listening on port %d", port)
+    return server

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -32,6 +32,7 @@ from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
 )
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow as MoonMindRun
+from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     publish_artifacts_activity,
@@ -94,6 +95,10 @@ async def main_async() -> None:
         f"concurrency={topology.concurrency_limit}"
     )
 
+    # Start healthcheck server before connecting to Temporal so probes
+    # can confirm the process is alive even during initial connection.
+    healthcheck_server = await start_healthcheck_server()
+
     client = await Client.connect(
         settings.temporal.address, namespace=settings.temporal.namespace
     )
@@ -127,8 +132,12 @@ async def main_async() -> None:
     finally:
         if runtime_resources is not None:
             await runtime_resources.aclose()
+        if healthcheck_server is not None:
+            healthcheck_server.close()
+            await healthcheck_server.wait_closed()
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     asyncio.run(main_async())
+

--- a/tests/unit/workflows/temporal/test_worker_healthcheck.py
+++ b/tests/unit/workflows/temporal/test_worker_healthcheck.py
@@ -1,0 +1,117 @@
+"""Unit tests for the Temporal worker healthcheck HTTP server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+import pytest
+
+from moonmind.workflows.temporal.worker_healthcheck import (
+    _build_response_body,
+    _is_enabled,
+    _port,
+    start_healthcheck_server,
+)
+
+
+def test_build_response_body_returns_valid_json(monkeypatch):
+    """Response body should be valid JSON with required keys."""
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "sandbox")
+    body = json.loads(_build_response_body())
+    assert body["status"] == "ok"
+    assert body["fleet"] == "sandbox"
+    assert "uptime_seconds" in body
+    assert isinstance(body["uptime_seconds"], int)
+
+
+def test_build_response_body_defaults_fleet(monkeypatch):
+    """Fleet should default to 'unknown' when env var is missing."""
+    monkeypatch.delenv("TEMPORAL_WORKER_FLEET", raising=False)
+    body = json.loads(_build_response_body())
+    assert body["fleet"] == "unknown"
+
+
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+    ],
+)
+def test_is_enabled_respects_env(monkeypatch, env_value, expected):
+    """WORKER_HEALTHCHECK_ENABLED should control server startup."""
+    monkeypatch.setenv("WORKER_HEALTHCHECK_ENABLED", env_value)
+    assert _is_enabled() is expected
+
+
+def test_is_enabled_defaults_to_true(monkeypatch):
+    """When no env var is set, healthcheck should be enabled."""
+    monkeypatch.delenv("WORKER_HEALTHCHECK_ENABLED", raising=False)
+    assert _is_enabled() is True
+
+
+def test_port_defaults_to_8080(monkeypatch):
+    """Default port should be 8080."""
+    monkeypatch.delenv("WORKER_HEALTHCHECK_PORT", raising=False)
+    assert _port() == 8080
+
+
+def test_port_reads_env(monkeypatch):
+    """Port should be configurable via WORKER_HEALTHCHECK_PORT."""
+    monkeypatch.setenv("WORKER_HEALTHCHECK_PORT", "9090")
+    assert _port() == 9090
+
+
+def test_port_ignores_non_numeric(monkeypatch):
+    """Non-numeric port values should fall back to default."""
+    monkeypatch.setenv("WORKER_HEALTHCHECK_PORT", "abc")
+    assert _port() == 8080
+
+
+@pytest.mark.asyncio
+async def test_start_healthcheck_server_disabled(monkeypatch):
+    """When disabled, start_healthcheck_server should return None."""
+    monkeypatch.setenv("WORKER_HEALTHCHECK_ENABLED", "false")
+    server = await start_healthcheck_server()
+    assert server is None
+
+
+@pytest.mark.asyncio
+async def test_start_healthcheck_server_responds(monkeypatch):
+    """Server should start and respond to HTTP requests on /healthz."""
+    monkeypatch.setenv("WORKER_HEALTHCHECK_ENABLED", "true")
+    monkeypatch.setenv("WORKER_HEALTHCHECK_PORT", "0")  # Auto-assign port
+    monkeypatch.setenv("TEMPORAL_WORKER_FLEET", "test_fleet")
+
+    server = await start_healthcheck_server()
+    assert server is not None
+
+    try:
+        # Get the auto-assigned port
+        sockets = server.sockets
+        assert sockets, "Server should have at least one socket"
+        port = sockets[0].getsockname()[1]
+
+        # Make an HTTP request
+        url = f"http://127.0.0.1:{port}/healthz"
+        loop = asyncio.get_event_loop()
+        response_bytes = await loop.run_in_executor(
+            None, lambda: urllib.request.urlopen(url, timeout=5).read()
+        )
+        body = json.loads(response_bytes)
+
+        assert body["status"] == "ok"
+        assert body["fleet"] == "test_fleet"
+        assert isinstance(body["uptime_seconds"], int)
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tools/auth-claude-volume.sh
+++ b/tools/auth-claude-volume.sh
@@ -1,48 +1,173 @@
 #!/usr/bin/env bash
+# Populate the claude_auth_volume Docker volume with Claude Code OAuth
+# credentials so the MoonMind sandbox worker inherits the host user's
+# account tier.
+#
+# Usage:
+#   tools/auth-claude-volume.sh            # sync local ~/.claude creds
+#   tools/auth-claude-volume.sh --sync     # same as above (explicit)
+#   tools/auth-claude-volume.sh --login    # interactive claude login
+#   tools/auth-claude-volume.sh --check    # verify volume credentials
+#
+# Environment overrides:
+#   CLAUDE_AUTH_HOST_DIR  Host credential directory (default: ~/.claude)
+#   CLAUDE_VOLUME_NAME   Docker volume name (default: claude_auth_volume)
+#   CLAUDE_VOLUME_PATH   Container-side auth root (default: /home/app/.claude)
+#   CLAUDE_HOME          Legacy alias for CLAUDE_VOLUME_PATH
 set -euo pipefail
 
-NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
-AUTH_SERVICE="${CLAUDE_AUTH_SERVICE:-temporal-worker-sandbox}"
-AUTH_PROFILE="${CLAUDE_AUTH_PROFILE:-}"
 export CLAUDE_VOLUME_NAME="${CLAUDE_VOLUME_NAME:-claude_auth_volume}"
+VOLUME_NAME="${CLAUDE_VOLUME_NAME}"
+HOST_CLAUDE_DIR="${CLAUDE_AUTH_HOST_DIR:-${HOME}/.claude}"
+CLAUDE_VOLUME_PATH="${CLAUDE_VOLUME_PATH:-${CLAUDE_HOME:-/home/app/.claude}}"
+CLAUDE_HOME="${CLAUDE_VOLUME_PATH}"
 
-CLAUDE_HOME="${CLAUDE_HOME:-/home/app/.claude}"
-CLAUDE_TERM="${TERM:-xterm-256color}"
+# ---------------------------------------------------------------------------
+_require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Error: docker CLI is not available." >&2
+    exit 127
+  fi
+}
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "Error: docker CLI is not available." >&2
-  exit 127
-fi
+_ensure_volume() {
+  if ! docker volume inspect "$VOLUME_NAME" >/dev/null 2>&1; then
+    echo "Creating Docker volume '$VOLUME_NAME'..."
+    docker volume create "$VOLUME_NAME" >/dev/null
+  fi
+}
 
-if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-  docker network create "$NETWORK_NAME" >/dev/null
-fi
+# ---------------------------------------------------------------------------
+# --sync (default): copy host ~/.claude credentials into the Docker volume
+# ---------------------------------------------------------------------------
+cmd_sync() {
+  _require_docker
+  _ensure_volume
 
-if ! [ -t 0 ] || ! [ -t 1 ]; then
-  echo "Error: Claude login requires an interactive terminal."
-  echo "Run this command from an interactive shell."
-  exit 1
-fi
+  if [ ! -d "${HOST_CLAUDE_DIR}" ]; then
+    echo "Error: No Claude credential directory found at ${HOST_CLAUDE_DIR}" >&2
+    echo "" >&2
+    echo "Either:" >&2
+    echo "  1. Run 'claude login' locally to authenticate, then re-run this script." >&2
+    echo "  2. Run '$0 --login' to authenticate interactively inside the container." >&2
+    exit 1
+  fi
 
-COMPOSE_NETWORK_ARGS=()
-if docker compose run --help 2>/dev/null | grep -Eq '(^|[[:space:]])--network([[:space:]]|=|$)'; then
-  COMPOSE_NETWORK_ARGS+=(--network "$NETWORK_NAME")
-fi
+  echo "Syncing Claude credentials from ${HOST_CLAUDE_DIR} into volume '${VOLUME_NAME}'..."
 
-COMPOSE_PROFILE_ARGS=()
-if [[ -n "$AUTH_PROFILE" ]]; then
-  COMPOSE_PROFILE_ARGS+=(--profile "$AUTH_PROFILE")
-fi
+  # Copy the entire host credential directory into the volume.
+  # Claude's file layout can vary (credentials.json, settings.json, cache/, etc.)
+  # so we sync everything present rather than a fixed list.
+  docker run --rm \
+    -v "${VOLUME_NAME}:${CLAUDE_HOME}" \
+    -v "${HOST_CLAUDE_DIR}:/host-claude-auth:ro" \
+    alpine:3.20 sh -c "
+      cp -a /host-claude-auth/. '${CLAUDE_HOME}/' &&
+      chown -R 1000:1000 '${CLAUDE_HOME}' &&
+      chmod 0775 '${CLAUDE_HOME}' &&
+      echo '  Synced the following files:' &&
+      find '${CLAUDE_HOME}' -maxdepth 2 -type f -exec basename {} \;
+    "
 
-docker compose run --rm -it \
-  ${COMPOSE_PROFILE_ARGS[@]+"${COMPOSE_PROFILE_ARGS[@]}"} \
-  --entrypoint /bin/bash \
-  -e MOONMIND_CLAUDE_CLI_AUTH_MODE=oauth \
-  -e ANTHROPIC_API_KEY= \
-  -e CLAUDE_API_KEY= \
-  -e TERM="${CLAUDE_TERM}" \
-  -e CLAUDE_HOME="${CLAUDE_HOME}" \
-  -e CLAUDE_VOLUME_NAME="${CLAUDE_VOLUME_NAME}" \
-  "${COMPOSE_NETWORK_ARGS[@]}" \
-  "$AUTH_SERVICE" \
-  -lc 'unset ANTHROPIC_API_KEY CLAUDE_API_KEY; stty sane 2>/dev/null || true; mkdir -p "${CLAUDE_HOME:-/home/app/.claude}"; exec claude login'
+  echo ""
+  echo "Done. Restart the sandbox worker to pick up the new credentials:"
+  echo "  docker compose restart temporal-worker-sandbox"
+}
+
+# ---------------------------------------------------------------------------
+# --login: interactive claude login inside a container
+# ---------------------------------------------------------------------------
+cmd_login() {
+  _require_docker
+
+  local NETWORK_NAME="${MOONMIND_DOCKER_NETWORK:-local-network}"
+  local AUTH_SERVICE="${CLAUDE_AUTH_SERVICE:-temporal-worker-sandbox}"
+  local AUTH_PROFILE="${CLAUDE_AUTH_PROFILE:-}"
+  local CLAUDE_TERM="${TERM:-xterm-256color}"
+
+  if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+    docker network create "$NETWORK_NAME" >/dev/null
+  fi
+
+  if ! [ -t 0 ] || ! [ -t 1 ]; then
+    echo "Error: --login requires an interactive terminal." >&2
+    exit 1
+  fi
+
+  local COMPOSE_NETWORK_ARGS=()
+  if docker compose run --help 2>/dev/null | grep -Eq '(^|[[:space:]])--network([[:space:]]|=|$)'; then
+    COMPOSE_NETWORK_ARGS+=(--network "$NETWORK_NAME")
+  fi
+
+  local COMPOSE_PROFILE_ARGS=()
+  if [ -n "$AUTH_PROFILE" ]; then
+    COMPOSE_PROFILE_ARGS+=(--profile "$AUTH_PROFILE")
+  fi
+
+  docker compose run --rm -it \
+    ${COMPOSE_PROFILE_ARGS[@]+"${COMPOSE_PROFILE_ARGS[@]}"} \
+    --entrypoint /bin/bash \
+    -e MOONMIND_CLAUDE_CLI_AUTH_MODE=oauth \
+    -e ANTHROPIC_API_KEY= \
+    -e CLAUDE_API_KEY= \
+    -e TERM="${CLAUDE_TERM}" \
+    -e CLAUDE_HOME="${CLAUDE_HOME}" \
+    -e CLAUDE_VOLUME_NAME="${CLAUDE_VOLUME_NAME}" \
+    ${COMPOSE_NETWORK_ARGS[@]+"${COMPOSE_NETWORK_ARGS[@]}"} \
+    "$AUTH_SERVICE" \
+    -lc 'unset ANTHROPIC_API_KEY CLAUDE_API_KEY; stty sane 2>/dev/null || true; mkdir -p "${CLAUDE_HOME:-/home/app/.claude}"; exec claude login'
+}
+
+# ---------------------------------------------------------------------------
+# --check: verify the volume has valid credentials
+# ---------------------------------------------------------------------------
+cmd_check() {
+  _require_docker
+  _ensure_volume
+
+  echo "Checking credentials in volume '${VOLUME_NAME}'..."
+  echo ""
+
+  docker run --rm \
+    -v "${VOLUME_NAME}:${CLAUDE_HOME}:ro" \
+    alpine:3.20 sh -c "
+      creds='${CLAUDE_HOME}/credentials.json'
+      settings='${CLAUDE_HOME}/settings.json'
+
+      if [ ! -f \"\$creds\" ]; then
+        echo 'MISSING: credentials.json — no credentials in volume'
+        echo ''
+        echo 'Provision credentials with one of:'
+        echo '  $0 --sync    (copy from host ~/.claude)'
+        echo '  $0 --login   (interactive login in container)'
+        exit 1
+      fi
+      echo 'FOUND: credentials.json'
+
+      if [ -f \"\$settings\" ]; then
+        echo \"SETTINGS: \$(cat \"\$settings\")\"
+      fi
+
+      echo ''
+      echo 'Files in volume:'
+      find '${CLAUDE_HOME}' -maxdepth 2 -type f -exec basename {} \;
+    "
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+case "${1:-}" in
+  --login)  cmd_login ;;
+  --check)  cmd_check ;;
+  --sync|"") cmd_sync ;;
+  -h|--help)
+    sed -nE '2,/^[^#]/{ /^#/s/^# ?//p; }' "$0"
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    echo "Usage: $0 [--sync|--login|--check|--help]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Brings `tools/auth-claude-volume.sh` to feature parity with `auth-gemini-volume.sh` by adding `--sync`, `--check`, and `--help` modes (49 → 157 lines).

**Roadmap item**: Milestone 1 — *Claude auth volume flow matches Codex/Gemini parity*
**Spec**: 072 (`managed-agents-auth`)

## Changes

### `tools/auth-claude-volume.sh` — Rewritten

| Mode | Description |
|------|-------------|
| `--sync` (default) | Copy host `~/.claude/` credentials into the Docker volume |
| `--login` | Interactive `claude login` inside a container (unchanged) |
| `--check` | Verify volume has `credentials.json` and list files |
| `--help` | Print usage from header comments |

New env overrides: `CLAUDE_AUTH_HOST_DIR`, `CLAUDE_VOLUME_NAME`, `CLAUDE_VOLUME_PATH`.

Also fixed macOS BSD `sed` portability for `--help` (`-E` flag instead of GNU `\?`).

### `docs/ManagedAgents/ManagedAgentsAuthentication.md`

Updated provisioning table to reflect Claude's new modes.

## Testing

- All **1538 unit tests pass** (`./tools/test_unit.sh`)
- `--help` verified on macOS
- No adapter/profile/docker-compose changes needed (already had Claude support)