### PR TITLE
docs: complete Phase 1 of Temporal Agent Alignment Plan

### DIFF
--- a/docs/tmp/TemporalAgentAlignmentPlan.md
+++ b/docs/tmp/TemporalAgentAlignmentPlan.md
@@ -35,23 +35,23 @@ This plan closes that gap through five phases of work, each independently shippa
 
 **Goal:** Fix remaining correctness gaps and add operational visibility to `MoonMind.Run`.
 
-- [ ] **1.1** Add `@workflow.query get_status` to `MoonMind.Run`
+- [x] **1.1** Add `@workflow.query get_status` to `MoonMind.Run`
   - **Files:** `run.py`
   - Return `_state`, `_paused`, `_cancel_requested`, `_step_count`, `_summary`, `_awaiting_external`, `_waiting_reason`
   - Aligns with the client's `describe_workflow`
 
-- [ ] **1.2** Refactor integration polling loop to separate "operator resume" from "poll terminal"
+- [x] **1.2** Refactor integration polling loop to separate "operator resume" from "poll terminal"
   - **Files:** `run.py` (lines 864-918)
   - Introduce a distinct `_poll_terminal` flag instead of reusing `_resume_requested` for two different intents
   - Makes loop termination easier to reason about; eliminates post-loop `_resume_requested = False` reset
   - ⚠️ Requires a `workflow.patched()` gate (see 5.3) if any in-flight workflows have integration stages
 
-- [ ] **1.3** Explore Signal-With-Start for AuthProfileManager bootstrapping
+- [x] **1.3** Explore Signal-With-Start for AuthProfileManager bootstrapping
   - **Files:** `agent_run.py` (`_ensure_manager_and_signal`)
   - Evaluate whether the Python SDK `start_workflow(..., start_signal=...)` or `signal_with_start` API can replace the current try/catch/activity/retry pattern
   - If SDK support is incomplete, document the limitation and keep the existing approach
 
-- [ ] **1.4** Define error taxonomy document
+- [x] **1.4** Define error taxonomy document
   - **Files:** New `docs/Temporal/ErrorTaxonomy.md`, modify `activity_catalog.py`
   - Map each `ApplicationError` subtype to retry vs non-retryable classification
   - Update `non_retryable_error_codes` to reference the taxonomy

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -145,6 +145,11 @@ class MoonMindAgentRun:
 
         Tries the signal. If the manager workflow doesn't exist, starts it
         via the ``auth_profile.ensure_manager`` activity and retries once.
+        
+        Note: The Temporal Python SDK does not currently support `signal_with_start`
+        or starting detached workflows directly from within a workflow context. 
+        Therefore, we must use this try/catch/activity/retry approach instead of a
+        built-in signal-with-start API.
         """
         manager_handle = workflow.get_external_workflow_handle(manager_id)
         signal_payload = {

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -146,10 +146,10 @@ class MoonMindAgentRun:
         Tries the signal. If the manager workflow doesn't exist, starts it
         via the ``auth_profile.ensure_manager`` activity and retries once.
         
-        Note: The Temporal Python SDK does not currently support `signal_with_start`
-        or starting detached workflows directly from within a workflow context. 
-        Therefore, we must use this try/catch/activity/retry approach instead of a
-        built-in signal-with-start API.
+        Note: The Temporal Python SDK does not provide a `signal_with_start`
+        method on `workflow.ExternalWorkflowHandle` objects for use inside a
+        workflow. Therefore, we use this try/catch/activity/retry pattern to
+        emulate the behavior.
         """
         manager_handle = workflow.get_external_workflow_handle(manager_id)
         signal_payload = {


### PR DESCRIPTION
This PR fulfills Phase 1 of the Temporal Agent Alignment Plan. Tasks 1.1, 1.2, and 1.4 were already implemented in the codebase. This PR documents the SDK limitation for 1.3 (signal_with_start) and checks off all tasks in the Phase 1 tracker.