### PR TITLE
fix: add missing Live Output and Live Logs DOM elements to task detail page

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -7621,6 +7621,31 @@
       }</tbody>
         </table>
       </section>
+      <section id="temporal-live-output-section"></section>
+      <section>
+        <h3>Live Logs</h3>
+        <div id="temporal-live-logs-inactive">
+          <button type="button" id="temporal-start-tailing" class="secondary">▶ Start Tailing</button>
+        </div>
+        <div id="temporal-live-logs-active" style="display:none;">
+          <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem;flex-wrap:wrap;">
+            <label for="temporal-output-filter" style="font-size:0.85rem;">Filter:</label>
+            <select id="temporal-output-filter" style="font-size:0.85rem;">
+              <option value="all">All</option>
+              <option value="stages">Stages</option>
+              <option value="logs">Logs</option>
+              <option value="warnings">Warnings</option>
+            </select>
+            <label style="font-size:0.85rem;display:flex;align-items:center;gap:0.25rem;">
+              <input type="checkbox" id="temporal-follow-output" checked /> Follow
+            </label>
+            <button type="button" id="temporal-copy-output" class="secondary" style="font-size:0.8rem;">Copy</button>
+            <button type="button" id="temporal-stop-tailing" class="secondary queue-action-danger" style="font-size:0.8rem;">■ Stop</button>
+            <span id="temporal-live-transport-status" class="small" style="margin-left:auto;opacity:0.7;"></span>
+          </div>
+          <pre id="temporal-live-output" style="max-height:400px;overflow:auto;background:var(--card-bg,#16213e);padding:0.75rem;border-radius:6px;font-size:0.8rem;white-space:pre-wrap;word-break:break-all;"></pre>
+        </div>
+      </section>
       ${debugFields}
     `;
   }

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -7628,22 +7628,23 @@
           <button type="button" id="temporal-start-tailing" class="secondary">▶ Start Tailing</button>
         </div>
         <div id="temporal-live-logs-active" style="display:none;">
-          <div style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem;flex-wrap:wrap;">
-            <label for="temporal-output-filter" style="font-size:0.85rem;">Filter:</label>
-            <select id="temporal-output-filter" style="font-size:0.85rem;">
+          <div class="queue-live-output-toolbar">
+            <label for="temporal-output-filter" class="queue-inline-filter">Filter:
+            <select id="temporal-output-filter">
               <option value="all">All</option>
               <option value="stages">Stages</option>
               <option value="logs">Logs</option>
               <option value="warnings">Warnings</option>
             </select>
-            <label style="font-size:0.85rem;display:flex;align-items:center;gap:0.25rem;">
+            </label>
+            <label class="queue-inline-toggle">
               <input type="checkbox" id="temporal-follow-output" checked /> Follow
             </label>
-            <button type="button" id="temporal-copy-output" class="secondary" style="font-size:0.8rem;">Copy</button>
-            <button type="button" id="temporal-stop-tailing" class="secondary queue-action-danger" style="font-size:0.8rem;">■ Stop</button>
-            <span id="temporal-live-transport-status" class="small" style="margin-left:auto;opacity:0.7;"></span>
+            <button type="button" id="temporal-copy-output" class="secondary">Copy</button>
+            <button type="button" id="temporal-stop-tailing" class="secondary queue-action-danger">■ Stop</button>
+            <span id="temporal-live-transport-status" class="small"></span>
           </div>
-          <pre id="temporal-live-output" style="max-height:400px;overflow:auto;background:var(--card-bg,#16213e);padding:0.75rem;border-radius:6px;font-size:0.8rem;white-space:pre-wrap;word-break:break-all;"></pre>
+          <pre id="temporal-live-output" class="queue-live-output"></pre>
         </div>
       </section>
       ${debugFields}

--- a/tests/task_dashboard/test_temporal_dashboard.js
+++ b/tests/task_dashboard/test_temporal_dashboard.js
@@ -380,9 +380,15 @@ const helpers = loadTemporalHelpers();
     "temporal-live-transport-status",
   ];
 
+  function htmlHasElementWithId(htmlString, elementId) {
+    const escapedId = elementId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const idPattern = new RegExp(`id\\s*=\\s*(['"])${escapedId}\\1`);
+    return idPattern.test(htmlString);
+  }
+
   for (const id of requiredIds) {
     assert(
-      html.includes(`id="${id}"`),
+      htmlHasElementWithId(html, id),
       `Detail markup must include element with id="${id}"`,
     );
   }

--- a/tests/task_dashboard/test_temporal_dashboard.js
+++ b/tests/task_dashboard/test_temporal_dashboard.js
@@ -353,3 +353,37 @@ const helpers = loadTemporalHelpers();
   assert.strictEqual(rows.length, 1);
   assert.strictEqual(rows[0].runtimeMode, "codex", "targetRuntime (camelCase) should take precedence");
 })();
+
+(function testRenderTemporalDetailMarkupIncludesLiveLogsDomElements() {
+  const html = helpers.renderTemporalDetailMarkup({
+    execution: { state: "executing", workflowType: "MoonMind.Run" },
+    latestWorkflowId: "mm:wf-live-test",
+    latestRunId: "run-live-test",
+    artifacts: { artifacts: [] },
+    waitingReason: "",
+    detailTitle: "Live Logs Test",
+    attentionRequired: false,
+    noticeHtml: "",
+    debugFields: "",
+  });
+
+  const requiredIds = [
+    "temporal-live-output-section",
+    "temporal-live-logs-inactive",
+    "temporal-live-logs-active",
+    "temporal-start-tailing",
+    "temporal-stop-tailing",
+    "temporal-live-output",
+    "temporal-follow-output",
+    "temporal-output-filter",
+    "temporal-copy-output",
+    "temporal-live-transport-status",
+  ];
+
+  for (const id of requiredIds) {
+    assert(
+      html.includes(`id="${id}"`),
+      `Detail markup must include element with id="${id}"`,
+    );
+  }
+})();


### PR DESCRIPTION
## Problem

The task detail page in Mission Control was missing the **Live Output** (tmate iframe) panel and the **Live Logs** (event tailing) section. All backend APIs, JS handlers, and CSS existed, but `renderTemporalDetailMarkup()` never emitted the DOM elements those handlers bind to via `document.getElementById()`, causing them to silently no-op.

## Changes

### `dashboard.js`
Added two sections to `renderTemporalDetailMarkup()` between Artifacts and Debug:

1. **`temporal-live-output-section`** — empty container that `renderTemporalLiveOutputPanel()` dynamically populates with the tmate iframe / status messages.

2. **Live Logs section** with the full tailing UI:
   - Start/Stop tailing buttons
   - Output filter (All / Stages / Logs / Warnings)
   - Follow-output checkbox
   - Copy button
   - Transport status indicator
   - `<pre>` output element

### `test_temporal_dashboard.js`
Added a test verifying all 10 required element IDs are present in the rendered detail markup.

## Testing

All 2003 Python unit tests and 14 JS subtests pass via `./tools/test_unit.sh`.