### PR TITLE
fix: route request_slot signal through AuthProfileManager auto-start fallback

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -449,7 +449,7 @@ class MoonMindAgentRun:
                     manager_handle = await self._ensure_manager_and_signal(
                         manager_id,
                         runtime_id,
-                        request_slot=False,
+                        request_slot=True,
                     )
                     profile_count = await self._sync_manager_profiles(
                         manager_handle=manager_handle,
@@ -461,14 +461,6 @@ class MoonMindAgentRun:
                             type="ProfileResolutionError",
                             non_retryable=True,
                         )
-
-                    await manager_handle.signal(
-                        "request_slot",
-                        {
-                            "requester_workflow_id": workflow.info().workflow_id,
-                            "runtime_id": runtime_id,
-                        },
-                    )
 
                     # Wait indefinitely for an auth profile slot.
                     # Awaiting time does not count against the execution timeout;

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -61,36 +61,52 @@ class TestEnsureManagerAutoStart:
         """There must be no bare ``manager_handle.signal("request_slot", ...)``
         between ``_ensure_manager_and_signal`` and ``slot_assigned_event``.
         All request_slot signals must go through the auto-start wrapper."""
-        source = inspect.getsource(MoonMindAgentRun.run)
-        lines = source.splitlines()
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        tree = ast.parse(source)
 
-        # Find _ensure_manager_and_signal call
-        ensure_idx = None
-        slot_wait_idx = None
-        for i, line in enumerate(lines):
-            if "_ensure_manager_and_signal" in line and ensure_idx is None:
-                ensure_idx = i
-            if "slot_assigned_event" in line and "is_set" in line:
-                slot_wait_idx = i
-                break
+        # Collect line numbers of key landmarks and bare signal calls.
+        ensure_manager_line = None
+        slot_wait_line = None
+        bare_signal_lines: list[int] = []
 
-        assert ensure_idx is not None, (
-            "Could not find _ensure_manager_and_signal in run()"
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute):
+                continue
+
+            # Landmark: self._ensure_manager_and_signal(...)
+            if func.attr == "_ensure_manager_and_signal" and ensure_manager_line is None:
+                ensure_manager_line = node.lineno
+
+            # Landmark: ...slot_assigned_event.is_set()
+            if func.attr == "is_set" and isinstance(func.value, ast.Attribute):
+                if "slot_assigned_event" in ast.dump(func.value):
+                    slot_wait_line = node.lineno
+
+            # Detect any .signal("request_slot", ...) call
+            if func.attr == "signal" and node.args:
+                first_arg = node.args[0]
+                if isinstance(first_arg, ast.Constant) and first_arg.value == "request_slot":
+                    bare_signal_lines.append(node.lineno)
+
+        assert ensure_manager_line is not None, (
+            "Could not find _ensure_manager_and_signal call in run()"
         )
