### PR TITLE
fix: use -p flag and positional prompt for Claude CLI

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -41,8 +41,11 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         if effort:
             cmd.extend(["--effort", effort])
 
+        # -p (--print) enables non-interactive mode, required for managed runs.
+        # The prompt is a positional argument in Claude CLI, not a --prompt flag.
+        cmd.append("-p")
         if request.instruction_ref:
-            cmd.extend(["--prompt", request.instruction_ref])
+            cmd.append(request.instruction_ref)
 
         return cmd
 

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -150,7 +150,7 @@ class TestClaudeCodeBuildCommand:
         profile = _make_profile(command_template=["claude"])
         request = _make_request(instruction_ref="Refactor this")
         cmd = s.build_command(profile, request)
-        assert cmd == ["claude", "--prompt", "Refactor this"]
+        assert cmd == ["claude", "-p", "Refactor this"]
 
     def test_with_model_and_effort(self) -> None:
         s = ClaudeCodeStrategy()
@@ -165,7 +165,7 @@ class TestClaudeCodeBuildCommand:
             "claude",
             "--model", "claude-4-opus",
             "--effort", "high",
-            "--prompt", "Do it",
+            "-p", "Do it",
         ]
 
     def test_param_override(self) -> None:
@@ -187,7 +187,7 @@ class TestClaudeCodeBuildCommand:
         profile = _make_profile(command_template=["claude"])
         request = _make_request()
         cmd = s.build_command(profile, request)
-        assert cmd == ["claude"]
+        assert cmd == ["claude", "-p"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

All Claude Code managed workflows exit immediately with code 1 in ~2 seconds because `ClaudeCodeStrategy.build_command()` passes `--prompt <instruction>` — **Claude CLI v2.1.50 has no `--prompt` flag**.

The CLI reports:
```
error: unknown option '--prompt'
(Did you mean one of --from-pr, --print?)
```

## Fix

- Changed `--prompt` to `-p` (`--print`: non-interactive mode, required for managed subprocess runs)
- Instruction is now passed as a positional argument (matching how Codex CLI handles it)
- `-p` flag is always added since managed runs are non-interactive

## Tests

Updated 3 assertions in `test_remaining_strategies.py` to match the new behavior. All 27 strategy tests pass.