### PR TITLE
fix(agent-runtime): classify Gemini quota exhaustion as integration failure

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -34,6 +34,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
     AgentRunStatus,
     AgentRunResult,
+    ManagedRunRecord,
     ManagedRuntimeProfile,
 )
 from moonmind.workflows.skills.artifact_store import InMemoryArtifactStore
@@ -103,6 +104,21 @@ _PLACEHOLDER_DIGEST_FRAGMENT = "sha256:dummy"
 _GITHUB_REPOSITORY_SLUG_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _GITHUB_PULL_REQUEST_URL_PATTERN = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/pull/\d+"
+)
+_GEMINI_ERROR_REPORT_DIR = Path("/tmp")
+_GEMINI_ERROR_REPORT_GLOB = "gemini-client-error-*.json"
+_GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS = 45
+_GEMINI_QUOTA_MARKERS: tuple[str, ...] = (
+    "terminalquotaerror",
+    "quota_exhausted",
+    "exhausted your capacity",
+    "quota will reset after",
+)
+_GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
+    "rate limit",
+    "too many requests",
+    " 429",
+    "code: 429",
 )
 
 
@@ -3010,6 +3026,12 @@ class TemporalAgentRuntimeActivities:
             run_store=self._run_store,
         )
         result = await adapter.fetch_result(run_id)
+        record = self._run_store.load(run_id)
+        if record is not None:
+            result = self._maybe_enrich_gemini_failure_result(
+                result=result,
+                record=record,
+            )
         result_dict = result.model_dump(mode="json", by_alias=True)
         meta = dict(result_dict.get("metadata") or {})
 
@@ -3032,6 +3054,107 @@ class TemporalAgentRuntimeActivities:
             result_dict["metadata"] = meta
 
         return result_dict
