### PR TITLE
Update task dashboard to remove Outcome column and populate Runtime and Skill

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -284,6 +284,12 @@ def _serialize_execution(
         str(params.get(key) or "").strip() or None
         for key in ["targetRuntime", "model", "effort"]
     ]
+    task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
+    tool_params = task_params.get("tool") if isinstance(task_params.get("tool"), dict) else {}
+    skill_params = task_params.get("skill") if isinstance(task_params.get("skill"), dict) else {}
+    target_skill = (
+        str(tool_params.get("name") or skill_params.get("name") or "").strip() or None
+    )
 
     return ExecutionModel(
         task_id=record.workflow_id,
@@ -310,6 +316,7 @@ def _serialize_execution(
         search_attributes=search_attributes,
         memo=memo,
         target_runtime=target_runtime,
+        target_skill=target_skill,
         model=param_model,
         effort=param_effort,
         artifact_refs=(

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3308,18 +3308,16 @@
           "",
         ).trim(),
         queueName: "-",
-        runtimeMode: String(
-          pick(item, "targetRuntime", "target_runtime", "runtime") ||
-          pick(searchAttributes, "mm_target_runtime", "mm_runtime", "runtime") ||
-          pick(memo, "targetRuntime", "runtime") ||
-          ""
-        ).trim() || null,
-        skillId: String(
-          pick(item, "targetSkill", "target_skill", "skillId", "skill_id", "skill") ||
-          pick(searchAttributes, "mm_target_skill", "mm_skill_id", "mm_skill", "skillId", "skill") ||
-          pick(memo, "targetSkill", "skillId", "skill") ||
-          ""
-        ).trim() || null,
+        runtimeMode: String([
+          pick(item, "targetRuntime", "target_runtime", "runtime"),
+          pick(searchAttributes, "mm_target_runtime", "mm_runtime", "runtime"),
+          pick(memo, "targetRuntime", "runtime"),
+        ].find(v => v != null) || "").trim() || null,
+        skillId: String([
+          pick(item, "targetSkill", "target_skill", "skillId", "skill_id", "skill"),
+          pick(searchAttributes, "mm_target_skill", "mm_skill_id", "mm_skill", "skillId", "skill"),
+          pick(memo, "targetSkill", "skillId", "skill"),
+        ].find(v => v != null) || "").trim() || null,
         rawStatus: rawState,
         rawState,
         temporalStatus: pick(item, "temporalStatus") || "",

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -2505,18 +2505,6 @@
   // fields") and add tests that exercise the new label/value pairs.
   const queueFieldDefinitions = [
     {
-      key: "finishOutcome",
-      label: "Outcome",
-      render: (row) => {
-        const stage = String(row.finishOutcomeStage || "").trim();
-        const reason = String(row.finishOutcomeReason || "").trim();
-        const tooltipParts = [stage, reason].filter(Boolean);
-        const title = tooltipParts.length ? ` title="${escapeHtml(tooltipParts.join(" | "))}"` : "";
-        return `<span${title}>${finishOutcomeBadge(row.finishOutcomeCode)}</span>`;
-      },
-      tableSection: "primary",
-    },
-    {
       key: "runtimeMode",
       label: "Runtime",
       render: (row) => renderRuntime(row.runtimeMode),
@@ -3320,8 +3308,18 @@
           "",
         ).trim(),
         queueName: "-",
-        runtimeMode: pick(item, "targetRuntime", "target_runtime") || null,
-        skillId: null,
+        runtimeMode: String(
+          pick(item, "targetRuntime", "target_runtime", "runtime") ||
+          pick(searchAttributes, "mm_target_runtime", "mm_runtime", "runtime") ||
+          pick(memo, "targetRuntime", "runtime") ||
+          ""
+        ).trim() || null,
+        skillId: String(
+          pick(item, "targetSkill", "target_skill", "skillId", "skill_id", "skill") ||
+          pick(searchAttributes, "mm_target_skill", "mm_skill_id", "mm_skill", "skillId", "skill") ||
+          pick(memo, "targetSkill", "skillId", "skill") ||
+          ""
+        ).trim() || null,
         rawStatus: rawState,
         rawState,
         temporalStatus: pick(item, "temporalStatus") || "",

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -339,6 +339,7 @@ class ExecutionModel(BaseModel):
     )
     memo: dict[str, Any] = Field(default_factory=dict, alias="memo")
     target_runtime: Optional[str] = Field(None, alias="targetRuntime")
+    target_skill: Optional[str] = Field(None, alias="targetSkill")
     model: Optional[str] = Field(None, alias="model")
     effort: Optional[str] = Field(None, alias="effort")
     artifact_refs: list[str] = Field(default_factory=list, alias="artifactRefs")

--- a/tests/task_dashboard/test_queue_layouts.js
+++ b/tests/task_dashboard/test_queue_layouts.js
@@ -153,7 +153,6 @@ function createProposalRow(overrides = {}) {
 (function testQueueFieldDefinitionsProvideSingleSourceOfTruth() {
   const keys = queueFieldDefinitions.map((definition) => definition.key);
   const expectedKeys = [
-    "finishOutcome",
     "runtimeMode",
     "skillId",
     "createdAt",
@@ -163,7 +162,6 @@ function createProposalRow(overrides = {}) {
   assert.strictEqual(keys.length, expectedKeys.length);
   assert.strictEqual(keys.join(","), expectedKeys.join(","));
   const labels = queueFieldDefinitions.map((definition) => definition.label);
-  assert(labels.includes("Outcome"));
   assert(labels.includes("Finished"));
   const rendered = renderQueueFieldValue(
     {


### PR DESCRIPTION
This PR modifies the Task Dashboard's `Tasks` list view.
1. Removes the `Outcome` column from the list view.
2. Updates the `toTemporalRows` method to properly extract `Runtime` and `Skill` values from Temporal executions by checking the root `item`, `searchAttributes`, and `memo` to ensure the data is populated correctly in the UI.

Corresponding tests in `test_queue_layouts.js` were updated, and a visual verification using Playwright was successful.

---
*PR created automatically by Jules for task [10992586732531644121](https://jules.google.com/task/10992586732531644121) started by @nsticco*