### PR TITLE
feat: implement Phase 5 of managed agent abstractions

### DIFF
--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -373,15 +373,15 @@ Checkboxes reflect **implementation in the repo** as of **2026-03-22**. Run `./t
 
 **Goal**: Enable per-runtime workspace preparation and clean up remaining tech debt.
 
-- [ ] Implement `GeminiCliStrategy.prepare_workspace()` — write `.gemini/` instruction files or `GEMINI_INSTRUCTIONS`
-- [ ] Implement `ClaudeCodeStrategy.prepare_workspace()` — write `CLAUDE.md` with task context
+- [x] Implement `GeminiCliStrategy.prepare_workspace()` — write `.gemini/` instruction files or `GEMINI_INSTRUCTIONS`
+- [x] Implement `ClaudeCodeStrategy.prepare_workspace()` — write `CLAUDE.md` with task context
 - [x] Implement and verify `CursorCliStrategy.prepare_workspace()` — write `.cursor/rules/` and `.cursor/cli.json` via existing helpers
 - [x] Add workspace prep call in `launcher.py:launch()` after workspace resolution, before subprocess spawn *(calls `await strategy.prepare_workspace(...)`)*
 - [x] Wire launcher subprocess env through `strategy.shape_environment()` (launcher line 419)
-- [ ] Factor shared env-shaping helpers (`_OAUTH_CLEARED_VARS`, `_shape_environment_for_oauth`) into `moonmind/auth/env_shaping.py` for reuse by both strategies and the OAuth session orchestrator (per UniversalTmateOAuth.md alignment)
-- [ ] Clean up `agent_runtime_env_keys` in `settings.py` if confirmed dead config
-- [ ] Remove dead imports and unused code from adapter and launcher
-- [ ] Update `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` to reference the managed runtime strategy pattern
-- [ ] Move this file to `docs/ManagedAgents/SharedManagedAgentAbstractions.md`
+- [x] Factor shared env-shaping helpers (`_OAUTH_CLEARED_VARS`, `_shape_environment_for_oauth`) into `moonmind/auth/env_shaping.py` for reuse by both strategies and the OAuth session orchestrator (per UniversalTmateOAuth.md alignment)
+- [x] Clean up `agent_runtime_env_keys` in `settings.py` if confirmed dead config
+- [x] Remove dead imports and unused code from adapter and launcher
+- [x] Update `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` to reference the managed runtime strategy pattern
+- [x] Move this file to `docs/ManagedAgents/SharedManagedAgentAbstractions.md`
 
-**Output**: **Partial.** The **hook** in `launch()` is live. **Cursor** workspace prep is **complete**. **Codex** workspace prep (RAG context injection) is **complete**. **Env shaping delegation** in launcher is **complete**. Per-runtime workspace **content** for Gemini/Claude and shared env factoring are **still open**.
+**Output**: **Complete.** Per-runtime workspace preparation, shared env factoring, settings cleanup, and documentation updates have all been completed successfully.

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -297,7 +297,7 @@ Because of that, they must be launched asynchronously and supervised durably.
 The managed path should follow the same conceptual lifecycle as the external path:
 
 1. `ManagedAgentAdapter.start(...)` persists a durable run record.
-2. A runtime launcher starts the CLI runtime as a subprocess or equivalent managed execution unit.
+2. A runtime launcher starts the CLI runtime as a subprocess or equivalent managed execution unit. This is facilitated by the `ManagedRuntimeStrategy` pattern and its registry `RUNTIME_STRATEGIES`.
 3. A supervisor tracks process/container state, heartbeats, and output streams.
 4. On completion or interruption, the supervisor writes final state into the durable run record.
 5. MoonMind converts supervisor events into workflow Signals or Updates for the waiting `MoonMind.AgentRun` workflow.

--- a/moonmind/auth/env_shaping.py
+++ b/moonmind/auth/env_shaping.py
@@ -1,0 +1,70 @@
+"""Environment shaping helpers for OAuth and API-key modes.
+
+These helpers are shared across managed runtime strategies and the OAuth
+Session orchestrator to ensure consistent handling of sensitive credentials
+and environment overrides.
+"""
+
+from __future__ import annotations
+
+# Env-var prefixes / names cleared when shaping OAuth environments (DOC-REQ-007).
+# These are the sensitive keys that must NOT appear in child-process environments.
+_OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
+    {
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+    }
+)
+
+
+def _shape_environment_for_oauth(
+    base_env: dict[str, str],
+    *,
+    volume_mount_path: str | None,
+) -> dict[str, str]:
+    """Return env dict shaped for OAuth volume-mount mode.
+
+    Clears sensitive API-key vars and sets browser-auth helpers if a
+    volume mount path is provided.  Does NOT expose secrets.
+    """
+    env = dict(base_env)
+    for key in _OAUTH_CLEARED_VARS:
+        env.pop(key, None)
+    if volume_mount_path:
+        env["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
+    return env
+
+
+def _shape_environment_for_api_key(
+    base_env: dict[str, str],
+    *,
+    api_key_ref: str | None,
+    account_label: str | None,
+) -> dict[str, str]:
+    """Return env dict shaped for API-key mode.
+
+    The api_key_ref is a *reference* (e.g. a secret store key name), not the
+    raw credential.  The actual resolution of the reference into a real key
+    is delegated to the runtime launcher (out of scope for Phase 5).
+    """
+    env = dict(base_env)
+    for key in _OAUTH_CLEARED_VARS:
+        env.pop(key, None)
+    if api_key_ref:
+        # Pass only the reference, never the real value.
+        env["MANAGED_API_KEY_REF"] = api_key_ref
+    if account_label:
+        env["MANAGED_ACCOUNT_LABEL"] = account_label
+    return env
+
+__all__ = [
+    "_OAUTH_CLEARED_VARS",
+    "_shape_environment_for_oauth",
+    "_shape_environment_for_api_key",
+]

--- a/moonmind/auth/env_shaping.py
+++ b/moonmind/auth/env_shaping.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 # Env-var prefixes / names cleared when shaping OAuth environments (DOC-REQ-007).
 # These are the sensitive keys that must NOT appear in child-process environments.
-_OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
+OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
     {
         "GOOGLE_API_KEY",
         "GEMINI_API_KEY",
@@ -23,7 +23,7 @@ _OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
 )
 
 
-def _shape_environment_for_oauth(
+def shape_environment_for_oauth(
     base_env: dict[str, str],
     *,
     volume_mount_path: str | None,
@@ -34,14 +34,14 @@ def _shape_environment_for_oauth(
     volume mount path is provided.  Does NOT expose secrets.
     """
     env = dict(base_env)
-    for key in _OAUTH_CLEARED_VARS:
+    for key in OAUTH_CLEARED_VARS:
         env.pop(key, None)
     if volume_mount_path:
         env["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
     return env
 
 
-def _shape_environment_for_api_key(
+def shape_environment_for_api_key(
     base_env: dict[str, str],
     *,
     api_key_ref: str | None,
@@ -54,7 +54,7 @@ def _shape_environment_for_api_key(
     is delegated to the runtime launcher (out of scope for Phase 5).
     """
     env = dict(base_env)
-    for key in _OAUTH_CLEARED_VARS:
+    for key in OAUTH_CLEARED_VARS:
         env.pop(key, None)
     if api_key_ref:
         # Pass only the reference, never the real value.
@@ -64,7 +64,7 @@ def _shape_environment_for_api_key(
     return env
 
 __all__ = [
-    "_OAUTH_CLEARED_VARS",
-    "_shape_environment_for_oauth",
-    "_shape_environment_for_api_key",
+    "OAUTH_CLEARED_VARS",
+    "shape_environment_for_oauth",
+    "shape_environment_for_api_key",
 ]

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -635,11 +635,6 @@ class WorkflowSettings(BaseSettings):
         alias="WORKFLOW_PROMPT_PACK_VERSION",
         description="Prompt pack version associated with the selected agent.",
     )
-    agent_runtime_env_keys: tuple[str, ...] = Field(
-        ("CODEX_ENV", "CODEX_MODEL", "CODEX_PROFILE", "CODEX_API_KEY"),
-        alias="WORKFLOW_AGENT_RUNTIME_ENV_KEYS",
-        description="Environment variable names forwarded to the agent runtime snapshot.",
-    )
     skills_enabled: bool = Field(
         True,
         validation_alias=AliasChoices("WORKFLOW_USE_SKILLS", "WORKFLOW_USE_SKILLS"),
@@ -967,7 +962,7 @@ class WorkflowSettings(BaseSettings):
             return stripped or None
         return value
 
-    @field_validator("allowed_agent_backends", "agent_runtime_env_keys", mode="before")
+    @field_validator("allowed_agent_backends", mode="before")
     @classmethod
     def _split_agent_csv(cls, value: Optional[str | Sequence[str]]) -> tuple[str, ...]:
         """Allow comma-delimited strings for tuple-based agent settings."""
@@ -1131,9 +1126,6 @@ class WorkflowSettings(BaseSettings):
         # Ensure tuples are deduplicated even when env provided sequences
         allowed = tuple(dict.fromkeys(self.allowed_agent_backends or ()))
         self.allowed_agent_backends = allowed
-        self.agent_runtime_env_keys = tuple(
-            dict.fromkeys(self.agent_runtime_env_keys or ())
-        )
         self.allowed_skills = tuple(dict.fromkeys(self.allowed_skills or ()))
 
         for attr in (

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -43,23 +43,14 @@ from moonmind.schemas.agent_runtime_models import (
     TERMINAL_AGENT_RUN_STATES,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.auth.env_shaping import (
+    _OAUTH_CLEARED_VARS,
+    _shape_environment_for_api_key,
+    _shape_environment_for_oauth,
+)
 
 logger = logging.getLogger(__name__)
 
-# Env-var prefixes / names cleared when shaping OAuth environments (DOC-REQ-007).
-# These are the sensitive keys that must NOT appear in child-process environments.
-_OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
-    {
-        "GOOGLE_API_KEY",
-        "GEMINI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "OPENAI_API_KEY",
-        "CODEX_API_KEY",
-        "GITHUB_TOKEN",
-        "GH_TOKEN",
-    }
-)
 _BASE_ENV_FILTER_FRAGMENTS: tuple[str, ...] = (
     "password",
     "token",
@@ -92,47 +83,6 @@ def _should_filter_base_env_var(key: str) -> bool:
         return False
     lowered = normalized_key.lower()
     return any(fragment in lowered for fragment in _BASE_ENV_FILTER_FRAGMENTS)
-
-
-def _shape_environment_for_oauth(
-    base_env: dict[str, str],
-    *,
-    volume_mount_path: str | None,
-) -> dict[str, str]:
-    """Return env dict shaped for OAuth volume-mount mode.
-
-    Clears sensitive API-key vars and sets browser-auth helpers if a
-    volume mount path is provided.  Does NOT expose secrets.
-    """
-    env = dict(base_env)
-    for key in _OAUTH_CLEARED_VARS:
-        env.pop(key, None)
-    if volume_mount_path:
-        env["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
-    return env
-
-
-def _shape_environment_for_api_key(
-    base_env: dict[str, str],
-    *,
-    api_key_ref: str | None,
-    account_label: str | None,
-) -> dict[str, str]:
-    """Return env dict shaped for API-key mode.
-
-    The api_key_ref is a *reference* (e.g. a secret store key name), not the
-    raw credential.  The actual resolution of the reference into a real key
-    is delegated to the runtime launcher (out of scope for Phase 5).
-    """
-    env = dict(base_env)
-    for key in _OAUTH_CLEARED_VARS:
-        env.pop(key, None)
-    if api_key_ref:
-        # Pass only the reference, never the real value.
-        env["MANAGED_API_KEY_REF"] = api_key_ref
-    if account_label:
-        env["MANAGED_ACCOUNT_LABEL"] = account_label
-    return env
 
 
 def _derive_pr_resolver_failure(

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -44,9 +44,9 @@ from moonmind.schemas.agent_runtime_models import (
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.auth.env_shaping import (
-    _OAUTH_CLEARED_VARS,
-    _shape_environment_for_api_key,
-    _shape_environment_for_oauth,
+    OAUTH_CLEARED_VARS,
+    shape_environment_for_api_key,
+    shape_environment_for_oauth,
 )
 
 logger = logging.getLogger(__name__)
@@ -203,12 +203,12 @@ class ManagedAgentAdapter:
             if not _should_filter_base_env_var(k)
         }
         if auth_mode == "oauth":
-            shaped_env = _shape_environment_for_oauth(
+            shaped_env = shape_environment_for_oauth(
                 base_env,
                 volume_mount_path=profile.get("volume_mount_path"),
             )
         else:
-            shaped_env = _shape_environment_for_api_key(
+            shaped_env = shape_environment_for_api_key(
                 base_env,
                 api_key_ref=profile.get("api_key_ref"),
                 account_label=profile.get("account_label"),
@@ -475,7 +475,7 @@ __all__ = [
     "SlotRequestFunc",
     "SlotReleaseFunc",
     "CooldownReportFunc",
-    "_shape_environment_for_api_key",
-    "_shape_environment_for_oauth",
-    "_OAUTH_CLEARED_VARS",
+    "shape_environment_for_api_key",
+    "shape_environment_for_oauth",
+    "OAUTH_CLEARED_VARS",
 ]

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -83,8 +83,8 @@ class ManagedRuntimeStrategy(ABC):
         Default implementation returns a copy of *base_env* unchanged.
         Override to filter, add, or clear runtime-specific variables.
 
-        Note: The underlying helpers (``_OAUTH_CLEARED_VARS``,
-        ``_shape_environment_for_oauth``) are also used by the OAuth
+        Note: The underlying helpers (``OAUTH_CLEARED_VARS``,
+        ``shape_environment_for_oauth``) are also used by the OAuth
         Session orchestrator (``UniversalTmateOAuth.md`` §9.2).  Shared
         env-shaping logic should be factored into common utilities
         rather than duplicated.

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -44,3 +44,15 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
             cmd.extend(["--prompt", request.instruction_ref])
 
         return cmd
+
+    async def prepare_workspace(
+        self,
+        workspace_path: Any,
+        request: Any,
+    ) -> None:
+        """Write CLAUDE.md in the workspace."""
+        if not getattr(request, "instruction_ref", None):
+            return
+
+        instruction_path = workspace_path / "CLAUDE.md"
+        instruction_path.write_text(request.instruction_ref, encoding="utf-8")

--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from moonmind.workflows.temporal.runtime.strategies.base import (
@@ -47,7 +48,7 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
 
     async def prepare_workspace(
         self,
-        workspace_path: Any,
+        workspace_path: Path,
         request: Any,
     ) -> None:
         """Write CLAUDE.md in the workspace."""

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from moonmind.workflows.temporal.runtime.strategies.base import (
@@ -76,7 +77,7 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
 
     async def prepare_workspace(
         self,
-        workspace_path: Any,
+        workspace_path: Path,
         request: Any,
     ) -> None:
         """Write .gemini/instruction.md in the workspace."""

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -73,3 +73,17 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
             if k not in env and k in os.environ:
                 env[k] = os.environ[k]
         return env
+
+    async def prepare_workspace(
+        self,
+        workspace_path: Any,
+        request: Any,
+    ) -> None:
+        """Write .gemini/instruction.md in the workspace."""
+        if not getattr(request, "instruction_ref", None):
+            return
+
+        gemini_dir = workspace_path / ".gemini"
+        gemini_dir.mkdir(parents=True, exist_ok=True)
+        instruction_path = gemini_dir / "instruction.md"
+        instruction_path.write_text(request.instruction_ref, encoding="utf-8")

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -30,9 +30,9 @@ from api_service.db.models import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
-    _OAUTH_CLEARED_VARS,
-    _shape_environment_for_api_key,
-    _shape_environment_for_oauth,
+    OAUTH_CLEARED_VARS,
+    shape_environment_for_api_key,
+    shape_environment_for_oauth,
 )
 from moonmind.workflows.temporal.artifacts import (
     LocalTemporalArtifactStore,
@@ -99,9 +99,9 @@ def test_shape_environment_for_oauth_clears_sensitive_vars():
         "OPENAI_API_KEY": "openai-key",
         "PATH": "/usr/bin",
     }
-    shaped = _shape_environment_for_oauth(base, volume_mount_path="/mnt/auth")
+    shaped = shape_environment_for_oauth(base, volume_mount_path="/mnt/auth")
     # Sensitive keys must be absent.
-    for key in _OAUTH_CLEARED_VARS:
+    for key in OAUTH_CLEARED_VARS:
         assert key not in shaped, f"Expected {key} to be cleared"
     assert shaped["HOME"] == "/home/user"
     assert shaped["MANAGED_AUTH_VOLUME_PATH"] == "/mnt/auth"
@@ -109,7 +109,7 @@ def test_shape_environment_for_oauth_clears_sensitive_vars():
 
 def test_shape_environment_for_oauth_without_mount_path():
     base = {"HOME": "/home/user", "GEMINI_API_KEY": "secret"}
-    shaped = _shape_environment_for_oauth(base, volume_mount_path=None)
+    shaped = shape_environment_for_oauth(base, volume_mount_path=None)
     assert "MANAGED_AUTH_VOLUME_PATH" not in shaped
     assert "GEMINI_API_KEY" not in shaped
 
@@ -121,7 +121,7 @@ def test_shape_environment_for_oauth_clears_github_cli_tokens():
         "GITHUB_TOKEN": "github-token",
         "OPENAI_API_KEY": "secret",
     }
-    shaped = _shape_environment_for_oauth(base, volume_mount_path=None)
+    shaped = shape_environment_for_oauth(base, volume_mount_path=None)
     assert "GH_TOKEN" not in shaped
     assert "GITHUB_TOKEN" not in shaped
     assert "OPENAI_API_KEY" not in shaped
@@ -129,7 +129,7 @@ def test_shape_environment_for_oauth_clears_github_cli_tokens():
 
 def test_shape_environment_for_api_key_sets_ref():
     base = {"HOME": "/home/user"}
-    shaped = _shape_environment_for_api_key(
+    shaped = shape_environment_for_api_key(
         base, api_key_ref="secrets/my-api-key", account_label="ci-bot"
     )
     assert shaped["MANAGED_API_KEY_REF"] == "secrets/my-api-key"
@@ -139,7 +139,7 @@ def test_shape_environment_for_api_key_sets_ref():
 
 def test_shape_environment_for_api_key_without_ref():
     base = {"HOME": "/home/user"}
-    shaped = _shape_environment_for_api_key(base, api_key_ref=None, account_label=None)
+    shaped = shape_environment_for_api_key(base, api_key_ref=None, account_label=None)
     assert "MANAGED_API_KEY_REF" not in shaped
     assert "MANAGED_ACCOUNT_LABEL" not in shaped
 


### PR DESCRIPTION
This pull request implements the remaining items of Phase 5 for Managed Agent abstractions:
- It implements workspace preparation for both the Gemini CLI and Claude Code runtimes.
- It factors out shared environment-shaping functions into a new module `moonmind/auth/env_shaping.py` to be reused securely across runtime strategies and adapters.
- It removes dead settings properties (`agent_runtime_env_keys`).
- It updates the relevant documentation to reflect the codebase's current `ManagedRuntimeStrategy` pattern implementation.

---
*PR created automatically by Jules for task [18123079030657257361](https://jules.google.com/task/18123079030657257361) started by @nsticco*