### PR TITLE
Add Claude CLI auth mode and oauth environment shaping

### DIFF
--- a/.agents/skills/fix-comments/tools/get_branch_pr_comments.py
+++ b/.agents/skills/fix-comments/tools/get_branch_pr_comments.py
@@ -75,37 +75,34 @@ def run_json_command(
     output: str | None = None
     for attempt in range(1, max_attempts + 1):
         try:
-            output = subprocess.check_output(
+            completed = subprocess.run(
                 command,
-                stderr=subprocess.STDOUT,
                 text=True,
+                capture_output=True,
+                check=False,
             )
+            output = completed.stdout
+            stderr = completed.stderr
+            if completed.returncode != 0:
+                details = "\n".join(
+                    item.strip() for item in (output or "", stderr or "") if item.strip()
+                )
+                retryable = is_retryable_command_error(details)
+                if attempt >= max_attempts or not retryable:
+                    error_text = details or f"Command exited with {completed.returncode}"
+                    raise RuntimeError(f"{failure_hint}\n{error_text}")
+
+                delay = min(
+                    max_delay_seconds, initial_delay_seconds * (2 ** (attempt - 1))
+                )
+                eprint(
+                    f"Retryable error on attempt {attempt}/{max_attempts} for command `{sanitized_command(command)}`: "
+                    f"{details}. Retrying in {delay:.1f}s..."
+                )
+                time.sleep(delay)
+                continue
         except FileNotFoundError as exc:
             raise RuntimeError(f"Required command not found: {command[0]}") from exc
-        except subprocess.TimeoutExpired as exc:
-            if attempt >= max_attempts:
-                raise RuntimeError(f"{failure_hint}\nRequest timed out") from exc
-
-            delay = min(max_delay_seconds, initial_delay_seconds * (2 ** (attempt - 1)))
-            eprint(
-                f"Retryable error on attempt {attempt}/{max_attempts} (timeout). "
-                f"Retrying in {delay:.1f}s..."
-            )
-            time.sleep(delay)
-            continue
-        except subprocess.CalledProcessError as exc:
-            output_text = exc.output.strip() if exc.output else ""
-            retryable = is_retryable_command_error(output_text)
-            if attempt >= max_attempts or not retryable:
-                raise RuntimeError(f"{failure_hint}\n{output_text}") from exc
-
-            delay = min(max_delay_seconds, initial_delay_seconds * (2 ** (attempt - 1)))
-            eprint(
-                f"Retryable error on attempt {attempt}/{max_attempts} for command `{sanitized_command(command)}`: "
-                f"{output_text}. Retrying in {delay:.1f}s..."
-            )
-            time.sleep(delay)
-            continue
 
     if output is None:
         raise RuntimeError(

--- a/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_snapshot.py
@@ -34,25 +34,38 @@ def run_command(
 ):
     for attempt in range(1, max_attempts + 1):
         try:
-            output = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
+            completed = subprocess.run(
+                cmd,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            output = completed.stdout
+            stderr = completed.stderr
+            if completed.returncode != 0:
+                details = "\n".join(
+                    item.strip() for item in (output or "", stderr or "") if item.strip()
+                )
+                if attempt < max_attempts:
+                    delay = min(
+                        max_delay_seconds, initial_delay_seconds * (2 ** (attempt - 1))
+                    )
+                    print(
+                        f"Retryable error on attempt {attempt}/{max_attempts} for command: {' '.join(cmd)}. Retrying in {delay:.1f}s...",
+                        file=sys.stderr,
+                    )
+                    time.sleep(delay)
+                    continue
+                print(
+                    f"Command failed: {' '.join(cmd)}\n{failure_hint}\n{details}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
             if output.strip() == "":
                 return {}
             return json.loads(output)
-        except subprocess.CalledProcessError as e:
-            if attempt < max_attempts:
-                delay = min(
-                    max_delay_seconds, initial_delay_seconds * (2 ** (attempt - 1))
-                )
-                print(
-                    f"Retryable error on attempt {attempt}/{max_attempts} for command: {' '.join(cmd)}. Retrying in {delay:.1f}s...",
-                    file=sys.stderr,
-                )
-                time.sleep(delay)
-                continue
-            print(
-                f"Command failed: {' '.join(cmd)}\n{failure_hint}\n{e.output}",
-                file=sys.stderr,
-            )
+        except FileNotFoundError:
+            print(f"Command not found: {cmd[0]}", file=sys.stderr)
             sys.exit(1)
         except json.JSONDecodeError:
             print(f"Command returned invalid JSON: {' '.join(cmd)}", file=sys.stderr)
@@ -61,11 +74,17 @@ def run_command(
 
 def run_command_optional(cmd) -> dict | list | None:
     try:
-        output = subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        return None
+        completed = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
     except OSError:
         return None
+    if completed.returncode != 0:
+        return None
+    output = completed.stdout
     if output.strip() == "":
         return {}
     try:

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -400,6 +400,7 @@ class CodexWorkerConfig:
     gemini_cli_auth_mode: str = "api_key"
     gemini_allowed_tools: tuple[str, ...] = _DEFAULT_GEMINI_ALLOWED_TOOLS
     claude_binary: str = "claude"
+    claude_cli_auth_mode: str = "api_key"
     jules_enabled: bool = False
     jules_api_url: str | None = None
     jules_api_key: str | None = None
@@ -685,6 +686,14 @@ class CodexWorkerConfig:
         else:
             gemini_allowed_tools = tuple(
                 cls._normalize_runtime_option_values(str(gemini_allowed_tools_raw))
+            )
+        claude_cli_auth_mode = (
+            str(source.get("MOONMIND_CLAUDE_CLI_AUTH_MODE", "api_key")).strip().lower()
+            or "api_key"
+        )
+        if claude_cli_auth_mode not in {"api_key", "oauth"}:
+            raise ValueError(
+                "MOONMIND_CLAUDE_CLI_AUTH_MODE must be one of: api_key, oauth"
             )
         claude_binary = (
             str(source.get("MOONMIND_CLAUDE_BINARY", "claude")).strip() or "claude"
@@ -1058,6 +1067,7 @@ class CodexWorkerConfig:
             gemini_cli_auth_mode=gemini_cli_auth_mode,
             gemini_allowed_tools=gemini_allowed_tools,
             claude_binary=claude_binary,
+            claude_cli_auth_mode=claude_cli_auth_mode,
             jules_enabled=jules_gate.enabled,
             jules_api_url=jules_api_url,
             jules_api_key=jules_api_key,
@@ -10124,34 +10134,64 @@ class CodexWorker:
         *,
         runtime_mode: str,
     ) -> Mapping[str, str] | None:
-        if runtime_mode != "gemini_cli":
+        if runtime_mode not in {"gemini_cli", "claude"}:
             return None
-        if self._config.gemini_cli_auth_mode != "oauth":
-            return None
-        gemini_home = str(
-            environ.get("GEMINI_CLI_HOME") or environ.get("GEMINI_HOME") or ""
-        ).strip()
-        if not gemini_home:
-            logger.warning(
-                "MOONMIND_GEMINI_CLI_AUTH_MODE=oauth is set but GEMINI_CLI_HOME/GEMINI_HOME "
-                "is missing; retaining API key variables for Gemini runtime command auth.",
-                extra={"gemini_cli_auth_mode": self._config.gemini_cli_auth_mode},
-            )
-            return None
-        if not Path(gemini_home).is_dir() or not os.access(
-            gemini_home, os.W_OK | os.X_OK
-        ):
-            logger.warning(
-                "Gemini auth home is not a writable directory; retaining API key variables "
-                "for Gemini runtime command auth.",
-                gemini_home,
-                extra={"gemini_cli_auth_mode": self._config.gemini_cli_auth_mode},
-            )
-            return None
-        env = dict(environ)
-        env.pop("GEMINI_API_KEY", None)
-        env.pop("GOOGLE_API_KEY", None)
-        return env
+
+        if runtime_mode == "gemini_cli":
+            if self._config.gemini_cli_auth_mode != "oauth":
+                return None
+            gemini_home = str(
+                environ.get("GEMINI_CLI_HOME") or environ.get("GEMINI_HOME") or ""
+            ).strip()
+            if not gemini_home:
+                logger.warning(
+                    "MOONMIND_GEMINI_CLI_AUTH_MODE=oauth is set but GEMINI_CLI_HOME/GEMINI_HOME "
+                    "is missing; retaining API key variables for Gemini runtime command auth.",
+                    extra={"gemini_cli_auth_mode": self._config.gemini_cli_auth_mode},
+                )
+                return None
+            if not Path(gemini_home).is_dir() or not os.access(
+                gemini_home, os.W_OK | os.X_OK
+            ):
+                logger.warning(
+                    "Gemini auth home is not a writable directory; retaining API key variables "
+                    "for Gemini runtime command auth.",
+                    gemini_home,
+                    extra={"gemini_cli_auth_mode": self._config.gemini_cli_auth_mode},
+                )
+                return None
+            env = dict(environ)
+            env.pop("GEMINI_API_KEY", None)
+            env.pop("GOOGLE_API_KEY", None)
+            return env
+
+        if runtime_mode == "claude":
+            if self._config.claude_cli_auth_mode != "oauth":
+                return None
+            claude_home = str(
+                environ.get("CLAUDE_HOME") or ""
+            ).strip()
+            if not claude_home:
+                logger.warning(
+                    "MOONMIND_CLAUDE_CLI_AUTH_MODE=oauth is set but CLAUDE_HOME "
+                    "is missing; retaining API key variables for Claude runtime command auth.",
+                    extra={"claude_cli_auth_mode": self._config.claude_cli_auth_mode},
+                )
+                return None
+            if not Path(claude_home).is_dir() or not os.access(
+                claude_home, os.W_OK | os.X_OK
+            ):
+                logger.warning(
+                    "Claude auth home is not a writable directory; retaining API key variables "
+                    "for Claude runtime command auth.",
+                    claude_home,
+                    extra={"claude_cli_auth_mode": self._config.claude_cli_auth_mode},
+                )
+                return None
+            env = dict(environ)
+            env.pop("ANTHROPIC_API_KEY", None)
+            env.pop("CLAUDE_API_KEY", None)
+            return env
 
     def _ensure_jules_runtime_enabled(self) -> None:
         """Validate Jules runtime settings before executing delegated steps."""

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1914,6 +1914,23 @@ class AppSettings(BaseSettings):
         description="Compatibility passthrough for legacy Gemini auth home.",
         exclude=True,
     )
+    moonmind_claude_cli_auth_mode: Optional[str] = Field(
+        None,
+        env="MOONMIND_CLAUDE_CLI_AUTH_MODE",
+        validation_alias=AliasChoices(
+            "moonmind_claude_cli_auth_mode",
+            "MOONMIND_CLAUDE_CLI_AUTH_MODE",
+        ),
+        description="Compatibility passthrough for legacy Claude CLI auth mode.",
+        exclude=True,
+    )
+    claude_home: Optional[str] = Field(
+        None,
+        env="CLAUDE_HOME",
+        validation_alias=AliasChoices("claude_home", "CLAUDE_HOME"),
+        description="Compatibility passthrough for legacy Claude auth home.",
+        exclude=True,
+    )
 
     # Default providers and models
     default_chat_provider: str = Field("google", env="DEFAULT_CHAT_PROVIDER")

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -5912,6 +5912,7 @@ async def test_config_from_env_defaults_and_overrides(monkeypatch) -> None:
     monkeypatch.setenv("MOONMIND_SKILL_POLICY_MODE", "allowlist")
     monkeypatch.setenv("MOONMIND_GIT_USER_NAME", "Nate Sticco")
     monkeypatch.setenv("MOONMIND_GIT_USER_EMAIL", "nsticco@gmail.com")
+    monkeypatch.setenv("MOONMIND_CLAUDE_CLI_AUTH_MODE", "oauth")
 
     config = CodexWorkerConfig.from_env()
 
@@ -5923,6 +5924,7 @@ async def test_config_from_env_defaults_and_overrides(monkeypatch) -> None:
     assert str(config.workdir) == "/tmp/moonmind-worker"
     assert config.default_codex_model == "gpt-5-codex"
     assert config.default_codex_effort == "high"
+    assert config.claude_cli_auth_mode == "oauth"
     assert config.skill_policy_mode == "allowlist"
     assert config.worker_capabilities == ("codex", "git")
     assert config.docker_binary == "docker"
@@ -6048,6 +6050,7 @@ async def test_config_from_env_uses_defaults(monkeypatch) -> None:
     monkeypatch.delenv("MOONMIND_SKILL_POLICY_MODE", raising=False)
     monkeypatch.delenv("WORKFLOW_SKILL_POLICY_MODE", raising=False)
     monkeypatch.delenv("SKILL_POLICY_MODE", raising=False)
+    monkeypatch.delenv("MOONMIND_CLAUDE_CLI_AUTH_MODE", raising=False)
 
     config = CodexWorkerConfig.from_env()
 
@@ -6060,6 +6063,7 @@ async def test_config_from_env_uses_defaults(monkeypatch) -> None:
     assert config.allowed_skills == ("auto",)
     assert config.default_codex_model is None
     assert config.default_codex_effort is None
+    assert config.claude_cli_auth_mode == "api_key"
     assert config.legacy_job_types_enabled is True
     assert config.worker_runtime == "codex"
     assert config.allowed_types == ("task", "codex_exec", "codex_skill")

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -30,6 +30,20 @@ def get_pr_comments_module() -> dict[str, Any]:
 
 
 @pytest.fixture
+def get_branch_pr_comments_module() -> dict[str, Any]:
+    return _load_module(
+        str(
+            REPO_ROOT
+            / ".agents"
+            / "skills"
+            / "fix-comments"
+            / "tools"
+            / "get_branch_pr_comments.py"
+        )
+    )
+
+
+@pytest.fixture
 def pr_resolve_snapshot_module() -> dict[str, Any]:
     return _load_module(
         str(
@@ -135,6 +149,48 @@ def test_infer_repo_from_pr_url_returns_none_for_invalid_url(
     assert infer_repo("") is None
     assert infer_repo("not a url") is None
     assert infer_repo("https://github.com/org") is None
+
+
+def test_get_branch_pr_comments_run_json_command_ignores_stderr_warnings(
+    get_branch_pr_comments_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_json_command = get_branch_pr_comments_module["run_json_command"]
+
+    class _Completed:
+        returncode = 0
+        stdout = '{"ok": true, "count": 2}'
+        stderr = "Warning: transient GraphQL issue ignored"
+
+    monkeypatch.setattr(
+        get_branch_pr_comments_module["subprocess"],
+        "run",
+        lambda *args, **kwargs: _Completed(),
+    )
+
+    payload = run_json_command(["fake", "command"], "failure hint")
+    assert payload == {"ok": True, "count": 2}
+
+
+def test_pr_resolve_snapshot_run_command_ignores_stderr_warnings(
+    pr_resolve_snapshot_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_command = pr_resolve_snapshot_module["run_command"]
+
+    class _Completed:
+        returncode = 0
+        stdout = '{"ok": true, "result": "ready"}'
+        stderr = "Warning: retryable network issue recovered"
+
+    monkeypatch.setattr(
+        pr_resolve_snapshot_module["subprocess"],
+        "run",
+        lambda *args, **kwargs: _Completed(),
+    )
+
+    payload = run_command(["fake", "snapshot"], "failure hint")
+    assert payload == {"ok": True, "result": "ready"}
 
 
 def test_review_bot_comments_are_actionable_by_default(
@@ -509,4 +565,3 @@ def test_summarize_ci_head_checks_propagate_failures(
     assert summary["nonSecurityCheckCount"] == 1
     assert len(summary["failedChecks"]) == 1
     assert summary["failedChecks"][0]["name"] == "test"
-


### PR DESCRIPTION
This implements the `claude_cli_auth_mode` configuration for managed agents, ensuring that when the Claude runtime is configured to use `oauth`, it correctly requires a valid `CLAUDE_HOME` and explicitly drops `ANTHROPIC_API_KEY` and `CLAUDE_API_KEY` from the execution environment to prevent silent fallback to key-based auth. This fully aligns the Claude implementation with the Gemini CLI authentication architecture documented in ManagedAgentsAuthentication.md.

---
*PR created automatically by Jules for task [4582438183876041327](https://jules.google.com/task/4582438183876041327) started by @nsticco*