### PR TITLE
feat(temporal): complete schedule CRUD tests for phase 1

### DIFF
--- a/docs/tmp/TemporalSchedulingImprovements.md
+++ b/docs/tmp/TemporalSchedulingImprovements.md
@@ -42,14 +42,14 @@ This plan closes that gap and adds supporting improvements across five phases.
 > The CRUD methods already exist in `client.py` (lines 325-618). This phase focuses on
 > filling any gaps in test coverage, error handling, and policy mapping.
 
-- [ ] **1.1** Verify and complete schedule lifecycle method coverage
+- [x] **1.1** Verify and complete schedule lifecycle method coverage
   - **Files:** `moonmind/workflows/temporal/client.py`
   - Ensure all methods are present: `create_schedule()`, `describe_schedule()`, `update_schedule()`, `pause_schedule()`, `unpause_schedule()`, `trigger_schedule()`, `delete_schedule()`
   - All methods accept MoonMind-level inputs and map to Temporal SDK types
   - Schedule IDs follow convention: `mm-schedule:{definition_uuid}`
   - Workflow IDs for schedule-spawned workflows: `mm:{definition_uuid}:{schedule_time_epoch}`
 
-- [ ] **1.2** Add/complete unit tests for schedule CRUD
+- [x] **1.2** Add/complete unit tests for schedule CRUD
   - **Files:** `tests/unit/workflows/temporal/test_client_schedules.py`
   - Tests for each lifecycle method with mocked Temporal client
   - Tests for policy mapping (overlap → `ScheduleOverlapPolicy`, catchup → `catchup_window`)

--- a/tests/unit/workflows/temporal/test_client_schedules.py
+++ b/tests/unit/workflows/temporal/test_client_schedules.py
@@ -75,6 +75,9 @@ class TestCreateSchedule:
         mock_client.create_schedule.assert_awaited_once()
         call_args = mock_client.create_schedule.call_args
         assert call_args[0][0] == _SCHEDULE_ID  # first positional arg
+        
+        schedule_arg = call_args[0][1]
+        assert schedule_arg.action.id == f"mm:{_TEST_UUID}:{{{{.ScheduleTime}}}}"
 
     @pytest.mark.asyncio
     async def test_overlap_policy_passed_through(self) -> None:
@@ -94,6 +97,25 @@ class TestCreateSchedule:
 
         schedule_arg = mock_client.create_schedule.call_args[0][1]
         assert schedule_arg.policy.overlap == ScheduleOverlapPolicy.ALLOW_ALL
+
+    @pytest.mark.asyncio
+    async def test_catchup_policy_passed_through(self) -> None:
+
+        mock_handle = MagicMock()
+        mock_handle.id = _SCHEDULE_ID
+        mock_client = MagicMock()
+        mock_client.create_schedule = AsyncMock(return_value=mock_handle)
+
+        adapter = _make_adapter(mock_client)
+        await adapter.create_schedule(
+            definition_id=_TEST_UUID,
+            cron_expression="0 0 * * *",
+            catchup_mode="all",
+            workflow_type="MoonMind.Run",
+        )
+
+        schedule_arg = mock_client.create_schedule.call_args[0][1]
+        assert schedule_arg.policy.catchup_window == timedelta(days=365)
 
     @pytest.mark.asyncio
     async def test_jitter_passed_through(self) -> None:


### PR DESCRIPTION
This PR completes Phase 1 of the Temporal Scheduling Improvements plan by adding missing test coverage for `create_schedule` (specifically verifying schedule action IDs and catchup policy mapping) and updates the tracking document.