+
+    @staticmethod
+    def _is_generic_process_exit_summary(summary: str | None) -> bool:
+        text = str(summary or "").strip().lower()
+        if not text:
+            return True
+        return text.startswith("process exited with code")
+
+    @classmethod
+    def _maybe_enrich_gemini_failure_result(
+        cls,
+        *,
+        result: AgentRunResult,
+        record: ManagedRunRecord,
+    ) -> AgentRunResult:
+        if record.runtime_id != "gemini_cli":
+            return result
+        if record.status != "failed":
+            return result
+        if result.failure_class not in {None, "execution_error"}:
+            return result
+        if not cls._is_generic_process_exit_summary(result.summary):
+            return result
+
+        report = cls._load_gemini_error_report(record)
+        if report is None:
+            return result
+
+        message = str(report.get("message") or "").strip()
+        stack = str(report.get("stack") or "").strip()
+        merged = "\n".join(part for part in (message, stack) if part).lower()
+        if not merged:
+            return result
+
+        if any(marker in merged for marker in _GEMINI_QUOTA_MARKERS):
+            summary = message or "Gemini API quota exhausted"
+            return result.model_copy(
+                update={
+                    "summary": summary,
+                    "failure_class": "integration_error",
+                    "provider_error_code": "quota_exhausted",
+                }
+            )
+
+        if any(marker in merged for marker in _GEMINI_RATE_LIMIT_MARKERS):
+            summary = message or "Gemini API rate limit exceeded"
+            return result.model_copy(
+                update={
+                    "summary": summary,
+                    "failure_class": "integration_error",
+                    "provider_error_code": "429",
+                }
+            )
+
+        return result
+
+    @classmethod
+    def _load_gemini_error_report(
+        cls,
+        record: ManagedRunRecord,
+    ) -> dict[str, str] | None:
+        reports_dir = _GEMINI_ERROR_REPORT_DIR
+        if not reports_dir.exists():
+            return None
+
+        started_at = record.started_at.timestamp() - _GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS
+        finished_dt = record.finished_at or record.started_at
+        finished_at = finished_dt.timestamp() + _GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS
+
+        candidates: list[tuple[float, Path]] = []
+        for path in reports_dir.glob(_GEMINI_ERROR_REPORT_GLOB):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            modified_at = stat.st_mtime
+            if modified_at < started_at or modified_at > finished_at:
+                continue
+            distance = abs(modified_at - finished_dt.timestamp())
+            candidates.append((distance, path))
+
+        if not candidates:
+            return None
+
+        for _, path in sorted(candidates, key=lambda item: item[0]):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            error_obj = payload.get("error")
+            if not isinstance(error_obj, dict):
+                continue
+            message = str(error_obj.get("message") or "").strip()
+            stack = str(error_obj.get("stack") or "").strip()
+            if not message and not stack:
+                continue
+            return {"message": message, "stack": stack}
+
+        return None
 
     async def _push_workspace_branch(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3088,26 +3088,22 @@ class TemporalAgentRuntimeActivities:
         if not merged:
             return result
 
+        update_payload: dict[str, Any] | None = None
         if any(marker in merged for marker in _GEMINI_QUOTA_MARKERS):
-            summary = message or "Gemini API quota exhausted"
-            return result.model_copy(
-                update={
-                    "summary": summary,
-                    "failure_class": "integration_error",
-                    "provider_error_code": "quota_exhausted",
-                }
-            )
+            update_payload = {
+                "summary": message or "Gemini API quota exhausted",
+                "failure_class": "integration_error",
+                "provider_error_code": "quota_exhausted",
+            }
+        elif any(marker in merged for marker in _GEMINI_RATE_LIMIT_MARKERS):
+            update_payload = {
+                "summary": message or "Gemini API rate limit exceeded",
+                "failure_class": "integration_error",
+                "provider_error_code": "429",
+            }
 
-        if any(marker in merged for marker in _GEMINI_RATE_LIMIT_MARKERS):
-            summary = message or "Gemini API rate limit exceeded"
-            return result.model_copy(
-                update={
-                    "summary": summary,
-                    "failure_class": "integration_error",
-                    "provider_error_code": "429",
-                }
-            )
-
+        if update_payload is not None:
+            return result.model_copy(update=update_payload)
         return result
 
     @classmethod
@@ -3116,15 +3112,20 @@ class TemporalAgentRuntimeActivities:
         record: ManagedRunRecord,
     ) -> dict[str, str] | None:
         reports_dir = _GEMINI_ERROR_REPORT_DIR
-        if not reports_dir.exists():
+        if not reports_dir.exists() or not reports_dir.is_dir():
             return None
 
         started_at = record.started_at.timestamp() - _GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS
         finished_dt = record.finished_at or record.started_at
         finished_at = finished_dt.timestamp() + _GEMINI_ERROR_REPORT_TIME_PADDING_SECONDS
 
-        candidates: list[tuple[float, Path]] = []
-        for path in reports_dir.glob(_GEMINI_ERROR_REPORT_GLOB):
+        candidates: list[tuple[int, float, Path]] = []
+        try:
+            report_paths = list(reports_dir.glob(_GEMINI_ERROR_REPORT_GLOB))
+        except OSError:
+            return None
+
+        for path in report_paths:
             try:
                 stat = path.stat()
             except OSError:
@@ -3133,12 +3134,14 @@ class TemporalAgentRuntimeActivities:
             if modified_at < started_at or modified_at > finished_at:
                 continue
             distance = abs(modified_at - finished_dt.timestamp())
-            candidates.append((distance, path))
+            # Prefer reports that clearly reference this run/workspace.
+            discriminator = 0 if cls._report_matches_record(path, record) else 1
+            candidates.append((discriminator, distance, path))
 
         if not candidates:
             return None
 
-        for _, path in sorted(candidates, key=lambda item: item[0]):
+        for _, _, path in sorted(candidates, key=lambda item: (item[0], item[1])):
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
@@ -3155,6 +3158,29 @@ class TemporalAgentRuntimeActivities:
             return {"message": message, "stack": stack}
 
         return None
