### PR TITLE
Implement Task Proposal Promotion Endpoint

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -82,7 +82,7 @@ def status_maps() -> dict[str, dict[str, str]]:
 
 
 def _build_supported_task_runtimes() -> list[str]:
-    supported: list[str] = ["codex", "gemini_cli", "claude"]
+    supported: list[str] = ["codex", "gemini_cli", "claude", "codex_cloud"]
     if settings.jules_runtime_gate.enabled:
         supported.append("jules")
     return supported

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -23,6 +23,7 @@ from moonmind.schemas.task_proposal_models import (
     TaskProposalTaskPreview,
 )
 from moonmind.workflows import get_task_proposal_service
+from moonmind.workflows.temporal import TemporalExecutionService
 from moonmind.workflows.task_proposals.models import (
     TaskProposal,
     TaskProposalOriginSource,
@@ -270,6 +271,28 @@ async def get_proposal(
     return _serialize_proposal(proposal, similar=similar_rows)
 
 
+def _get_temporal_execution_service(
+    session: AsyncSession = Depends(get_async_session),
+) -> TemporalExecutionService:
+    from moonmind.config.settings import settings
+    return TemporalExecutionService(
+        session,
+        namespace=settings.temporal.namespace,
+        integration_task_queue=settings.temporal.activity_integrations_task_queue,
+        integration_poll_initial_seconds=(
+            settings.temporal.integration_poll_initial_seconds
+        ),
+        integration_poll_max_seconds=settings.temporal.integration_poll_max_seconds,
+        integration_poll_jitter_ratio=settings.temporal.integration_poll_jitter_ratio,
+        run_continue_as_new_step_threshold=(
+            settings.temporal.run_continue_as_new_step_threshold
+        ),
+        run_continue_as_new_wait_cycle_threshold=(
+            settings.temporal.run_continue_as_new_wait_cycle_threshold
+        ),
+    )
+
+
 @router.post("/{proposal_id}/promote", response_model=TaskProposalPromoteResponse)
 async def promote_proposal(
     *,
@@ -278,6 +301,7 @@ async def promote_proposal(
         default_factory=TaskProposalPromoteRequest
     ),
     service: TaskProposalService = Depends(_get_service),
+    execution_service: TemporalExecutionService = Depends(_get_temporal_execution_service),
     user: User = Depends(get_current_user()),
 ) -> TaskProposalPromoteResponse:
     try:
@@ -314,7 +338,7 @@ async def promote_proposal(
         else:
             override_payload = None
 
-        proposal, execution = await service.promote_proposal(
+        proposal, final_request = await service.promote_proposal(
             proposal_id=proposal_id,
             promoted_by_user_id=getattr(user, "id"),
             priority_override=payload.priority,
@@ -322,6 +346,32 @@ async def promote_proposal(
             note=payload.note,
             task_create_request_override=override_payload,
         )
+
+        initial_parameters = dict(final_request.get("payload") or {})
+        title = str(proposal.title or "").strip()[:200]
+        if not title:
+            instructions = str(initial_parameters.get("task", {}).get("instructions") or "").strip()
+            title = instructions.splitlines()[0][:200] if instructions else "Promoted Task"
+
+        from uuid import uuid4 as _uuid4
+        await execution_service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=getattr(user, "id"),
+            owner_type="user",
+            title=title,
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters=initial_parameters,
+            idempotency_key=str(_uuid4()),
+            repository=proposal.repository,
+            integration=None,
+            summary=proposal.summary,
+            start_delay=None,
+            scheduled_for=None,
+        )
+
     except TaskProposalStatusError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -353,7 +353,6 @@ async def promote_proposal(
             instructions = str(initial_parameters.get("task", {}).get("instructions") or "").strip()
             title = instructions.splitlines()[0][:200] if instructions else "Promoted Task"
 
-        from uuid import uuid4 as _uuid4
         await execution_service.create_execution(
             workflow_type="MoonMind.Run",
             owner_id=getattr(user, "id"),
@@ -364,7 +363,7 @@ async def promote_proposal(
             manifest_artifact_ref=None,
             failure_policy=None,
             initial_parameters=initial_parameters,
-            idempotency_key=str(_uuid4()),
+            idempotency_key=f"proposal-promote-{proposal_id}",
             repository=proposal.repository,
             integration=None,
             summary=proposal.summary,

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -678,8 +678,11 @@ class TaskProposalService:
     ) -> tuple[TaskProposal, dict[str, Any]]:
         """Validate and finalize a proposal for execution promotion.
 
-        Returns the updated TaskProposal and the finalized Temporal
-        initial_parameters (taskCreateRequest payload) ready to execute.
+        Returns the updated TaskProposal and the finalized taskCreateRequest
+        envelope (suitable for use as ``initial_parameters``) ready to execute.
+        The returned envelope may differ from the stored proposal record when
+        an override is provided; the stored ``task_create_request`` is not
+        mutated by this method.
         """
         proposal = await self._repository.get_proposal_for_update(proposal_id)
         if proposal.status is not TaskProposalStatus.OPEN:
@@ -739,7 +742,6 @@ class TaskProposalService:
                 "payload": payload,
             }
         )
-        proposal.task_create_request = final_request
         proposal.decision_note = self._scrub_text(self._clean_str(note)) or None
         await self._repository.commit()
         await self._repository.refresh(proposal)

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -675,9 +675,13 @@ class TaskProposalService:
         max_attempts_override: int | None = None,
         note: str | None = None,
         task_create_request_override: dict[str, Any] | None = None,
-    ) -> tuple[TaskProposal, Any]:
-        """Deprecated."""
-        raise NotImplementedError("Legacy queue backend is disabled")
+    ) -> tuple[TaskProposal, dict[str, Any]]:
+        """Validate and finalize a proposal for execution promotion.
+
+        Returns the updated TaskProposal and the finalized Temporal
+        initial_parameters (taskCreateRequest payload) ready to execute.
+        """
+        proposal = await self._repository.get_proposal_for_update(proposal_id)
         if proposal.status is not TaskProposalStatus.OPEN:
             raise TaskProposalStatusError(
                 f"proposal status {proposal.status.value} cannot be promoted"
@@ -722,13 +726,12 @@ class TaskProposalService:
         if max_attempts < 1:
             raise TaskProposalValidationError("maxAttempts must be >= 1")
 
-        job = None
-
         proposal.status = TaskProposalStatus.PROMOTED
         proposal.promoted_at = datetime.now(UTC)
         proposal.promoted_by_user_id = promoted_by_user_id
         proposal.decided_by_user_id = promoted_by_user_id
-        proposal.task_create_request = self._scrub_json(
+
+        final_request = self._scrub_json(
             {
                 **request,
                 "priority": priority,
@@ -736,17 +739,17 @@ class TaskProposalService:
                 "payload": payload,
             }
         )
+        proposal.task_create_request = final_request
         proposal.decision_note = self._scrub_text(self._clean_str(note)) or None
         await self._repository.commit()
         await self._repository.refresh(proposal)
         logger.info(
-            "Promoted proposal %s to job %s (priority=%s maxAttempts=%s)",
+            "Prepared promoted proposal %s for execution (priority=%s maxAttempts=%s)",
             proposal.id,
-            job.id,
             priority,
             max_attempts,
         )
-        return proposal, job
+        return proposal, final_request
 
     async def dismiss_proposal(
         self,

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -23,7 +23,7 @@ from moonmind.config.settings import settings
 from .job_types import CANONICAL_TASK_JOB_TYPE, LEGACY_TASK_JOB_TYPES
 
 DEFAULT_TASK_RUNTIME = "codex"
-SUPPORTED_RUNTIME_MODES = {"codex", "gemini_cli", "claude", "jules", "universal"}
+SUPPORTED_RUNTIME_MODES = {"codex", "codex_cloud", "gemini_cli", "claude", "jules", "universal"}
 SUPPORTED_EXECUTION_RUNTIMES = {"codex", "gemini_cli", "claude", "jules"}
 SUPPORTED_PUBLISH_MODES = {"none", "branch", "pr"}
 _SECRET_REF_MOUNT_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -108,7 +108,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
     assert "defaultTaskModelByRuntime" in config["system"]
     assert "defaultTaskEffortByRuntime" in config["system"]
     assert config["system"]["workerRuntimeEnv"] == "MOONMIND_WORKER_RUNTIME"
-    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude"]
+    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude", "codex_cloud"]
     assert "claude" in config["system"]["supportedWorkerRuntimes"]
     assert "taskTemplateCatalog" in config["system"]
     assert "enabled" in config["system"]["taskTemplateCatalog"]
@@ -170,7 +170,7 @@ def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
 
     config = build_runtime_config("/tasks")
 
-    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude"]
+    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude", "codex_cloud"]
     assert config["system"]["defaultTaskRuntime"] == "claude"
 
 
@@ -206,7 +206,7 @@ def test_build_runtime_config_includes_claude_without_api_key(monkeypatch) -> No
 
     config = build_runtime_config("/tasks")
 
-    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude"]
+    assert config["system"]["supportedTaskRuntimes"] == ["codex", "gemini_cli", "claude", "codex_cloud"]
 
 
 def test_build_runtime_config_uses_temporal_dashboard_settings(monkeypatch) -> None:
@@ -259,6 +259,7 @@ def test_build_runtime_config_includes_jules_when_enabled(monkeypatch) -> None:
         "codex",
         "gemini_cli",
         "claude",
+        "codex_cloud",
         "jules",
     ]
 

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api_service.api.routers.task_proposals import _get_service, router
+from api_service.api.routers.task_proposals import _get_service, _get_temporal_execution_service, router
 from api_service.auth_providers import get_current_user, get_current_user_optional
 from moonmind.workflows.task_proposals.models import (
     TaskProposalOriginSource,
@@ -20,12 +20,17 @@ from moonmind.workflows.task_proposals.models import (
 def client() -> tuple[TestClient, AsyncMock]:
     app = FastAPI()
     service = AsyncMock()
+    execution_service = AsyncMock()
     app.include_router(router)
 
     async def _service_override():
         return service
 
+    async def _execution_service_override():
+        return execution_service
+
     app.dependency_overrides[_get_service] = _service_override
+    app.dependency_overrides[_get_temporal_execution_service] = _execution_service_override
 
     mock_user = SimpleNamespace(id=uuid4(), email="user@example.com", is_active=True)
 
@@ -133,8 +138,13 @@ def test_promote_proposal_returns_proposal(
 ) -> None:
     test_client, service = client
     proposal = _build_proposal()
-    execution_mock = SimpleNamespace(workflow_id="wf-1")
-    service.promote_proposal.return_value = (proposal, execution_mock)
+    final_request = {
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {"instructions": "do something"}
+        }
+    }
+    service.promote_proposal.return_value = (proposal, final_request)
 
     response = test_client.post(
         f"/api/proposals/{proposal.id}/promote",
@@ -152,8 +162,13 @@ def test_promote_proposal_accepts_override_payload(
 ) -> None:
     test_client, service = client
     proposal = _build_proposal()
-    execution_mock = SimpleNamespace(workflow_id="wf-2")
-    service.promote_proposal.return_value = (proposal, execution_mock)
+    final_request = {
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {"instructions": "edit"}
+        }
+    }
+    service.promote_proposal.return_value = (proposal, final_request)
 
     response = test_client.post(
         f"/api/proposals/{proposal.id}/promote",
@@ -241,9 +256,17 @@ def test_promote_proposal_with_runtime_mode_shortcut(
             },
         },
     }
-    execution_mock = SimpleNamespace(workflow_id="wf-3")
+    final_request = {
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "do stuff",
+                "runtime": {"mode": "gemini_cli"}
+            }
+        }
+    }
     service.get_proposal.return_value = proposal
-    service.promote_proposal.return_value = (proposal, execution_mock)
+    service.promote_proposal.return_value = (proposal, final_request)
 
     response = test_client.post(
         f"/api/proposals/{proposal.id}/promote",

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -17,7 +17,7 @@ from moonmind.workflows.task_proposals.models import (
 
 
 @pytest.fixture
-def client() -> tuple[TestClient, AsyncMock]:
+def client() -> tuple[TestClient, AsyncMock, AsyncMock]:
     app = FastAPI()
     service = AsyncMock()
     execution_service = AsyncMock()
@@ -41,7 +41,7 @@ def client() -> tuple[TestClient, AsyncMock]:
     app.dependency_overrides[get_current_user_optional()] = _user_override
 
     with TestClient(app) as test_client:
-        yield test_client, service
+        yield test_client, service, execution_service
 
 
 def _build_proposal() -> SimpleNamespace:
@@ -74,8 +74,8 @@ def _build_proposal() -> SimpleNamespace:
     )
 
 
-def test_create_proposal_with_user_auth(client: tuple[TestClient, AsyncMock]) -> None:
-    test_client, service = client
+def test_create_proposal_with_user_auth(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
+    test_client, service, _execution_service = client
     proposal = _build_proposal()
     service.create_proposal.return_value = proposal
 
@@ -107,8 +107,8 @@ def test_create_proposal_with_user_auth(client: tuple[TestClient, AsyncMock]) ->
 
 
 
-def test_list_proposals_supports_filters(client: tuple[TestClient, AsyncMock]) -> None:
-    test_client, service = client
+def test_list_proposals_supports_filters(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
+    test_client, service, _execution_service = client
     proposal = _build_proposal()
     service.list_proposals.return_value = ([proposal], None)
     origin_id = uuid4()
@@ -134,9 +134,9 @@ def test_list_proposals_supports_filters(client: tuple[TestClient, AsyncMock]) -
 
 
 def test_promote_proposal_returns_proposal(
-    client: tuple[TestClient, AsyncMock],
+    client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
-    test_client, service = client
+    test_client, service, execution_service = client
     proposal = _build_proposal()
     final_request = {
         "payload": {
@@ -155,12 +155,16 @@ def test_promote_proposal_returns_proposal(
     body = response.json()
     assert "proposal" in body
     assert body["proposal"]["title"] == "Add tests"
+    execution_service.create_execution.assert_awaited_once()
+    call_kwargs = execution_service.create_execution.await_args.kwargs
+    assert call_kwargs["idempotency_key"] == f"proposal-promote-{proposal.id}"
+    assert call_kwargs["initial_parameters"] == final_request["payload"]
 
 
 def test_promote_proposal_accepts_override_payload(
-    client: tuple[TestClient, AsyncMock],
+    client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
-    test_client, service = client
+    test_client, service, execution_service = client
     proposal = _build_proposal()
     final_request = {
         "payload": {
@@ -193,8 +197,8 @@ def test_promote_proposal_accepts_override_payload(
     )
 
 
-def test_dismiss_proposal_returns_payload(client: tuple[TestClient, AsyncMock]) -> None:
-    test_client, service = client
+def test_dismiss_proposal_returns_payload(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
+    test_client, service, _execution_service = client
     proposal = _build_proposal()
     proposal.status = TaskProposalStatus.DISMISSED
     service.dismiss_proposal.return_value = proposal
@@ -209,8 +213,8 @@ def test_dismiss_proposal_returns_payload(client: tuple[TestClient, AsyncMock]) 
     assert body["status"] == "dismissed"
 
 
-def test_get_proposal_includes_similar(client: tuple[TestClient, AsyncMock]) -> None:
-    test_client, service = client
+def test_get_proposal_includes_similar(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
+    test_client, service, _execution_service = client
     proposal = _build_proposal()
     similar = _build_proposal()
     service.get_proposal.return_value = proposal
@@ -224,8 +228,8 @@ def test_get_proposal_includes_similar(client: tuple[TestClient, AsyncMock]) -> 
     assert body["similar"]
 
 
-def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock]) -> None:
-    test_client, service = client
+def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
+    test_client, service, _execution_service = client
     proposal = _build_proposal()
     service.update_review_priority.return_value = proposal
 
@@ -239,10 +243,10 @@ def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock]) -> None:
 
 
 def test_promote_proposal_with_runtime_mode_shortcut(
-    client: tuple[TestClient, AsyncMock],
+    client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:
     """runtimeMode shortcut builds a task_create_request_override for the service."""
-    test_client, service = client
+    test_client, service, execution_service = client
     proposal = _build_proposal()
     proposal.task_create_request = {
         "type": "task",
@@ -279,3 +283,6 @@ def test_promote_proposal_with_runtime_mode_shortcut(
     assert override is not None
     assert override["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
     assert override["payload"]["repository"] == "Moon/Repo"
+    execution_service.create_execution.assert_awaited_once()
+    call_kwargs = execution_service.create_execution.await_args.kwargs
+    assert call_kwargs["idempotency_key"] == f"proposal-promote-{proposal.id}"


### PR DESCRIPTION
This PR connects the Task Proposal system to the active Temporal execution substrate, fulfilling the design in `TaskProposalSystem.md`.

When a proposal is reviewed and approved (promoted) by an operator, the legacy queue dispatch is bypassed entirely. The proposal's instructions, merged with operator overrides like the selected runtime, are dispatched as a native `MoonMind.Run` workflow on Temporal, making it natively trackable in Mission Control.

---
*PR created automatically by Jules for task [9935017614463237864](https://jules.google.com/task/9935017614463237864) started by @nsticco*