### PR TITLE
fix: move managed agent git push from fire-and-forget to deterministic fetch_result

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2965,11 +2965,31 @@ class TemporalAgentRuntimeActivities:
                 "run_store is required for agent_runtime.fetch_result"
             )
         run_id, _agent_id = self._agent_runtime_request_identifiers(request)
-        publish_mode = (
-            request.get("publish_mode")
-            or request.get("publishMode")
-            or "none"
-        ) if isinstance(request, Mapping) else "none"
+        if isinstance(request, Mapping):
+            raw_publish_mode = (
+                request.get("publish_mode")
+                or request.get("publishMode")
+                or "none"
+            )
+        else:
+            raw_publish_mode = "none"
+
+        publish_mode = str(raw_publish_mode).strip().lower()
+        _ALLOWED_PUBLISH_MODES = {"none", "pr", "branch"}
+        if publish_mode not in _ALLOWED_PUBLISH_MODES:
+            logger.warning(
+                "Received invalid publish_mode %r for run_id %s; defaulting to 'none'",
+                raw_publish_mode,
+                run_id,
+            )
+            publish_mode = "none"
+
+        target_branch = (
+            request.get("target_branch")
+            or request.get("targetBranch")
+            or request.get("publish_base_branch")
+            or request.get("publishBaseBranch")
+        ) if isinstance(request, Mapping) else None
 
         async def _unused_profile_fetcher(**_kwargs: Any) -> dict[str, Any]:
             return {"profiles": []}
@@ -2992,7 +3012,7 @@ class TemporalAgentRuntimeActivities:
         # Push the agent's work branch if publish_mode requires it and the
         # agent completed without failure.
         if result.failure_class is None and publish_mode != "none":
-            push_info = self._push_workspace_branch(run_id)
+            push_info = await self._push_workspace_branch(run_id, target_branch=target_branch)
             meta.update(push_info)
 
         # Enrich result with pull_request_url detected from workspace git
@@ -3009,13 +3029,21 @@ class TemporalAgentRuntimeActivities:
 
         return result_dict
 
-    def _push_workspace_branch(self, run_id: str) -> dict[str, str]:
+    async def _push_workspace_branch(
+        self,
+        run_id: str,
+        *,
+        target_branch: str | None = None,
+    ) -> dict[str, str]:
         """Push the workspace branch to origin.
 
         Returns a dict with ``push_status``, ``push_branch``, and optionally
         ``push_error`` that the caller merges into result metadata.
+
+        Uses ``asyncio.create_subprocess_exec`` to avoid blocking the event
+        loop.
         """
-        import subprocess
+        import asyncio as _asyncio
 
         if self._run_store is None:
             return {"push_status": "skipped", "push_error": "no run store"}
@@ -3026,19 +3054,25 @@ class TemporalAgentRuntimeActivities:
 
         workspace = record.workspace_path
         try:
