### PR TITLE
fix: use URL-safe base64 for Temporal pagination tokens

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1259,7 +1259,14 @@ async def list_executions(
             query_str = " AND ".join(query_parts) if query_parts else ""
 
             import base64
-            token_bytes = base64.b64decode(next_page_token) if next_page_token else None
+
+            token_bytes = None
+            if next_page_token:
+                try:
+                    token_bytes = base64.urlsafe_b64decode(next_page_token)
+                except Exception:
+                    # Fallback for legacy tokens that may not be URL-safe
+                    token_bytes = base64.b64decode(next_page_token)
 
             count_info = await client.count_workflows(query=query_str)
 
@@ -1286,7 +1293,9 @@ async def list_executions(
 
             new_token_str = None
             if iterator.next_page_token:
-                new_token_str = base64.b64encode(iterator.next_page_token).decode("utf-8")
+                new_token_str = base64.urlsafe_b64encode(iterator.next_page_token).decode(
+                    "utf-8"
+                )
 
             return ExecutionListResponse(
                 items=items,
@@ -1354,7 +1363,7 @@ async def list_executions(
         degraded_count=False,
         refreshed_at=max(
             (_compatibility_refreshed_at(item) for item in result.items),
-            default=None,
+            default=datetime.now(UTC),
         ),
     )
 

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3423,7 +3423,7 @@
     const parsedLimit = Number(params.get("limit") || DEFAULT_QUEUE_PAGE_SIZE);
     return {
       limit: QUEUE_PAGE_SIZE_OPTIONS.includes(parsedLimit) ? parsedLimit : DEFAULT_QUEUE_PAGE_SIZE,
-      cursor: String(params.get("cursor") || "").trim() || null,
+      cursor: (String(params.get("nextPageToken") || "").trim() || String(params.get("cursor") || "").trim()) || null,
     };
   }
 
@@ -3448,6 +3448,9 @@
   async function renderQueueListPage() {
     const initialQuery = new URLSearchParams(window.location.search || "");
     const initialSource = String(initialQuery.get("source") || "").trim().toLowerCase();
+    if (initialSource === "temporal" && !filterState.source) {
+      filterState.source = "temporal";
+    }
     const initialPagination = parseQueuePaginationFromSearch(window.location.search || "");
     const initialFilterRuntime = String(initialQuery.get("filterRuntime") || "").trim().toLowerCase();
     const initialTemporalToken = String(initialQuery.get("nextPageToken") || "").trim() || null;


### PR DESCRIPTION
### 🚀 Summary
Fixed task pagination when using the Temporal backend by switching to URL-safe base64 encoding for opaque pagination tokens and aligning parameter names between the frontend and backend.

### 💡 What
- **Backend (`executions.py`)**: Replaced `base64.b64encode/decode` with `base64.urlsafe_b64encode/decode` for `next_page_token` when `source=temporal`. Added a fallback for standard base64 for backward compatibility.
- **Backend (`executions.py`)**: Ensured `refreshed_at` is always populated in the `ExecutionListResponse` by defaulting to `now()` if no items are found.
- **Frontend (`dashboard.js`)**: Updated `parseQueuePaginationFromSearch` to check for `nextPageToken` in addition to `cursor`.
- **Frontend (`dashboard.js`)**: Ensured `filterState.source` is initialized to `"temporal"` if provided in the initial URL, ensuring it is correctly synced back.

### 🎯 Why
Standard base64 characters like `+` are interpreted as spaces in URLs, which corrupts the Temporal pagination token and causes 422 errors when trying to fetch subsequent pages. The frontend also failed to reload pagination state correctly because it wasn't looking for the `nextPageToken` parameter name used by the Temporal API branch.

### 📊 Measured Improvement
- Pagination tokens are no longer corrupted by URL encoding/decoding.
- Page refreshes on the task list now correctly preserve the current Temporal pagination token and source filter.
- 422/500 errors on empty filtered results due to missing `refreshed_at` are eliminated.

Fixes #849

---
*PR created automatically by Jules for task [5894618848056969562](https://jules.google.com/task/5894618848056969562) started by @nsticco*