### PR TITLE
feat(temporal): implement Phase 2 workflow message contracts

### DIFF
--- a/debug_test.py
+++ b/debug_test.py
@@ -1,0 +1,7 @@
+import asyncio
+import pytest
+from moonmind.workflows.temporal.service import ALLOWED_UPDATE_NAMES
+from moonmind.schemas.temporal_models import SUPPORTED_UPDATE_NAMES
+
+print("ALLOWED:", ALLOWED_UPDATE_NAMES)
+print("SUPPORTED:", SUPPORTED_UPDATE_NAMES)

--- a/debug_test.py
+++ b/debug_test.py
@@ -1,7 +1,0 @@
-import asyncio
-import pytest
-from moonmind.workflows.temporal.service import ALLOWED_UPDATE_NAMES
-from moonmind.schemas.temporal_models import SUPPORTED_UPDATE_NAMES
-
-print("ALLOWED:", ALLOWED_UPDATE_NAMES)
-print("SUPPORTED:", SUPPORTED_UPDATE_NAMES)

--- a/docs/tmp/014-TemporalMessageContracts.md
+++ b/docs/tmp/014-TemporalMessageContracts.md
@@ -1,0 +1,44 @@
+# Temporal Message Contracts (Phase 2)
+
+This document establishes explicit Query/Signal/Update contracts for job orchestration workflows, fulfilling the Phase 2 deliverables of the Temporal Message Passing Improvements plan.
+
+## 1. MoonMind.Run
+
+### Updates (Control-Plane Commands)
+- **Pause**: Pauses workflow execution. Rejects if already paused, or if the workflow is in a terminal state.
+- **Resume**: Resumes workflow execution. Rejects if not paused/awaiting external completion, or if terminal.
+- **Approve**: Sets approval flag for external systems. Rejects if workflow is terminal.
+- **Cancel**: Requests workflow cancellation natively inside the workflow and unblocks waiting states. Rejects if already canceled or terminal.
+- **update_parameters**: Updates execution parameters.
+- **update_title**: Updates the execution title.
+
+### Signals (Fire-and-Forget Events)
+- **ExternalEvent**: Captures asynchronous events from external systems (e.g., integrations) where a trackable update isn't strictly necessary.
+- **child_state_changed**: Captures status changes from child orchestrators (e.g., AgentRun).
+
+### Queries (Read-Only Views)
+- **get_status**: Returns current execution state (`state`, `paused`, `cancel_requested`, `step_count`, `summary`, `awaiting_external`, `waiting_reason`). Contains NO mutating operations or side effects.
+
+## 2. MoonMind.ManifestIngest
+
+### Updates
+- **Pause**: Pauses the ingestion process.
+- **Resume**: Resumes the ingestion process.
+- **CancelNodes**: Cancels specific execution nodes.
+- **RetryNodes**: Retries specific failed nodes.
+- **UpdateManifest**: Applies modifications to the ingestion manifest.
+- **SetConcurrency**: Modifies the maximum number of concurrent nodes.
+
+## 3. Implementation Plan for Workflow Updates
+
+- [x] **Transition**: `pause`, `resume`, `approve`, and `cancel` have been converted from `@workflow.signal` to `@workflow.update` with corresponding `@update.validator` methods in `MoonMind.Run` (`moonmind/workflows/temporal/workflows/run.py`).
+- [x] **Validation Rules**: Added to prevent resuming a canceled workflow, pausing an already paused workflow, or modifying a workflow in a terminal state (COMPLETED, CANCELED, FAILED).
+- [x] **Unblock Waiting**: Updated `Cancel` update to clear the `_paused` flag to unblock `wait_condition` immediately upon cancellation.
+- [x] **Update API Models**: Added `Cancel` and `Approve` to `SUPPORTED_UPDATE_NAMES` in `moonmind/schemas/temporal_models.py`.
+- [x] **Test Adjustments**: Updated `test_run_signals_updates.py` to use `execute_update` instead of `signal` and `start_signal`.
+
+## 4. Refactor List (Anti-Patterns Addressed)
+- **Anti-Pattern**: Control plane commands like `Pause` and `Resume` were implemented as Signals instead of Updates, lacking synchronous validation to reject invalid state transitions.
+  - **Resolution**: Refactored `MoonMind.Run` to use Updates for `Pause`, `Resume`, `Approve`, and `Cancel` with strong state validation.
+- **Anti-Pattern**: Using `signal_with_start` to create workflows paused.
+  - **Resolution**: Tests are adjusted to start the workflow normally and send a synchronous `Pause` update, ensuring correct handler invocation.

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -26,7 +26,7 @@ SUPPORTED_UPDATE_NAMES = (
     "Cancel",
     "Approve",
 )
