### PR TITLE
fix: task list Scheduled column sort falls back to createdAt

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3274,10 +3274,9 @@
       let leftVal;
       let rightVal;
       if (TIMESTAMP_SORT_FIELDS.has(field)) {
-        const leftRaw = field === "scheduledFor" ? (left[field] || left.createdAt) : left[field];
-        const rightRaw = field === "scheduledFor" ? (right[field] || right.createdAt) : right[field];
-        leftVal = Date.parse(leftRaw || 0) || 0;
-        rightVal = Date.parse(rightRaw || 0) || 0;
+        const getRawTimestamp = (row) => field === "scheduledFor" ? (row[field] || row.createdAt) : row[field];
+        leftVal = Date.parse(getRawTimestamp(left) || 0) || 0;
+        rightVal = Date.parse(getRawTimestamp(right) || 0) || 0;
         if (leftVal !== rightVal) {
           return dir * (leftVal - rightVal);
         }

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -3274,8 +3274,10 @@
       let leftVal;
       let rightVal;
       if (TIMESTAMP_SORT_FIELDS.has(field)) {
-        leftVal = Date.parse(left[field] || 0) || 0;
-        rightVal = Date.parse(right[field] || 0) || 0;
+        const leftRaw = field === "scheduledFor" ? (left[field] || left.createdAt) : left[field];
+        const rightRaw = field === "scheduledFor" ? (right[field] || right.createdAt) : right[field];
+        leftVal = Date.parse(leftRaw || 0) || 0;
+        rightVal = Date.parse(rightRaw || 0) || 0;
         if (leftVal !== rightVal) {
           return dir * (leftVal - rightVal);
         }

--- a/tests/task_dashboard/test_task_layouts.js
+++ b/tests/task_dashboard/test_task_layouts.js
@@ -294,6 +294,18 @@ function createProposalRow(overrides = {}) {
   assert.strictEqual(sorted[2].rawStatus, 'succeeded');
 })();
 
+(function testSortRowsByColumnScheduledForFallsBackToCreatedAt() {
+  const rows = [
+    createTaskRow({ id: 'job-a', scheduledFor: null, createdAt: '2026-03-10T00:00:00Z' }),
+    createTaskRow({ id: 'job-b', scheduledFor: null, createdAt: '2026-03-12T00:00:00Z' }),
+    createTaskRow({ id: 'job-c', scheduledFor: '2026-03-15T00:00:00Z', createdAt: '2026-03-08T00:00:00Z' }),
+  ];
+  const sorted = sortRowsByColumn(rows, 'scheduledFor', 'desc');
+  assert.strictEqual(sorted[0].id, 'job-c', 'Explicit scheduledFor should sort first when newest');
+  assert.strictEqual(sorted[1].id, 'job-b', 'Null scheduledFor should fall back to createdAt');
+  assert.strictEqual(sorted[2].id, 'job-a', 'Oldest createdAt should sort last');
+})();
+
 (function testSortRowsByColumnDoesNotMutateOriginalArray() {
   const rows = [
     createTaskRow({ id: 'job-1', title: 'Zebra task' }),


### PR DESCRIPTION
## Problem

The task list defaults to sorting by the **Scheduled** column descending, but most tasks have `scheduledFor` set to `null` (only deferred tasks populate it). This caused `Date.parse(null || 0)` → `0` for all non-deferred tasks, making them compare as equal and effectively unsorted.

The **display** column already fell back to `createdAt` (`row.scheduledFor || row.createdAt`), but the **sort comparator** did not.

## Fix

Apply the same `scheduledFor || createdAt` fallback in `sortRowsByColumn` so non-deferred tasks sort by creation time.

## Changes

- **`dashboard.js`** — `sortRowsByColumn` now uses `createdAt` as fallback when sorting by `scheduledFor` and the value is missing
- **`test_task_layouts.js`** — New test `testSortRowsByColumnScheduledForFallsBackToCreatedAt` validates fallback behavior

## Testing

All 1836 unit tests pass.