### PR TITLE
fix(batch-pr-resolver): read taskId from API response, not id

### DIFF
--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -472,7 +472,7 @@ async def _submit_jobs_via_http(
                 response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
                 response.raise_for_status()
                 data = response.json()
-                job_id = str(data.get("id", "")) or "(unknown)"
+                job_id = str(data.get("taskId", "")) or "(unknown)"
                 created.append(
                     {
                         "pr": submission.pr_number,

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -318,7 +318,7 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
 
     fake_response = MagicMock()
     fake_response.raise_for_status = MagicMock()
-    fake_response.json = MagicMock(return_value={"id": "uuid-1234", "status": "queued"})
+    fake_response.json = MagicMock(return_value={"taskId": "mm:uuid-1234", "status": "queued"})
 
     mock_post = AsyncMock(return_value=fake_response)
 
@@ -349,7 +349,7 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
 
     assert errors == []
     assert len(created) == 1
-    assert created[0]["jobId"] == "uuid-1234"
+    assert created[0]["jobId"] == "mm:uuid-1234"
     assert created[0]["pr"] == 42
     mock_post.assert_awaited_once()
     call_path = mock_post.await_args[0][0]


### PR DESCRIPTION
## Summary

- Fix `batch_pr_resolver.py` HTTP submission path to read `taskId` from the API response instead of the non-existent `id` field
- Update unit test mock to reflect the actual API response shape (`taskId` with `mm:` prefix)

## Root cause

The MoonMind API's `POST /api/executions` endpoint returns `taskId` (e.g. `"mm:uuid-..."`) as the job identifier, not `id`. The `_submit_jobs_via_http` function was calling `data.get("id", "")` which always returned `"(unknown)"`, making all queued job IDs untrackable.

## Test plan

- [x] Unit tests pass: `21 passed` in `tests/unit/test_batch_pr_resolver.py`
- [x] Verified in agent runtime container that API returns `taskId` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)