-        assert slot_wait_idx is not None, (
-            "Could not find slot_assigned_event.is_set in run()"
+        assert slot_wait_line is not None, (
+            "Could not find slot_assigned_event.is_set call in run()"
         )
 
-        # Check that no bare request_slot signal exists between the two
-        region = lines[ensure_idx:slot_wait_idx]
-        bare_signals = [
-            line for line in region
-            if '"request_slot"' in line and "signal" in line
-            and "_ensure_manager_and_signal" not in line
+        # Any bare .signal("request_slot") between the two landmarks is a violation.
+        violations = [
+            ln for ln in bare_signal_lines
+            if ensure_manager_line < ln < slot_wait_line
         ]
-        assert len(bare_signals) == 0, (
-            f"Found bare manager_handle.signal('request_slot', ...) between "
-            f"_ensure_manager_and_signal and slot_assigned_event wait. "
+        assert len(violations) == 0, (
+            f"Found bare .signal('request_slot', ...) calls at lines {violations} "
+            f"between _ensure_manager_and_signal (line {ensure_manager_line}) and "
+            f"slot_assigned_event wait (line {slot_wait_line}). "
             f"All request_slot signals must go through _ensure_manager_and_signal "
-            f"for auto-start fallback. Offending lines: {bare_signals}"
+            f"for auto-start fallback."
         )

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -1,0 +1,96 @@
+"""Tests for AuthProfileManager auto-start in MoonMind.AgentRun.
+
+The ``_ensure_manager_and_signal`` call in the managed-agent slot
+acquisition path must use ``request_slot=True`` so that the auto-start
+fallback fires when the AuthProfileManager workflow doesn't exist.
+A bare ``manager_handle.signal("request_slot", ...)`` bypasses this
+fallback and causes ExternalWorkflowExecutionNotFound crashes.
+"""
+
+import ast
+import inspect
+import textwrap
+
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+class TestEnsureManagerAutoStart:
+    """Verify request_slot is routed through the auto-start fallback."""
+
+    def test_ensure_manager_called_with_request_slot_true(self):
+        """``_ensure_manager_and_signal`` must be called with
+        ``request_slot=True`` so the auto-start fallback is triggered
+        when the AuthProfileManager is missing."""
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        tree = ast.parse(source)
+
+        found_ensure_manager_call = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match self._ensure_manager_and_signal(...)
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "_ensure_manager_and_signal"
+            ):
+                continue
+            found_ensure_manager_call = True
+
+            # Find the request_slot keyword arg
+            request_slot_kw = [
+                kw for kw in node.keywords if kw.arg == "request_slot"
+            ]
+            assert len(request_slot_kw) == 1, (
+                "_ensure_manager_and_signal must have exactly one request_slot kwarg"
+            )
+            kw_value = request_slot_kw[0].value
+            # Must be True (ast.Constant with value True)
+            assert isinstance(kw_value, ast.Constant) and kw_value.value is True, (
+                "_ensure_manager_and_signal must be called with request_slot=True "
+                "so the auto-start fallback fires when the AuthProfileManager "
+                "doesn't exist. Using request_slot=False bypasses auto-start "
+                "and causes ExternalWorkflowExecutionNotFound crashes."
+            )
+
+        assert found_ensure_manager_call, (
+            "Could not find _ensure_manager_and_signal call in MoonMindAgentRun.run"
+        )
+
+    def test_no_bare_request_slot_signal_after_ensure_manager(self):
+        """There must be no bare ``manager_handle.signal("request_slot", ...)``
+        between ``_ensure_manager_and_signal`` and ``slot_assigned_event``.
+        All request_slot signals must go through the auto-start wrapper."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+        lines = source.splitlines()
+
+        # Find _ensure_manager_and_signal call
+        ensure_idx = None
+        slot_wait_idx = None
+        for i, line in enumerate(lines):
+            if "_ensure_manager_and_signal" in line and ensure_idx is None:
+                ensure_idx = i
+            if "slot_assigned_event" in line and "is_set" in line:
+                slot_wait_idx = i
+                break
+
+        assert ensure_idx is not None, (
+            "Could not find _ensure_manager_and_signal in run()"
+        )
+        assert slot_wait_idx is not None, (
+            "Could not find slot_assigned_event.is_set in run()"
+        )
+
+        # Check that no bare request_slot signal exists between the two
+        region = lines[ensure_idx:slot_wait_idx]
+        bare_signals = [
+            line for line in region
+            if '"request_slot"' in line and "signal" in line
+            and "_ensure_manager_and_signal" not in line
+        ]
+        assert len(bare_signals) == 0, (
+            f"Found bare manager_handle.signal('request_slot', ...) between "
+            f"_ensure_manager_and_signal and slot_assigned_event wait. "
+            f"All request_slot signals must go through _ensure_manager_and_signal "
+            f"for auto-start fallback. Offending lines: {bare_signals}"
+        )


### PR DESCRIPTION
## Problem

All managed-runtime Claude Code workflows (including MiniMax) fail immediately with:
```
ExternalWorkflowExecutionNotFound: Unable to signal external workflow because it was not found
```

## Root Cause

The `MoonMind.AgentRun` workflow's slot acquisition called `_ensure_manager_and_signal(request_slot=False)`, bypassing the auto-start fallback. A subsequent bare `manager_handle.signal("request_slot")` had no error handling, so when the `AuthProfileManager` workflow didn't exist for `claude_code`, the signal crashed the workflow.

Confirmed via Temporal CLI: only `cursor_cli` and `gemini_cli` managers were running — no `claude_code` manager existed.

## Fix

- Changed `request_slot=False` → `request_slot=True` so the auto-start fallback fires when the manager is missing
- Removed the duplicate bare `request_slot` signal that bypassed the fallback

## Tests

- Added structural unit tests in `test_agent_run_ensure_manager.py` verifying:
  - `_ensure_manager_and_signal` is called with `request_slot=True`
  - No bare `request_slot` signal exists between the `_ensure_manager_and_signal` call and the slot wait
- All 58 existing agent_run/managed_agent tests pass with no regressions