### PR TITLE
feat(ui): add "Deferred (run in N minutes)" schedule mode to task dashboard

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -5044,7 +5044,7 @@
           </div>
           <div id="schedule-deferred-minutes-fields" class="hidden">
             <label>Minutes from now
-              <input type="number" name="scheduleDeferredMinutes" min="1" placeholder="e.g. 15" />
+              <input type="number" name="scheduleDeferredMinutes" min="1" max="525600" step="1" placeholder="e.g. 15" />
             </label>
           </div>
           <div id="schedule-recurring-fields" class="hidden">
@@ -6559,14 +6559,24 @@
           };
         } else if (scheduleMode === "deferred_minutes") {
           const scheduleDeferredMinutesRaw = String(formData.get("scheduleDeferredMinutes") || "").trim();
-          const scheduleDeferredMinutes = parseInt(scheduleDeferredMinutesRaw, 10);
-          if (isNaN(scheduleDeferredMinutes) || scheduleDeferredMinutes <= 0) {
+          const scheduleDeferredMinutes = Number(scheduleDeferredMinutesRaw);
+          if (!Number.isFinite(scheduleDeferredMinutes) || !Number.isInteger(scheduleDeferredMinutes) || scheduleDeferredMinutes <= 0) {
             message.className = "notice error queue-submit-message";
-            message.textContent = "A valid positive number of minutes is required for deferred scheduling.";
+            message.textContent = "A valid positive whole number of minutes is required for deferred scheduling.";
             return;
           }
-          const scheduledForDate = new Date();
-          scheduledForDate.setMinutes(scheduledForDate.getMinutes() + scheduleDeferredMinutes);
+          if (scheduleDeferredMinutes > 525600) {
+            message.className = "notice error queue-submit-message";
+            message.textContent = "Deferred minutes cannot exceed 525 600 (one year).";
+            return;
+          }
+          const scheduledForMs = Date.now() + scheduleDeferredMinutes * 60000;
+          const scheduledForDate = new Date(scheduledForMs);
+          if (!Number.isFinite(scheduledForDate.getTime())) {
+            message.className = "notice error queue-submit-message";
+            message.textContent = "Unable to compute a valid schedule date from the provided minutes.";
+            return;
+          }
           requestBody.payload.schedule = {
             mode: "once",
             scheduledFor: scheduledForDate.toISOString(),

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -5033,12 +5033,18 @@
             <select name="scheduleMode" id="schedule-mode-select">
               <option value="immediate" selected>Immediate</option>
               <option value="once">Deferred (run once at a specific time)</option>
+              <option value="deferred_minutes">Deferred (run in N minutes)</option>
               <option value="recurring">Recurring (create a cron schedule)</option>
             </select>
           </label>
           <div id="schedule-once-fields" class="hidden">
             <label>Scheduled For
               <input type="datetime-local" name="scheduledFor" id="schedule-datetime" />
+            </label>
+          </div>
+          <div id="schedule-deferred-minutes-fields" class="hidden">
+            <label>Minutes from now
+              <input type="number" name="scheduleDeferredMinutes" min="1" placeholder="e.g. 15" />
             </label>
           </div>
           <div id="schedule-recurring-fields" class="hidden">
@@ -6214,12 +6220,16 @@
     // --- Schedule panel toggle ---
     const scheduleModeSelect = form.querySelector("#schedule-mode-select");
     const scheduleOnceFields = form.querySelector("#schedule-once-fields");
+    const scheduleDeferredMinutesFields = form.querySelector("#schedule-deferred-minutes-fields");
     const scheduleRecurringFields = form.querySelector("#schedule-recurring-fields");
     if (scheduleModeSelect) {
       scheduleModeSelect.addEventListener("change", () => {
         const mode = String(scheduleModeSelect.value || "immediate").trim();
         if (scheduleOnceFields) {
           scheduleOnceFields.classList.toggle("hidden", mode !== "once");
+        }
+        if (scheduleDeferredMinutesFields) {
+          scheduleDeferredMinutesFields.classList.toggle("hidden", mode !== "deferred_minutes");
         }
         if (scheduleRecurringFields) {
           scheduleRecurringFields.classList.toggle("hidden", mode !== "recurring");
@@ -6543,6 +6553,20 @@
             message.textContent = "Scheduled time must be a valid future date.";
             return;
           }
+          requestBody.payload.schedule = {
+            mode: "once",
+            scheduledFor: scheduledForDate.toISOString(),
+          };
+        } else if (scheduleMode === "deferred_minutes") {
+          const scheduleDeferredMinutesRaw = String(formData.get("scheduleDeferredMinutes") || "").trim();
+          const scheduleDeferredMinutes = parseInt(scheduleDeferredMinutesRaw, 10);
+          if (isNaN(scheduleDeferredMinutes) || scheduleDeferredMinutes <= 0) {
+            message.className = "notice error queue-submit-message";
+            message.textContent = "A valid positive number of minutes is required for deferred scheduling.";
+            return;
+          }
+          const scheduledForDate = new Date();
+          scheduledForDate.setMinutes(scheduledForDate.getMinutes() + scheduleDeferredMinutes);
           requestBody.payload.schedule = {
             mode: "once",
             scheduledFor: scheduledForDate.toISOString(),


### PR DESCRIPTION
This PR introduces a new convenience option to the Task Dashboard UI for scheduling tasks.

Users can now select "Deferred (run in N minutes)" from the Schedule Mode dropdown, enter a positive number of minutes, and submit. The frontend calculates the target future absolute date/time based on the user's current local time and maps it to the existing `once` scheduling mode expected by the backend. This fulfills the user requirement without needing any server-side API changes or backend parsing logic modifications.

Changes include:
- Adding a new `<option>` to the `scheduleMode` select.
- Adding a new hidden `<div>` with a number input for `scheduleDeferredMinutes`.
- Updating the schedule panel toggle logic to show/hide the correct fields.
- Updating the form submit handler to parse the minutes, validate the input, calculate the target future absolute time, and construct the correct `mode: "once"` payload for the API.
- Verified frontend changes successfully with a Playwright script.

---
*PR created automatically by Jules for task [11377714617228309111](https://jules.google.com/task/11377714617228309111) started by @nsticco*