### PR TITLE
fix: clear model and effort fields for jules runtime

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -5523,6 +5523,12 @@
       if (effortInputElement.value.trim() === activeDefaultEffort) {
         effortInputElement.value = nextDefaultEffort;
       }
+
+      if (runtimeKey === "jules") {
+        modelInputElement.value = "";
+        effortInputElement.value = "";
+      }
+
       activeDefaultModel = nextDefaultModel;
       activeDefaultEffort = nextDefaultEffort;
     };

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,6 @@
+import re
+with open('tests/unit/services/temporal/runtime/test_launcher.py', 'r') as f:
+    c = f.read()
+c = c.replace('    record, process, _ = await launcher.launch(\n    record, process, _ = await launcher.launch(', '    record, process, _ = await launcher.launch(')
+with open('tests/unit/services/temporal/runtime/test_launcher.py', 'w') as f:
+    f.write(c)

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -93,7 +93,7 @@ async def test_launch_spawns_process(tmp_path):
     profile = _make_profile(command_template=["echo", "hello"])
     request = _make_request()
 
-    record, process = await launcher.launch(
+    record, process, _ = await launcher.launch(
         run_id="run-1", request=request, profile=profile
     )
     await process.wait()
@@ -115,7 +115,7 @@ async def test_idempotent_launch_rejects_active(tmp_path):
     request = _make_request()
 
     # First launch
-    record, process = await launcher.launch(
+    record, process, _ = await launcher.launch(
         run_id="run-1", request=request, profile=profile
     )
     await process.wait()


### PR DESCRIPTION
When `jules` is selected as the runtime on the create tasks dashboard, the `model` and `effort` fields are automatically cleared out. This allows Jules to receive tasks without unintended codex default values.

---
*PR created automatically by Jules for task [13977504059737845578](https://jules.google.com/task/13977504059737845578) started by @nsticco*