### PR TITLE
⚡ optimize seed template import performance

### DIFF
--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import asyncio
 import logging
 import os
 import re
@@ -1110,7 +1109,8 @@ class TaskTemplateCatalogService:
     ) -> int:
         loaded = load_seed_template_definitions(seed_dir)
 
-        async def _import_one(item: dict[str, Any]) -> bool:
+        created = 0
+        for item in loaded:
             scope = str(item.get("scope", "global")).strip() or "global"
             version = str(item.get("version", "1.0.0")).strip() or "1.0.0"
             try:
@@ -1134,12 +1134,9 @@ class TaskTemplateCatalogService:
                     seed_source=item.get("seedSource"),
                     auto_commit=False,
                 )
-                return True
+                created += 1
             except TaskTemplateConflictError:
-                return False
-
-        results = await asyncio.gather(*[_import_one(item) for item in loaded])
-        created = sum(1 for r in results if r)
+                pass
         if created > 0:
             await self._session.commit()
         return created

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import asyncio
 import logging
 import os
 import re
@@ -1108,8 +1109,8 @@ class TaskTemplateCatalogService:
         seed_dir: Path,
     ) -> int:
         loaded = load_seed_template_definitions(seed_dir)
-        created = 0
-        for item in loaded:
+
+        async def _import_one(item: dict[str, Any]) -> bool:
             scope = str(item.get("scope", "global")).strip() or "global"
             version = str(item.get("version", "1.0.0")).strip() or "1.0.0"
             try:
@@ -1131,8 +1132,14 @@ class TaskTemplateCatalogService:
                     version=version,
                     release_status=TaskTemplateReleaseStatus.ACTIVE,
                     seed_source=item.get("seedSource"),
+                    auto_commit=False,
                 )
-                created += 1
+                return True
             except TaskTemplateConflictError:
-                continue
+                return False
+
+        results = await asyncio.gather(*[_import_one(item) for item in loaded])
+        created = sum(1 for r in results if r)
+        if created > 0:
+            await self._session.commit()
         return created


### PR DESCRIPTION
💡 **What:** 
The optimization refactors the sequential loop in `import_seed_templates` to use `asyncio.gather`, allowing concurrent processing of template definitions. Crucially, it also changes the database transaction pattern by calling `create_template` with `auto_commit=False` and performing a single batch `commit()` at the end of the import process.

🎯 **Why:** 
The previous implementation awaited `create_template` sequentially and performed a separate database commit for every single template. This created significant I/O overhead due to repeated transaction management (WAL writes, syncs, etc.) and sequential network roundtrips to the database.

📊 **Measured Improvement:** 
Due to environment constraints in the sandbox (missing dependencies preventing `pytest` or custom benchmark script execution), a precise performance baseline could not be established. However, the theoretical improvement is significant:
- **Transaction Overhead:** Reduced from $O(N)$ commits to $O(1)$, which is the most impactful change for database-heavy operations.
- **Concurrency:** $O(N)$ sequential awaits are replaced with concurrent execution, allowing for overlapping I/O where the underlying driver and database support it.

The changes were verified for syntax and style using `ruff`.

---
*PR created automatically by Jules for task [3036339325992137731](https://jules.google.com/task/3036339325992137731) started by @nsticco*