### PR TITLE
Fix: Reduce process cancellation tail latency

### DIFF
--- a/moonmind/workflows/temporal/runtime/process_control.py
+++ b/moonmind/workflows/temporal/runtime/process_control.py
@@ -13,7 +13,7 @@ import sys
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_GRACE_SECONDS: float = 5.0
+DEFAULT_GRACE_SECONDS: float = 2.0
 
 
 async def cancel_managed_process(

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -31,7 +31,7 @@ from .strategies import get_strategy
 
 HEARTBEAT_INTERVAL = 30  # seconds
 GRACEFUL_TERMINATE_WAIT_SECONDS = (
-    2.0  # seconds to wait for graceful SIGTERM before SIGKILL
+    1.0  # seconds to wait for graceful SIGTERM before SIGKILL
 )
 
 


### PR DESCRIPTION
This pull request adjusts the `SIGTERM` / `SIGKILL` graceful wait constants for CLI tools and managed agent cancellations.

By reducing `DEFAULT_GRACE_SECONDS` in `process_control.py` from 5.0 to 2.0 and `GRACEFUL_TERMINATE_WAIT_SECONDS` in `supervisor.py` from 2.0 to 1.0, this directly addresses the P2 improvement identified in `docs/tmp/010-CancellationAnalysis.md` to reduce cancellation tail latency while still providing CLI tools with a short, functional window to gracefully exit before being forcefully terminated.

All unit tests pass successfully.

---
*PR created automatically by Jules for task [12439080973778194620](https://jules.google.com/task/12439080973778194620) started by @nsticco*