### PR TITLE
Refactor Temporal artifact activities for Type Safety Phase 2

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,57 +1,57 @@
 [
   {
-    "id": 4147586544,
+    "id": 4147688756,
     "disposition": "not-applicable",
-    "rationale": "Informational bot greeting."
+    "rationale": "Informational greeting from jules bot."
   },
   {
-    "id": 4147586750,
+    "id": 4147689011,
     "disposition": "not-applicable",
-    "rationale": "Informational usage limit warning."
+    "rationale": "Informational usage limit message from codex bot."
   },
   {
-    "id": 4025232733,
+    "id": 4025366377,
     "disposition": "not-applicable",
-    "rationale": "Informational review summary."
+    "rationale": "Overall code review summary from gemini-code-assist bot."
   },
   {
-    "id": 3004484766,
+    "id": 3004601024,
     "disposition": "addressed",
-    "rationale": "Removed unnecessary pass statement from SyncProfilesSignal."
+    "rationale": "Added tests for TemporalArtifactActivities covering the new Pydantic models, legacy dictionaries, and kwargs fallbacks."
   },
   {
-    "id": 3004484768,
+    "id": 3004601027,
     "disposition": "addressed",
-    "rationale": "Removed unnecessary pass statement from FinalizeSessionSignal."
+    "rationale": "Refactored artifact_read validation, consolidating parameter access and narrowing the exception block."
   },
   {
-    "id": 3004484771,
+    "id": 3004601028,
     "disposition": "addressed",
-    "rationale": "Removed unnecessary pass statement from CancelSessionSignal."
+    "rationale": "Refactored artifact_write_complete validation, consolidating parameter access and narrowing the exception block."
   },
   {
-    "id": 3004484777,
+    "id": 3004601511,
     "disposition": "addressed",
-    "rationale": "Removed unused Literal import."
+    "rationale": "Tightened the type hint of request for artifact_read by adding ArtifactReadInput."
   },
   {
-    "id": 3004485458,
+    "id": 3004601518,
     "disposition": "addressed",
-    "rationale": "Removed unused Literal import."
+    "rationale": "Narrowed exception scope to ValidationError instead of generic Exception in artifact_read."
   },
   {
-    "id": 3004485460,
+    "id": 3004601523,
     "disposition": "addressed",
-    "rationale": "Wrapped provider_summary Field across lines to fix formatting."
+    "rationale": "Tightened the type hint of request for artifact_write_complete by adding ArtifactWriteCompleteInput."
   },
   {
-    "id": 3004485464,
+    "id": 3004601525,
     "disposition": "addressed",
-    "rationale": "Moved tests to tests/unit/schemas/."
+    "rationale": "Narrowed exception scope to ValidationError instead of generic Exception in artifact_write_complete."
   },
   {
-    "id": 4025233682,
+    "id": 4025366822,
     "disposition": "not-applicable",
-    "rationale": "Informational PR overview."
+    "rationale": "Suppressed low confidence comment by reviewer about legacy list payloads."
   }
 ]

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -53,5 +53,10 @@
     "id": 4025366822,
     "disposition": "not-applicable",
     "rationale": "Suppressed low confidence comment by reviewer about legacy list payloads."
+  },
+  {
+    "id": 3004791140,
+    "disposition": "addressed",
+    "rationale": "Removed unused import TemporalArtifactValidationError."
   }
 ]

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -27,7 +27,7 @@ from .temporal_artifact_models import ArtifactRefModel
 
 def _decode_b64(v: str | bytes | list[int]) -> bytes:
     """Safely decode base64 strings, raw bytes, or legacy list[int] to bytes.
-    
+
     The list[int] fallback supports in-flight histories where the Temporal JSON
     serializer previously encoded raw bytes as an integer array.
     """
@@ -39,7 +39,11 @@ def _decode_b64(v: str | bytes | list[int]) -> bytes:
         validated: list[int] = []
         for idx, item in enumerate(v):
             # Reject non-ints (including bools) and out-of-range values.
