### PR TITLE
fix: generate multi-node plans for multi-step Jules workflows

### DIFF
--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -247,15 +247,71 @@ def _build_runtime_planner():
             .isoformat()
             .replace("+00:00", "Z")
         )
-        node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
         failure_mode = str(
             parameter_payload.get("failurePolicy") or "FAIL_FAST"
         ).strip()
         if failure_mode not in {"FAIL_FAST", "CONTINUE"}:
             failure_mode = "FAIL_FAST"
 
-        nodes: list[dict[str, Any]] = [
-            {
+        # --- Expand task.steps[] into multiple plan nodes ---
+        raw_steps = task_payload.get("steps")
+        has_multi_steps = (
+            isinstance(raw_steps, list)
+            and len(raw_steps) > 1
+            and all(isinstance(s, Mapping) for s in raw_steps)
+        )
+
+        nodes: list[dict[str, Any]] = []
+        edges: list[dict[str, str]] = []
+
+        if has_multi_steps:
+            for idx, step_entry in enumerate(raw_steps):
+                step_instructions = str(step_entry.get("instructions") or "").strip()
+                if not step_instructions:
+                    step_instructions = instructions  # fall back to task-level
+
+                step_id = str(step_entry.get("id") or "").strip() or f"step-{idx + 1}"
+                step_node_inputs: dict[str, Any] = {
+                    **node_inputs,
+                    "instructions": step_instructions,
+                }
+
+                # Per-step tool/skill override
+                step_tool = _coerce_mapping(step_entry.get("tool")) or _coerce_mapping(
+                    step_entry.get("skill")
+                )
+                step_tool_name = str(
+                    step_tool.get("name") or step_tool.get("id") or ""
+                ).strip()
+                step_runtime = runtime_mode
+                if step_tool_name:
+                    step_runtime = step_tool_name
+
+                nodes.append({
+                    "id": step_id,
+                    "tool": {
+                        "type": "agent_runtime",
+                        "name": step_runtime,
+                        "version": "1.0",
+                    },
+                    "inputs": step_node_inputs,
+                })
+
+                if idx > 0:
+                    prev_id = str(raw_steps[idx - 1].get("id") or "").strip() or f"step-{idx}"
+                    edges.append({"from": prev_id, "to": step_id})
+
+            # Append PR suffix to the *last* node when publishMode is "pr"
+            if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
+                pr_suffix = (
+                    "\n\nAfter completing the changes above, create a GitHub "
+                    "pull request with the changes using `gh pr create`."
+                )
+                last_inputs = nodes[-1]["inputs"]
+                last_inputs["instructions"] = last_inputs["instructions"] + pr_suffix
+        else:
+            node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
+            nodes.append({
                 "id": node_id,
                 "tool": {
                     "type": "agent_runtime",
@@ -263,19 +319,14 @@ def _build_runtime_planner():
                     "version": "1.0",
                 },
                 "inputs": node_inputs,
-            }
-        ]
+            })
 
-        if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
-            # Append PR creation instructions to the primary node so the
-            # agent creates the PR in the same workspace where the changes
-            # were made.  A separate node would run in a fresh checkout with
-            # no changes to publish.
-            pr_suffix = (
-                "\n\nAfter completing the changes above, create a GitHub "
-                "pull request with the changes using `gh pr create`."
-            )
-            node_inputs["instructions"] = instructions + pr_suffix
+            if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
+                pr_suffix = (
+                    "\n\nAfter completing the changes above, create a GitHub "
+                    "pull request with the changes using `gh pr create`."
+                )
+                node_inputs["instructions"] = instructions + pr_suffix
 
         return {
             "plan_version": "1.0",
@@ -289,7 +340,7 @@ def _build_runtime_planner():
             },
             "policy": {"failure_mode": failure_mode, "max_concurrency": 1},
             "nodes": nodes,
-            "edges": [],
+            "edges": edges,
         }
 
     return _runtime_planner

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -265,6 +265,7 @@ def _build_runtime_planner():
         edges: list[dict[str, str]] = []
 
         if has_multi_steps:
+            prev_step_id: str | None = None
             for idx, step_entry in enumerate(raw_steps):
                 step_instructions = str(step_entry.get("instructions") or "").strip()
                 if not step_instructions:
@@ -297,18 +298,9 @@ def _build_runtime_planner():
                     "inputs": step_node_inputs,
                 })
 
-                if idx > 0:
-                    prev_id = str(raw_steps[idx - 1].get("id") or "").strip() or f"step-{idx}"
-                    edges.append({"from": prev_id, "to": step_id})
-
-            # Append PR suffix to the *last* node when publishMode is "pr"
-            if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
-                pr_suffix = (
-                    "\n\nAfter completing the changes above, create a GitHub "
-                    "pull request with the changes using `gh pr create`."
-                )
-                last_inputs = nodes[-1]["inputs"]
-                last_inputs["instructions"] = last_inputs["instructions"] + pr_suffix
+                if prev_step_id:
+                    edges.append({"from": prev_step_id, "to": step_id})
+                prev_step_id = step_id
         else:
             node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
             nodes.append({
@@ -321,12 +313,15 @@ def _build_runtime_planner():
                 "inputs": node_inputs,
             })
 