-SUPPORTED_SIGNAL_NAMES = ("ExternalEvent", "Approve", "Pause", "Resume")
+SUPPORTED_SIGNAL_NAMES = ("ExternalEvent",)
 
 from moonmind.schemas.manifest_ingest_models import (
     ManifestExecutionPolicyModel,

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -23,6 +23,8 @@ SUPPORTED_UPDATE_NAMES = (
     "Resume",
     "CancelNodes",
     "RetryNodes",
+    "Cancel",
+    "Approve",
 )
 SUPPORTED_SIGNAL_NAMES = ("ExternalEvent", "Approve", "Pause", "Resume")
 

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -568,6 +568,7 @@ class TemporalExecutionService:
 
         if (
             update_name in MANIFEST_UPDATE_NAMES
+            and update_name not in {"Pause", "Resume"}
             and record.workflow_type is not TemporalWorkflowType.MANIFEST_INGEST
         ):
             raise TemporalExecutionValidationError(
@@ -663,6 +664,37 @@ class TemporalExecutionService:
                 plan_artifact_ref=plan_artifact_ref,
                 parameters_patch=parameters_patch,
             )
+        elif update_name == "Pause":
+            record.paused = True
+            self._set_waiting_metadata(
+                record,
+                waiting_reason="operator_paused",
+                attention_required=True,
+            )
+            self._set_state(record, MoonMindWorkflowState.AWAITING_EXTERNAL)
+            self._set_wait_metadata(
+                record,
+                waiting_reason="operator_paused",
+                attention_required=True,
+            )
+            self._update_summary(record, "Execution paused.")
+            response = {"accepted": True, "applied": "async"}
+        elif update_name == "Resume":
+            record.paused = False
+            self._clear_waiting_metadata(record)
+            self._set_state(record, MoonMindWorkflowState.EXECUTING)
+            self._update_summary(record, "Execution resumed.")
+            response = {"accepted": True, "applied": "async"}
+        elif update_name == "Approve":
+            record.paused = False
+            self._clear_waiting_metadata(record)
+            self._set_state(record, MoonMindWorkflowState.EXECUTING)
+            self._update_summary(record, "Approval update received.")
+            response = {"accepted": True, "applied": "async"}
+        elif update_name == "Cancel":
+            self._set_state(record, MoonMindWorkflowState.CANCELED)
+            self._update_summary(record, "Execution canceled.")
+            response = {"accepted": True, "applied": "async"}
         else:
             raise TemporalExecutionValidationError(
                 f"Unsupported update name: {update_name}"
@@ -786,35 +818,6 @@ class TemporalExecutionService:
                     event_type=event_type,
                     payload=signal_payload,
                 )
-        elif signal_name == "Approve":
-            approval_type = signal_payload.get("approval_type")
-            if not approval_type:
-                raise TemporalExecutionValidationError(
-                    "Approve requires payload.approval_type"
-                )
-            record.paused = False
-            self._clear_waiting_metadata(record)
-            self._set_state(record, MoonMindWorkflowState.EXECUTING)
-            self._update_summary(record, "Approval signal received.")
-        elif signal_name == "Pause":
-            record.paused = True
-            self._set_waiting_metadata(
-                record,
-                waiting_reason="operator_paused",
-                attention_required=True,
-            )
-            self._set_state(record, MoonMindWorkflowState.AWAITING_EXTERNAL)
-            self._set_wait_metadata(
-                record,
-                waiting_reason="operator_paused",
-                attention_required=True,
-            )
-            self._update_summary(record, "Execution paused.")
-        elif signal_name == "Resume":
-            record.paused = False
-            self._clear_waiting_metadata(record)
-            self._set_state(record, MoonMindWorkflowState.EXECUTING)
-            self._update_summary(record, "Execution resumed.")
 
         await self._sync_integration_correlation_record(record)
         await self._session.commit()

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1510,13 +1510,20 @@ class MoonMindRunWorkflow:
         elif new_state == "running":
             self._set_state(STATE_EXECUTING, summary="Agent is running.")
 
-    @workflow.signal
+    @workflow.update(name="Pause")
     def pause(self) -> None:
         self._paused = True
         self._waiting_reason = "Paused by user"
         self._update_search_attributes()
 
-    @workflow.signal
+    @pause.validator
+    def validate_pause(self) -> None:
+        if self._paused:
+            raise ValueError("Workflow is already paused.")
+        if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
+            raise ValueError("Cannot pause a completed workflow.")
+
+    @workflow.update(name="Resume")
     def resume(self) -> None:
         self._paused = False
         self._waiting_reason = None
@@ -1524,18 +1531,38 @@ class MoonMindRunWorkflow:
             self._resume_requested = True
         self._update_search_attributes()
 
-    @workflow.signal
+    @resume.validator
+    def validate_resume(self) -> None:
+        if not self._paused and not self._awaiting_external:
+            raise ValueError("Workflow is not paused or awaiting external completion.")
+        if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
+            raise ValueError("Cannot resume a completed workflow.")
+
+    @workflow.update(name="Approve")
     def approve(self) -> None:
         self._approve_requested = True
         if self._awaiting_external:
             self._resume_requested = True
 
-    @workflow.signal
+    @approve.validator
+    def validate_approve(self) -> None:
+        if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
+            raise ValueError("Cannot approve a completed workflow.")
+
+    @workflow.update(name="Cancel")
     def cancel(self, reason: Optional[str] = None) -> None:
         self._cancel_requested = True
+        self._paused = False
         self._close_status = CLOSE_STATUS_CANCELED
         summary = f"Canceled: {reason}" if reason else "Canceled."
         self._set_state(STATE_CANCELED, summary=summary)
+
+    @cancel.validator
+    def validate_cancel(self, reason: Optional[str] = None) -> None:
+        if self._cancel_requested:
+            raise ValueError("Workflow is already canceled.")
+        if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
+            raise ValueError("Cannot cancel a completed workflow.")
 
     @workflow.signal(name="ExternalEvent")
     def external_event(self, payload: dict[str, Any]) -> None:

--- a/tests/unit/api/test_execution_service.py
+++ b/tests/unit/api/test_execution_service.py
@@ -171,11 +171,10 @@ async def test_action_validation_relies_on_temporal(
     with pytest.raises(TemporalExecutionValidationError) as exc:
         await service.signal_execution(
             workflow_id="mm:123",
-            signal_name="Pause",
+            signal_name="ExternalEvent",
             payload={},
             payload_artifact_ref=None,
         )
-
     assert "Temporal signal failed: Temporal workflow is already closed" in str(
         exc.value
     )

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -590,7 +590,7 @@ async def test_manifest_only_updates_rejected_for_non_manifest_workflow(tmp_path
         with pytest.raises(TemporalExecutionValidationError) as exc_info:
             await service.update_execution(
                 workflow_id=created.workflow_id,
-                update_name="Pause",
+                update_name="UpdateManifest",
                 input_artifact_ref=None,
                 plan_artifact_ref=None,
                 parameters_patch=None,
@@ -623,11 +623,9 @@ async def test_request_rerun_clears_pause_flags_when_continuing_as_new(tmp_path)
             idempotency_key=None,
         )
 
-        await service.signal_execution(
+        await service.update_execution(
             workflow_id=created.workflow_id,
-            signal_name="Pause",
-            payload=None,
-            payload_artifact_ref=None,
+            update_name="Pause",
         )
 
         rerun = await service.update_execution(
@@ -701,22 +699,18 @@ async def test_signal_pause_resume_and_external_event_transitions(tmp_path):
             idempotency_key=None,
         )
 
-        await service.signal_execution(
+        await service.update_execution(
             workflow_id=created.workflow_id,
-            signal_name="Pause",
-            payload=None,
-            payload_artifact_ref=None,
+            update_name="Pause",
         )
         paused = await service.describe_execution(created.workflow_id)
         assert paused.state is MoonMindWorkflowState.AWAITING_EXTERNAL
         assert paused.memo["waiting_reason"] == "operator_paused"
         assert paused.memo["attention_required"] is True
 
-        await service.signal_execution(
+        await service.update_execution(
             workflow_id=created.workflow_id,
-            signal_name="Resume",
-            payload=None,
-            payload_artifact_ref=None,
+            update_name="Resume",
         )
         resumed = await service.describe_execution(created.workflow_id)
         assert resumed.state is MoonMindWorkflowState.EXECUTING

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -88,15 +88,15 @@ async def test_run_workflow_pause_resume(mock_run_environment):
                 },
                 id="test-wf-pause",
                 task_queue="test-task-queue-signals",
-                start_signal="pause",
             )
+            await handle.execute_update("Pause")
             
             # Workflow should be paused and waiting.
             await asyncio.sleep(0.1)
             status = await handle.query("get_status")
             assert status.get("paused") is True
             
-            await handle.signal("resume")
+            await handle.execute_update("Resume")
             result = await handle.result()
             assert result["status"] == "success"
 
@@ -118,15 +118,15 @@ async def test_run_workflow_update_parameters(mock_run_environment):
                 },
                 id="test-wf-update",
                 task_queue="test-task-queue-signals",
-                start_signal="pause",
             )
+            await handle.execute_update("Pause")
             
             await handle.execute_update(
                 "update_parameters",
-                {"parameters": {"param1": "new_value", "param2": "value2"}}
+                {"new_parameters": {"param1": "new_value", "param2": "value2"}}
             )
             
-            await handle.signal("resume")
+            await handle.execute_update("Resume")
             result = await handle.result()
             assert result["status"] == "success"
 
@@ -148,11 +148,10 @@ async def test_run_workflow_cancel_signal(mock_run_environment):
                 },
                 id="test-wf-cancel",
                 task_queue="test-task-queue-signals",
-                start_signal="pause",
             )
+            await handle.execute_update("Pause")
             
-            await handle.signal("cancel")
-            await handle.signal("resume")
+            await handle.execute_update("Cancel")
             result = await handle.result()
             assert result["status"] == "canceled"
 


### PR DESCRIPTION
This PR implements the deliverables for Phase 2 of the Temporal Workflow Message Passing Improvements plan.

- Refactored `MoonMind.Run` to use Workflow Updates with validators instead of signals for `Pause`, `Resume`, `Approve`, and `Cancel`.
- Added new update models to `SUPPORTED_UPDATE_NAMES` in API.
- Wrote `docs/tmp/014-TemporalMessageContracts.md` specifying explicit per-workflow Query/Signal/Update contracts.
- Updated relevant unit tests.