### PR TITLE
feat: Jules branch-publish auto-merge with targetBranch support

### DIFF
--- a/docs/ExternalAgents/JulesClientAdapter.md
+++ b/docs/ExternalAgents/JulesClientAdapter.md
@@ -81,6 +81,7 @@ Current responsibilities:
 - normalize Jules status strings into canonical MoonMind run states
 - map Jules task responses into `AgentRunHandle`, `AgentRunStatus`, and `AgentRunResult`
 - provide truthful best-effort cancellation behavior
+- set `automationMode` to `FULLY_AUTONOMOUS` when `publishMode` is `"pr"` or `"branch"` so Jules creates a PR
 
 ### 3.4 Workflow Orchestration
 
@@ -135,6 +136,7 @@ Public operations:
 - `create_task()`
 - `resolve_task()`
 - `get_task()`
+- `merge_pull_request()` — merges a Jules-created GitHub PR via the GitHub API (used for branch publish auto-merge)
 
 This layer should remain transport-oriented and should not accumulate workflow semantics such as polling policy, Temporal wait behavior, or artifact publication.
 
@@ -179,7 +181,87 @@ The following logic should remain Jules-specific:
 - Jules-specific result summary construction
 - Jules-specific cancel path via task resolution
 
-## 6. Relationship to the Universal External Adapter Plan
+## 6. Branch Publish Auto-Merge
+
+### 6.1 Problem
+
+The Jules API only supports `AUTO_CREATE_PR` as an automation mode — there is no "branch only" mode. When a user selects `publishMode: "branch"`, the intent is to land changes directly on a target branch, not to leave an open PR.
+
+Additionally, the `startingBranch` field controls both where Jules starts its work **and** the PR's merge target. This means users cannot natively say "start from `main` but merge into `feature-branch`."
+
+### 6.2 Mechanism
+
+MoonMind solves both problems with a two-step post-completion flow:
+
+1. **Base branch update** — If `targetBranch` is specified and differs from `startingBranch`, the PR's base branch is updated via `PATCH /repos/.../pulls/...` before merging.
+2. **Auto-merge** — The PR is merged via `PUT /repos/.../pulls/.../merge`.
+
+This decouples "where Jules works from" and "where changes should land."
+
+### 6.3 Workflow Flow
+
+When `publishMode == "branch"` and `integration == "jules"`:
+
+1. **Adapter** — `JulesAgentAdapter.do_start()` sets `automation_mode = "FULLY_AUTONOMOUS"` for both `pr` and `branch` publish modes.
+2. **Integration stage** — `MoonMind.Run._run_integration_stage()` polls Jules until the session reaches a terminal state.
+3. **Fetch result** — On `succeeded`, the workflow calls `integration.jules.fetch_result` to get the session data and extracts the PR URL.
+4. **Update base** *(conditional)* — If `targetBranch` is set and differs from `startingBranch`, the activity calls `JulesClient.update_pull_request_base()` to change the PR's base branch using the GitHub API.
+5. **Auto-merge** — The workflow calls `integration.jules.merge_pr`. This activity delegates to `JulesClient.merge_pull_request()`, which merges the PR via the GitHub API.
+6. **Result** — Changes land directly on the target branch. The Jules-created PR is closed automatically by GitHub upon merge.
+
+```
+Jules (AUTO_CREATE_PR, startingBranch=main)
+  ↓ creates PR targeting main
+  ↓ MoonMind polls until completed
+  ↓ MoonMind extracts PR URL from session output
+  ↓ [if targetBranch ≠ startingBranch] PATCH PR base → targetBranch
+  ↓ PUT merge PR
+  ↓ Changes land on targetBranch ✓
+```
+
+When `targetBranch` is the same as `startingBranch` (or not specified), the base-update step is skipped.
+
+### 6.4 Error Handling
+
+The auto-merge step is **best-effort**:
+
+- If the PR URL cannot be extracted from the session result, the workflow logs a warning and continues.
+- If the base-branch update fails (e.g., target branch does not exist), the merge is **not attempted** and the PR remains open for manual resolution.
+- If the GitHub merge API returns an error (e.g., merge conflicts, branch protection rules), the merge fails gracefully and the PR remains open for manual resolution.
+- Network or timeout errors are caught and logged without failing the workflow.
+
+### 6.5 Configuration
+
+- **`GITHUB_TOKEN`** — Required environment variable for the merge API call. Must have `repo` scope or sufficient permissions to update and merge PRs.
+- **`startingBranch`** — Set via `workspaceSpec.startingBranch` or `workspaceSpec.branch` in the `AgentExecutionRequest`. Defaults to `main`. This is where Jules starts its work.
+- **`targetBranch`** — Set via `parameters.targetBranch` or `workspaceSpec.targetBranch`. When set and different from `startingBranch`, the PR's base branch is updated before merging. When not set, the PR merges into `startingBranch`.
+- **Merge method** — Currently defaults to `"merge"` (merge commit). Configurable in `JulesClient.merge_pull_request(merge_method=...)`.
+
+### 6.6 Temporal Activities
+
+| Activity | Queue | Purpose |
+|----------|-------|---------|
+| `integration.jules.merge_pr` | `mm.activity.integrations` | Optionally update PR base, then merge via GitHub API |
+
+### 6.7 Schema
+
+`JulesIntegrationMergePRResult` (in `moonmind/schemas/jules_models.py`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pr_url` | `str` | The GitHub PR URL that was merged |
+| `merged` | `bool` | Whether the merge succeeded |
+| `merge_sha` | `str \| None` | SHA of the merge commit (if successful) |
+| `summary` | `str` | Human-readable summary of the result |
+
+### 6.8 Client Methods
+
+| Method | Purpose |
+|--------|---------|
+| `JulesClient.merge_pull_request()` | `PUT` merge a GitHub PR |
+| `JulesClient.update_pull_request_base()` | `PATCH` a PR's base (target) branch |
+
+## 7. Relationship to the Universal External Adapter Plan
 
 Jules should be the reference provider when extracting a reusable external-adapter base.
 
@@ -202,7 +284,7 @@ That means future refactoring should aim to preserve this separation:
 
 If a future provider requires materially different behavior, it should justify that divergence explicitly rather than silently bypassing the shared pattern.
 
-## 7. MCP Tooling Posture
+## 8. MCP Tooling Posture
 
 Earlier descriptions made Jules MCP tooling look like a separate architectural layer equal to the adapter and workflow lifecycle. That framing is misleading.
 
@@ -214,7 +296,7 @@ The correct posture is:
 
 `JulesToolRegistry` is therefore an adjunct surface, not the core Jules architecture.
 
-## 8. Implementation Guidance
+## 9. Implementation Guidance
 
 To align Jules with the shared external-agent design, the practical next steps are:
 
@@ -224,7 +306,7 @@ To align Jules with the shared external-agent design, the practical next steps a
 4. Ensure workflow orchestration remains in `MoonMind.AgentRun`, not in Jules-specific code.
 5. Ensure MCP, dashboard, and REST surfaces consume the same Jules normalization and runtime-gate logic.
 
-## 9. Summary
+## 10. Summary
 
 Jules should no longer be described as a separate "4-layer integration."
 

--- a/moonmind/schemas/jules_models.py
+++ b/moonmind/schemas/jules_models.py
@@ -250,11 +250,26 @@ class JulesIntegrationCancelResult(BaseModel):
     summary: Optional[str] = Field(None, alias="summary")
 
 
+class JulesIntegrationMergePRResult(BaseModel):
+    """Result returned by `integration.jules.merge_pr`."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    activity_name: Literal["integration.jules.merge_pr"] = Field(
+        "integration.jules.merge_pr", alias="activityName"
+    )
+    pr_url: str = Field(..., alias="prUrl")
+    merged: bool = Field(..., alias="merged")
+    merge_sha: Optional[str] = Field(None, alias="mergeSha")
+    summary: str = Field(..., alias="summary")
+
+
 __all__ = [
     "GitHubRepoContext",
     "JulesCreateTaskRequest",
     "JulesIntegrationCancelResult",
     "JulesIntegrationFetchResult",
+    "JulesIntegrationMergePRResult",
     "JulesIntegrationStartRequest",
     "JulesIntegrationStartResult",
     "JulesIntegrationStatusResult",

--- a/moonmind/workflows/adapters/jules_agent_adapter.py
+++ b/moonmind/workflows/adapters/jules_agent_adapter.py
@@ -95,7 +95,10 @@ class JulesAgentAdapter(BaseExternalAgentAdapter):
         automation_mode = None
         if request.parameters:
             automation_mode = request.parameters.get("automationMode")
-            if not automation_mode and request.parameters.get("publishMode") == "pr":
+            if not automation_mode and request.parameters.get("publishMode") in (
+                "pr",
+                "branch",
+            ):
                 automation_mode = "FULLY_AUTONOMOUS"
 
         response = await self._client.create_task(

--- a/moonmind/workflows/adapters/jules_client.py
+++ b/moonmind/workflows/adapters/jules_client.py
@@ -280,6 +280,42 @@ class JulesClient:
             summary=f"Jules task {external_operation_id} cancellation accepted.",
         )
 
+    # ------------------------------------------------------------------
+    # GitHub PR helpers (used by branch-publish auto-merge)
+    # ------------------------------------------------------------------
+
+    _GITHUB_PR_URL_RE = re.compile(
+        r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)"
+    )
+
+    @staticmethod
+    def _parse_github_pr_url(
+        pr_url: str,
+    ) -> tuple[str, str, str] | None:
+        """Extract ``(owner, repo, pr_number)`` from a GitHub PR URL.
+
+        Returns ``None`` when the URL does not match the expected format.
+        """
+        match = JulesClient._GITHUB_PR_URL_RE.match(pr_url)
+        if not match:
+            return None
+        return match.group(1), match.group(2), match.group(3)
+
+    @staticmethod
+    def _resolve_github_token(explicit_token: str | None = None) -> str:
+        """Return the GitHub token from the explicit arg or ``GITHUB_TOKEN`` env."""
+        token = (explicit_token or os.environ.get("GITHUB_TOKEN", "")).strip()
+        return token
+
+    @staticmethod
+    def _github_headers(token: str) -> dict[str, str]:
+        """Build standard GitHub API v3 request headers."""
+        return {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
     async def merge_pull_request(
         self,
         *,
@@ -293,18 +329,16 @@ class JulesClient:
         auto-merge the PR that Jules created into the target branch.
         """
 
-        match = re.match(
-            r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
-        )
-        if not match:
+        parsed = self._parse_github_pr_url(pr_url)
+        if not parsed:
             return JulesIntegrationMergePRResult(
                 prUrl=pr_url,
                 merged=False,
                 summary=f"Could not parse PR URL: {pr_url}",
             )
 
-        owner, repo, pr_number = match.group(1), match.group(2), match.group(3)
-        token = github_token or os.environ.get("GITHUB_TOKEN", "").strip()
+        owner, repo, pr_number = parsed
+        token = self._resolve_github_token(github_token)
         if not token:
             return JulesIntegrationMergePRResult(
                 prUrl=pr_url,
@@ -313,11 +347,7 @@ class JulesClient:
             )
 
         api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/merge"
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
+        headers = self._github_headers(token)
         payload = {"merge_method": merge_method}
 
         async with httpx.AsyncClient(timeout=30.0) as gh_client:
@@ -377,23 +407,17 @@ class JulesClient:
         branch differs from the branch Jules started from.
         """
 
-        match = re.match(
-            r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
-        )
-        if not match:
+        parsed = self._parse_github_pr_url(pr_url)
+        if not parsed:
             return False, f"Could not parse PR URL: {pr_url}"
 
-        owner, repo, pr_number = match.group(1), match.group(2), match.group(3)
-        token = github_token or os.environ.get("GITHUB_TOKEN", "").strip()
+        owner, repo, pr_number = parsed
+        token = self._resolve_github_token(github_token)
         if not token:
             return False, "GITHUB_TOKEN is not configured; cannot update PR base."
 
         api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
-        headers = {
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
+        headers = self._github_headers(token)
         payload = {"base": new_base}
 
         async with httpx.AsyncClient(timeout=30.0) as gh_client:

--- a/moonmind/workflows/adapters/jules_client.py
+++ b/moonmind/workflows/adapters/jules_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import re
 from typing import Any
 
 import httpx
@@ -14,6 +16,7 @@ from moonmind.schemas.jules_models import (
     JulesGetTaskRequest,
     JulesIntegrationCancelResult,
     JulesIntegrationFetchResult,
+    JulesIntegrationMergePRResult,
     JulesIntegrationStartRequest,
     JulesIntegrationStartResult,
     JulesIntegrationStatusResult,
@@ -276,6 +279,149 @@ class JulesClient:
             normalizedStatus=normalized,
             summary=f"Jules task {external_operation_id} cancellation accepted.",
         )
+
+    async def merge_pull_request(
+        self,
+        *,
+        pr_url: str,
+        merge_method: str = "merge",
+        github_token: str | None = None,
+    ) -> JulesIntegrationMergePRResult:
+        """Merge a GitHub pull request by URL.
+
+        This is used after Jules completes a branch-publish session to
+        auto-merge the PR that Jules created into the target branch.
+        """
+
+        match = re.match(
+            r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
+        )
+        if not match:
+            return JulesIntegrationMergePRResult(
+                prUrl=pr_url,
+                merged=False,
+                summary=f"Could not parse PR URL: {pr_url}",
+            )
+
+        owner, repo, pr_number = match.group(1), match.group(2), match.group(3)
+        token = github_token or os.environ.get("GITHUB_TOKEN", "").strip()
+        if not token:
+            return JulesIntegrationMergePRResult(
+                prUrl=pr_url,
+                merged=False,
+                summary="GITHUB_TOKEN is not configured; cannot merge PR.",
+            )
+
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/merge"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        payload = {"merge_method": merge_method}
+
+        async with httpx.AsyncClient(timeout=30.0) as gh_client:
+            try:
+                response = await gh_client.put(api_url, headers=headers, json=payload)
+                response.raise_for_status()
+                data = response.json()
+                return JulesIntegrationMergePRResult(
+                    prUrl=pr_url,
+                    merged=data.get("merged", True),
+                    mergeSha=data.get("sha"),
+                    summary=(
+                        f"PR {owner}/{repo}#{pr_number} merged successfully."
+                    ),
+                )
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                body = exc.response.text[:500] if exc.response else "(no body)"
+                logger.error(
+                    "GitHub merge API returned HTTP %s for %s: %s",
+                    status_code, pr_url, body,
+                )
+                return JulesIntegrationMergePRResult(
+                    prUrl=pr_url,
+                    merged=False,
+                    summary=(
+                        f"GitHub merge failed with HTTP {status_code} "
+                        f"for PR {owner}/{repo}#{pr_number}."
+                    ),
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                logger.error(
+                    "GitHub merge request failed for %s: %s",
+                    pr_url, exc.__class__.__name__,
+                )
+                return JulesIntegrationMergePRResult(
+                    prUrl=pr_url,
+                    merged=False,
+                    summary=(
+                        f"GitHub merge request failed: {exc.__class__.__name__}"
+                    ),
+                )
+
+    async def update_pull_request_base(
+        self,
+        *,
+        pr_url: str,
+        new_base: str,
+        github_token: str | None = None,
+    ) -> tuple[bool, str]:
+        """Update a GitHub PR's base (target) branch.
+
+        Returns ``(success, summary)`` where *success* is ``True`` when the
+        base branch was changed successfully.
+
+        Used before ``merge_pull_request()`` when the user's desired target
+        branch differs from the branch Jules started from.
+        """
+
+        match = re.match(
+            r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url
+        )
+        if not match:
+            return False, f"Could not parse PR URL: {pr_url}"
+
+        owner, repo, pr_number = match.group(1), match.group(2), match.group(3)
+        token = github_token or os.environ.get("GITHUB_TOKEN", "").strip()
+        if not token:
+            return False, "GITHUB_TOKEN is not configured; cannot update PR base."
+
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        payload = {"base": new_base}
+
+        async with httpx.AsyncClient(timeout=30.0) as gh_client:
+            try:
+                response = await gh_client.patch(api_url, headers=headers, json=payload)
+                response.raise_for_status()
+                return True, (
+                    f"PR {owner}/{repo}#{pr_number} base updated to '{new_base}'."
+                )
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                body = exc.response.text[:500] if exc.response else "(no body)"
+                logger.error(
+                    "GitHub update-base API returned HTTP %s for %s: %s",
+                    status_code, pr_url, body,
+                )
+                return False, (
+                    f"Failed to update PR base to '{new_base}' "
+                    f"(HTTP {status_code})."
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                logger.error(
+                    "GitHub update-base request failed for %s: %s",
+                    pr_url, exc.__class__.__name__,
+                )
+                return False, (
+                    f"GitHub update-base request failed: {exc.__class__.__name__}"
+                )
 
     async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
         return await self._request_with_retry("POST", path, json=json)

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -15,6 +15,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunResult,
     AgentRunStatus,
 )
+from moonmind.schemas.jules_models import JulesIntegrationMergePRResult
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
 from moonmind.workflows.adapters.jules_client import JulesClient
 
@@ -71,9 +72,53 @@ async def jules_cancel_activity(run_id: str) -> AgentRunStatus:
     return await adapter.cancel(run_id)
 
 
+@activity.defn(name="integration.jules.merge_pr")
+async def jules_merge_pr_activity(payload: dict) -> JulesIntegrationMergePRResult:
+    """Auto-merge a Jules-created PR into its target branch via GitHub API.
+
+    Used when ``publishMode == "branch"`` to merge the PR that Jules
+    created during an ``AUTO_CREATE_PR`` session.
+
+    Accepts a dict with:
+    - ``pr_url`` (str): the GitHub PR URL to merge
+    - ``target_branch`` (str, optional): if set and differs from the PR's
+      current base, the PR base is updated before merging
+    """
+
+    import os
+
+    gate = build_runtime_gate_state()
+    if not gate.enabled:
+        raise RuntimeError(
+            f"{JULES_RUNTIME_DISABLED_MESSAGE} (missing: {', '.join(gate.missing)})"
+        )
+
+    pr_url = payload.get("pr_url") or payload.get("prUrl") or ""
+    target_branch = payload.get("target_branch") or payload.get("targetBranch")
+
+    jules_url = os.environ.get("JULES_API_URL", "").strip() or "https://jules.googleapis.com/v1alpha"
+    jules_key = os.environ.get("JULES_API_KEY", "").strip()
+    client = JulesClient(base_url=jules_url, api_key=jules_key)
+
+    # If a target branch is specified, update the PR's base before merging
+    if target_branch:
+        success, summary = await client.update_pull_request_base(
+            pr_url=pr_url, new_base=target_branch,
+        )
+        if not success:
+            return JulesIntegrationMergePRResult(
+                prUrl=pr_url,
+                merged=False,
+                summary=f"Base branch update failed: {summary}",
+            )
+
+    return await client.merge_pull_request(pr_url=pr_url)
+
+
 __all__ = [
     "jules_cancel_activity",
     "jules_fetch_result_activity",
+    "jules_merge_pr_activity",
     "jules_start_activity",
     "jules_status_activity",
 ]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -493,6 +493,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=2, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="integration.jules.merge_pr",
+            family="integration",
+            capability_class="integration:jules",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 300),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
+        ),
+        TemporalActivityDefinition(
             activity_type="integration.codex_cloud.start",
             family="integration",
             capability_class="integration:codex_cloud",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -898,6 +898,7 @@ class MoonMindRunWorkflow:
                 workflow.logger.warning(
                     "Jules branch-publish auto-merge failed (best-effort): %s",
                     exc,
+                    exc_info=True,
                 )
 
     async def _run_proposals_stage(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -802,6 +802,104 @@ class MoonMindRunWorkflow:
         self._attention_required = False
         self._update_search_attributes()
 
+        # --- Jules branch-publish auto-merge ---
+        # When publishMode is "branch" and the integration is Jules, the
+        # workflow uses AUTO_CREATE_PR so Jules produces a PR targeting the
+        # starting branch.  After Jules succeeds, we auto-merge that PR so
+        # the changes land directly on the target branch.
+        publish_mode = self._publish_mode(parameters)
+        if (
+            publish_mode == "branch"
+            and self._integration == "jules"
+            and not self._cancel_requested
+            and status == "succeeded"
+        ):
+            workflow.logger.info("Jules branch-publish: fetching result for PR merge")
+            try:
+                fetch_result = await workflow.execute_activity(
+                    self._integration_activity_type("fetch_result"),
+                    {
+                        "principal": self._principal(),
+                        "correlation_id": correlation_id,
+                        "parameters": integration_parameters,
+                    },
+                    start_to_close_timeout=timedelta(minutes=5),
+                    task_queue=INTEGRATIONS_TASK_QUEUE,
+                    retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+                )
+                pr_url = (
+                    self._get_from_result(fetch_result, "external_url")
+                    or self._get_from_result(fetch_result, "url")
+                )
+                # If external_url is the session URL, try to extract PR URL
+                # from the summary or output_refs text.
+                if pr_url and not _GITHUB_PR_URL_PATTERN.search(pr_url):
+                    summary_text = self._get_from_result(fetch_result, "summary") or ""
+                    pr_match = _GITHUB_PR_URL_PATTERN.search(summary_text)
+                    if pr_match:
+                        pr_url = pr_match.group(0)
+                    else:
+                        pr_url = None
+
+                if pr_url:
+                    # Determine if the PR's base branch needs updating.
+                    # If targetBranch is specified and differs from
+                    # startingBranch (which Jules used as the PR base),
+                    # the activity will PATCH the PR before merging.
+                    ws = parameters.get("workspaceSpec") or {}
+                    starting_branch = (
+                        ws.get("startingBranch") or ws.get("branch") or "main"
+                    )
+                    target_branch = (
+                        parameters.get("targetBranch")
+                        or ws.get("targetBranch")
+                    )
+                    # Only pass target_branch when it differs from starting
+                    effective_target = (
+                        target_branch
+                        if target_branch and target_branch != starting_branch
+                        else None
+                    )
+
+                    workflow.logger.info(
+                        "Jules branch-publish: merging PR %s (target=%s)",
+                        pr_url,
+                        effective_target or starting_branch,
+                    )
+                    merge_payload = {"pr_url": pr_url}
+                    if effective_target:
+                        merge_payload["target_branch"] = effective_target
+
+                    merge_result = await workflow.execute_activity(
+                        "integration.jules.merge_pr",
+                        merge_payload,
+                        start_to_close_timeout=timedelta(minutes=2),
+                        task_queue=INTEGRATIONS_TASK_QUEUE,
+                        retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+                    )
+                    merged = self._get_from_result(merge_result, "merged")
+                    merge_summary = (
+                        self._get_from_result(merge_result, "summary") or ""
+                    )
+                    if merged:
+                        workflow.logger.info(
+                            "Jules branch-publish: PR merged: %s", merge_summary
+                        )
+                    else:
+                        workflow.logger.warning(
+                            "Jules branch-publish: merge failed: %s", merge_summary
+                        )
+                else:
+                    workflow.logger.warning(
+                        "Jules branch-publish: no PR URL found in result; "
+                        "skipping auto-merge"
+                    )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Jules branch-publish auto-merge failed (best-effort): %s",
+                    exc,
+                )
+
     async def _run_proposals_stage(
         self, *, parameters: dict[str, Any]
     ) -> None:

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -223,3 +223,23 @@ async def test_start_defaults_automation_mode_for_pr_publish():
     create_req = client.created[0]
     assert create_req.automation_mode == "FULLY_AUTONOMOUS"
 
+
+async def test_start_defaults_automation_mode_for_branch_publish():
+    client = _FakeJulesAdapterClient()
+    adapter = JulesAgentAdapter(client_factory=lambda: client)
+
+    req = AgentExecutionRequest(
+        agentKind="external",
+        agentId="jules",
+        executionProfileRef="profile:jules-default",
+        correlationId="corr-1",
+        idempotencyKey="idem-branch-pub",
+        parameters={"description": "foo", "publishMode": "branch"},
+    )
+
+    await adapter.start(req)
+
+    assert len(client.created) == 1
+    create_req = client.created[0]
+    assert create_req.automation_mode == "FULLY_AUTONOMOUS"
+

--- a/tests/unit/workflows/temporal/test_jules_merge_pr.py
+++ b/tests/unit/workflows/temporal/test_jules_merge_pr.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Jules merge-PR client method and activity."""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.schemas.jules_models import JulesIntegrationMergePRResult
+from moonmind.workflows.adapters.jules_client import JulesClient
+
+
+pytestmark = [pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# JulesClient.merge_pull_request
+# ---------------------------------------------------------------------------
+
+
+async def test_merge_pull_request_rejects_invalid_url():
+    """Non-GitHub PR URLs should return merged=False without calling the API."""
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    result = await client.merge_pull_request(pr_url="https://not-github.com/foo")
+    assert isinstance(result, JulesIntegrationMergePRResult)
+    assert result.merged is False
+    assert "Could not parse" in result.summary
+
+
+async def test_merge_pull_request_requires_github_token(monkeypatch):
+    """Without GITHUB_TOKEN, the method should report an error instead of crashing."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    result = await client.merge_pull_request(
+        pr_url="https://github.com/owner/repo/pull/42",
+    )
+    assert result.merged is False
+    assert "GITHUB_TOKEN" in result.summary
+
+
+async def test_merge_pull_request_success(monkeypatch):
+    """When the GitHub API returns 200, we should see merged=True with the SHA."""
+    import httpx
+
+    async def fake_put(self, url, *, headers=None, json=None, **kwargs):
+        return httpx.Response(
+            status_code=200,
+            json={"merged": True, "sha": "abc123def456"},
+            request=httpx.Request("PUT", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "put", fake_put)
+
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    result = await client.merge_pull_request(
+        pr_url="https://github.com/owner/repo/pull/42",
+        github_token="test-token",
+    )
+    assert result.merged is True
+    assert result.merge_sha == "abc123def456"
+    assert "owner/repo#42" in result.summary
+
+
+async def test_merge_pull_request_http_error(monkeypatch):
+    """When the GitHub API returns an error status, merged=False with details."""
+    import httpx
+
+    async def fake_put(self, url, *, headers=None, json=None, **kwargs):
+        response = httpx.Response(
+            status_code=405,
+            text="Pull Request is not mergeable",
+            request=httpx.Request("PUT", url),
+        )
+        response.raise_for_status()
+
+    monkeypatch.setattr(httpx.AsyncClient, "put", fake_put)
+
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    result = await client.merge_pull_request(
+        pr_url="https://github.com/owner/repo/pull/99",
+        github_token="test-token",
+    )
+    assert result.merged is False
+    assert "405" in result.summary
+
+
+# ---------------------------------------------------------------------------
+# JulesClient.update_pull_request_base
+# ---------------------------------------------------------------------------
+
+
+async def test_update_pull_request_base_rejects_invalid_url():
+    """Non-GitHub PR URLs should fail without calling the API."""
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    ok, summary = await client.update_pull_request_base(
+        pr_url="https://not-github.com/foo",
+        new_base="develop",
+    )
+    assert ok is False
+    assert "Could not parse" in summary
+
+
+async def test_update_pull_request_base_requires_github_token(monkeypatch):
+    """Without GITHUB_TOKEN, the method should report an error."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    ok, summary = await client.update_pull_request_base(
+        pr_url="https://github.com/owner/repo/pull/42",
+        new_base="develop",
+    )
+    assert ok is False
+    assert "GITHUB_TOKEN" in summary
+
+
+async def test_update_pull_request_base_success(monkeypatch):
+    """When the GitHub API returns 200, ok should be True."""
+    import httpx
+
+    async def fake_patch(self, url, *, headers=None, json=None, **kwargs):
+        return httpx.Response(
+            status_code=200,
+            json={"base": {"ref": json["base"]}},
+            request=httpx.Request("PATCH", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "patch", fake_patch)
+
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    ok, summary = await client.update_pull_request_base(
+        pr_url="https://github.com/owner/repo/pull/42",
+        new_base="develop",
+        github_token="test-token",
+    )
+    assert ok is True
+    assert "develop" in summary
+
+
+async def test_update_pull_request_base_http_error(monkeypatch):
+    """When the GitHub API returns an error, ok should be False."""
+    import httpx
+
+    async def fake_patch(self, url, *, headers=None, json=None, **kwargs):
+        response = httpx.Response(
+            status_code=422,
+            text="Validation Failed",
+            request=httpx.Request("PATCH", url),
+        )
+        response.raise_for_status()
+
+    monkeypatch.setattr(httpx.AsyncClient, "patch", fake_patch)
+
+    client = JulesClient(base_url="https://unused", api_key="unused")
+    ok, summary = await client.update_pull_request_base(
+        pr_url="https://github.com/owner/repo/pull/42",
+        new_base="nonexistent-branch",
+        github_token="test-token",
+    )
+    assert ok is False
+    assert "422" in summary


### PR DESCRIPTION
## Summary

When `publishMode` is `"branch"` and the integration is Jules, the workflow now automatically merges the Jules-created PR after completion. This allows users to have Jules work land directly on a target branch instead of leaving an open PR.

## Key Features

- **Auto-merge**: After Jules completes, the workflow extracts the PR URL and merges it via the GitHub API
- **Target branch support**: If `targetBranch` differs from `startingBranch`, the PR's base branch is updated before merging — allowing Jules to work from one branch while landing changes on another
- **Best-effort**: Merge failures are logged but don't fail the workflow; the PR remains open for manual resolution

## Changes

| File | Change |
|------|--------|
| `jules_agent_adapter.py` | Sets `FULLY_AUTONOMOUS` for both `pr` and `branch` publishMode |
| `jules_models.py` | New `JulesIntegrationMergePRResult` model |
| `jules_client.py` | New `merge_pull_request()` and `update_pull_request_base()` methods |
| `jules_activities.py` | New `integration.jules.merge_pr` Temporal activity |
| `activity_catalog.py` | Registered the new activity |
| `run.py` | Wired auto-merge into `_run_integration_stage` with conditional base-update |
| `JulesClientAdapter.md` | New section 6: Branch Publish Auto-Merge docs |
| `test_jules_agent_adapter.py` | 1 new adapter test |
| `test_jules_merge_pr.py` | 8 new tests for merge + base-update |

## Configuration

- **`GITHUB_TOKEN`** — Required env var for the merge API call (needs `repo` scope)
- **`targetBranch`** — Set via `parameters.targetBranch` or `workspaceSpec.targetBranch` to land changes on a branch different from `startingBranch`

## Testing

- 1734 unit tests pass (9 new)
- E2E testing requires live `GITHUB_TOKEN` + `JULES_API_KEY`