### PR TITLE
docs: mark Phase 1 of 055-UnitTestWarnings as complete

### DIFF
--- a/docs/tmp/055-UnitTestWarnings.md
+++ b/docs/tmp/055-UnitTestWarnings.md
@@ -2,7 +2,7 @@
 
 Running the unit tests resulted in several warnings that can be broken down into the following phases to address systematically:
 
-## Phase 1: Pydantic V2 Migration
+## Phase 1: Pydantic V2 Migration (Complete)
 These warnings are caused by the upgrade to Pydantic V2 and require straightforward search-and-replace changes.
 - **Fields with `env` Argument**: Replace the deprecated `env="VAR"` with `alias="VAR"` or `validation_alias="VAR"` (or via `SettingsConfigDict` features depending on how `settings.py` is configured). Affects many fields in:
   - `moonmind/config/settings.py`


### PR DESCRIPTION
Marked Phase 1 of `055-UnitTestWarnings.md` as `(Complete)`. During execution, I discovered that all the code-level requirements (replacing `env="VAR"`, replacing `.dict()` with `.model_dump()`, and `.parse_obj()` with `.model_validate()`) in `moonmind/config/settings.py` and other referenced files had already been accomplished in previous commits. Validated via `grep` and unit tests.

---
*PR created automatically by Jules for task [16345405560888447077](https://jules.google.com/task/16345405560888447077) started by @nsticco*