### PR TITLE
fix: detect no-commit push and skip PR creation gracefully

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3116,20 +3116,32 @@ class TemporalAgentRuntimeActivities:
             # git push succeeds as a no-op when the branch is already
             # up-to-date, which would cause repo.create_pr to fail
             # with HTTP 422 ("No commits between main and <branch>").
+            base_ref = f"origin/{target_branch or 'main'}"
             try:
                 count_proc = await _asyncio.create_subprocess_exec(
                     "git", "-C", workspace,
-                    "rev-list", "--count", f"origin/main..{current_branch}",
+                    "rev-list", "--count", f"{base_ref}..{current_branch}",
                     stdout=_asyncio.subprocess.PIPE,
                     stderr=_asyncio.subprocess.PIPE,
                 )
                 count_stdout, _ = await _asyncio.wait_for(
                     count_proc.communicate(), timeout=10,
                 )
+                if count_proc.returncode != 0:
+                    raise RuntimeError(
+                        f"git rev-list failed with return code {count_proc.returncode}"
+                    )
                 commit_count = int(
                     count_stdout.decode("utf-8", errors="replace").strip() or "0"
                 )
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "Failed to count commits for run %s, falling back to "
+                    "assuming commits exist: %s",
+                    run_id,
+                    exc,
+                    exc_info=True,
+                )
                 # If rev-list fails, assume commits exist and let PR
                 # creation handle it.
                 commit_count = -1
@@ -3137,9 +3149,10 @@ class TemporalAgentRuntimeActivities:
             if commit_count == 0:
                 logger.warning(
                     "Post-agent git push completed for run %s but branch "
-                    "'%s' has no commits over origin/main",
+                    "'%s' has no commits over %s",
                     run_id,
                     current_branch,
+                    base_ref,
                 )
                 return {
                     "push_status": "no_commits",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3112,6 +3112,40 @@ class TemporalAgentRuntimeActivities:
                     "push_error": error_detail,
                 }
 
+            # Verify the branch actually has commits over origin/main.
+            # git push succeeds as a no-op when the branch is already
+            # up-to-date, which would cause repo.create_pr to fail
+            # with HTTP 422 ("No commits between main and <branch>").
+            try:
+                count_proc = await _asyncio.create_subprocess_exec(
+                    "git", "-C", workspace,
+                    "rev-list", "--count", f"origin/main..{current_branch}",
+                    stdout=_asyncio.subprocess.PIPE,
+                    stderr=_asyncio.subprocess.PIPE,
+                )
+                count_stdout, _ = await _asyncio.wait_for(
+                    count_proc.communicate(), timeout=10,
+                )
+                commit_count = int(
+                    count_stdout.decode("utf-8", errors="replace").strip() or "0"
+                )
+            except Exception:
+                # If rev-list fails, assume commits exist and let PR
+                # creation handle it.
+                commit_count = -1
+
+            if commit_count == 0:
+                logger.warning(
+                    "Post-agent git push completed for run %s but branch "
+                    "'%s' has no commits over origin/main",
+                    run_id,
+                    current_branch,
+                )
+                return {
+                    "push_status": "no_commits",
+                    "push_branch": current_branch,
+                }
+
             logger.info(
                 "Post-agent git push completed for run %s (branch=%s)",
                 run_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -810,46 +810,46 @@ class MoonMindRunWorkflow:
                     raise ValueError(
                         "publishMode 'pr' requested but no PR URL was returned, and missing repo/branch to create it natively"
                     )
-                
-                self._get_logger().info(
-                    f"Creating PR natively from {head_branch} into {base_branch} for repo {self._repo}"
-                )
-                create_payload = {
-                    "repo": self._repo,
-                    "head": head_branch,
-                    "base": base_branch,
-                    "title": self._title or "Automated changes by MoonMind",
-                    "body": self._summary or "Automated changes by MoonMind.",
-                }
-                try:
-                    create_result = await workflow.execute_activity(
-                        "repo.create_pr",
-                        create_payload,
-                        start_to_close_timeout=timedelta(minutes=2),
-                        task_queue=INTEGRATIONS_TASK_QUEUE,
-                        retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                else:
+                    self._get_logger().info(
+                        f"Creating PR natively from {head_branch} into {base_branch} for repo {self._repo}"
                     )
-                    pr_url = self._get_from_result(create_result, "url")
-                    created = self._get_from_result(create_result, "created")
-                    summary = self._get_from_result(create_result, "summary") or ""
-                    if pr_url:
-                        pull_request_url = pr_url
-                        self._get_logger().info(f"Natively created PR: {pull_request_url}")
-                    else:
-                        if "422" in summary:
-                            self._get_logger().warning(
-                                f"Native PR creation failed with validation error (likely no commits): {summary}"
-                            )
+                    create_payload = {
+                        "repo": self._repo,
+                        "head": head_branch,
+                        "base": base_branch,
+                        "title": self._title or "Automated changes by MoonMind",
+                        "body": self._summary or "Automated changes by MoonMind.",
+                    }
+                    try:
+                        create_result = await workflow.execute_activity(
+                            "repo.create_pr",
+                            create_payload,
+                            start_to_close_timeout=timedelta(minutes=2),
+                            task_queue=INTEGRATIONS_TASK_QUEUE,
+                            retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        )
+                        pr_url = self._get_from_result(create_result, "url")
+                        created = self._get_from_result(create_result, "created")
+                        summary = self._get_from_result(create_result, "summary") or ""
+                        if pr_url:
+                            pull_request_url = pr_url
+                            self._get_logger().info(f"Natively created PR: {pull_request_url}")
                         else:
-                            raise ValueError(
-                                f"PR creation activity returned no URL"
-                                f" (created={created}): {summary}"
-                            )
-                except Exception as e:
-                    raise ValueError(
-                        f"publishMode 'pr' requested; native PR creation failed: {e}"
-                    ) from e
+                            if "422" in summary:
+                                self._get_logger().warning(
+                                    f"Native PR creation failed with validation error (likely no commits): {summary}"
+                                )
+                            else:
+                                raise ValueError(
+                                    f"PR creation activity returned no URL"
+                                    f" (created={created}): {summary}"
+                                )
+                    except Exception as e:
+                        raise ValueError(
+                            f"publishMode 'pr' requested; native PR creation failed: {e}"
+                        ) from e
         self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -799,7 +799,14 @@ class MoonMindRunWorkflow:
                     or "main"
                 )
                 
-                if not self._repo or not head_branch:
+                push_status = agent_outputs.get("push_status", "")
+                if push_status == "no_commits":
+                    self._get_logger().info(
+                        "Skipping native PR creation: agent made no commits "
+                        "on branch '%s'.",
+                        agent_outputs.get("push_branch") or head_branch,
+                    )
+                elif not self._repo or not head_branch:
                     raise ValueError(
                         "publishMode 'pr' requested but no PR URL was returned, and missing repo/branch to create it natively"
                     )

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -153,8 +153,11 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"feature/delete-spec-048\n", b""))
                 proc.returncode = 0