+
+    @staticmethod
+    def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:
+        """Best-effort run discriminator for Gemini error reports."""
+        try:
+            payload_text = path.read_text(encoding="utf-8")
+        except OSError:
+            return False
+
+        run_id = str(record.run_id or "").strip()
+        if run_id and run_id in payload_text:
+            return True
+
+        workspace_path = str(record.workspace_path or "").strip()
+        if workspace_path and workspace_path in payload_text:
+            return True
+
+        if run_id:
+            run_workspace_marker = f"/work/agent_jobs/workspaces/{run_id}/repo"
+            if run_workspace_marker in payload_text:
+                return True
+
+        return False
 
     async def _push_workspace_branch(
         self,

--- a/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
@@ -25,6 +25,7 @@ def _save_failed_record(
     started_at: datetime,
     finished_at: datetime,
     error_message: str,
+    workspace_path: str = "/tmp/workspace",
 ) -> None:
     store.save(
         ManagedRunRecord(
@@ -36,7 +37,7 @@ def _save_failed_record(
             exitCode=1,
             startedAt=started_at,
             finishedAt=finished_at,
-            workspacePath="/tmp/workspace",
+            workspacePath=workspace_path,
             errorMessage=error_message,
             failureClass="execution_error",
         )
@@ -130,3 +131,114 @@ async def test_fetch_result_keeps_non_generic_failure_summary(
     assert result["failureClass"] == "execution_error"
     assert result["summary"] == "pr-resolver reported blocked state"
     assert result["providerErrorCode"] is None
+
+
+async def test_fetch_result_maps_gemini_rate_limit_to_429(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(activity_runtime_module, "_GEMINI_ERROR_REPORT_DIR", report_dir)
+
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    started_at = now - timedelta(minutes=3)
+    finished_at = now - timedelta(minutes=2)
+    _save_failed_record(
+        run_store,
+        run_id="gemini-run-429",
+        runtime_id="gemini_cli",
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message="Process exited with code 1",
+    )
+
+    report_path = report_dir / "gemini-client-error-rate-limit.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "error": {
+                    "message": "Error 429: Too many requests, rate limit exceeded",
+                    "stack": "SomeStack: 429",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(report_path, (finished_at.timestamp(), finished_at.timestamp()))
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result({"run_id": "gemini-run-429"})
+
+    assert result["failureClass"] == "integration_error"
+    assert result["providerErrorCode"] == "429"
+    assert "rate limit" in result["summary"].lower()
+
+
+async def test_fetch_result_prefers_report_with_matching_run_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(activity_runtime_module, "_GEMINI_ERROR_REPORT_DIR", report_dir)
+
+    run_id = "gemini-run-match"
+    workspace_path = f"/work/agent_jobs/workspaces/{run_id}/repo"
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    started_at = now - timedelta(minutes=3)
+    finished_at = now - timedelta(minutes=2)
+    _save_failed_record(
+        run_store,
+        run_id=run_id,
+        runtime_id="gemini_cli",
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message="Process exited with code 1",
+        workspace_path=workspace_path,
+    )
+
+    # Closer by mtime but unrelated to the run (generic 429).
+    generic_report = report_dir / "gemini-client-error-generic.json"
+    generic_report.write_text(
+        json.dumps(
+            {
+                "error": {
+                    "message": "Error 429: Too many requests",
+                    "stack": "generic stack",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(
+        generic_report,
+        ((finished_at + timedelta(seconds=2)).timestamp(), (finished_at + timedelta(seconds=2)).timestamp()),
+    )
+
+    # Slightly farther by mtime but includes workspace marker for this run.
+    matching_report = report_dir / "gemini-client-error-matching.json"
+    matching_report.write_text(
+        json.dumps(
+            {
+                "error": {
+                    "message": "You have exhausted your capacity on this model.",
+                    "stack": "TerminalQuotaError: quota exhausted",
+                },
+                "context": [{"workspace": workspace_path}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(
+        matching_report,
+        ((finished_at + timedelta(seconds=6)).timestamp(), (finished_at + timedelta(seconds=6)).timestamp()),
+    )
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result({"run_id": run_id})
+
+    assert result["failureClass"] == "integration_error"
+    assert result["providerErrorCode"] == "quota_exhausted"

--- a/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
@@ -1,0 +1,132 @@
+"""Unit tests for managed `agent_runtime.fetch_result` enrichment paths."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _save_failed_record(
+    store: ManagedRunStore,
+    *,
+    run_id: str,
+    runtime_id: str,
+    started_at: datetime,
+    finished_at: datetime,
+    error_message: str,
+) -> None:
+    store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId=runtime_id,
+            runtimeId=runtime_id,
+            status="failed",
+            pid=1234,
+            exitCode=1,
+            startedAt=started_at,
+            finishedAt=finished_at,
+            workspacePath="/tmp/workspace",
+            errorMessage=error_message,
+            failureClass="execution_error",
+        )
+    )
+
+
+async def test_fetch_result_maps_gemini_quota_report_to_integration_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(activity_runtime_module, "_GEMINI_ERROR_REPORT_DIR", report_dir)
+
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    started_at = now - timedelta(minutes=3)
+    finished_at = now - timedelta(minutes=2)
+    _save_failed_record(
+        run_store,
+        run_id="gemini-run-1",
+        runtime_id="gemini_cli",
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message="Process exited with code 1",
+    )
+
+    report_path = report_dir / "gemini-client-error-Turn.run-sendMessageStream-test.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "error": {
+                    "message": (
+                        "You have exhausted your capacity on this model. "
+                        "Your quota will reset after 4h50m26s."
+                    ),
+                    "stack": "TerminalQuotaError: quota exhausted",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(report_path, (finished_at.timestamp(), finished_at.timestamp()))
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result({"run_id": "gemini-run-1"})
+
+    assert result["failureClass"] == "integration_error"
+    assert result["providerErrorCode"] == "quota_exhausted"
+    assert "exhausted your capacity" in result["summary"].lower()
+
+
+async def test_fetch_result_keeps_non_generic_failure_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(activity_runtime_module, "_GEMINI_ERROR_REPORT_DIR", report_dir)
+
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    started_at = now - timedelta(minutes=3)
+    finished_at = now - timedelta(minutes=2)
+    _save_failed_record(
+        run_store,
+        run_id="gemini-run-2",
+        runtime_id="gemini_cli",
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message="pr-resolver reported blocked state",
+    )
+
+    report_path = report_dir / "gemini-client-error-Turn.run-sendMessageStream-test2.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "error": {
+                    "message": "You have exhausted your capacity on this model.",
+                    "stack": "TerminalQuotaError: quota exhausted",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    os.utime(report_path, (finished_at.timestamp(), finished_at.timestamp()))
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result({"run_id": "gemini-run-2"})
+
+    assert result["failureClass"] == "execution_error"
+    assert result["summary"] == "pr-resolver reported blocked state"
+    assert result["providerErrorCode"] is None


### PR DESCRIPTION
## Summary
- detect Gemini CLI error-report artifacts for the managed run window in `agent_runtime.fetch_result`
- map quota/rate-limit failures to `integration_error` with provider codes (`quota_exhausted` / `429`) instead of generic `execution_error`
- preserve existing non-generic failure summaries (do not overwrite task-specific errors)
- add unit coverage for enrichment and non-overwrite behavior

## Why
Managed Gemini runs were failing with TerminalQuotaError (capacity exhausted) but surfaced only as generic `execution_error`, causing retries that could not succeed until quota reset.

## Testing
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py`
- result: `2 passed`