-            if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
-                pr_suffix = (
-                    "\n\nAfter completing the changes above, create a GitHub "
-                    "pull request with the changes using `gh pr create`."
-                )
-                node_inputs["instructions"] = instructions + pr_suffix
+        # Append PR creation instructions to the last node so the agent
+        # creates the PR in the same workspace where the changes were made.
+        if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
+            pr_suffix = (
+                "\n\nAfter completing the changes above, create a GitHub "
+                "pull request with the changes using `gh pr create`."
+            )
+            last_inputs = nodes[-1]["inputs"]
+            last_inputs["instructions"] = last_inputs["instructions"] + pr_suffix
 
         return {
             "plan_version": "1.0",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -81,6 +81,149 @@ def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions(
         )
 
 
+def _make_snapshot():
+    return SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+
+def test_runtime_planner_multi_step_generates_multiple_nodes_with_edges():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Objective",
+                "steps": [
+                    {"id": "s1", "instructions": "Step one instructions"},
+                    {"id": "s2", "instructions": "Step two instructions"},
+                    {"id": "s3", "instructions": "Step three instructions"},
+                ],
+                "runtime": {"mode": "jules"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    nodes = plan["nodes"]
+    edges = plan["edges"]
+
+    assert len(nodes) == 3
+    assert nodes[0]["id"] == "s1"
+    assert nodes[0]["inputs"]["instructions"] == "Step one instructions"
+    assert nodes[1]["id"] == "s2"
+    assert nodes[1]["inputs"]["instructions"] == "Step two instructions"
+    assert nodes[2]["id"] == "s3"
+    assert nodes[2]["inputs"]["instructions"] == "Step three instructions"
+
+    # All nodes use agent_runtime tool type
+    for node in nodes:
+        assert node["tool"]["type"] == "agent_runtime"
+        assert node["tool"]["name"] == "jules"
+
+    # Sequential edges
+    assert len(edges) == 2
+    assert edges[0] == {"from": "s1", "to": "s2"}
+    assert edges[1] == {"from": "s2", "to": "s3"}
+
+
+def test_runtime_planner_single_step_falls_back_to_single_node():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do the thing",
+                "steps": [
+                    {"id": "only", "instructions": "Only step"},
+                ],
+                "runtime": {"mode": "jules"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    # Single-step array should use the single-node fallback path
+    assert len(plan["nodes"]) == 1
+    assert plan["edges"] == []
+    assert plan["nodes"][0]["inputs"]["instructions"] == "Do the thing"
+
+
+def test_runtime_planner_no_steps_falls_back_to_single_node():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do the thing",
+                "runtime": {"mode": "jules"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert len(plan["nodes"]) == 1
+    assert plan["edges"] == []
+    assert plan["nodes"][0]["inputs"]["instructions"] == "Do the thing"
+
+
+def test_runtime_planner_multi_step_step_fallback_instructions():
+    """When a step has no instructions, the task-level instructions are used."""
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Task-level fallback",
+                "steps": [
+                    {"id": "a", "instructions": "Explicit step A"},
+                    {"id": "b"},  # no instructions
+                ],
+                "runtime": {"mode": "jules"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert len(plan["nodes"]) == 2
+    assert plan["nodes"][0]["inputs"]["instructions"] == "Explicit step A"
+    assert plan["nodes"][1]["inputs"]["instructions"] == "Task-level fallback"
+
+
+def test_runtime_planner_multi_step_auto_generated_ids():
+    """When steps lack explicit IDs, sequential IDs are generated."""
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Objective",
+                "steps": [
+                    {"instructions": "First"},
+                    {"instructions": "Second"},
+                ],
+                "runtime": {"mode": "jules"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][0]["id"] == "step-1"
+    assert plan["nodes"][1]["id"] == "step-2"
+    assert plan["edges"] == [{"from": "step-1", "to": "step-2"}]
+
+
 @pytest.mark.asyncio
 @patch("moonmind.workflows.temporal.worker_runtime.start_healthcheck_server")
 @patch("moonmind.workflows.temporal.worker_runtime.describe_configured_worker")


### PR DESCRIPTION
## Problem

Multi-step workflows submitted to the Jules runtime only displayed instructions for step 1. The artifact correctly showed the total step count, but all subsequent step instructions were lost.

## Root Cause

`_build_runtime_planner()` in `worker_runtime.py` always produced **exactly one plan node** using the top-level `task.instructions`, regardless of how many steps the user submitted. The `task.steps[]` array was only used for counting (`stepCount` metric) and never translated into per-step plan nodes.

The downstream execution layer (`run.py` + `agent_run.py`) already had full multi-step Jules session-reuse support via `jules_session_id` propagation — the bug was isolated to plan generation.

## Fix

Updated `_build_runtime_planner()` to:
- Check for `task.steps[]` with >1 entries
- Generate one plan node per step with per-step `instructions`
- Add sequential dependency edges (`step-1 → step-2 → step-3`) for Jules session reuse
- Fall back to existing single-node behavior when steps are absent or ≤1
- Apply PR publish suffix to the *last* node in multi-step mode

## Tests

Added 5 unit tests covering:
- Multi-step plan generation (3 steps → 3 nodes + 2 edges)
- Single-step fallback (preserves existing behavior)
- No-steps fallback (preserves existing behavior)
- Fallback instructions (steps without instructions use task-level)
- Auto-generated IDs (generates step-1, step-2 when IDs missing)

All 1880 unit tests pass.