### PR TITLE
feat(temporal): configure heartbeats, timeouts, and TRY_CANCEL for long-running activities

### DIFF
--- a/docs/tmp/CancellationAnalysis.md
+++ b/docs/tmp/CancellationAnalysis.md
@@ -141,7 +141,7 @@ await workflow.execute_activity(
 
 Validate behavior with **workflow tests** and, where applicable, **replay** tests—changing cancellation semantics affects in-flight histories.
 
-### P0 — Heartbeats + heartbeat timeouts in long-running activities
+### ~~P0 — Heartbeats + heartbeat timeouts in long-running activities~~ (Done)
 
 Ensure activities that can run for minutes:
 

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -628,7 +628,7 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(300, 600),
+            timeouts=TemporalActivityTimeouts(300, 600, heartbeat_timeout_seconds=30),
             retries=_activity_retries(max_attempts=3, max_interval_seconds=120),
         ),
         TemporalActivityDefinition(
@@ -637,7 +637,7 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(300, 600),
+            timeouts=TemporalActivityTimeouts(300, 600, heartbeat_timeout_seconds=30),
             retries=_activity_retries(max_attempts=3, max_interval_seconds=120),
         ),
         TemporalActivityDefinition(

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -7,6 +7,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from temporalio import activity
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -172,6 +173,10 @@ class ManagedRunSupervisor:
                 )
                 return exit_code
             except asyncio.TimeoutError:
+                try:
+                    activity.heartbeat({"run_id": run_id})
+                except Exception:
+                    pass
                 self._store.update_status(
                     run_id,
                     "running",

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -175,8 +175,9 @@ class ManagedRunSupervisor:
             except asyncio.TimeoutError:
                 try:
                     activity.heartbeat({"run_id": run_id})
-                except Exception:
-                    pass
+                except Exception as e:
+                    # Activity heartbeat failures are non-fatal for the supervisor loop
+                    logger.debug("Activity heartbeat failed: %s", e)
                 self._store.update_status(
                     run_id,
                     "running",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -358,6 +358,7 @@ class MoonMindRunWorkflow:
                     "link_type": "plan",
                 },
             },
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
             **self._execute_kwargs_for_route(plan_route),
         )
         resolved_plan_ref = (
@@ -547,6 +548,7 @@ class MoonMindRunWorkflow:
                                     "node_id": node_id,
                                 },
                             },
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
                             **self._execute_kwargs_for_route(route),
                         )
                     except Exception:


### PR DESCRIPTION
Implements Temporal best practices for slow activity cancellation. Sets timeouts, heartbeats, and TRY_CANCEL for agent execution.

---
*PR created automatically by Jules for task [15045403907617483351](https://jules.google.com/task/15045403907617483351) started by @nsticco*