### PR TITLE
feat: auto-seed MiniMax auth profile for Claude Code

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -500,13 +500,12 @@ async def _auto_seed_auth_profiles() -> list[str]:
                 )
                 session.add(profile)
                 seeded.append(profile_def["runtime_id"])
-                logger.info(
-                    "Auto-seeded auth profile '%s' for runtime '%s'",
-                    profile_def["profile_id"],
-                    profile_def["runtime_id"],
-                )
 
             await session.commit()
+            logger.info(
+                "Committed %d auto-seeded managed-agent auth profile row(s).",
+                len(seeded),
+            )
     except Exception as e:
         logger.error("Failed to auto-seed auth profiles: %s", e, exc_info=True)
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -443,6 +443,29 @@ async def _auto_seed_auth_profiles() -> list[str]:
         },
     ]
 
+    # Conditionally add MiniMax profile when the API key is available.
+    if os.environ.get("MINIMAX_API_KEY"):
+        _DEFAULT_PROFILES.append({
+            "profile_id": "claude_minimax",
+            "runtime_id": "claude_code",
+            "auth_mode": ManagedAgentAuthMode.API_KEY,
+            "api_key_ref": "MINIMAX_API_KEY",
+            "api_key_env_var": "ANTHROPIC_AUTH_TOKEN",
+            "runtime_env_overrides": {
+                "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+                "ANTHROPIC_MODEL": "MiniMax-M2.7",
+                "ANTHROPIC_SMALL_FAST_MODEL": "MiniMax-M2.7",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7",
+                "API_TIMEOUT_MS": "3000000",
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            },
+            "volume_ref": None,
+            "volume_mount_path": None,
+            "account_label": "Claude Code via MiniMax (auto-seeded)",
+        })
+
     seeded: list[str] = []
     try:
         async with get_async_session_context() as session:
@@ -464,9 +487,12 @@ async def _auto_seed_auth_profiles() -> list[str]:
                     profile_id=profile_def["profile_id"],
                     runtime_id=profile_def["runtime_id"],
                     auth_mode=profile_def["auth_mode"],
-                    volume_ref=profile_def["volume_ref"],
-                    volume_mount_path=profile_def["volume_mount_path"],
-                    account_label=profile_def["account_label"],
+                    volume_ref=profile_def.get("volume_ref"),
+                    volume_mount_path=profile_def.get("volume_mount_path"),
+                    account_label=profile_def.get("account_label"),
+                    api_key_ref=profile_def.get("api_key_ref"),
+                    api_key_env_var=profile_def.get("api_key_env_var"),
+                    runtime_env_overrides=profile_def.get("runtime_env_overrides"),
                     max_parallel_runs=1,
                     cooldown_after_429_seconds=300,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -458,7 +458,7 @@ async def _auto_seed_auth_profiles() -> list[str]:
                 "ANTHROPIC_DEFAULT_SONNET_MODEL": "MiniMax-M2.7",
                 "ANTHROPIC_DEFAULT_OPUS_MODEL": "MiniMax-M2.7",
                 "ANTHROPIC_DEFAULT_HAIKU_MODEL": "MiniMax-M2.7",
-                "API_TIMEOUT_MS": "3000000",
+                "API_TIMEOUT_MS": "600000",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
             },
             "volume_ref": None,

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -9539,7 +9539,7 @@
                 <label>
                   Runtime env overrides (JSON object, API key mode)
                   <textarea name="runtime_env_overrides_json" rows="8" class="wide"
-                    placeholder='{\n  "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",\n  "ANTHROPIC_MODEL": "MiniMax-M2.7",\n  "API_TIMEOUT_MS": "3000000",\n  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"\n}'></textarea>
+                    placeholder='{\n  "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",\n  "ANTHROPIC_MODEL": "MiniMax-M2.7",\n  "API_TIMEOUT_MS": "600000",\n  "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"\n}'></textarea>
                 </label>
                 <label>
                   Max Parallel Runs

--- a/tests/unit/api_service/test_auth_profile_auto_seed.py
+++ b/tests/unit/api_service/test_auth_profile_auto_seed.py
@@ -119,7 +119,7 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
     assert mm_profile.runtime_env_overrides is not None
     assert mm_profile.runtime_env_overrides["ANTHROPIC_BASE_URL"] == "https://api.minimax.io/anthropic"
     assert mm_profile.runtime_env_overrides["ANTHROPIC_MODEL"] == "MiniMax-M2.7"
-    assert mm_profile.runtime_env_overrides["API_TIMEOUT_MS"] == "3000000"
+    assert mm_profile.runtime_env_overrides["API_TIMEOUT_MS"] == "600000"
     assert mm_profile.volume_ref is None
     assert mm_profile.volume_mount_path is None
 

