### PR TITLE
docs: Mark Phase 1 of 055-UnitTestWarnings.md as complete

### DIFF
--- a/docs/tmp/055-UnitTestWarnings.md
+++ b/docs/tmp/055-UnitTestWarnings.md
@@ -4,10 +4,10 @@ Running the unit tests resulted in several warnings that can be broken down into
 
 ## Phase 1: Pydantic V2 Migration (Complete)
 These warnings are caused by the upgrade to Pydantic V2 and require straightforward search-and-replace changes.
-- **Fields with `env` Argument**: Replace the deprecated `env="VAR"` with `alias="VAR"` or `validation_alias="VAR"` (or via `SettingsConfigDict` features depending on how `settings.py` is configured). Affects many fields in:
+- [x] **Fields with `env` Argument**: Replace the deprecated `env="VAR"` with `alias="VAR"` or `validation_alias="VAR"` (or via `SettingsConfigDict` features depending on how `settings.py` is configured). Affects many fields in:
   - `moonmind/config/settings.py`
   - `moonmind/config/jules_settings.py`
-- **Method Deprecations**:
+- [x] **Method Deprecations**:
   - Replace `.dict()` with `.model_dump()` in `api_service/services/profile_service.py` (line 120) and potentially in Temporalio converter code if within project bounds.
   - Replace `.parse_obj()` with `.model_validate()` where found.
 


### PR DESCRIPTION
This pull request updates `docs/tmp/055-UnitTestWarnings.md` to explicitly mark the tasks under "Phase 1: Pydantic V2 Migration" as completed (`- [x]`), as the required codebase modifications (deprecating `env=` in `Field()`, replacing `.dict()` with `.model_dump()`, and replacing `.parse_obj()` with `.model_validate()`) were verified as already implemented.

---
*PR created automatically by Jules for task [9073063205192331072](https://jules.google.com/task/9073063205192331072) started by @nsticco*