### PR TITLE
fix: populate runtime column in task list

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3319,7 +3319,7 @@
           "",
         ).trim(),
         queueName: "-",
-        runtimeMode: null,
+        runtimeMode: pick(item, "targetRuntime", "target_runtime") || null,
         skillId: null,
         rawStatus: rawState,
         rawState,

--- a/tests/task_dashboard/test_temporal_dashboard.js
+++ b/tests/task_dashboard/test_temporal_dashboard.js
@@ -299,3 +299,55 @@ const helpers = loadTemporalHelpers();
   const activeSlice = html.slice(Math.max(0, activeIdx - 100), activeIdx + 100);
   assert(activeSlice.includes('display:none'), "Active container should be hidden by default");
 })();
+
+(function testToTemporalRowsExtractsRuntimeModeFromTargetRuntime() {
+  const rows = helpers.toTemporalRows([
+    {
+      workflowId: "mm:rt-camel",
+      state: "executing",
+      targetRuntime: "codex",
+      startedAt: "2026-03-20T10:00:00Z",
+    },
+  ]);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].runtimeMode, "codex", "should extract runtimeMode from targetRuntime (camelCase)");
+})();
+
+(function testToTemporalRowsExtractsRuntimeModeFromSnakeCaseTargetRuntime() {
+  const rows = helpers.toTemporalRows([
+    {
+      workflowId: "mm:rt-snake",
+      state: "executing",
+      target_runtime: "gemini_cli",
+      startedAt: "2026-03-20T10:00:00Z",
+    },
+  ]);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].runtimeMode, "gemini_cli", "should extract runtimeMode from target_runtime (snake_case)");
+})();
+
+(function testToTemporalRowsRuntimeModeDefaultsToNullWhenMissing() {
+  const rows = helpers.toTemporalRows([
+    {
+      workflowId: "mm:rt-none",
+      state: "executing",
+      startedAt: "2026-03-20T10:00:00Z",
+    },
+  ]);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].runtimeMode, null, "should default runtimeMode to null when neither property exists");
+})();
+
+(function testToTemporalRowsTargetRuntimeTakesPrecedenceOverSnakeCase() {
+  const rows = helpers.toTemporalRows([
+    {
+      workflowId: "mm:rt-both",
+      state: "executing",
+      targetRuntime: "codex",
+      target_runtime: "gemini_cli",
+      startedAt: "2026-03-20T10:00:00Z",
+    },
+  ]);
+  assert.strictEqual(rows.length, 1);
+  assert.strictEqual(rows[0].runtimeMode, "codex", "targetRuntime (camelCase) should take precedence");
+})();


### PR DESCRIPTION
The task list dashboard's runtime column was blank for Temporal executions because `runtimeMode` was hardcoded to `null` during row serialization. This commit extracts the runtime mode properly from the `item` payload.

---
*PR created automatically by Jules for task [8304350698984573495](https://jules.google.com/task/8304350698984573495) started by @nsticco*