-            branch_result = subprocess.run(
-                ["git", "-C", workspace, "rev-parse", "--abbrev-ref", "HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=10,
+            branch_proc = await _asyncio.create_subprocess_exec(
+                "git", "-C", workspace, "rev-parse", "--abbrev-ref", "HEAD",
+                stdout=_asyncio.subprocess.PIPE,
+                stderr=_asyncio.subprocess.PIPE,
             )
-            if branch_result.returncode != 0:
+            stdout_bytes, stderr_bytes = await _asyncio.wait_for(
+                branch_proc.communicate(), timeout=10,
+            )
+            if branch_proc.returncode != 0:
                 return {
                     "push_status": "failed",
-                    "push_error": f"could not determine branch: {branch_result.stderr.strip()}",
+                    "push_error": f"could not determine branch: {stderr_bytes.decode('utf-8', errors='replace').strip()}",
                 }
-            current_branch = branch_result.stdout.strip()
-            if not current_branch or current_branch in ("main", "master", "HEAD"):
+            current_branch = stdout_bytes.decode("utf-8", errors="replace").strip()
+
+            protected = {"main", "master", "HEAD"}
+            if target_branch:
+                protected.add(target_branch)
+            if not current_branch or current_branch in protected:
                 logger.warning(
                     "Post-agent git push skipped for run %s: "
                     "HEAD is on protected branch '%s'",
@@ -3050,20 +3084,22 @@ class TemporalAgentRuntimeActivities:
                     "push_branch": current_branch or "(unknown)",
                 }
 
-            push_result = subprocess.run(
-                ["git", "-C", workspace, "push", "-u", "origin", current_branch],
-                capture_output=True,
-                text=True,
-                timeout=120,
+            push_proc = await _asyncio.create_subprocess_exec(
+                "git", "-C", workspace, "push", "-u", "origin", current_branch,
+                stdout=_asyncio.subprocess.PIPE,
+                stderr=_asyncio.subprocess.PIPE,
             )
-            if push_result.returncode != 0:
-                error_detail = push_result.stderr.strip() or "(no stderr)"
+            push_stdout, push_stderr = await _asyncio.wait_for(
+                push_proc.communicate(), timeout=120,
+            )
+            if push_proc.returncode != 0:
+                error_detail = push_stderr.decode("utf-8", errors="replace").strip() or "(no stderr)"
                 logger.error(
                     "Post-agent git push FAILED for run %s "
                     "(branch=%s, rc=%d): %s",
                     run_id,
                     current_branch,
-                    push_result.returncode,
+                    push_proc.returncode,
                     error_detail,
                 )
                 return {

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2803,64 +2803,7 @@ class TemporalAgentRuntimeActivities:
                 logger.error("Supervisor failed for run %s", run_id, exc_info=True)
                 return
 
-            if record.status == "completed" and workspace_path:
-                publish_mode = request.parameters.get("publishMode", "none")
-                if publish_mode != "none":
-                    # Deterministic git push: ensure the agent's work branch
-                    # is on the remote before the parent workflow tries to
-                    # create a PR.
-                    try:
-                        # Safety: resolve current branch and refuse to push
-                        # protected branches (main/master/target).
-                        branch_res = await _run_command(
-                            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                            cwd=Path(workspace_path),
-                            check=True,
-                        )
-                        current_branch = branch_res.stdout.strip()
-                        target_branch = (
-                            request.parameters.get("publishBaseBranch")
-                            or request.parameters.get("startingBranch")
-                            or "main"
-                        )
-                        protected = {"main", "master", target_branch}
-                        if not current_branch or current_branch in protected:
-                            logger.warning(
-                                "Post-agent git push skipped for run %s: "
-                                "HEAD is on protected branch '%s'",
-                                run_id,
-                                current_branch or "(detached/unknown)",
-                            )
-                        else:
-                            push_res = await _run_command(
-                                ["git", "push", "-u", "origin", current_branch],
-                                cwd=Path(workspace_path),
-                                check=False,
-                            )
-                            if push_res.returncode != 0:
-                                logger.error(
-                                    "Post-agent git push FAILED for run %s "
-                                    "(branch=%s, rc=%d): %s",
-                                    run_id,
-                                    current_branch,
-                                    push_res.returncode,
-                                    push_res.stderr.strip()
-                                    if push_res.stderr
-                                    else "(no stderr)",
-                                )
-                            else:
-                                logger.info(
-                                    "Post-agent git push completed for run %s "
-                                    "(branch=%s)",
-                                    run_id,
-                                    current_branch,
-                                )
-                    except Exception:
-                        logger.warning(
-                            "Post-agent git push failed for run %s",
-                            run_id,
-                            exc_info=True,
-                        )
+
 
         task = asyncio.create_task(_supervise_and_publish())
         self._supervision_tasks.add(task)
@@ -3010,12 +2953,23 @@ class TemporalAgentRuntimeActivities:
         request: Any = None,
         /,
     ) -> dict[str, Any]:
-        """Read one managed run result via activity execution."""
+        """Read one managed run result via activity execution.
+
+        When *publish_mode* is not ``"none"``, this activity also pushes the
+        agent's work branch to the remote **before** returning the result.
+        This is deterministic (the workflow awaits this activity) instead of
+        the old fire-and-forget pattern that could silently lose pushes.
+        """
         if self._run_store is None:
             raise TemporalActivityRuntimeError(
                 "run_store is required for agent_runtime.fetch_result"
             )
         run_id, _agent_id = self._agent_runtime_request_identifiers(request)
+        publish_mode = (
+            request.get("publish_mode")
+            or request.get("publishMode")
+            or "none"
+        ) if isinstance(request, Mapping) else "none"
 
         async def _unused_profile_fetcher(**_kwargs: Any) -> dict[str, Any]:
             return {"profiles": []}
@@ -3033,6 +2987,13 @@ class TemporalAgentRuntimeActivities:
         )
         result = await adapter.fetch_result(run_id)
         result_dict = result.model_dump(mode="json", by_alias=True)
+        meta = dict(result_dict.get("metadata") or {})
+
+        # Push the agent's work branch if publish_mode requires it and the
+        # agent completed without failure.
+        if result.failure_class is None and publish_mode != "none":
+            push_info = self._push_workspace_branch(run_id)
+            meta.update(push_info)
 
         # Enrich result with pull_request_url detected from workspace git
         # state.  Managed agents run inside tmate so their stdout doesn't
@@ -3041,11 +3002,95 @@ class TemporalAgentRuntimeActivities:
         if result.failure_class is None:
             pr_url = self._detect_pr_url_from_workspace(run_id)
             if pr_url:
-                meta = dict(result_dict.get("metadata") or {})
                 meta["pull_request_url"] = pr_url
-                result_dict["metadata"] = meta
+
+        if meta:
+            result_dict["metadata"] = meta
 
         return result_dict
+
+    def _push_workspace_branch(self, run_id: str) -> dict[str, str]:
+        """Push the workspace branch to origin.
+
+        Returns a dict with ``push_status``, ``push_branch``, and optionally
+        ``push_error`` that the caller merges into result metadata.
+        """
+        import subprocess
+
+        if self._run_store is None:
+            return {"push_status": "skipped", "push_error": "no run store"}
+
+        record = self._run_store.load(run_id)
+        if record is None or not record.workspace_path:
+            return {"push_status": "skipped", "push_error": "no workspace"}
+
+        workspace = record.workspace_path
+        try:
+            branch_result = subprocess.run(
+                ["git", "-C", workspace, "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if branch_result.returncode != 0:
+                return {
+                    "push_status": "failed",
+                    "push_error": f"could not determine branch: {branch_result.stderr.strip()}",
+                }
+            current_branch = branch_result.stdout.strip()
+            if not current_branch or current_branch in ("main", "master", "HEAD"):
+                logger.warning(
+                    "Post-agent git push skipped for run %s: "
+                    "HEAD is on protected branch '%s'",
+                    run_id,
+                    current_branch or "(detached/unknown)",
+                )
+                return {
+                    "push_status": "protected_branch",
+                    "push_branch": current_branch or "(unknown)",
+                }
+
+            push_result = subprocess.run(
+                ["git", "-C", workspace, "push", "-u", "origin", current_branch],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if push_result.returncode != 0:
+                error_detail = push_result.stderr.strip() or "(no stderr)"
+                logger.error(
+                    "Post-agent git push FAILED for run %s "
+                    "(branch=%s, rc=%d): %s",
+                    run_id,
+                    current_branch,
+                    push_result.returncode,
+                    error_detail,
+                )
+                return {
+                    "push_status": "failed",
+                    "push_branch": current_branch,
+                    "push_error": error_detail,
+                }
+
+            logger.info(
+                "Post-agent git push completed for run %s (branch=%s)",
+                run_id,
+                current_branch,
+            )
+            return {
+                "push_status": "pushed",
+                "push_branch": current_branch,
+            }
+        except Exception as exc:
+            logger.warning(
+                "Post-agent git push failed for run %s",
+                run_id,
+                exc_info=True,
+            )
+            return {
+                "push_status": "failed",
+                "push_error": str(exc),
+            }
 
     def _detect_pr_url_from_workspace(self, run_id: str) -> str | None:
         """Best-effort detection of a PR URL from the workspace git state."""

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -3,6 +3,7 @@ import logging
 import os
 import dataclasses
 from datetime import timedelta
+from typing import Any
 from temporalio import workflow, activity
 from temporalio.exceptions import ApplicationError, CancelledError
 from temporalio.workflow import ActivityCancellationType
@@ -1141,14 +1142,23 @@ class MoonMindAgentRun:
                         self.final_result = AgentRunResult(**result_dict) if isinstance(result_dict, dict) else result_dict
                     else:
                         if use_managed_status_activity:
-                            publish_mode = (request.parameters or {}).get("publishMode", "none")
+                            raw_publish_mode = (request.parameters or {}).get("publishMode")
+                            publish_mode = str(raw_publish_mode).strip().lower() if isinstance(raw_publish_mode, str) and raw_publish_mode.strip() else "none"
+                            params = request.parameters or {}
+                            target_branch = params.get("publishBaseBranch") or params.get("startingBranch")
+
+                            activity_input: dict[str, Any] = {
+                                "run_id": self.run_id,
+                                "agent_id": request.agent_id,
+                            }
+                            if publish_mode != "none":
+                                activity_input["publish_mode"] = publish_mode
+                            if target_branch:
+                                activity_input["target_branch"] = target_branch
+
                             result_payload = await self._execute_activity_with_routing(
                                 "agent_runtime.fetch_result",
-                                {
-                                    "run_id": self.run_id,
-                                    "agent_id": request.agent_id,
-                                    "publish_mode": publish_mode,
-                                },
+                                activity_input,
                                 AGENT_RUNTIME_TASK_QUEUE,
                                 AGENT_RUNTIME_ACTIVITY_TIMEOUT,
                                 cancellation_type=ActivityCancellationType.TRY_CANCEL,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1141,11 +1141,13 @@ class MoonMindAgentRun:
                         self.final_result = AgentRunResult(**result_dict) if isinstance(result_dict, dict) else result_dict
                     else:
                         if use_managed_status_activity:
+                            publish_mode = (request.parameters or {}).get("publishMode", "none")
                             result_payload = await self._execute_activity_with_routing(
                                 "agent_runtime.fetch_result",
                                 {
                                     "run_id": self.run_id,
                                     "agent_id": request.agent_id,
+                                    "publish_mode": publish_mode,
                                 },
                                 AGENT_RUNTIME_TASK_QUEUE,
                                 AGENT_RUNTIME_ACTIVITY_TIMEOUT,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -65,96 +66,148 @@ def _make_subprocess_result(
 class TestPushWorkspaceBranch:
     """Tests for TemporalAgentRuntimeActivities._push_workspace_branch."""
 
-    def test_push_skipped_no_store(self):
+    @pytest.mark.asyncio
+    async def test_push_skipped_no_store(self):
         activities = TemporalAgentRuntimeActivities(run_store=None)
-        result = activities._push_workspace_branch("run-1")
+        result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "skipped"
         assert "no run store" in result.get("push_error", "")
 
-    def test_push_skipped_no_workspace(self):
+    @pytest.mark.asyncio
+    async def test_push_skipped_no_workspace(self):
         store = _make_mock_store(workspace_path=None)
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "skipped"
         assert "no workspace" in result.get("push_error", "")
 
-    def test_push_skipped_record_not_found(self):
+    @pytest.mark.asyncio
+    async def test_push_skipped_record_not_found(self):
         store = MagicMock()
         store.load.return_value = None
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "skipped"
 
-    @patch("subprocess.run")
-    def test_push_protected_branch_main(self, mock_run):
-        mock_run.return_value = _make_subprocess_result(stdout="main\n")
+    @pytest.mark.asyncio
+    async def test_push_protected_branch_main(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"main\n", b""))
+            proc.returncode = 0
+            mock_exec.return_value = proc
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "protected_branch"
         assert result["push_branch"] == "main"
 
-    @patch("subprocess.run")
-    def test_push_protected_branch_master(self, mock_run):
-        mock_run.return_value = _make_subprocess_result(stdout="master\n")
+    @pytest.mark.asyncio
+    async def test_push_protected_branch_master(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"master\n", b""))
+            proc.returncode = 0
+            mock_exec.return_value = proc
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "protected_branch"
         assert result["push_branch"] == "master"
 
-    @patch("subprocess.run")
-    def test_push_protected_branch_head(self, mock_run):
-        mock_run.return_value = _make_subprocess_result(stdout="HEAD\n")
+    @pytest.mark.asyncio
+    async def test_push_protected_branch_head(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
+            proc.returncode = 0
+            mock_exec.return_value = proc
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "protected_branch"
 
-    @patch("subprocess.run")
-    def test_push_success(self, mock_run):
-        # First call: rev-parse returns feature branch
-        # Second call: git push succeeds
-        mock_run.side_effect = [
-            _make_subprocess_result(stdout="feature/delete-spec-048\n"),
-            _make_subprocess_result(returncode=0),
-        ]
+    @pytest.mark.asyncio
+    async def test_push_protected_target_branch(self):
+        """target_branch is included in the protected set."""
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"develop\n", b""))
+            proc.returncode = 0
+            mock_exec.return_value = proc
+            result = await activities._push_workspace_branch("run-1", target_branch="develop")
+        assert result["push_status"] == "protected_branch"
+        assert result["push_branch"] == "develop"
+
+    @pytest.mark.asyncio
+    async def test_push_success(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"feature/delete-spec-048\n", b""))
+                proc.returncode = 0
+            else:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "feature/delete-spec-048"
         assert "push_error" not in result
 
-    @patch("subprocess.run")
-    def test_push_failure(self, mock_run):
-        mock_run.side_effect = [
-            _make_subprocess_result(stdout="feature/delete-spec-048\n"),
-            _make_subprocess_result(returncode=128, stderr="remote: Permission denied"),
-        ]
+    @pytest.mark.asyncio
+    async def test_push_failure(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"feature/delete-spec-048\n", b""))
+                proc.returncode = 0
+            else:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b"remote: Permission denied"))
+                proc.returncode = 128
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "failed"
         assert result["push_branch"] == "feature/delete-spec-048"
         assert "Permission denied" in result["push_error"]
 
-    @patch("subprocess.run")
-    def test_push_branch_detection_failure(self, mock_run):
-        mock_run.return_value = _make_subprocess_result(
-            returncode=1, stderr="fatal: not a git repository",
-        )
+    @pytest.mark.asyncio
+    async def test_push_branch_detection_failure(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b"fatal: not a git repository"))
+            proc.returncode = 1
+            mock_exec.return_value = proc
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "failed"
         assert "could not determine branch" in result["push_error"]
 
