### PR TITLE
feat: Add starting branch, target branch, and publish mode to task details dashboard

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -298,13 +298,37 @@ def _serialize_execution(
     if not isinstance(publish_payload, dict):
         publish_payload = {}
 
-    starting_branch = str(git_payload.get("startingBranch") or params.get("startingBranch") or "").strip() or None
-    if not starting_branch:
-        default_branch = str(git_payload.get("defaultBranch") or params.get("defaultBranch") or "main").strip()
+    # Precedence: task.git.startingBranch > task.startingBranch > params.startingBranch
+    starting_branch = str(
+        git_payload.get("startingBranch")
+        or task_payload.get("startingBranch")
+        or params.get("startingBranch")
+        or ""
+    ).strip() or None
+    # Only show the "(default)" fallback when git context exists in the payload.
+    has_git_context = bool(git_payload) or any(
+        task_payload.get(k) or params.get(k)
+        for k in ("startingBranch", "newBranch", "defaultBranch", "branch")
+    )
+    if not starting_branch and has_git_context:
+        default_branch = str(
+            git_payload.get("defaultBranch") or params.get("defaultBranch") or "main"
+        ).strip()
         starting_branch = f"{default_branch} (default)"
 
-    target_branch = str(git_payload.get("newBranch") or params.get("newBranch") or "").strip() or None
-    publish_mode = str(params.get("publishMode") or publish_payload.get("mode") or "").strip() or None
+    # Precedence: task.git.newBranch > task.newBranch > params.newBranch
+    target_branch = str(
+        git_payload.get("newBranch")
+        or task_payload.get("newBranch")
+        or params.get("newBranch")
+        or ""
+    ).strip() or None
+
+    _ALLOWED_PUBLISH_MODES = {"branch", "pr", "none"}
+    raw_publish_mode = str(
+        params.get("publishMode") or publish_payload.get("mode") or ""
+    ).strip() or None
+    publish_mode = raw_publish_mode if raw_publish_mode in _ALLOWED_PUBLISH_MODES else None
 
     return ExecutionModel(
         task_id=record.workflow_id,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -279,11 +279,32 @@ def _serialize_execution(
         attention_required=attention_required,
     )
 
-    params = dict(getattr(record, "parameters", None) or {})
+    params_raw = getattr(record, "parameters", None)
+    params = dict(params_raw) if isinstance(params_raw, dict) else {}
     target_runtime, param_model, param_effort = [
         str(params.get(key) or "").strip() or None
         for key in ["targetRuntime", "model", "effort"]
     ]
+
+    task_payload = params.get("task")
+    if not isinstance(task_payload, dict):
+        task_payload = {}
+
+    git_payload = task_payload.get("git")
+    if not isinstance(git_payload, dict):
+        git_payload = {}
+
+    publish_payload = task_payload.get("publish")
+    if not isinstance(publish_payload, dict):
+        publish_payload = {}
+
+    starting_branch = str(git_payload.get("startingBranch") or params.get("startingBranch") or "").strip() or None
+    if not starting_branch:
+        default_branch = str(git_payload.get("defaultBranch") or params.get("defaultBranch") or "main").strip()
+        starting_branch = f"{default_branch} (default)"
+
+    target_branch = str(git_payload.get("newBranch") or params.get("newBranch") or "").strip() or None
+    publish_mode = str(params.get("publishMode") or publish_payload.get("mode") or "").strip() or None
 
     return ExecutionModel(
         task_id=record.workflow_id,
@@ -312,6 +333,9 @@ def _serialize_execution(
         target_runtime=target_runtime,
         model=param_model,
         effort=param_effort,
+        starting_branch=starting_branch,
+        target_branch=target_branch,
+        publish_mode=publish_mode,
         artifact_refs=(
             list(record.artifact_refs or []) if include_artifact_refs else []
         ),

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -9018,6 +9018,9 @@
         ${pick(execution, "targetRuntime") ? `<div class="card"><strong>Runtime:</strong> ${escapeHtml(formatRuntimeLabel(pick(execution, "targetRuntime")))}</div>` : ""}
         ${pick(execution, "model") ? `<div class="card"><strong>Model:</strong> <code>${escapeHtml(String(pick(execution, "model")))}</code></div>` : ""}
         ${pick(execution, "effort") ? `<div class="card"><strong>Effort:</strong> ${escapeHtml(String(pick(execution, "effort")))}</div>` : ""}
+        ${pick(execution, "startingBranch") ? `<div class="card"><strong>Starting Branch:</strong> <code>${escapeHtml(String(pick(execution, "startingBranch")))}</code></div>` : ""}
+        ${pick(execution, "targetBranch") ? `<div class="card"><strong>Target Branch:</strong> <code>${escapeHtml(String(pick(execution, "targetBranch")))}</code></div>` : ""}
+        ${pick(execution, "publishMode") ? `<div class="card"><strong>Publish Mode:</strong> <code>${escapeHtml(String(pick(execution, "publishMode")))}</code></div>` : ""}
         <div class="card"><strong>Latest Run:</strong> <code>${escapeHtml(latestRunId || "-")}</code></div>
         <div class="card"><strong>Started:</strong> ${escapeHtml(formatTimestamp(pick(execution, "startedAt")))}</div>
         <div class="card"><strong>Updated:</strong> ${escapeHtml(formatTimestamp(pick(execution, "updatedAt")))}</div>

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -341,6 +341,9 @@ class ExecutionModel(BaseModel):
     target_runtime: Optional[str] = Field(None, alias="targetRuntime")
     model: Optional[str] = Field(None, alias="model")
     effort: Optional[str] = Field(None, alias="effort")
+    starting_branch: Optional[str] = Field(None, alias="startingBranch")
+    target_branch: Optional[str] = Field(None, alias="targetBranch")
+    publish_mode: Optional[str] = Field(None, alias="publishMode")
     artifact_refs: list[str] = Field(default_factory=list, alias="artifactRefs")
     actions: ExecutionActionCapabilityModel = Field(
         default_factory=ExecutionActionCapabilityModel, alias="actions"


### PR DESCRIPTION
This PR extracts the starting branch, target branch, and publish mode from the task payload and displays them in the task dashboard details section. It implements fallback logic to display a '(default)' suffix for the starting branch if initially left empty.

---
*PR created automatically by Jules for task [8378591092104891736](https://jules.google.com/task/8378591092104891736) started by @nsticco*