### PR TITLE
Update Create Page UI Label to Provider Profile

### DIFF
--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -4639,9 +4639,9 @@
             ${runtimeOptions}
           </select>
         </label>
-        <div id="queue-auth-profile-wrap" class="hidden">
+        <div id="queue-provider-profile-wrap" class="hidden">
           <label>Provider Profile
-            <select name="authProfile">
+            <select name="providerProfile">
               <option value="">Default (system chooses)</option>
             </select>
           </label>
@@ -4902,7 +4902,7 @@
           .toLowerCase(),
         model: String(formData.get("model") || "").trim(),
         effort: String(formData.get("effort") || "").trim(),
-        authProfileId: String(formData.get("authProfile") || "").trim(),
+        authProfileId: String(formData.get("providerProfile") || "").trim(),
         priority: Number.isFinite(priority) ? priority : 0,
         maxAttempts: Number.isFinite(maxAttempts) ? maxAttempts : 3,
         proposeTasks: formData.get("proposeTasks") !== null,
@@ -4926,9 +4926,9 @@
     const effortInputElement = form.querySelector('input[name="effort"]');
     const modelDatalistNode = form.querySelector("#queue-model-options");
     const effortDatalistNode = form.querySelector("#queue-effort-options");
-    const authProfileWrap = form.querySelector("#queue-auth-profile-wrap");
+    const authProfileWrap = form.querySelector("#queue-provider-profile-wrap");
     const authProfileHint = form.querySelector("#queue-auth-profile-hint");
-    const authProfileSelect = form.querySelector('select[name="authProfile"]');
+    const authProfileSelect = form.querySelector('select[name="providerProfile"]');
     let applyQueueDraftAuthProfileOnce = true;
     let authProfileFetchToken = 0;
 
@@ -6088,7 +6088,7 @@
       }
       const model = String(formData.get("model") || "").trim() || null;
       const effort = String(formData.get("effort") || "").trim() || null;
-      const authProfileRef = String(formData.get("authProfile") || "").trim();
+      const authProfileRef = String(formData.get("providerProfile") || "").trim();
       const startingBranch = String(formData.get("startingBranch") || "").trim() || null;
       const newBranch = String(formData.get("newBranch") || "").trim() || null;
       const affinityKey = queueDraftAffinityKey || null;

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -4640,7 +4640,7 @@
           </select>
         </label>
         <div id="queue-auth-profile-wrap" class="hidden">
-          <label>Auth profile
+          <label>Provider Profile
             <select name="authProfile">
               <option value="">Default (system chooses)</option>
             </select>


### PR DESCRIPTION
This change updates the `api_service/static/task_dashboard/dashboard.js` file to change the `<label>` text for the profile selection from "Auth profile" to "Provider Profile". This aligns the UI with the backend and documentation changes migrating from "auth profiles" to "provider profiles".

---
*PR created automatically by Jules for task [17061431639917209221](https://jules.google.com/task/17061431639917209221) started by @nsticco*