### PR TITLE
docs: close roadmap item H.1 for single substrate migration

### DIFF
--- a/docs/tmp/016-SingleSubstrateMigration.md
+++ b/docs/tmp/016-SingleSubstrateMigration.md
@@ -129,7 +129,7 @@ Code is **Temporal-primary**; remaining items are mostly **vocabulary**, **query
 - [x] **5.4** Delete `docs/tmp/OrchestratorRemovalPlan.md` — superseded *(done)*
 - [ ] **5.5** Update `docs/MoonMindArchitecture.md` if any queue/system execution references remain
 - [ ] **5.6** Update remaining Temporal architecture docs (`TemporalArchitecture.md`, `ActivityCatalogAndWorkerTopology.md`, `WorkflowTypeCatalogAndLifecycle.md`, `RoutingPolicy.md`) to remove transitional queue/system language, purge obsolete feature flags, and use steady-state Temporal vocabulary *(may overlap dedicated trackers under `docs/tmp/remaining-work/`)* 
-- [ ] **5.7** Update Roadmap: close H.1 (system removal) and mark substrate migration items done
+- [x] **5.7** Update Roadmap: close H.1 (system removal) and mark substrate migration items done
 - [ ] **5.8** Delete or archive **this** document once Phase 5 is complete and readers are pointed at canonical `docs/Temporal/` sources
 
 **Cross-links:** When editing canonical docs, align **namespace** story with [009-DefaultNamespace.md](009-DefaultNamespace.md), **scheduling** with [014-TemporalSchedulingImprovements.md](014-TemporalSchedulingImprovements.md), and **control-plane messages** with [014-TemporalMessageContracts.md](014-TemporalMessageContracts.md).

--- a/docs/tmp/102-Roadmap.md
+++ b/docs/tmp/102-Roadmap.md
@@ -254,7 +254,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 These are technical debt items that don't map to README claims but improve code quality and maintainability.
 
 ### Remaining tasks
-- [ ] **H.1** Complete legacy system removal — Migration exists (`c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining queue/dashboard phases tracked in `docs/tmp/SingleSubstrateMigration.md`.
+- [x] **H.1** Complete legacy system removal — Migration exists (`c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining queue/dashboard phases tracked in `docs/tmp/SingleSubstrateMigration.md`.
 - [ ] **H.2** Spec deduplication — Merge duplicate specs identified in `docs/tmp/SpecMergeReview.md`: Worker Pause (038/040), Claude gating (044/046), Manifest Phase 0 (032/034), Jules events (048 stub → delete), Task Presets (026/028)
 - [ ] **H.3** Legacy skill dispatch cleanup — Remove dead `tool.type == "skill"` branch in `run.py`; all current plan generators emit `agent_runtime` nodes. See `docs/tmp/skill-system-alignment.md`.
 - [ ] **H.4** Delete legacy docs identified in `docs/LegacyDocsReview.md` — 6 docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.)
@@ -278,7 +278,7 @@ The milestones below are ordered by **impact on delivering the README promise** 
 | 🟡 P2 | **8 — Universal Integration (MCP)** | 🔧 Partial | 4 items |
 | 🟢 P3 | **10 — Vendor Portability & Model Flexibility** | 🔧 Partial | 4 items |
 | 🟢 P3 | **1 — Managed Agent Runtimes** | ✅ Shipped | 2 items |
-| 🟢 P3 | **H — Housekeeping / Cleanup** | 🔧 Partial | 4 items |
+| 🟢 P3 | **H — Housekeeping / Cleanup** | 🔧 Partial | 3 items |
 
 ---
 

--- a/docs/tmp/102-Roadmap.md
+++ b/docs/tmp/102-Roadmap.md
@@ -254,7 +254,7 @@ Remaining items within each milestone are numbered **M.N** (milestone.item) and 
 These are technical debt items that don't map to README claims but improve code quality and maintainability.
 
 ### Remaining tasks
-- [x] **H.1** Complete legacy system removal — Migration exists (`c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining queue/dashboard phases tracked in `docs/tmp/SingleSubstrateMigration.md`.
+- [x] **H.1** Complete legacy system removal — Code removal is complete (migration `c1d2e3f4a5b6`); requirements and guard tests in `specs/087-orchestrator-removal/` and `tests/unit/orchestrator_removal/`. Remaining documentation updates are tracked in `docs/tmp/016-SingleSubstrateMigration.md`.
 - [ ] **H.2** Spec deduplication — Merge duplicate specs identified in `docs/tmp/SpecMergeReview.md`: Worker Pause (038/040), Claude gating (044/046), Manifest Phase 0 (032/034), Jules events (048 stub → delete), Task Presets (026/028)
 - [ ] **H.3** Legacy skill dispatch cleanup — Remove dead `tool.type == "skill"` branch in `run.py`; all current plan generators emit `agent_runtime` nodes. See `docs/tmp/skill-system-alignment.md`.
 - [ ] **H.4** Delete legacy docs identified in `docs/LegacyDocsReview.md` — 6 docs flagged for deletion (`CodexCliWorkers.md`, `GeminiCliWorkers.md`, `SpecKitAutomation.md`, etc.)
@@ -288,7 +288,7 @@ The milestones below are ordered by **impact on delivering the README promise** 
 |------|-------------|-----------|
 | `Roadmap.md` | **Keep** | This file — the living roadmap |
 | `CancellationAnalysis.md` | **Delete** | Recommendations shipped (TRY_CANCEL in all activities, force-terminate path). Analysis preserved in Milestone 4 entries. |
-| `OrchestratorRemovalPlan.md` | **Deleted** | Superseded by spec 087, in-repo removal work, and `SingleSubstrateMigration.md`. |
+| `OrchestratorRemovalPlan.md` | **Deleted** | Superseded by spec 087, in-repo removal work, and `016-SingleSubstrateMigration.md`. |
 | `RagDocUpdates.md` | **Delete** | Marked "Status: Complete". Spec merge plan fully executed (spec 088 shipped). |
 | `SpecMergeReview.md` | **Keep until H.2 complete** | Actionable merge candidates not yet resolved. Tracked as H.2 in Housekeeping. |
 | `skill-system-alignment.md` | **Keep until H.3 complete** | Legacy skill branch still present in `run.py`. Tracked as H.3 in Housekeeping. |


### PR DESCRIPTION
Closes H.1 item in the roadmap and updates the substrate migration checklist for 5.7.

---
*PR created automatically by Jules for task [9758716760024745059](https://jules.google.com/task/9758716760024745059) started by @nsticco*