### PR TITLE
fix(gemini-cli): remove dead instruction.md writing from prepare_workspace

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -100,7 +100,6 @@ class ManagedRuntimeStrategy(ABC):
 
         Override for runtimes that need workspace files:
         - Cursor: ``.cursor/rules/``, ``.cursor/cli.json``
-        - Gemini: ``.gemini/`` instruction files
         - Claude: ``CLAUDE.md``
         """
 

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 from moonmind.workflows.temporal.runtime.strategies.base import (
@@ -64,23 +63,9 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
         worker process environment when present, adding them to base_env.
         """
         import os
-        
+
         env = dict(base_env)
         for k in _GEMINI_ENV_PASSTHROUGH_KEYS:
             if k not in env and k in os.environ:
                 env[k] = os.environ[k]
         return env
-
-    async def prepare_workspace(
-        self,
-        workspace_path: Path,
-        request: Any,
-    ) -> None:
-        """Write .gemini/instruction.md in the workspace."""
-        if not getattr(request, "instruction_ref", None):
-            return
-
-        gemini_dir = workspace_path / ".gemini"
-        gemini_dir.mkdir(parents=True, exist_ok=True)
-        instruction_path = gemini_dir / "instruction.md"
-        instruction_path.write_text(request.instruction_ref, encoding="utf-8")


### PR DESCRIPTION
## Summary

- `GeminiCliStrategy.prepare_workspace` was writing `instruction_ref` to `.gemini/instruction.md`, but the Gemini CLI has no mechanism to read that file — the instruction was already correctly delivered via `--prompt` in `build_command`
- The apparent "double send" seen in error report context (`gemini-client-error-Turn.run-*.json`) was a Gemini CLI SDK artifact: `turn.js` builds error context as `[...getHistory(), createUserContent(req)]` where `req` is already present in history, creating a duplicate entry in the report only — not in the actual API call
- Removes the dead `prepare_workspace` override and unused `Path` import; fixes stale Gemini reference in base class docstring

## Test plan

- [x] All 2024 unit tests pass (`./tools/test_unit.sh`)
- [x] No tests for `GeminiCliStrategy.prepare_workspace` existed (none needed — method was dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)