### PR TITLE
feat(ui): auth profile selector on task create

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -289,6 +289,21 @@
 
   const listSubmitRuntimes = () => Array.from(new Set([...supportedTaskRuntimes]));
 
+  /** Maps task submit runtime (dashboard) to managed_agent_auth_profiles.runtime_id. */
+  const mapTaskRuntimeToAuthProfileRuntimeId = (mode) => {
+    const m = String(mode || "").trim().toLowerCase();
+    if (m === "gemini_cli") {
+      return "gemini_cli";
+    }
+    if (m === "claude") {
+      return "claude_code";
+    }
+    if (m === "codex") {
+      return "codex_cli";
+    }
+    return "";
+  };
+
   const TASK_RUNTIME_LABELS = {
     codex: "Codex CLI",
     gemini: "Gemini CLI",
@@ -1657,6 +1672,12 @@
       ? publishNode.mode
       : payload.publishMode || extractPublishModeFromPayload(payload);
 
+    const authProfileId = (() => {
+      const ref =
+        runtimeNode.executionProfileRef ?? runtimeNode.execution_profile_ref;
+      return typeof ref === "string" ? ref.trim() : "";
+    })();
+
     return {
       editJobId: String(pick(job, "id") || "").trim(),
       expectedUpdatedAt: String(pick(job, "updatedAt") || "").trim(),
@@ -1689,6 +1710,7 @@
       steps,
       appliedTemplateState,
       templateFeatureRequest: "",
+      authProfileId,
     };
   }
 
@@ -4850,6 +4872,7 @@
       ? sanitizedWorkerDraft.steps
       : [];
     const queueDraftAffinityKey = String(sanitizedWorkerDraft.affinityKey || "").trim();
+    const queueDraftAuthProfile = String(sanitizedWorkerDraft.authProfileId || "").trim();
     const attachmentAcceptedTypes = attachmentPolicy.allowedContentTypes.join(",");
     const attachmentSectionHtml =
       attachmentPolicy.enabled && !isEditMode
@@ -4927,6 +4950,14 @@
             ${runtimeOptions}
           </select>
         </label>
+        <div id="queue-auth-profile-wrap" class="hidden">
+          <label>Auth profile
+            <select name="authProfile">
+              <option value="">Default (system chooses)</option>
+            </select>
+          </label>
+          <p class="small" id="queue-auth-profile-hint"></p>
+        </div>
         <datalist id="queue-model-options">
         </datalist>
         <datalist id="queue-effort-options">
@@ -5182,6 +5213,7 @@
           .toLowerCase(),
         model: String(formData.get("model") || "").trim(),
         effort: String(formData.get("effort") || "").trim(),
+        authProfileId: String(formData.get("authProfile") || "").trim(),
         priority: Number.isFinite(priority) ? priority : 0,
         maxAttempts: Number.isFinite(maxAttempts) ? maxAttempts : 3,
         proposeTasks: formData.get("proposeTasks") !== null,
@@ -5205,6 +5237,77 @@
     const effortInputElement = form.querySelector('input[name="effort"]');
     const modelDatalistNode = form.querySelector("#queue-model-options");
     const effortDatalistNode = form.querySelector("#queue-effort-options");
+    const authProfileWrap = form.querySelector("#queue-auth-profile-wrap");
+    const authProfileHint = form.querySelector("#queue-auth-profile-hint");
+    const authProfileSelect = form.querySelector('select[name="authProfile"]');
+    let applyQueueDraftAuthProfileOnce = true;
+
+    const refreshAuthProfileOptions = async (runtimeMode) => {
+      if (!authProfileWrap || !authProfileSelect) {
+        return;
+      }
+      if (!authProfileEndpoints) {
+        authProfileWrap.classList.add("hidden");
+        return;
+      }
+      const mappedRuntimeId = mapTaskRuntimeToAuthProfileRuntimeId(runtimeMode);
+      if (!mappedRuntimeId) {
+        authProfileWrap.classList.add("hidden");
+        authProfileSelect.innerHTML =
+          '<option value="">Default (system chooses)</option>';
+        if (authProfileHint) {
+          authProfileHint.textContent = "";
+        }
+        return;
+      }
+      const previousSelection = String(authProfileSelect.value || "").trim();
+      authProfileWrap.classList.remove("hidden");
+      if (authProfileHint) {
+        authProfileHint.textContent =
+          "Optional. Choose stored credentials for this runtime, or leave default for automatic selection.";
+      }
+      try {
+        const url = `${authProfileEndpoints.list}?runtime_id=${encodeURIComponent(
+          mappedRuntimeId,
+        )}&enabled_only=true`;
+        const profiles = await fetchJson(url);
+        const list = Array.isArray(profiles) ? profiles : [];
+        const options = ['<option value="">Default (system chooses)</option>'];
+        list.forEach((profile) => {
+          const pid = String(profile.profile_id || "").trim();
+          if (!pid) {
+            return;
+          }
+          const label = String(profile.account_label || "").trim() || pid;
+          options.push(
+            `<option value="${escapeHtml(pid)}">${escapeHtml(label)}</option>`,
+          );
+        });
+        authProfileSelect.innerHTML = options.join("");
+        const desired = String(previousSelection || "").trim();
+        let pickId = desired;
+        if (!pickId && applyQueueDraftAuthProfileOnce) {
+          pickId = String(queueDraftAuthProfile || "").trim();
+        }
+        applyQueueDraftAuthProfileOnce = false;
+        if (
+          pickId &&
+          list.some((p) => String(p.profile_id || "").trim() === pickId)
+        ) {
+          authProfileSelect.value = pickId;
+        }
+      } catch (_error) {
+        console.warn("submit form: could not load auth profiles", _error);
+        authProfileWrap.classList.add("hidden");
+        authProfileSelect.innerHTML =
+          '<option value="">Default (system chooses)</option>';
+        if (authProfileHint) {
+          authProfileHint.textContent =
+            "Could not load auth profiles. The run will use default profile selection.";
+        }
+      }
+    };
+
     const stepsList = document.getElementById("queue-steps-list");
     const runtimeModelDefaults = {
       ...configuredModelDefaults,
@@ -5331,9 +5434,11 @@
         activeWorkerRuntime = nextRuntime;
         applyQueueSubmitRuntimeUiState(activeWorkerRuntime);
         loadRuntimeCapabilities(nextRuntime);
+        void refreshAuthProfileOptions(nextRuntime);
         refreshSkillDatalist();
         scheduleWorkerDraftPersist();
       });
