### PR TITLE
Increase agent runtime worker concurrency

### DIFF
--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -109,7 +109,7 @@ class TemporalSettings(BaseSettings):
         ge=1,
     )
     agent_runtime_worker_concurrency: int | None = Field(
-        4,
+        16,
         validation_alias="TEMPORAL_AGENT_RUNTIME_WORKER_CONCURRENCY",
         ge=1,
     )


### PR DESCRIPTION
This commit increases the default agent runtime worker concurrency from 4 to 16 in `moonmind/config/settings.py`. This change is to increase the worker throughput on the `mm.activity.agent_runtime` task queue so that operations like `agent_runtime.cancel` do not get unnecessarily queued behind other long-running tasks.

---
*PR created automatically by Jules for task [16772659377210589625](https://jules.google.com/task/16772659377210589625) started by @nsticco*