### PR TITLE
Add Docker ARM build pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,6 +49,6 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.version_tag }}
             ${{ steps.meta.outputs.image_name }}:latest
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This change updates the GitHub Actions workflow to build and publish Docker images for both linux/amd64 and linux/arm64 architectures. The Dockerfile and installation scripts already have some support for ARM, so this change enables the multi-platform build in CI.

Fixes #855

---
*PR created automatically by Jules for task [8855465386892395547](https://jules.google.com/task/8855465386892395547) started by @nsticco*