-            if not isinstance(item, int) or isinstance(item, bool) or not 0 <= item <= 255:
+            if (
+                not isinstance(item, int)
+                or isinstance(item, bool)
+                or not 0 <= item <= 255
+            ):
                 raise ValueError(
                     "Expected list[int] with values in range 0-255; "
                     f"found invalid element at index {idx}: {item!r}"
@@ -55,9 +59,11 @@ def _decode_b64(v: str | bytes | list[int]) -> bytes:
             return v.encode("utf-8")
     raise ValueError(f"Expected base64 string, bytes, or list[int]; got {type(v)}")
 
+
 def _encode_b64(b: bytes) -> str:
     """Encode bytes to base64 string for safe JSON serialization."""
     return base64.b64encode(b).decode("ascii")
+
 
 # A specialized type for binary fields at the Temporal activity boundary.
 # It guarantees that Pydantic will serialize the bytes to a base64 string,
@@ -114,7 +120,9 @@ class PlanGenerateInput(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    principal: str = Field(..., description="The principal requesting the plan generation.")
+    principal: str = Field(
+        ..., description="The principal requesting the plan generation."
+    )
     inputs_ref: str | ArtifactRefModel | None = Field(
         default=None,
         description="The artifact ID or an artifact reference dict/model for inputs.",

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -1516,8 +1516,12 @@ class TemporalArtifactService:
 
         expires_at = datetime.now(UTC) + timedelta(seconds=self._presign_ttl_seconds)
         if artifact.storage_backend is db_models.TemporalArtifactStorageBackend.S3:
-            is_json = (artifact.content_type or "").split(";", 1)[0].strip().lower() == "application/json"
-            download_filename = f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
+            is_json = (artifact.content_type or "").split(";", 1)[
+                0
+            ].strip().lower() == "application/json"
+            download_filename = (
+                f"{artifact.artifact_id}.json" if is_json else artifact.artifact_id
+            )
             url = self._store.presign_download(
                 storage_key=artifact.storage_key,
                 expires_in_seconds=self._presign_ttl_seconds,
@@ -1938,10 +1942,48 @@ class TemporalArtifactActivities:
 
     async def artifact_read(
         self,
+        request: Mapping[str, Any] | Any | None = None,
+        /,
         *,
-        artifact_ref: ArtifactRef | Mapping[str, Any] | str,
-        principal: str,
+        artifact_ref: ArtifactRef | Mapping[str, Any] | str | None = None,
+        principal: str | None = None,
     ) -> bytes:
+        from moonmind.schemas.temporal_activity_models import ArtifactReadInput
+
+        if request is not None and isinstance(request, ArtifactReadInput):
+            # Model fast path
+            if principal is None:
+                principal = request.principal
+            if artifact_ref is None:
+                artifact_ref = getattr(
+                    request.artifact_ref, "artifact_id", request.artifact_ref
+                )
+
+        if isinstance(request, Mapping):
+            try:
+                # Validate legacy dictionary through the new model
+                model = ArtifactReadInput.model_validate(request)
+                if principal is None:
+                    principal = model.principal
+                if artifact_ref is None:
+                    artifact_ref = getattr(
+                        model.artifact_ref, "artifact_id", model.artifact_ref
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse artifact.read legacy payload as ArtifactReadInput: %s",
+                    e,
+                )
+                if principal is None:
+                    principal = request.get("principal")
+                if artifact_ref is None:
+                    artifact_ref = request.get("artifact_ref")
+
+        if artifact_ref is None:
+            raise TemporalArtifactValidationError("artifact_ref is required")
+        if not principal:
+            raise TemporalArtifactValidationError("principal is required")
+
         _artifact, payload = await self._service.read(
             artifact_id=self._normalize_activity_artifact_id(artifact_ref),
             principal=principal,
@@ -1950,12 +1992,60 @@ class TemporalArtifactActivities:
 
     async def artifact_write_complete(
         self,
+        request: Mapping[str, Any] | Any | None = None,
+        /,
         *,
-        artifact_id: str,
-        payload: bytes | str | list[int],
-        principal: str,
+        artifact_id: str | None = None,
+        payload: bytes | str | list[int] | None = None,
+        principal: str | None = None,
         content_type: str | None = None,
     ) -> ArtifactRef:
+        from moonmind.schemas.temporal_activity_models import ArtifactWriteCompleteInput
+
+        if request is not None and isinstance(request, ArtifactWriteCompleteInput):
+            # Model fast path
+            if principal is None:
+                principal = request.principal
+            if artifact_id is None:
+                artifact_id = request.artifact_id
+            if payload is None:
+                payload = request.payload
+            if content_type is None:
+                content_type = request.content_type
+
+        if isinstance(request, Mapping):
+            try:
+                # Validate legacy dictionary through the new model
+                model = ArtifactWriteCompleteInput.model_validate(request)
+                if principal is None:
+                    principal = model.principal
+                if artifact_id is None:
+                    artifact_id = model.artifact_id
+                if payload is None:
+                    payload = model.payload
+                if content_type is None:
+                    content_type = model.content_type
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse artifact.write_complete legacy payload as ArtifactWriteCompleteInput: %s",
+                    e,
+                )
+                if principal is None:
+                    principal = request.get("principal")
+                if artifact_id is None:
+                    artifact_id = request.get("artifact_id")
+                if payload is None:
+                    payload = request.get("payload")
+                if content_type is None and "content_type" in request:
+                    content_type = request.get("content_type")
+
+        if not artifact_id:
+            raise TemporalArtifactValidationError("artifact_id is required")
+        if payload is None:
+            raise TemporalArtifactValidationError("payload is required")
+        if not principal:
+            raise TemporalArtifactValidationError("principal is required")
+
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
         elif isinstance(payload, list):
@@ -2100,7 +2190,9 @@ class TemporalArtifactActivities:
                     "provider_id": row.provider_id,
                     "tags": row.tags or [],
                     "priority": row.priority,
-                    "auth_mode": "oauth" if row.credential_source.value == "oauth_volume" else "api_key",
+                    "auth_mode": "oauth"
+                    if row.credential_source.value == "oauth_volume"
+                    else "api_key",
                     "credential_source": row.credential_source.value,
                     "runtime_materialization_mode": row.runtime_materialization_mode.value,
                     "volume_ref": row.volume_ref,
@@ -2253,7 +2345,10 @@ class TemporalArtifactActivities:
                 else:
                     # Transient RPC errors (UNAVAILABLE, DEADLINE_EXCEEDED, etc.)
                     # should NOT cause slot release — assume still running.
-                    results[wf_id] = {"running": True, "status": f"RPC_ERROR_{exc.status.name}"}
+                    results[wf_id] = {
+                        "running": True,
+                        "status": f"RPC_ERROR_{exc.status.name}",
+                    }
             except Exception as exc:
                 # Unknown errors should NOT cause slot release — assume
                 # the workflow is still running to prevent incorrect
@@ -2306,7 +2401,9 @@ class TemporalArtifactActivities:
                     {
                         "workflow_id": row.workflow_id,
                         "profile_id": row.profile_id,
-                        "granted_at": row.granted_at.isoformat() if row.granted_at else None,
+                        "granted_at": row.granted_at.isoformat()
+                        if row.granted_at
+                        else None,
                     }
                     for row in rows
                 ]
@@ -2323,7 +2420,7 @@ class TemporalArtifactActivities:
                     )
                 )
                 saved_count = 0
-                for lease in (leases or []):
+                for lease in leases or []:
                     workflow_id = lease.get("workflow_id")
                     profile_id = lease.get("profile_id")
                     if not workflow_id or not profile_id:

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -11,8 +11,14 @@ import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    from moonmind.schemas.temporal_activity_models import (
+        ArtifactReadInput,
+        ArtifactWriteCompleteInput,
+    )
 
 import boto3
 from botocore.exceptions import ClientError
@@ -1942,34 +1948,27 @@ class TemporalArtifactActivities:
 
     async def artifact_read(
         self,
-        request: Mapping[str, Any] | Any | None = None,
+        request: "ArtifactReadInput | Mapping[str, Any] | None" = None,
         /,
         *,
         artifact_ref: ArtifactRef | Mapping[str, Any] | str | None = None,
         principal: str | None = None,
     ) -> bytes:
         from moonmind.schemas.temporal_activity_models import ArtifactReadInput
+        try:
+            from pydantic import ValidationError
+        except ImportError:
+            ValidationError = Exception
 
+        model = None
         if request is not None and isinstance(request, ArtifactReadInput):
             # Model fast path
-            if principal is None:
-                principal = request.principal
-            if artifact_ref is None:
-                artifact_ref = getattr(
-                    request.artifact_ref, "artifact_id", request.artifact_ref
-                )
-
-        if isinstance(request, Mapping):
+            model = request
+        elif isinstance(request, Mapping):
             try:
                 # Validate legacy dictionary through the new model
                 model = ArtifactReadInput.model_validate(request)
-                if principal is None:
-                    principal = model.principal
-                if artifact_ref is None:
-                    artifact_ref = getattr(
-                        model.artifact_ref, "artifact_id", model.artifact_ref
-                    )
-            except Exception as e:
+            except ValidationError as e:
                 logger.warning(
                     "Failed to parse artifact.read legacy payload as ArtifactReadInput: %s",
                     e,
@@ -1978,6 +1977,14 @@ class TemporalArtifactActivities:
                     principal = request.get("principal")
                 if artifact_ref is None:
                     artifact_ref = request.get("artifact_ref")
+
+        if model:
+            if principal is None:
+                principal = model.principal
+            if artifact_ref is None:
+                artifact_ref = getattr(
+                    model.artifact_ref, "artifact_id", model.artifact_ref
+                )
 
         if artifact_ref is None:
             raise TemporalArtifactValidationError("artifact_ref is required")
@@ -1992,7 +1999,7 @@ class TemporalArtifactActivities:
 
     async def artifact_write_complete(
         self,
-        request: Mapping[str, Any] | Any | None = None,
+        request: "ArtifactWriteCompleteInput | Mapping[str, Any] | None" = None,
         /,
         *,
         artifact_id: str | None = None,
@@ -2001,31 +2008,20 @@ class TemporalArtifactActivities:
         content_type: str | None = None,
     ) -> ArtifactRef:
         from moonmind.schemas.temporal_activity_models import ArtifactWriteCompleteInput
+        try:
+            from pydantic import ValidationError
+        except ImportError:
+            ValidationError = Exception
 
+        model = None
         if request is not None and isinstance(request, ArtifactWriteCompleteInput):
             # Model fast path
-            if principal is None:
-                principal = request.principal
-            if artifact_id is None:
-                artifact_id = request.artifact_id
-            if payload is None:
-                payload = request.payload
-            if content_type is None:
-                content_type = request.content_type
-
-        if isinstance(request, Mapping):
+            model = request
+        elif isinstance(request, Mapping):
             try:
                 # Validate legacy dictionary through the new model
                 model = ArtifactWriteCompleteInput.model_validate(request)
-                if principal is None:
-                    principal = model.principal
-                if artifact_id is None:
-                    artifact_id = model.artifact_id
-                if payload is None:
-                    payload = model.payload
-                if content_type is None:
-                    content_type = model.content_type
-            except Exception as e:
+            except ValidationError as e:
                 logger.warning(
                     "Failed to parse artifact.write_complete legacy payload as ArtifactWriteCompleteInput: %s",
                     e,
@@ -2038,6 +2034,16 @@ class TemporalArtifactActivities:
                     payload = request.get("payload")
                 if content_type is None and "content_type" in request:
                     content_type = request.get("content_type")
+
+        if model:
+            if principal is None:
+                principal = model.principal
+            if artifact_id is None:
+                artifact_id = model.artifact_id
+            if payload is None:
+                payload = model.payload
+            if content_type is None:
+                content_type = model.content_type
 
         if not artifact_id:
             raise TemporalArtifactValidationError("artifact_id is required")

--- a/tests/unit/workflows/temporal/test_artifacts_activities.py
+++ b/tests/unit/workflows/temporal/test_artifacts_activities.py
@@ -1,0 +1,124 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from moonmind.schemas.temporal_activity_models import ArtifactReadInput, ArtifactWriteCompleteInput
+from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities, TemporalArtifactValidationError
+
+@pytest.fixture
+def mock_service():
+    service = AsyncMock()
+    # Mock read
+    mock_artifact = AsyncMock()
+    service.read.return_value = (mock_artifact, b"test payload")
+    
+    # Mock write_complete
+    service.write_complete.return_value = mock_artifact
+    return service
+
+@pytest.fixture
+def activities(mock_service):
+    return TemporalArtifactActivities(mock_service)
+
+@pytest.fixture
+def patch_build_artifact_ref():
+    with patch("moonmind.workflows.temporal.artifacts.build_artifact_ref") as mock_build:
+        mock_build.return_value = {"artifact_id": "test-id"}
+        yield mock_build
+
+@pytest.mark.asyncio
+async def test_artifact_read_pydantic_model(activities, mock_service):
+    request = ArtifactReadInput(
+        artifact_ref="test-ref",
+        principal="test-principal"
+    )
+    payload = await activities.artifact_read(request)
+    assert payload == b"test payload"
+    mock_service.read.assert_called_once_with(artifact_id="test-ref", principal="test-principal")
+
+@pytest.mark.asyncio
+async def test_artifact_read_legacy_dict_validation_path(activities, mock_service):
+    request = {
+        "artifact_ref": "test-ref",
+        "principal": "test-principal"
+    }
+    payload = await activities.artifact_read(request)
+    assert payload == b"test payload"
+    mock_service.read.assert_called_once_with(artifact_id="test-ref", principal="test-principal")
+
+@pytest.mark.asyncio
+async def test_artifact_read_fallback_logic(activities, mock_service):
+    # Pass a dict that fails validation (e.g. missing principal)
+    request = {
+        "artifact_ref": "test-ref",
+    }
+    # Provide principal via kwargs to satisfy the fallback and requirement
+    payload = await activities.artifact_read(request, principal="test-principal")
+    assert payload == b"test payload"
+    mock_service.read.assert_called_once_with(artifact_id="test-ref", principal="test-principal")
+
+@pytest.mark.asyncio
+async def test_artifact_read_kwargs_path(activities, mock_service):
+    payload = await activities.artifact_read(artifact_ref="test-ref", principal="test-principal")
+    assert payload == b"test payload"
+    mock_service.read.assert_called_once_with(artifact_id="test-ref", principal="test-principal")
+
+@pytest.mark.asyncio
+async def test_artifact_write_complete_pydantic_model(activities, mock_service, patch_build_artifact_ref):
+    request = ArtifactWriteCompleteInput(
+        artifact_id="test-id",
+        payload=b"test payload",
+        principal="test-principal",
+        content_type="text/plain"
+    )
+    await activities.artifact_write_complete(request)
+    mock_service.write_complete.assert_called_once_with(
+        artifact_id="test-id",
+        principal="test-principal",
+        payload=b"test payload",
+        content_type="text/plain"
+    )
+
+@pytest.mark.asyncio
+async def test_artifact_write_complete_legacy_dict(activities, mock_service, patch_build_artifact_ref):
+    request = {
+        "artifact_id": "test-id",
+        "payload": "dGVzdCBwYXlsb2Fk", # base64 for "test payload"
+        "principal": "test-principal",
+        "content_type": "text/plain"
+    }
+    await activities.artifact_write_complete(request)
+    mock_service.write_complete.assert_called_once_with(
+        artifact_id="test-id",
+        principal="test-principal",
+        payload=b"test payload",
+        content_type="text/plain"
+    )
+
+@pytest.mark.asyncio
+async def test_artifact_write_complete_fallback_logic(activities, mock_service, patch_build_artifact_ref):
+    # A dict that fails validation (e.g., payload is un-decodable object or just missing from dict but provided via kwargs)
+    request = {
+        "artifact_id": "test-id",
+    }
+    await activities.artifact_write_complete(request, principal="test-principal", payload=b"test payload", content_type="text/plain")
+    mock_service.write_complete.assert_called_once_with(
+        artifact_id="test-id",
+        principal="test-principal",
+        payload=b"test payload",
+        content_type="text/plain"
+    )
+
+@pytest.mark.asyncio
+async def test_artifact_write_complete_kwargs_path(activities, mock_service, patch_build_artifact_ref):
+    await activities.artifact_write_complete(
+        artifact_id="test-id",
+        payload=b"test payload",
+        principal="test-principal",
+        content_type="text/plain"
+    )
+    mock_service.write_complete.assert_called_once_with(
+        artifact_id="test-id",
+        principal="test-principal",
+        payload=b"test payload",
+        content_type="text/plain"
+    )

--- a/tests/unit/workflows/temporal/test_artifacts_activities.py
+++ b/tests/unit/workflows/temporal/test_artifacts_activities.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from moonmind.schemas.temporal_activity_models import ArtifactReadInput, ArtifactWriteCompleteInput
-from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities, TemporalArtifactValidationError
+from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 
 @pytest.fixture
 def mock_service():


### PR DESCRIPTION
The task requested the implementation of Phase 2 of the Temporal Type Safety migration, which targets the refactoring of activity definitions and worker wiring. 

Specifically, this PR updates `moonmind/workflows/temporal/artifacts.py` to:
- Take the newly defined Pydantic input models (`ArtifactReadInput`, `ArtifactWriteCompleteInput`) at the public activity boundary.
- Implement a dual-read narrow adapter. The methods accept `request` as a positional-only argument that maps dictionary payloads via `model_validate`, whilst maintaining safety by falling back on explicitly named legacy keyword arguments if mapping fails or in the case of direct kwarg execution.
- Maintain history compatibility for in-flight and older execution shapes, ensuring the `bytes` deserialization vulnerability is mitigated explicitly via the new typing strategy.

Code was tested with existing suite passing perfectly. Formatting using `ruff` was executed to maintain linting parity.

---
*PR created automatically by Jules for task [12507181425896405177](https://jules.google.com/task/12507181425896405177) started by @nsticco*