+      void refreshAuthProfileOptions(runtimeSelect.value);
     }
     form.addEventListener("input", scheduleWorkerDraftPersist);
     form.addEventListener("change", scheduleWorkerDraftPersist);
@@ -6284,6 +6389,7 @@
       }
       const model = String(formData.get("model") || "").trim() || null;
       const effort = String(formData.get("effort") || "").trim() || null;
+      const authProfileRef = String(formData.get("authProfile") || "").trim();
       const startingBranch = String(formData.get("startingBranch") || "").trim() || null;
       const newBranch = String(formData.get("newBranch") || "").trim() || null;
       const affinityKey = queueDraftAffinityKey || null;
@@ -6463,7 +6569,12 @@
           },
           ...(Object.keys(skillArgs).length > 0 ? { inputs: skillArgs } : {}),
           proposeTasks,
-          runtime: { mode: runtimeMode, model, effort },
+          runtime: {
+            mode: runtimeMode,
+            model,
+            effort,
+            ...(authProfileRef ? { executionProfileRef: authProfileRef } : {}),
+          },
           git: { startingBranch, newBranch },
           publish: {
             mode: publishMode,

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -291,17 +291,13 @@
 
   /** Maps task submit runtime (dashboard) to managed_agent_auth_profiles.runtime_id. */
   const mapTaskRuntimeToAuthProfileRuntimeId = (mode) => {
+    const runtimeMap = {
+      gemini_cli: "gemini_cli",
+      claude: "claude_code",
+      codex: "codex_cli",
+    };
     const m = String(mode || "").trim().toLowerCase();
-    if (m === "gemini_cli") {
-      return "gemini_cli";
-    }
-    if (m === "claude") {
-      return "claude_code";
-    }
-    if (m === "codex") {
-      return "codex_cli";
-    }
-    return "";
+    return runtimeMap[m] || "";
   };
 
   const TASK_RUNTIME_LABELS = {
@@ -5267,10 +5263,15 @@
           "Optional. Choose stored credentials for this runtime, or leave default for automatic selection.";
       }
       try {
+        authProfileFetchToken += 1;
+        const currentToken = authProfileFetchToken;
         const url = `${authProfileEndpoints.list}?runtime_id=${encodeURIComponent(
           mappedRuntimeId,
         )}&enabled_only=true`;
         const profiles = await fetchJson(url);
+        if (currentToken !== authProfileFetchToken) {
+          return;
+        }
         const list = Array.isArray(profiles) ? profiles : [];
         const options = ['<option value="">Default (system chooses)</option>'];
         list.forEach((profile) => {

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,37 +1,32 @@
 [
   {
-    "id": 4140314860,
+    "id": 4140357289,
     "disposition": "not-applicable",
-    "rationale": "Codex usage limit notification from bot, not actionable feedback."
+    "rationale": "Informational codex limits message."
   },
   {
-    "id": 2999078770,
-    "disposition": "not-applicable",
-    "rationale": "CodeQL false positive: the logged values are profile_id strings (e.g. 'claude_anthropic'), not credentials."
-  },
-  {
-    "id": 4018984796,
-    "disposition": "not-applicable",
-    "rationale": "Gemini review summary with 'no feedback to provide'."
-  },
-  {
-    "id": 2999086104,
+    "id": 2999114981,
     "disposition": "addressed",
-    "rationale": "Changed docstring from 'Upsert' to 'Seed' to match insert-only behavior."
+    "rationale": "Refactored mapTaskRuntimeToAuthProfileRuntimeId to use an object."
   },
   {
-    "id": 2999086110,
-    "disposition": "addressed",
-    "rationale": "Added non-blank value check for ANTHROPIC_MODEL env override to prevent launching Claude without model selection."
-  },
-  {
-    "id": 2999086122,
-    "disposition": "addressed",
-    "rationale": "Already fixed in previous commit: migration now uses convert_from/convert_to instead of ::text/::bytea casts."
-  },
-  {
-    "id": 4018990233,
+    "id": 4019019138,
     "disposition": "not-applicable",
-    "rationale": "Copilot PR overview/summary comment, not actionable feedback."
+    "rationale": "Informational code review summary."
+  },
+  {
+    "id": 2999128540,
+    "disposition": "addressed",
+    "rationale": "Added parameter_payload fallback for executionProfileRef."
+  },
+  {
+    "id": 2999128570,
+    "disposition": "addressed",
+    "rationale": "Added a request token to prevent race conditions during auth profile fetching."
+  },
+  {
+    "id": 4019033863,
+    "disposition": "not-applicable",
+    "rationale": "Informational PR overview message."
   }
 ]

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -204,6 +204,12 @@ def _build_runtime_planner():
         if isinstance(effort, str) and effort.strip():
             runtime_node["effort"] = effort.strip()
 
+        exec_profile_ref = runtime_payload.get("executionProfileRef") or runtime_payload.get(
+            "execution_profile_ref"
+        )
+        if isinstance(exec_profile_ref, str) and exec_profile_ref.strip():
+            runtime_node["executionProfileRef"] = exec_profile_ref.strip()
+
         # --- Build node inputs ---
         node_inputs: dict[str, Any] = {
             "instructions": instructions,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -204,8 +204,11 @@ def _build_runtime_planner():
         if isinstance(effort, str) and effort.strip():
             runtime_node["effort"] = effort.strip()
 
-        exec_profile_ref = runtime_payload.get("executionProfileRef") or runtime_payload.get(
-            "execution_profile_ref"
+        exec_profile_ref = (
+            runtime_payload.get("executionProfileRef")
+            or runtime_payload.get("execution_profile_ref")
+            or parameter_payload.get("executionProfileRef")
+            or parameter_payload.get("execution_profile_ref")
         )
         if isinstance(exec_profile_ref, str) and exec_profile_ref.strip():
             runtime_node["executionProfileRef"] = exec_profile_ref.strip()

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -20,6 +20,59 @@ from moonmind.workflows.temporal.workflows.agent_run import (
 from moonmind.workflows.temporal.workers import WORKFLOW_FLEET
 
 
+def test_runtime_planner_preserves_execution_profile_ref():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Use the minimax profile for this Claude run.",
+                "runtime": {
+                    "mode": "claude",
+                    "executionProfileRef": "claude-minimax-oauth",
+                },
+            }
+        },
+        parameters={"targetRuntime": "claude"},
+        snapshot=snapshot,
+    )
+
+    runtime_node = plan["nodes"][0]["inputs"]["runtime"]
+    assert runtime_node["mode"] == "claude"
+    assert runtime_node["executionProfileRef"] == "claude-minimax-oauth"
+
+
+def test_runtime_planner_preserves_execution_profile_ref_snake_case():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Anthropic API key profile.",
+                "runtime": {
+                    "mode": "claude",
+                    "execution_profile_ref": "anthropic-work",
+                },
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert (
+        plan["nodes"][0]["inputs"]["runtime"]["executionProfileRef"]
+        == "anthropic-work"
+    )
+
+
 def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary
Adds an **Auth profile** control to the Mission Control task create form (\/tasks/new\), next to **Runtime**, so operators can pick which stored managed-agent profile to use (e.g. different Claude Code credential sets) while keeping runtime as Claude Code, Codex, or Gemini CLI.

## Changes
- **Dashboard:** Loads enabled profiles from \GET /api/v1/auth-profiles?runtime_id=…&enabled_only=true\ using the same runtime mapping as \MoonMind.AgentRun\ (\claude\ → \claude_code\, etc.). Selected value is sent as \	ask.runtime.executionProfileRef\. Draft/prefill preserves \uthProfileId\.
- **Planner:** \_build_runtime_planner\ now forwards \xecutionProfileRef\ / \xecution_profile_ref\ from \	ask.runtime\ into plan node inputs (previously dropped).
- **Tests:** Planner regression tests for profile ref preservation.

## Notes
- Hidden for runtimes without managed auth profiles (e.g. Jules).
- Requires \system.authProfiles\ in dashboard config (already present in view model).

Made with [Cursor](https://cursor.com)