### PR TITLE
fix: guard jules_session_id metadata to Jules-only agents

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1203,7 +1203,8 @@ class MoonMindAgentRun:
                 # Jules session reuse across plan nodes.
                 if self.run_id and hasattr(self.final_result, "metadata"):
                     result_meta = dict(self.final_result.metadata or {})
-                    result_meta["jules_session_id"] = self.run_id
+                    if self._external_agent_id == "jules":
+                        result_meta["jules_session_id"] = self.run_id
                     self.final_result = self.final_result.model_copy(
                         update={"metadata": result_meta}
                     )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1203,7 +1203,7 @@ class MoonMindAgentRun:
                 # Jules session reuse across plan nodes.
                 if self.run_id and hasattr(self.final_result, "metadata"):
                     result_meta = dict(self.final_result.metadata or {})
-                    if self._external_agent_id == "jules":
+                    if self._external_agent_id in {"jules", "jules_api"}:
                         result_meta["jules_session_id"] = self.run_id
                     self.final_result = self.final_result.model_copy(
                         update={"metadata": result_meta}

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -708,9 +708,13 @@ class MoonMindRunWorkflow:
 
             # --- Multi-step Jules: extract session_id only on success ---
             if tool_type == "agent_runtime":
-                extracted_id = self._extract_jules_session_id(child_result)
-                if extracted_id:
-                    jules_session_id = extracted_id
+                node_runtime_mode = str(
+                    node_inputs.get("runtime", {}).get("mode", "")
+                ).strip().lower()
+                if node_runtime_mode == "jules":
+                    extracted_id = self._extract_jules_session_id(child_result)
+                    if extracted_id:
+                        jules_session_id = extracted_id
             if require_pull_request_url and pull_request_url is None:
                 pull_request_url = self._extract_pull_request_url(execution_result)
                 
@@ -748,7 +752,7 @@ class MoonMindRunWorkflow:
             
             ws = self._mapping_value(parameters, "workspaceSpec", "workspace_spec") or {}
             
-            if last_tool in ("jules", "jules_api", "github_pr_creator") or jules_session_id:
+            if last_tool in ("jules", "jules_api", "github_pr_creator"):
                 self._get_logger().info(
                     "Skipping native PR creation: agent '%s' handles its own PRs.",
                     last_tool or "jules",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -708,10 +708,15 @@ class MoonMindRunWorkflow:
 
             # --- Multi-step Jules: extract session_id only on success ---
             if tool_type == "agent_runtime":
-                node_runtime_mode = str(
-                    node_inputs.get("runtime", {}).get("mode", "")
+                _rt = node_inputs.get("runtime") or {}
+                _node_agent_id = (
+                    _rt.get("mode")
+                    or _rt.get("agent_id")
+                    or node_inputs.get("targetRuntime")
+                    or tool_name
+                    or ""
                 ).strip().lower()
-                if node_runtime_mode == "jules":
+                if _node_agent_id in {"jules", "jules_api"}:
                     extracted_id = self._extract_jules_session_id(child_result)
                     if extracted_id:
                         jules_session_id = extracted_id
@@ -749,13 +754,26 @@ class MoonMindRunWorkflow:
             last_tool = str(
                 (ordered_nodes[-1].get("tool", {}) if ordered_nodes else {}).get("name") or ""
             ).strip().lower()
+            # Derive the last node's effective agent_id using the same
+            # resolution logic as _build_agent_execution_request so that
+            # Jules-via-runtime-settings (e.g. tool.name="auto" with
+            # inputs.runtime.mode="jules") is correctly detected.
+            _last_inputs = ordered_nodes[-1].get("inputs", {}) if ordered_nodes else {}
+            _last_rt = _last_inputs.get("runtime") or {}
+            last_agent_id = (
+                _last_rt.get("mode")
+                or _last_rt.get("agent_id")
+                or _last_inputs.get("targetRuntime")
+                or last_tool
+                or ""
+            ).strip().lower()
             
             ws = self._mapping_value(parameters, "workspaceSpec", "workspace_spec") or {}
             
-            if last_tool in ("jules", "jules_api", "github_pr_creator"):
+            if last_agent_id in ("jules", "jules_api", "github_pr_creator"):
                 self._get_logger().info(
                     "Skipping native PR creation: agent '%s' handles its own PRs.",
-                    last_tool or "jules",
+                    last_agent_id,
                 )
             else:
                 agent_outputs = {}

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -825,3 +825,137 @@ async def test_run_execution_stage_publish_mode_pr_jules_skips_native_pr(
     )
 
     assert not create_pr_called, "repo.create_pr should not have been called"
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_non_jules_agent_with_session_id_creates_native_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test: a non-Jules agent_runtime (e.g. Claude) that returns
+    jules_session_id in result metadata must NOT suppress native PR creation.
+
+    Root cause: agent_run.py unconditionally injected jules_session_id into
+    every AgentRunResult.metadata, and run.py used ``or jules_session_id`` to
+    skip PR creation.  This test ensures the fix works: the PR-skip guard
+    should NOT trigger for non-Jules agents even when the metadata contains
+    a jules_session_id.
+    """
+    wf = MoonMindRunWorkflow()
+    wf._owner_id = "owner-1"
+    wf._repo = "MoonLadderStudios/MoonMind"
+    wf._title = "Automated changes"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999", "created": True}
+
+        if activity_type == "artifact.read":
+            if payload.get("artifact_ref") == "artifact://registry/1":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "auto",
+                                "version": "1.0",
+                                "description": "Auto",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Test Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "node-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "claude", "model": "MiniMax-M2.7"},
+                                "instructions": "Remove spec from the specs directory",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        # Simulates a Claude agent result that spuriously includes
+        # jules_session_id (the old bug).
+        return {
+            "summary": "Completed with status completed",
+            "metadata": {
+                "push_status": "pushed",
+                "push_branch": "auto-0526d401",
+                "branch": "auto-0526d401",
+                "jules_session_id": "cb4cca35-fake-session-id",
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await wf._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert create_pr_called, (
+        "repo.create_pr SHOULD have been called for a non-Jules agent "
+        "even when child result metadata contains jules_session_id"
+    )


### PR DESCRIPTION
## Problem

Workflow `mm:5f7dc3ea-1d8b-4c5f-87c4-cfc8e6e2f27c` ("Remove spec specs/048-jules-external-events") completed successfully but **never created a PR**, despite `publishMode: pr`. The Claude agent pushed to branch `auto-0526d401` but native PR creation was silently skipped.

## Root Cause

`agent_run.py:1206` unconditionally stamped `jules_session_id = self.run_id` into **every** `AgentRunResult.metadata`, including non-Jules agents. The parent `Run` workflow then:
1. Extracted the spurious `jules_session_id` from the Claude agent's result
2. Hit the `or jules_session_id` guard and skipped native PR creation

## Fix (3 changes)

1. **`agent_run.py`** — Guard injection: `if self._external_agent_id == "jules"`
2. **`run.py`** — Only extract `jules_session_id` for Jules-mode plan nodes
3. **`run.py`** — Remove `or jules_session_id` from PR-skip guard

## Tests

- Added regression test for the exact bug scenario
- All 2003 unit tests pass