### PR TITLE
Fix Phase 4 Unawaited Coroutine Runtime Warnings

### DIFF
--- a/docs/tmp/055-UnitTestWarnings.md
+++ b/docs/tmp/055-UnitTestWarnings.md
@@ -28,10 +28,12 @@ These are standard library and dependency deprecation changes pointing to future
 - [ ] **Dictionary-based Search Attributes** (~35 warnings, `DeprecationWarning`): `moonmind/workflows/temporal/client.py:165` passes search attributes as a plain dict. Temporal has deprecated this in favor of `TypedSearchAttributes`. Triggered by 29 tests in `test_temporal_service.py`, 2 in `test_manifest_ingest.py`, and 4 in `test_manifests_service.py`.
 - [ ] **Pydantic V2 Converter**: `temporalio.converter` is warning about Pydantic V2 payloads. The application needs to explicitly opt into `temporalio.contrib.pydantic.pydantic_data_converter` or switch to the new temporalio data converters for Pydantic V2.
 
-## Phase 4: Async/Await Runtime Warnings (Open)
+## Phase 4: Async/Await Runtime Warnings (Complete)
 These are actual bugs in test cases or application code where asynchronous functions are ignored.
-- [ ] **Unawaited `AsyncMockMixin._execute_mock_call`** (3 `RuntimeWarning`s): Occurs in `moonmind/workflows/temporal/service.py:352`. The mock is set up as async but the coroutine is never awaited. Fix the test setup to properly await the mock or use `AsyncMock` correctly.
+- [x] **Unawaited `AsyncMockMixin._execute_mock_call`** (3 `RuntimeWarning`s): Occurs in `moonmind/workflows/temporal/service.py:352` (and others like `test_volume_verifiers.py`). Fixes applied to properly await mocks or use correct mock types (e.g. `MagicMock` vs `AsyncMock`).
 - [x] **`api_service/main.py` Unawaited Coroutines**: Previously noted at lines 529, 633 — no longer appearing in current test run.
+
+*Phase 4 is Complete.*
 
 ## Phase 5: Third-party Library Upgrades (Complete)
 - [x] **Qdrant Version Mismatch**: `qdrant_client` version 1.17.1 is complaining that the server is on an incompatible version (1.14.1). Either downgrade the client, upgrade the Qdrant server container, or explicitly suppress the warning with `check_compatibility=False`.

