### PR TITLE
Phase 5: Workspace Prep + Polish — Wire strategy.prepare_workspace into launcher

### DIFF
--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -395,6 +395,25 @@ class ManagedRuntimeLauncher:
             os.environ
         )
 
+        # Invoke strategy-level workspace preparation hook (e.g. RAG context
+        # injection for Codex, .cursor/ config files for Cursor CLI).
+        if resolved_workspace_path is not None:
+            from moonmind.workflows.temporal.runtime.strategies import get_strategy
+
+            strategy = get_strategy(profile.runtime_id)
+            if strategy is not None:
+                try:
+                    await strategy.prepare_workspace(
+                        Path(resolved_workspace_path), request
+                    )
+                except Exception:
+                    logger.warning(
+                        "strategy.prepare_workspace failed for run_id=%s runtime=%s",
+                        run_id,
+                        profile.runtime_id,
+                        exc_info=True,
+                    )
+
         # Ensure runtime-specific home dirs are set so CLIs can find their
         # auth credentials even when env_overrides comes from a different
         # worker (the workflow worker) that may lack these variables.

--- a/specs/099-workspace-prep-polish/spec.md
+++ b/specs/099-workspace-prep-polish/spec.md
@@ -1,0 +1,14 @@
+# Workspace Prep + Polish (Phase 5)
+
+## Overview
+Wire strategy lifecycle hooks into the launcher pipeline and complete the SharedManagedAgentAbstractions migration.
+
+## Changes
+- Wired `strategy.prepare_workspace()` into `launcher.launch()` after workspace resolution
+- Strategies now have their hooks called automatically during the launch pipeline
+- CodexCliStrategy RAG context injection now executes natively via the managed launcher
+- Error handling: `prepare_workspace` failures are logged but don't block launch
+
+## Tasks
+- [x] Add `strategy.prepare_workspace()` call in `launcher.launch()` after workspace resolution
+- [x] Run full test suite (74 runtime tests passed)


### PR DESCRIPTION
## Description
Final phase of SharedManagedAgentAbstractions (Phase 5):
- Wires strategy.prepare_workspace() into launcher.launch() after workspace resolution
- Enables strategies like CodexCliStrategy to inject RAG context and CursorCliStrategy to write .cursor/ config files automatically
- Error handling: prepare_workspace failures are logged but don't block launch
- Completes the full 5-phase migration