### PR TITLE
feat: multi-step Jules workflow via sendMessage API

### DIFF
--- a/docs/ExternalAgents/JulesClientAdapter.md
+++ b/docs/ExternalAgents/JulesClientAdapter.md
@@ -266,7 +266,106 @@ The auto-merge step is **best-effort**:
 | `JulesClient.merge_pull_request()` | `PUT` merge a GitHub PR |
 | `JulesClient.update_pull_request_base()` | `PATCH` a PR's base (target) branch |
 
-## 7. Relationship to the Universal External Adapter Plan
+## 7. Multi-Step Workflow Execution
+
+### 7.1 Problem
+
+When a MoonMind plan contains multiple steps that target Jules, the current system creates an independent Jules session per step. Each session has no context of prior steps — it cannot see what was changed, why, or what the broader plan looks like. This leads to:
+
+- No shared context between steps (step 2 does not know what step 1 did)
+- One session per step (N billing events for an N-step plan)
+- No accumulated file changes (each session starts from the same branch snapshot)
+- Multiple independent PRs instead of one cohesive PR
+
+### 7.2 Solution: `sendMessage`-Based Multi-Turn Sessions
+
+The Jules API exposes a `sendMessage` endpoint that allows additional prompts to be sent to an existing session:
+
+```
+POST https://jules.googleapis.com/v1alpha/{session=sessions/*}:sendMessage
+{ "prompt": string }
+```
+
+MoonMind uses this to treat a multi-step Jules plan as a **single long-lived session** with multiple turns:
+
+1. **Step 1**: `sessions.create` with the first step's prompt → poll until `COMPLETED`
+2. **Step N** (for each subsequent step): `sessions.sendMessage` with the next step's prompt → poll until `COMPLETED` again
+3. **Final**: the session's accumulated changes produce one PR
+
+This keeps Jules's full working context (file changes, conversation, reasoning) across all steps in a single session.
+
+### 7.3 Session Lifecycle
+
+```
+Step 1: sessions.create(prompt=step_1_instructions)
+  ↓ Jules: QUEUED → PLANNING → IN_PROGRESS → COMPLETED
+  ↓ MoonMind detects COMPLETED, checks if more steps remain
+  ↓
+Step 2: sessions.sendMessage(prompt=step_2_instructions)
+  ↓ Jules: COMPLETED → QUEUED/IN_PROGRESS → COMPLETED
+  ↓ MoonMind detects COMPLETED, checks if more steps remain
+  ↓
+ ... (repeat for each remaining step)
+  ↓
+Final: all steps COMPLETED → mark workflow as succeeded
+```
+
+**Key state transitions:**
+
+| Event | MoonMind action |
+|-------|----------------|
+| Session reaches `COMPLETED` and more steps remain | Call `sendMessage` with next step's prompt, resume polling |
+| Session reaches `COMPLETED` and no steps remain | Mark workflow as succeeded, extract PR URL |
+| Session reaches `FAILED` at any step | Mark workflow as failed, stop sending steps |
+| Session reaches `AWAITING_USER_FEEDBACK` | Continue polling (maps to `running` in MoonMind) |
+
+### 7.4 Transport Layer
+
+A new `send_message()` method on `JulesClient` handles the `sendMessage` API call:
+
+| Method | API | Purpose |
+|--------|-----|---------|
+| `JulesClient.send_message()` | `POST /sessions/{id}:sendMessage` | Send follow-up prompt to existing session |
+
+Request model:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `session_id` | `str` | ID of the existing session |
+| `prompt` | `str` | The next step's instructions |
+
+The response body is empty on success. After calling `sendMessage`, the caller must resume polling `sessions.get` to track the session's state through its next execution cycle.
+
+### 7.5 Adapter Layer
+
+The adapter layer decides whether to use `create_task` or `send_message` based on whether the request includes a `session_id` from a prior step:
+
+- **First step**: No `session_id` → `do_start()` calls `create_task()` → returns handle with the new `session_id`
+- **Subsequent steps**: Has `session_id` → `do_continue()` calls `send_message()` → returns updated handle reusing the same `session_id`
+
+### 7.6 Workflow Orchestration
+
+Multi-step Jules dispatch is coordinated by `MoonMind.AgentRun` (or `MoonMind.Run`'s execution loop):
+
+1. The workflow receives the ordered list of plan steps.
+2. For the first Jules step, it dispatches via `integration.jules.start` as today.
+3. After Jules completes step 1, the workflow checks whether more Jules steps remain in the plan.
+4. If yes, it calls `integration.jules.send_message` with the next step's prompt and the existing `session_id`, then resumes polling.
+5. This repeats until all steps complete or a step fails.
+6. Only after the final step completes does the workflow mark the run as succeeded.
+
+### 7.7 Error Handling
+
+- **Step failure**: If Jules reaches `FAILED` at any step, the workflow stops sending further steps and marks the run as failed. The PR (if any) reflects partial progress.
+- **`sendMessage` transport failure**: Retried using the same retry policy as `create_task`. If retries exhaust, the workflow fails.
+- **Session not resumable**: If `sendMessage` returns a `4xx` error (session is in a non-resumable state), the workflow fails with a clear error.
+- **Cancellation mid-step**: If the workflow is cancelled while waiting for Jules to complete an intermediate step, the existing cancel path via `resolve_task` is used.
+
+### 7.8 Single-Step Backward Compatibility
+
+When a plan has only one Jules step, the flow is identical to the current behavior — `create_task`, poll, fetch result. No `sendMessage` call is made.
+
+## 8. Relationship to the Universal External Adapter Plan
 
 Jules should be the reference provider when extracting a reusable external-adapter base.
 
@@ -289,7 +388,7 @@ That means future refactoring should aim to preserve this separation:
 
 If a future provider requires materially different behavior, it should justify that divergence explicitly rather than silently bypassing the shared pattern.
 
-## 8. MCP Tooling Posture
+## 9. MCP Tooling Posture
 
 Earlier descriptions made Jules MCP tooling look like a separate architectural layer equal to the adapter and workflow lifecycle. That framing is misleading.
 
@@ -301,7 +400,7 @@ The correct posture is:
 
 `JulesToolRegistry` is therefore an adjunct surface, not the core Jules architecture.
 
-## 9. Implementation Guidance
+## 10. Implementation Guidance
 
 To align Jules with the shared external-agent design, the practical next steps are:
 
@@ -311,7 +410,7 @@ To align Jules with the shared external-agent design, the practical next steps a
 4. Ensure workflow orchestration remains in `MoonMind.AgentRun`, not in Jules-specific code.
 5. Ensure MCP, dashboard, and REST surfaces consume the same Jules normalization and runtime-gate logic.
 
-## 10. Summary
+## 11. Summary
 
 Jules should no longer be described as a separate "4-layer integration."
 

--- a/moonmind/schemas/jules_models.py
+++ b/moonmind/schemas/jules_models.py
@@ -133,6 +133,18 @@ class JulesGetTaskRequest(BaseModel):
     task_id: str = Field(..., alias="taskId")
 
 
+class JulesSendMessageRequest(BaseModel):
+    """Request payload for sending a follow-up message to an existing Jules session.
+
+    See: https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/sendMessage
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    session_id: str = Field(..., alias="sessionId")
+    prompt: str = Field(..., alias="prompt", min_length=1)
+
+
 class PullRequest(BaseModel):
     """A pull request created by a Jules session.
 
@@ -309,6 +321,7 @@ __all__ = [
     "JulesIntegrationStatusResult",
     "JulesResolveTaskRequest",
     "JulesGetTaskRequest",
+    "JulesSendMessageRequest",
     "JulesTaskResponse",
     "JulesNormalizedStatus",
     "SourceContext",

--- a/moonmind/workflows/adapters/jules_agent_adapter.py
+++ b/moonmind/workflows/adapters/jules_agent_adapter.py
@@ -16,6 +16,7 @@ from moonmind.schemas.jules_models import (
     JulesCreateTaskRequest,
     JulesGetTaskRequest,
     JulesResolveTaskRequest,
+    JulesSendMessageRequest,
     JulesTaskResponse,
     SourceContext,
     normalize_jules_status,
@@ -127,6 +128,24 @@ class JulesAgentAdapter(BaseExternalAgentAdapter):
             provider_status=provider_status,
             normalized_status=normalized_status,
             external_url=str(response.url or "").strip() or None,
+        )
+
+    async def send_message(self, *, run_id: str, prompt: str) -> AgentRunStatus:
+        """Send a follow-up prompt to an existing Jules session.
+
+        Used for multi-step workflows: resumes the session with new
+        instructions instead of creating a new session.  Returns a
+        running status since the session is now actively processing.
+        """
+        await self._client.send_message(
+            JulesSendMessageRequest(sessionId=run_id, prompt=prompt)
+        )
+        return self.build_status(
+            run_id=run_id,
+            agent_id="jules",
+            status="running",
+            provider_status="IN_PROGRESS",
+            normalized_status="running",
         )
 
     async def do_status(self, run_id: str) -> AgentRunStatus:

--- a/moonmind/workflows/adapters/jules_client.py
+++ b/moonmind/workflows/adapters/jules_client.py
@@ -21,6 +21,7 @@ from moonmind.schemas.jules_models import (
     JulesIntegrationStartResult,
     JulesIntegrationStatusResult,
     JulesResolveTaskRequest,
+    JulesSendMessageRequest,
     JulesTaskResponse,
     normalize_jules_status,
 )
@@ -98,6 +99,19 @@ class JulesClient:
             json=request.model_dump(by_alias=True, mode="json", exclude_none=True),
         )
         return JulesTaskResponse.model_validate(data)
+
+    async def send_message(self, request: JulesSendMessageRequest) -> None:
+        """Send a follow-up prompt to an existing Jules session.
+
+        Used for multi-step workflows: after a session reaches COMPLETED,
+        this resumes it with new instructions.  The Jules API returns an
+        empty body on success; callers must resume polling ``get_task()``
+        to track the session through its next execution cycle.
+
+        See: https://developers.google.com/jules/api/reference/rest/v1alpha/sessions/sendMessage
+        """
+        path = f"/sessions/{request.session_id}:sendMessage"
+        await self._post_json_empty(path, json={"prompt": request.prompt})
 
     async def resolve_task(self, request: JulesResolveTaskRequest) -> JulesTaskResponse:
         data = await self._post_json(
@@ -456,6 +470,12 @@ class JulesClient:
     async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
         return await self._request_with_retry("POST", path, json=json)
 
+    async def _post_json_empty(self, path: str, *, json: dict[str, Any]) -> None:
+        """POST expecting an empty (or ignored) response body."""
+        await self._request_with_retry(
+            "POST", path, json=json, allow_empty_response=True
+        )
+
     async def _get_json(self, path: str) -> dict[str, Any]:
         return await self._request_with_retry("GET", path)
 
@@ -465,12 +485,15 @@ class JulesClient:
         path: str,
         *,
         json: dict[str, Any] | None = None,
+        allow_empty_response: bool = False,
     ) -> dict[str, Any]:
         last_error: Exception | None = None
         for attempt in range(1, self._retry_attempts + 1):
             try:
                 response = await self._client.request(method, path, json=json)
                 response.raise_for_status()
+                if allow_empty_response and not response.content.strip():
+                    return {}
                 payload = response.json()
                 if isinstance(payload, dict):
                     return payload

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -72,6 +72,25 @@ async def jules_cancel_activity(run_id: str) -> AgentRunStatus:
     return await adapter.cancel(run_id)
 
 
+@activity.defn(name="integration.jules.send_message")
+async def jules_send_message_activity(payload: dict) -> AgentRunStatus:
+    """Send a follow-up prompt to an existing Jules session.
+
+    Used for multi-step workflows: resumes the session with new
+    instructions instead of creating a new session.
+
+    Accepts a dict with:
+    - ``session_id`` (str): the Jules session ID to send a message to
+    - ``prompt`` (str): the follow-up prompt/instructions to send
+    """
+
+    adapter = _build_adapter()
+    return await adapter.send_message(
+        run_id=payload["session_id"],
+        prompt=payload["prompt"],
+    )
+
+
 @activity.defn(name="integration.jules.merge_pr")
 async def jules_merge_pr_activity(payload: dict) -> JulesIntegrationMergePRResult:
     """Auto-merge a Jules-created PR into its target branch via GitHub API.
@@ -119,6 +138,7 @@ __all__ = [
     "jules_cancel_activity",
     "jules_fetch_result_activity",
     "jules_merge_pr_activity",
+    "jules_send_message_activity",
     "jules_start_activity",
     "jules_status_activity",
 ]

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -83,11 +83,23 @@ async def jules_send_message_activity(payload: dict) -> AgentRunStatus:
     - ``session_id`` (str): the Jules session ID to send a message to
     - ``prompt`` (str): the follow-up prompt/instructions to send
     """
+    from pydantic import BaseModel, Field, ValidationError
+
+    class _SendMessagePayload(BaseModel):
+        session_id: str = Field(min_length=1)
+        prompt: str = Field(min_length=1)
+
+    try:
+        validated = _SendMessagePayload.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError(
+            f"Invalid payload for jules_send_message_activity: {exc}"
+        ) from exc
 
     adapter = _build_adapter()
     return await adapter.send_message(
-        run_id=payload["session_id"],
-        prompt=payload["prompt"],
+        run_id=validated.session_id,
+        prompt=validated.prompt,
     )
 
 

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -502,6 +502,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="integration.jules.send_message",
+            family="integration",
+            capability_class="integration:jules",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 300),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=120),
+        ),
+        TemporalActivityDefinition(
             activity_type="integration.codex_cloud.start",
             family="integration",
             capability_class="integration:codex_cloud",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1696,6 +1696,63 @@ class TemporalIntegrationActivities:
 
         return await client.merge_pull_request(pr_url=pr_url)
 
+    async def integration_jules_send_message(
+        self,
+        *,
+        session_id: str,
+        prompt: str,
+        principal: str | None = None,
+        execution_ref: ExecutionRef | dict[str, Any] | None = None,
+    ) -> IntegrationStatusResult:
+        """Send a follow-up prompt to an existing Jules session.
+
+        Used for multi-step workflows: resumes the session with new
+        instructions instead of creating a new session.
+        """
+        if not session_id or not session_id.strip():
+            raise TemporalActivityRuntimeError(
+                "integration.jules.send_message requires a non-empty session_id"
+            )
+        if not prompt or not prompt.strip():
+            raise TemporalActivityRuntimeError(
+                "integration.jules.send_message requires a non-empty prompt"
+            )
+
+        result = await self._adapter.send_message(
+            run_id=session_id,
+            prompt=prompt,
+        )
+        status_snapshot = self._status_snapshot(
+            str(result.metadata.get("providerStatus") or "running")
+        )
+
+        tracking_ref = None
+        if self._artifact_service is not None and principal is not None:
+            tracking_ref = await _write_json_artifact(
+                self._artifact_service,
+                principal=principal,
+                payload={
+                    "activity": "integration.jules.send_message",
+                    "sessionId": session_id,
+                    "providerStatus": status_snapshot.provider_status,
+                    "normalizedStatus": status_snapshot.normalized_status,
+                },
+                execution_ref=execution_ref,
+                metadata_json={
+                    "name": "jules_send_message.json",
+                    "producer": "activity:integration.jules.send_message",
+                    "labels": ["integration", "jules", "send_message"],
+                },
+            )
+
+        return IntegrationStatusResult(
+            external_id=session_id,
+            status=status_snapshot.provider_status,
+            tracking_ref=tracking_ref,
+            normalized_status=status_snapshot.normalized_status,
+            provider_status=status_snapshot.provider_status,
+        )
+
     # ---- Codex Cloud integration handlers ----
 
     @staticmethod

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -195,6 +195,7 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     ),
     "integration.jules.cancel": ("integrations", "integration_jules_cancel"),
     "integration.jules.merge_pr": ("integrations", "integration_jules_merge_pr"),
