### PR TITLE
Fix: Task Proposal Title Derivation

### DIFF
--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -347,8 +347,14 @@ async def promote_proposal(
         )
 
         initial_parameters = dict(final_request.get("payload") or {})
-        instructions = str(initial_parameters.get("task", {}).get("instructions") or "").strip()
-        title = instructions.splitlines()[0][:200] if instructions else str(proposal.title or "").strip()[:200]
+        instructions = str(
+            initial_parameters.get("task", {}).get("instructions") or ""
+        )
+        title_lines = [line.strip() for line in instructions.splitlines() if line.strip()]
+        if title_lines:
+            title = title_lines[0][:200]
+        else:
+            title = str(proposal.title or "").strip()[:200]
         if not title:
             title = "Promoted Task"
 

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -347,10 +347,10 @@ async def promote_proposal(
         )
 
         initial_parameters = dict(final_request.get("payload") or {})
-        title = str(proposal.title or "").strip()[:200]
+        instructions = str(initial_parameters.get("task", {}).get("instructions") or "").strip()
+        title = instructions.splitlines()[0][:200] if instructions else str(proposal.title or "").strip()[:200]
         if not title:
-            instructions = str(initial_parameters.get("task", {}).get("instructions") or "").strip()
-            title = instructions.splitlines()[0][:200] if instructions else "Promoted Task"
+            title = "Promoted Task"
 
         await execution_service.create_execution(
             workflow_type="MoonMind.Run",

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,207 +1,42 @@
 [
   {
-    "id": 4140862776,
+    "id": 4145013865,
     "disposition": "not-applicable",
-    "rationale": "Informational welcome message from Jules bot."
+    "rationale": "Jules informational onboarding comment; no requested code change."
   },
   {
-    "id": 4140863129,
+    "id": 4145014416,
     "disposition": "not-applicable",
-    "rationale": "Informational limit warning from Codex connector."
+    "rationale": "Codex usage-limit notice; no code or review action requested."
   },
   {
-    "id": 2999559753,
+    "id": 3003014318,
     "disposition": "addressed",
-    "rationale": "Fixed module path for Task 1.1."
+    "rationale": "Title derivation now selects the first non-empty instruction line after trimming."
   },
   {
-    "id": 2999559762,
-    "disposition": "addressed",
-    "rationale": "Updated Task 2.2 to query the database projection."
-  },
-  {
-    "id": 4019514409,
+    "id": 4023453992,
     "disposition": "not-applicable",
-    "rationale": "Review summary, not actionable."
+    "rationale": "High-level review summary with no additional actionable request beyond line comments."
   },
   {
-    "id": 2999570557,
+    "id": 3003019253,
     "disposition": "addressed",
-    "rationale": "Rephrased Task 3.1 as a verification step since it's already implemented."
+    "rationale": "Instruction line extraction now strips whitespace before truncation."
   },
   {
-    "id": 2999570573,
+    "id": 3003019281,
     "disposition": "addressed",
-    "rationale": "Updated Task 4.1 to point to the current executions endpoint."
+    "rationale": "Long conditional replaced with wrapped multi-line logic compliant with formatter limits."
   },
   {
-    "id": 2999570589,
+    "id": 3003019304,
     "disposition": "addressed",
-    "rationale": "Fixed module path for Task 1.1, resolving duplicate feedback."
+    "rationale": "Added unit test covering multi-line instructions and trailing-space trimming behavior."
   },
   {
-    "id": 2999570604,
-    "disposition": "addressed",
-    "rationale": "Marked Phase 1 Tasks 1.2-1.4 as already implemented."
-  },
-  {
-    "id": 4019526648,
+    "id": 4023458720,
     "disposition": "not-applicable",
-    "rationale": "PR overview message, not actionable."
-  },
-  {
-    "id": 4140955156,
-    "disposition": "not-applicable",
-    "rationale": "Informational bot comment."
-  },
-  {
-    "id": 2999643522,
-    "disposition": "addressed",
-    "rationale": "Replaced all occurrences of 'agent_runtime' with 'skill' in moonmind/workflows/temporal/workflows/run.py."
-  },
-  {
-    "id": 4019616450,
-    "disposition": "not-applicable",
-    "rationale": "PR review summary."
-  },
-  {
-    "id": 2999652254,
-    "disposition": "addressed",
-    "rationale": "Fixed indentation on line 93 of docs/Temporal/WorkflowSchedulingGuide.md."
-  },
-  {
-    "id": 2999652291,
-    "disposition": "addressed",
-    "rationale": "Added scheduled and proposals to _STATUS_MAPS['temporal'] in api_service/api/routers/task_dashboard_view_model.py."
-  },
-  {
-    "id": 2999652305,
-    "disposition": "addressed",
-    "rationale": "Added PROPOSALS to MoonMindWorkflowState enum in api_service/db/models.py."
-  },
-  {
-    "id": 2999652317,
-    "disposition": "addressed",
-    "rationale": "Added PROPOSALS to MoonMindWorkflowState enum in api_service/db/models.py."
-  },
-  {
-    "id": 4019626055,
-    "disposition": "not-applicable",
-    "rationale": "PR review summary."
-  },
-  {
-    "id": 4140946136,
-    "disposition": "not-applicable",
-    "rationale": "Informational greeting from bot, no action needed."
-  },
-  {
-    "id": 4140946365,
-    "disposition": "not-applicable",
-    "rationale": "Informational bot comment about usage limits."
-  },
-  {
-    "id": 4019593582,
-    "disposition": "not-applicable",
-    "rationale": "Bot review summary with no actionable feedback."
-  },
-  {
-    "id": 2999644167,
-    "disposition": "addressed",
-    "rationale": "Updated section 2 to correctly reference PUT /api/queue/jobs/{id} and POST /api/executions/{workflowId}/update."
-  },
-  {
-    "id": 2999644181,
-    "disposition": "addressed",
-    "rationale": "Rewrote section 3 to describe the implemented Temporal Workflow Updates approach instead of cancel and restart."
-  },
-  {
-    "id": 4019617115,
-    "disposition": "not-applicable",
-    "rationale": "Informational PR overview from bot, no action needed."
-  },
-  {
-    "id": 2999534543,
-    "disposition": "addressed",
-    "rationale": "Refactored mutli-source extraction into a loop over shared constants."
-  },
-  {
-    "id": 4019480679,
-    "disposition": "not-applicable",
-    "rationale": "General PR review summary comment."
-  },
-  {
-    "id": 2999534550,
-    "disposition": "addressed",
-    "rationale": "Defined shared task run keys in schemas."
-  },
-  {
-    "id": 4140840805,
-    "disposition": "not-applicable",
-    "rationale": "Codex usage limit warning from bot."
-  },
-  {
-    "id": 2999548693,
-    "disposition": "addressed",
-    "rationale": "Cleared task_run_id from record.parameters during continue_as_new."
-  },
-  {
-    "id": 2999548723,
-    "disposition": "addressed",
-    "rationale": "Added parameter cleanup logic to _continue_as_new and added unit test assertions."
-  },
-  {
-    "id": 2999548746,
-    "disposition": "addressed",
-    "rationale": "Fixed import order in test_agent_runtime_activities.py."
-  },
-  {
-    "id": 2999548778,
-    "disposition": "addressed",
-    "rationale": "Added UUID validation logic in _report_task_run_binding activity."
-  },
-  {
-    "id": 4019501946,
-    "disposition": "not-applicable",
-    "rationale": "Copilot PR review summary comment."
-  },
-  {
-    "id": 4140813236,
-    "disposition": "not-applicable",
-    "rationale": "Informational comment from Jules bot."
-  },
-  {
-    "id": 4140813664,
-    "disposition": "not-applicable",
-    "rationale": "Informational comment from Codex bot."
-  },
-  {
-    "id": 2999518289,
-    "disposition": "addressed",
-    "rationale": "Removed check_compatibility=False and upgraded Qdrant server version to 1.17.1 in docker-compose.yaml to fix the version mismatch."
-  },
-  {
-    "id": 2999518294,
-    "disposition": "addressed",
-    "rationale": "Removed check_compatibility=False."
-  },
-  {
-    "id": 4019463291,
-    "disposition": "not-applicable",
-    "rationale": "Review summary from Gemini bot."
-  },
-  {
-    "id": 2999521446,
-    "disposition": "not-applicable",
-    "rationale": "We reverted the addition of check_compatibility=False, so the formatting returns to the original Black-compliant shape."
-  },
-  {
-    "id": 2999521460,
-    "disposition": "not-applicable",
-    "rationale": "We reverted the addition of check_compatibility=False, so testing it is no longer relevant."
-  },
-  {
-    "id": 4019466479,
-    "disposition": "not-applicable",
-    "rationale": "Review summary from Copilot bot."
+    "rationale": "Copilot review overview comment; actionable items were handled in individual line comments."
   }
 ]

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -158,6 +158,7 @@ def test_promote_proposal_returns_proposal(
     call_kwargs = execution_service.create_execution.await_args.kwargs
     assert call_kwargs["idempotency_key"] == f"proposal-promote-{proposal.id}"
     assert call_kwargs["initial_parameters"] == final_request["payload"]
+    assert call_kwargs["title"] == "do something"
 
 
 def test_promote_proposal_accepts_override_payload(
@@ -194,6 +195,8 @@ def test_promote_proposal_accepts_override_payload(
         kwargs["task_create_request_override"]["payload"]["task"]["instructions"]
         == "edit"
     )
+    call_kwargs = execution_service.create_execution.await_args.kwargs
+    assert call_kwargs["title"] == "edit"
 
 
 def test_dismiss_proposal_returns_payload(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
@@ -285,3 +288,4 @@ def test_promote_proposal_with_runtime_mode_shortcut(
     execution_service.create_execution.assert_awaited_once()
     call_kwargs = execution_service.create_execution.await_args.kwargs
     assert call_kwargs["idempotency_key"] == f"proposal-promote-{proposal.id}"
+    assert call_kwargs["title"] == "do stuff"

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -161,6 +161,31 @@ def test_promote_proposal_returns_proposal(
     assert call_kwargs["title"] == "do something"
 
 
+def test_promote_proposal_uses_first_non_empty_instruction_line_for_title(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, execution_service = client
+    proposal = _build_proposal()
+    final_request = {
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "\n\n  First line with spaces   \nSecond line\nThird line"
+            },
+        }
+    }
+    service.promote_proposal.return_value = (proposal, final_request)
+
+    response = test_client.post(
+        f"/api/proposals/{proposal.id}/promote",
+        json={"priority": 5},
+    )
+
+    assert response.status_code == 200
+    call_kwargs = execution_service.create_execution.await_args.kwargs
+    assert call_kwargs["title"] == "First line with spaces"
+
+
 def test_promote_proposal_accepts_override_payload(
     client: tuple[TestClient, AsyncMock, AsyncMock],
 ) -> None:


### PR DESCRIPTION
The title of task proposals should be based on the proposal being made and not the original task title. This PR fixes the promote logic to use the new instructions for the execution title.

---
*PR created automatically by Jules for task [8742153843347946247](https://jules.google.com/task/8742153843347946247) started by @nsticco*