### PR TITLE
feat(pr-resolver): succeed immediately when PR is already merged

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -46,8 +46,8 @@ def _check_pr_merged(selector: str | None) -> bool:
         return False
     cmd = ["gh", "pr", "view", str(selector), "--json", "state"]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    except OSError:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=60)
+    except (OSError, subprocess.TimeoutExpired):
         return False
     if result.returncode != 0:
         return False

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -35,6 +35,32 @@ CONFLICTING_MERGEABLE = {"CONFLICTING", "DIRTY"}
 DIRECT_MERGE_STATE = {"CLEAN"}
 
 
+def _check_pr_merged(selector: str | None) -> bool:
+    """Best-effort check whether the PR identified by *selector* is merged.
+
+    Returns ``True`` when ``gh pr view`` reports ``state: MERGED``.
+    Returns ``False`` on any error or non-merged state so the caller
+    can fall through to standard error handling.
+    """
+    if not selector:
+        return False
+    cmd = ["gh", "pr", "view", str(selector), "--json", "state"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError:
+        return False
+    if result.returncode != 0:
+        return False
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    return (
+        isinstance(payload, dict)
+        and normalize_text(payload.get("state")).upper() == "MERGED"
+    )
+
+
 def _is_conflicting(pr: dict[str, Any]) -> bool:
     mergeable = pr.get("mergeable")
     merge_state = normalize_text(pr.get("mergeStateStatus")).upper()
@@ -197,6 +223,20 @@ def main() -> None:
                 _run_snapshot(snapshot_script, args.pr, snapshot_path)
             except subprocess.CalledProcessError as exc:
                 if exc.returncode == EXIT_CODE_FAILED:
+                    # The snapshot failed — but the PR may simply have been
+                    # merged (and its branch deleted) between task creation
+                    # and execution.  Check before reporting failure.
+                    if _check_pr_merged(args.pr):
+                        _write_result(
+                            result_path,
+                            snapshot={"pr": {"state": "MERGED"}},
+                            decision="already merged (detected after snapshot failure)",
+                            merge_outcome="merged",
+                            status="merged",
+                            reason="already_merged",
+                        )
+                        print("PR is already merged (detected after snapshot failure).")
+                        sys.exit(EXIT_CODE_MERGED)
                     _write_result(
                         result_path,
                         snapshot={"pr": {}},

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -6836,6 +6836,14 @@ class CodexWorker:
         else:
             pr_node = snapshot_payload.get("pr")
             pr = pr_node if isinstance(pr_node, Mapping) else {}
+
+            # Shortcircuit: if the PR is already merged, skip all signal
+            # checks — the objective is satisfied regardless of stale
+            # snapshot data (e.g. CI, comments, merge state).
+            pr_state = str(pr.get("state") or "").strip().upper()
+            if pr_state == "MERGED":
+                return StepGateResult(passed=True)
+
             comments_node = snapshot_payload.get("commentsSummary")
             comments_summary = (
                 comments_node if isinstance(comments_node, Mapping) else {}

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -807,3 +807,83 @@ def test_summarize_ci_head_checks_propagate_failures(
     assert summary["nonSecurityCheckCount"] == 1
     assert len(summary["failedChecks"]) == 1
     assert summary["failedChecks"][0]["name"] == "test"
+
+
+def test_finalize_already_merged_pr_returns_already_merged(
+    pr_resolve_finalize_module: dict[str, Any],
+) -> None:
+    evaluate_finalize_action = pr_resolve_finalize_module["evaluate_finalize_action"]
+
+    decision = evaluate_finalize_action(
+        {
+            "pr": {
+                "state": "MERGED",
+                "mergeable": "UNKNOWN",
+                "mergeStateStatus": "UNKNOWN",
+            },
+            "ci": {"isRunning": False, "hasFailures": False, "signalQuality": "ok"},
+            "commentsFetch": {"succeeded": True, "source": "fixture"},
+            "commentsSummary": {
+                "hasActionableComments": False,
+                "includeBotReviewComments": True,
+            },
+        }
+    )
+
+    assert decision == {"action": "already_merged", "reason": "already_merged"}
+
+
+def test_finalize_pr_not_found_but_merged_succeeds(
+    pr_resolve_finalize_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When snapshot refresh fails but the PR is actually merged,
+    finalize should report status=merged and exit with EXIT_CODE_MERGED."""
+    import subprocess as _subprocess
+
+    main = pr_resolve_finalize_module["main"]
+    globals_dict = main.__globals__
+    exit_code_merged = pr_resolve_finalize_module["EXIT_CODE_MERGED"]
+    exit_code_failed = pr_resolve_finalize_module["EXIT_CODE_FAILED"]
+
+    # Simulate snapshot refresh failure with EXIT_CODE_FAILED
+    def _boom(
+        _snapshot_script: Path,
+        _pr: str | None,
+        _snapshot_path: Path,
+    ) -> None:
+        raise _subprocess.CalledProcessError(
+            returncode=int(exit_code_failed),
+            cmd=["python3", "pr_resolve_snapshot.py"],
+            output="",
+            stderr="no pull requests found",
+        )
+
+    monkeypatch.setitem(globals_dict, "_run_snapshot", _boom)
+
+    # Simulate _check_pr_merged returning True (PR was merged)
+    monkeypatch.setitem(globals_dict, "_check_pr_merged", lambda _selector: True)
+
+    result_path = tmp_path / "pr_resolver_result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "123",
+            "--result-path",
+            str(result_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+    assert int(raised.value.code) == int(exit_code_merged)
+
+    import json
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "merged"
+    assert payload["reason"] == "already_merged"
+    assert payload["merge_outcome"] == "merged"


### PR DESCRIPTION
## Summary

When `batch-pr-resolver` queues tasks for PRs that get merged before the task runs, the pr-resolver now detects this and reports success instead of failure.

## Changes

### `pr_resolve_finalize.py`
- Added `_check_pr_merged()` helper that runs `gh pr view <selector> --json state` to detect merged PRs
- When snapshot refresh fails with `pr_not_found`, checks if the PR was actually merged before reporting failure
- If merged → writes `status=merged` result and exits with `EXIT_CODE_MERGED` (0) instead of `EXIT_CODE_FAILED`

### `worker.py`
- Added shortcircuit in `_validate_pr_resolution_final_state`: if `pr.state == "MERGED"`, the validation gate passes immediately, skipping stale signal checks (CI, comments, merge state)

### `test_pr_resolver_tools.py`
- `test_finalize_already_merged_pr_returns_already_merged` — verifies `evaluate_finalize_action` returns `already_merged` for merged PRs
- `test_finalize_pr_not_found_but_merged_succeeds` — verifies snapshot-failure recovery when PR is actually merged

## Testing

All 1833 unit tests pass (0 failures).