+    "integration.jules.send_message": ("integrations", "integration_jules_send_message"),
     "agent_runtime.launch": ("agent_runtime", "agent_runtime_launch"),
     "integration.codex_cloud.start": ("integrations", "integration_codex_cloud_start"),
     "integration.codex_cloud.status": ("integrations", "integration_codex_cloud_status"),

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -299,11 +299,17 @@ class MoonMindAgentRun:
                         # to the existing session instead of creating a new one.
                         jules_session_id = (request.parameters or {}).get("jules_session_id")
                         if jules_session_id and validated_id == "jules":
+                            prompt = (request.instruction_ref or "").strip()
+                            if not prompt:
+                                raise ApplicationError(
+                                    "Jules continuation step requires a non-empty instruction_ref (prompt)",
+                                    non_retryable=True,
+                                )
                             await workflow.execute_activity(
                                 "integration.jules.send_message",
                                 {
                                     "session_id": jules_session_id,
-                                    "prompt": request.instruction_ref or "",
+                                    "prompt": prompt,
                                 },
                                 task_queue=INTEGRATIONS_TASK_QUEUE,
                                 start_to_close_timeout=INTEGRATIONS_ACTIVITY_TIMEOUT,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -293,39 +293,59 @@ class MoonMindAgentRun:
                         adapter = None
                         skip_poll_and_fetch = True
                     else:
-                        # Start via Temporal activity on the integrations fleet
-                        # (determinism-safe: no adapter construction in-workflow).
-                        handle_dict = await workflow.execute_activity(
-                            f"integration.{validated_id}.start",
-                            request,
-                            task_queue=INTEGRATIONS_TASK_QUEUE,
-                            start_to_close_timeout=INTEGRATIONS_ACTIVITY_TIMEOUT,
-                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                        )
-
-                        if isinstance(handle_dict, dict) and "external_id" in handle_dict:
-                            status = handle_dict.get("normalized_status", "unknown")
-                            if status not in {"queued", "launching", "running", "awaiting_callback", "awaiting_approval", "intervention_requested", "collecting_results", "completed", "failed", "cancelled", "timed_out"}:
-                                status = "running"
-                            handle = AgentRunHandle(
-                                runId=handle_dict["external_id"],
-                                agentKind="external",
-                                agentId=validated_id,
-                                status=status,
-                                startedAt=workflow.now(),
-                                metadata={
-                                    "providerStatus": handle_dict.get("provider_status", "unknown"),
-                                    "normalizedStatus": status,
-                                    "externalUrl": handle_dict.get("url"),
-                                    "callbackSupported": handle_dict.get("callback_supported", False),
-                                }
+                        # --- Multi-step Jules support ---
+                        # If a jules_session_id is provided in request.parameters,
+                        # this is a continuation step: send a follow-up message
+                        # to the existing session instead of creating a new one.
+                        jules_session_id = (request.parameters or {}).get("jules_session_id")
+                        if jules_session_id and validated_id == "jules":
+                            await workflow.execute_activity(
+                                "integration.jules.send_message",
+                                {
+                                    "session_id": jules_session_id,
+                                    "prompt": request.instruction_ref or "",
+                                },
+                                task_queue=INTEGRATIONS_TASK_QUEUE,
+                                start_to_close_timeout=INTEGRATIONS_ACTIVITY_TIMEOUT,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
                             )
+                            self.run_id = jules_session_id
+                            self.run_status = "running"
+                            poll_interval = 15
                         else:
-                            handle = AgentRunHandle(**handle_dict) if isinstance(handle_dict, dict) else handle_dict
+                            # Start via Temporal activity on the integrations fleet
+                            # (determinism-safe: no adapter construction in-workflow).
+                            handle_dict = await workflow.execute_activity(
+                                f"integration.{validated_id}.start",
+                                request,
+                                task_queue=INTEGRATIONS_TASK_QUEUE,
+                                start_to_close_timeout=INTEGRATIONS_ACTIVITY_TIMEOUT,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
 
-                        self.run_id = handle.run_id
-                        self.run_status = handle.status
-                        poll_interval = handle.poll_hint_seconds or 10
+                            if isinstance(handle_dict, dict) and "external_id" in handle_dict:
+                                status = handle_dict.get("normalized_status", "unknown")
+                                if status not in {"queued", "launching", "running", "awaiting_callback", "awaiting_approval", "intervention_requested", "collecting_results", "completed", "failed", "cancelled", "timed_out"}:
+                                    status = "running"
+                                handle = AgentRunHandle(
+                                    runId=handle_dict["external_id"],
+                                    agentKind="external",
+                                    agentId=validated_id,
+                                    status=status,
+                                    startedAt=workflow.now(),
+                                    metadata={
+                                        "providerStatus": handle_dict.get("provider_status", "unknown"),
+                                        "normalizedStatus": status,
+                                        "externalUrl": handle_dict.get("url"),
+                                        "callbackSupported": handle_dict.get("callback_supported", False),
+                                    }
+                                )
+                            else:
+                                handle = AgentRunHandle(**handle_dict) if isinstance(handle_dict, dict) else handle_dict
+
+                            self.run_id = handle.run_id
+                            self.run_status = handle.status
+                            poll_interval = handle.poll_hint_seconds or 10
                         adapter = None  # External ops route through activities, not adapter
                 else:
                     raise ValueError(f"Unknown agent kind: {request.agent_kind}")
@@ -413,6 +433,17 @@ class MoonMindAgentRun:
                     if "diagnosticsRef" in enriched_result and "diagnostics_ref" in enriched_result:
                         del enriched_result["diagnostics_ref"]
                     self.final_result = AgentRunResult(**enriched_result)
+
+                # Inject run_id into result metadata so the parent
+                # workflow (MoonMind.Run) can track it for multi-step
+                # Jules session reuse across plan nodes.
+                if self.run_id and hasattr(self.final_result, "metadata"):
+                    result_meta = dict(self.final_result.metadata or {})
+                    result_meta["jules_session_id"] = self.run_id
+                    self.final_result = self.final_result.model_copy(
+                        update={"metadata": result_meta}
+                    )
+
                 return self.final_result
 
         except asyncio.TimeoutError:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -472,14 +472,12 @@ class MoonMindRunWorkflow:
                         task_queue=WORKFLOW_TASK_QUEUE,
                     )
                     execution_result = self._map_agent_run_result(child_result)
-                    # --- Multi-step Jules: extract session_id from result ---
-                    if request.agent_id == "jules":
-                        extracted_id = self._extract_jules_session_id(child_result)
-                        if extracted_id:
-                            jules_session_id = extracted_id
                 except Exception:
                     if failure_mode == "FAIL_FAST":
                         raise
+                    # Clear session on failure so later Jules steps start fresh.
+                    if "request" in dir() and getattr(request, "agent_id", None) == "jules":
+                        jules_session_id = None
                     continue
 
             elif tool_type == "skill":
@@ -558,7 +556,16 @@ class MoonMindRunWorkflow:
                     raise ValueError(
                         f"plan node execution returned status {result_status}{detail}"
                     )
+                # Clear session on failure so later Jules steps start fresh.
+                if tool_type == "agent_runtime" and node_inputs.get("runtime", {}).get("mode") == "jules":
+                    jules_session_id = None
                 continue
+
+            # --- Multi-step Jules: extract session_id only on success ---
+            if tool_type == "agent_runtime":
+                extracted_id = self._extract_jules_session_id(child_result)
+                if extracted_id:
+                    jules_session_id = extracted_id
             if require_pull_request_url and pull_request_url is None:
                 pull_request_url = self._extract_pull_request_url(execution_result)
                 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -391,6 +391,13 @@ class MoonMindRunWorkflow:
         pull_request_url: str | None = None
         skill_definitions_by_key: dict[tuple[str, str], Any] = {}
 
+        # Track the Jules session ID across plan nodes for multi-step
+        # session reuse.  After the first Jules step completes, its
+        # session_id is extracted from the result metadata.  Subsequent
+        # Jules steps receive this ID so MoonMind.AgentRun calls
+        # sendMessage instead of creating a new session.
+        jules_session_id: str | None = None
+
         if registry_snapshot_ref:
             registry_payload = await workflow.execute_activity(
                 "artifact.read",
@@ -448,6 +455,16 @@ class MoonMindRunWorkflow:
                         node_id=node_id,
                         tool_name=tool_name,
                     )
+                    # --- Multi-step Jules: inject session_id for continuation ---
+                    if jules_session_id and request.agent_id == "jules":
+                        request = request.model_copy(
+                            update={
+                                "parameters": {
+                                    **request.parameters,
+                                    "jules_session_id": jules_session_id,
+                                }
+                            }
+                        )
                     child_result = await workflow.execute_child_workflow(
                         "MoonMind.AgentRun",
                         request,
@@ -455,6 +472,11 @@ class MoonMindRunWorkflow:
                         task_queue=WORKFLOW_TASK_QUEUE,
                     )
                     execution_result = self._map_agent_run_result(child_result)
+                    # --- Multi-step Jules: extract session_id from result ---
+                    if request.agent_id == "jules":
+                        extracted_id = self._extract_jules_session_id(child_result)
+                        if extracted_id:
+                            jules_session_id = extracted_id
                 except Exception:
                     if failure_mode == "FAIL_FAST":
                         raise
@@ -730,6 +752,15 @@ class MoonMindRunWorkflow:
             "status": status,
             "outputs": outputs,
         }
+
+    @staticmethod
+    def _extract_jules_session_id(result: Any) -> str | None:
+        """Extract the Jules session ID from an ``AgentRunResult`` for multi-step reuse."""
+        if isinstance(result, dict):
+            metadata = result.get("metadata") or {}
+        else:
+            metadata = getattr(result, "metadata", {}) or {}
+        return metadata.get("jules_session_id")
 
     @staticmethod
     def _agent_kind_for_id(agent_id: str) -> str:

--- a/tests/integration/test_jules_integration.py
+++ b/tests/integration/test_jules_integration.py
@@ -91,7 +91,8 @@ def _step1_request() -> AgentExecutionRequest:
             "title": "[Integration Test] Multi-step lifecycle check",
             "description": (
                 "Add a single-line comment '# MoonMind integration test' "
-                "to the very top of README.md. Do not change anything else."
+                "to the very top of README.md. Do not change anything else. "
+                "Do not run any tests."
             ),
             "metadata": {
                 "origin": "multi-step-integration-test",
@@ -196,7 +197,7 @@ class TestJulesAdapterLifecycle:
             step2_prompt = (
                 "Now add a second comment line '# Multi-step test step 2' "
                 "directly below the line you just added. "
-                "Do not change anything else."
+                "Do not change anything else. Do not run any tests."
             )
 
             await adapter.send_message(

--- a/tests/integration/test_jules_integration.py
+++ b/tests/integration/test_jules_integration.py
@@ -1,4 +1,4 @@
-"""Integration test: real Jules API lifecycle via the universal adapter pattern.
+"""Integration test: real Jules API multi-step lifecycle via sendMessage.
 
 Requires ``JULES_API_KEY`` in the environment (or ``.env``).
 Skipped automatically when the key is absent.
@@ -6,10 +6,20 @@ Skipped automatically when the key is absent.
 Run manually::
 
     python -m pytest tests/integration/test_jules_integration.py -v -s
+
+This test creates a Jules session with a trivial prompt, polls until the
+session reaches a terminal state (``completed``), then sends a second
+prompt via ``sendMessage`` and polls again.  Both steps must reach a
+terminal state for the test to pass.
+
+**WARNING**: This test creates real Jules sessions against the configured
+repository and will consume Jules task quota.  Each session may create a
+real PR.  Use a test/scratch repository if possible.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
@@ -39,6 +49,14 @@ _JULES_API_URL = (
     or "https://jules.googleapis.com/v1alpha"
 )
 
+# Polling constants
+_POLL_INTERVAL_SECONDS = 15
+_MAX_POLL_MINUTES = 20  # generous ceiling per step
+_MAX_POLL_ITERATIONS = int(_MAX_POLL_MINUTES * 60 / _POLL_INTERVAL_SECONDS)
+
+# Terminal adapter statuses
+_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
 pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.integration,
@@ -52,13 +70,17 @@ def _build_adapter() -> JulesAgentAdapter:
     return JulesAgentAdapter(client_factory=lambda: client)
 
 
-def _integration_request() -> AgentExecutionRequest:
-    """Build a minimal AgentExecutionRequest for a Jules integration test."""
-    correlation_id = f"integ-test-{uuid.uuid4().hex[:8]}"
+def _step1_request() -> AgentExecutionRequest:
+    """Build a minimal request that should provoke the fastest Jules completion.
+
+    The prompt is intentionally trivial — we just want Jules to finish ASAP
+    so we can exercise the sendMessage → poll cycle.
+    """
+    correlation_id = f"multi-step-test-{uuid.uuid4().hex[:8]}"
     return AgentExecutionRequest(
         agentKind="external",
         agentId="jules",
-        executionProfileRef="profile:jules-integration-test",
+        executionProfileRef="profile:jules-multistep-integ-test",
         correlationId=correlation_id,
         idempotencyKey=f"idem-{correlation_id}",
         workspaceSpec={
@@ -66,85 +88,157 @@ def _integration_request() -> AgentExecutionRequest:
             "branch": "main",
         },
         parameters={
-            "title": "[Integration Test] MoonMind adapter lifecycle check",
+            "title": "[Integration Test] Multi-step lifecycle check",
             "description": (
-                "This is an automated MoonMind integration test for the "
-                "MoonLadderStudios/MoonMind repository. No action is needed — "
-                "this task will be cancelled automatically by the test harness."
+                "Add a single-line comment '# MoonMind integration test' "
+                "to the very top of README.md. Do not change anything else."
             ),
             "metadata": {
-                "origin": "integration-test",
+                "origin": "multi-step-integration-test",
                 "repo": "MoonLadderStudios/MoonMind",
             },
         },
     )
 
 
-class TestJulesAdapterLifecycle:
-    """End-to-end adapter lifecycle: start → status → cancel."""
+async def _poll_until_terminal(
+    adapter: JulesAgentAdapter,
+    run_id: str,
+    *,
+    step_label: str = "step",
+) -> AgentRunStatus:
+    """Poll the adapter until the session reaches a terminal state.
 
-    async def test_create_poll_and_cancel(self) -> None:
-        """Create a real Jules task, poll its status, and cancel it."""
+    Returns the final ``AgentRunStatus``.  Raises ``TimeoutError`` if
+    the maximum number of poll iterations is exceeded.
+    """
+    for i in range(1, _MAX_POLL_ITERATIONS + 1):
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        status: AgentRunStatus = await adapter.status(run_id)
+        normalized = status.status
+        logger.info(
+            "[%s] poll %d/%d — status=%s (provider=%s)",
+            step_label,
+            i,
+            _MAX_POLL_ITERATIONS,
+            normalized,
+            status.metadata.get("providerStatus", "?"),
+        )
+        if normalized in _TERMINAL_STATUSES:
+            return status
+
+    raise TimeoutError(
+        f"[{step_label}] Jules session {run_id} did not reach a terminal "
+        f"state after {_MAX_POLL_ITERATIONS} polls ({_MAX_POLL_MINUTES} min)"
+    )
+
+
+class TestJulesAdapterLifecycle:
+    """End-to-end multi-step lifecycle: start → poll → sendMessage → poll.
+
+    A single test covers the full adapter surface (start, status,
+    sendMessage, cancel) using one real Jules session to minimise quota
+    usage.
+    """
+
+    async def test_two_step_send_message_flow(self) -> None:
+        """Create a Jules task, wait for completion, send step 2, wait again.
+
+        This validates that:
+        1. A session can be created and polled to completion.
+        2. ``sendMessage`` can resume the session with a new prompt.
+        3. The resumed session can be polled to completion.
+        4. The session ID remains stable across both steps.
+        """
         adapter = _build_adapter()
-        request = _integration_request()
+        request = _step1_request()
         created_run_id: str | None = None
 
         try:
-            # ---- START ----
+            # ============================================================
+            # STEP 1: Create session and poll until done
+            # ============================================================
+            logger.info("=== STEP 1: Creating Jules session ===")
             handle: AgentRunHandle = await adapter.start(request)
             created_run_id = handle.run_id
 
-            logger.info("Jules task created: run_id=%s", handle.run_id)
-            logger.info("  status=%s", handle.status)
-            logger.info("  poll_hint_seconds=%s", handle.poll_hint_seconds)
-
+            logger.info(
+                "Jules session created: run_id=%s  status=%s",
+                handle.run_id,
+                handle.status,
+            )
             assert handle.run_id, "run_id must be non-empty"
             assert handle.status in {
                 "queued",
                 "running",
                 "awaiting_callback",
                 "completed",
-            }, f"unexpected status: {handle.status}"
+            }, f"unexpected initial status: {handle.status}"
             assert handle.poll_hint_seconds is not None, (
                 "poll_hint_seconds should be auto-populated from capability descriptor"
             )
 
-            # ---- STATUS ----
-            status: AgentRunStatus = await adapter.status(handle.run_id)
-
-            logger.info("Jules task status: %s", status.status)
-
-            assert status.run_id == handle.run_id
-            assert status.status in {
-                "queued",
-                "running",
-                "awaiting_callback",
-                "completed",
-                "failed",
-                "cancelled",
-            }, f"unexpected status: {status.status}"
-
-            # ---- CANCEL ----
-            cancel_result: AgentRunStatus = await adapter.cancel(handle.run_id)
-
+            step1_result = await _poll_until_terminal(
+                adapter, handle.run_id, step_label="step-1"
+            )
             logger.info(
-                "Jules task cancel result: status=%s metadata=%s",
-                cancel_result.status,
-                cancel_result.metadata,
+                "=== STEP 1 COMPLETE: status=%s ===", step1_result.status
+            )
+            assert step1_result.status == "completed", (
+                f"Step 1 ended with status={step1_result.status}, expected completed"
             )
 
-            # Cancel may or may not be accepted depending on task state
-            assert cancel_result.status in {
-                "cancelled",
-                "completed",
-                "failed",
-                "intervention_requested",
-            }, f"unexpected cancel status: {cancel_result.status}"
+            # ============================================================
+            # STEP 2: Send follow-up message and poll until done
+            # ============================================================
+            logger.info("=== STEP 2: Sending follow-up via sendMessage ===")
+
+            step2_prompt = (
+                "Now add a second comment line '# Multi-step test step 2' "
+                "directly below the line you just added. "
+                "Do not change anything else."
+            )
+
+            await adapter.send_message(
+                run_id=handle.run_id, prompt=step2_prompt
+            )
+            logger.info("sendMessage accepted — polling for step 2 completion")
+
+            step2_result = await _poll_until_terminal(
+                adapter, handle.run_id, step_label="step-2"
+            )
+            logger.info(
+                "=== STEP 2 COMPLETE: status=%s ===", step2_result.status
+            )
+            assert step2_result.status == "completed", (
+                f"Step 2 ended with status={step2_result.status}, expected completed"
+            )
+
+            # ---- Verify session ID stability ----
+            assert step2_result.run_id == handle.run_id, (
+                "Session ID must remain stable across steps"
+            )
+
+            logger.info(
+                "✅ Multi-step integration test PASSED — session %s "
+                "completed both steps successfully.",
+                handle.run_id,
+            )
 
         except Exception:
             if created_run_id:
                 logger.warning(
-                    "Test failed — Jules task %s may need manual cleanup",
+                    "Test failed — Jules session %s may need manual cleanup",
                     created_run_id,
                 )
+                # Best-effort cleanup: try to cancel/finish the session
+                try:
+                    await adapter.cancel(created_run_id)
+                    logger.info("Cleanup: cancelled session %s", created_run_id)
+                except Exception as cleanup_err:
+                    logger.warning(
+                        "Cleanup cancel failed for %s: %s",
+                        created_run_id,
+                        cleanup_err,
+                    )
             raise

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -26,6 +26,7 @@ class _FakeJulesAdapterClient:
         self.created: list[object] = []
         self.lookups: list[object] = []
         self.resolved: list[object] = []
+        self.sent_messages: list[object] = []
         self.closed_count = 0
 
     async def create_task(self, request):
@@ -56,6 +57,10 @@ class _FakeJulesAdapterClient:
 
     async def aclose(self):
         self.closed_count += 1
+
+    async def send_message(self, request):
+        self.sent_messages.append(request)
+        return None
 
 
 def _request(*, idempotency_key: str = "idem-1") -> AgentExecutionRequest:
@@ -242,4 +247,20 @@ async def test_start_defaults_automation_mode_for_branch_publish():
     assert len(client.created) == 1
     create_req = client.created[0]
     assert create_req.automation_mode == "AUTO_CREATE_PR"
+
+
+async def test_send_message_returns_running_status():
+    """send_message() should call the client and return a running status."""
+    client = _FakeJulesAdapterClient()
+    adapter = JulesAgentAdapter(client_factory=lambda: client)
+
+    status = await adapter.send_message(run_id="session-42", prompt="Continue with step 2.")
+
+    assert status.run_id == "session-42"
+    assert status.status == "running"
+    assert status.metadata["normalizedStatus"] == "running"
+    assert len(client.sent_messages) == 1
+    sent_req = client.sent_messages[0]
+    assert sent_req.session_id == "session-42"
+    assert sent_req.prompt == "Continue with step 2."
 

--- a/tests/unit/workflows/adapters/test_jules_client.py
+++ b/tests/unit/workflows/adapters/test_jules_client.py
@@ -392,3 +392,46 @@ async def test_aclose_skips_injected_client():
     # injected client should still be usable
     assert not injected.is_closed
     await injected.aclose()
+
+
+@pytest.mark.asyncio
+async def test_send_message_success():
+    """send_message() should POST to /sessions/{id}:sendMessage."""
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        assert request.method == "POST"
+        assert "/sessions/session-42:sendMessage" in request.url.path
+        body = json.loads(request.content)
+        assert body == {"prompt": "Continue with step 2."}
+        return httpx.Response(200, content=b"")
+
+    client = _make_client(handler)
+    from moonmind.schemas.jules_models import JulesSendMessageRequest
+
+    await client.send_message(
+        JulesSendMessageRequest(sessionId="session-42", prompt="Continue with step 2.")
+    )
+    assert len(captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_message_retries_on_503():
+    """send_message() should retry on 503."""
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            return httpx.Response(503)
+        return httpx.Response(200, content=b"")
+
+    client = _make_client(handler, retry_attempts=3, retry_delay_seconds=0.0)
+    from moonmind.schemas.jules_models import JulesSendMessageRequest
+
+    await client.send_message(
+        JulesSendMessageRequest(sessionId="session-42", prompt="retry prompt")
+    )
+    assert call_count == 3

--- a/tests/unit/workflows/temporal/test_jules_activities.py
+++ b/tests/unit/workflows/temporal/test_jules_activities.py
@@ -89,6 +89,7 @@ class _FakeAdapter:
         self.status = AsyncMock(return_value=_mock_status())
         self.fetch_result = AsyncMock(return_value=_mock_result())
         self.cancel = AsyncMock(return_value=_mock_cancel_status())
+        self.send_message = AsyncMock(return_value=_mock_status())
 
 
 @pytest.fixture
@@ -167,3 +168,19 @@ async def test_build_adapter_raises_when_no_api_key():
     ):
         with pytest.raises(RuntimeError, match="JULES_API_KEY"):
             _build_adapter()
+
+
+async def test_jules_send_message_activity_calls_adapter(_patch_build_adapter):
+    from moonmind.workflows.temporal.activities.jules_activities import (
+        jules_send_message_activity,
+    )
+
+    result = await jules_send_message_activity({
+        "session_id": "session-42",
+        "prompt": "Continue with step 2.",
+    })
+    assert result.run_id == "task-001"
+    _patch_build_adapter.send_message.assert_awaited_once_with(
+        run_id="session-42",
+        prompt="Continue with step 2.",
+    )


### PR DESCRIPTION
Add support for sequential, context-aware steps within a single Jules session using the sendMessage API instead of creating independent sessions per step.

Transport layer:
- Add JulesSendMessageRequest model to jules_models.py
- Add send_message(), _post_json_empty(), allow_empty_response to JulesClient

Adapter layer:
- Add send_message() to JulesAgentAdapter

Activity layer:
- Add jules_send_message_activity
- Register integration.jules.send_message in activity catalog and runtime

Workflow layer:
- MoonMind.AgentRun: branch on jules_session_id parameter to call sendMessage instead of start; inject session_id into result metadata
- MoonMind.Run: track jules_session_id across plan nodes via _extract_jules_session_id(); inject into subsequent Jules requests

Tests:
- 4 new unit tests across client, adapter, and activity layers
- Replace single-step integration test with multi-step sendMessage test to minimize Jules task quota usage

Docs:
- Update JulesClientAdapter.md with sendMessage API section