### PR TITLE
fix(gemini_cli): remove unsupported --effort flag from CLI invocation

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -48,10 +48,6 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
         if model:
             cmd.extend(["--model", model])
 
-        effort = self.get_effort(profile, request)
-        if effort:
-            cmd.extend(["--effort", effort])
-
         if request.instruction_ref:
             cmd.extend(["--yolo", "--prompt", request.instruction_ref])
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -123,7 +123,8 @@ def test_build_command_gemini_cli():
     assert "--model" in cmd
     assert "--yolo" in cmd
     assert "--prompt" in cmd
-    assert "--effort" in cmd
+    # Gemini CLI does not support --effort
+    assert "--effort" not in cmd
     assert "Fix the bug" in cmd
 
 

--- a/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
@@ -123,15 +123,13 @@ class TestGeminiCliBuildCommand:
         profile = _make_profile(default_effort="high")
         request = _make_request(instruction_ref="Think hard")
         cmd = s.build_command(profile, request)
-        # effort should be silently ignored since Gemini CLI doesn't support it
-        assert "--effort" not in cmd
         assert cmd == [
             "gemini",
             "--yolo", "--prompt", "Think hard",
         ]
 
-    def test_with_model_and_effort(self) -> None:
-        """Gemini CLI supports --model but not --effort."""
+    def test_with_model_and_ignored_effort(self) -> None:
+        """Gemini CLI applies --model but ignores --effort."""
         s = GeminiCliStrategy()
         profile = _make_profile(
             default_model="gemini-2.5-pro",
@@ -139,12 +137,25 @@ class TestGeminiCliBuildCommand:
         )
         request = _make_request(instruction_ref="Go")
         cmd = s.build_command(profile, request)
-        assert "--model" in cmd
-        assert "--effort" not in cmd
         assert cmd == [
             "gemini",
             "--model", "gemini-2.5-pro",
             "--yolo", "--prompt", "Go",
+        ]
+
+    def test_effort_param_is_ignored(self) -> None:
+        """Effort from request.parameters should also be ignored."""
+        s = GeminiCliStrategy()
+        profile = _make_profile()
+        request = _make_request(
+            instruction_ref="Think hard",
+            parameters={"effort": "high"},
+        )
+        cmd = s.build_command(profile, request)
+        assert "--effort" not in cmd
+        assert cmd == [
+            "gemini",
+            "--yolo", "--prompt", "Think hard",
         ]
 
     def test_no_instruction_ref(self) -> None:

--- a/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_gemini_cli.py
@@ -117,18 +117,21 @@ class TestGeminiCliBuildCommand:
             "--yolo", "--prompt", "Help",
         ]
 
-    def test_with_effort(self) -> None:
+    def test_effort_is_ignored(self) -> None:
+        """Gemini CLI does not support --effort; it should not be added."""
         s = GeminiCliStrategy()
         profile = _make_profile(default_effort="high")
         request = _make_request(instruction_ref="Think hard")
         cmd = s.build_command(profile, request)
+        # effort should be silently ignored since Gemini CLI doesn't support it
+        assert "--effort" not in cmd
         assert cmd == [
             "gemini",
-            "--effort", "high",
             "--yolo", "--prompt", "Think hard",
         ]
 
     def test_with_model_and_effort(self) -> None:
+        """Gemini CLI supports --model but not --effort."""
         s = GeminiCliStrategy()
         profile = _make_profile(
             default_model="gemini-2.5-pro",
@@ -136,10 +139,11 @@ class TestGeminiCliBuildCommand:
         )
         request = _make_request(instruction_ref="Go")
         cmd = s.build_command(profile, request)
+        assert "--model" in cmd
+        assert "--effort" not in cmd
         assert cmd == [
             "gemini",
             "--model", "gemini-2.5-pro",
-            "--effort", "medium",
             "--yolo", "--prompt", "Go",
         ]
 


### PR DESCRIPTION
## Summary

- Remove `--effort` flag from `GeminiCliStrategy.build_command()` since Gemini CLI does not support this argument
- All agent runs were failing with "Unknown argument: effort" and exit code 1 because the strategy was passing an unsupported flag to the CLI

## Test plan

- [x] Unit tests updated to verify `--effort` is not added to Gemini CLI commands
- [x] All 2003 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)