### PR TITLE
fix(api): populate Runtime and Skill in task list (Temporal source=temporal)

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from temporalio.client import Client
 from temporalio.service import RPCError
@@ -20,6 +21,7 @@ from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
 from api_service.db.models import (
     MoonMindWorkflowState,
+    TemporalExecutionCanonicalRecord,
     TemporalExecutionCloseStatus,
     TemporalExecutionRecord,
     User,
@@ -304,6 +306,10 @@ def _serialize_execution(
         str(params.get(key) or "").strip() or None
         for key in ["targetRuntime", "model", "effort"]
     ]
+    if not target_runtime:
+        runtime_nested = params.get("runtime")
+        if isinstance(runtime_nested, dict):
+            target_runtime = str(runtime_nested.get("mode") or "").strip() or None
     if not target_runtime:
         target_runtime = (
             _coerce_temporal_scalar(search_attributes.get("mm_target_runtime"))
@@ -1235,7 +1241,10 @@ async def list_executions(
 
     if source == "temporal":
         try:
-            from api_service.core.sync import map_temporal_state_to_projection
+            from api_service.core.sync import (
+                map_temporal_state_to_projection,
+                merged_parameters_for_projection,
+            )
 
             client = temporal_client
 
@@ -1274,10 +1283,23 @@ async def list_executions(
             )
             await iterator.fetch_next_page()
 
+            page = iterator.current_page or []
+            canonical_map: dict[str, TemporalExecutionCanonicalRecord] = {}
+            if page:
+                workflow_ids = [wf.id for wf in page]
+                stmt = select(TemporalExecutionCanonicalRecord).where(
+                    TemporalExecutionCanonicalRecord.workflow_id.in_(workflow_ids)
+                )
+                canonical_rows = (await session.execute(stmt)).scalars().all()
+                canonical_map = {row.workflow_id: row for row in canonical_rows}
+
             items = []
-            if iterator.current_page:
-                for wf in iterator.current_page:
+            if page:
+                for wf in page:
                     payload = await map_temporal_state_to_projection(wf)
+                    payload["parameters"] = merged_parameters_for_projection(
+                        payload, canonical_map.get(wf.id)
+                    )
                     # We need a record-like object for serialization
                     from types import SimpleNamespace
 

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -56,6 +56,26 @@ def _coerce_temporal_scalar(value: Any) -> str | None:
     return text or None
 
 
+def merged_parameters_for_projection(
+    payload: dict[str, Any],
+    canonical: TemporalExecutionCanonicalRecord | None,
+) -> dict[str, Any]:
+    """Merge creation-time parameters from the canonical DB row with memo-derived parameters.
+
+    ``map_temporal_state_to_projection`` sets ``parameters`` from workflow memo only; memo
+    typically does not repeat ``targetRuntime`` or task tool snapshots. The canonical row
+    in ``temporal_execution_sources`` holds those creation-time fields.
+
+    Both ``sync_execution_projection`` and the ``GET /api/executions?source=temporal`` list
+    path must apply the same merge so ``_serialize_execution`` can populate Runtime/Skill.
+    """
+    synced_params = payload.get("parameters") or {}
+    if canonical is None:
+        return dict(synced_params)
+    canonical_params = canonical.parameters or {}
+    return {**canonical_params, **synced_params}
+
+
 async def map_temporal_state_to_projection(
     desc: WorkflowExecutionDescription,
 ) -> dict[str, Any]:
@@ -257,9 +277,7 @@ async def sync_execution_projection(
     # The memo-derived parameters from map_temporal_state_to_projection are typically
     # empty; the canonical record is the source of truth for creation-time parameters.
     if canonical is not None:
-        canonical_params = canonical.parameters or {}
-        synced_params = payload.get("parameters") or {}
-        projection.parameters = {**canonical_params, **synced_params}
+        projection.parameters = merged_parameters_for_projection(payload, canonical)
 
     if canonical is not None and canonical.state != state_value:
         canonical.state = state_value

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -700,6 +700,40 @@ def test_serialize_execution_surfaces_runtime_model_effort_from_parameters() -> 
     assert dumped["effort"] == "high"
 
 
+def test_serialize_execution_surfaces_runtime_from_nested_parameters_runtime_key() -> None:
+    """Some payloads store mode under parameters.runtime.mode without top-level targetRuntime."""
+    record = SimpleNamespace(
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={"title": "Nested RT", "summary": "OK"},
+        owner_id="user-1",
+        entry="run",
+        workflow_type=SimpleNamespace(value="MoonMind.Run"),
+        state=MoonMindWorkflowState.EXECUTING,
+        workflow_id="mm:rt-nested",
+        namespace="moonmind",
+        run_id="run-1",
+        artifact_refs=[],
+        created_at="2026-03-19T00:00:00Z",
+        started_at="2026-03-19T00:00:00Z",
+        updated_at="2026-03-19T00:00:00Z",
+        closed_at=None,
+        integration_state=None,
+        parameters={
+            "runtime": {"mode": "gemini_cli", "model": "gemini-2.0"},
+        },
+        paused=False,
+        waiting_reason=None,
+        attention_required=False,
+    )
+
+    payload = _serialize_execution(record)
+
+    assert payload.target_runtime == "gemini_cli"
+    dumped = payload.model_dump(by_alias=True)
+    assert dumped["targetRuntime"] == "gemini_cli"
+
+
 def test_describe_execution_exposes_task_and_temporal_run_identity() -> None:
     for test_client, service in _client_with_service():
         service.describe_execution.return_value = _build_execution_record()

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Iterator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -11,10 +11,13 @@ from fastapi.testclient import TestClient
 
 import api_service.api.routers.executions as executions_module
 from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
 
 
-def _override_user_dependencies(app: FastAPI, *, is_superuser: bool) -> AsyncMock:
-    mock_user = AsyncMock()
+def _override_user_dependencies(app: FastAPI, *, is_superuser: bool) -> MagicMock:
+    # Plain MagicMock: AsyncMock user objects can trigger "never awaited" warnings
+    # when routes or FastAPI touch attributes during teardown.
+    mock_user = MagicMock()
     mock_user.id = "user-123"
     mock_user.is_superuser = is_superuser
     app.dependency_overrides[get_current_user()] = lambda: mock_user
@@ -27,24 +30,39 @@ def _override_user_dependencies(app: FastAPI, *, is_superuser: bool) -> AsyncMoc
 
 
 @pytest.fixture
-def client() -> Iterator[tuple[TestClient, AsyncMock, AsyncMock]]:
+def client() -> Iterator[tuple[TestClient, AsyncMock, MagicMock, MagicMock]]:
     app = FastAPI()
     app.include_router(executions_module.router)
     service = AsyncMock()
     app.dependency_overrides[executions_module._get_service] = lambda: service
     user = _override_user_dependencies(app, is_superuser=False)
 
+    # MagicMock + explicit AsyncMocks: a bare AsyncMock session makes every
+    # attribute an async mock; incidental access can leave unawaited coroutines.
+    mock_session = MagicMock()
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock(return_value=None)
+    mock_session.rollback = AsyncMock(return_value=None)
+
+    async def _session_dep():
+        yield mock_session
+
+    app.dependency_overrides[get_async_session] = _session_dep
+
     with TestClient(app) as test_client:
-        yield test_client, service, user
+        yield test_client, service, user, mock_session
 
     app.dependency_overrides.clear()
 
 
-@pytest.mark.asyncio
-async def test_list_executions_source_temporal_bypasses_db_and_queries_temporal(
+def test_list_executions_source_temporal_bypasses_db_and_queries_temporal(
     client,
 ) -> None:
-    test_client, service, user = client
+    test_client, service, user, _mock_session = client
 
     executions_module.get_temporal_client_adapter.cache_clear()
 
@@ -105,9 +123,84 @@ async def test_list_executions_source_temporal_bypasses_db_and_queries_temporal(
         assert item["waitingReason"] == "external_completion"
 
 
-@pytest.mark.asyncio
-async def test_describe_execution_source_temporal_syncs_projection(client) -> None:
-    test_client, service, user = client
+def test_list_executions_source_temporal_merges_canonical_parameters(
+    client,
+) -> None:
+    """Temporal list uses memo-only parameters; merge DB canonical row for Runtime/Skill."""
+    from types import SimpleNamespace
+
+    test_client, service, user, mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    # One canonical row matching the workflow id from Temporal list
+    canon = SimpleNamespace()
+    canon.workflow_id = "mm:wf-1"
+    canon.parameters = {
+        "targetRuntime": "codex",
+        "task": {"tool": {"name": "fix-ci", "version": "1"}},
+    }
+    mock_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [canon]
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        from datetime import UTC, datetime
+        from types import SimpleNamespace
+
+        memo_data = {"waiting_reason": "external_completion"}
+
+        async def _memo():
+            return memo_data
+
+        mock_wf = SimpleNamespace()
+        mock_wf.id = "mm:wf-1"
+        mock_wf.run_id = "run-1"
+        mock_wf.namespace = "moonmind"
+        mock_wf.workflow_type = "MoonMind.Run"
+        mock_wf.status = 1
+        mock_wf.memo = _memo
+        mock_wf.search_attributes = {
+            "mm_state": b'"awaiting_external"',
+            "mm_entry": b'["run"]',
+        }
+        mock_wf.start_time = datetime.now(UTC)
+        mock_wf.execution_time = None
+        mock_wf.close_time = None
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = [mock_wf]
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = lambda **kwargs: mock_iterator
+
+        mock_count = SimpleNamespace(count=1)
+        mock_client.count_workflows = AsyncMock(return_value=mock_count)
+
+        response = test_client.get(
+            "/api/executions",
+            params={
+                "source": "temporal",
+                "workflowType": "MoonMind.Run",
+                "state": "awaiting_external",
+            },
+        )
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert item["targetRuntime"] == "codex"
+        assert item["targetSkill"] == "fix-ci"
+
+
+def test_describe_execution_source_temporal_syncs_projection(client) -> None:
+    test_client, service, user, _mock_session = client
 
     executions_module.get_temporal_client_adapter.cache_clear()
 
@@ -164,9 +257,8 @@ async def test_describe_execution_source_temporal_syncs_projection(client) -> No
         )
 
 
-@pytest.mark.asyncio
-async def test_describe_execution_canonicalizes_mm_prefix(client) -> None:
-    test_client, service, user = client
+def test_describe_execution_canonicalizes_mm_prefix(client) -> None:
+    test_client, service, user, _mock_session = client
 
     executions_module.get_temporal_client_adapter.cache_clear()
 
@@ -204,7 +296,9 @@ async def test_describe_execution_canonicalizes_mm_prefix(client) -> None:
         ) as mock_adapter_cls,
     ):
         mock_adapter = mock_adapter_cls.return_value
-        mock_client = AsyncMock()
+        # Stand-in Temporal client: bare AsyncMock creates stray coroutines if touched;
+        # this path does not use the client when authoritative read is off.
+        mock_client = MagicMock()
         mock_adapter.get_client = AsyncMock(return_value=mock_client)
 
         mock_canon.return_value = ("mm:wf-123", True)
@@ -219,9 +313,8 @@ async def test_describe_execution_canonicalizes_mm_prefix(client) -> None:
         )
 
 
-@pytest.mark.asyncio
-async def test_temporal_unavailability_returns_503(client) -> None:
-    test_client, service, user = client
+def test_temporal_unavailability_returns_503(client) -> None:
+    test_client, service, user, _mock_session = client
 
     executions_module.get_temporal_client_adapter.cache_clear()
 

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock
 
 from temporalio.client import WorkflowExecutionDescription, WorkflowExecutionStatus
 
-from api_service.core.sync import map_temporal_state_to_projection
+from api_service.core.sync import (
+    map_temporal_state_to_projection,
+    merged_parameters_for_projection,
+)
 from api_service.db.models import (
     MoonMindWorkflowState,
     TemporalExecutionCloseStatus,
@@ -141,3 +144,23 @@ def test_map_temporal_state_to_projection_memo_parameters_empty_by_default():
     assert params.get("targetRuntime") is None
     assert params.get("model") is None
     assert params.get("effort") is None
+
+
+def test_merged_parameters_for_projection_combines_canonical_with_memo_payload():
+    from types import SimpleNamespace
+
+    canonical = SimpleNamespace()
+    canonical.parameters = {
+        "targetRuntime": "codex",
+        "task": {"tool": {"name": "fix-ci"}},
+    }
+    payload = {"parameters": {"model": "gpt-5"}}
+    merged = merged_parameters_for_projection(payload, canonical)
+    assert merged["targetRuntime"] == "codex"
+    assert merged["task"]["tool"]["name"] == "fix-ci"
+    assert merged["model"] == "gpt-5"
+
+
+def test_merged_parameters_for_projection_without_canonical_returns_memo_only():
+    payload = {"parameters": {"targetRuntime": "jules"}}
+    assert merged_parameters_for_projection(payload, None) == {"targetRuntime": "jules"}


### PR DESCRIPTION
## Problem
The task dashboard loads executions with \GET /api/executions?source=temporal\. That code path built each row from \map_temporal_state_to_projection\ only, where \parameters\ come from workflow memo. Creation-time fields such as \	argetRuntime\ and task tool/skill names are stored in the DB (\	emporal_execution_sources.parameters\) and merged during projection sync, but the Temporal **list** endpoint never applied that merge—so Runtime and Skill stayed empty despite prior UI/serialization tweaks.

## Changes
- Introduce \merged_parameters_for_projection()\ in \pi_service/core/sync.py\ and use it from \sync_execution_projection\ (same merge semantics, DRY).
- In \list_executions\ when \source=temporal\, batch-load \TemporalExecutionCanonicalRecord\ rows for the current page and merge canonical \parameters\ into the payload before \_serialize_execution\.
- In \_serialize_execution\, fall back to \parameters.runtime.mode\ when top-level \	argetRuntime\ is absent.
- Tests: merge helper, temporal list with canonical row, nested runtime serialization; temporal API test fixture cleanups (session/user/client mocks, sync tests).

## Verification
- Unit tests updated; \	ests/unit/api/test_executions_temporal.py\ exercised in Docker CI image.

\ar/\ was left untracked (local artifact path).

Made with [Cursor](https://cursor.com)