### PR TITLE
fix(ui): enable live log tailing for MoonMind.Run tasks

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -194,6 +194,7 @@
       ? systemConfig.temporalCompatibility
       : {};
   const defaultQueueName = String(systemConfig.defaultQueue || "moonmind.jobs");
+  const WORKFLOWS_WITHOUT_LIVE_LOGS = ["MoonMind.ManifestIngest", "MoonMind.AuthProfileManager"];
   const taskSourceResolverEndpoint = String(
     systemConfig.taskSourceResolver || "/api/tasks/{taskId}/source",
   );
@@ -7564,7 +7565,7 @@
       }</tbody>
         </table>
       </section>
-      ${["MoonMind.ManifestIngest", "MoonMind.AuthProfileManager"].includes(String(pick(execution, "workflowType") || "")) ? "" : `
+      ${WORKFLOWS_WITHOUT_LIVE_LOGS.includes(String(pick(execution, "workflowType") || "")) ? "" : `
       <section id="temporal-live-logs-section">
         <h3>Live Logs</h3>
         <div id="temporal-live-logs-inactive">

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -7564,7 +7564,7 @@
       }</tbody>
         </table>
       </section>
-      ${["MoonMind.Run", "MoonMind.ManifestIngest", "MoonMind.AuthProfileManager"].includes(String(pick(execution, "workflowType") || "")) ? "" : `
+      ${["MoonMind.ManifestIngest", "MoonMind.AuthProfileManager"].includes(String(pick(execution, "workflowType") || "")) ? "" : `
       <section id="temporal-live-logs-section">
         <h3>Live Logs</h3>
         <div id="temporal-live-logs-inactive">


### PR DESCRIPTION
Enabled live log tailing (tmate) options for `MoonMind.Run` managed agent runtime tasks in the frontend task dashboard by adjusting the UI exclusion logic in `dashboard.js`.

---
*PR created automatically by Jules for task [1718578962023248082](https://jules.google.com/task/1718578962023248082) started by @nsticco*