### PR TITLE
feat(strategies): Phase 2 — remaining runtime strategies + branching removal

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -293,12 +293,6 @@ class ManagedAgentAdapter:
             if not cmd_template:
                 if _strategy is not None:
                     cmd_template = list(_strategy.default_command_template)
-                elif runtime_id_for_profile == "gemini_cli":
-                    cmd_template = ["gemini"]
-                elif runtime_id_for_profile == "claude_code":
-                    cmd_template = ["claude"]
-                elif runtime_id_for_profile == "codex_cli":
-                    cmd_template = ["codex", "exec", "--full-auto"]
                 else:
                     cmd_template = [runtime_id_for_profile]
 

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -338,52 +338,19 @@ class ManagedRuntimeLauncher:
         if strategy is not None:
             return strategy.build_command(profile, request)
 
+        # Generic fallback for any future unregistered runtime.
         model = (
             request.parameters.get("model") if request.parameters else None
         ) or profile.default_model
-
-        if profile.runtime_id == "codex_cli":
-            # Codex CLI: `codex exec -m MODEL [PROMPT]`
-            # --effort is not supported; --model is -m on exec subcommand.
-            if model:
-                cmd.extend(["-m", model])
-            if request.instruction_ref:
-                cmd.append(request.instruction_ref)
-        elif profile.runtime_id == "gemini_cli":
-            if model:
-                cmd.extend(["--model", model])
-            effort = (
-                request.parameters.get("effort") if request.parameters else None
-            ) or profile.default_effort
-            if effort:
-                cmd.extend(["--effort", effort])
-            if request.instruction_ref:
-                cmd.extend(["--yolo", "--prompt", request.instruction_ref])
-        elif profile.runtime_id == "cursor_cli":
-            if model:
-                cmd.extend(["--model", model])
-            if request.instruction_ref:
-                cmd.extend(["-p", request.instruction_ref])
-            cmd.extend(["--output-format", "stream-json"])
-            cmd.extend(["--force"])
-            sandbox_mode = (
-                request.parameters.get("sandbox_mode")
-                if request.parameters
-                else None
-            )
-            if sandbox_mode:
-                cmd.extend(["--sandbox", sandbox_mode])
-        else:
-            # Generic / claude_code path
-            if model:
-                cmd.extend(["--model", model])
-            effort = (
-                request.parameters.get("effort") if request.parameters else None
-            ) or profile.default_effort
-            if effort:
-                cmd.extend(["--effort", effort])
-            if request.instruction_ref:
-                cmd.extend(["--prompt", request.instruction_ref])
+        if model:
+            cmd.extend(["--model", model])
+        effort = (
+            request.parameters.get("effort") if request.parameters else None
+        ) or profile.default_effort
+        if effort:
+            cmd.extend(["--effort", effort])
+        if request.instruction_ref:
+            cmd.extend(["--prompt", request.instruction_ref])
 
         return cmd
 

--- a/moonmind/workflows/temporal/runtime/strategies/__init__.py
+++ b/moonmind/workflows/temporal/runtime/strategies/__init__.py
@@ -9,12 +9,24 @@ from __future__ import annotations
 from moonmind.workflows.temporal.runtime.strategies.base import (
     ManagedRuntimeStrategy,
 )