--- a/tests/unit/api_service/test_auth_profile_auto_seed.py
+++ b/tests/unit/api_service/test_auth_profile_auto_seed.py
@@ -39,9 +39,11 @@ def _module_db(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_auto_seed_creates_default_profiles(_module_db):
+async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     """When the table is empty, auto-seeding should create 3 default profiles."""
     from api_service.main import _auto_seed_auth_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
 
     seeded = await _auto_seed_auth_profiles()
     assert set(seeded) == {"gemini_cli", "codex_cli", "claude_code"}
@@ -57,9 +59,11 @@ async def test_auto_seed_creates_default_profiles(_module_db):
 
 
 @pytest.mark.asyncio
-async def test_auto_seed_is_idempotent(_module_db):
+async def test_auto_seed_is_idempotent(_module_db, monkeypatch):
     """Calling auto-seed twice should not duplicate profiles."""
     from api_service.main import _auto_seed_auth_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
 
     first = await _auto_seed_auth_profiles()
     assert len(first) == 3
@@ -87,3 +91,54 @@ async def test_auto_seed_skipped_when_env_set(_module_db, monkeypatch):
         result = await session.execute(select(ManagedAgentAuthProfile))
         profiles = result.scalars().all()
     assert len(profiles) == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
+    """When MINIMAX_API_KEY is set, a 4th 'claude_minimax' profile should be seeded."""
+    from api_service.main import _auto_seed_auth_profiles
+
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+
+    seeded = await _auto_seed_auth_profiles()
+    assert "claude_code" in seeded  # seeded twice (default + minimax)
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(select(ManagedAgentAuthProfile))
+        profiles = result.scalars().all()
+
+    assert len(profiles) == 4
+    profile_ids = {p.profile_id for p in profiles}
+    assert "claude_minimax" in profile_ids
+
+    # Verify MiniMax profile details.
+    mm_profile = next(p for p in profiles if p.profile_id == "claude_minimax")
+    assert mm_profile.runtime_id == "claude_code"
+    assert mm_profile.api_key_ref == "MINIMAX_API_KEY"
+    assert mm_profile.api_key_env_var == "ANTHROPIC_AUTH_TOKEN"
+    assert mm_profile.runtime_env_overrides is not None
+    assert mm_profile.runtime_env_overrides["ANTHROPIC_BASE_URL"] == "https://api.minimax.io/anthropic"
+    assert mm_profile.runtime_env_overrides["ANTHROPIC_MODEL"] == "MiniMax-M2.7"
+    assert mm_profile.runtime_env_overrides["API_TIMEOUT_MS"] == "3000000"
+    assert mm_profile.volume_ref is None
+    assert mm_profile.volume_mount_path is None
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_excludes_minimax_when_env_unset(_module_db, monkeypatch):
+    """When MINIMAX_API_KEY is absent, only the 3 default profiles are seeded."""
+    from api_service.main import _auto_seed_auth_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+
+    seeded = await _auto_seed_auth_profiles()
+    assert set(seeded) == {"gemini_cli", "codex_cli", "claude_code"}
+
+    async with db_base.async_session_maker() as session:
+        result = await session.execute(select(ManagedAgentAuthProfile))
+        profiles = result.scalars().all()
+
+    profile_ids = {p.profile_id for p in profiles}
+    assert "claude_minimax" not in profile_ids
+    assert len(profiles) == 3
+


### PR DESCRIPTION
## Summary

When `MINIMAX_API_KEY` is present in the environment, a `claude_minimax` auth profile is auto-seeded at startup with all MiniMax-specific env vars needed to route Claude Code through MiniMax's Anthropic API proxy.

## Changes

### `api_service/main.py`
- Added conditional MiniMax profile to `_auto_seed_auth_profiles()` — only seeded when `MINIMAX_API_KEY` is set
- Extended the seeding loop to pass through `api_key_ref`, `api_key_env_var`, and `runtime_env_overrides` using `.get()`

### `tests/unit/api_service/test_auth_profile_auto_seed.py`
- Added `monkeypatch.delenv("MINIMAX_API_KEY")` isolation to existing tests
- Added `test_auto_seed_includes_minimax_when_env_set` — verifies 4 profiles with full MiniMax env-override verification
- Added `test_auto_seed_excludes_minimax_when_env_unset` — confirms 3 profiles only

## MiniMax env vars injected

| Env var | Value |
|---|---|
| `ANTHROPIC_AUTH_TOKEN` | Resolved from `MINIMAX_API_KEY` at runtime |
| `ANTHROPIC_BASE_URL` | `https://api.minimax.io/anthropic` |
| `ANTHROPIC_MODEL` | `MiniMax-M2.7` |
| `ANTHROPIC_SMALL_FAST_MODEL` | `MiniMax-M2.7` |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `MiniMax-M2.7` |
| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `MiniMax-M2.7` |
| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `MiniMax-M2.7` |
| `API_TIMEOUT_MS` | `3000000` |
| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` |

## Test results

```
5 passed, 2 skipped, 157 warnings in 19.23s
```