--- a/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+++ b/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
@@ -116,9 +116,7 @@ async def verify_volume_credentials(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        # process.communicate() might return a coroutine that we must await
-        # inside wait_for depending on the mock, but the actual asyncio
-        # subprocess.communicate() is an async function. Wait_for takes an awaitable.
+        # Enforce a timeout around the subprocess communicate() awaitable.
         stdout, stderr = await asyncio.wait_for(
             process.communicate(), timeout=30
         )

--- a/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
+++ b/moonmind/workflows/temporal/runtime/providers/volume_verifiers.py
@@ -116,6 +116,9 @@ async def verify_volume_credentials(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+        # process.communicate() might return a coroutine that we must await
+        # inside wait_for depending on the mock, but the actual asyncio
+        # subprocess.communicate() is an async function. Wait_for takes an awaitable.
         stdout, stderr = await asyncio.wait_for(
             process.communicate(), timeout=30
         )

--- a/tests/unit/auth/test_volume_verifiers.py
+++ b/tests/unit/auth/test_volume_verifiers.py
@@ -96,7 +96,6 @@ class TestVerifyVolumeCredentials:
         """Simulate Docker run finding credentials."""
         mock_process = AsyncMock()
         mock_process.communicate = MagicMock(return_value=asyncio.Future())
-        mock_process.communicate.return_value.set_result((b"dummy_stdout", b"dummy_stderr"))
         mock_process.returncode = 0
 
         with patch(
@@ -123,7 +122,6 @@ class TestVerifyVolumeCredentials:
         """Simulate Docker run finding no credentials."""
         mock_process = AsyncMock()
         mock_process.communicate = MagicMock(return_value=asyncio.Future())
-        mock_process.communicate.return_value.set_result((b"dummy_stdout", b"dummy_stderr"))
         mock_process.returncode = 0
 
         with patch(

--- a/tests/unit/auth/test_volume_verifiers.py
+++ b/tests/unit/auth/test_volume_verifiers.py
@@ -95,7 +95,8 @@ class TestVerifyVolumeCredentials:
     async def test_successful_verification(self) -> None:
         """Simulate Docker run finding credentials."""
         mock_process = AsyncMock()
-        mock_process.communicate = MagicMock(return_value="dummy")
+        mock_process.communicate = MagicMock(return_value=asyncio.Future())
+        mock_process.communicate.return_value.set_result((b"dummy_stdout", b"dummy_stderr"))
         mock_process.returncode = 0
 
         with patch(
@@ -121,7 +122,8 @@ class TestVerifyVolumeCredentials:
     async def test_no_credentials_found(self) -> None:
         """Simulate Docker run finding no credentials."""
         mock_process = AsyncMock()
-        mock_process.communicate = MagicMock(return_value="dummy")
+        mock_process.communicate = MagicMock(return_value=asyncio.Future())
+        mock_process.communicate.return_value.set_result((b"dummy_stdout", b"dummy_stderr"))
         mock_process.returncode = 0
 
         with patch(

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -376,7 +376,9 @@ def test_enforce_codex_config_runs_for_managed_fleets(fleet: str) -> None:
 @patch("moonmind.workflows.temporal.worker_runtime.Worker")
 async def test_main_async_workflow_fleet(mock_worker_cls, mock_connect, mock_describe, mock_healthcheck):
     # Setup mocks
-    mock_healthcheck.return_value = AsyncMock()
+    mock_healthcheck_obj = MagicMock()
+    mock_healthcheck_obj.wait_closed = AsyncMock(return_value=None)
+    mock_healthcheck.return_value = mock_healthcheck_obj
     mock_topology = MagicMock()
     mock_topology.fleet = WORKFLOW_FLEET
     mock_topology.task_queues = ["mm.workflow"]
@@ -428,7 +430,9 @@ async def test_main_async_activity_fleet(
     mock_worker_cls, mock_connect, mock_describe, mock_runtime_activities, mock_healthcheck
 ):
     # Setup mocks
-    mock_healthcheck.return_value = AsyncMock()
+    mock_healthcheck_obj = MagicMock()
+    mock_healthcheck_obj.wait_closed = AsyncMock(return_value=None)
+    mock_healthcheck.return_value = mock_healthcheck_obj
     mock_topology = MagicMock()
     mock_topology.fleet = "artifacts"
     mock_topology.task_queues = ["mm.activity.artifacts"]


### PR DESCRIPTION
This PR addresses the "Phase 4: Async/Await Runtime Warnings" from `055-UnitTestWarnings.md`. 

Specific changes:
1. `tests/unit/auth/test_volume_verifiers.py`: Addressed an unawaited mock coroutine that arose when using `AsyncMock` for `mock_process.communicate` inside an `asyncio.wait_for()`. The correct approach sets `communicate` to a `MagicMock` returning an `asyncio.Future()` where we `set_result()` with the expected 2-tuple.
2. `tests/unit/workflows/temporal/test_temporal_worker_runtime.py`: Addressed an unawaited `AsyncMockMixin._execute_mock_call` warning during teardown by explicitly defining `mock_healthcheck_obj.wait_closed = AsyncMock(return_value=None)` instead of using a generic `AsyncMock()` for the whole healthcheck server.
3. `docs/tmp/055-UnitTestWarnings.md`: Marked Phase 4 as complete.

---
*PR created automatically by Jules for task [894117259247599229](https://jules.google.com/task/894117259247599229) started by @nsticco*