### PR TITLE
Align Jules runtime with bundled execution semantics

### DIFF
--- a/moonmind/workflows/adapters/jules_agent_adapter.py
+++ b/moonmind/workflows/adapters/jules_agent_adapter.py
@@ -152,6 +152,13 @@ class JulesAgentAdapter(BaseExternalAgentAdapter):
             metadata = dict(handle.metadata)
             metadata["pullRequestUrl"] = response.pull_request_url
             handle = handle.model_copy(update={"metadata": metadata})
+        if automation_mode or request.parameters.get("publishMode"):
+            handle_metadata = dict(handle.metadata)
+            if automation_mode:
+                handle_metadata["automationMode"] = automation_mode
+            if request.parameters.get("publishMode"):
+                handle_metadata["publishMode"] = request.parameters["publishMode"]
+            handle = handle.model_copy(update={"metadata": handle_metadata})
         return handle
 
     async def send_message(self, *, run_id: str, prompt: str) -> AgentRunStatus:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1951,6 +1951,19 @@ class TemporalIntegrationActivities:
         from moonmind.workflows.adapters.github_service import GitHubService
 
         svc = GitHubService()
+        target_branch = payload.get("target_branch") or payload.get("targetBranch")
+        if target_branch:
+            success, summary = await svc.update_pull_request_base(
+                pr_url=payload.get("pr_url") or payload.get("prUrl") or "",
+                new_base=target_branch,
+            )
+            if not success:
+                return {
+                    "prUrl": payload.get("pr_url") or payload.get("prUrl") or "",
+                    "merged": False,
+                    "mergeSha": None,
+                    "summary": f"Base branch update failed: {summary}",
+                }
         result = await svc.merge_pull_request(
             pr_url=payload.get("pr_url") or payload.get("prUrl") or "",
             merge_method=payload.get("merge_method") or payload.get("mergeMethod") or "merge",

--- a/moonmind/workflows/temporal/jules_bundle.py
+++ b/moonmind/workflows/temporal/jules_bundle.py
@@ -1,0 +1,205 @@
+"""Helpers for one-shot Jules bundle compilation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+JULES_AGENT_IDS = frozenset({"jules", "jules_api"})
+
+
+@dataclass(frozen=True)
+class JulesBundleSpec:
+    bundle_id: str
+    bundled_node_ids: tuple[str, ...]
+    representative_node: dict[str, Any]
+    compiled_brief: str
+    manifest: dict[str, Any]
+
+
+def _runtime_agent_id(node: dict[str, Any]) -> str:
+    tool = node.get("tool") or {}
+    inputs = node.get("inputs") or {}
+    runtime = inputs.get("runtime") or {}
+    return str(
+        runtime.get("mode")
+        or runtime.get("agent_id")
+        or inputs.get("targetRuntime")
+        or tool.get("name")
+        or ""
+    ).strip().lower()
+
+
+def is_jules_agent_runtime_node(node: dict[str, Any]) -> bool:
+    tool = node.get("tool") or {}
+    if str(tool.get("type") or "").strip().lower() != "agent_runtime":
+        return False
+    return _runtime_agent_id(node) in JULES_AGENT_IDS
+
+
+def eligible_for_bundle(
+    first_node: dict[str, Any],
+    next_node: dict[str, Any],
+) -> bool:
+    if not (is_jules_agent_runtime_node(first_node) and is_jules_agent_runtime_node(next_node)):
+        return False
+
+    first_inputs = first_node.get("inputs") or {}
+    next_inputs = next_node.get("inputs") or {}
+
+    keys = ("repository", "repo", "startingBranch", "targetBranch", "branch", "publishMode")
+    for key in keys:
+        if (first_inputs.get(key) or "") != (next_inputs.get(key) or ""):
+            return False
+    return True
+
+
+def group_consecutive_jules_nodes(
+    ordered_nodes: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    groups: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+
+    for node in ordered_nodes:
+        if not is_jules_agent_runtime_node(node):
+            if current:
+                groups.append(current)
+                current = []
+            continue
+        if not current:
+            current = [node]
+            continue
+        if eligible_for_bundle(current[-1], node):
+            current.append(node)
+            continue
+        groups.append(current)
+        current = [node]
+
+    if current:
+        groups.append(current)
+    return groups
+
+
+def build_bundle_spec(
+    nodes: list[dict[str, Any]],
+    *,
+    workflow_id: str,
+    workflow_run_id: str,
+) -> JulesBundleSpec:
+    if len(nodes) < 2:
+        raise ValueError("Jules bundle spec requires at least two nodes")
+
+    first = nodes[0]
+    first_inputs = dict(first.get("inputs") or {})
+    bundled_node_ids = tuple(str(node.get("id") or "").strip() or f"node-{idx + 1}" for idx, node in enumerate(nodes))
+    bundle_id = f"{workflow_id}:jules-bundle:{bundled_node_ids[0]}:{bundled_node_ids[-1]}"
+
+    repo = str(first_inputs.get("repository") or first_inputs.get("repo") or "").strip() or "(unknown)"
+    starting_branch = str(first_inputs.get("startingBranch") or first_inputs.get("branch") or "main").strip() or "main"
+    target_branch = str(first_inputs.get("targetBranch") or "").strip() or None
+    publish_mode = str(first_inputs.get("publishMode") or "none").strip() or "none"
+
+    checklist_entries: list[str] = []
+    manifest_items: list[dict[str, str]] = []
+    for idx, node in enumerate(nodes, start=1):
+        inputs = node.get("inputs") or {}
+        raw_instruction = str(inputs.get("instructions") or "").strip()
+        instruction = raw_instruction or f"Complete logical work item {node.get('id') or idx}."
+        checklist_entries.append(f"{idx}. {instruction}")
+        manifest_items.append(
+            {
+                "nodeId": bundled_node_ids[idx - 1],
+                "instruction": instruction,
+            }
+        )
+
+    compiled_brief = "\n".join(
+        [
+            "You are implementing a multi-part repository task as one cohesive change.",
+            "",
+            "Mission:",
+            f"Complete the bundled Jules work represented by logical nodes: {', '.join(bundled_node_ids)}.",
+            "",
+            "Repository Context:",
+            f"- Repository: {repo}",
+            f"- Starting branch: {starting_branch}",
+            f"- Target branch: {target_branch or starting_branch}",
+            f"- Publish mode: {publish_mode}",
+            "- Runtime: Jules via MoonMind",
+            "",
+            "Execution Rules:",
+            "- Complete the work as one cohesive implementation.",
+            "- Follow the ordered checklist below sequentially.",
+            "- Make the minimum necessary changes.",
+            "- Avoid unrelated refactors.",
+            "- If blocked or unsafe, stop and explain the blocker rather than guessing.",
+            "- Track which checklist items were completed in the final summary.",
+            "",
+            "Ordered Checklist:",
+            *checklist_entries,
+            "",
+            "Validation Checklist:",
+            "- Run relevant validation for the changed files when possible.",
+            "- If validation cannot run, say so and explain why.",
+            "",
+            "Final Response Requirements:",
+            "- Summarize the changes made.",
+            "- State which checklist items were completed.",
+            "- Note incomplete items, blockers, assumptions, or follow-up recommendations.",
+            "- Include validation results.",
+        ]
+    )
+
+    manifest = {
+        "bundleId": bundle_id,
+        "bundleStrategy": "one_shot_jules",
+        "bundledNodeIds": list(bundled_node_ids),
+        "repository": repo,
+        "startingBranch": starting_branch,
+        "targetBranch": target_branch,
+        "publishMode": publish_mode,
+        "executionRules": [
+            "complete_as_one_cohesive_change",
+            "ordered_checklist_execution",
+            "avoid_unrelated_refactors",
+            "report_blockers_instead_of_guessing",
+        ],
+        "orderedChecklist": manifest_items,
+        "validationChecklist": [
+            "run_relevant_validation_when_possible",
+            "report_unrun_validation_with_reason",
+        ],
+        "correlationId": workflow_id,
+        "idempotencyKey": f"{workflow_id}:{bundle_id}:{workflow_run_id}",
+    }
+
+    synthetic_inputs = dict(first_inputs)
+    synthetic_inputs["instructions"] = compiled_brief
+    synthetic_inputs["bundleId"] = bundle_id
+    synthetic_inputs["bundledNodeIds"] = list(bundled_node_ids)
+    synthetic_inputs["bundleStrategy"] = "one_shot_jules"
+
+    representative_node = {
+        "id": bundle_id,
+        "tool": dict(first.get("tool") or {}),
+        "inputs": synthetic_inputs,
+        "options": dict(first.get("options") or {}),
+    }
+
+    return JulesBundleSpec(
+        bundle_id=bundle_id,
+        bundled_node_ids=bundled_node_ids,
+        representative_node=representative_node,
+        compiled_brief=compiled_brief,
+        manifest=manifest,
+    )
+
+
+__all__ = [
+    "JULES_AGENT_IDS",
+    "JulesBundleSpec",
+    "build_bundle_spec",
+    "eligible_for_bundle",
+    "group_consecutive_jules_nodes",
+    "is_jules_agent_runtime_node",
+]

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -305,13 +305,16 @@ def _build_runtime_planner():
         )
 
         # If no explicit steps but stepCount > 1, synthesise N identical
-        # nodes so the Run workflow iterates them and chains jules_session_id
-        # across steps (multi-step session reuse).
+        # nodes for runtimes that still execute sequentially step-by-step.
+        # Jules is excluded because the workflow now bundles standard
+        # multi-step work into one one-shot execution brief instead of
+        # chaining provider follow-up messages.
         effective_step_count = node_inputs.get("stepCount")
         expand_step_count = (
             not has_multi_steps
             and isinstance(effective_step_count, int)
             and effective_step_count > 1
+            and str(runtime_mode).strip().lower() not in {"jules", "jules_api"}
         )
 
         nodes: list[dict[str, Any]] = []
@@ -356,8 +359,7 @@ def _build_runtime_planner():
                 prev_step_id = step_id
         elif expand_step_count:
             # Expand stepCount into N sequential nodes with the same
-            # instructions.  The Run workflow chains jules_session_id
-            # across nodes so each step continues the previous session.
+            # instructions for runtimes that still execute step-by-step.
             prev_step_id = None
             for idx in range(effective_step_count):
                 step_id = f"node-{idx + 1}"

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -57,6 +57,7 @@ from moonmind.workflows.temporal.workflows.auth_profile_manager import MoonMindA
 from moonmind.workflows.temporal.workflows.manifest_ingest import (
     MoonMindManifestIngestWorkflow as MoonMindManifestIngest,
 )
+from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow as MoonMindRun
 from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
 from moonmind.workflows.temporal.workflows.agent_run import (
@@ -314,7 +315,7 @@ def _build_runtime_planner():
             not has_multi_steps
             and isinstance(effective_step_count, int)
             and effective_step_count > 1
-            and str(runtime_mode).strip().lower() not in {"jules", "jules_api"}
+            and str(runtime_mode).strip().lower() not in JULES_AGENT_IDS
         )
 
         nodes: list[dict[str, Any]] = []

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -890,76 +890,49 @@ class MoonMindAgentRun:
                         adapter = None
                         skip_poll_and_fetch = True
                     else:
-                        # --- Multi-step Jules support ---
-                        # If a jules_session_id is provided in request.parameters,
-                        # this is a continuation step: send a follow-up message
-                        # to the existing session instead of creating a new one.
-                        jules_session_id = (request.parameters or {}).get("jules_session_id")
-                        if jules_session_id and validated_id == "jules":
-                            prompt = (request.instruction_ref or "").strip()
-                            if not prompt:
+                        # Start via Temporal activity on the integrations fleet
+                        # (determinism-safe: no adapter construction in-workflow).
+                        act_name = f"integration.{validated_id}.start"
+                        handle_dict = await self._execute_activity_with_routing(
+                            act_name,
+                            request,
+                            INTEGRATIONS_TASK_QUEUE,
+                            INTEGRATIONS_ACTIVITY_TIMEOUT,
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+
+                        )
+
+                        if isinstance(handle_dict, dict) and "external_id" in handle_dict:
+                            try:
+                                status, normalized_for_metadata = self._coerce_external_start_status(
+                                    handle_dict
+                                )
+                            except ValueError as exc:
+                                self._get_logger().warning(str(exc))
                                 raise ApplicationError(
-                                    "Jules continuation step requires a non-empty instruction_ref (prompt)",
+                                    str(exc),
+                                    type="UnsupportedStatus",
                                     non_retryable=True,
-                                )
-                            await self._execute_activity_with_routing(
-                                "integration.jules.send_message",
-                                {
-                                    "session_id": jules_session_id,
-                                    "prompt": prompt,
-                                },
-                                INTEGRATIONS_TASK_QUEUE,
-                                INTEGRATIONS_ACTIVITY_TIMEOUT,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-
+                                ) from exc
+                            handle = AgentRunHandle(
+                                runId=handle_dict["external_id"],
+                                agentKind="external",
+                                agentId=validated_id,
+                                status=status,
+                                startedAt=workflow.now(),
+                                metadata={
+                                    "providerStatus": handle_dict.get("provider_status", handle_dict.get("status", "unknown")),
+                                    "normalizedStatus": normalized_for_metadata,
+                                    "externalUrl": handle_dict.get("url"),
+                                    "callbackSupported": handle_dict.get("callback_supported", False),
+                                }
                             )
-                            self.run_id = jules_session_id
-                            self.run_status = "running"
-                            poll_interval = 15
                         else:
-                            # Start via Temporal activity on the integrations fleet
-                            # (determinism-safe: no adapter construction in-workflow).
-                            act_name = f"integration.{validated_id}.start"
-                            handle_dict = await self._execute_activity_with_routing(
-                                act_name,
-                                request,
-                                INTEGRATIONS_TASK_QUEUE,
-                                INTEGRATIONS_ACTIVITY_TIMEOUT,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            handle = AgentRunHandle(**handle_dict) if isinstance(handle_dict, dict) else handle_dict
 
-                            )
-
-                            if isinstance(handle_dict, dict) and "external_id" in handle_dict:
-                                try:
-                                    status, normalized_for_metadata = self._coerce_external_start_status(
-                                        handle_dict
-                                    )
-                                except ValueError as exc:
-                                    self._get_logger().warning(str(exc))
-                                    raise ApplicationError(
-                                        str(exc),
-                                        type="UnsupportedStatus",
-                                        non_retryable=True,
-                                    ) from exc
-                                handle = AgentRunHandle(
-                                    runId=handle_dict["external_id"],
-                                    agentKind="external",
-                                    agentId=validated_id,
-                                    status=status,
-                                    startedAt=workflow.now(),
-                                    metadata={
-                                        "providerStatus": handle_dict.get("provider_status", handle_dict.get("status", "unknown")),
-                                        "normalizedStatus": normalized_for_metadata,
-                                        "externalUrl": handle_dict.get("url"),
-                                        "callbackSupported": handle_dict.get("callback_supported", False),
-                                    }
-                                )
-                            else:
-                                handle = AgentRunHandle(**handle_dict) if isinstance(handle_dict, dict) else handle_dict
-
-                            self.run_id = handle.run_id
-                            self.run_status = handle.status
-                            poll_interval = handle.poll_hint_seconds or 10
+                        self.run_id = handle.run_id
+                        self.run_status = handle.status
+                        poll_interval = handle.poll_hint_seconds or 10
                         adapter = None  # External ops route through activities, not adapter
                 else:
                     raise ValueError(f"Unknown agent kind: {request.agent_kind}")
@@ -1170,6 +1143,96 @@ class MoonMindAgentRun:
                             # Managed agent legacy path.
                             self.final_result = await adapter.fetch_result(self.run_id)
 
+                if (
+                    request.agent_kind == "external"
+                    and self._external_agent_id in {"jules", "jules_api"}
+                    and self.final_result is not None
+                    and self.final_result.failure_class is None
+                ):
+                    publish_mode = str(
+                        (request.parameters or {}).get("publishMode") or "none"
+                    ).strip().lower()
+                    if publish_mode == "branch":
+                        result_meta = dict(self.final_result.metadata or {})
+                        pr_url = str(
+                            result_meta.get("pullRequestUrl")
+                            or result_meta.get("externalUrl")
+                            or ""
+                        ).strip()
+                        if not pr_url:
+                            self.final_result = self.final_result.model_copy(
+                                update={
+                                    "summary": "Jules branch publication failed: no pull request URL was available for merge.",
+                                    "failure_class": "execution_error",
+                                    "provider_error_code": "branch_publish_failed",
+                                    "metadata": {
+                                        **result_meta,
+                                        "publishOutcome": "publish_failed",
+                                    },
+                                }
+                            )
+                        else:
+                            workspace_spec = request.workspace_spec or {}
+                            starting_branch = str(
+                                workspace_spec.get("startingBranch")
+                                or workspace_spec.get("branch")
+                                or "main"
+                            ).strip() or "main"
+                            target_branch = str(
+                                (request.parameters or {}).get("targetBranch")
+                                or workspace_spec.get("targetBranch")
+                                or ""
+                            ).strip()
+                            merge_payload: dict[str, Any] = {"pr_url": pr_url}
+                            if target_branch and target_branch != starting_branch:
+                                merge_payload["target_branch"] = target_branch
+                            merge_result = await self._execute_activity_with_routing(
+                                "repo.merge_pr",
+                                merge_payload,
+                                INTEGRATIONS_TASK_QUEUE,
+                                INTEGRATIONS_ACTIVITY_TIMEOUT,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+                            merged = bool(
+                                merge_result.get("merged")
+                                if isinstance(merge_result, dict)
+                                else False
+                            )
+                            merge_summary = (
+                                merge_result.get("summary")
+                                if isinstance(merge_result, dict)
+                                else ""
+                            ) or ""
+                            if merged:
+                                self.final_result = self.final_result.model_copy(
+                                    update={
+                                        "metadata": {
+                                            **result_meta,
+                                            "publishOutcome": "branch_merged",
+                                            "pullRequestUrl": pr_url,
+                                            "mergeSha": (
+                                                merge_result.get("mergeSha")
+                                                if isinstance(merge_result, dict)
+                                                else None
+                                            ),
+                                        }
+                                    }
+                                )
+                            else:
+                                self.final_result = self.final_result.model_copy(
+                                    update={
+                                        "summary": merge_summary
+                                        or "Jules branch publication failed during merge.",
+                                        "failure_class": "execution_error",
+                                        "provider_error_code": "branch_publish_failed",
+                                        "metadata": {
+                                            **result_meta,
+                                            "publishOutcome": "publish_failed",
+                                            "pullRequestUrl": pr_url,
+                                        },
+                                    }
+                                )
+
                 # Check for 429
                 if request.agent_kind == "managed" and manager_handle and self.final_result.provider_error_code == PROVIDER_RATE_LIMIT_ERROR_CODE:
                     await manager_handle.signal("report_cooldown", {"profile_id": request.execution_profile_ref, "cooldown_seconds": 300})
@@ -1197,17 +1260,6 @@ class MoonMindAgentRun:
                     if "diagnosticsRef" in enriched_result and "diagnostics_ref" in enriched_result:
                         del enriched_result["diagnostics_ref"]
                     self.final_result = AgentRunResult(**enriched_result)
-
-                # Inject run_id into result metadata so the parent
-                # workflow (MoonMind.Run) can track it for multi-step
-                # Jules session reuse across plan nodes.
-                if self.run_id and hasattr(self.final_result, "metadata"):
-                    result_meta = dict(self.final_result.metadata or {})
-                    if self._external_agent_id in {"jules", "jules_api"}:
-                        result_meta["jules_session_id"] = self.run_id
-                    self.final_result = self.final_result.model_copy(
-                        update={"metadata": result_meta}
-                    )
 
                 return self.final_result
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -890,10 +890,37 @@ class MoonMindAgentRun:
                         adapter = None
                         skip_poll_and_fetch = True
                     else:
-                        # Start via Temporal activity on the integrations fleet
-                        # (determinism-safe: no adapter construction in-workflow).
-                        act_name = f"integration.{validated_id}.start"
-                        handle_dict = await self._execute_activity_with_routing(
+                        jules_session_id = (request.parameters or {}).get("jules_session_id")
+                        if (
+                            not workflow.patched("moonmind.agent_run.jules_multi_step_removal")
+                            and jules_session_id
+                            and validated_id == "jules"
+                        ):
+                            prompt = (request.instruction_ref or "").strip()
+                            if not prompt:
+                                raise ApplicationError(
+                                    "Jules continuation step requires a non-empty instruction_ref (prompt)",
+                                    non_retryable=True,
+                                )
+                            await self._execute_activity_with_routing(
+                                "integration.jules.send_message",
+                                {
+                                    "session_id": jules_session_id,
+                                    "prompt": prompt,
+                                },
+                                INTEGRATIONS_TASK_QUEUE,
+                                INTEGRATIONS_ACTIVITY_TIMEOUT,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+                            self.run_id = jules_session_id
+                            self.run_status = "running"
+                            poll_interval = 15
+                            adapter = None
+                        else:
+                            # Start via Temporal activity on the integrations fleet
+                            # (determinism-safe: no adapter construction in-workflow).
+                            act_name = f"integration.{validated_id}.start"
+                            handle_dict = await self._execute_activity_with_routing(
                             act_name,
                             request,
                             INTEGRATIONS_TASK_QUEUE,
@@ -1260,6 +1287,21 @@ class MoonMindAgentRun:
                     if "diagnosticsRef" in enriched_result and "diagnostics_ref" in enriched_result:
                         del enriched_result["diagnostics_ref"]
                     self.final_result = AgentRunResult(**enriched_result)
+
+                # Inject run_id into result metadata so the parent
+                # workflow (MoonMind.Run) can track it for multi-step
+                # Jules session reuse across plan nodes.
+                if (
+                    not workflow.patched("moonmind.agent_run.jules_multi_step_removal")
+                    and self.run_id
+                    and hasattr(self.final_result, "metadata")
+                ):
+                    result_meta = dict(self.final_result.metadata or {})
+                    if self._external_agent_id in {"jules", "jules_api"}:
+                        result_meta["jules_session_id"] = self.run_id
+                    self.final_result = self.final_result.model_copy(
+                        update={"metadata": result_meta}
+                    )
 
                 return self.final_result
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -581,7 +581,10 @@ class MoonMindRunWorkflow:
             nodes=plan_definition.nodes,
             edges=plan_definition.edges,
         )
-        ordered_nodes = await self._bundle_ordered_nodes_for_execution(ordered_nodes)
+        if workflow.patched("jules-bundling-v1"):
+            ordered_nodes = await self._bundle_ordered_nodes_for_execution(
+                ordered_nodes
+            )
 
         registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         failure_mode = plan_definition.policy.failure_mode

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -14,6 +14,11 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
     )
+    from moonmind.workflows.temporal.jules_bundle import (
+        build_bundle_spec,
+        eligible_for_bundle,
+        is_jules_agent_runtime_node,
+    )
     from moonmind.workflows.tasks.routing import _coerce_bool
 
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
@@ -214,6 +219,84 @@ class MoonMindRunWorkflow:
         if not isinstance(decoded, Mapping):
             raise ValueError(error_message)
         return self._json_mapping(decoded, path="activity_payload")
+
+    async def _write_json_artifact(
+        self,
+        *,
+        name: str,
+        payload: dict[str, Any],
+    ) -> str:
+        artifact_create_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("artifact.create")
+        artifact_write_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("artifact.write_complete")
+        artifact_ref, _upload_desc = await workflow.execute_activity(
+            "artifact.create",
+            {
+                "principal": self._principal(),
+                "name": name,
+                "content_type": "application/json",
+            },
+            **self._execute_kwargs_for_route(artifact_create_route),
+        )
+        artifact_id = (
+            self._get_from_result(artifact_ref, "artifact_id")
+            or self._get_from_result(artifact_ref, "artifactId")
+            or ""
+        )
+        if not artifact_id:
+            raise ValueError(f"artifact.create returned no artifact_id for {name}")
+        await workflow.execute_activity(
+            "artifact.write_complete",
+            {
+                "principal": self._principal(),
+                "artifact_id": artifact_id,
+                "payload": json.dumps(payload),
+                "content_type": "application/json",
+            },
+            **self._execute_kwargs_for_route(artifact_write_route),
+        )
+        return str(artifact_id)
+
+    async def _bundle_ordered_nodes_for_execution(
+        self,
+        ordered_nodes: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        bundled_nodes: list[dict[str, Any]] = []
+        bundle_index = 0
+        idx = 0
+        while idx < len(ordered_nodes):
+            node = ordered_nodes[idx]
+            if not is_jules_agent_runtime_node(node):
+                bundled_nodes.append(node)
+                idx += 1
+                continue
+
+            group = [node]
+            cursor = idx + 1
+            while cursor < len(ordered_nodes) and eligible_for_bundle(group[-1], ordered_nodes[cursor]):
+                group.append(ordered_nodes[cursor])
+                cursor += 1
+
+            if len(group) > 1:
+                bundle_index += 1
+                bundle_spec = build_bundle_spec(
+                    group,
+                    workflow_id=workflow.info().workflow_id,
+                    workflow_run_id=workflow.info().run_id,
+                )
+                manifest_ref = await self._write_json_artifact(
+                    name=f"reports/jules_bundle_{bundle_index}.json",
+                    payload=bundle_spec.manifest,
+                )
+                representative = dict(bundle_spec.representative_node)
+                representative_inputs = dict(representative.get("inputs") or {})
+                representative_inputs["bundleManifestRef"] = manifest_ref
+                representative["inputs"] = representative_inputs
+                bundled_nodes.append(representative)
+            else:
+                bundled_nodes.extend(group)
+            idx = cursor
+
+        return bundled_nodes
 
     def _ordered_plan_node_payloads(
         self,
@@ -498,6 +581,7 @@ class MoonMindRunWorkflow:
             nodes=plan_definition.nodes,
             edges=plan_definition.edges,
         )
+        ordered_nodes = await self._bundle_ordered_nodes_for_execution(ordered_nodes)
 
         registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         failure_mode = plan_definition.policy.failure_mode
@@ -505,13 +589,6 @@ class MoonMindRunWorkflow:
         require_pull_request_url = publish_mode == "pr" and self._integration is None
         pull_request_url: str | None = None
         skill_definitions_by_key: dict[tuple[str, str], Any] = {}
-
-        # Track the Jules session ID across plan nodes for multi-step
-        # session reuse.  After the first Jules step completes, its
-        # session_id is extracted from the result metadata.  Subsequent
-        # Jules steps receive this ID so MoonMind.AgentRun calls
-        # sendMessage instead of creating a new session.
-        jules_session_id: str | None = None
 
         if registry_snapshot_ref:
             registry_payload = await workflow.execute_activity(
@@ -573,17 +650,6 @@ class MoonMindRunWorkflow:
                             node_id=node_id,
                             tool_name=tool_name,
                         )
-                        # --- Multi-step Jules: adjust parameters for proper PR creation ---
-                        if request.agent_id == "jules":
-                            new_params = dict(request.parameters or {})
-                            if publish_mode == "pr":
-                                new_params["publishMode"] = "branch"
-                                new_params.pop("automationMode", None)
-                            if jules_session_id:
-                                new_params["jules_session_id"] = jules_session_id
-                            
-                            if new_params != (request.parameters or {}):
-                                request = request.model_copy(update={"parameters": new_params})
                         child_workflow_id = f"{workflow.info().workflow_id}:agent:{node_id}"
                         if system_retries > 0:
                             child_workflow_id = f"{child_workflow_id}:retry{system_retries}"
@@ -597,9 +663,6 @@ class MoonMindRunWorkflow:
                     except Exception:
                         if failure_mode == "FAIL_FAST":
                             raise
-                        # Clear session on failure so later Jules steps start fresh.
-                        if "request" in dir() and getattr(request, "agent_id", None) == "jules":
-                            jules_session_id = None
                         result_status = "FAILED"
                         break
 
@@ -690,8 +753,6 @@ class MoonMindRunWorkflow:
                             f"Retrying plan node {node_id} after {failure_message} "
                             f"(attempt {system_retries} of 3)"
                         )
-                        if tool_type == "agent_runtime" and node_inputs.get("runtime", {}).get("mode") == "jules":
-                            jules_session_id = None
                         continue
 
                     if failure_mode == "FAIL_FAST":
@@ -703,9 +764,6 @@ class MoonMindRunWorkflow:
                         raise ValueError(
                             f"plan node execution returned status {result_status}{detail}"
                         )
-                    # Clear session on failure so later Jules steps start fresh.
-                    if tool_type == "agent_runtime" and node_inputs.get("runtime", {}).get("mode") == "jules":
-                        jules_session_id = None
                     break
 
                 break
@@ -713,20 +771,6 @@ class MoonMindRunWorkflow:
             if result_status is None or result_status != "COMPLETED":
                 continue
 
-            # --- Multi-step Jules: extract session_id only on success ---
-            if tool_type == "agent_runtime":
-                _rt = node_inputs.get("runtime") or {}
-                _node_agent_id = (
-                    _rt.get("mode")
-                    or _rt.get("agent_id")
-                    or node_inputs.get("targetRuntime")
-                    or tool_name
-                    or ""
-                ).strip().lower()
-                if _node_agent_id in {"jules", "jules_api"}:
-                    extracted_id = self._extract_jules_session_id(child_result)
-                    if extracted_id:
-                        jules_session_id = extracted_id
             if require_pull_request_url and pull_request_url is None:
                 pull_request_url = self._extract_pull_request_url(execution_result)
                 
@@ -970,6 +1014,37 @@ class MoonMindRunWorkflow:
             param_val = runtime_block.get(param_key) or node_inputs.get(param_key)
             if param_val is not None:
                 parameters[param_key] = param_val
+        raw_metadata = runtime_block.get("metadata") or node_inputs.get("metadata")
+        if isinstance(raw_metadata, Mapping):
+            parameters["metadata"] = self._json_mapping(
+                raw_metadata, path=f"node[{node_id}].metadata"
+            )
+        bundle_payload: dict[str, Any] = {}
+        for bundle_key in (
+            "bundleId",
+            "bundledNodeIds",
+            "bundleManifestRef",
+            "bundleStrategy",
+        ):
+            if node_inputs.get(bundle_key) is not None:
+                bundle_payload[bundle_key] = self._json_value(
+                    node_inputs.get(bundle_key),
+                    path=f"node[{node_id}].{bundle_key}",
+                )
+        if bundle_payload:
+            metadata_payload = (
+                parameters.get("metadata")
+                if isinstance(parameters.get("metadata"), dict)
+                else {}
+            )
+            moonmind_payload = (
+                metadata_payload.get("moonmind")
+                if isinstance(metadata_payload.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload.update(bundle_payload)
+            metadata_payload["moonmind"] = moonmind_payload
+            parameters["metadata"] = metadata_payload
 
         return AgentExecutionRequest(
             agent_kind=agent_kind,
@@ -1018,15 +1093,6 @@ class MoonMindRunWorkflow:
         }
 
     @staticmethod
-    def _extract_jules_session_id(result: Any) -> str | None:
-        """Extract the Jules session ID from an ``AgentRunResult`` for multi-step reuse."""
-        if isinstance(result, dict):
-            metadata = result.get("metadata") or {}
-        else:
-            metadata = getattr(result, "metadata", {}) or {}
-        return metadata.get("jules_session_id")
-
-    @staticmethod
     def _agent_kind_for_id(agent_id: str) -> str:
         """Derive ``agent_kind`` from ``agent_id``."""
         return "managed" if agent_id.lower() in _MANAGED_AGENT_IDS else "external"
@@ -1071,22 +1137,72 @@ class MoonMindRunWorkflow:
                     f"Failed to extract step instructions for integration multi-step: {e}"
                 )
 
-        instructions_to_run = step_instructions if (step_instructions and self._integration == "jules") else [None]
-
         integration_parameters = dict(parameters)
-        
-        # --- Multi-step Jules: adjust parameters for proper PR creation ---
-        if self._integration == "jules":
-            publish_mode = self._publish_mode(integration_parameters)
-            if publish_mode == "pr":
-                integration_parameters["publishMode"] = "branch"
-                integration_parameters.pop("automationMode", None)
-                
+        instructions_to_run = [None]
+
         integration_parameters.setdefault(
             "title", self._title or "MoonMind Integration"
         )
-        if instructions_to_run[0]:
-            integration_parameters["description"] = instructions_to_run[0]
+        if self._integration == "jules" and len(step_instructions) > 1:
+            workspace_spec = integration_parameters.get("workspaceSpec") or {}
+            repo_value = (
+                self._repo
+                or workspace_spec.get("repository")
+                or workspace_spec.get("repo")
+                or ""
+            )
+            pseudo_nodes = []
+            for index, instruction in enumerate(step_instructions, start=1):
+                pseudo_nodes.append(
+                    {
+                        "id": f"integration-step-{index}",
+                        "tool": {
+                            "type": "agent_runtime",
+                            "name": "jules",
+                            "version": "1.0",
+                        },
+                        "inputs": {
+                            "instructions": instruction,
+                            "repository": repo_value,
+                            "repo": repo_value,
+                            "startingBranch": workspace_spec.get("startingBranch")
+                            or workspace_spec.get("branch")
+                            or "main",
+                            "targetBranch": workspace_spec.get("targetBranch"),
+                            "publishMode": self._publish_mode(integration_parameters) or "none",
+                        },
+                    }
+                )
+            bundle_spec = build_bundle_spec(
+                pseudo_nodes,
+                workflow_id=workflow.info().workflow_id,
+                workflow_run_id=workflow.info().run_id,
+            )
+            manifest_ref = await self._write_json_artifact(
+                name="reports/jules_integration_bundle.json",
+                payload=bundle_spec.manifest,
+            )
+            integration_parameters["description"] = bundle_spec.compiled_brief
+            metadata = integration_parameters.get("metadata")
+            if metadata is None:
+                metadata = {}
+            if not isinstance(metadata, dict):
+                raise ValueError("integration metadata must be an object when provided")
+            moonmind_meta = metadata.get("moonmind")
+            if not isinstance(moonmind_meta, dict):
+                moonmind_meta = {}
+            moonmind_meta.update(
+                {
+                    "bundleId": bundle_spec.bundle_id,
+                    "bundledNodeIds": list(bundle_spec.bundled_node_ids),
+                    "bundleManifestRef": manifest_ref,
+                    "bundleStrategy": "one_shot_jules",
+                }
+            )
+            metadata["moonmind"] = moonmind_meta
+            integration_parameters["metadata"] = metadata
+        elif step_instructions:
+            integration_parameters["description"] = step_instructions[0]
         else:
             integration_parameters.setdefault(
                 "description",
@@ -1129,28 +1245,6 @@ class MoonMindRunWorkflow:
         for step_index, instruction in enumerate(instructions_to_run):
             if self._cancel_requested:
                 break
-
-            if step_index > 0:
-                self._resume_requested = False
-                self._external_status = "running"
-                self._update_memo()
-                self._get_logger().info(f"Jules multi-step integration: sending step {step_index + 1}/{len(instructions_to_run)}")
-                try:
-                    await workflow.execute_activity(
-                        self._integration_activity_type("send_message"),
-                        {
-                            "session_id": external_id,
-                            "prompt": instruction,
-                        },
-                        start_to_close_timeout=timedelta(minutes=5),
-                        task_queue=INTEGRATIONS_TASK_QUEUE,
-                        retry_policy=DEFAULT_ACTIVITY_RETRY_POLICY,
-                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                    )
-                except Exception as exc:
-                    self._get_logger().warning(f"Failed to send follow-up step {step_index + 1} to Jules: {exc}")
-                    self._external_status = "failed"
-                    break
 
             poll_interval_seconds = 5
             max_poll_interval_seconds = 300
@@ -1321,20 +1415,17 @@ class MoonMindRunWorkflow:
                             "Jules branch-publish: PR merged: %s", merge_summary
                         )
                     else:
-                        self._get_logger().warning(
-                            "Jules branch-publish: merge failed: %s", merge_summary
+                        raise ValueError(
+                            f"Jules branch-publish: merge failed: {merge_summary}"
                         )
                 else:
-                    self._get_logger().warning(
-                        "Jules branch-publish: no PR URL found in result; "
-                        "skipping auto-merge"
+                    raise ValueError(
+                        "Jules branch-publish: no PR URL found in result"
                     )
             except Exception as exc:
-                self._get_logger().warning(
-                    "Jules branch-publish auto-merge failed (best-effort): %s",
-                    exc,
-                    exc_info=True,
-                )
+                raise ValueError(
+                    f"Jules branch-publish auto-merge failed: {exc}"
+                ) from exc
 
     async def _run_proposals_stage(
         self, *, parameters: dict[str, Any]

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1143,7 +1143,11 @@ class MoonMindRunWorkflow:
         integration_parameters.setdefault(
             "title", self._title or "MoonMind Integration"
         )
-        if self._integration == "jules" and len(step_instructions) > 1:
+        if (
+            self._integration == "jules"
+            and len(step_instructions) > 1
+            and workflow.patched("moonmind.run.jules_one_shot_bundle")
+        ):
             workspace_spec = integration_parameters.get("workspaceSpec") or {}
             repo_value = (
                 self._repo
@@ -1183,14 +1187,15 @@ class MoonMindRunWorkflow:
                 payload=bundle_spec.manifest,
             )
             integration_parameters["description"] = bundle_spec.compiled_brief
-            metadata = integration_parameters.get("metadata")
-            if metadata is None:
-                metadata = {}
+            metadata = integration_parameters.setdefault("metadata", {})
             if not isinstance(metadata, dict):
                 raise ValueError("integration metadata must be an object when provided")
-            moonmind_meta = metadata.get("moonmind")
+
+            moonmind_meta = metadata.setdefault("moonmind", {})
             if not isinstance(moonmind_meta, dict):
                 moonmind_meta = {}
+                metadata["moonmind"] = moonmind_meta
+
             moonmind_meta.update(
                 {
                     "bundleId": bundle_spec.bundle_id,
@@ -1199,7 +1204,6 @@ class MoonMindRunWorkflow:
                     "bundleStrategy": "one_shot_jules",
                 }
             )
-            metadata["moonmind"] = moonmind_meta
             integration_parameters["metadata"] = metadata
         elif step_instructions:
             integration_parameters["description"] = step_instructions[0]

--- a/specs/105-jules-provider-adapter/checklists/requirements.md
+++ b/specs/105-jules-provider-adapter/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Jules Provider Adapter Runtime Alignment
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-27  
+**Feature**: `specs/105-jules-provider-adapter/spec.md`
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Spec validated after initial authoring; no clarification blockers were found.

--- a/specs/105-jules-provider-adapter/contracts/jules-bundle-runtime-contract.md
+++ b/specs/105-jules-provider-adapter/contracts/jules-bundle-runtime-contract.md
@@ -1,0 +1,74 @@
+# Contract: Jules Bundle Runtime
+
+## Purpose
+
+Define the orchestration-owned contract for turning multiple logical Jules-targeted plan nodes into one bundled Jules execution.
+
+## 1. Bundle Eligibility
+
+MoonMind may bundle consecutive logical nodes only when all of the following are true:
+
+- each node targets Jules as the effective runtime,
+- nodes are consecutive in execution order,
+- nodes share the same repository/workspace context,
+- nodes share compatible publish semantics,
+- no node requires a human approval boundary before the next node,
+- later instructions do not depend on artifacts that must first be created by an earlier separate runtime boundary.
+
+If any eligibility rule fails, MoonMind must create a separate Jules bundle node instead of falling back to standard multi-step `sendMessage` progression.
+
+## 2. Compiled Brief Shape
+
+Each bundled Jules execution brief must contain these sections in order:
+
+1. Mission
+2. Repository and Workspace Context
+3. Execution Rules
+4. Ordered Work Checklist
+5. Validation Checklist
+6. Deliverable Requirements
+
+The brief must be deterministic, checklist-shaped, and suitable for one-shot provider execution.
+
+## 3. Bundle Manifest Metadata
+
+MoonMind must retain compact metadata for each bundle:
+
+| Key | Meaning |
+|---|---|
+| `bundleId` | Stable synthetic execution identifier |
+| `bundledNodeIds` | Ordered logical nodes represented by the bundle |
+| `bundleManifestRef` | Artifact ref for the full manifest |
+| `bundleStrategy` | Expected value `one_shot_jules` |
+| `correlationId` | MoonMind correlation ID |
+| `idempotencyKey` | MoonMind idempotency key |
+
+## 4. Follow-Up Message Policy
+
+`sendMessage` remains allowed only for:
+
+- clarification responses,
+- operator intervention,
+- explicit resume flows.
+
+`sendMessage` must not be used as the standard progression path between logical implementation steps inside a bundled Jules run.
+
+## 5. Truthful Branch Publication
+
+When `publishMode == "branch"`:
+
+- MoonMind must request Jules PR automation at start.
+- MoonMind must extract the resulting PR URL after provider completion.
+- If `targetBranch` differs from `startingBranch`, MoonMind must update the PR base before merge.
+- MoonMind must merge the PR successfully before reporting branch publication success.
+- If any of these steps fail, MoonMind must surface a non-success outcome.
+
+## 6. Truthful Bundle Result Semantics
+
+Provider completion does not by itself guarantee MoonMind success.
+
+MoonMind must treat a bundled run as incomplete or failed when:
+
+- required checklist outcomes were not actually completed,
+- required verification fails,
+- requested branch publication does not land on the intended target branch.

--- a/specs/105-jules-provider-adapter/contracts/requirements-traceability.md
+++ b/specs/105-jules-provider-adapter/contracts/requirements-traceability.md
@@ -1,0 +1,16 @@
+# Requirements Traceability: Jules Provider Adapter Runtime Alignment
+
+| DOC-REQ | Functional Requirement(s) | Implementation Surface | Validation Strategy |
+|---|---|---|---|
+| DOC-REQ-001 | FR-005, FR-011 | `jules_client.py`, `jules_agent_adapter.py`, workflow helper changes avoid moving orchestration into transport | Unit tests confirm transport helpers stay transport-focused; workflow tests cover orchestration separately |
+| DOC-REQ-002 | FR-005, FR-011 | `jules_agent_adapter.py`, `agent_run.py` | Existing adapter tests plus updated workflow-boundary tests |
+| DOC-REQ-003 | FR-006, FR-011 | `jules_agent_adapter.py` start behavior, external/integration start paths | Unit test for AUTO_CREATE_PR start behavior |
+| DOC-REQ-004 | FR-007, FR-011 | `run.py`, `jules_activities.py`, merge helper path | Workflow test for successful branch publication including merge |
+| DOC-REQ-005 | FR-007, FR-008, FR-009 | `run.py`, result handling, merge/base-update failure mapping | Workflow tests for missing PR URL, base-update failure, merge rejection, verification failure |
+| DOC-REQ-006 | FR-001, FR-012 | `run.py`, `worker_runtime.py` | Workflow tests show consecutive Jules work executes as one bundle / one provider session |
+| DOC-REQ-007 | FR-001, FR-002, FR-012 | Bundle compiler/helper logic plus `run.py` dispatch | Workflow tests inspect compiled one-shot brief shape |
+| DOC-REQ-008 | FR-003, FR-009, FR-012 | Bundle manifest/result metadata handling in `run.py` / `agent_run.py` | Workflow tests validate bundle IDs, node IDs, and manifest refs are preserved |
+| DOC-REQ-009 | FR-004, FR-010, FR-012 | `agent_run.py`, `jules_activities.py`, removal of normal `jules_session_id` chaining | Workflow tests verify no normal step chaining via `send_message`; clarification path tests remain passing |
+| DOC-REQ-010 | FR-009 | Bundle result summary handling in `agent_run.py` / `run.py` | Workflow tests assert incomplete checklist state is surfaced, not hidden |
+| DOC-REQ-011 | FR-008, FR-009, FR-012 | MoonMind verification and publish-result ownership in `run.py` / result handling | Workflow tests validate provider success can still end as MoonMind non-success |
+| DOC-REQ-012 | FR-004, FR-005, FR-010 | `agent_run.py`, `run.py`, Jules activities | Workflow tests prove orchestration stays in workflow layers while transport remains thin |

--- a/specs/105-jules-provider-adapter/data-model.md
+++ b/specs/105-jules-provider-adapter/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: Jules Provider Adapter Runtime Alignment
+
+## Overview
+
+This feature does not introduce a new database schema. It introduces three execution-side data structures that must stay compact, deterministic, and artifact-friendly.
+
+## 1. Jules Bundle Node
+
+Represents one synthetic execution unit created from one or more consecutive Jules-targeted logical plan nodes.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `bundleId` | string | Stable identifier for the synthetic Jules bundle |
+| `bundledNodeIds` | list[string] | Ordered logical node IDs represented by the bundle |
+| `repository` | string | Repository context shared by the bundled work |
+| `startingBranch` | string | Starting branch for the Jules run |
+| `targetBranch` | string \| null | Optional branch publication target |
+| `publishMode` | string | Requested publish behavior (`none`, `pr`, `branch`) |
+| `compiledBrief` | string | Consolidated one-shot brief sent to Jules |
+| `bundleManifestRef` | string \| null | Artifact reference for the full bundle manifest |
+
+### Validation Rules
+
+- `bundledNodeIds` must be non-empty and preserve original execution order.
+- All bundled nodes must share compatible repo/workspace/publish context.
+- `compiledBrief` must be produced deterministically from the same ordered inputs.
+
+## 2. Jules Bundle Manifest
+
+Artifact-backed traceability record that explains how MoonMind transformed logical nodes into one Jules provider run.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `bundleId` | string | Primary manifest key |
+| `bundleStrategy` | string | Expected value: `one_shot_jules` |
+| `bundledNodeIds` | list[string] | Ordered original node IDs |
+| `mission` | string | High-level objective |
+| `workspaceContext` | object | Repo/branch/publish metadata used for compilation |
+| `executionRules` | list[string] | Ordered execution constraints given to Jules |
+| `orderedChecklist` | list[object] | Human/audit-readable work checklist entries |
+| `validationChecklist` | list[string] | Expected validation steps |
+| `deliverableRequirements` | list[string] | Required final-summary disclosures |
+| `correlationId` | string | MoonMind correlation identifier |
+| `idempotencyKey` | string | MoonMind idempotency key used for the bundled run |
+
+### Validation Rules
+
+- `bundleStrategy` must be explicit and stable for replay/auditability.
+- Every bundled logical node must appear in `bundledNodeIds`.
+- Checklist ordering must match the execution order represented by the bundle.
+
+## 3. Bundle Result Summary
+
+MoonMind-owned completion summary for one bundled Jules execution.
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `bundleId` | string | Bundle being summarized |
+| `providerStatus` | string | Raw or normalized provider completion status |
+| `publishOutcome` | string | `not_requested`, `pr_created`, `branch_merged`, `publish_failed`, or similar |
+| `verificationOutcome` | string | `passed`, `incomplete`, or `failed` |
+| `incompleteChecklistItems` | list[string] | Checklist items Jules did not clearly complete |
+| `pullRequestUrl` | string \| null | PR URL if one exists |
+| `mergeSha` | string \| null | Merge SHA for successful branch publication |
+| `summary` | string | Compact operator-facing summary |
+
+### State Transitions
+
+| State | Meaning |
+|---|---|
+| `provider_completed` | Jules reached a terminal provider-success state |
+| `publish_verified` | Required PR/merge outcome completed |
+| `verification_failed` | MoonMind verification disproved requested outcome |
+| `incomplete` | Bundle ended without satisfying all required checklist outcomes |
+
+### Validation Rules
+
+- `branch_merged` is valid only when a merge SHA or equivalent verified merge outcome exists.
+- `verificationOutcome = passed` is invalid when `incompleteChecklistItems` is non-empty.
+- Provider-reported success alone is insufficient to mark bundle success when publish or verification expectations remain unmet.

--- a/specs/105-jules-provider-adapter/plan.md
+++ b/specs/105-jules-provider-adapter/plan.md
@@ -1,0 +1,212 @@
+# Implementation Plan: Jules Provider Adapter Runtime Alignment
+
+**Branch**: `105-jules-provider-adapter` | **Date**: 2026-03-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/105-jules-provider-adapter/spec.md`
+
+## Summary
+
+Align Jules runtime behavior with the updated provider design by replacing step-chained Jules execution with one-shot bundle dispatch, making branch publication outcomes truthful, and preserving `sendMessage` only for clarification/resume exception paths. The implementation stays inside MoonMind orchestration layers (`worker_runtime.py`, `run.py`, `agent_run.py`, Jules activities/tests) so the Jules transport and shared adapter layers remain thin and reusable.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+ (`pyproject.toml` currently allows `>=3.10,<3.14`)  
+**Primary Dependencies**: Temporal Python SDK, Pydantic v2, httpx, pytest/pytest-asyncio  
+**Storage**: Artifact-backed workflow metadata plus workflow-local state; no new database schema  
+**Testing**: pytest via `./tools/test_unit.sh`; targeted integration coverage where needed  
+**Target Platform**: Linux server workers under Docker Compose / Temporal  
+**Project Type**: Single Python project centered on the `moonmind` package  
+**Performance Goals**: Reduce Jules session churn and follow-up round trips by collapsing standard multi-step work into one provider session while keeping polling cadence and workflow overhead bounded  
+**Constraints**: Temporal replay safety, no raw secrets in workflow history/logs, truthful publish semantics, no docs-only outcome for this runtime-intent feature, compatibility safety for in-flight workflow histories  
+**Scale/Scope**: Existing Jules execution and integration workflow paths, plus workflow-boundary regression tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Orchestrate, Don't Recreate | **PASS** | Jules remains a provider-specific runtime behind MoonMind orchestration; no provider logic moves into a MoonMind-specific cognitive engine. |
+| II. One-Click Agent Deployment | **PASS** | No deployment topology change; feature stays within existing Compose/worker flows. |
+| III. Avoid Vendor Lock-In | **PASS** | Bundle compilation lives in generic orchestration layers, not in Jules transport internals. |
+| IV. Own Your Data | **PASS** | Bundle manifests/results use MoonMind-controlled artifact/state surfaces. |
+| V. Skills Are First-Class | **PASS** | No skill runtime changes. |
+| VI. Thin Scaffolding, Thick Contracts | **PASS** | Consolidates runtime semantics behind a bundle/manifest contract instead of adding more provider-specific choreography. |
+| VII. Runtime Configurability | **PASS** | Existing runtime gate and publish controls remain config-driven. |
+| VIII. Modular Architecture | **PASS** | Changes target workflow helpers and Jules-specific activities without broad core rewrites. |
+| IX. Resilient by Default | **PASS** | Plan adds workflow-boundary tests for truthful branch publication and replay-safe bundle dispatch. |
+| X. Continuous Improvement | **PASS** | Result metadata becomes more explicit about incomplete bundles and verification failures. |
+| XI. Spec-Driven Development | **PASS** | Implementation is anchored to this spec with `DOC-REQ-*` traceability. |
+| XII. Canonical Docs vs Tmp | **PASS** | Canonical behavior comes from `docs/ExternalAgents/JulesAdapter.md`; migration/implementation detail stays in spec artifacts. |
+| XIII. Delete, Don't Deprecate | **PASS** | Normal multi-step Jules session chaining will be removed rather than retained as a silent compatibility path for new executions. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/105-jules-provider-adapter/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   ├── jules-bundle-runtime-contract.md
+│   └── requirements-traceability.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/
+├── worker_runtime.py                         # Current step expansion logic still generates sequential Jules nodes
+├── activities/jules_activities.py           # Jules workflow activities, branch publish helper
+├── activity_catalog.py                      # Existing Jules activity routing
+└── workflows/
+    ├── run.py                               # Current jules_session_id chaining + integration-stage send_message progression
+    └── agent_run.py                         # External polling path, clarification exception path, result metadata
+
+moonmind/workflows/adapters/
+├── jules_agent_adapter.py                   # Shared adapter boundary, AUTO_CREATE_PR start behavior
+└── jules_client.py                          # Thin provider transport; merge/base-update helpers
+
+moonmind/schemas/
+└── agent_runtime_models.py                  # Canonical request/result contracts used by workflows/adapters
+
+tests/unit/workflows/temporal/
+├── test_jules_merge_pr.py                   # Existing branch-merge helper tests
+├── test_jules_activities.py                 # Jules activity tests
+└── workflows/test_run_integration.py        # Existing multi-step send_message workflow tests to replace
+
+tests/unit/workflows/temporal/workflows/
+├── test_run_artifacts.py
+└── test_run_integration.py
+
+tests/integration/
+└── test_jules_integration.py                # Real Jules sendMessage lifecycle test to update or retire
+```
+
+**Structure Decision**: Keep the implementation inside existing Temporal workflow and Jules adapter/activity modules. Add a dedicated bundle contract artifact under `specs/105-jules-provider-adapter/contracts/` rather than creating a new top-level runtime package.
+
+## Research Summary
+
+1. **Bundle at orchestration time, not in the provider adapter**: `JulesAgentAdapter` and `JulesClient` are already close to the desired thin-boundary design. The problematic step-chaining behavior lives in `worker_runtime.py` and `run.py`, so bundle compilation should happen after ordered plan nodes are known and before child/external execution starts.
+2. **Remove `jules_session_id` as the standard execution path**: Both `run.py` and `agent_run.py` currently preserve and consume `jules_session_id` for normal step progression. That is the direct contradiction to the updated doc and should be deleted for standard flows.
+3. **Keep clarification auto-answer in `MoonMind.AgentRun`**: The current auto-answer loop already lives in `agent_run.py`, which matches the updated design. It should be preserved as the only normal `sendMessage` exception path.
+4. **Make branch publication a MoonMind-owned success gate**: `run.py` currently treats branch auto-merge as best-effort in the integration path. That needs to become a required success boundary when the caller requested `publishMode == "branch"`.
+5. **Use workflow-boundary tests as the primary regression anchor**: The changed behavior crosses planner/orchestrator/adapters. Unit-only transport tests are insufficient; replay-safe workflow tests must prove one-shot bundling, no step chaining, and truthful branch publication failure mapping.
+
+## Phase 0: Research Output
+
+Research is captured in `research.md` and resolves the main design choices:
+
+- where to bundle Jules work,
+- how to encode bundle manifest metadata without bloating workflow history,
+- how to preserve clarification-only `sendMessage`,
+- how to map branch publication failures to MoonMind-owned outcomes.
+
+## Phase 1: Design & Contracts
+
+### Data Model Design
+
+Create lightweight execution-side models/documented structures for:
+
+- a synthetic Jules bundle node derived from ordered plan nodes,
+- a bundle manifest describing original node IDs and compiled brief sections,
+- a bundle result summary describing provider outcome, verification outcome, publish outcome, and incomplete checklist state.
+
+### Contract Design
+
+Document two contracts:
+
+1. `contracts/jules-bundle-runtime-contract.md`
+   - bundle eligibility rules,
+   - consolidated brief shape,
+   - bundle manifest metadata fields,
+   - truthful result and branch-publication outcome rules.
+2. `contracts/requirements-traceability.md`
+   - one row per `DOC-REQ-*`,
+   - mapped FRs,
+   - implementation surfaces,
+   - explicit validation strategy.
+
+### Planned Implementation Surfaces
+
+#### Change 1: Jules Bundle Compilation in Workflow Orchestration
+
+**Primary files**: `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/worker_runtime.py`
+
+- Replace standard multi-node Jules progression with deterministic bundle grouping for consecutive Jules-targeted execution nodes.
+- Compile grouped work into one checklist-shaped brief and one bundle manifest.
+- Remove `jules_session_id` propagation from normal execution.
+
+#### Change 2: Preserve Clarification-Only Follow-Up Messaging
+
+**Primary files**: `moonmind/workflows/temporal/workflows/agent_run.py`, `moonmind/workflows/temporal/activities/jules_activities.py`
+
+- Keep `integration.jules.send_message` and auto-answer behavior only for clarification/intervention/resume flows.
+- Ensure standard bundled execution never routes subsequent logical steps through `sendMessage`.
+
+#### Change 3: Truthful Branch Publication and Result Ownership
+
+**Primary files**: `moonmind/workflows/temporal/workflows/run.py`, `moonmind/workflows/temporal/activities/jules_activities.py`, `moonmind/workflows/adapters/jules_agent_adapter.py`
+
+- Preserve AUTO_CREATE_PR start behavior for `pr`/`branch`.
+- Make branch publication success contingent on PR extraction, optional base retarget, merge success, and any required MoonMind verification.
+- Surface non-success outcomes when publication or verification fails.
+
+#### Change 4: Result Metadata and Bundle Visibility
+
+**Primary files**: `moonmind/workflows/temporal/workflows/agent_run.py`, `moonmind/workflows/temporal/workflows/run.py`
+
+- Attach bundle manifest/result metadata to final result handling.
+- Expose incomplete checklist or verification failures explicitly instead of relying on raw provider success alone.
+
+#### Change 5: Boundary-Level Regression Coverage
+
+**Primary files**: `tests/unit/workflows/temporal/workflows/test_run_integration.py`, `tests/unit/workflows/temporal/test_jules_merge_pr.py`, `tests/unit/workflows/temporal/test_jules_activities.py`, `tests/integration/test_jules_integration.py`
+
+- Replace current multi-step send-message workflow expectations with one-shot bundle expectations.
+- Add failure-path coverage for branch publication truthfulness and clarification-only `sendMessage` exception behavior.
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Orchestrate, Don't Recreate | **PASS** | Design keeps bundling and verification in orchestration, not in provider cognition. |
+| III. Avoid Vendor Lock-In | **PASS** | The bundle contract is orchestration-owned and can later support other providers with different policies. |
+| VIII. Modular Architecture | **PASS** | Run/worker orchestration changes are isolated; transport remains thin. |
+| IX. Resilient by Default | **PASS** | Truthful failure mapping plus workflow-boundary tests protect unattended execution. |
+| XI. Spec-Driven Development | **PASS** | `DOC-REQ-*` mappings and bundle contract keep design traceable. |
+| XIII. Delete, Don't Deprecate | **PASS** | Old normal-path chaining is removed instead of being left as a fallback for new runs. |
+
+## Verification Plan
+
+### Required Automated Coverage
+
+Run unit/workflow tests via the canonical script:
+
+```bash
+./tools/test_unit.sh
+```
+
+Targeted additions/updates must cover:
+
+1. Consecutive Jules plan nodes collapse into one bundled execution request.
+2. Standard bundled execution no longer invokes `integration.jules.send_message`.
+3. Clarification/auto-answer flows still invoke `integration.jules.send_message` when Jules asks for feedback.
+4. Branch publish success requires merge completion.
+5. Missing PR URL, base-update failure, merge rejection, and incomplete bundle verification map to non-success outcomes.
+6. In-flight/replay-safe compatibility coverage for any changed workflow control-flow branch that can affect existing histories.
+
+### Manual/Integration Validation
+
+- Optional real-provider smoke check only after unit/workflow coverage passes, using a scratch repo and low-risk prompt.
+- Confirm result metadata and summaries expose bundle identity and branch publication outcome clearly.
+
+## Complexity Tracking
+
+No constitution violations require special justification.

--- a/specs/105-jules-provider-adapter/quickstart.md
+++ b/specs/105-jules-provider-adapter/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Jules Provider Adapter Runtime Alignment
+
+## Goal
+
+Validate that MoonMind dispatches standard Jules work as one bundled execution, preserves clarification-only follow-up messaging, and reports branch publication truthfully.
+
+## Prerequisites
+
+- Jules runtime is configured in the local/dev environment.
+- The feature branch `105-jules-provider-adapter` is checked out.
+- Unit-test dependencies are installed.
+
+## Validation Steps
+
+1. Run the unit/workflow suite with the canonical script:
+
+```bash
+./tools/test_unit.sh
+```
+
+2. Confirm updated workflow-boundary coverage proves:
+   - consecutive Jules plan nodes are bundled into one execution,
+   - normal bundled execution does not use `integration.jules.send_message`,
+   - clarification/auto-answer flows can still use `integration.jules.send_message`,
+   - branch publication succeeds only after merge verification,
+   - branch publication failure scenarios report non-success outcomes.
+
+3. If a real-provider smoke test is needed, run it only against a scratch repository and verify:
+   - one provider session is created for the bundled work,
+   - the final result exposes bundle metadata,
+   - `publishMode: "branch"` only reports success when the requested target branch actually receives the changes.
+
+## Expected Outcome
+
+- No normal Jules multi-step session chaining remains for new executions.
+- Bundle/result metadata is visible in workflow results.
+- Branch publication semantics are truthful in both success and failure paths.

--- a/specs/105-jules-provider-adapter/research.md
+++ b/specs/105-jules-provider-adapter/research.md
@@ -1,0 +1,48 @@
+# Research: Jules Provider Adapter Runtime Alignment
+
+## Decision 1: Bundle Jules work in MoonMind orchestration, not in transport
+
+- **Decision**: Perform Jules bundle grouping and brief compilation in `MoonMind.Run` after ordered plan nodes are known, while keeping `JulesClient` and `JulesAgentAdapter` transport-focused.
+- **Rationale**: The current contradiction to the doc lives in orchestration (`worker_runtime.py`, `run.py`, `agent_run.py`), not in the provider HTTP layer.
+- **Alternatives considered**:
+  - Add bundling logic to `JulesAgentAdapter`: rejected because it would mix workflow planning semantics into the provider adapter.
+  - Add bundling logic to `JulesClient`: rejected because transport must remain thin and replay-insensitive.
+
+## Decision 2: Remove normal `jules_session_id` chaining for new executions
+
+- **Decision**: Delete the normal execution-path use of `jules_session_id` / sequential `sendMessage` continuation for new Jules work.
+- **Rationale**: The updated doc explicitly replaces multi-step progression with one-shot bundled execution and the repo constitution prefers deletion over compatibility aliases for pre-release internal behavior.
+- **Alternatives considered**:
+  - Keep `jules_session_id` as a hidden fallback: rejected because it would preserve the exact brittle behavior the doc now forbids.
+  - Continue using `sendMessage` for some multi-step cases: rejected because the new standard is bundle-first, with `sendMessage` reserved for exception flows only.
+
+## Decision 3: Preserve clarification handling as the only normal follow-up message path
+
+- **Decision**: Keep `integration.jules.send_message` only for clarification, intervention, and explicit resume flows, with auto-answer remaining in `MoonMind.AgentRun`.
+- **Rationale**: This already matches the updated doc and avoids moving workflow choreography into the transport layer.
+- **Alternatives considered**:
+  - Remove `sendMessage` entirely: rejected because clarification/resume still require it.
+  - Move clarification logic into Jules activities only: rejected because the workflow must own stateful polling and escalation policy.
+
+## Decision 4: Treat branch publication as a MoonMind success gate
+
+- **Decision**: Make `publishMode == "branch"` succeed only after PR extraction, optional base retarget, merge completion, and any required MoonMind verification.
+- **Rationale**: The updated doc defines these steps as part of completion semantics, not best-effort post-processing.
+- **Alternatives considered**:
+  - Keep merge as best-effort logging only: rejected because it would allow false success reporting.
+  - Trust provider completion alone: rejected because provider success does not guarantee the requested branch outcome landed.
+
+## Decision 5: Use artifact-backed bundle manifests instead of inflating workflow payloads
+
+- **Decision**: Persist bundle manifest details in artifact-backed metadata and carry compact identifiers/refs in workflow results.
+- **Rationale**: This preserves auditability and bundle explanation without bloating workflow history or violating compact-payload guidance.
+- **Alternatives considered**:
+  - Store the full compiled brief and checklist inline in workflow state: rejected because it increases history size and replay risk.
+  - Omit bundle metadata entirely: rejected because operators need traceability from bundle results back to logical plan nodes.
+
+## Decision 6: Anchor verification in workflow-boundary tests
+
+- **Decision**: Update workflow-level tests first-class, including replay-sensitive control-flow coverage for changed branching behavior.
+- **Rationale**: Bundling, branch publication, and clarification exception handling all cross module boundaries and can affect in-flight workflow histories.
+- **Alternatives considered**:
+  - Rely only on adapter/client unit tests: rejected because they would miss orchestration regressions.

--- a/specs/105-jules-provider-adapter/spec.md
+++ b/specs/105-jules-provider-adapter/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Jules Provider Adapter Runtime Alignment
+
+**Feature Branch**: `105-jules-provider-adapter`  
+**Created**: 2026-03-27  
+**Status**: Draft  
+**Input**: User description: "Implement the updated Jules Provider Adapter docs/ExternalAgents/JulesAdapter.md"
+
+## Source Document Requirements
+
+Extracted from `docs/ExternalAgents/JulesAdapter.md`:
+
+| Requirement ID | Source Citation | Requirement Summary |
+|---|---|---|
+| DOC-REQ-001 | §3.2, §4.2 | Jules transport must remain a thin provider client that owns schema mapping, auth, retry policy, and scrubbed failures without absorbing workflow orchestration semantics. |
+| DOC-REQ-002 | §3.3, §5.1 | Jules must plug into the shared external-agent boundary through the shared adapter contract and translate request, status, result, and cancel semantics through that contract. |
+| DOC-REQ-003 | §3.3, §6.3 | When Jules publish mode is `pr` or `branch`, MoonMind must start Jules with `automationMode = AUTO_CREATE_PR`. |
+| DOC-REQ-004 | §6.2, §6.3, §6.4 | For `publishMode == "branch"`, MoonMind must treat PR URL extraction, optional base-branch retargeting, and merge completion as part of successful completion semantics. |
+| DOC-REQ-005 | §6.4, §7.11 | If PR extraction, base update, merge, or post-provider verification fails, MoonMind must not report branch publication as successful. |
+| DOC-REQ-006 | §7.2, §7.4 | Multi-step Jules work must execute as one bundled Jules execution node and one provider session rather than step-by-step session reuse. |
+| DOC-REQ-007 | §7.4, §7.6, §7.7 | MoonMind must compile bundled Jules work into one consolidated, checklist-shaped execution brief with mission, workspace context, execution rules, ordered work, validation, and deliverable requirements. |
+| DOC-REQ-008 | §7.9, §7.10 | Bundle metadata must preserve the represented logical node IDs, bundle identity, and idempotency/correlation context so auditability survives bundling. |
+| DOC-REQ-009 | §7.11, §10.4 | `sendMessage` must remain available for clarification, operator intervention, and explicit resume flows, but not as the normal multi-step workflow progression path. |
+| DOC-REQ-010 | §7.11, §12 | If Jules reports success but leaves bundled checklist items incomplete, MoonMind must surface that incomplete state truthfully in result handling rather than silently treating the whole bundle as complete. |
+| DOC-REQ-011 | §7.11, §11 | MoonMind-owned verification and publication checks must be able to override provider-reported success when the requested outcome was not actually achieved. |
+| DOC-REQ-012 | §3.4, §7.9, §10.1 | Generic workflow orchestration for Jules must live in MoonMind workflow layers, with clarification auto-answer staying in `MoonMind.AgentRun` rather than moving transport logic into provider-specific code. |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - One-Shot Bundled Jules Execution (Priority: P1)
+
+A workflow designer wants MoonMind to hand Jules one coherent repo task instead of a brittle chain of follow-up messages, so that Jules plans and executes the whole change in one stable session.
+
+**Why this priority**: This is the primary architecture change in the updated design and removes the biggest reliability risk in the current Jules execution path.
+
+**Independent Test**: Can be fully tested by executing a plan with multiple consecutive Jules-targeted nodes and verifying MoonMind dispatches one bundled Jules run with one consolidated brief and one result boundary.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plan contains multiple consecutive Jules-targeted implementation nodes in the same repo and publish context, **When** MoonMind prepares execution, **Then** it bundles that work into one Jules execution node and starts exactly one Jules session for the bundle.
+2. **Given** a bundled Jules run is created, **When** the provider request is sent, **Then** the request includes one consolidated checklist-shaped brief and bundle metadata that preserves the original represented node IDs for auditability.
+
+---
+
+### User Story 2 - Truthful Branch Publication (Priority: P1)
+
+An operator chooses Jules with `publishMode: "branch"` and expects MoonMind to report success only if the changes actually land on the requested target branch rather than merely creating a PR.
+
+**Why this priority**: Branch publication semantics are operator-visible and billing-relevant; falsely reporting success would violate the documented contract and create hidden delivery failures.
+
+**Independent Test**: Can be fully tested by driving a Jules branch-publication flow through workflow boundary tests that cover successful merge, missing PR URL, base-update failure, and merge rejection outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Jules run completes with `publishMode: "branch"` and a target branch different from the starting branch, **When** MoonMind finalizes the run, **Then** it retargets the PR base if needed, merges the PR, and reports branch publication as successful only after those steps succeed.
+2. **Given** a Jules branch-publication run cannot produce a PR URL or the merge path fails, **When** MoonMind finalizes the run, **Then** it returns a MoonMind-owned non-success outcome instead of claiming the requested branch publication completed.
+
+---
+
+### User Story 3 - Clarification-Only Follow-Up Messaging (Priority: P2)
+
+An operator still needs Jules clarification handling and auto-answer support, but wants follow-up provider messages reserved for exception flows instead of being the normal way MoonMind advances multi-step work.
+
+**Why this priority**: The updated design explicitly keeps clarification support while removing the brittle step-to-step progression model.
+
+**Independent Test**: Can be tested by verifying normal bundled Jules execution never uses the continuation path, while clarification and explicit resume flows still use `sendMessage` safely.
+
+**Acceptance Scenarios**:
+
+1. **Given** MoonMind is executing standard bundled Jules work, **When** later logical plan items in that bundle are reached, **Then** MoonMind does not reuse a previous Jules session through normal step-progression follow-up messages.
+2. **Given** Jules explicitly asks for clarification or an operator resumes a blocked run, **When** MoonMind responds, **Then** it may still use the follow-up messaging path without reviving normal multi-step session chaining.
+
+---
+
+### User Story 4 - Truthful Bundle Results and Verification (Priority: P2)
+
+An operator reviewing a completed Jules-backed run wants MoonMind to show whether the entire bundled checklist actually finished, including any incomplete items or MoonMind verification failures that should prevent a success claim.
+
+**Why this priority**: Bundling only works safely if the system preserves truthful completion semantics instead of hiding partial provider completion behind a generic success state.
+
+**Independent Test**: Can be tested by simulating a Jules result that omits required checklist outcomes and verifying MoonMind surfaces incomplete or failed completion details in bundle result handling.
+
+**Acceptance Scenarios**:
+
+1. **Given** Jules returns a provider-success state but MoonMind verification detects incomplete bundled checklist outcomes, **When** the run result is assembled, **Then** MoonMind records the run as incomplete or failed according to policy instead of silently reporting full success.
+
+### Edge Cases
+
+- What happens when a bundled Jules brief exceeds safe provider limits? MoonMind should fail early or deterministically split the work into multiple bundle nodes rather than silently truncating the brief.
+- What happens when only some consecutive Jules nodes are safe to bundle together? MoonMind should create multiple deterministic Jules bundle nodes instead of reviving step-by-step continuation.
+- What happens when Jules reports success but MoonMind cannot extract a PR URL for `publishMode: "branch"`? The run must not be reported as successful branch publication.
+- What happens when a clarification cycle occurs during a bundled run? The clarification path may use follow-up messaging, but normal task progression must still remain bundle-driven rather than step-driven.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001** (DOC-REQ-006, DOC-REQ-007): System MUST bundle eligible consecutive Jules-targeted plan work into one execution node and one provider session rather than executing standard multi-step Jules progression through session reuse.
+- **FR-002** (DOC-REQ-007): System MUST compile each bundled Jules execution into one consolidated brief that includes mission, repository/workspace context, execution rules, ordered work checklist, validation checklist, and deliverable requirements.
+- **FR-003** (DOC-REQ-008): System MUST persist bundle metadata that identifies the bundle, the represented logical node IDs, the bundle manifest reference, the bundle strategy, and the correlation/idempotency context used for that bundled run.
+- **FR-004** (DOC-REQ-009, DOC-REQ-012): System MUST remove normal workflow progression through `jules_session_id` or equivalent step-chaining state while preserving follow-up messaging only for clarification, intervention, or explicit resume flows.
+- **FR-005** (DOC-REQ-001, DOC-REQ-002, DOC-REQ-012): System MUST keep Jules transport and provider adapter responsibilities separated from workflow orchestration so transport remains thin and the shared adapter contract remains the Jules integration boundary.
+- **FR-006** (DOC-REQ-003): System MUST request Jules PR automation automatically whenever the requested publish mode is `pr` or `branch`.
+- **FR-007** (DOC-REQ-004, DOC-REQ-005): System MUST treat `publishMode: "branch"` as successful only when MoonMind can extract the Jules-created PR, optionally retarget its base branch, merge it, and confirm the requested branch outcome.
+- **FR-008** (DOC-REQ-005, DOC-REQ-011): System MUST map missing PR URLs, base-update failures, merge failures, or post-provider verification failures to MoonMind-owned non-success outcomes instead of reporting successful branch publication.
+- **FR-009** (DOC-REQ-010, DOC-REQ-011): System MUST surface incomplete bundled checklist completion or verification mismatches in final result summaries and metadata rather than treating all provider-reported completions as fully successful.
+- **FR-010** (DOC-REQ-012): System MUST keep Jules clarification auto-answer behavior in the generic `MoonMind.AgentRun` workflow path and must not move that workflow choreography into Jules transport code.
+- **FR-011** (DOC-REQ-003, DOC-REQ-004): System MUST preserve existing Jules adapter/request translation behavior needed for provider start, status, result, and truthful cancel/best-effort cancel semantics while applying the updated publish and bundling rules.
+- **FR-012** (DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-009, DOC-REQ-010, DOC-REQ-011): System MUST add or update workflow-boundary regression coverage for bundle dispatch, clarification exception handling, bundle-result truthfulness, and branch publication outcomes.
+
+### Key Entities *(include if feature involves data)*
+
+- **Jules Bundle Node**: The synthetic execution node that represents one or more logical Jules-targeted plan nodes as one provider run.
+- **Jules Bundle Manifest**: The durable metadata record that explains which logical nodes were bundled, how the one-shot brief was assembled, and what verification expectations apply.
+- **Bundle Result Summary**: The MoonMind-owned completion record that combines provider status, publication outcome, verification outcome, and incomplete-checklist reporting for one bundled Jules run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Workflow tests covering consecutive Jules plan nodes show one bundled child execution and one provider session instead of step-by-step `sendMessage` progression.
+- **SC-002**: Workflow tests for `publishMode: "branch"` pass for successful merge, missing PR URL, base-retarget failure, and merge rejection scenarios with truthful final statuses.
+- **SC-003**: Normal bundled Jules execution paths contain no continuation-state handoff equivalent to `jules_session_id`, while clarification-only follow-up messaging coverage still passes.
+- **SC-004**: Bundle result metadata and summaries expose incomplete bundled checklist outcomes or verification failures in automated tests rather than reporting unconditional success.
+- **SC-005**: Updated Jules adapter/workflow tests pass through the repo’s standard unit test path for the touched runtime and workflow files.
+
+## Assumptions
+
+- Consecutive Jules-targeted plan nodes can be identified deterministically from existing plan-node runtime metadata without changing the external plan artifact contract.
+- Existing clarification and auto-answer behavior remains valid as an exception path and should be preserved unless it conflicts with the updated one-shot execution rules.
+- Existing Jules transport, schema, and runtime gate pieces are largely reusable; the primary work is in orchestration, bundle metadata, truthful result handling, and regression coverage.

--- a/specs/105-jules-provider-adapter/tasks.md
+++ b/specs/105-jules-provider-adapter/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: Jules Provider Adapter Runtime Alignment
+
+**Input**: Design documents from `/specs/105-jules-provider-adapter/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Workflow-boundary and unit tests are required because this feature changes Temporal orchestration behavior, result semantics, and provider-to-workflow contracts.
+
+**Organization**: Tasks are grouped by user story to keep bundled execution, truthful publication, and clarification-only follow-up behavior independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish the bundle contract and test baseline for runtime changes.
+
+- [ ] T001 Capture/update Jules workflow test fixtures in `tests/unit/workflows/temporal/workflows/test_run_integration.py` and `tests/unit/workflows/temporal/test_jules_activities.py` so the implementation can replace step-chained expectations deterministically (supports DOC-REQ-006, DOC-REQ-007, DOC-REQ-009, DOC-REQ-012)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared runtime structures needed before any user-story-specific orchestration work.
+
+- [X] T002 Create `moonmind/workflows/temporal/jules_bundle.py` with deterministic bundle eligibility, one-shot brief compilation, and manifest metadata helpers for `DOC-REQ-006`, `DOC-REQ-007`, and `DOC-REQ-008`
+- [X] T003 Update `moonmind/workflows/temporal/worker_runtime.py` so Jules-related step planning preserves bundle-friendly metadata instead of assuming normal `jules_session_id` step chaining for `DOC-REQ-006` and `DOC-REQ-007`
+
+**Checkpoint**: Bundle helpers and planner-side metadata are ready for workflow execution changes.
+
+---
+
+## Phase 3: User Story 1 - One-Shot Bundled Jules Execution (Priority: P1) 🎯 MVP
+
+**Goal**: Consecutive Jules-targeted work executes as one synthetic bundle node and one provider session with a checklist-shaped brief.
+
+**Independent Test**: A plan with multiple consecutive Jules nodes produces one bundled execution request, one provider session, preserved bundle metadata, and no normal continuation session handoff.
+
+### Tests for User Story 1
+
+- [X] T004 [P] [US1] Replace the current multi-step send-message workflow expectations in `tests/unit/workflows/temporal/workflows/test_run_integration.py` with one-shot bundle dispatch assertions covering `DOC-REQ-006`, `DOC-REQ-007`, and `DOC-REQ-008`
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update `moonmind/workflows/temporal/workflows/run.py` to collapse consecutive Jules `agent_runtime` nodes into a synthetic bundled execution that uses `moonmind/workflows/temporal/jules_bundle.py` for `DOC-REQ-006`, `DOC-REQ-007`, and `DOC-REQ-008`
+- [X] T006 [US1] Update `moonmind/workflows/temporal/workflows/agent_run.py` to remove normal `jules_session_id` continuation handling for bundled execution while retaining compact bundle result metadata for `DOC-REQ-008`, `DOC-REQ-009`, and `DOC-REQ-012`
+
+**Checkpoint**: Standard Jules execution is bundle-first and no longer relies on normal step-to-step provider follow-up messages.
+
+---
+
+## Phase 4: User Story 2 - Truthful Branch Publication (Priority: P1)
+
+**Goal**: `publishMode: "branch"` succeeds only when MoonMind can prove the requested PR/merge outcome actually landed on the target branch.
+
+**Independent Test**: Workflow and activity tests cover successful merge, missing PR URL, base-update failure, merge rejection, and verification-failure paths with truthful final statuses.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Add workflow-boundary failure-path coverage in `tests/unit/workflows/temporal/workflows/test_run_integration.py` and `tests/unit/workflows/temporal/test_run_artifacts.py` for `DOC-REQ-004`, `DOC-REQ-005`, `DOC-REQ-010`, and `DOC-REQ-011`
+- [X] T008 [P] [US2] Extend `tests/unit/workflows/temporal/test_jules_merge_pr.py` and `tests/unit/workflows/temporal/test_jules_activities.py` to validate AUTO_CREATE_PR, base retargeting, merge failure handling, and explicit non-success mapping for `DOC-REQ-003`, `DOC-REQ-004`, and `DOC-REQ-005`
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Update `moonmind/workflows/temporal/workflows/run.py` so branch-publication success requires PR extraction, optional base retarget, merge completion, and verification-aware failure mapping for `DOC-REQ-004`, `DOC-REQ-005`, `DOC-REQ-010`, and `DOC-REQ-011`
+- [X] T010 [US2] Update `moonmind/workflows/temporal/activities/jules_activities.py` and `moonmind/workflows/adapters/jules_agent_adapter.py` so Jules start/publish metadata preserves AUTO_CREATE_PR behavior and returns explicit branch-publication failure details for `DOC-REQ-001`, `DOC-REQ-002`, `DOC-REQ-003`, `DOC-REQ-004`, `DOC-REQ-005`, and `DOC-REQ-011`
+
+**Checkpoint**: Branch publication outcomes are MoonMind-owned and truthful.
+
+---
+
+## Phase 5: User Story 3 - Clarification-Only Follow-Up Messaging (Priority: P2)
+
+**Goal**: `sendMessage` stays available for clarification/intervention/resume flows without being the standard progression mechanism for bundled Jules execution.
+
+**Independent Test**: Normal bundled runs never call `integration.jules.send_message`, while clarification/auto-answer flows still do.
+
+### Tests for User Story 3
+
+- [X] T011 [P] [US3] Update clarification/resume-path tests in `tests/unit/workflows/temporal/test_jules_activities.py` and `tests/unit/workflows/temporal/workflows/test_run_integration.py` so only exception flows invoke `integration.jules.send_message` for `DOC-REQ-009` and `DOC-REQ-012`
+
+### Implementation for User Story 3
+
+- [X] T012 [US3] Refine `moonmind/workflows/temporal/workflows/agent_run.py` and `moonmind/workflows/temporal/activities/jules_activities.py` so clarification auto-answer remains the valid `sendMessage` path while bundled execution cannot route normal work through it for `DOC-REQ-009` and `DOC-REQ-012`
+
+**Checkpoint**: Clarification still works, but normal multi-step chaining is gone.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish regression coverage, remove obsolete test assumptions, and validate the full runtime diff.
+
+- [X] T013 [P] Update `tests/integration/test_jules_integration.py` to replace or retire the obsolete real-provider multi-step `sendMessage` lifecycle expectation in favor of one-shot bundled execution coverage for `DOC-REQ-006` and `DOC-REQ-009`
+- [X] T014 [P] Run `./tools/test_unit.sh` and fix any workflow/adapter regressions introduced across `moonmind/workflows/temporal/` and `tests/unit/workflows/temporal/` to validate all `DOC-REQ-*`
+- [X] T015 [P] Run `bash ".specify/scripts/bash/validate-implementation-scope.sh" --check diff --mode runtime --base-ref origin/main` and confirm the final diff includes runtime changes under `moonmind/` plus test coverage under `tests/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1**: Starts immediately.
+- **Phase 2**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3**: Depends on Phase 2.
+- **Phase 4**: Depends on Phase 3 because truthful publish handling consumes bundle/result semantics.
+- **Phase 5**: Depends on Phase 3 and can overlap Phase 4 after bundle-first execution exists.
+- **Phase 6**: Depends on all implementation phases being complete.
+
+### User Story Dependencies
+
+- **US1**: No dependency on later stories; it is the MVP.
+- **US2**: Depends on US1 bundle/result behavior.
+- **US3**: Depends on US1 removal of normal session chaining.
+
+### Within Each User Story
+
+- Tests should fail against the old multi-step behavior before the new runtime logic is finished.
+- Workflow/orchestration changes should land before cleanup of obsolete integration expectations.
+- Final validation must use the repo’s canonical unit-test and scope-validation commands.
+
+### Parallel Opportunities
+
+- `T004`, `T007`, `T008`, and `T011` can be developed in parallel once foundational work is ready.
+- `T009` and `T012` can proceed in parallel after `T005`/`T006`.
+- `T013`, `T014`, and `T015` are parallelizable after implementation stabilizes.
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add workflow-boundary failure-path coverage in tests/unit/workflows/temporal/workflows/test_run_integration.py and tests/unit/workflows/temporal/test_run_artifacts.py"
+Task: "Extend tests/unit/workflows/temporal/test_jules_merge_pr.py and tests/unit/workflows/temporal/test_jules_activities.py for AUTO_CREATE_PR and merge failure handling"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational phases.
+2. Finish US1 so standard Jules execution is bundle-first.
+3. Validate that normal `sendMessage` progression is gone before moving on.
+
+### Incremental Delivery
+
+1. Bundle consecutive Jules work into one execution node.
+2. Make branch publication truthful and verification-aware.
+3. Preserve clarification-only follow-up messaging.
+4. Replace obsolete integration expectations and run full validation.
+
+### Notes
+
+- Every `DOC-REQ-*` is covered by at least one implementation task and at least one validation task.
+- Runtime scope minimums are satisfied by `moonmind/workflows/temporal/` changes plus test tasks under `tests/`.
+- Do not reintroduce a hidden compatibility path for standard multi-step Jules session chaining.

--- a/tests/integration/test_jules_integration.py
+++ b/tests/integration/test_jules_integration.py
@@ -1,4 +1,4 @@
-"""Integration test: real Jules API multi-step lifecycle via sendMessage.
+"""Integration test: real Jules API one-shot bundled lifecycle.
 
 Requires ``JULES_API_KEY`` in the environment (or ``.env``).
 Skipped automatically when the key is absent.
@@ -7,10 +7,10 @@ Run manually::
 
     python -m pytest tests/integration/test_jules_integration.py -v -s
 
-This test creates a Jules session with a trivial prompt, polls until the
-session reaches a terminal state (``completed``), then sends a second
-prompt via ``sendMessage`` and polls again.  Both steps must reach a
-terminal state for the test to pass.
+This test creates one Jules session with a checklist-shaped prompt and
+polls until the session reaches a terminal state (``completed``). It is a
+smoke test for the bundled one-shot execution path and intentionally does
+not exercise normal multi-step ``sendMessage`` progression.
 
 **WARNING**: This test creates real Jules sessions against the configured
 repository and will consume Jules task quota.  Each session may create a
@@ -70,17 +70,13 @@ def _build_adapter() -> JulesAgentAdapter:
     return JulesAgentAdapter(client_factory=lambda: client)
 
 
-def _step1_request() -> AgentExecutionRequest:
-    """Build a minimal request that should provoke the fastest Jules completion.
-
-    The prompt is intentionally trivial — we just want Jules to finish ASAP
-    so we can exercise the sendMessage → poll cycle.
-    """
-    correlation_id = f"multi-step-test-{uuid.uuid4().hex[:8]}"
+def _bundled_request() -> AgentExecutionRequest:
+    """Build one checklist-shaped request for the bundled Jules smoke test."""
+    correlation_id = f"bundle-test-{uuid.uuid4().hex[:8]}"
     return AgentExecutionRequest(
         agentKind="external",
         agentId="jules",
-        executionProfileRef="profile:jules-multistep-integ-test",
+        executionProfileRef="profile:jules-bundle-integ-test",
         correlationId=correlation_id,
         idempotencyKey=f"idem-{correlation_id}",
         workspaceSpec={
@@ -88,14 +84,18 @@ def _step1_request() -> AgentExecutionRequest:
             "branch": "main",
         },
         parameters={
-            "title": "[Integration Test] Multi-step lifecycle check",
+            "title": "[Integration Test] Bundled lifecycle check",
             "description": (
-                "Add a single-line comment '# MoonMind integration test' "
-                "to the very top of README.md. Do not change anything else. "
-                "Do not run any tests."
+                "You are implementing one cohesive bundled change.\n\n"
+                "Ordered Checklist:\n"
+                "1. Add a single-line comment '# MoonMind integration test' to the very top of README.md.\n"
+                "2. Add a second line '# Bundled integration step 2' directly below it.\n\n"
+                "Validation Checklist:\n"
+                "- Do not run tests.\n"
+                "- Do not change anything else."
             ),
             "metadata": {
-                "origin": "multi-step-integration-test",
+                "origin": "bundled-integration-test",
                 "repo": "MoonLadderStudios/MoonMind",
             },
         },
@@ -135,31 +135,16 @@ async def _poll_until_terminal(
 
 
 class TestJulesAdapterLifecycle:
-    """End-to-end multi-step lifecycle: start → poll → sendMessage → poll.
+    """End-to-end bundled lifecycle: start one task, poll, then fetch result."""
 
-    A single test covers the full adapter surface (start, status,
-    sendMessage, cancel) using one real Jules session to minimise quota
-    usage.
-    """
-
-    async def test_two_step_send_message_flow(self) -> None:
-        """Create a Jules task, wait for completion, send step 2, wait again.
-
-        This validates that:
-        1. A session can be created and polled to completion.
-        2. ``sendMessage`` can resume the session with a new prompt.
-        3. The resumed session can be polled to completion.
-        4. The session ID remains stable across both steps.
-        """
+    async def test_one_shot_bundled_flow(self) -> None:
+        """Create a bundled Jules task and wait for terminal completion."""
         adapter = _build_adapter()
-        request = _step1_request()
+        request = _bundled_request()
         created_run_id: str | None = None
 
         try:
-            # ============================================================
-            # STEP 1: Create session and poll until done
-            # ============================================================
-            logger.info("=== STEP 1: Creating Jules session ===")
+            logger.info("=== BUNDLED RUN: Creating Jules session ===")
             handle: AgentRunHandle = await adapter.start(request)
             created_run_id = handle.run_id
 
@@ -179,50 +164,20 @@ class TestJulesAdapterLifecycle:
                 "poll_hint_seconds should be auto-populated from capability descriptor"
             )
 
-            step1_result = await _poll_until_terminal(
-                adapter, handle.run_id, step_label="step-1"
+            bundled_result = await _poll_until_terminal(
+                adapter, handle.run_id, step_label="bundled-run"
             )
             logger.info(
-                "=== STEP 1 COMPLETE: status=%s ===", step1_result.status
+                "=== BUNDLED RUN COMPLETE: status=%s ===", bundled_result.status
             )
-            assert step1_result.status == "completed", (
-                f"Step 1 ended with status={step1_result.status}, expected completed"
+            assert bundled_result.status == "completed", (
+                f"Bundled run ended with status={bundled_result.status}, expected completed"
             )
-
-            # ============================================================
-            # STEP 2: Send follow-up message and poll until done
-            # ============================================================
-            logger.info("=== STEP 2: Sending follow-up via sendMessage ===")
-
-            step2_prompt = (
-                "Now add a second comment line '# Multi-step test step 2' "
-                "directly below the line you just added. "
-                "Do not change anything else. Do not run any tests."
-            )
-
-            await adapter.send_message(
-                run_id=handle.run_id, prompt=step2_prompt
-            )
-            logger.info("sendMessage accepted — polling for step 2 completion")
-
-            step2_result = await _poll_until_terminal(
-                adapter, handle.run_id, step_label="step-2"
-            )
-            logger.info(
-                "=== STEP 2 COMPLETE: status=%s ===", step2_result.status
-            )
-            assert step2_result.status == "completed", (
-                f"Step 2 ended with status={step2_result.status}, expected completed"
-            )
-
-            # ---- Verify session ID stability ----
-            assert step2_result.run_id == handle.run_id, (
-                "Session ID must remain stable across steps"
-            )
+            final_result = await adapter.fetch_result(handle.run_id)
+            assert final_result.failure_class is None
 
             logger.info(
-                "✅ Multi-step integration test PASSED — session %s "
-                "completed both steps successfully.",
+                "✅ Bundled integration test PASSED — session %s completed successfully.",
                 handle.run_id,
             )
 

--- a/tests/unit/workflows/adapters/test_jules_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_jules_agent_adapter.py
@@ -270,11 +270,13 @@ async def test_start_defaults_automation_mode_for_branch_publish():
         parameters={"description": "foo", "publishMode": "branch"},
     )
 
-    await adapter.start(req)
+    handle = await adapter.start(req)
 
     assert len(client.created) == 1
     create_req = client.created[0]
     assert create_req.automation_mode == "AUTO_CREATE_PR"
+    assert handle.metadata["automationMode"] == "AUTO_CREATE_PR"
+    assert handle.metadata["publishMode"] == "branch"
 
 
 async def test_send_message_returns_running_status():

--- a/tests/unit/workflows/temporal/test_jules_activities.py
+++ b/tests/unit/workflows/temporal/test_jules_activities.py
@@ -186,6 +186,78 @@ async def test_jules_send_message_activity_calls_adapter(_patch_build_adapter):
     )
 
 
+async def test_repo_merge_pr_activity_updates_base_before_merge():
+    from moonmind.workflows.temporal.activities.jules_activities import (
+        repo_merge_pr_activity,
+    )
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.GitHubService"
+    ) as mock_service_cls:
+        service = mock_service_cls.return_value
+        service.update_pull_request_base = AsyncMock(
+            return_value=(True, "Base updated to main")
+        )
+        service.merge_pull_request = AsyncMock(
+            return_value=type(
+                "MergeResult",
+                (),
+                {
+                    "model_dump": lambda self, by_alias=True: {
+                        "prUrl": "https://github.com/org/repo/pull/123",
+                        "merged": True,
+                        "mergeSha": "abc123",
+                        "summary": "Merged successfully",
+                    }
+                },
+            )()
+        )
+
+        result = await repo_merge_pr_activity(
+            {
+                "pr_url": "https://github.com/org/repo/pull/123",
+                "target_branch": "main",
+            }
+        )
+
+    service.update_pull_request_base.assert_awaited_once_with(
+        pr_url="https://github.com/org/repo/pull/123",
+        new_base="main",
+    )
+    service.merge_pull_request.assert_awaited_once_with(
+        pr_url="https://github.com/org/repo/pull/123",
+        merge_method="merge",
+    )
+    assert result["merged"] is True
+    assert result["mergeSha"] == "abc123"
+
+
+async def test_repo_merge_pr_activity_returns_non_success_when_base_update_fails():
+    from moonmind.workflows.temporal.activities.jules_activities import (
+        repo_merge_pr_activity,
+    )
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.GitHubService"
+    ) as mock_service_cls:
+        service = mock_service_cls.return_value
+        service.update_pull_request_base = AsyncMock(
+            return_value=(False, "Target branch does not exist")
+        )
+        service.merge_pull_request = AsyncMock()
+
+        result = await repo_merge_pr_activity(
+            {
+                "pr_url": "https://github.com/org/repo/pull/123",
+                "target_branch": "main",
+            }
+        )
+
+    service.merge_pull_request.assert_not_awaited()
+    assert result["merged"] is False
+    assert "Base branch update failed" in result["summary"]
+
+
 # --- T019: integration.jules.list_activities tests ---
 
 

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -295,6 +295,39 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
     assert captured[2][1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 
+def test_build_agent_execution_request_includes_bundle_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+
+    request = workflow._build_agent_execution_request(
+        node_inputs={
+            "instructions": "Bundled work",
+            "repository": "org/repo",
+            "startingBranch": "main",
+            "publishMode": "branch",
+            "bundleId": "bundle-1",
+            "bundledNodeIds": ["node-1", "node-2"],
+            "bundleManifestRef": "artifact://bundle/1",
+            "bundleStrategy": "one_shot_jules",
+        },
+        node_id="bundle-1",
+        tool_name="jules",
+    )
+
+    moonmind_meta = request.parameters["metadata"]["moonmind"]
+    assert moonmind_meta["bundleId"] == "bundle-1"
+    assert moonmind_meta["bundledNodeIds"] == ["node-1", "node-2"]
+    assert moonmind_meta["bundleManifestRef"] == "artifact://bundle/1"
+    assert moonmind_meta["bundleStrategy"] == "one_shot_jules"
+
+
 @pytest.mark.asyncio
 async def test_run_execution_stage_fail_fast_raises_when_tool_returns_failed_status(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _request(**overrides: Any) -> AgentExecutionRequest:
+    payload = {
+        "agentKind": "external",
+        "agentId": "jules",
+        "executionProfileRef": "profile:jules-default",
+        "correlationId": "corr-1",
+        "idempotencyKey": "idem-1",
+        "instructionRef": "Implement the requested change.",
+        "workspaceSpec": {"startingBranch": "feature-branch"},
+        "parameters": {"publishMode": "none"},
+    }
+    payload.update(overrides)
+    return AgentExecutionRequest(**payload)
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-agent-run-1",
+            "run_id": "run-1",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+
+
+async def test_agent_run_jules_starts_new_run_instead_of_continuation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    async def fake_execute_activity(
+        activity: object,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity == agent_run_module.resolve_external_adapter:
+            return "jules"
+        if activity == agent_run_module.external_adapter_execution_style:
+            return "polling"
+        raise AssertionError(f"Unexpected workflow.execute_activity call: {activity!r}")
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_activity_with_routing(
+        activity_name: str,
+        payload: Any,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "integration.jules.start":
+            return {"external_id": "new-session-1", "status": "queued"}
+        if activity_name == "integration.jules.status":
+            return {"normalized_status": "completed"}
+        if activity_name == "integration.jules.fetch_result":
+            return {"summary": "Done", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_activity_with_routing", fake_execute_activity_with_routing)
+    monkeypatch.setattr(
+        run,
+        "_get_route_info",
+        lambda *_args, **_kwargs: asyncio.sleep(
+            0,
+            result=(
+                "test-queue",
+                timedelta(seconds=30),
+                timedelta(seconds=30),
+                None,
+                None,
+            ),
+        ),
+    )
+
+    result = await run.run(
+        _request(
+            parameters={
+                "publishMode": "none",
+                "jules_session_id": "legacy-session-42",
+            }
+        )
+    )
+
+    assert routed_calls[0][0] == "integration.jules.start"
+    assert all(name != "integration.jules.send_message" for name, _ in routed_calls)
+    assert run.run_id == "new-session-1"
+    assert result.failure_class is None
+
+
+async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    async def fake_execute_activity(
+        activity: object,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity == agent_run_module.resolve_external_adapter:
+            return "jules"
+        if activity == agent_run_module.external_adapter_execution_style:
+            return "polling"
+        raise AssertionError(f"Unexpected workflow.execute_activity call: {activity!r}")
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_activity_with_routing(
+        activity_name: str,
+        payload: Any,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "integration.jules.start":
+            return {"external_id": "session-1", "status": "queued"}
+        if activity_name == "integration.jules.status":
+            return {"normalized_status": "completed"}
+        if activity_name == "integration.jules.fetch_result":
+            return {
+                "summary": "Provider reported success.",
+                "metadata": {
+                    "pullRequestUrl": "https://github.com/org/repo/pull/123",
+                },
+            }
+        if activity_name == "repo.merge_pr":
+            return {"merged": False, "summary": "Merge rejected"}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_activity_with_routing", fake_execute_activity_with_routing)
+    monkeypatch.setattr(
+        run,
+        "_get_route_info",
+        lambda *_args, **_kwargs: asyncio.sleep(
+            0,
+            result=(
+                "test-queue",
+                timedelta(seconds=30),
+                timedelta(seconds=30),
+                None,
+                None,
+            ),
+        ),
+    )
+
+    result = await run.run(
+        _request(
+            workspaceSpec={"startingBranch": "feature-branch", "targetBranch": "main"},
+            parameters={"publishMode": "branch", "targetBranch": "main"},
+        )
+    )
+
+    assert any(name == "repo.merge_pr" for name, _ in routed_calls)
+    merge_payload = next(payload for name, payload in routed_calls if name == "repo.merge_pr")
+    assert merge_payload == {
+        "pr_url": "https://github.com/org/repo/pull/123",
+        "target_branch": "main",
+    }
+    assert result.failure_class == "execution_error"
+    assert result.provider_error_code == "branch_publish_failed"
+    assert result.metadata["publishOutcome"] == "publish_failed"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -502,11 +502,15 @@ async def test_run_integration_stage_multi_step_bundles_into_single_start(
             return {"normalized_status": "completed"}
         return {}
 
-    async def fake_wait_condition(cond: Callable[[], bool], timeout: timedelta) -> None:
+    def fake_wait_condition(cond: Callable[[], bool], timeout: timedelta) -> None:
         raise asyncio.TimeoutError()
+
+    def fake_patched(patch_id: str) -> bool:
+        return True
 
     monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
     monkeypatch.setattr(run_workflow_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
 
     await mock_run_workflow._run_integration_stage(
         parameters={"repo": "org/repo"},

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -180,6 +180,116 @@ async def test_run_integration_legacy_unpatched_poll_completion_still_completes(
 
 
 @pytest.mark.asyncio
+async def test_run_execution_stage_bundles_consecutive_jules_nodes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "org/repo"
+    workflow._title = "Bundled Jules execution"
+
+    child_calls: list[object] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            if payload.get("artifact_ref") == "art:sha256:456":
+                import json
+
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "repo.run_tests",
+                                "version": "1.0.0",
+                                "description": "Run tests",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.skill.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 3},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return _mock_plan_payload(
+                nodes=[
+                    {
+                        "id": "jules-step-1",
+                        "tool": {"type": "agent_runtime", "name": "jules", "version": "1.0"},
+                        "inputs": {
+                            "repository": "org/repo",
+                            "startingBranch": "main",
+                            "publishMode": "none",
+                            "instructions": "Step 1",
+                        },
+                    },
+                    {
+                        "id": "jules-step-2",
+                        "tool": {"type": "agent_runtime", "name": "jules", "version": "1.0"},
+                        "inputs": {
+                            "repository": "org/repo",
+                            "startingBranch": "main",
+                            "publishMode": "none",
+                            "instructions": "Step 2",
+                        },
+                    },
+                ]
+            )
+        if activity_type == "artifact.create":
+            return ({"artifact_id": "artifact://bundle/1"}, {"upload_url": "unused"})
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: Any,
+    ) -> object:
+        child_calls.append(args)
+        return {"summary": "Bundled run complete", "metadata": {}, "output_refs": []}
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_search_attributes", lambda _attributes: None)
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "org/repo", "publishMode": "none"},
+        plan_ref="plan-1",
+    )
+
+    assert len(child_calls) == 1
+    request = child_calls[0]
+    assert "Ordered Checklist:" in request.instruction_ref
+    assert "1. Step 1" in request.instruction_ref
+    assert "2. Step 2" in request.instruction_ref
+    assert request.parameters["metadata"]["moonmind"]["bundleManifestRef"] == "artifact://bundle/1"
+    assert request.parameters["metadata"]["moonmind"]["bundleStrategy"] == "one_shot_jules"
+
+
+@pytest.mark.asyncio
 async def test_run_integration_stage_signal_driven_completion(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
@@ -278,7 +388,87 @@ async def test_run_integration_stage_branch_publish_auto_merge_after_signal(
 
 
 @pytest.mark.asyncio
-async def test_run_integration_stage_multi_step_sends_messages(
+async def test_run_integration_stage_branch_publish_requires_pr_url(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_type == "artifact.read":
+            return _mock_plan_payload(
+                [{"id": "1", "tool": {"type": "skill", "name": "t", "version": "1.0"}, "inputs": {"instructions": "Do something"}}]
+            )
+        if activity_type == "integration.jules.start":
+            return {"external_id": "ext-1"}
+        if activity_type == "integration.jules.fetch_result":
+            return {"summary": "Done"}
+        return {}
+
+    async def fake_wait_condition(cond: Callable[[], bool], timeout: timedelta) -> None:
+        mock_run_workflow.external_event(
+            {"correlation_id": "ext-1", "normalized_status": "completed"}
+        )
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "wait_condition", fake_wait_condition)
+
+    with pytest.raises(ValueError, match="no PR URL found"):
+        await mock_run_workflow._run_integration_stage(
+            parameters={
+                "repo": "org/repo",
+                "publishMode": "branch",
+                "workspaceSpec": {"startingBranch": "feature-branch"},
+            },
+            plan_ref="plan-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_integration_stage_branch_publish_requires_merge_success(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_type == "artifact.read":
+            return _mock_plan_payload(
+                [{"id": "1", "tool": {"type": "skill", "name": "t", "version": "1.0"}, "inputs": {"instructions": "Do something"}}]
+            )
+        if activity_type == "integration.jules.start":
+            return {"external_id": "ext-1"}
+        if activity_type == "integration.jules.fetch_result":
+            return {"url": "https://github.com/org/repo/pull/123", "summary": "Done"}
+        if activity_type == "repo.merge_pr":
+            return {"merged": False, "summary": "Merge rejected"}
+        return {}
+
+    async def fake_wait_condition(cond: Callable[[], bool], timeout: timedelta) -> None:
+        mock_run_workflow.external_event(
+            {"correlation_id": "ext-1", "normalized_status": "completed"}
+        )
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "wait_condition", fake_wait_condition)
+
+    with pytest.raises(ValueError, match="merge failed"):
+        await mock_run_workflow._run_integration_stage(
+            parameters={
+                "repo": "org/repo",
+                "publishMode": "branch",
+                "workspaceSpec": {"startingBranch": "feature-branch"},
+            },
+            plan_ref="plan-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_integration_stage_multi_step_bundles_into_single_start(
     mock_run_workflow: MoonMindRunWorkflow,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -302,10 +492,12 @@ async def test_run_integration_stage_multi_step_sends_messages(
                     {"from": "step2", "to": "step3"}
                 ]
             )
+        if activity_type == "artifact.create":
+            return ({"artifact_id": "artifact://bundle/1"}, {"upload_url": "unused"})
+        if activity_type == "artifact.write_complete":
+            return {"ok": True}
         if activity_type == "integration.jules.start":
             return {"external_id": "ext-session-123", "tracking_ref": "track-1"}
-        if activity_type == "integration.jules.send_message":
-            return {"status": "running"}
         if activity_type == "integration.jules.status":
             return {"normalized_status": "completed"}
         return {}
@@ -322,16 +514,18 @@ async def test_run_integration_stage_multi_step_sends_messages(
     )
     
     start_calls = [c for c in captured if c[0] == "integration.jules.start"]
-    send_message_calls = [c for c in captured if c[0] == "integration.jules.send_message"]
+    artifact_create_calls = [c for c in captured if c[0] == "artifact.create"]
+    artifact_write_calls = [c for c in captured if c[0] == "artifact.write_complete"]
     status_calls = [c for c in captured if c[0] == "integration.jules.status"]
     
     assert len(start_calls) == 1
-    assert start_calls[0][1]["parameters"]["description"] == "Step 1"
-    
-    assert len(send_message_calls) == 2
-    assert send_message_calls[0][1]["prompt"] == "Step 2"
-    assert send_message_calls[1][1]["prompt"] == "Step 3"
-    
-    # 3 steps, so 3 status polls (1 for start, 2 for send_message)
-    assert len(status_calls) == 3
+    description = start_calls[0][1]["parameters"]["description"]
+    assert "Ordered Checklist:" in description
+    assert "1. Step 1" in description
+    assert "2. Step 2" in description
+    assert "3. Step 3" in description
+    assert len(artifact_create_calls) == 1
+    assert len(artifact_write_calls) == 1
+    assert all(c[0] != "integration.jules.send_message" for c in captured)
+    assert len(status_calls) == 1
     assert mock_run_workflow._external_status == "completed"


### PR DESCRIPTION
## Summary
- replace step-chained Jules execution with one-shot bundle compilation in the Temporal run and agent-run workflows
- make publishMode branch succeed only when MoonMind can extract, retarget when needed, and merge the generated PR, with explicit non-success mapping on failure
- add spec-kit artifacts plus unit/integration coverage for bundled execution, clarification-only follow-up messaging, and branch publication handling

## Test plan
- [x] ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/workflows/test_run_integration.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/test_jules_activities.py
- [x] ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/adapters/test_jules_agent_adapter.py tests/unit/workflows/temporal/test_jules_activities.py
- [x] bash .specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main