### PR TITLE
Refactor absolute markdown links to relative paths

### DIFF
--- a/docs/Temporal/WorkflowSchedulingGuide.md
+++ b/docs/Temporal/WorkflowSchedulingGuide.md
@@ -11,10 +11,10 @@ This guide covers how to start Temporal workflows at a specific time and how to 
 
 ## 2. Related Docs
 
-- [TemporalArchitecture.md](file:///Users/nsticco/MoonMind/docs/Temporal/TemporalArchitecture.md) — platform foundation and migration phases
-- [WorkflowTypeCatalogAndLifecycle.md](file:///Users/nsticco/MoonMind/docs/Temporal/WorkflowTypeCatalogAndLifecycle.md) — workflow types, state model, update/signal contracts
-- [MissionControlArchitecture.md](file:///Users/nsticco/MoonMind/docs/UI/MissionControlArchitecture.md) — dashboard source model, route map, schedule source config
-- [ActivityCatalogAndWorkerTopology.md](file:///Users/nsticco/MoonMind/docs/Temporal/ActivityCatalogAndWorkerTopology.md) — activity routing and worker fleet
+- [TemporalArchitecture.md](TemporalArchitecture.md) — platform foundation and migration phases
+- [WorkflowTypeCatalogAndLifecycle.md](WorkflowTypeCatalogAndLifecycle.md) — workflow types, state model, update/signal contracts
+- [MissionControlArchitecture.md](../UI/MissionControlArchitecture.md) — dashboard source model, route map, schedule source config
+- [ActivityCatalogAndWorkerTopology.md](ActivityCatalogAndWorkerTopology.md) — activity routing and worker fleet
 
 ---
 

--- a/docs/UI/MissionControlArchitecture.md
+++ b/docs/UI/MissionControlArchitecture.md
@@ -553,7 +553,7 @@ The same `POST /api/executions` or `POST /api/queue/jobs` endpoint is used. The 
 }
 ```
 
-See [WorkflowSchedulingGuide.md § 4.4](file:///Users/nsticco/MoonMind/docs/Temporal/WorkflowSchedulingGuide.md) for the full `schedule` object schema and backend behavior.
+See [WorkflowSchedulingGuide.md § 4.4](../Temporal/WorkflowSchedulingGuide.md) for the full `schedule` object schema and backend behavior.
 
 #### Scheduled Execution Detail Banner
 

--- a/docs/tmp/CancellationAnalysis.md
+++ b/docs/tmp/CancellationAnalysis.md
@@ -52,31 +52,31 @@ When a cancel is requested:
 
 Some of these activities have timeouts up to **5 minutes** (`AGENT_RUNTIME_ACTIVITY_TIMEOUT`, `INTEGRATIONS_ACTIVITY_TIMEOUT`).
 
-> 📍 [agent_run.py:38-42](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py#L38-L42)
+> 📍 [agent_run.py:38-42](../../moonmind/workflows/temporal/workflows/agent_run.py#L38-L42)
 
 ### 2. **Cancel activity dispatch adds queuing latency**
 
 After the `CancelledError` is caught, the workflow dispatches a **new activity** (`agent_runtime.cancel`) to the `mm.activity.agent_runtime` task queue with a 1-minute timeout. If the agent-runtime worker fleet is busy or has only one worker, this activity sits in the queue waiting to be picked up.
 
-> 📍 [agent_run.py:367-373](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py#L367-L373)
+> 📍 [agent_run.py:367-373](../../moonmind/workflows/temporal/workflows/agent_run.py#L367-L373)
 
 ### 3. **Child workflow cancel propagation**
 
 For Temporal-executed tasks, the `MoonMind.Run` workflow runs `MoonMind.AgentRun` as a **child workflow**. Cancel propagation from parent to child adds another round-trip through the Temporal server. If the parent is itself blocked in an activity, the cancel doesn't even reach the child immediately.
 
-> 📍 [run.py:451-456](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/run.py#L451-L456)
+> 📍 [run.py:451-456](../../moonmind/workflows/temporal/workflows/run.py#L451-L456)
 
 ### 4. **Auth slot release before process kill**
 
 In the `CancelledError` handler, the workflow first tries to release the auth slot by signaling the `AuthProfileManager` workflow **before** dispatching the cancel activity. If the AuthProfileManager is slow to respond or not running, this adds delay before the actual process gets killed.
 
-> 📍 [agent_run.py:345-355](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py#L345-L355)
+> 📍 [agent_run.py:345-355](../../moonmind/workflows/temporal/workflows/agent_run.py#L345-L355)
 
 ### 5. **Graceful shutdown wait**
 
 The supervisor's `_terminate_process` sends `SIGTERM` and waits **2 seconds** before sending `SIGKILL`. Gemini CLI may not handle `SIGTERM` quickly (it may be in the middle of an API call or file write), so this adds 2s minimum.
 
-> 📍 [supervisor.py:197-207](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/runtime/supervisor.py#L197-L207)
+> 📍 [supervisor.py:197-207](../../moonmind/workflows/temporal/runtime/supervisor.py#L197-L207)
 
 ---
 
@@ -86,10 +86,10 @@ The supervisor's `_terminate_process` sends `SIGTERM` and waits **2 seconds** be
 
 | # | Change | Impact | File |
 |---|--------|--------|------|
-| 1 | **Enable Temporal activity cancellation** via `cancellation_type=ActivityCancellationType.TRY_CANCEL` on `execute_activity` calls in `agent_run.py`. This lets Temporal deliver cancellation to activities without waiting for them to complete. | High — eliminates the #1 bottleneck | [agent_run.py](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py) |
-| 2 | **Kill the process directly from the workflow** instead of dispatching a separate activity. Use `workflow.execute_local_activity()` or send a direct signal to the supervisor, avoiding the task queue hop entirely. | Medium — eliminates queuing delay | [agent_run.py](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py) |
-| 3 | **Parallelize slot release and process cancel** — run both concurrently in the `CancelledError` handler using `asyncio.gather()` instead of sequentially. | Low-Medium — shaves seconds | [agent_run.py](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/workflows/agent_run.py) |
-| 4 | **Reduce `GRACEFUL_TERMINATE_WAIT_SECONDS`** from 2.0 to 0.5 seconds. Gemini CLI doesn't need graceful shutdown — it's a CLI tool running agent loops. | Low — but consistent 1.5s saved | [supervisor.py](file:///Users/nsticco/MoonMind/moonmind/workflows/temporal/runtime/supervisor.py) |
+| 1 | **Enable Temporal activity cancellation** via `cancellation_type=ActivityCancellationType.TRY_CANCEL` on `execute_activity` calls in `agent_run.py`. This lets Temporal deliver cancellation to activities without waiting for them to complete. | High — eliminates the #1 bottleneck | [agent_run.py](../../moonmind/workflows/temporal/workflows/agent_run.py) |
+| 2 | **Kill the process directly from the workflow** instead of dispatching a separate activity. Use `workflow.execute_local_activity()` or send a direct signal to the supervisor, avoiding the task queue hop entirely. | Medium — eliminates queuing delay | [agent_run.py](../../moonmind/workflows/temporal/workflows/agent_run.py) |
+| 3 | **Parallelize slot release and process cancel** — run both concurrently in the `CancelledError` handler using `asyncio.gather()` instead of sequentially. | Low-Medium — shaves seconds | [agent_run.py](../../moonmind/workflows/temporal/workflows/agent_run.py) |
+| 4 | **Reduce `GRACEFUL_TERMINATE_WAIT_SECONDS`** from 2.0 to 0.5 seconds. Gemini CLI doesn't need graceful shutdown — it's a CLI tool running agent loops. | Low — but consistent 1.5s saved | [supervisor.py](../../moonmind/workflows/temporal/runtime/supervisor.py) |
 
 ### Medium-Term Improvements
 

--- a/specs/038-worker-pause/checklists/requirements.md
+++ b/specs/038-worker-pause/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-17
-**Feature**: [spec.md](file:///Users/nsticco/MoonMind/specs/038-worker-pause/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/038-worker-pause/plan.md
+++ b/specs/038-worker-pause/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Worker Pause System (Temporal Era)
 
-**Branch**: `038-worker-pause` | **Date**: 2026-03-17 | **Spec**: [spec.md](file:///Users/nsticco/MoonMind/specs/038-worker-pause/spec.md)
+**Branch**: `038-worker-pause` | **Date**: 2026-03-17 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `/specs/038-worker-pause/spec.md`
 
 ## Summary

--- a/specs/038-worker-pause/tasks.md
+++ b/specs/038-worker-pause/tasks.md
@@ -1,8 +1,8 @@
 # Tasks: Worker Pause System (Temporal Era)
 
 **Feature**: `038-worker-pause` | **Branch**: `038-worker-pause`
-**Spec**: [spec.md](file:///Users/nsticco/MoonMind/specs/038-worker-pause/spec.md)
-**Plan**: [plan.md](file:///Users/nsticco/MoonMind/specs/038-worker-pause/plan.md)
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
 
 ## Phase 1: Setup & Foundation
 

--- a/specs/083-manifest-phase0/checklists/requirements.md
+++ b/specs/083-manifest-phase0/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-17
-**Feature**: [spec.md](file:///Users/nsticco/MoonMind/specs/083-manifest-phase0/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/084-live-log-tailing/checklists/requirements.md
+++ b/specs/084-live-log-tailing/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-17
-**Feature**: [spec.md](file:///Users/nsticco/MoonMind/specs/084-live-log-tailing/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/084-live-log-tailing/plan.md
+++ b/specs/084-live-log-tailing/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Live Log Tailing
 
-**Branch**: `084-live-log-tailing` | **Date**: 2026-03-17 | **Spec**: [spec.md](file:///Users/nsticco/MoonMind/specs/084-live-log-tailing/spec.md)
+**Branch**: `084-live-log-tailing` | **Date**: 2026-03-17 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `specs/084-live-log-tailing/spec.md`
 
 ## Summary

--- a/specs/086-step-review-gate/checklists/requirements.md
+++ b/specs/086-step-review-gate/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-18
-**Feature**: [spec.md](file:///Users/nsticco/MoonMind/specs/086-step-review-gate/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/086-step-review-gate/plan.md
+++ b/specs/086-step-review-gate/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Step Review Gate
 
-**Branch**: `086-step-review-gate` | **Date**: 2026-03-18 | **Spec**: [spec.md](file:///Users/nsticco/MoonMind/specs/086-step-review-gate/spec.md)
+**Branch**: `086-step-review-gate` | **Date**: 2026-03-18 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `specs/086-step-review-gate/spec.md`
 
 ## Summary

--- a/specs/086-workflow-scheduling/checklists/requirements.md
+++ b/specs/086-workflow-scheduling/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-03-18
-**Feature**: [spec.md](file:///Users/nsticco/MoonMind/specs/086-workflow-scheduling/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/086-workflow-scheduling/plan.md
+++ b/specs/086-workflow-scheduling/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Workflow Scheduling
 
-**Branch**: `086-workflow-scheduling` | **Date**: 2026-03-18 | **Spec**: [spec.md](file:///Users/nsticco/MoonMind/specs/086-workflow-scheduling/spec.md)
+**Branch**: `086-workflow-scheduling` | **Date**: 2026-03-18 | **Spec**: [spec.md](spec.md)
 **Input**: Feature specification from `/specs/086-workflow-scheduling/spec.md`
 
 ## Summary


### PR DESCRIPTION
Replaced absolute paths `file:///Users/nsticco/MoonMind/` in all markdown files with their correct relative paths to ensure the documentation is usable across different environments and by all contributors. Checked and fixed references throughout `specs/` and `docs/`. Tests passed locally.

---
*PR created automatically by Jules for task [10667578836130372571](https://jules.google.com/task/10667578836130372571) started by @nsticco*