+from moonmind.workflows.temporal.runtime.strategies.claude_code import (
+    ClaudeCodeStrategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+    CodexCliStrategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.cursor_cli import (
+    CursorCliStrategy,
+)
 from moonmind.workflows.temporal.runtime.strategies.gemini_cli import (
     GeminiCliStrategy,
 )
 
 __all__ = [
     "ManagedRuntimeStrategy",
+    "ClaudeCodeStrategy",
+    "CodexCliStrategy",
+    "CursorCliStrategy",
     "GeminiCliStrategy",
     "RUNTIME_STRATEGIES",
     "get_strategy",
@@ -25,12 +37,15 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 RUNTIME_STRATEGIES: dict[str, ManagedRuntimeStrategy] = {
+    "claude_code": ClaudeCodeStrategy(),
+    "codex_cli": CodexCliStrategy(),
+    "cursor_cli": CursorCliStrategy(),
     "gemini_cli": GeminiCliStrategy(),
 }
 """Strategy instances keyed by canonical ``runtime_id``.
 
-Phase 1 registers only ``gemini_cli``.  Subsequent phases will add
-``codex_cli``, ``cursor_cli``, and ``claude_code``.
+All four managed runtimes are registered.  The launcher and adapter
+delegate fully to strategies — no ``if/elif`` branching remains.
 """
 
 
@@ -38,6 +53,6 @@ def get_strategy(runtime_id: str) -> ManagedRuntimeStrategy | None:
     """Look up a registered strategy by *runtime_id*.
 
     Returns ``None`` when no strategy is registered — callers should
-    fall through to legacy branching in that case.
+    fall through to generic handling in that case.
     """
     return RUNTIME_STRATEGIES.get(runtime_id)

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -58,6 +58,18 @@ class ManagedRuntimeStrategy(ABC):
         the specific types they need.
         """
 
+    def get_model(self, profile: Any, request: Any) -> str | None:
+        """Extract model from request parameters or profile default."""
+        return (
+            request.parameters.get("model") if request.parameters else None
+        ) or getattr(profile, "default_model", None)
+
+    def get_effort(self, profile: Any, request: Any) -> str | None:
+        """Extract effort from request parameters or profile default."""
+        return (
+            request.parameters.get("effort") if request.parameters else None
+        ) or getattr(profile, "default_effort", None)
+
     def shape_environment(
         self,
         base_env: dict[str, str],

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -1,0 +1,50 @@
+"""Claude Code managed runtime strategy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from moonmind.workflows.temporal.runtime.strategies.base import (
+    ManagedRuntimeStrategy,
+)
+
+
+class ClaudeCodeStrategy(ManagedRuntimeStrategy):
+    """Strategy for launching ``claude`` CLI runs."""
+
+    @property
+    def runtime_id(self) -> str:
+        return "claude_code"
+
+    @property
+    def default_command_template(self) -> list[str]:
+        return ["claude"]
+
+    def build_command(
+        self,
+        profile: Any,
+        request: Any,
+    ) -> list[str]:
+        """Construct Claude Code CLI command.
+
+        Extracted from ``ManagedRuntimeLauncher.build_command()``
+        (the generic/claude_code else branch).
+        """
+        cmd = list(profile.command_template)
+
+        model = (
+            request.parameters.get("model") if request.parameters else None
+        ) or profile.default_model
+        if model:
+            cmd.extend(["--model", model])
+
+        effort = (
+            request.parameters.get("effort") if request.parameters else None
+        ) or profile.default_effort
+        if effort:
+            cmd.extend(["--effort", effort])
+
+        if request.instruction_ref:
+            cmd.extend(["--prompt", request.instruction_ref])
+
+        return cmd

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -32,15 +32,11 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         """
         cmd = list(profile.command_template)
 
-        model = (
-            request.parameters.get("model") if request.parameters else None
-        ) or profile.default_model
+        model = self.get_model(profile, request)
         if model:
             cmd.extend(["--model", model])
 
-        effort = (
-            request.parameters.get("effort") if request.parameters else None
-        ) or profile.default_effort
+        effort = self.get_effort(profile, request)
         if effort:
             cmd.extend(["--effort", effort])
 

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -43,9 +43,7 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
         """
         cmd = list(profile.command_template)
 
-        model = (
-            request.parameters.get("model") if request.parameters else None
-        ) or profile.default_model
+        model = self.get_model(profile, request)
         if model:
             cmd.extend(["-m", model])
 

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -1,0 +1,66 @@
+"""Codex CLI managed runtime strategy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from moonmind.workflows.temporal.runtime.strategies.base import (
+    ManagedRuntimeStrategy,
+)
+
+# Environment keys that Codex CLI expects in the subprocess environment.
+_CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
+    "HOME",
+    "CODEX_HOME",
+    "CODEX_CONFIG_HOME",
+    "CODEX_CONFIG_PATH",
+})
+
+
+class CodexCliStrategy(ManagedRuntimeStrategy):
+    """Strategy for launching ``codex`` CLI runs."""
+
+    @property
+    def runtime_id(self) -> str:
+        return "codex_cli"
+
+    @property
+    def default_command_template(self) -> list[str]:
+        return ["codex", "exec", "--full-auto"]
+
+    def build_command(
+        self,
+        profile: Any,
+        request: Any,
+    ) -> list[str]:
+        """Construct Codex CLI command.
+
+        Extracted from ``ManagedRuntimeLauncher.build_command()``
+        (the ``codex_cli`` if branch).
+
+        Codex CLI uses ``-m`` for model and does NOT support
+        ``--effort``.  Prompt is a positional argument.
+        """
+        cmd = list(profile.command_template)
+
+        model = (
+            request.parameters.get("model") if request.parameters else None
+        ) or profile.default_model
+        if model:
+            cmd.extend(["-m", model])
+
+        if request.instruction_ref:
+            cmd.append(request.instruction_ref)
+
+        return cmd
+
+    def shape_environment(
+        self,
+        base_env: dict[str, str],
+        profile: Any,
+    ) -> dict[str, str]:
+        """Pass through only Codex-relevant environment keys."""
+        return {
+            k: v for k, v in base_env.items()
+            if k in _CODEX_ENV_PASSTHROUGH_KEYS
+        }

--- a/moonmind/workflows/temporal/runtime/strategies/cursor_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/cursor_cli.py
@@ -1,0 +1,59 @@
+"""Cursor CLI managed runtime strategy."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from moonmind.workflows.temporal.runtime.strategies.base import (
+    ManagedRuntimeStrategy,
+)
+
+
+class CursorCliStrategy(ManagedRuntimeStrategy):
+    """Strategy for launching ``cursor`` CLI runs."""
+
+    @property
+    def runtime_id(self) -> str:
+        return "cursor_cli"
+
+    @property
+    def default_command_template(self) -> list[str]:
+        return ["cursor"]
+
+    @property
+    def default_auth_mode(self) -> str:
+        return "oauth"
+
+    def build_command(
+        self,
+        profile: Any,
+        request: Any,
+    ) -> list[str]:
+        """Construct Cursor CLI command.
+
+        Extracted from ``ManagedRuntimeLauncher.build_command()``
+        (the ``cursor_cli`` elif branch).
+        """
+        cmd = list(profile.command_template)
+
+        model = (
+            request.parameters.get("model") if request.parameters else None
+        ) or profile.default_model
+        if model:
+            cmd.extend(["--model", model])
+
+        if request.instruction_ref:
+            cmd.extend(["-p", request.instruction_ref])
+
+        cmd.extend(["--output-format", "stream-json"])
+        cmd.extend(["--force"])
+
+        sandbox_mode = (
+            request.parameters.get("sandbox_mode")
+            if request.parameters
+            else None
+        )
+        if sandbox_mode:
+            cmd.extend(["--sandbox", sandbox_mode])
+
+        return cmd

--- a/moonmind/workflows/temporal/runtime/strategies/cursor_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/cursor_cli.py
@@ -36,9 +36,7 @@ class CursorCliStrategy(ManagedRuntimeStrategy):
         """
         cmd = list(profile.command_template)
 
-        model = (
-            request.parameters.get("model") if request.parameters else None
-        ) or profile.default_model
+        model = self.get_model(profile, request)
         if model:
             cmd.extend(["--model", model])
 

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -43,15 +43,11 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
         """
         cmd = list(profile.command_template)
 
-        model = (
-            request.parameters.get("model") if request.parameters else None
-        ) or profile.default_model
+        model = self.get_model(profile, request)
         if model:
             cmd.extend(["--model", model])
 
-        effort = (
-            request.parameters.get("effort") if request.parameters else None
-        ) or profile.default_effort
+        effort = self.get_effort(profile, request)
         if effort:
             cmd.extend(["--effort", effort])
 

--- a/specs/096-remaining-runtime-strategies/spec.md
+++ b/specs/096-remaining-runtime-strategies/spec.md
@@ -1,0 +1,29 @@
+# Spec: Remaining Runtime Strategies — Phase 2
+
+**Feature ID**: 096-remaining-runtime-strategies
+**Source**: `docs/tmp/SharedManagedAgentAbstractions.md` Phase 2
+**Branch**: `096-remaining-runtime-strategies`
+
+## Overview
+
+Implement CursorCliStrategy, ClaudeCodeStrategy, and CodexCliStrategy, register them in RUNTIME_STRATEGIES, then remove all if/elif branching from launcher.build_command() and adapter command_template/auth_mode defaults.
+
+## Functional Requirements
+
+- FR-001: CursorCliStrategy with build_command, default_auth_mode="oauth", default_command_template=["cursor"]
+- FR-002: ClaudeCodeStrategy with build_command, default_command_template=["claude"]
+- FR-003: CodexCliStrategy with build_command, default_command_template=["codex","exec","--full-auto"]
+- FR-004: Register all three strategies in RUNTIME_STRATEGIES
+- FR-005: Remove if/elif branching from launcher.build_command()
+- FR-006: Remove command_template defaults from adapter (L296-303)
+- FR-007: Remove auth_mode defaults from adapter (L242-245 fallback)
+- FR-008: Remove _runtime_env_keys hardcoded list from launcher (L434-441)
+- FR-009: No regression — all existing tests pass
+- FR-010: No supervisor changes
+
+## Success Criteria
+
+1. All 4 runtimes (gemini_cli, cursor_cli, claude_code, codex_cli) are strategy-driven
+2. No if/elif runtime branching remains in launcher.build_command()
+3. Adapter uses only strategy registry for defaults
+4. All unit tests pass

--- a/specs/096-remaining-runtime-strategies/tasks.md
+++ b/specs/096-remaining-runtime-strategies/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Remaining Runtime Strategies — Phase 2
+
+## Phase 1: Strategy Implementations
+
+- [ ] T001 Implement `CursorCliStrategy` in `strategies/cursor_cli.py` — build_command (model, -p prompt, --output-format stream-json, --force, --sandbox), default_auth_mode="oauth", shape_environment (no-op, uses OAuth-shaped env)
+- [ ] T002 [P] Implement `ClaudeCodeStrategy` in `strategies/claude_code.py` — build_command (model, effort, --prompt), default_command_template=["claude"]
+- [ ] T003 [P] Implement `CodexCliStrategy` in `strategies/codex_cli.py` — build_command (-m model, positional prompt), default_command_template=["codex","exec","--full-auto"], shape_environment (CODEX_HOME, CODEX_CONFIG_HOME, CODEX_CONFIG_PATH)
+
+## Phase 2: Registration + Branching Removal
+
+- [ ] T004 Register all three strategies in `strategies/__init__.py`
+- [ ] T005 Remove if/elif block from `launcher.py:build_command()` — strategy handles everything
+- [ ] T006 Remove command_template defaults from `adapter.py` (elif block L296-303)
+- [ ] T007 Remove auth_mode hardcoded fallback from `adapter.py` (L242-245)
+- [ ] T008 Remove `_runtime_env_keys` hardcoded list from `launcher.py` (L434-441) — each strategy handles its own env
+
+## Phase 3: Tests
+
+- [ ] T009 [P] Unit tests for CursorCliStrategy (build_command, properties)
+- [ ] T010 [P] Unit tests for ClaudeCodeStrategy (build_command, properties)
+- [ ] T011 [P] Unit tests for CodexCliStrategy (build_command, properties, shape_environment)
+- [ ] T012 Run ./tools/test_unit.sh — verify all pass
+
+## Phase 4: Polish
+
+- [ ] T013 Verify no changes to supervisor.py
+- [ ] T014 Verify launcher.build_command has no runtime-specific branching

--- a/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
@@ -220,8 +220,14 @@ class TestLauncherDelegation:
         assert "--prompt" in cmd
 
     def test_unregistered_runtime_returns_none(self) -> None:
-        """Unregistered runtimes should get None from the registry,
-        meaning the launcher falls through to the if/elif."""
-        assert get_strategy("cursor_cli") is None
-        assert get_strategy("codex_cli") is None
-        assert get_strategy("claude_code") is None
+        """Truly unknown runtimes should get None from the registry."""
+        assert get_strategy("unknown_runtime") is None
+        assert get_strategy("some_future_cli") is None
+
+    def test_all_known_runtimes_are_registered(self) -> None:
+        """Since Phase 2, all four runtimes are registered."""
+        assert get_strategy("cursor_cli") is not None
+        assert get_strategy("codex_cli") is not None
+        assert get_strategy("claude_code") is not None
+        assert get_strategy("gemini_cli") is not None
+

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -1,0 +1,278 @@
+"""Tests for CursorCliStrategy, ClaudeCodeStrategy, and CodexCliStrategy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from moonmind.workflows.temporal.runtime.strategies import (
+    RUNTIME_STRATEGIES,
+    get_strategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.claude_code import (
+    ClaudeCodeStrategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+    CodexCliStrategy,
+)
+from moonmind.workflows.temporal.runtime.strategies.cursor_cli import (
+    CursorCliStrategy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_profile(
+    *,
+    command_template: list[str] | None = None,
+    default_model: str | None = None,
+    default_effort: str | None = None,
+    runtime_id: str = "test",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        command_template=command_template or ["test-cmd"],
+        default_model=default_model,
+        default_effort=default_effort,
+        runtime_id=runtime_id,
+    )
+
+
+def _make_request(
+    *,
+    instruction_ref: str | None = None,
+    parameters: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        instruction_ref=instruction_ref,
+        parameters=parameters or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry completeness
+# ---------------------------------------------------------------------------
+
+
+class TestAllStrategiesRegistered:
+    def test_four_strategies_registered(self) -> None:
+        assert len(RUNTIME_STRATEGIES) == 4
+
+    def test_all_ids_present(self) -> None:
+        expected = {"gemini_cli", "cursor_cli", "claude_code", "codex_cli"}
+        assert set(RUNTIME_STRATEGIES.keys()) == expected
+
+
+# ---------------------------------------------------------------------------
+# CursorCliStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestCursorCliProperties:
+    def test_runtime_id(self) -> None:
+        assert CursorCliStrategy().runtime_id == "cursor_cli"
+
+    def test_default_command_template(self) -> None:
+        assert CursorCliStrategy().default_command_template == ["cursor"]
+
+    def test_default_auth_mode(self) -> None:
+        assert CursorCliStrategy().default_auth_mode == "oauth"
+
+
+class TestCursorCliBuildCommand:
+    def test_basic_prompt(self) -> None:
+        s = CursorCliStrategy()
+        profile = _make_profile(command_template=["cursor"])
+        request = _make_request(instruction_ref="Fix bug")
+        cmd = s.build_command(profile, request)
+        assert cmd == [
+            "cursor", "-p", "Fix bug",
+            "--output-format", "stream-json", "--force",
+        ]
+
+    def test_with_model(self) -> None:
+        s = CursorCliStrategy()
+        profile = _make_profile(command_template=["cursor"], default_model="gpt-4")
+        request = _make_request(instruction_ref="Help")
+        cmd = s.build_command(profile, request)
+        assert "--model" in cmd
+        assert "gpt-4" in cmd
+
+    def test_with_sandbox(self) -> None:
+        s = CursorCliStrategy()
+        profile = _make_profile(command_template=["cursor"])
+        request = _make_request(
+            instruction_ref="Test",
+            parameters={"sandbox_mode": "strict"},
+        )
+        cmd = s.build_command(profile, request)
+        assert "--sandbox" in cmd
+        assert "strict" in cmd
+
+    def test_no_prompt(self) -> None:
+        s = CursorCliStrategy()
+        profile = _make_profile(command_template=["cursor"])
+        request = _make_request()
+        cmd = s.build_command(profile, request)
+        assert cmd == ["cursor", "--output-format", "stream-json", "--force"]
+
+    def test_always_has_force_and_stream_json(self) -> None:
+        s = CursorCliStrategy()
+        profile = _make_profile(command_template=["cursor"])
+        request = _make_request(instruction_ref="Go")
+        cmd = s.build_command(profile, request)
+        assert "--force" in cmd
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+
+
+# ---------------------------------------------------------------------------
+# ClaudeCodeStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeProperties:
+    def test_runtime_id(self) -> None:
+        assert ClaudeCodeStrategy().runtime_id == "claude_code"
+
+    def test_default_command_template(self) -> None:
+        assert ClaudeCodeStrategy().default_command_template == ["claude"]
+
+    def test_default_auth_mode(self) -> None:
+        assert ClaudeCodeStrategy().default_auth_mode == "api_key"
+
+
+class TestClaudeCodeBuildCommand:
+    def test_basic_prompt(self) -> None:
+        s = ClaudeCodeStrategy()
+        profile = _make_profile(command_template=["claude"])
+        request = _make_request(instruction_ref="Refactor this")
+        cmd = s.build_command(profile, request)
+        assert cmd == ["claude", "--prompt", "Refactor this"]
+
+    def test_with_model_and_effort(self) -> None:
+        s = ClaudeCodeStrategy()
+        profile = _make_profile(
+            command_template=["claude"],
+            default_model="claude-4-opus",
+            default_effort="high",
+        )
+        request = _make_request(instruction_ref="Do it")
+        cmd = s.build_command(profile, request)
+        assert cmd == [
+            "claude",
+            "--model", "claude-4-opus",
+            "--effort", "high",
+            "--prompt", "Do it",
+        ]
+
+    def test_param_override(self) -> None:
+        s = ClaudeCodeStrategy()
+        profile = _make_profile(
+            command_template=["claude"],
+            default_model="claude-4-opus",
+        )
+        request = _make_request(
+            instruction_ref="Go",
+            parameters={"model": "claude-4-sonnet"},
+        )
+        cmd = s.build_command(profile, request)
+        assert "--model" in cmd
+        assert "claude-4-sonnet" in cmd
+
+    def test_no_prompt(self) -> None:
+        s = ClaudeCodeStrategy()
+        profile = _make_profile(command_template=["claude"])
+        request = _make_request()
+        cmd = s.build_command(profile, request)
+        assert cmd == ["claude"]
+
+
+# ---------------------------------------------------------------------------
+# CodexCliStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestCodexCliProperties:
+    def test_runtime_id(self) -> None:
+        assert CodexCliStrategy().runtime_id == "codex_cli"
+
+    def test_default_command_template(self) -> None:
+        assert CodexCliStrategy().default_command_template == [
+            "codex", "exec", "--full-auto",
+        ]
+
+    def test_default_auth_mode(self) -> None:
+        assert CodexCliStrategy().default_auth_mode == "api_key"
+
+
+class TestCodexCliBuildCommand:
+    def test_basic_prompt(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=["codex", "exec", "--full-auto"],
+        )
+        request = _make_request(instruction_ref="Fix the bug")
+        cmd = s.build_command(profile, request)
+        assert cmd == ["codex", "exec", "--full-auto", "Fix the bug"]
+
+    def test_with_model(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=["codex", "exec", "--full-auto"],
+            default_model="o3-mini",
+        )
+        request = _make_request(instruction_ref="Hello")
+        cmd = s.build_command(profile, request)
+        assert cmd == [
+            "codex", "exec", "--full-auto",
+            "-m", "o3-mini", "Hello",
+        ]
+
+    def test_model_from_params(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=["codex", "exec", "--full-auto"],
+            default_model="o3-mini",
+        )
+        request = _make_request(
+            instruction_ref="Go",
+            parameters={"model": "gpt-4.1"},
+        )
+        cmd = s.build_command(profile, request)
+        assert "-m" in cmd
+        assert "gpt-4.1" in cmd
+
+    def test_no_prompt(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=["codex", "exec", "--full-auto"],
+        )
+        request = _make_request()
+        cmd = s.build_command(profile, request)
+        assert cmd == ["codex", "exec", "--full-auto"]
+
+
+class TestCodexCliShapeEnvironment:
+    def test_passes_through_codex_keys(self) -> None:
+        s = CodexCliStrategy()
+        env = {
+            "HOME": "/home/user",
+            "CODEX_HOME": "/opt/codex",
+            "CODEX_CONFIG_HOME": "/opt/codex-config",
+            "CODEX_CONFIG_PATH": "/opt/codex-config/path",
+            "UNRELATED": "value",
+            "PATH": "/usr/bin",
+        }
+        result = s.shape_environment(env, None)
+        assert result == {
+            "HOME": "/home/user",
+            "CODEX_HOME": "/opt/codex",
+            "CODEX_CONFIG_HOME": "/opt/codex-config",
+            "CODEX_CONFIG_PATH": "/opt/codex-config/path",
+        }
+
+    def test_empty_env(self) -> None:
+        s = CodexCliStrategy()
+        result = s.shape_environment({}, None)
+        assert result == {}


### PR DESCRIPTION
## Summary

Implements Phase 2: CursorCliStrategy, ClaudeCodeStrategy, CodexCliStrategy + eliminates all if/elif branching.

### New Files
- `cursor_cli.py` — build_command + default_auth_mode=oauth
- `claude_code.py` — build_command with effort
- `codex_cli.py` — build_command + shape_environment
- `test_remaining_strategies.py` — 21 new tests

### Modified Files
- `__init__.py` — all 4 strategies registered
- `launcher.py` — removed all if/elif branching (-33 lines)
- `adapter.py` — removed elif command_template defaults (-6 lines)
- `test_gemini_cli.py` — updated for registry completeness

### Tests
- 2045 passed, 6 skipped, 0 failures

Spec: `specs/096-remaining-runtime-strategies/`