-    @patch("subprocess.run", side_effect=OSError("git not found"))
-    def test_push_exception_returns_failed(self, mock_run):
+    @pytest.mark.asyncio
+    async def test_push_exception_returns_failed(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
-        result = activities._push_workspace_branch("run-1")
+        with patch("asyncio.create_subprocess_exec", side_effect=OSError("git not found")):
+            result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "failed"
         assert "git not found" in result["push_error"]
 
@@ -183,6 +236,7 @@ class TestFetchResultPushIntegration:
         with (
             patch.object(
                 activities, "_push_workspace_branch",
+                new_callable=AsyncMock,
                 return_value={"push_status": "pushed", "push_branch": "my-branch"},
             ) as mock_push,
             patch.object(
@@ -200,7 +254,7 @@ class TestFetchResultPushIntegration:
                 {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
             )
 
-        mock_push.assert_called_once_with("run-1")
+        mock_push.assert_called_once_with("run-1", target_branch=None)
         assert result["metadata"]["push_status"] == "pushed"
         assert result["metadata"]["push_branch"] == "my-branch"
 
@@ -232,7 +286,7 @@ class TestFetchResultPushIntegration:
             adapter_instance = MockAdapter.return_value
             adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
 
-            result = await activities.agent_runtime_fetch_result(
+            await activities.agent_runtime_fetch_result(
                 {"run_id": "run-1", "agent_id": "claude", "publish_mode": "none"},
             )
 
@@ -267,7 +321,7 @@ class TestFetchResultPushIntegration:
             adapter_instance = MockAdapter.return_value
             adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
 
-            result = await activities.agent_runtime_fetch_result(
+            await activities.agent_runtime_fetch_result(
                 {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
             )
 
@@ -289,6 +343,7 @@ class TestFetchResultPushIntegration:
         with (
             patch.object(
                 activities, "_push_workspace_branch",
+                new_callable=AsyncMock,
                 return_value={
                     "push_status": "failed",
                     "push_branch": "my-branch",
@@ -342,7 +397,7 @@ class TestFetchResultPushIntegration:
             adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
 
             # No publish_mode key at all
-            result = await activities.agent_runtime_fetch_result(
+            await activities.agent_runtime_fetch_result(
                 {"run_id": "run-1", "agent_id": "claude"},
             )
 

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import subprocess
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, AsyncMock, patch

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -1,0 +1,349 @@
+"""Unit tests for _push_workspace_branch and fetch_result push integration."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalAgentRuntimeActivities,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_store(
+    *,
+    workspace_path: str | None = "/work/agent_jobs/run-1/repo",
+    status: str = "completed",
+    failure_class: str | None = None,
+    agent_id: str = "claude",
+    runtime_id: str = "claude_code",
+) -> MagicMock:
+    """Build a MagicMock run_store that returns a deterministic record."""
+    record = MagicMock()
+    record.run_id = "run-1"
+    record.agent_id = agent_id
+    record.runtime_id = runtime_id
+    record.status = status
+    record.workspace_path = workspace_path
+    record.pid = 12345
+    record.exit_code = 0
+    record.started_at = datetime.now(tz=UTC)
+    record.finished_at = datetime.now(tz=UTC)
+    record.last_heartbeat_at = None
+    record.log_artifact_ref = None
+    record.diagnostics_ref = None
+    record.error_message = None
+    record.failure_class = failure_class
+    store = MagicMock()
+    store.load.return_value = record
+    return store
+
+
+def _make_subprocess_result(
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _push_workspace_branch
+# ---------------------------------------------------------------------------
+
+
+class TestPushWorkspaceBranch:
+    """Tests for TemporalAgentRuntimeActivities._push_workspace_branch."""
+
+    def test_push_skipped_no_store(self):
+        activities = TemporalAgentRuntimeActivities(run_store=None)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "skipped"
+        assert "no run store" in result.get("push_error", "")
+
+    def test_push_skipped_no_workspace(self):
+        store = _make_mock_store(workspace_path=None)
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "skipped"
+        assert "no workspace" in result.get("push_error", "")
+
+    def test_push_skipped_record_not_found(self):
+        store = MagicMock()
+        store.load.return_value = None
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "skipped"
+
+    @patch("subprocess.run")
+    def test_push_protected_branch_main(self, mock_run):
+        mock_run.return_value = _make_subprocess_result(stdout="main\n")
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "protected_branch"
+        assert result["push_branch"] == "main"
+
+    @patch("subprocess.run")
+    def test_push_protected_branch_master(self, mock_run):
+        mock_run.return_value = _make_subprocess_result(stdout="master\n")
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "protected_branch"
+        assert result["push_branch"] == "master"
+
+    @patch("subprocess.run")
+    def test_push_protected_branch_head(self, mock_run):
+        mock_run.return_value = _make_subprocess_result(stdout="HEAD\n")
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "protected_branch"
+
+    @patch("subprocess.run")
+    def test_push_success(self, mock_run):
+        # First call: rev-parse returns feature branch
+        # Second call: git push succeeds
+        mock_run.side_effect = [
+            _make_subprocess_result(stdout="feature/delete-spec-048\n"),
+            _make_subprocess_result(returncode=0),
+        ]
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/delete-spec-048"
+        assert "push_error" not in result
+
+    @patch("subprocess.run")
+    def test_push_failure(self, mock_run):
+        mock_run.side_effect = [
+            _make_subprocess_result(stdout="feature/delete-spec-048\n"),
+            _make_subprocess_result(returncode=128, stderr="remote: Permission denied"),
+        ]
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "failed"
+        assert result["push_branch"] == "feature/delete-spec-048"
+        assert "Permission denied" in result["push_error"]
+
+    @patch("subprocess.run")
+    def test_push_branch_detection_failure(self, mock_run):
+        mock_run.return_value = _make_subprocess_result(
+            returncode=1, stderr="fatal: not a git repository",
+        )
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "failed"
+        assert "could not determine branch" in result["push_error"]
+
+    @patch("subprocess.run", side_effect=OSError("git not found"))
+    def test_push_exception_returns_failed(self, mock_run):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        result = activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "failed"
+        assert "git not found" in result["push_error"]
+
+
+# ---------------------------------------------------------------------------
+# agent_runtime_fetch_result — push integration
+# ---------------------------------------------------------------------------
+
+
+class TestFetchResultPushIntegration:
+    """Tests for publish_mode-aware git push inside fetch_result."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_pushes_when_publish_mode_pr(self):
+        """Push attempted when publish_mode=pr and agent succeeded."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        mock_result = MagicMock()
+        mock_result.failure_class = None
+        mock_result.model_dump.return_value = {
+            "summary": "done",
+            "metadata": {},
+        }
+
+        with (
+            patch.object(
+                activities, "_push_workspace_branch",
+                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+            ) as mock_push,
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        mock_push.assert_called_once_with("run-1")
+        assert result["metadata"]["push_status"] == "pushed"
+        assert result["metadata"]["push_branch"] == "my-branch"
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_skips_push_when_publish_mode_none(self):
+        """No push when publish_mode=none."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        mock_result = MagicMock()
+        mock_result.failure_class = None
+        mock_result.model_dump.return_value = {
+            "summary": "done",
+            "metadata": {},
+        }
+
+        with (
+            patch.object(
+                activities, "_push_workspace_branch",
+            ) as mock_push,
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "none"},
+            )
+
+        mock_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_skips_push_on_failure(self):
+        """No push when agent failed (failure_class set)."""
+        store = _make_mock_store(failure_class="execution_error")
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        mock_result = MagicMock()
+        mock_result.failure_class = "execution_error"
+        mock_result.model_dump.return_value = {
+            "summary": "failed",
+            "failureClass": "execution_error",
+            "metadata": {},
+        }
+
+        with (
+            patch.object(
+                activities, "_push_workspace_branch",
+            ) as mock_push,
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        mock_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_reports_push_failure_in_metadata(self):
+        """Push failure details propagated to result metadata."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        mock_result = MagicMock()
+        mock_result.failure_class = None
+        mock_result.model_dump.return_value = {
+            "summary": "done",
+            "metadata": {},
+        }
+
+        with (
+            patch.object(
+                activities, "_push_workspace_branch",
+                return_value={
+                    "push_status": "failed",
+                    "push_branch": "my-branch",
+                    "push_error": "remote: Permission denied",
+                },
+            ),
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert result["metadata"]["push_status"] == "failed"
+        assert result["metadata"]["push_error"] == "remote: Permission denied"
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_defaults_publish_mode_none(self):
+        """When publish_mode not provided, defaults to 'none' (no push)."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        mock_result = MagicMock()
+        mock_result.failure_class = None
+        mock_result.model_dump.return_value = {
+            "summary": "done",
+            "metadata": {},
+        }
+
+        with (
+            patch.object(
+                activities, "_push_workspace_branch",
+            ) as mock_push,
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=mock_result)
+
+            # No publish_mode key at all
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude"},
+            )
+
+        mock_push.assert_not_called()


### PR DESCRIPTION
## Problem

Managed agent workflows reported `status: completed` while the git push silently failed — no PR created, no error surfaced to the operator. This is a double failure (silent + false-success) that violates Constitution Principle IX (Resilient by Default).

**Root cause:** Git push ran inside a fire-and-forget `asyncio.create_task(_supervise_and_publish())` in the `agent_runtime.launch` activity. The supervisor set `status = completed` **before** the push ran, creating a race with the `agent_runtime.status` poll loop. Push failures were swallowed silently.

## Changes

### `activity_runtime.py`
- **Removed** git push from the fire-and-forget `_supervise_and_publish` background task
- **Added** `_push_workspace_branch()` method with structured return metadata (`push_status`, `push_branch`, `push_error`)
- **Updated** `agent_runtime_fetch_result` to call push when `publish_mode != "none"` and agent succeeded — this activity is **awaited** by the workflow, so failures are now visible

### `agent_run.py`
- Threads `publishMode` from `AgentExecutionRequest.parameters` to the `agent_runtime.fetch_result` activity call

### `test_fetch_result_push.py` [NEW]
- 16 unit tests covering push success/failure/protected-branch/skip/exception scenarios and fetch_result integration

## Verification

| Suite | Result |
|-------|--------|
| New push tests (16) | ✅ All passed |
| Existing agent runtime tests (17) | ✅ All passed |
| Full unit test suite (1988) | ✅ All passed, 0 failures |