-            else:  # push
+            elif call_count == 2:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"2\n", b""))
                 proc.returncode = 0
             return proc
 
@@ -209,6 +212,87 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "failed"
         assert "git not found" in result["push_error"]
+
+    @pytest.mark.asyncio
+    async def test_push_no_commits(self):
+        """Push succeeds but branch has no commits over origin/main."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"0\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "no_commits"
+        assert result["push_branch"] == "auto-abc123"
+        assert "push_error" not in result
+
+    @pytest.mark.asyncio
+    async def test_push_with_commits(self):
+        """Push succeeds and branch has commits over origin/main."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"3\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "auto-abc123"
+
+    @pytest.mark.asyncio
+    async def test_push_revlist_failure_falls_through(self):
+        """When rev-list --count fails, we fall through to 'pushed' (safe default)."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count — simulate failure
+                raise OSError("git rev-list failed")
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "auto-abc123"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -270,7 +270,7 @@ class TestPushWorkspaceBranch:
 
     @pytest.mark.asyncio
     async def test_push_revlist_failure_falls_through(self):
-        """When rev-list --count fails, we fall through to 'pushed' (safe default)."""
+        """When rev-list --count raises, we fall through to 'pushed' (safe default)."""
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
         call_count = 0
@@ -293,6 +293,69 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "auto-abc123"
+
+    @pytest.mark.asyncio
+    async def test_push_revlist_nonzero_returncode_falls_through(self):
+        """Non-zero rev-list returncode falls through to 'pushed' instead of false no_commits."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count — non-zero exit with empty stdout
+                proc.communicate = AsyncMock(return_value=(b"", b"fatal: bad revision"))
+                proc.returncode = 128
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+        # Should NOT be no_commits; should fall through to pushed
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "auto-abc123"
+
+    @pytest.mark.asyncio
+    async def test_push_revlist_uses_target_branch(self):
+        """Rev-list command uses target_branch instead of hardcoded origin/main."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        captured_revlist_args = None
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count, captured_revlist_args
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                captured_revlist_args = args
+                proc.communicate = AsyncMock(return_value=(b"5\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1", target_branch="develop",
+            )
+        assert result["push_status"] == "pushed"
+        # Verify the rev-list range uses origin/develop, not origin/main
+        assert captured_revlist_args is not None
+        revlist_range = [a for a in captured_revlist_args if ".." in str(a)]
+        assert len(revlist_range) == 1
+        assert "origin/develop" in revlist_range[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Workflow `mm:5d98d502` completed its agent execution successfully but PR creation failed with GitHub HTTP 422: `"No commits between main and auto-6b4ec195"`.

## Root Cause

`git push` of an already-up-to-date branch succeeds (exit code 0) even when there are zero new commits. `_push_workspace_branch` reported `push_status: "pushed"` without verifying commits actually existed. The Run workflow then blindly called `repo.create_pr`, triggering the 422.

## Changes

### `activity_runtime.py`
After a successful push, added `git rev-list --count origin/main..{branch}` verification. Returns `push_status: "no_commits"` when the count is 0. Falls back to `"pushed"` if rev-list fails (safe default).

### `run.py`
Added guard before `repo.create_pr`: checks `agent_outputs.get("push_status")` for `"no_commits"` and skips PR creation gracefully instead of hitting the 422.

### `test_fetch_result_push.py`
- Added `test_push_no_commits`: push succeeds but rev-list returns 0 → `"no_commits"`
- Added `test_push_with_commits`: push succeeds and rev-list returns >0 → `"pushed"`
- Added `test_push_revlist_failure_falls_through`: rev-list failure → falls back to `"pushed"`
- Updated `test_push_success`: handles the new third subprocess call

## Testing

All **2006 unit tests pass** ✅