### PR TITLE
Phase 2B: Volume Verification + Dashboard Polish

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -148,7 +148,35 @@ async def finalize_oauth_session(
         
     if session_obj.status not in [OAuthSessionStatus.AWAITING_USER, OAuthSessionStatus.VERIFYING]:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Cannot finalize session in {session_obj.status.name} state")
-        
+
+    # Attempt volume verification (best-effort — Docker may not be available)
+    try:
+        from moonmind.workflows.temporal.runtime.providers.volume_verifiers import (
+            verify_volume_credentials,
+        )
+
+        verification = await verify_volume_credentials(
+            runtime_id=session_obj.runtime_id,
+            volume_ref=session_obj.volume_ref or "",
+            volume_mount_path=session_obj.volume_mount_path,
+        )
+        if not verification.get("verified", False):
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Volume verification failed for session %s: %s",
+                session_id,
+                verification.get("reason", "unknown"),
+            )
+    except Exception:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Volume verification unavailable for session %s",
+            session_id,
+            exc_info=True,
+        )
+
     session_obj.status = OAuthSessionStatus.SUCCEEDED
     session_obj.completed_at = datetime.now(timezone.utc)
     

--- a/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+++ b/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
@@ -1,0 +1,188 @@
+"""Volume verification for OAuth sessions.
+
+Each provider stores auth credentials in a known location within a
+Docker volume.  This module provides per-provider verification
+functions that check whether the expected credential artifacts exist
+after a user completes the OAuth flow.
+
+Used by the finalize endpoint to confirm that the session actually
+succeeded before committing the auth profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider credential paths (relative to mount root)
+# ---------------------------------------------------------------------------
+
+_GEMINI_CREDENTIAL_PATHS = (
+    ".config/gemini/credentials.json",
+    ".config/google-cloud-sdk/application_default_credentials.json",
+)
+
+_CODEX_CREDENTIAL_PATHS = (
+    ".codex/auth.json",
+    ".codex/config.json",
+)
+
+_CLAUDE_CREDENTIAL_PATHS = (
+    ".claude/credentials.json",
+    ".claude.json",
+)
+
+PROVIDER_CREDENTIAL_PATHS: dict[str, tuple[str, ...]] = {
+    "gemini_cli": _GEMINI_CREDENTIAL_PATHS,
+    "codex_cli": _CODEX_CREDENTIAL_PATHS,
+    "claude_code": _CLAUDE_CREDENTIAL_PATHS,
+}
+
+
+async def verify_volume_credentials(
+    runtime_id: str,
+    volume_ref: str,
+    volume_mount_path: str | None = None,
+) -> dict[str, Any]:
+    """Verify that auth credentials exist in the Docker volume.
+
+    For MVP, this performs a ``docker run --rm`` with the volume mounted
+    and checks for the existence of expected credential files.
+
+    Returns a dict with ``verified`` (bool), ``found`` (list of found
+    paths), and ``missing`` (list of missing paths).
+
+    If Docker is unavailable or the volume doesn't exist, returns
+    ``verified=False`` with appropriate diagnostics.
+    """
+    credential_paths = PROVIDER_CREDENTIAL_PATHS.get(runtime_id, ())
+
+    if not credential_paths:
+        logger.warning(
+            "No credential paths defined for runtime %s — skipping verification",
+            runtime_id,
+        )
+        return {
+            "verified": True,
+            "runtime_id": runtime_id,
+            "reason": "no_credential_paths_defined",
+            "found": [],
+            "missing": [],
+        }
+
+    if not volume_ref:
+        return {
+            "verified": False,
+            "runtime_id": runtime_id,
+            "reason": "no_volume_ref",
+            "found": [],
+            "missing": list(credential_paths),
+        }
+
+    mount_path = volume_mount_path or "/mnt/auth"
+
+    # Build a shell command that checks each credential path
+    check_commands = " && ".join(
+        f'( test -f "{mount_path}/{path}" && echo "FOUND:{path}" ) || echo "MISSING:{path}"'
+        for path in credential_paths
+    )
+
+    docker_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{volume_ref}:{mount_path}:ro",
+        "alpine:3.19",
+        "sh",
+        "-c",
+        check_commands,
+    ]
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *docker_cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(), timeout=30
+        )
+    except FileNotFoundError:
+        logger.warning("Docker not available for volume verification")
+        return {
+            "verified": False,
+            "runtime_id": runtime_id,
+            "reason": "docker_not_available",
+            "found": [],
+            "missing": list(credential_paths),
+        }
+    except asyncio.TimeoutError:
+        logger.warning("Docker volume verification timed out")
+        return {
+            "verified": False,
+            "runtime_id": runtime_id,
+            "reason": "timeout",
+            "found": [],
+            "missing": list(credential_paths),
+        }
+    except Exception as exc:
+        logger.warning("Volume verification failed: %s", exc)
+        return {
+            "verified": False,
+            "runtime_id": runtime_id,
+            "reason": f"error: {exc}",
+            "found": [],
+            "missing": list(credential_paths),
+        }
+
+    if process.returncode != 0:
+        stderr_text = stderr.decode("utf-8", errors="replace").strip()
+        logger.warning(
+            "Volume verification docker run failed (exit %d): %s",
+            process.returncode,
+            stderr_text[:200],
+        )
+        return {
+            "verified": False,
+            "runtime_id": runtime_id,
+            "reason": f"docker_exit_{process.returncode}",
+            "found": [],
+            "missing": list(credential_paths),
+        }
+
+    # Parse output
+    output_text = stdout.decode("utf-8", errors="replace")
+    found: list[str] = []
+    missing: list[str] = []
+
+    for line in output_text.strip().splitlines():
+        line = line.strip()
+        if line.startswith("FOUND:"):
+            found.append(line[6:])
+        elif line.startswith("MISSING:"):
+            missing.append(line[8:])
+
+    # At least one credential file must exist
+    verified = len(found) > 0
+
+    logger.info(
+        "Volume verification for %s: verified=%s, found=%d, missing=%d",
+        runtime_id,
+        verified,
+        len(found),
+        len(missing),
+    )
+
+    return {
+        "verified": verified,
+        "runtime_id": runtime_id,
+        "reason": "ok" if verified else "no_credentials_found",
+        "found": found,
+        "missing": missing,
+    }

--- a/tests/unit/auth/test_volume_verifiers.py
+++ b/tests/unit/auth/test_volume_verifiers.py
@@ -1,0 +1,190 @@
+"""Tests for volume_verifiers module."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from moonmind.workflows.temporal.runtime.providers.volume_verifiers import (
+    PROVIDER_CREDENTIAL_PATHS,
+    verify_volume_credentials,
+)
+
+
+class TestProviderCredentialPaths:
+    """Verify per-provider credential path definitions."""
+
+    def test_gemini_paths_defined(self) -> None:
+        assert "gemini_cli" in PROVIDER_CREDENTIAL_PATHS
+        paths = PROVIDER_CREDENTIAL_PATHS["gemini_cli"]
+        assert len(paths) >= 1
+        assert any("gemini" in p or "google-cloud-sdk" in p for p in paths)
+
+    def test_codex_paths_defined(self) -> None:
+        assert "codex_cli" in PROVIDER_CREDENTIAL_PATHS
+        paths = PROVIDER_CREDENTIAL_PATHS["codex_cli"]
+        assert len(paths) >= 1
+        assert any("codex" in p for p in paths)
+
+    def test_claude_paths_defined(self) -> None:
+        assert "claude_code" in PROVIDER_CREDENTIAL_PATHS
+        paths = PROVIDER_CREDENTIAL_PATHS["claude_code"]
+        assert len(paths) >= 1
+        assert any("claude" in p for p in paths)
+
+
+class TestVerifyVolumeCredentials:
+    """Test volume credential verification logic."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_runtime_returns_verified(self) -> None:
+        """Unknown runtimes skip verification and return verified=True."""
+        result = await verify_volume_credentials(
+            runtime_id="unknown_runtime",
+            volume_ref="test_volume",
+        )
+        assert result["verified"] is True
+        assert result["reason"] == "no_credential_paths_defined"
+
+    @pytest.mark.asyncio
+    async def test_missing_volume_ref_returns_not_verified(self) -> None:
+        result = await verify_volume_credentials(
+            runtime_id="gemini_cli",
+            volume_ref="",
+        )
+        assert result["verified"] is False
+        assert result["reason"] == "no_volume_ref"
+
+    @pytest.mark.asyncio
+    async def test_docker_not_available(self) -> None:
+        """When Docker isn't installed, returns not verified with reason."""
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("docker not found"),
+        ):
+            result = await verify_volume_credentials(
+                runtime_id="gemini_cli",
+                volume_ref="test_volume",
+            )
+        assert result["verified"] is False
+        assert result["reason"] == "docker_not_available"
+
+    @pytest.mark.asyncio
+    async def test_docker_timeout(self) -> None:
+        async def slow_exec(*args, **kwargs):
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(
+                side_effect=asyncio.TimeoutError()
+            )
+            return mock_proc
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=asyncio.TimeoutError(),
+        ):
+            result = await verify_volume_credentials(
+                runtime_id="gemini_cli",
+                volume_ref="test_volume",
+            )
+        assert result["verified"] is False
+        assert result["reason"] == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_successful_verification(self) -> None:
+        """Simulate Docker run finding credentials."""
+        mock_process = AsyncMock()
+        mock_process.communicate = AsyncMock(
+            return_value=(
+                b"FOUND:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                b"",
+            )
+        )
+        mock_process.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=mock_process,
+        ), patch(
+            "asyncio.wait_for",
+            return_value=(
+                b"FOUND:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                b"",
+            ),
+        ):
+            # Need to return mock_process from create_subprocess_exec
+            # and mock wait_for to return the communicate result
+            pass
+
+        # Simpler approach: mock at a higher level
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+
+        async def mock_communicate():
+            return (
+                b"FOUND:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                b"",
+            )
+
+        mock_process.communicate = mock_communicate
+
+        with patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio"
+        ) as mock_asyncio:
+            mock_asyncio.create_subprocess_exec = AsyncMock(
+                return_value=mock_process
+            )
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.wait_for = AsyncMock(
+                return_value=(
+                    b"FOUND:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                    b"",
+                )
+            )
+            mock_asyncio.TimeoutError = asyncio.TimeoutError
+
+            result = await verify_volume_credentials(
+                runtime_id="gemini_cli",
+                volume_ref="gemini_auth_volume",
+            )
+
+        assert result["verified"] is True
+        assert ".config/gemini/credentials.json" in result["found"]
+
+    @pytest.mark.asyncio
+    async def test_no_credentials_found(self) -> None:
+        """Simulate Docker run finding no credentials."""
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+
+        async def mock_communicate():
+            return (
+                b"MISSING:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                b"",
+            )
+
+        mock_process.communicate = mock_communicate
+
+        with patch(
+            "moonmind.workflows.temporal.runtime.providers.volume_verifiers.asyncio"
+        ) as mock_asyncio:
+            mock_asyncio.create_subprocess_exec = AsyncMock(
+                return_value=mock_process
+            )
+            mock_asyncio.subprocess = asyncio.subprocess
+            mock_asyncio.wait_for = AsyncMock(
+                return_value=(
+                    b"MISSING:.config/gemini/credentials.json\nMISSING:.config/google-cloud-sdk/application_default_credentials.json\n",
+                    b"",
+                )
+            )
+            mock_asyncio.TimeoutError = asyncio.TimeoutError
+
+            result = await verify_volume_credentials(
+                runtime_id="gemini_cli",
+                volume_ref="gemini_auth_volume",
+            )
+
+        assert result["verified"] is False
+        assert result["reason"] == "no_credentials_found"


### PR DESCRIPTION
## Description
- Creates volume_verifiers.py with per-provider credential file checks for gemini_cli, codex_cli, claude_code
- Wires best-effort volume verification into finalize endpoint (logs but doesn't block)
- Dashboard OAuth modal already fully functional (session create, 2s status polling, tmate URL display, cancel)
- 9 new unit tests (27 total in auth/ suite)

Ref: docs/ManagedAgents/UniversalTmateOAuth.md