### PR TITLE
fix: improve Jules auto-answer fallback message

### DIFF
--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -83,10 +83,7 @@ async def _generate_llm_answer(prompt: str) -> str:
             "No GEMINI_API_KEY or GOOGLE_API_KEY set; falling back to "
             "default auto-answer behaviour"
         )
-        return (
-            "I'll proceed with the most reasonable default. "
-            "Please continue with the implementation."
-        )
+        return "Proceed with your recommendation."
 
     try:
         import google.generativeai as genai  # type: ignore[import-untyped]
@@ -106,10 +103,7 @@ async def _generate_llm_answer(prompt: str) -> str:
             exc_info=True,
         )
 
-    return (
-        "I'll proceed with the most reasonable default. "
-        "Please continue with the implementation."
-    )
+    return "Proceed with your recommendation."
 
 
 @activity.defn(name="integration.jules.start")

--- a/moonmind/workflows/temporal/activities/jules_activities.py
+++ b/moonmind/workflows/temporal/activities/jules_activities.py
@@ -27,6 +27,8 @@ from moonmind.workflows.adapters.jules_client import JulesClient
 
 logger = logging.getLogger(__name__)
 
+_JULES_FALLBACK_ANSWER = "Proceed with your recommendation."
+
 
 def _build_client() -> JulesClient:
     """Build a ``JulesClient`` from environment config.
@@ -83,7 +85,7 @@ async def _generate_llm_answer(prompt: str) -> str:
             "No GEMINI_API_KEY or GOOGLE_API_KEY set; falling back to "
             "default auto-answer behaviour"
         )
-        return "Proceed with your recommendation."
+        return _JULES_FALLBACK_ANSWER
 
     try:
         import google.generativeai as genai  # type: ignore[import-untyped]


### PR DESCRIPTION
## Problem

When Jules asks MoonMind a clarification question during an automated run and no `GEMINI_API_KEY` is configured (or the LLM call fails), the fallback message was:

> *"I'll proceed with the most reasonable default. Please continue with the implementation."*

This is vague and unhelpful — especially when Jules asks specific yes/no questions like *"Should I delete these files?"*

## Fix

Changed the fallback to **"Proceed with your recommendation."** — a clear, actionable directive that affirms whatever Jules was proposing.

## Changes

- `moonmind/workflows/temporal/activities/jules_activities.py`: Updated both fallback paths (no-API-key and LLM-failure) in `_generate_llm_answer()`