### PR TITLE
feat: add runtime selection dropdown at proposal promotion time

### DIFF
--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -299,11 +299,49 @@ async def promote_proposal(
     user: User = Depends(get_current_user()),
 ) -> TaskProposalPromoteResponse:
     try:
-        override_payload = (
-            payload.task_create_request_override.model_dump(by_alias=True)
-            if payload.task_create_request_override is not None
-            else None
-        )
+        # Build the override: explicit taskCreateRequestOverride takes
+        # precedence; runtimeMode is a lightweight shortcut that
+        # constructs one on-the-fly when the full override is absent.
+        if payload.task_create_request_override is not None:
+            override_payload = payload.task_create_request_override.model_dump(
+                by_alias=True
+            )
+        elif payload.runtime_mode:
+            runtime_mode = payload.runtime_mode.strip()
+            if not runtime_mode:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail={
+                        "code": "invalid_request",
+                        "message": "runtimeMode must be a non-empty string",
+                    },
+                )
+            # Fetch the stored proposal to extract the repository for
+            # the override envelope that the service expects.
+            stored = await service.get_proposal(proposal_id)
+            stored_request = stored.task_create_request or {}
+            stored_payload = (
+                stored_request.get("payload")
+                if isinstance(stored_request, dict)
+                else {}
+            ) or {}
+            repo = (
+                stored_payload.get("repository", "")
+                if isinstance(stored_payload, dict)
+                else ""
+            )
+            override_payload = {
+                "type": "task",
+                "priority": stored_request.get("priority", 0),
+                "maxAttempts": stored_request.get("maxAttempts", 3),
+                "payload": {
+                    "repository": repo,
+                    "task": {"runtime": {"mode": runtime_mode}},
+                },
+            }
+        else:
+            override_payload = None
+
         proposal, job = await service.promote_proposal(
             proposal_id=proposal_id,
             promoted_by_user_id=getattr(user, "id"),

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -320,16 +320,8 @@ async def promote_proposal(
             # the override envelope that the service expects.
             stored = await service.get_proposal(proposal_id)
             stored_request = stored.task_create_request or {}
-            stored_payload = (
-                stored_request.get("payload")
-                if isinstance(stored_request, dict)
-                else {}
-            ) or {}
-            repo = (
-                stored_payload.get("repository", "")
-                if isinstance(stored_payload, dict)
-                else ""
-            )
+            stored_payload = stored_request.get("payload") or {}
+            repo = stored_payload.get("repository", "")
             override_payload = {
                 "type": "task",
                 "priority": stored_request.get("priority", 0),

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3357,7 +3357,7 @@
         : {};
     taskNode.runtime = runtimeNode;
     const runtimeMode = window.prompt(
-      "Agent runtime (gemini_cli/jules/codex/claude, or leave blank for default)",
+      `Agent runtime (${supportedTaskRuntimes.join("/")}, or leave blank for default)`,
       runtimeNode.mode || "",
     );
     if (runtimeMode === null) {
@@ -10740,7 +10740,7 @@
           pick(row, "repository") || pick(preview, "repository") || "-",
         )}</div>
             <div class="card"><strong>Runtime:</strong> ${escapeHtml(
-          pick(preview, "runtimeMode") || "-",
+          pick(preview, "runtimeMode") || "(default)",
         )}</div>
             <div class="card"><strong>Publish Mode:</strong> ${escapeHtml(
           pick(preview, "publishMode") || "-",
@@ -10776,6 +10776,21 @@
             ${signalMarkup}
           </section>
           <div class="actions">
+            <label style="display:inline-flex;align-items:center;gap:0.5rem;margin-right:0.5rem">
+              Runtime
+              <select id="proposal-runtime-select">
+                ${supportedTaskRuntimes
+                  .map(
+                    (rt) =>
+                      `<option value="${escapeHtml(rt)}" ${
+                        rt === (pick(preview, "runtimeMode") || defaultTaskRuntime)
+                          ? "selected"
+                          : ""
+                      }>${escapeHtml(rt)}</option>`,
+                  )
+                  .join("")}
+              </select>
+            </label>
             <button
               type="button"
               class="queue-action"
@@ -10809,7 +10824,10 @@
         promoteButton.addEventListener("click", async () => {
           promoteButton.disabled = true;
           try {
-            await apiPromoteProposal(proposalId);
+            const runtimeSelect = document.getElementById("proposal-runtime-select");
+            const selectedRuntime = runtimeSelect ? runtimeSelect.value : null;
+            const overrides = selectedRuntime ? { runtimeMode: selectedRuntime } : {};
+            await apiPromoteProposal(proposalId, overrides);
             detailNotice = "Proposal promoted and consumed. It will disappear from the queue list.";
             await load(true);
             return;

--- a/docs/Tasks/TaskProposalSystem.md
+++ b/docs/Tasks/TaskProposalSystem.md
@@ -2,8 +2,8 @@
 
 Status: Active  
 Owners: MoonMind Engineering  
-Last Updated: 2026-03-16  
-Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskFinishSummarySystem.md`, `docs/Temporal/TemporalArchitecture.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/ExternalAgents/ExternalAgentIntegrationSystem.md`
+Last Updated: 2026-03-19  
+Related: `docs/Tasks/TaskArchitecture.md`, `docs/Tasks/TaskFinishSummarySystem.md`, `docs/Tasks/SkillAndPlanContracts.md`, `docs/Temporal/TemporalArchitecture.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/ExternalAgents/ExternalAgentIntegrationSystem.md`
 
 ---
 
@@ -117,8 +117,10 @@ each step. This provides structured inputs for proposal generation:
   classification, and diagnostics. Proposal generators can analyze these to identify
   follow-up fixes, missed tests, or run-quality improvements.
 - **External agents** (Jules, BYOA) — the `ExternalAgentAdapter` normalizes provider
-  results into the same `AgentRunResult` contract. Proposal generators can analyze
-  external agent outputs using the same logic as managed agent outputs.
+  results into the same `AgentRunResult` contract via the `BaseExternalAgentAdapter`
+  pattern (see `docs/ExternalAgents/ExternalAgentIntegrationSystem.md`). Proposal
+  generators consume only the normalized result and must not reach back into
+  provider-specific APIs or transport clients for additional data.
 
 This means proposal generation is runtime-agnostic at the generator level — it
 operates on `AgentRunResult` and step-level artifacts regardless of whether the
@@ -310,6 +312,10 @@ Rules:
 4. Generators must not include secrets, raw credentials, or unsafe command logs.
 5. The `tool.type` in proposed `taskCreateRequest` should be `"agent_runtime"` to
    route promoted tasks through the `MoonMind.AgentRun` execution path.
+6. The `runtime.mode` value (e.g. `codex`, `gemini_cli`, `jules`, `claude`) determines
+   which `AgentAdapter` implementation handles the promoted task — `ManagedAgentAdapter`
+   for managed runtimes, or the appropriate `ExternalAgentAdapter` subclass for
+   external agents. See `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` §4.
 
 ---
 
@@ -321,15 +327,132 @@ The lifecycle remains:
 
 1. `MoonMind.Run` creates proposal records via submission activities.
 2. Reviewers inspect, snooze, reprioritize, dismiss, or edit proposals.
-3. Promotion creates a new task request from the stored `taskCreateRequest`.
-4. That promoted task becomes a new `MoonMind.Run` workflow execution, which
-   dispatches its steps through `MoonMind.AgentRun` child workflows as usual.
+3. The operator selects a runtime (see §7.1) and promotes the proposal.
+4. Promotion creates a new task request from the stored `taskCreateRequest`,
+   with any operator overrides merged.
+5. That promoted task becomes a new `MoonMind.Run` workflow execution. Because
+   the proposed `taskCreateRequest` uses `tool.type = "agent_runtime"`, the
+   execution stage dispatches work as a `MoonMind.AgentRun` child workflow —
+   identical to any other task submission that targets an agent runtime.
 
 This separation matters:
 
 1. Proposal generation is exploratory and best-effort.
-2. Promotion is explicit human approval.
+2. Promotion is explicit human approval with runtime choice.
 3. Temporal is the execution substrate only after promotion.
+
+### 7.1 Runtime selection at promotion time
+
+Operators must be able to choose which agent runtime executes a promoted proposal.
+The proposal review UI presents a **runtime dropdown** alongside the Promote
+action.
+
+#### UX behavior
+
+1. The dropdown is pre-populated with the runtime from the proposal's
+   `taskCreateRequest.payload.task.runtime.mode` (e.g. `codex`).
+2. The operator may accept the default or select a different runtime before
+   promoting.
+3. The available options come from the backend — the dashboard view model
+   serves `system.supportedTaskRuntimes` in the runtime config payload that
+   initializes Mission Control. The UI must read this list from the config;
+   it must never hardcode its own list of runtimes.
+
+#### Runtime list — backend as source of truth
+
+The canonical list of available runtimes is built by the backend in
+`_build_supported_task_runtimes()` within `task_dashboard_view_model.py`.
+This function assembles the list from application settings and feature gates
+(e.g. `settings.jules_runtime_gate.enabled`) and includes only runtimes
+that are currently enabled for the deployment.
+
+The list is served to the UI as `system.supportedTaskRuntimes` inside the
+`build_runtime_config()` payload. The same list drives the create page
+runtime selector, the proposal detail runtime dropdown, and the
+Edit & Promote prompt. This ensures that adding a new runtime to the
+backend settings automatically surfaces it in all UI surfaces.
+
+The runtime-to-adapter mapping (reference only — the backend resolves this
+at execution time, not at promotion time):
+
+| Value | Adapter | Category |
+|-------|---------|----------|
+| `gemini_cli` | `ManagedAgentAdapter` | Managed |
+| `claude_code` | `ManagedAgentAdapter` | Managed |
+| `codex` | `ManagedAgentAdapter` | Managed |
+| `jules` | `JulesAgentAdapter` | External |
+| `codex_cloud` | `CodexCloudAgentAdapter` | External |
+
+New runtimes are added by updating `_build_supported_task_runtimes()` and
+the corresponding adapter registration. The UI inherits the change
+automatically through the served config.
+
+#### API contract
+
+The promote endpoint `POST /api/proposals/{id}/promote` accepts a
+`TaskProposalPromoteRequest` body. Runtime selection can be expressed in
+two ways:
+
+**Option A — `runtimeMode` shortcut** (preferred for UI):
+
+```json
+{
+  "runtimeMode": "gemini_cli",
+  "note": "Switching to Gemini CLI for this proposal"
+}
+```
+
+The router constructs a `taskCreateRequestOverride` from the shortcut,
+using the stored proposal's repository and other envelope fields.
+
+**Option B — full `taskCreateRequestOverride`** (for advanced use):
+
+```json
+{
+  "taskCreateRequestOverride": {
+    "payload": {
+      "task": {
+        "runtime": {
+          "mode": "gemini_cli"
+        }
+      }
+    }
+  },
+  "note": "Switching to Gemini CLI for this proposal"
+}
+```
+
+When both `runtimeMode` and `taskCreateRequestOverride` are provided,
+`taskCreateRequestOverride` takes precedence and `runtimeMode` is ignored.
+
+When `taskCreateRequestOverride` is provided, the API merges it into the
+stored `taskCreateRequest` before creating the new task. The merge follows
+JSON Merge Patch semantics — only the fields present in the override are
+replaced; all other fields in the original `taskCreateRequest` are preserved.
+
+#### Resolution precedence
+
+The final `runtime.mode` for a promoted task is resolved as (highest wins):
+
+1. `taskCreateRequestOverride.payload.task.runtime.mode` — operator choice
+   at promotion time.
+2. `taskCreateRequest.payload.task.runtime.mode` — value from the original
+   proposal (set by the generator or by `proposalPolicy.defaultRuntime`).
+3. System default runtime — fallback if neither the proposal nor the operator
+   specifies a runtime.
+
+#### Rules
+
+1. The dropdown must always show the current effective runtime so operators
+   know what will execute before clicking Promote.
+2. Runtime selection does not alter the stored proposal record — the override
+   is applied only to the promoted task.
+3. If an operator selects a runtime that is disabled or unavailable, the
+   promote request must fail with an actionable error before any workflow
+   starts.
+4. `TaskProposalTaskPreview.runtimeMode` (returned in proposal list/detail
+   responses) reflects the proposal's stored runtime, not any pending
+   override — the override exists only at promotion time.
 
 ---
 

--- a/docs/Temporal/TemporalAgentExecution.md
+++ b/docs/Temporal/TemporalAgentExecution.md
@@ -2,7 +2,7 @@
 
 **Status:** Active design  
 **Owner:** MoonMind Platform  
-**Last updated:** 2026-03-12  
+**Last updated:** 2026-03-19  
 **Audience:** backend, workflow authors, operators
 
 ## 1. Purpose
@@ -120,48 +120,55 @@ provided in the input payload (pre-planned job), this stage is skipped.
 
 ### 2.4 Execution stage (implemented)
 
+The execution stage dispatches plan steps using two paths depending on the
+step's `tool.type`:
+
+- **`tool.type = "agent_runtime"`** — dispatched as a `MoonMind.AgentRun`
+  child workflow via `workflow.execute_child_workflow("MoonMind.AgentRun", ...)`.
+  This is the primary path for all agent execution (both managed and external).
+- **Other tool types** (e.g. `"skill"`) — dispatched as a standard Temporal
+  activity via `workflow.execute_activity()`.
+
 ```
 _run_execution_stage()
   │
   │  1. Read the resolved plan from plan_ref
   │  2. For each node in plan.nodes (a Step ToolInvocation):
-  │     a. Resolve routing via TemporalActivityCatalog.resolve_skill()
-  │     b. Build the invocation payload
-  │     c. Execute activity:
+  │     a. Check tool.type to determine dispatch path
+  │     b. Build the execution payload
+  │     c. Dispatch:
   │
-  ▼
-workflow.execute_activity("mm.skill.execute", {
-    invocation_payload: {
-        id:           "<node-id>",
-        tool:         { type: "skill", name: "pr-resolver", version: "1.0" },
-        inputs:       { repo: "...", pr: "42", branch: "..." },
-        options:      { ... }
-    },
-    registry_snapshot_ref: "<artifact-ref>",
-    principal:            "<owner-id>",
-    context:              { workflow_id, run_id, ... }
-})
+  ├── tool.type == "agent_runtime":
+  │   │
+  │   ▼
+  │ workflow.execute_child_workflow("MoonMind.AgentRun", AgentExecutionRequest {
+  │     agent_kind:    "managed" | "external",
+  │     agent_id:      "gemini_cli" | "codex_cli" | "jules" | ...,
+  │     instruction_ref, input_refs, workspace_spec, parameters, ...
+  │ })
+  │   │
+  │   ▼
+  │ MoonMind.AgentRun child workflow
+  │   → selects AgentAdapter (ManagedAgentAdapter or ExternalAgentAdapter)
+  │   → start → wait → fetch_result → publish outputs
+  │   → returns AgentRunResult { output_refs, summary, diagnostics, ... }
   │
-  ▼
-TemporalSkillActivities.mm_skill_execute()       ← activity_runtime.py
-  │
-  │  1. Resolve registry snapshot (from ref or inline)
-  │  2. Parse invocation_payload as ToolInvocation (skill subtype)
-  │  3. Delegate to execute_skill_activity() → SkillActivityDispatcher
-  │  4. Return ToolResult { status, outputs, output_artifacts }
-  │
-  ▼
-SkillActivityDispatcher.execute()                ← skill_dispatcher.py
-  │
-  │  1. Look up handler by activity_type ("mm.skill.execute")
-  │     or by skill name+version from registry
-  │  2. Execute the handler (the actual tool logic; skill subtype today)
-  │  3. Return ToolResult
+  └── tool.type == "skill" (or other activity-based types):
+      │
+      ▼
+    workflow.execute_activity("mm.skill.execute", ...)
+      → returns ToolResult { status, outputs, output_artifacts }
 ```
 
 For **generic LLM text instructions** (no specific tool), planning produces
-`tool = { type: "skill", name: "auto", version: "1.0" }` and the dispatcher
-routes that tool to the runtime CLI handler in the Temporal worker runtime.
+`tool = { type: "agent_runtime", name: "auto", version: "1.0" }` and the
+workflow dispatches it as a `MoonMind.AgentRun` child workflow. The `runtime.mode`
+field (e.g. `codex`, `gemini_cli`, `jules`) determines which `AgentAdapter`
+implementation handles the run.
+
+For the full agent execution model including managed runtime supervision, external
+agent callbacks, and auth-profile controls, see
+[`ManagedAndExternalAgentExecutionModel.md`](ManagedAndExternalAgentExecutionModel.md).
 
 ---
 
@@ -227,6 +234,8 @@ Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inpu
 | `plan.generate` | llm | `mm.activity.llm` | LLM-driven plan generation |
 | `plan.validate` | llm | `mm.activity.llm` | Plan validation against registry |
 | `mm.skill.execute` | by_capability | `mm.activity.llm` (default) | Skill dispatch via registry |
+| `agent_runtime.publish_artifacts` | agent_runtime | `mm.activity.agent_runtime` | Publish agent run outputs |
+| `agent_runtime.cancel` | agent_runtime | `mm.activity.agent_runtime` | Cancel managed/external agent run |
 | `sandbox.run_command` | sandbox | `mm.activity.sandbox` | Shell command execution |
 | `sandbox.checkout_repo` | sandbox | `mm.activity.sandbox` | Git repo checkout |
 | `sandbox.apply_patch` | sandbox | `mm.activity.sandbox` | Patch application |
@@ -241,6 +250,7 @@ Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inpu
 | `workflow` | `mm.workflow` | workflow orchestration | Lightweight, no side effects |
 | `llm` | `mm.activity.llm` | LLM calls, plan generation | Rate-limited by provider |
 | `sandbox` | `mm.activity.sandbox` | Shell exec, git, builds | CPU/memory heavy |
+| `agent_runtime` | `mm.activity.agent_runtime` | Managed runtime supervision, auth profiles | Provider rate-limited |
 | `artifacts` | `mm.activity.artifacts` | Artifact storage IO | IO-bound |
 | `integrations` | `mm.activity.integrations` | Jules, webhooks | Rate-limited |
 
@@ -254,9 +264,9 @@ Serialized payload form (legacy accepted): `{ id, skill: { name, version }, inpu
 | **`TemporalExecutionService.create_execution`** | ✅ Implemented | Creates DB record + starts workflow |
 | **`MoonMind.Run` workflow definition** | ✅ Implemented | Full lifecycle with signals/updates |
 | **Planning stage** (`plan.generate`) | ✅ Implemented | Activity + planner callback |
-| **Execution stage** (`_run_execution_stage`) | ✅ Implemented | Reads plan artifact, routes nodes via `mm.skill.execute`, and honors failure policy |
-| **`mm.skill.execute` activity** | ✅ Implemented | `TemporalSkillActivities.mm_skill_execute` is wired up |
-| **`SkillActivityDispatcher`** | ✅ Implemented | Routing by activity type and skill name/version |
+| **Execution stage** (`_run_execution_stage`) | ✅ Implemented | Reads plan artifact, dispatches `agent_runtime` nodes as `MoonMind.AgentRun` child workflows, non-agent nodes as activities |
+| **`MoonMind.AgentRun` child workflow** | ✅ Implemented | Unified agent execution lifecycle for managed and external agents |
+| **`AgentAdapter` protocol** | ✅ Implemented | `ManagedAgentAdapter` + `JulesAgentAdapter` + `CodexCloudAgentAdapter` |
 | **`SkillInvocation` contract** | ✅ Implemented | Validated dataclass in `skill_plan_contracts.py` |
 | **Activity catalog** | ✅ Implemented | 18 activities, 5 fleets, correct routing |
 | **Worker runtime bindings** | ✅ Implemented | `build_activity_bindings` wires handlers to catalog |
@@ -296,20 +306,22 @@ canonical open backlog is maintained in
 ┌─────────────────── Temporal Server ───────────────────────────────────────┐
 │                                                                           │
 │   MoonMind.Run  (task queue: mm.workflow)                                 │
-│   ┌─────────────────────────────────────────────────────────────┐         │
-│   │ initialize ──► plan ──► execute ──► finalize                │         │
-│   │                  │          │                                │         │
-│   │                  │          │                                │         │
-│   │    ┌─────────────┘          └──────────────┐                │         │
-│   │    ▼                                       ▼                │         │
-│   │  plan.generate              mm.skill.execute (per node)     │         │
-│   │  (mm.activity.llm)          (routed by capability)          │         │
-│   │                                       │                     │         │
-│   │                              ┌────────┼────────┐            │         │
-│   │                              ▼        ▼        ▼            │         │
-│   │                           sandbox    llm   integrations     │         │
-│   │                           fleet     fleet     fleet         │         │
-│   └─────────────────────────────────────────────────────────────┘         │
+│   ┌──────────────────────────────────────────────────────────────────┐    │
+│   │ initialize ──► plan ──► execute ──► [proposals] ──► finalize    │    │
+│   │                  │          │                                    │    │
+│   │    ┌─────────────┘          └──────────────────┐                │    │
+│   │    ▼                                          ▼                 │    │
+│   │  plan.generate          per-step dispatch by tool.type          │    │
+│   │  (mm.activity.llm)      ┌──────────────┬──────────────┐         │    │
+│   │                         ▼              ▼              ▼         │    │
+│   │                  agent_runtime     skill/other     sandbox      │    │
+│   │                  (child wf)        (activity)      (activity)   │    │
+│   │                      │                                          │    │
+│   │                      ▼                                          │    │
+│   │               MoonMind.AgentRun                                 │    │
+│   │               ├─ ManagedAgentAdapter → Gemini CLI / Codex CLI   │    │
+│   │               └─ ExternalAgentAdapter → Jules / BYOA            │    │
+│   └──────────────────────────────────────────────────────────────────┘    │
 │                                                                           │
 └───────────────────────────────────────────────────────────────────────────┘
 ```

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -120,6 +120,14 @@ class TaskProposalPromoteRequest(BaseModel):
     priority: Optional[int] = Field(None, alias="priority")
     max_attempts: Optional[int] = Field(None, alias="maxAttempts")
     note: Optional[str] = Field(None, alias="note")
+    runtime_mode: Optional[str] = Field(
+        None,
+        alias="runtimeMode",
+        description=(
+            "Shortcut to override the agent runtime mode (e.g. gemini_cli, "
+            "jules, codex). Ignored when taskCreateRequestOverride is provided."
+        ),
+    )
     task_create_request_override: Optional[CreateJobRequest] = Field(
         None, alias="taskCreateRequestOverride"
     )

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from datetime import UTC, datetime
 
 from moonmind.schemas.agent_runtime_models import (

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -296,3 +296,49 @@ def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock]) -> None:
 
     assert response.status_code == 200
     service.update_review_priority.assert_awaited()
+
+
+def test_promote_proposal_with_runtime_mode_shortcut(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    """runtimeMode shortcut builds a task_create_request_override for the service."""
+    test_client, service = client
+    proposal = _build_proposal()
+    proposal.task_create_request = {
+        "type": "task",
+        "priority": 0,
+        "maxAttempts": 3,
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "do stuff",
+                "runtime": {"mode": "codex"},
+            },
+        },
+    }
+    now = datetime.now(UTC)
+    job = SimpleNamespace(
+        id=uuid4(),
+        type="task",
+        status="queued",
+        priority=0,
+        payload={"repository": "Moon/Repo"},
+        attempt=0,
+        max_attempts=3,
+        created_at=now,
+        updated_at=now,
+    )
+    service.get_proposal.return_value = proposal
+    service.promote_proposal.return_value = (proposal, job)
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/promote",
+        json={"runtimeMode": "gemini_cli"},
+    )
+
+    assert response.status_code == 200
+    kwargs = service.promote_proposal.await_args.kwargs
+    override = kwargs["task_create_request_override"]
+    assert override is not None
+    assert override["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
+    assert override["payload"]["repository"] == "Moon/Repo"

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -177,6 +177,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
         integration_activities=mock_jules_activities_cls.return_value,
         agent_runtime_activities=mock_agent_runtime_activities_cls.return_value,
         proposal_activities=mock_proposal_activities_cls.return_value,
+        review_activities=ANY,
     )
     mock_proposal_activities_cls.assert_called_once_with(
         artifact_service=mock_service_cls.return_value,


### PR DESCRIPTION
## Summary

Adds a runtime selection dropdown to the Mission Control proposal detail page, allowing operators to choose which agent runtime runs a promoted task before clicking Promote.

## Changes

### Backend
- **`task_proposal_models.py`** — Added `runtimeMode` shortcut field to `TaskProposalPromoteRequest`, so the UI can send `{ "runtimeMode": "gemini_cli" }` instead of constructing a full `taskCreateRequestOverride`
- **`task_proposals.py`** — Router converts `runtimeMode` into a proper `taskCreateRequestOverride` envelope using the stored proposal's repository and envelope fields. `taskCreateRequestOverride` takes precedence when both are provided

### Frontend
- **`dashboard.js`** — Added runtime dropdown to proposal detail page action bar, reading from backend-served `supportedTaskRuntimes` config (DRY with the create page). Promote button sends selected runtime via `runtimeMode` field. Edit & Promote prompt also uses dynamic list

### Docs
- **`TaskProposalSystem.md`** §7.1 — Documented backend-driven runtime list architecture (`_build_supported_task_runtimes()` → `build_runtime_config()` → UI) and the `runtimeMode` shortcut API contract
- **`TemporalAgentExecution.md`** — Updated to reflect current `MoonMind.AgentRun` dispatch model

### Tests
- **`test_task_proposals.py`** — Added `test_promote_proposal_with_runtime_mode_shortcut` verifying the shortcut builds a correct override with the selected runtime mode

## Test Results
1734 passed, 3 pre-existing failures (unrelated), 2 skipped