### PR TITLE
feat: Milestone 2 — External / Black-Box Agent Coordination

### DIFF
--- a/api_service/api/routers/__init__.py
+++ b/api_service/api/routers/__init__.py
@@ -4,6 +4,7 @@ from api_service.api.routers.execution_integrations import (
     router as execution_integrations_router,
 )
 from api_service.api.routers.executions import router as executions_router
+from api_service.api.routers.external_runs import router as external_runs_router
 from api_service.api.routers.recurring_tasks import router as recurring_tasks_router
 from api_service.api.routers.task_compatibility import (
     router as task_compatibility_router,
@@ -12,6 +13,7 @@ from api_service.api.routers.task_compatibility import (
 __all__ = [
     "execution_integrations_router",
     "executions_router",
+    "external_runs_router",
     "recurring_tasks_router",
     "task_compatibility_router",
 ]

--- a/api_service/api/routers/external_runs.py
+++ b/api_service/api/routers/external_runs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -93,7 +92,8 @@ async def _query_external_runs(
 
     query_parts = ['WorkflowType = "MoonMind.AgentRun"']
     if agent_id:
-        query_parts.append(f'AgentId = "{agent_id}"')
+        escaped_agent_id = agent_id.replace('\\', '\\\\').replace('"', '\\"')
+        query_parts.append(f'AgentId = "{escaped_agent_id}"')
     if status_filter:
         temporal_status = status_filter.strip().capitalize()
         if temporal_status in {"Running", "Completed", "Failed", "Canceled", "Terminated", "TimedOut"}:
@@ -174,7 +174,7 @@ async def list_external_runs(
         limit=limit + 1,
     )
     has_more = len(runs) > limit
-    items = runs[:limit]
+    items = list(runs[:limit])
     return {
         "items": items,
         "total": len(items),
@@ -184,13 +184,60 @@ async def list_external_runs(
 
 @router.get("/{workflow_id}", response_model=ExternalRunDetail)
 async def get_external_run(workflow_id: str) -> dict[str, Any]:
-    """Get detail for one external agent run."""
+    """Get detail for one external agent run by direct workflow handle lookup."""
 
-    runs = await _query_external_runs(limit=200)
-    for run in runs:
-        if run.get("workflowId") == workflow_id:
-            return run
-    raise HTTPException(status_code=404, detail=f"External run {workflow_id} not found")
+    get_client = _get_temporal_client()
+    if get_client is None:
+        raise HTTPException(status_code=503, detail="Temporal client not available")
+
+    try:
+        client = await get_client()
+        handle = client.get_workflow_handle(workflow_id)
+        desc = await handle.describe()
+    except Exception:
+        logger.warning("Failed to describe workflow %s", workflow_id, exc_info=True)
+        raise HTTPException(status_code=404, detail=f"External run {workflow_id} not found")
+
+    memo = {}
+    if hasattr(desc, "memo") and desc.memo:
+        memo = dict(desc.memo) if isinstance(desc.memo, dict) else {}
+
+    if memo.get("agent_kind") != "external":
+        raise HTTPException(status_code=404, detail=f"External run {workflow_id} not found")
+
+    return {
+        "workflowId": workflow_id,
+        "runId": getattr(desc, "run_id", None),
+        "agentId": memo.get("agent_id", "unknown"),
+        "status": str(getattr(desc, "status", "unknown")).lower(),
+        "providerStatus": memo.get("provider_status"),
+        "normalizedStatus": memo.get("normalized_status"),
+        "externalUrl": memo.get("external_url"),
+        "startedAt": (
+            desc.start_time.isoformat()
+            if hasattr(desc, "start_time") and desc.start_time
+            else None
+        ),
+        "closedAt": (
+            desc.close_time.isoformat()
+            if hasattr(desc, "close_time") and desc.close_time
+            else None
+        ),
+        "correlationId": memo.get("correlation_id"),
+        "metadata": {
+            k: v
+            for k, v in memo.items()
+            if k
+            not in {
+                "agent_kind",
+                "agent_id",
+                "provider_status",
+                "normalized_status",
+                "external_url",
+                "correlation_id",
+            }
+        },
+    }
 
 
 __all__ = ["router"]

--- a/api_service/api/routers/external_runs.py
+++ b/api_service/api/routers/external_runs.py
@@ -1,0 +1,196 @@
+"""API router for external agent run status tracking."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/external-runs", tags=["external-runs"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class ExternalRunSummary(BaseModel):
+    """List-level summary of one external agent run."""
+
+    workflow_id: str = Field(..., alias="workflowId")
+    run_id: Optional[str] = Field(None, alias="runId")
+    agent_id: str = Field(..., alias="agentId")
+    status: str
+    provider_status: Optional[str] = Field(None, alias="providerStatus")
+    normalized_status: Optional[str] = Field(None, alias="normalizedStatus")
+    external_url: Optional[str] = Field(None, alias="externalUrl")
+    started_at: Optional[str] = Field(None, alias="startedAt")
+    closed_at: Optional[str] = Field(None, alias="closedAt")
+
+    model_config = {"populate_by_name": True}
+
+
+class ExternalRunDetail(ExternalRunSummary):
+    """Full detail of one external agent run."""
+
+    correlation_id: Optional[str] = Field(None, alias="correlationId")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ExternalRunListResponse(BaseModel):
+    """Paginated list response for external runs."""
+
+    items: list[ExternalRunSummary]
+    total: int
+    has_more: bool = Field(False, alias="hasMore")
+
+    model_config = {"populate_by_name": True}
+
+
+# ---------------------------------------------------------------------------
+# Helpers — Temporal client
+# ---------------------------------------------------------------------------
+
+
+def _get_temporal_client() -> Any:
+    """Lazy-import the shared Temporal client accessor."""
+
+    try:
+        from api_service.services.temporal.client import get_temporal_client
+
+        return get_temporal_client
+    except ImportError:
+        return None
+
+
+async def _query_external_runs(
+    *,
+    agent_id: str | None = None,
+    status_filter: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Query Temporal for MoonMind.AgentRun workflows with agent_kind=external.
+
+    Falls back to an empty list if the Temporal client is unavailable
+    (e.g. in unit tests or environments without Temporal).
+    """
+
+    get_client = _get_temporal_client()
+    if get_client is None:
+        logger.warning("Temporal client not available; returning empty external runs")
+        return []
+
+    try:
+        client = await get_client()
+    except Exception:
+        logger.warning("Failed to connect to Temporal; returning empty external runs", exc_info=True)
+        return []
+
+    query_parts = ['WorkflowType = "MoonMind.AgentRun"']
+    if agent_id:
+        query_parts.append(f'AgentId = "{agent_id}"')
+    if status_filter:
+        temporal_status = status_filter.strip().capitalize()
+        if temporal_status in {"Running", "Completed", "Failed", "Canceled", "Terminated", "TimedOut"}:
+            query_parts.append(f"ExecutionStatus = '{temporal_status}'")
+
+    query = " AND ".join(query_parts)
+
+    results: list[dict[str, Any]] = []
+    try:
+        async for workflow in client.list_workflows(query=query):
+            memo = {}
+            if hasattr(workflow, "memo") and workflow.memo:
+                memo = dict(workflow.memo) if isinstance(workflow.memo, dict) else {}
+
+            agent_kind = memo.get("agent_kind", "")
+            if agent_kind != "external":
+                # Additional filter: only include external agent runs
+                continue
+
+            item: dict[str, Any] = {
+                "workflowId": workflow.id,
+                "runId": getattr(workflow, "run_id", None),
+                "agentId": memo.get("agent_id", "unknown"),
+                "status": str(getattr(workflow, "status", "unknown")).lower(),
+                "providerStatus": memo.get("provider_status"),
+                "normalizedStatus": memo.get("normalized_status"),
+                "externalUrl": memo.get("external_url"),
+                "startedAt": (
+                    workflow.start_time.isoformat()
+                    if hasattr(workflow, "start_time") and workflow.start_time
+                    else None
+                ),
+                "closedAt": (
+                    workflow.close_time.isoformat()
+                    if hasattr(workflow, "close_time") and workflow.close_time
+                    else None
+                ),
+                "correlationId": memo.get("correlation_id"),
+                "metadata": {
+                    k: v
+                    for k, v in memo.items()
+                    if k
+                    not in {
+                        "agent_kind",
+                        "agent_id",
+                        "provider_status",
+                        "normalized_status",
+                        "external_url",
+                        "correlation_id",
+                    }
+                },
+            }
+            results.append(item)
+            if len(results) >= limit:
+                break
+    except Exception:
+        logger.warning("Failed to query Temporal workflows", exc_info=True)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=ExternalRunListResponse)
+async def list_external_runs(
+    agent_id: Optional[str] = Query(None, description="Filter by agent ID"),
+    status: Optional[str] = Query(None, description="Filter by execution status"),
+    limit: int = Query(50, ge=1, le=200, description="Max results to return"),
+) -> dict[str, Any]:
+    """List external agent runs with optional filtering."""
+
+    runs = await _query_external_runs(
+        agent_id=agent_id,
+        status_filter=status,
+        limit=limit + 1,
+    )
+    has_more = len(runs) > limit
+    items = runs[:limit]
+    return {
+        "items": items,
+        "total": len(items),
+        "hasMore": has_more,
+    }
+
+
+@router.get("/{workflow_id}", response_model=ExternalRunDetail)
+async def get_external_run(workflow_id: str) -> dict[str, Any]:
+    """Get detail for one external agent run."""
+
+    runs = await _query_external_runs(limit=200)
+    for run in runs:
+        if run.get("workflowId") == workflow_id:
+            return run
+    raise HTTPException(status_code=404, detail=f"External run {workflow_id} not found")
+
+
+__all__ = ["router"]

--- a/api_service/api/routers/external_runs.py
+++ b/api_service/api/routers/external_runs.py
@@ -109,6 +109,10 @@ async def _query_external_runs(
                 memo = dict(workflow.memo) if isinstance(workflow.memo, dict) else {}
 
             agent_kind = memo.get("agent_kind", "")
+            # TODO: For a true total count, register agent_kind as a Temporal
+            # custom search attribute and use client.count_workflows(query=query).
+            # Post-query filtering is a pragmatic first step while the schema
+            # does not include AgentKind as a search attribute.
             if agent_kind != "external":
                 # Additional filter: only include external agent runs
                 continue
@@ -177,6 +181,9 @@ async def list_external_runs(
     items = list(runs[:limit])
     return {
         "items": items,
+        # NOTE: total reflects the current page, not the global count.
+        # Accurate pagination requires making agent_kind a Temporal search
+        # attribute and using client.count_workflows().
         "total": len(items),
         "hasMore": has_more,
     }

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -65,6 +65,19 @@ _STATUS_MAPS: dict[str, dict[str, str]] = {
         "awaiting_action": "awaiting_action",
         "cancelled": "cancelled",
     },
+    "external": {
+        "queued": "queued",
+        "running": "running",
+        "completed": "succeeded",
+        "succeeded": "succeeded",
+        "failed": "failed",
+        "cancelled": "cancelled",
+        "canceled": "cancelled",
+        "timed_out": "failed",
+        "awaiting_callback": "awaiting_action",
+        "intervention_requested": "awaiting_action",
+        "unknown": "queued",
+    },
 }
 
 
@@ -247,6 +260,10 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "artifactMetadata": temporal_dashboard.artifact_metadata_endpoint,
                 "artifactPresignDownload": temporal_dashboard.artifact_presign_download_endpoint,
                 "artifactDownload": temporal_dashboard.artifact_download_endpoint,
+            },
+            "externalRuns": {
+                "list": "/api/external-runs",
+                "detail": "/api/external-runs/{workflowId}",
             },
         },
         "features": {

--- a/api_service/templates/task_dashboard.html
+++ b/api_service/templates/task_dashboard.html
@@ -56,6 +56,7 @@
       <a href="/tasks/schedules" data-nav>Schedules</a>
       <a href="/tasks/schedules/new" data-nav>New Schedule</a>
       <a href="/tasks/proposals" data-nav>Proposals</a>
+      <a href="/tasks/external" data-nav>External Runs</a>
       <a href="/tasks/settings" data-nav>⚙️ System</a>
     </nav>
 

--- a/moonmind/codex_cloud/__init__.py
+++ b/moonmind/codex_cloud/__init__.py
@@ -1,0 +1,1 @@
+"""Codex Cloud external agent integration."""

--- a/moonmind/codex_cloud/settings.py
+++ b/moonmind/codex_cloud/settings.py
@@ -1,0 +1,105 @@
+"""Shared helpers for gating Codex Cloud runtime support on API configuration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+CODEX_CLOUD_DISABLED_MESSAGE = (
+    "targetRuntime=codex_cloud requires CODEX_CLOUD_ENABLED=true "
+    "with CODEX_CLOUD_API_URL and CODEX_CLOUD_API_KEY configured"
+)
+"""Canonical error text for disabled Codex Cloud runtime configuration."""
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+@dataclass(frozen=True, slots=True)
+class CodexCloudRuntimeGate:
+    """Represents whether Codex Cloud runtime is enabled plus diagnostics context."""
+
+    enabled: bool
+    missing: tuple[str, ...]
+    error_message: str
+
+
+def _clean_value(value: object | None) -> str:
+    return str(value or "").strip()
+
+
+def _resolve_enabled_flag(
+    *, enabled: bool | None = None, env: Mapping[str, Any] | None = None
+) -> bool:
+    if isinstance(enabled, bool):
+        return enabled
+    source = env if env is not None else os.environ
+    raw = _clean_value(source.get("CODEX_CLOUD_ENABLED"))  # type: ignore[arg-type]
+    if not raw:
+        return False
+    lowered = raw.lower()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+    return False
+
+
+def build_codex_cloud_gate(
+    *,
+    enabled: bool | None = None,
+    api_url: str | None = None,
+    api_key: str | None = None,
+    env: Mapping[str, Any] | None = None,
+    error_message: str = CODEX_CLOUD_DISABLED_MESSAGE,
+) -> CodexCloudRuntimeGate:
+    """Return normalized gate state for Codex Cloud runtime."""
+
+    source = env if env is not None else os.environ
+    runtime_enabled = _resolve_enabled_flag(enabled=enabled, env=source)
+    resolved_url = _clean_value(api_url) or _clean_value(
+        source.get("CODEX_CLOUD_API_URL")  # type: ignore[arg-type]
+    )
+    resolved_key = _clean_value(api_key) or _clean_value(
+        source.get("CODEX_CLOUD_API_KEY")  # type: ignore[arg-type]
+    )
+
+    missing: list[str] = []
+    if not runtime_enabled:
+        missing.append("CODEX_CLOUD_ENABLED")
+    if not resolved_url:
+        missing.append("CODEX_CLOUD_API_URL")
+    if not resolved_key:
+        missing.append("CODEX_CLOUD_API_KEY")
+
+    return CodexCloudRuntimeGate(
+        enabled=not missing,
+        missing=tuple(missing),
+        error_message=error_message,
+    )
+
+
+def is_codex_cloud_enabled(
+    *,
+    enabled: bool | None = None,
+    api_url: str | None = None,
+    api_key: str | None = None,
+    env: Mapping[str, Any] | None = None,
+) -> bool:
+    """Return whether Codex Cloud runtime should be enabled."""
+
+    return build_codex_cloud_gate(
+        enabled=enabled,
+        api_url=api_url,
+        api_key=api_key,
+        env=env,
+    ).enabled
+
+
+__all__ = [
+    "CODEX_CLOUD_DISABLED_MESSAGE",
+    "CodexCloudRuntimeGate",
+    "build_codex_cloud_gate",
+    "is_codex_cloud_enabled",
+]

--- a/moonmind/workflows/adapters/__init__.py
+++ b/moonmind/workflows/adapters/__init__.py
@@ -8,17 +8,22 @@ from .codex_client import (
     CodexDiffRetrievalError,
     CodexSubmissionResult,
 )
+from .codex_cloud_agent_adapter import CodexCloudAgentAdapter
+from .external_adapter_registry import ExternalAdapterRegistry, build_default_registry
 from .github_client import GitHubClient, GitHubPublishResult
 from .jules_agent_adapter import JulesAgentAdapter
 
 __all__ = [
     "AgentAdapter",
     "CodexClient",
+    "CodexCloudAgentAdapter",
     "CodexDiffNotReadyError",
     "CodexDiffRetrievalError",
     "CodexSubmissionResult",
     "CodexDiffResult",
+    "ExternalAdapterRegistry",
     "GitHubClient",
     "GitHubPublishResult",
     "JulesAgentAdapter",
+    "build_default_registry",
 ]

--- a/moonmind/workflows/adapters/codex_cloud_agent_adapter.py
+++ b/moonmind/workflows/adapters/codex_cloud_agent_adapter.py
@@ -1,0 +1,198 @@
+"""External-agent adapter implementation backed by the Codex Cloud provider."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
+from moonmind.workflows.adapters.codex_cloud_client import (
+    CodexCloudClient,
+    CodexCloudClientError,
+    normalize_codex_cloud_status,
+)
+
+CodexCloudClientFactory = Callable[[], CodexCloudClient]
+
+_CODEX_CLOUD_TO_AGENT_RUN_STATUS: dict[str, str] = {
+    "queued": "queued",
+    "running": "running",
+    "succeeded": "completed",
+    "failed": "failed",
+    "canceled": "cancelled",
+    "unknown": "awaiting_callback",
+}
+
+
+def _to_agent_status(raw_status: str | None) -> str:
+    normalized = normalize_codex_cloud_status(raw_status)
+    return _CODEX_CLOUD_TO_AGENT_RUN_STATUS.get(normalized, "awaiting_callback")
+
+
+def _extract_parameters_metadata(
+    parameters: Mapping[str, Any] | None,
+) -> tuple[str, str, dict[str, Any]]:
+    payload = dict(parameters or {})
+    title = str(payload.get("title") or "MoonMind Agent Task").strip()
+    description = str(payload.get("description") or "").strip()
+    metadata = payload.get("metadata")
+    if metadata is None:
+        metadata_payload: dict[str, Any] = {}
+    elif isinstance(metadata, Mapping):
+        metadata_payload = dict(metadata)
+    else:
+        raise ValueError("parameters.metadata must be an object")
+    return title, description, metadata_payload
+
+
+class CodexCloudAgentAdapter:
+    """Normalize Codex Cloud provider interactions into canonical agent contracts.
+
+    Follows the same pattern as ``JulesAgentAdapter``:
+    - Client lifecycle: single client created at construction, reused for pooling.
+    - In-memory idempotency guard per activity attempt.
+    """
+
+    def __init__(self, *, client_factory: CodexCloudClientFactory) -> None:
+        self._client_factory = client_factory
+        self.__client: CodexCloudClient | None = None
+        self._starts_by_idempotency: dict[str, AgentRunHandle] = {}
+
+    @property
+    def _client(self) -> CodexCloudClient:
+        if self.__client is None:
+            self.__client = self._client_factory()
+        return self.__client
+
+    async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+        if request.agent_kind != "external":
+            raise ValueError("CodexCloudAgentAdapter only supports external agent_kind")
+        if str(request.agent_id).strip().lower() != "codex_cloud":
+            raise ValueError("CodexCloudAgentAdapter only supports agent_id=codex_cloud")
+
+        cached = self._starts_by_idempotency.get(request.idempotency_key)
+        if cached is not None:
+            return cached
+
+        title, description, metadata = _extract_parameters_metadata(request.parameters)
+        if not description and request.instruction_ref:
+            description = request.instruction_ref
+        if not description and request.input_refs:
+            description = f"MoonMind artifact refs: {', '.join(request.input_refs)}"
+        if not description:
+            description = f"MoonMind delegated run {request.correlation_id}"
+
+        moonmind_meta = metadata.setdefault("moonmind", {})
+        if isinstance(moonmind_meta, Mapping):
+            moonmind_payload = dict(moonmind_meta)
+            moonmind_payload.setdefault("correlationId", request.correlation_id)
+            moonmind_payload.setdefault("idempotencyKey", request.idempotency_key)
+            metadata["moonmind"] = moonmind_payload
+
+        response = await self._client.create_task(
+            title=title,
+            description=description,
+            metadata=metadata,
+        )
+
+        task_id = str(response.get("taskId") or response.get("id") or "")
+        provider_status = str(response.get("status") or "").strip() or "unknown"
+
+        handle = AgentRunHandle(
+            runId=task_id,
+            agentKind="external",
+            agentId="codex_cloud",
+            status=_to_agent_status(provider_status),
+            startedAt=datetime.now(tz=UTC),
+            metadata={
+                "providerStatus": provider_status,
+                "normalizedStatus": normalize_codex_cloud_status(provider_status),
+                "externalUrl": str(response.get("url") or "").strip() or None,
+            },
+        )
+        self._starts_by_idempotency[request.idempotency_key] = handle
+        return handle
+
+    async def status(self, run_id: str) -> AgentRunStatus:
+        response = await self._client.get_task(run_id)
+        provider_status = str(response.get("status") or "").strip() or "unknown"
+        normalized_status = normalize_codex_cloud_status(provider_status)
+        return AgentRunStatus(
+            runId=run_id,
+            agentKind="external",
+            agentId="codex_cloud",
+            status=_to_agent_status(provider_status),
+            metadata={
+                "providerStatus": provider_status,
+                "normalizedStatus": normalized_status,
+                "externalUrl": str(response.get("url") or "").strip() or None,
+            },
+        )
+
+    async def fetch_result(self, run_id: str) -> AgentRunResult:
+        response = await self._client.get_task(run_id)
+        provider_status = str(response.get("status") or "").strip() or "unknown"
+        normalized_status = normalize_codex_cloud_status(provider_status)
+        failure_class = None
+        if normalized_status == "failed":
+            failure_class = "integration_error"
+        elif normalized_status == "canceled":
+            failure_class = "execution_error"
+
+        summary = f"Codex Cloud task {run_id} ended with provider status '{provider_status}'."
+        return AgentRunResult(
+            outputRefs=[],
+            summary=summary,
+            failureClass=failure_class,
+            providerErrorCode=provider_status if failure_class else None,
+            metadata={
+                "normalizedStatus": normalized_status,
+                "externalUrl": str(response.get("url") or "").strip() or None,
+            },
+        )
+
+    async def cancel(self, run_id: str) -> AgentRunStatus:
+        try:
+            response = await self._client.cancel_task(run_id)
+        except CodexCloudClientError as exc:
+            if exc.status_code in {404, 405, 501}:
+                return AgentRunStatus(
+                    runId=run_id,
+                    agentKind="external",
+                    agentId="codex_cloud",
+                    status="intervention_requested",
+                    metadata={
+                        "cancelAccepted": False,
+                        "unsupported": True,
+                    },
+                )
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="external",
+                agentId="codex_cloud",
+                status="intervention_requested",
+                metadata={"cancelAccepted": False},
+            )
+
+        provider_status = str(response.get("status") or "").strip() or "canceled"
+        return AgentRunStatus(
+            runId=run_id,
+            agentKind="external",
+            agentId="codex_cloud",
+            status=_to_agent_status(provider_status),
+            metadata={
+                "providerStatus": provider_status,
+                "normalizedStatus": normalize_codex_cloud_status(provider_status),
+                "externalUrl": str(response.get("url") or "").strip() or None,
+                "cancelAccepted": True,
+            },
+        )
+
+
+__all__ = ["CodexCloudAgentAdapter"]

--- a/moonmind/workflows/adapters/codex_cloud_client.py
+++ b/moonmind/workflows/adapters/codex_cloud_client.py
@@ -179,7 +179,8 @@ class CodexCloudClient:
                             try:
                                 delay = max(delay, float(retry_after))
                             except (ValueError, TypeError):
-                                pass
+                                # Malformed Retry-After header — fall back to default delay.
+                                logger.debug("Ignoring unparseable Retry-After header: %r", retry_after)
                     logger.warning(
                         "Codex Cloud request %s failed with HTTP %s (attempt %s/%s); retrying in %.1fs",
                         path,

--- a/moonmind/workflows/adapters/codex_cloud_client.py
+++ b/moonmind/workflows/adapters/codex_cloud_client.py
@@ -1,0 +1,227 @@
+"""Async HTTP adapter for the Codex Cloud API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class CodexCloudClientError(RuntimeError):
+    """Raised when Codex Cloud API requests fail.
+
+    The string representation is intentionally scrubbed to avoid
+    leaking secrets (API keys, bearer tokens, etc.).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        request_path: str | None = None,
+        ambiguous: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.request_path = request_path
+        self.ambiguous = ambiguous
+
+    def __str__(self) -> str:
+        parts = ["Codex Cloud API request failed"]
+        if self.request_path:
+            parts.append(f"path={self.request_path}")
+        if self.status_code is not None:
+            parts.append(f"status={self.status_code}")
+        if self.ambiguous:
+            parts.append("ambiguous")
+        return ": ".join(parts)
+
+
+# Codex Cloud normalized status set.
+_CODEX_CLOUD_STATUS_MAP: dict[str, str] = {
+    "accepted": "queued",
+    "assigned": "queued",
+    "canceled": "canceled",
+    "cancelled": "canceled",
+    "completed": "succeeded",
+    "created": "queued",
+    "done": "succeeded",
+    "error": "failed",
+    "failed": "failed",
+    "finished": "succeeded",
+    "in_progress": "running",
+    "open": "queued",
+    "pending": "queued",
+    "processing": "running",
+    "queued": "queued",
+    "running": "running",
+    "started": "running",
+    "submitted": "queued",
+    "succeeded": "succeeded",
+    "success": "succeeded",
+    "timed_out": "failed",
+    "timeout": "failed",
+}
+
+
+def normalize_codex_cloud_status(raw_status: str | None) -> str:
+    """Map raw Codex Cloud status values to the provider-neutral status set."""
+
+    normalized = str(raw_status or "").strip().lower()
+    if not normalized:
+        return "unknown"
+    return _CODEX_CLOUD_STATUS_MAP.get(normalized, "unknown")
+
+
+class CodexCloudClient:
+    """HTTP wrapper for Codex Cloud task management endpoints."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float = 30.0,
+        retry_attempts: int = 3,
+        retry_delay_seconds: float = 1.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._retry_attempts = retry_attempts
+        self._retry_delay_seconds = retry_delay_seconds
+        if client is not None:
+            self._client = client
+            self._owns_client = False
+        else:
+            headers = {
+                "Accept": "application/json",
+                "Authorization": f"Bearer {api_key}",
+            }
+            self._client = httpx.AsyncClient(
+                base_url=base_url, timeout=timeout, headers=headers
+            )
+            self._owns_client = True
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def create_task(
+        self,
+        *,
+        title: str,
+        description: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create a new task and return the provider response."""
+
+        payload: dict[str, Any] = {
+            "title": title,
+            "description": description,
+        }
+        if metadata:
+            payload["metadata"] = metadata
+        return await self._post_json("/tasks", json=payload)
+
+    async def get_task(self, task_id: str) -> dict[str, Any]:
+        """Get a task by its provider ID."""
+
+        return await self._get_json(f"/tasks/{task_id}")
+
+    async def cancel_task(self, task_id: str) -> dict[str, Any]:
+        """Attempt to cancel a task."""
+
+        return await self._post_json(
+            f"/tasks/{task_id}/cancel",
+            json={},
+        )
+
+    async def _post_json(
+        self, path: str, *, json: dict[str, Any]
+    ) -> dict[str, Any]:
+        return await self._request_with_retry("POST", path, json=json)
+
+    async def _get_json(self, path: str) -> dict[str, Any]:
+        return await self._request_with_retry("GET", path)
+
+    async def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        last_error: Exception | None = None
+        for attempt in range(1, self._retry_attempts + 1):
+            try:
+                response = await self._client.request(method, path, json=json)
+                response.raise_for_status()
+                payload = response.json()
+                if isinstance(payload, dict):
+                    return payload
+                raise CodexCloudClientError(
+                    f"Codex Cloud response for {path} was not a JSON object",
+                    request_path=path,
+                )
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                retryable = (500 <= status_code < 600) or status_code == 429
+                last_error = exc
+                if retryable and attempt < self._retry_attempts:
+                    delay = self._retry_delay_seconds
+                    if status_code == 429:
+                        retry_after = exc.response.headers.get("Retry-After")
+                        if retry_after is not None:
+                            try:
+                                delay = max(delay, float(retry_after))
+                            except (ValueError, TypeError):
+                                pass
+                    logger.warning(
+                        "Codex Cloud request %s failed with HTTP %s (attempt %s/%s); retrying in %.1fs",
+                        path,
+                        status_code,
+                        attempt,
+                        self._retry_attempts,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise CodexCloudClientError(
+                    f"HTTP {status_code}",
+                    status_code=status_code,
+                    request_path=path,
+                ) from exc
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                last_error = exc
+                if attempt < self._retry_attempts:
+                    logger.warning(
+                        "Codex Cloud request %s failed due to %s (attempt %s/%s); retrying in %.1fs",
+                        path,
+                        exc.__class__.__name__,
+                        attempt,
+                        self._retry_attempts,
+                        self._retry_delay_seconds,
+                    )
+                    await asyncio.sleep(self._retry_delay_seconds)
+                    continue
+                break
+            except httpx.HTTPError as exc:
+                raise CodexCloudClientError(
+                    exc.__class__.__name__,
+                    request_path=path,
+                ) from exc
+        raise CodexCloudClientError(
+            last_error.__class__.__name__ if last_error else "unknown error",
+            request_path=path,
+        ) from last_error
+
+
+__all__ = [
+    "CodexCloudClient",
+    "CodexCloudClientError",
+    "normalize_codex_cloud_status",
+]

--- a/moonmind/workflows/adapters/external_adapter_registry.py
+++ b/moonmind/workflows/adapters/external_adapter_registry.py
@@ -1,0 +1,127 @@
+"""Registry mapping external agent IDs to adapter factories."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from moonmind.workflows.adapters.agent_adapter import AgentAdapter
+
+logger = logging.getLogger(__name__)
+
+AdapterFactory = Callable[[], AgentAdapter]
+
+
+class ExternalAdapterRegistry:
+    """Thread-safe registry of external-agent adapter factories.
+
+    Each factory is a zero-argument callable that returns a fully
+    constructed ``AgentAdapter`` instance.  Factories are keyed by
+    canonical ``agent_id`` (lowercased).
+    """
+
+    def __init__(self) -> None:
+        self._factories: dict[str, AdapterFactory] = {}
+
+    def register(self, agent_id: str, factory: AdapterFactory) -> None:
+        """Register *factory* for *agent_id* (case-insensitive)."""
+
+        key = agent_id.strip().lower()
+        if not key:
+            raise ValueError("agent_id must not be blank")
+        self._factories[key] = factory
+
+    def create(self, agent_id: str) -> AgentAdapter:
+        """Instantiate and return an adapter for *agent_id*.
+
+        Raises ``ValueError`` when no factory is registered for the
+        requested *agent_id*.
+        """
+
+        key = agent_id.strip().lower()
+        factory = self._factories.get(key)
+        if factory is None:
+            registered = sorted(self._factories) or ["(none)"]
+            raise ValueError(
+                f"No external adapter registered for agent_id={agent_id!r}. "
+                f"Registered: {', '.join(registered)}"
+            )
+        return factory()
+
+    @property
+    def registered_ids(self) -> list[str]:
+        """Return sorted list of registered agent IDs."""
+
+        return sorted(self._factories)
+
+    def __contains__(self, agent_id: str) -> bool:
+        return agent_id.strip().lower() in self._factories
+
+    def __len__(self) -> int:
+        return len(self._factories)
+
+
+def build_default_registry(
+    *,
+    env: dict[str, Any] | None = None,
+) -> ExternalAdapterRegistry:
+    """Build the default registry with Jules and Codex Cloud adapters.
+
+    Each adapter is only registered if its runtime gate is satisfied
+    (i.e. the provider is enabled and configured).
+    """
+
+    registry = ExternalAdapterRegistry()
+
+    # --- Jules ---
+    from moonmind.jules.runtime import is_jules_runtime_enabled
+
+    if is_jules_runtime_enabled(env=env):
+        import os
+
+        from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
+        from moonmind.workflows.adapters.jules_client import JulesClient
+
+        source = env if env is not None else dict(os.environ)
+        jules_url = str(source.get("JULES_API_URL", "")).strip()
+        jules_key = str(source.get("JULES_API_KEY", "")).strip()
+
+        def _jules_factory() -> AgentAdapter:
+            client = JulesClient(base_url=jules_url, api_key=jules_key)
+            return JulesAgentAdapter(client_factory=lambda: client)  # type: ignore[return-value]
+
+        registry.register("jules", _jules_factory)
+        registry.register("jules_api", _jules_factory)
+        logger.info("Registered Jules external adapter")
+
+    # --- Codex Cloud ---
+    from moonmind.codex_cloud.settings import is_codex_cloud_enabled
+
+    if is_codex_cloud_enabled(env=env):
+        import os
+
+        from moonmind.workflows.adapters.codex_cloud_agent_adapter import (
+            CodexCloudAgentAdapter,
+        )
+        from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient
+
+        source = env if env is not None else dict(os.environ)
+        cloud_url = str(source.get("CODEX_CLOUD_API_URL", "")).strip()
+        cloud_key = str(source.get("CODEX_CLOUD_API_KEY", "")).strip()
+
+        def _codex_cloud_factory() -> AgentAdapter:
+            client = CodexCloudClient(base_url=cloud_url, api_key=cloud_key)
+            return CodexCloudAgentAdapter(client_factory=lambda: client)  # type: ignore[return-value]
+
+        registry.register("codex_cloud", _codex_cloud_factory)
+        logger.info("Registered Codex Cloud external adapter")
+
+    return registry
+
+
+__all__ = [
+    "AdapterFactory",
+    "ExternalAdapterRegistry",
+    "build_default_registry",
+]

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -1,0 +1,70 @@
+"""Temporal activities for Jules external agent integration.
+
+Registered on the ``mm.activity.integrations`` task queue to satisfy
+spec 066 / FR-008.
+"""
+
+from __future__ import annotations
+
+from temporalio import activity
+
+from moonmind.jules.runtime import build_runtime_gate_state, JULES_RUNTIME_DISABLED_MESSAGE
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
+from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
+from moonmind.workflows.adapters.jules_client import JulesClient
+
+
+def _build_adapter() -> JulesAgentAdapter:
+    """Build a gated JulesAgentAdapter using env-based configuration.
+
+    Raises ``RuntimeError`` if the Jules runtime gate is unsatisfied.
+    """
+
+    import os
+
+    gate = build_runtime_gate_state()
+    if not gate.enabled:
+        raise RuntimeError(
+            f"{JULES_RUNTIME_DISABLED_MESSAGE} (missing: {', '.join(gate.missing)})"
+        )
+
+    jules_url = os.environ.get("JULES_API_URL", "").strip()
+    jules_key = os.environ.get("JULES_API_KEY", "").strip()
+    client = JulesClient(base_url=jules_url, api_key=jules_key)
+    return JulesAgentAdapter(client_factory=lambda: client)
+
+
+@activity.defn(name="integration.jules.start")
+async def jules_start_activity(request: AgentExecutionRequest) -> AgentRunHandle:
+    """Start a Jules-backed run via the canonical adapter contract."""
+
+    adapter = _build_adapter()
+    return await adapter.start(request)
+
+
+@activity.defn(name="integration.jules.status")
+async def jules_status_activity(run_id: str) -> AgentRunStatus:
+    """Poll current status for one Jules task."""
+
+    adapter = _build_adapter()
+    return await adapter.status(run_id)
+
+
+@activity.defn(name="integration.jules.fetch_result")
+async def jules_fetch_result_activity(run_id: str) -> AgentRunResult:
+    """Fetch terminal result for one completed Jules task."""
+
+    adapter = _build_adapter()
+    return await adapter.fetch_result(run_id)
+
+
+__all__ = [
+    "jules_fetch_result_activity",
+    "jules_start_activity",
+    "jules_status_activity",
+]

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -10,6 +10,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.adapters.agent_adapter import AgentAdapter
     from moonmind.workflows.adapters.managed_agent_adapter import ManagedAgentAdapter
+    from moonmind.workflows.adapters.external_adapter_registry import (
+        build_default_registry,
+    )
 
 # Map canonical AgentRunState literals to workflow-usable status constants.
 # The canonical model uses Literal strings, not an Enum, so we alias them here.
@@ -44,6 +47,18 @@ async def invoke_adapter_cancel(agent_kind: str, run_id: str) -> None:
         agent_kind,
         run_id,
     )
+
+
+def _create_external_adapter(agent_id: str) -> AgentAdapter:
+    """Instantiate an external adapter using the runtime-gated registry.
+
+    This function is called inside the workflow to create the appropriate
+    adapter for an external agent.  The registry respects runtime gates
+    so only providers that are enabled and configured will be available.
+    """
+
+    registry = build_default_registry()
+    return registry.create(agent_id)
 
 @workflow.defn(name="MoonMind.AgentRun")
 class MoonMindAgentRun:
@@ -111,10 +126,7 @@ class MoonMindAgentRun:
                         workflow_id=workflow.info().workflow_id,
                     )
                 elif request.agent_kind == "external":
-                    # TODO(Phase C): Wire JulesAgentAdapter with JulesClient.
-                    raise NotImplementedError(
-                        "External adapter instantiation not yet wired — pending Phase C migration"
-                    )
+                    adapter = _create_external_adapter(request.agent_id)
                 else:
                     raise ValueError(f"Unknown agent kind: {request.agent_kind}")
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -49,16 +49,20 @@ async def invoke_adapter_cancel(agent_kind: str, run_id: str) -> None:
     )
 
 
-def _create_external_adapter(agent_id: str) -> AgentAdapter:
-    """Instantiate an external adapter using the runtime-gated registry.
+@activity.defn(name="integration.resolve_external_adapter")
+async def resolve_external_adapter(agent_id: str) -> str:
+    """Activity: verify that *agent_id* has a registered adapter.
 
-    This function is called inside the workflow to create the appropriate
-    adapter for an external agent.  The registry respects runtime gates
-    so only providers that are enabled and configured will be available.
+    All non-deterministic work (reading env vars, dynamic imports) runs
+    here rather than in the workflow so that replays remain deterministic.
+
+    Returns the validated agent_id on success; raises if no adapter exists.
     """
 
     registry = build_default_registry()
-    return registry.create(agent_id)
+    # Validate the adapter is registered — this forces the gate check.
+    registry.create(agent_id)
+    return agent_id
 
 @workflow.defn(name="MoonMind.AgentRun")
 class MoonMindAgentRun:
@@ -126,7 +130,14 @@ class MoonMindAgentRun:
                         workflow_id=workflow.info().workflow_id,
                     )
                 elif request.agent_kind == "external":
-                    adapter = _create_external_adapter(request.agent_id)
+                    # Validate adapter availability in an activity (deterministic-safe).
+                    validated_id = await workflow.execute_activity(
+                        resolve_external_adapter,
+                        request.agent_id,
+                        start_to_close_timeout=timedelta(seconds=30),
+                    )
+                    registry = build_default_registry()
+                    adapter = registry.create(validated_id)
                 else:
                     raise ValueError(f"Unknown agent kind: {request.agent_kind}")
 

--- a/tests/unit/codex_cloud/test_codex_cloud_settings.py
+++ b/tests/unit/codex_cloud/test_codex_cloud_settings.py
@@ -1,0 +1,83 @@
+"""Unit tests for Codex Cloud runtime settings and gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.codex_cloud.settings import (
+    CodexCloudRuntimeGate,
+    build_codex_cloud_gate,
+    is_codex_cloud_enabled,
+)
+
+
+class TestCodexCloudGate:
+    def test_disabled_when_nothing_set(self):
+        gate = build_codex_cloud_gate(env={})
+        assert gate.enabled is False
+        assert "CODEX_CLOUD_ENABLED" in gate.missing
+
+    def test_disabled_when_only_enabled_flag_set(self):
+        gate = build_codex_cloud_gate(env={"CODEX_CLOUD_ENABLED": "true"})
+        assert gate.enabled is False
+        assert "CODEX_CLOUD_API_URL" in gate.missing
+        assert "CODEX_CLOUD_API_KEY" in gate.missing
+
+    def test_enabled_when_all_set(self):
+        gate = build_codex_cloud_gate(
+            env={
+                "CODEX_CLOUD_ENABLED": "true",
+                "CODEX_CLOUD_API_URL": "https://codex.test",
+                "CODEX_CLOUD_API_KEY": "key-123",
+            }
+        )
+        assert gate.enabled is True
+        assert gate.missing == ()
+
+    def test_disabled_when_enabled_is_false(self):
+        gate = build_codex_cloud_gate(
+            env={
+                "CODEX_CLOUD_ENABLED": "false",
+                "CODEX_CLOUD_API_URL": "https://codex.test",
+                "CODEX_CLOUD_API_KEY": "key-123",
+            }
+        )
+        assert gate.enabled is False
+        assert "CODEX_CLOUD_ENABLED" in gate.missing
+
+    def test_enabled_with_explicit_args(self):
+        gate = build_codex_cloud_gate(
+            enabled=True,
+            api_url="https://codex.test",
+            api_key="key-456",
+            env={},
+        )
+        assert gate.enabled is True
+
+    def test_enabled_accepts_alternate_true_values(self):
+        for value in ("1", "yes", "on", "True", "TRUE"):
+            gate = build_codex_cloud_gate(
+                env={
+                    "CODEX_CLOUD_ENABLED": value,
+                    "CODEX_CLOUD_API_URL": "https://codex.test",
+                    "CODEX_CLOUD_API_KEY": "key-123",
+                }
+            )
+            assert gate.enabled is True, f"Expected enabled for value={value!r}"
+
+
+class TestIsCodexCloudEnabled:
+    def test_returns_false_for_empty_env(self):
+        assert is_codex_cloud_enabled(env={}) is False
+
+    def test_returns_true_when_fully_configured(self):
+        assert (
+            is_codex_cloud_enabled(
+                env={
+                    "CODEX_CLOUD_ENABLED": "true",
+                    "CODEX_CLOUD_API_URL": "https://codex.test",
+                    "CODEX_CLOUD_API_KEY": "key-789",
+                }
+            )
+            is True
+        )

--- a/tests/unit/codex_cloud/test_codex_cloud_settings.py
+++ b/tests/unit/codex_cloud/test_codex_cloud_settings.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
-
 from moonmind.codex_cloud.settings import (
-    CodexCloudRuntimeGate,
     build_codex_cloud_gate,
     is_codex_cloud_enabled,
 )

--- a/tests/unit/workflows/adapters/test_codex_cloud_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_cloud_agent_adapter.py
@@ -1,0 +1,143 @@
+"""Unit tests for canonical Codex Cloud external-agent adapter behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.adapters.codex_cloud_agent_adapter import CodexCloudAgentAdapter
+from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClientError
+
+pytestmark = [pytest.mark.asyncio]
+
+
+class _FakeCodexCloudClient:
+    def __init__(
+        self,
+        *,
+        create_status: str = "pending",
+        get_status: str = "completed",
+        cancel_raises: bool = False,
+    ) -> None:
+        self.create_status = create_status
+        self.get_status = get_status
+        self.cancel_raises = cancel_raises
+        self.created: list[object] = []
+        self.lookups: list[str] = []
+        self.cancelled: list[str] = []
+        self.closed_count = 0
+
+    async def create_task(self, *, title, description, metadata=None):
+        call_record = {"title": title, "description": description, "metadata": metadata}
+        self.created.append(call_record)
+        return {
+            "taskId": "cc-task-123",
+            "status": self.create_status,
+            "url": f"https://codex-cloud.example.test/tasks/cc-task-123",
+        }
+
+    async def get_task(self, task_id):
+        self.lookups.append(task_id)
+        return {
+            "taskId": task_id,
+            "status": self.get_status,
+            "url": f"https://codex-cloud.example.test/tasks/{task_id}",
+        }
+
+    async def cancel_task(self, task_id):
+        if self.cancel_raises:
+            raise CodexCloudClientError(
+                "cancel unavailable", status_code=405, request_path=f"/tasks/{task_id}/cancel"
+            )
+        self.cancelled.append(task_id)
+        return {
+            "taskId": task_id,
+            "status": "canceled",
+            "url": f"https://codex-cloud.example.test/tasks/{task_id}",
+        }
+
+    async def aclose(self):
+        self.closed_count += 1
+
+
+def _request(*, idempotency_key: str = "idem-1") -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="external",
+        agentId="codex_cloud",
+        executionProfileRef="profile:codex-cloud-default",
+        correlationId="corr-1",
+        idempotencyKey=idempotency_key,
+        parameters={
+            "title": "MoonMind task",
+            "description": "Run integration checks",
+            "metadata": {"origin": "unit-test"},
+        },
+    )
+
+
+async def test_start_returns_canonical_handle_and_reuses_idempotency_key():
+    client = _FakeCodexCloudClient()
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    first = await adapter.start(_request(idempotency_key="idem-shared"))
+    second = await adapter.start(_request(idempotency_key="idem-shared"))
+
+    assert first.run_id == "cc-task-123"
+    assert first.status == "queued"
+    assert first.metadata["providerStatus"] == "pending"
+    assert first.metadata["normalizedStatus"] == "queued"
+    assert second.run_id == first.run_id
+    assert len(client.created) == 1
+
+
+async def test_status_normalizes_provider_states():
+    client = _FakeCodexCloudClient(get_status="completed")
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    status = await adapter.status("task-abc")
+
+    assert status.run_id == "task-abc"
+    assert status.status == "completed"
+    assert status.metadata["normalizedStatus"] == "succeeded"
+
+
+async def test_fetch_result_returns_summary():
+    client = _FakeCodexCloudClient(get_status="completed")
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    result = await adapter.fetch_result("task-abc")
+
+    assert result.summary is not None
+    assert "completed" in result.summary
+    assert result.failure_class is None
+
+
+async def test_fetch_result_includes_failure_class_on_failure():
+    client = _FakeCodexCloudClient(get_status="failed")
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    result = await adapter.fetch_result("task-abc")
+
+    assert result.failure_class == "integration_error"
+
+
+async def test_cancel_returns_intervention_requested_when_provider_rejects():
+    client = _FakeCodexCloudClient(cancel_raises=True)
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    status = await adapter.cancel("task-cancel")
+
+    assert status.run_id == "task-cancel"
+    assert status.status == "intervention_requested"
+    assert status.metadata["cancelAccepted"] is False
+
+
+async def test_cancel_returns_success_when_accepted():
+    client = _FakeCodexCloudClient(cancel_raises=False)
+    adapter = CodexCloudAgentAdapter(client_factory=lambda: client)
+
+    status = await adapter.cancel("task-cancel")
+
+    assert status.run_id == "task-cancel"
+    assert status.metadata["cancelAccepted"] is True
+    assert status.metadata["normalizedStatus"] == "canceled"

--- a/tests/unit/workflows/adapters/test_external_adapter_registry.py
+++ b/tests/unit/workflows/adapters/test_external_adapter_registry.py
@@ -1,0 +1,118 @@
+"""Unit tests for ExternalAdapterRegistry."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.adapters.external_adapter_registry import (
+    ExternalAdapterRegistry,
+    build_default_registry,
+)
+
+
+class _StubAdapter:
+    """Minimal stub satisfying the AgentAdapter protocol shape."""
+
+    def __init__(self, *, agent_id: str = "stub") -> None:
+        self.agent_id = agent_id
+
+
+# ---------------------------------------------------------------------------
+# ExternalAdapterRegistry core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestExternalAdapterRegistry:
+    def test_register_and_create_returns_adapter(self):
+        registry = ExternalAdapterRegistry()
+        registry.register("test", lambda: _StubAdapter(agent_id="test"))
+        adapter = registry.create("test")
+        assert isinstance(adapter, _StubAdapter)
+        assert adapter.agent_id == "test"
+
+    def test_create_raises_for_unknown_agent_id(self):
+        registry = ExternalAdapterRegistry()
+        with pytest.raises(ValueError, match="No external adapter registered"):
+            registry.create("nonexistent")
+
+    def test_register_is_case_insensitive(self):
+        registry = ExternalAdapterRegistry()
+        registry.register("Jules", lambda: _StubAdapter(agent_id="jules"))
+        adapter = registry.create("JULES")
+        assert isinstance(adapter, _StubAdapter)
+        assert adapter.agent_id == "jules"
+
+    def test_register_rejects_blank_agent_id(self):
+        registry = ExternalAdapterRegistry()
+        with pytest.raises(ValueError, match="must not be blank"):
+            registry.register("  ", lambda: _StubAdapter())
+
+    def test_registered_ids_returns_sorted_list(self):
+        registry = ExternalAdapterRegistry()
+        registry.register("beta", lambda: _StubAdapter())
+        registry.register("alpha", lambda: _StubAdapter())
+        assert registry.registered_ids == ["alpha", "beta"]
+
+    def test_contains_membership(self):
+        registry = ExternalAdapterRegistry()
+        registry.register("jules", lambda: _StubAdapter())
+        assert "jules" in registry
+        assert "codex_cloud" not in registry
+
+    def test_len(self):
+        registry = ExternalAdapterRegistry()
+        assert len(registry) == 0
+        registry.register("a", lambda: _StubAdapter())
+        assert len(registry) == 1
+
+
+# ---------------------------------------------------------------------------
+# build_default_registry with runtime gates
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDefaultRegistry:
+    def test_empty_env_has_no_adapters(self):
+        registry = build_default_registry(env={})
+        assert len(registry) == 0
+
+    def test_jules_registered_when_enabled(self):
+        env = {
+            "JULES_ENABLED": "true",
+            "JULES_API_URL": "https://jules.test",
+            "JULES_API_KEY": "test-key-123",
+        }
+        registry = build_default_registry(env=env)
+        assert "jules" in registry
+        assert "jules_api" in registry
+
+    def test_codex_cloud_registered_when_enabled(self):
+        env = {
+            "CODEX_CLOUD_ENABLED": "true",
+            "CODEX_CLOUD_API_URL": "https://codex.test",
+            "CODEX_CLOUD_API_KEY": "test-key-456",
+        }
+        registry = build_default_registry(env=env)
+        assert "codex_cloud" in registry
+
+    def test_both_registered_when_both_enabled(self):
+        env = {
+            "JULES_ENABLED": "true",
+            "JULES_API_URL": "https://jules.test",
+            "JULES_API_KEY": "test-key-jules",
+            "CODEX_CLOUD_ENABLED": "true",
+            "CODEX_CLOUD_API_URL": "https://codex.test",
+            "CODEX_CLOUD_API_KEY": "test-key-codex",
+        }
+        registry = build_default_registry(env=env)
+        assert "jules" in registry
+        assert "codex_cloud" in registry
+
+    def test_disabled_provider_not_registered(self):
+        env = {
+            "JULES_RUNTIME_ENABLED": "false",
+            "JULES_API_URL": "https://jules.test",
+            "JULES_API_KEY": "test-key",
+        }
+        registry = build_default_registry(env=env)
+        assert "jules" not in registry

--- a/tests/unit/workflows/adapters/test_external_adapter_registry.py
+++ b/tests/unit/workflows/adapters/test_external_adapter_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 
 from moonmind.workflows.adapters.external_adapter_registry import (
@@ -25,7 +27,7 @@ class _StubAdapter:
 class TestExternalAdapterRegistry:
     def test_register_and_create_returns_adapter(self):
         registry = ExternalAdapterRegistry()
-        registry.register("test", lambda: _StubAdapter(agent_id="test"))
+        registry.register("test", partial(_StubAdapter, agent_id="test"))
         adapter = registry.create("test")
         assert isinstance(adapter, _StubAdapter)
         assert adapter.agent_id == "test"
@@ -37,7 +39,7 @@ class TestExternalAdapterRegistry:
 
     def test_register_is_case_insensitive(self):
         registry = ExternalAdapterRegistry()
-        registry.register("Jules", lambda: _StubAdapter(agent_id="jules"))
+        registry.register("Jules", partial(_StubAdapter, agent_id="jules"))
         adapter = registry.create("JULES")
         assert isinstance(adapter, _StubAdapter)
         assert adapter.agent_id == "jules"
@@ -45,24 +47,24 @@ class TestExternalAdapterRegistry:
     def test_register_rejects_blank_agent_id(self):
         registry = ExternalAdapterRegistry()
         with pytest.raises(ValueError, match="must not be blank"):
-            registry.register("  ", lambda: _StubAdapter())
+            registry.register("  ", _StubAdapter)
 
     def test_registered_ids_returns_sorted_list(self):
         registry = ExternalAdapterRegistry()
-        registry.register("beta", lambda: _StubAdapter())
-        registry.register("alpha", lambda: _StubAdapter())
+        registry.register("beta", _StubAdapter)
+        registry.register("alpha", _StubAdapter)
         assert registry.registered_ids == ["alpha", "beta"]
 
     def test_contains_membership(self):
         registry = ExternalAdapterRegistry()
-        registry.register("jules", lambda: _StubAdapter())
+        registry.register("jules", _StubAdapter)
         assert "jules" in registry
         assert "codex_cloud" not in registry
 
     def test_len(self):
         registry = ExternalAdapterRegistry()
         assert len(registry) == 0
-        registry.register("a", lambda: _StubAdapter())
+        registry.register("a", _StubAdapter)
         assert len(registry) == 1
 
 
@@ -110,7 +112,7 @@ class TestBuildDefaultRegistry:
 
     def test_disabled_provider_not_registered(self):
         env = {
-            "JULES_RUNTIME_ENABLED": "false",
+            "JULES_ENABLED": "false",
             "JULES_API_URL": "https://jules.test",
             "JULES_API_KEY": "test-key",
         }


### PR DESCRIPTION
## Summary

Implements all four items of Milestone 2 from the roadmap, enabling MoonMind to coordinate with external agents (Jules, Codex Cloud) through a generic adapter pattern.

## Changes

### 1. Jules E2E Workflow Wiring
- Replaced `NotImplementedError` in `MoonMind.AgentRun` with registry-based external adapter dispatch
- Created `jules_activities.py` with named Temporal activities on `mm.activity.integrations` queue (spec 066 FR-008)

### 2. Codex Cloud Integration Adapter
- `CodexCloudClient` — async HTTP client with retry on 5xx/429
- `CodexCloudAgentAdapter` — `AgentAdapter` protocol implementation with idempotency and status normalization
- `codex_cloud/settings.py` — runtime gate (`CODEX_CLOUD_ENABLED`, `_API_URL`, `_API_KEY`)

### 3. Generic External-Agent Adapter Registry
- `ExternalAdapterRegistry` with `register()`, `create()`, and `build_default_registry()`
- Auto-discovers enabled providers based on runtime gate configuration
- Replaces hardcoded if/elif dispatch in the workflow

### 4. External Runs Dashboard
- `GET /api/external-runs` and `GET /api/external-runs/{workflow_id}` API endpoints
- "External Runs" nav link in Mission Control
- `external` status map + `externalRuns` source config in dashboard view model

## Testing

- **26 new tests** covering adapter registry, Codex Cloud adapter, and runtime gate
- **30 existing tests** pass with 0 regressions
- All tests run via `./tools/test_unit.sh`

## New Files
| File | Purpose |
|---|---|
| `moonmind/codex_cloud/settings.py` | Codex Cloud runtime gate |
| `moonmind/workflows/adapters/codex_cloud_client.py` | Async HTTP client for Codex Cloud |
| `moonmind/workflows/adapters/codex_cloud_agent_adapter.py` | AgentAdapter for Codex Cloud |
| `moonmind/workflows/adapters/external_adapter_registry.py` | Generic adapter registry |
| `moonmind/workflows/temporal/activities/jules_activities.py` | Jules Temporal activities |
| `api_service/api/routers/external_runs.py` | External runs API |
