### PR TITLE
docs: update OpenClaw adapter docs to reflect implementation behavior

### DIFF
--- a/docs/ExternalAgents/AddingExternalProvider.md
+++ b/docs/ExternalAgents/AddingExternalProvider.md
@@ -56,6 +56,7 @@ _CAPABILITY = ProviderCapabilityDescriptor(
     supportsCancel=True,
     supportsResultFetch=True,
     defaultPollHintSeconds=15,
+    execution_style="polling", # or "streaming_gateway" for long-running stream providers
 )
 
 class ProviderAgentAdapter(BaseExternalAgentAdapter):

--- a/docs/ExternalAgents/OpenClawAgentAdapter.md
+++ b/docs/ExternalAgents/OpenClawAgentAdapter.md
@@ -104,11 +104,9 @@ The shared runtime contract is `AgentAdapter` (`start`, `status`, `fetch_result`
 
 ### 6.4 Capability descriptor
 
-Today, `ProviderCapabilityDescriptor` describes poll-oriented providers. **Desired extension** (schema + codegen if needed):
+`ProviderCapabilityDescriptor` describes the integration style using the **`execution_style`** field: `polling` | `streaming_gateway`.
 
-- Add something equivalent to **`execution_style`**: `polling` | `streaming_gateway`.
-
-OpenClaw should register as **`streaming_gateway`** with **`supports_callbacks: false`**, and polling-related hints should be ignored by `MoonMind.AgentRun` when this style is active.
+OpenClaw registers as **`streaming_gateway`** with **`supports_callbacks: false`**, and polling-related hints are ignored by `MoonMind.AgentRun` when this style is active.
 
 ---
 
@@ -124,7 +122,7 @@ OpenClaw should register as **`streaming_gateway`** with **`supports_callbacks: 
 
 That pattern matches Jules and Codex Cloud. It does **not** match a single long-lived SSE connection that **is** the run.
 
-### 7.2 Desired behavior
+### 7.2 Implementation behavior
 
 For providers with `execution_style == streaming_gateway` (initially `openclaw` only):
 


### PR DESCRIPTION
Updated `docs/ExternalAgents/OpenClawAgentAdapter.md` to change the descriptions from "Desired State" to actual implementation behavior regarding `execution_style`. Also updated the boilerplate code in `docs/ExternalAgents/AddingExternalProvider.md` to include an example `execution_style` assignment to assist developers adding new external providers.

---
*PR created automatically by Jules for task [11816278423801859245](https://jules.google.com/task/11816278423801859245) started by @nsticco*