### PR TITLE
feat(temporal): implement phase 5 of temporal agent alignment plan

### DIFF
--- a/docs/Temporal/WorkerDeployment.md
+++ b/docs/Temporal/WorkerDeployment.md
@@ -1,0 +1,25 @@
+# Temporal Worker Deployment Runbook
+
+## Overview
+MoonMind utilizes Temporal for orchestrating workflows and background activities. 
+As MoonMind's execution is Temporal-native, we rely on Temporal's standard mechanisms for versioning, ensuring backward compatibility, and providing safe deployment rollouts.
+
+## Worker Versioning Registration
+MoonMind workers inject a Build Identifier (`MOONMIND_BUILD_ID`) dynamically upon startup (defaulting to the Git SHA). 
+When utilizing the Python SDK's versioning API (`use_worker_versioning=True`), this links the tasks being handled to the explicit version of the worker handling them.
+
+## Compatibility Matrix
+- When changing activity implementations, changes are generally backward-compatible unless they change the activity input or output schema.
+- When changing workflow implementation shapes (loop conditions, activity call ordering, signal handling logic), it **must** be versioned. 
+
+## Two-Version Side-By-Side Strategy for Workflow Changes
+If a change modifies the workflow topology:
+1. Wrap the new logic in a `workflow.patched("patch-name")` branch. The old logic runs in the `else` branch.
+2. The deployed worker will register the patch, ensuring new executions follow the new path, and older replay executions follow the old logic to maintain determinism.
+3. Once all older executions have completed, the patch and the old logic can be safely removed, finalizing the new default behavior.
+
+## Rollback Procedure
+If a regression is identified in the deployed workflow logic:
+- A previous Docker image or Git SHA should be deployed immediately.
+- Because Temporal workers execute deterministic code, tasks from newly started workflows will naturally route to the rolled-back worker pool once the new, erroneous build ID is removed.
+- Use `MOONMIND_BUILD_ID` overrides if a specific rollback target is desired without a code redeploy.

--- a/docs/tmp/015-TemporalAgentAlignmentPlan.md
+++ b/docs/tmp/015-TemporalAgentAlignmentPlan.md
@@ -172,16 +172,16 @@ This plan closes that gap through five phases of work, each independently shippa
 
 **Goal:** Enable safe rolling deploys for workflow code changes.
 
-- [ ] **5.1** Inject build identifier into worker startup
+- [x] **5.1** Inject build identifier into worker startup
   - **Files:** `worker_runtime.py`
   - Read `MOONMIND_BUILD_ID` (default: Git SHA) from environment
   - Pass to `Worker(...)` using the Python SDK's versioning API once stable (or use `workflow.patched()` gates in the interim)
 
-- [ ] **5.2** Document deployment runbook
+- [x] **5.2** Document deployment runbook
   - **Files:** New `docs/Temporal/WorkerDeployment.md`
   - Cover: version registration, compatibility matrix, rollback procedure, two-version side-by-side strategy for workflow changes
 
-- [ ] **5.3** Add `workflow.patched()` gates for in-flight compatibility
+- [x] **5.3** Add `workflow.patched()` gates for in-flight compatibility
   - **Files:** Workflow files as needed
   - For any workflow-shape-changing refactor (e.g., 1.2 loop refactor), use `workflow.patched("patch-id")` to branch between old and new behavior during replay
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -520,6 +520,16 @@ async def main_async() -> None:
     else:
         runtime_resources, activities = await _build_runtime_activities(topology)
 
+    import subprocess
+    def get_git_sha():
+        try:
+            return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+        except Exception:
+            return "unknown"
+
+    build_id = os.environ.get("MOONMIND_BUILD_ID") or get_git_sha()
+    logger.info(f"Worker build_id configured as: {build_id}")
+
     try:
         worker = Worker(
             client,
@@ -527,6 +537,8 @@ async def main_async() -> None:
             workflows=workflows,
             activities=activities,
             workflow_runner=UnsandboxedWorkflowRunner(),
+            build_id=build_id,
+            use_worker_versioning=True,
             **_worker_concurrency_kwargs(topology),
         )
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1107,7 +1107,11 @@ class MoonMindRunWorkflow:
 
                     status = self._get_from_result(poll_result, "normalized_status")
                     if status in ("completed", "failed", "canceled", "awaiting_feedback"):
-                        _poll_terminal = True
+                        if workflow.patched("integration-polling-loop-refactor"):
+                            _poll_terminal = True
+                        else:
+                            self._resume_requested = True
+
                         self._external_status = "completed" if status == "awaiting_feedback" else status
                         if status == "failed":
                             self._get_logger().warning(f"Integration failed: {poll_result}")
@@ -1119,6 +1123,9 @@ class MoonMindRunWorkflow:
                     poll_interval_seconds = min(
                         poll_interval_seconds * 2, max_poll_interval_seconds
                     )
+
+            if not workflow.patched("integration-polling-loop-refactor"):
+                self._resume_requested = False
 
             if self._external_status != "completed":
                 # If a step failed or was canceled, do not dispatch remaining steps


### PR DESCRIPTION
Implements Phase 5 of the Temporal Agent Alignment Plan from docs/tmp/015-TemporalAgentAlignmentPlan.md, which includes adding worker build ID versioning, deployment runbook documentation, and a patched gate for the integration polling loop refactor.