### PR TITLE
[codex] Handle Gemini 429 cooldown retries

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -253,7 +253,7 @@ async def finalize_oauth_session(
         "volume_mount_path": session_obj.volume_mount_path,
         "account_label": session_obj.account_label,
         "max_parallel_runs": metadata.get("max_parallel_runs", 1),
-        "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 300),
+        "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 900),
         "rate_limit_policy": policy_enum,
         "enabled": True,
     }

--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -52,7 +52,7 @@ class ProviderProfileCreate(BaseModel):
     command_behavior: Optional[dict[str, Any]] = None
 
     max_parallel_runs: int = Field(default=1, ge=1)
-    cooldown_after_429_seconds: int = Field(default=300, ge=0)
+    cooldown_after_429_seconds: int = Field(default=900, ge=0)
     rate_limit_policy: str = Field(default="backoff", pattern="^(backoff|queue|fail_fast)$")
     enabled: bool = True
     max_lease_duration_seconds: int = Field(default=7200, ge=60)

--- a/api_service/api/schemas_oauth_sessions.py
+++ b/api_service/api/schemas_oauth_sessions.py
@@ -12,7 +12,7 @@ class CreateOAuthSessionRequest(BaseModel):
     volume_ref: str
     account_label: str
     max_parallel_runs: int = 1
-    cooldown_after_429_seconds: int = 300
+    cooldown_after_429_seconds: int = 900
     rate_limit_policy: ManagedAgentRateLimitPolicy = ManagedAgentRateLimitPolicy.BACKOFF
 
 

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1843,7 +1843,7 @@ class ManagedAgentProviderProfile(Base):
         Integer, nullable=False, default=1, server_default=text("1")
     )
     cooldown_after_429_seconds: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=300, server_default=text("300")
+        Integer, nullable=False, default=900, server_default=text("900")
     )
     rate_limit_policy: Mapped[ManagedAgentRateLimitPolicy] = mapped_column(
         Enum(

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -534,7 +534,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                     clear_env_keys=profile_def.get("clear_env_keys"),
                     env_template=profile_def.get("env_template"),
                     max_parallel_runs=1,
-                    cooldown_after_429_seconds=300,
+                    cooldown_after_429_seconds=900,
                     rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
                     enabled=True,
                 )

--- a/api_service/migrations/versions/b7431e5f8a92_update_cooldown_default_900.py
+++ b/api_service/migrations/versions/b7431e5f8a92_update_cooldown_default_900.py
@@ -1,0 +1,32 @@
+"""Update default cooldown_after_429_seconds to 900
+
+Revision ID: b7431e5f8a92
+Revises: fa1b2c3d4e5f
+Create Date: 2026-03-28 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7431e5f8a92'
+down_revision = 'fa1b2c3d4e5f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'managed_agent_provider_profiles',
+        'cooldown_after_429_seconds',
+        server_default=sa.text('900')
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        'managed_agent_provider_profiles',
+        'cooldown_after_429_seconds',
+        server_default=sa.text('300')
+    )

--- a/api_service/static/task_dashboard/dashboard.js
+++ b/api_service/static/task_dashboard/dashboard.js
@@ -9490,7 +9490,7 @@
                 </label>
                 <label>
                   Cooldown After 429 (seconds)
-                  <input type="number" name="cooldown_after_429_seconds" min="0" value="60" />
+                  <input type="number" name="cooldown_after_429_seconds" min="0" value="900" />
                 </label>
                 <label>
                   Rate Limit Policy

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2359,7 +2359,7 @@ export interface components {
             max_parallel_runs: number;
             /**
              * Cooldown After 429 Seconds
-             * @default 300
+             * @default 900
              */
             cooldown_after_429_seconds: number;
             /** @default backoff */
@@ -3420,7 +3420,7 @@ export interface components {
             max_parallel_runs: number;
             /**
              * Cooldown After 429 Seconds
-             * @default 300
+             * @default 900
              */
             cooldown_after_429_seconds: number;
             /**

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -473,7 +473,7 @@ async def oauth_session_register_profile(
             "volume_mount_path": session_obj.volume_mount_path,
             "account_label": session_obj.account_label,
             "max_parallel_runs": metadata.get("max_parallel_runs", 1),
-            "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 300),
+            "cooldown_after_429_seconds": metadata.get("cooldown_after_429_seconds", 900),
             "rate_limit_policy": policy_enum,
             "enabled": True,
         }

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -125,6 +125,13 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
 )
 
 
+def _managed_runtime_artifact_root() -> Path:
+    root = Path(os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs"))
+    if root.name != "artifacts":
+        root = root / "artifacts"
+    return root
+
+
 class TemporalActivityRuntimeError(RuntimeError):
     """Raised when one of the Temporal activity helpers cannot complete."""
 
@@ -3196,38 +3203,61 @@ class TemporalAgentRuntimeActivities:
             return result
         if record.status != "failed":
             return result
-        if result.failure_class not in {None, "execution_error"}:
+        if result.failure_class not in {None, "execution_error", "integration_error"}:
             return result
         if not cls._is_generic_process_exit_summary(result.summary):
             return result
 
         report = cls._load_gemini_error_report(record)
-        if report is None:
-            return result
-
-        message = str(report.get("message") or "").strip()
-        stack = str(report.get("stack") or "").strip()
-        merged = "\n".join(part for part in (message, stack) if part).lower()
-        if not merged:
-            return result
-
-        update_payload: dict[str, Any] | None = None
-        if any(marker in merged for marker in _GEMINI_QUOTA_MARKERS):
-            update_payload = {
-                "summary": message or "Gemini API quota exhausted",
-                "failure_class": "integration_error",
-                "provider_error_code": "quota_exhausted",
-            }
-        elif any(marker in merged for marker in _GEMINI_RATE_LIMIT_MARKERS):
-            update_payload = {
-                "summary": message or "Gemini API rate limit exceeded",
-                "failure_class": "integration_error",
-                "provider_error_code": "429",
-            }
+        update_payload = cls._gemini_failure_update_payload(report=report, record=record)
 
         if update_payload is not None:
             return result.model_copy(update=update_payload)
         return result
+
+    @classmethod
+    def _gemini_failure_update_payload(
+        cls,
+        *,
+        report: dict[str, str] | None,
+        record: ManagedRunRecord,
+    ) -> dict[str, Any] | None:
+        message = ""
+        stack = ""
+        if report is not None:
+            message = str(report.get("message") or "").strip()
+            stack = str(report.get("stack") or "").strip()
+
+        if not message and not stack:
+            diagnostics = cls._load_managed_runtime_diagnostics(record)
+            parsed_output = diagnostics.get("parsed_output") if isinstance(diagnostics, dict) else None
+            if isinstance(parsed_output, dict):
+                error_messages = parsed_output.get("error_messages") or []
+                if isinstance(error_messages, list):
+                    joined = [str(item).strip() for item in error_messages if str(item).strip()]
+                    if joined:
+                        message = joined[0]
+                        stack = "\n".join(joined[1:])
+                if not message and parsed_output.get("rate_limited") is True:
+                    message = "Gemini API rate limit exceeded"
+
+        merged = "\n".join(part for part in (message, stack) if part).lower()
+        if not merged:
+            return None
+
+        if any(marker in merged for marker in _GEMINI_QUOTA_MARKERS):
+            return {
+                "summary": message or "Gemini API quota exhausted",
+                "failure_class": "integration_error",
+                "provider_error_code": "quota_exhausted",
+            }
+        if any(marker in merged for marker in _GEMINI_RATE_LIMIT_MARKERS):
+            return {
+                "summary": message or "Gemini API rate limit exceeded",
+                "failure_class": "integration_error",
+                "provider_error_code": "429",
+            }
+        return None
 
     @classmethod
     def _load_gemini_error_report(
@@ -3281,6 +3311,20 @@ class TemporalAgentRuntimeActivities:
             return {"message": message, "stack": stack}
 
         return None
+
+    @classmethod
+    def _load_managed_runtime_diagnostics(
+        cls,
+        record: ManagedRunRecord,
+    ) -> dict[str, Any] | None:
+        diagnostics_ref = str(record.diagnostics_ref or "").strip()
+        if not diagnostics_ref:
+            return None
+        path = (_managed_runtime_artifact_root() / diagnostics_ref).resolve()
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
 
     @staticmethod
     def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import inspect
 from typing import Any
 
 from moonmind.workflows.temporal.runtime.output_parser import (
@@ -32,6 +33,7 @@ class RuntimeLogStreamer:
         run_id: str,
         stream_name: str,
         parser: RuntimeOutputParser | None = None,
+        event_callback: Any | None = None,
     ) -> tuple[str, str, list[dict]]:
         """Read an asyncio.StreamReader in fixed-size chunks and write to an artifact file.
 
@@ -67,11 +69,19 @@ class RuntimeLogStreamer:
                     line_with_nl = line + "\n"
                     parsed_events = parser.parse_stream_chunk(line_with_nl)
                     events.extend(parsed_events)
+                    if parsed_events and event_callback is not None:
+                        callback_result = event_callback(parsed_events)
+                        if inspect.isawaitable(callback_result):
+                            await callback_result
 
         # Flush any remaining partial line to the parser (no trailing newline).
         if parser is not None and _line_buf:
             parsed_events = parser.parse_stream_chunk(_line_buf)
             events.extend(parsed_events)
+            if parsed_events and event_callback is not None:
+                callback_result = event_callback(parsed_events)
+                if inspect.isawaitable(callback_result):
+                    await callback_result
 
         data = b"".join(chunks)
         artifact_name = f"{stream_name}.log"
@@ -89,6 +99,7 @@ class RuntimeLogStreamer:
         *,
         run_id: str,
         parser: RuntimeOutputParser | None = None,
+        event_callback: Any | None = None,
     ) -> tuple[dict[str, str], str, str, ParsedOutput]:
         """Stream both stdout/stderr to artifacts and parse the output.
 
@@ -105,14 +116,26 @@ class RuntimeLogStreamer:
         # issues and performance regressions on heavy output processes.
         stdout_task = (
             asyncio.create_task(
-                self.stream_to_artifact(stdout_reader, run_id=run_id, stream_name="stdout", parser=parser)
+                self.stream_to_artifact(
+                    stdout_reader,
+                    run_id=run_id,
+                    stream_name="stdout",
+                    parser=parser,
+                    event_callback=event_callback,
+                )
             )
             if stdout_reader
             else None
         )
         stderr_task = (
             asyncio.create_task(
-                self.stream_to_artifact(stderr_reader, run_id=run_id, stream_name="stderr", parser=parser)
+                self.stream_to_artifact(
+                    stderr_reader,
+                    run_id=run_id,
+                    stream_name="stderr",
+                    parser=parser,
+                    event_callback=event_callback,
+                )
             )
             if stderr_reader
             else None

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -155,7 +155,7 @@ class RuntimeLogStreamer:
         effective_parser = parser or PlainTextOutputParser()
         parsed_output = effective_parser.parse(stdout_content, stderr_content)
 
-        return log_refs, stdout_content, stderr_content, parsed_output
+        return log_refs, stdout_content, stderr_content, parsed_output, events
 
     def collect_diagnostics(
         self,
@@ -189,3 +189,4 @@ class RuntimeLogStreamer:
             data=data,
         )
         return storage_ref
+ref

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -72,7 +72,7 @@ class RuntimeLogStreamer:
                     if parsed_events and event_callback is not None:
                         callback_result = event_callback(parsed_events)
                         if inspect.isawaitable(callback_result):
-                            await callback_result
+                            _ = await callback_result
 
         # Flush any remaining partial line to the parser (no trailing newline).
         if parser is not None and _line_buf:
@@ -81,7 +81,7 @@ class RuntimeLogStreamer:
             if parsed_events and event_callback is not None:
                 callback_result = event_callback(parsed_events)
                 if inspect.isawaitable(callback_result):
-                    await callback_result
+                    _ = await callback_result
 
         data = b"".join(chunks)
         artifact_name = f"{stream_name}.log"

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -100,13 +100,13 @@ class RuntimeLogStreamer:
         run_id: str,
         parser: RuntimeOutputParser | None = None,
         event_callback: Any | None = None,
-    ) -> tuple[dict[str, str], str, str, ParsedOutput]:
+    ) -> tuple[dict[str, str], str, str, ParsedOutput, list[dict]]:
         """Stream both stdout/stderr to artifacts and parse the output.
 
         Combines the two ``stream_to_artifact`` calls and runs the
         strategy's output parser over the decoded content.
 
-        Returns ``(log_refs, stdout_content, stderr_content, parsed_output)``.
+        Returns ``(log_refs, stdout_content, stderr_content, parsed_output, events)``.
         """
         log_refs: dict[str, str] = {}
         stdout_content = ""
@@ -189,4 +189,3 @@ class RuntimeLogStreamer:
             data=data,
         )
         return storage_ref
-ref

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -9,6 +9,17 @@ from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
+_GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
+    "model_capacity_exhausted",
+    "no capacity available for model",
+    "resource_exhausted",
+    "status: 429",
+    "status 429",
+    "too many requests",
+    "ratelimitexceeded",
+    "retrying with backoff",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class ParsedOutput:
@@ -61,6 +72,51 @@ class PlainTextOutputParser(RuntimeOutputParser):
 
     def parse_stream_chunk(self, chunk: str) -> list[dict]:
         return []
+
+
+class GeminiCliOutputParser(PlainTextOutputParser):
+    """Plain-text parser with Gemini-specific 429/capacity detection."""
+
+    @staticmethod
+    def _extract_rate_limit_lines(*texts: str) -> list[str]:
+        matches: list[str] = []
+        for text in texts:
+            for line in text.splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                lower = stripped.lower()
+                if any(marker in lower for marker in _GEMINI_RATE_LIMIT_MARKERS):
+                    matches.append(stripped)
+        return matches
+
+    def parse(self, stdout: str, stderr: str) -> ParsedOutput:
+        base = super().parse(stdout, stderr)
+        rate_limit_lines = self._extract_rate_limit_lines(stdout, stderr)
+        error_messages = list(base.error_messages)
+        for line in rate_limit_lines:
+            if line not in error_messages:
+                error_messages.append(line)
+        return ParsedOutput(
+            raw_text=base.raw_text,
+            events=[],
+            error_messages=error_messages,
+            rate_limited=bool(rate_limit_lines),
+            has_structured_output=False,
+        )
+
+    def parse_stream_chunk(self, chunk: str) -> list[dict]:
+        events: list[dict] = []
+        for line in self._extract_rate_limit_lines(chunk):
+            events.append(
+                {
+                    "type": "rate_limit",
+                    "provider": "gemini_cli",
+                    "status_code": 429,
+                    "message": line,
+                }
+            )
+        return events
 
 
 class NdjsonOutputParser(RuntimeOutputParser):

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -129,6 +129,10 @@ class ManagedRuntimeStrategy(ABC):
         """
         return PlainTextOutputParser()
 
+    def terminate_on_live_rate_limit(self) -> bool:
+        """Whether supervisor should stop the process on streamed rate-limit events."""
+        return False
+
     def should_retry_exit(self, failure_class: str | None) -> bool:
         """Determine if a failure class should trigger a self-heal retry.
 

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from moonmind.workflows.temporal.runtime.output_parser import (
+    GeminiCliOutputParser,
+    RuntimeOutputParser,
+)
 from moonmind.workflows.temporal.runtime.strategies.base import (
     ManagedRuntimeStrategy,
 )
@@ -69,3 +73,23 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
             if k not in env and k in os.environ:
                 env[k] = os.environ[k]
         return env
+
+    def classify_exit(
+        self,
+        exit_code: int | None,
+        stdout: str,
+        stderr: str,
+    ) -> tuple[str, str | None]:
+        parser = self.create_output_parser()
+        parsed = parser.parse(stdout, stderr)
+        if parsed.rate_limited:
+            return "failed", "integration_error"
+        if exit_code == 0:
+            return "completed", None
+        return "failed", "execution_error"
+
+    def create_output_parser(self) -> RuntimeOutputParser:
+        return GeminiCliOutputParser()
+
+    def terminate_on_live_rate_limit(self) -> bool:
+        return True

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -123,7 +123,7 @@ class ManagedRunSupervisor:
             if terminate_on_rate_limit_task is not None:
                 terminate_on_rate_limit_task.cancel()
                 with suppress(asyncio.CancelledError):
-                    await terminate_on_rate_limit_task
+                    _ = await terminate_on_rate_limit_task
 
             if timed_out:
                 exit_code = None

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -118,7 +118,7 @@ class ManagedRunSupervisor:
                 )
             (
                 (process_exit_code, timed_out),
-                (log_refs, stdout_content, stderr_content, parsed_output),
+                (log_refs, stdout_content, stderr_content, parsed_output, events),
             ) = await asyncio.gather(heartbeat_task, stream_task)
             if terminate_on_rate_limit_task is not None:
                 terminate_on_rate_limit_task.cancel()
@@ -437,8 +437,5 @@ class ManagedRunSupervisor:
             return True
         except (ProcessLookupError, PermissionError):
             return False
-        except OSError:
-            return False
-turn False
         except OSError:
             return False

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -78,6 +78,15 @@ class ManagedRunSupervisor:
             runtime_id = record.runtime_id if record else None
             strategy = get_strategy(runtime_id) if runtime_id else None
             parser = strategy.create_output_parser() if strategy else None
+            live_rate_limit_detected = asyncio.Event()
+
+            async def _handle_stream_events(events: list[dict[str, Any]]) -> None:
+                if strategy is None or not strategy.terminate_on_live_rate_limit():
+                    return
+                for event in events:
+                    if self._is_live_rate_limit_event(event):
+                        live_rate_limit_detected.set()
+                        break
 
             # Run heartbeat/wait and log streaming CONCURRENTLY so that OS
             # pipe buffers are drained in real-time.  Sequential streaming
@@ -96,12 +105,25 @@ class ManagedRunSupervisor:
                     process.stderr,
                     run_id=run_id,
                     parser=parser,
+                    event_callback=_handle_stream_events,
                 )
             )
+            terminate_on_rate_limit_task = None
+            if strategy is not None and strategy.terminate_on_live_rate_limit():
+                terminate_on_rate_limit_task = asyncio.create_task(
+                    self._terminate_on_live_rate_limit(
+                        process=process,
+                        trigger=live_rate_limit_detected,
+                    )
+                )
             (
                 (process_exit_code, timed_out),
                 (log_refs, stdout_content, stderr_content, parsed_output),
             ) = await asyncio.gather(heartbeat_task, stream_task)
+            if terminate_on_rate_limit_task is not None:
+                terminate_on_rate_limit_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await terminate_on_rate_limit_task
 
             if timed_out:
                 exit_code = None
@@ -277,6 +299,26 @@ class ManagedRunSupervisor:
         TmateSessionManager.gc_orphaned_sockets(active_session_names)
 
         return reconciled
+
+    @staticmethod
+    async def _terminate_on_live_rate_limit(
+        *,
+        process: asyncio.subprocess.Process,
+        trigger: asyncio.Event,
+    ) -> None:
+        await trigger.wait()
+        await ManagedRunSupervisor._terminate_process(process)
+
+    @staticmethod
+    def _is_live_rate_limit_event(event: dict[str, Any]) -> bool:
+        event_type = str(event.get("type") or "").strip().lower()
+        if event_type == "rate_limit":
+            return True
+        status_code = event.get("status_code") or event.get("statusCode")
+        try:
+            return int(status_code) == 429
+        except (TypeError, ValueError):
+            return False
 
     @staticmethod
     async def _terminate_process(process: asyncio.subprocess.Process) -> None:

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -142,7 +142,7 @@ class ManagedRunSupervisor:
                 duration_seconds=duration,
                 log_refs=log_refs,
                 parsed_output=parsed_output,
-                events=parsed_output.events,
+                events=events,
             )
 
             # Classify exit
@@ -437,5 +437,8 @@ class ManagedRunSupervisor:
             return True
         except (ProcessLookupError, PermissionError):
             return False
+        except OSError:
+            return False
+turn False
         except OSError:
             return False

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import dataclasses
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 from temporalio import workflow, activity
 from temporalio.exceptions import ApplicationError, CancelledError
@@ -99,6 +99,7 @@ MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
 # stuck (e.g. nondeterminism error) and resetting it.
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
+_DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
 
 
 @activity.defn(name="integration.get_activity_route")
@@ -184,6 +185,9 @@ class MoonMindAgentRun:
         self._auto_answer_count: int = 0
         self._pending_operator_messages: list[str] = []
         self._route_cache: dict[str, tuple[str, timedelta, timedelta, RetryPolicy | None, timedelta | None]] = {}
+        self._profile_snapshots: dict[str, dict[str, Any]] = {}
+        self._awaiting_slot_reason_override: str | None = None
+        self._slot_wait_timeout_override_seconds: int | None = None
 
     async def _get_route_info(self, activity_name: str, fallback_queue: str, fallback_timeout: timedelta) -> tuple[str, timedelta, timedelta, RetryPolicy | None, timedelta | None]:
         if activity_name in self._route_cache:
@@ -256,6 +260,49 @@ class MoonMindAgentRun:
             activity,
             args,
             **options,
+        )
+
+    @staticmethod
+    def _managed_runtime_id(agent_id: str) -> str:
+        runtime_mapping = {
+            "gemini_cli": "gemini_cli",
+            "claude": "claude_code",
+            "codex": "codex_cli",
+        }
+        return runtime_mapping.get(agent_id, agent_id)
+
+    def _cooldown_seconds_for_profile(self, profile_id: str | None) -> int:
+        normalized_profile_id = str(profile_id or "").strip()
+        if normalized_profile_id:
+            profile = self._profile_snapshots.get(normalized_profile_id) or {}
+            raw_seconds = profile.get("cooldown_after_429_seconds")
+            try:
+                seconds = int(raw_seconds)
+            except (TypeError, ValueError):
+                seconds = 0
+            if seconds >= 0:
+                return seconds
+        return _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS
+
+    @staticmethod
+    def _format_retry_timestamp(value: datetime) -> str:
+        rendered = value.isoformat()
+        if rendered.endswith("+00:00"):
+            return rendered[:-6] + "Z"
+        return rendered
+
+    def _build_managed_rate_limit_waiting_reason(
+        self,
+        *,
+        runtime_id: str,
+        profile_id: str | None,
+        cooldown_seconds: int,
+    ) -> str:
+        retry_at = workflow.now() + timedelta(seconds=max(cooldown_seconds, 0))
+        profile_fragment = f" on profile {profile_id}" if profile_id else ""
+        return (
+            f"Gemini capacity exhausted for {runtime_id}{profile_fragment}; retry scheduled for "
+            f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
         )
 
 
@@ -389,6 +436,11 @@ class MoonMindAgentRun:
                 raw_profiles = profile_snapshot.get("profiles", [])
                 if isinstance(raw_profiles, list):
                     profiles = raw_profiles
+            self._profile_snapshots = {
+                str(profile.get("profile_id")).strip(): profile
+                for profile in profiles
+                if isinstance(profile, dict) and str(profile.get("profile_id", "")).strip()
+            }
             await manager_handle.signal("sync_profiles", {"profiles": profiles})
             return len(profiles)
         except Exception:
@@ -646,12 +698,7 @@ class MoonMindAgentRun:
                 manager_handle = None
                 # Acquire auth slot if managed
                 if request.agent_kind == "managed":
-                    runtime_mapping = {
-                        "gemini_cli": "gemini_cli",
-                        "claude": "claude_code",
-                        "codex": "codex_cli",
-                    }
-                    runtime_id = runtime_mapping.get(request.agent_id, request.agent_id)
+                    runtime_id = self._managed_runtime_id(request.agent_id)
                     manager_id = f"auth-profile-manager:{runtime_id}"
 
                     self.slot_assigned_event.clear()
@@ -688,22 +735,31 @@ class MoonMindAgentRun:
 
                     if not self.slot_assigned_event.is_set():
                         self.run_status = RunStatus.awaiting_slot
+                        waiting_reason = (
+                            self._awaiting_slot_reason_override
+                            or f"Waiting for auth profile slot on {runtime_id}"
+                        )
+                        self._awaiting_slot_reason_override = None
                         if parent_info:
                             parent_handle = workflow.get_external_workflow_handle(
                                 parent_info.workflow_id, run_id=parent_info.run_id
                             )
                             await parent_handle.signal(
                                 "child_state_changed",
-                                args=["awaiting_slot", f"Waiting for auth profile slot on {runtime_id}"]
+                                args=["awaiting_slot", waiting_reason]
                             )
 
                     if workflow.patched("agent_run_slot_wait_retry_v1"):
                         slot_resets = 0
                         while not self.slot_assigned_event.is_set():
                             try:
+                                slot_wait_timeout_seconds = (
+                                    self._slot_wait_timeout_override_seconds
+                                    or _SLOT_WAIT_TIMEOUT_SECONDS
+                                )
                                 await workflow.wait_condition(
                                     lambda: self.slot_assigned_event.is_set(),
-                                    timeout=timedelta(seconds=_SLOT_WAIT_TIMEOUT_SECONDS),
+                                    timeout=timedelta(seconds=slot_wait_timeout_seconds),
                                 )
                             except TimeoutError:
                                 if slot_resets >= _SLOT_WAIT_MAX_RESETS:
@@ -731,6 +787,8 @@ class MoonMindAgentRun:
                     # Reset the execution clock so the timeout budget starts
                     # from slot acquisition, not from workflow start.
                     overall_start = workflow.now()
+                    self._awaiting_slot_reason_override = None
+                    self._slot_wait_timeout_override_seconds = None
                     
                     self.run_status = RunStatus.launching
                     if parent_info:
@@ -1308,10 +1366,46 @@ class MoonMindAgentRun:
 
                 # Check for 429
                 if request.agent_kind == "managed" and manager_handle and self.final_result.provider_error_code == PROVIDER_RATE_LIMIT_ERROR_CODE:
-                    await manager_handle.signal("report_cooldown", {"profile_id": request.execution_profile_ref, "cooldown_seconds": 300})
-                    await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                    runtime_id = self._managed_runtime_id(request.agent_id)
+                    profile_id = str(request.execution_profile_ref or self._assigned_profile_id or "").strip() or None
+                    cooldown_seconds = self._cooldown_seconds_for_profile(profile_id)
+                    waiting_reason = self._build_managed_rate_limit_waiting_reason(
+                        runtime_id=runtime_id,
+                        profile_id=profile_id,
+                        cooldown_seconds=cooldown_seconds,
+                    )
+                    parent_info = workflow.info().parent
+                    if parent_info:
+                        parent_handle = workflow.get_external_workflow_handle(
+                            parent_info.workflow_id, run_id=parent_info.run_id
+                        )
+                        await parent_handle.signal(
+                            "child_state_changed",
+                            args=["awaiting_slot", waiting_reason],
+                        )
+                    await manager_handle.signal(
+                        "report_cooldown",
+                        {
+                            "profile_id": profile_id or request.execution_profile_ref,
+                            "cooldown_seconds": cooldown_seconds,
+                        },
+                    )
+                    await manager_handle.signal(
+                        "release_slot",
+                        {
+                            "requester_workflow_id": workflow.info().workflow_id,
+                            "profile_id": profile_id or request.execution_profile_ref,
+                        },
+                    )
+                    self._awaiting_slot_reason_override = waiting_reason
+                    self._slot_wait_timeout_override_seconds = max(
+                        cooldown_seconds + 60,
+                        _SLOT_WAIT_TIMEOUT_SECONDS,
+                    )
                     self.completion_event.clear()
                     self.final_result = None
+                    self._assigned_profile_id = None
+                    self.run_status = RunStatus.awaiting_slot
                     continue # Retries loop
 
                 # Not a 429 or external agent

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1366,47 +1366,54 @@ class MoonMindAgentRun:
 
                 # Check for 429
                 if request.agent_kind == "managed" and manager_handle and self.final_result.provider_error_code == PROVIDER_RATE_LIMIT_ERROR_CODE:
-                    runtime_id = self._managed_runtime_id(request.agent_id)
-                    profile_id = str(request.execution_profile_ref or self._assigned_profile_id or "").strip() or None
-                    cooldown_seconds = self._cooldown_seconds_for_profile(profile_id)
-                    waiting_reason = self._build_managed_rate_limit_waiting_reason(
-                        runtime_id=runtime_id,
-                        profile_id=profile_id,
-                        cooldown_seconds=cooldown_seconds,
-                    )
-                    parent_info = workflow.info().parent
-                    if parent_info:
-                        parent_handle = workflow.get_external_workflow_handle(
-                            parent_info.workflow_id, run_id=parent_info.run_id
+                    if workflow.patched("gemini-429-cooldown-retry-signal"):
+                        runtime_id = self._managed_runtime_id(request.agent_id)
+                        profile_id = str(request.execution_profile_ref or self._assigned_profile_id or "").strip() or None
+                        cooldown_seconds = self._cooldown_seconds_for_profile(profile_id)
+                        waiting_reason = self._build_managed_rate_limit_waiting_reason(
+                            runtime_id=runtime_id,
+                            profile_id=profile_id,
+                            cooldown_seconds=cooldown_seconds,
                         )
-                        await parent_handle.signal(
-                            "child_state_changed",
-                            args=["awaiting_slot", waiting_reason],
+                        parent_info = workflow.info().parent
+                        if parent_info:
+                            parent_handle = workflow.get_external_workflow_handle(
+                                parent_info.workflow_id, run_id=parent_info.run_id
+                            )
+                            await parent_handle.signal(
+                                "child_state_changed",
+                                args=["awaiting_slot", waiting_reason],
+                            )
+                        await manager_handle.signal(
+                            "report_cooldown",
+                            {
+                                "profile_id": profile_id or request.execution_profile_ref,
+                                "cooldown_seconds": cooldown_seconds,
+                            },
                         )
-                    await manager_handle.signal(
-                        "report_cooldown",
-                        {
-                            "profile_id": profile_id or request.execution_profile_ref,
-                            "cooldown_seconds": cooldown_seconds,
-                        },
-                    )
-                    await manager_handle.signal(
-                        "release_slot",
-                        {
-                            "requester_workflow_id": workflow.info().workflow_id,
-                            "profile_id": profile_id or request.execution_profile_ref,
-                        },
-                    )
-                    self._awaiting_slot_reason_override = waiting_reason
-                    self._slot_wait_timeout_override_seconds = max(
-                        cooldown_seconds + 60,
-                        _SLOT_WAIT_TIMEOUT_SECONDS,
-                    )
-                    self.completion_event.clear()
-                    self.final_result = None
-                    self._assigned_profile_id = None
-                    self.run_status = RunStatus.awaiting_slot
-                    continue # Retries loop
+                        await manager_handle.signal(
+                            "release_slot",
+                            {
+                                "requester_workflow_id": workflow.info().workflow_id,
+                                "profile_id": profile_id or request.execution_profile_ref,
+                            },
+                        )
+                        self._awaiting_slot_reason_override = waiting_reason
+                        self._slot_wait_timeout_override_seconds = max(
+                            cooldown_seconds + 60,
+                            _SLOT_WAIT_TIMEOUT_SECONDS,
+                        )
+                        self.completion_event.clear()
+                        self.final_result = None
+                        self._assigned_profile_id = None
+                        self.run_status = RunStatus.awaiting_slot
+                        continue # Retries loop
+                    else:
+                        await manager_handle.signal("report_cooldown", {"profile_id": request.execution_profile_ref, "cooldown_seconds": 300})
+                        await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                        self.completion_event.clear()
+                        self.final_result = None
+                        continue # Retries loop
 
                 # Not a 429 or external agent
                 if manager_handle and request.execution_profile_ref:

--- a/moonmind/workflows/temporal/workflows/auth_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/auth_profile_manager.py
@@ -283,9 +283,12 @@ class MoonMindAuthProfileManagerWorkflow:
         self._event_count += 1
         self._has_new_events = True
         profile_id = payload["profile_id"]
-        cooldown_seconds = payload.get("cooldown_seconds", 300)
         profile = self._profiles.get(profile_id)
         if profile:
+            cooldown_seconds = payload.get(
+                "cooldown_seconds",
+                profile.cooldown_after_429_seconds,
+            )
             now = workflow.now()
             cooldown_until = now + timedelta(seconds=cooldown_seconds)
             profile.cooldown_until = cooldown_until.isoformat()
@@ -423,7 +426,7 @@ class MoonMindAuthProfileManagerWorkflow:
             state = ProfileSlotState(
                 profile_id=pid,
                 max_parallel_runs=p.get("max_parallel_runs", 1),
-                cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 300),
+                cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 900),
                 rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                 enabled=p.get("enabled", True),
                 max_lease_duration_seconds=p.get(
@@ -472,7 +475,7 @@ class MoonMindAuthProfileManagerWorkflow:
                     profile_id=pid,
                     max_parallel_runs=p.get("max_parallel_runs", 1),
                     cooldown_after_429_seconds=p.get(
-                        "cooldown_after_429_seconds", 300
+                        "cooldown_after_429_seconds", 900
                     ),
                     rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                     enabled=p.get("enabled", True),

--- a/openapi.json
+++ b/openapi.json
@@ -7709,7 +7709,7 @@
           "cooldown_after_429_seconds": {
             "type": "integer",
             "title": "Cooldown After 429 Seconds",
-            "default": 300
+            "default": 900
           },
           "rate_limit_policy": {
             "$ref": "#/components/schemas/ManagedAgentRateLimitPolicy",
@@ -10601,7 +10601,7 @@
             "type": "integer",
             "minimum": 0.0,
             "title": "Cooldown After 429 Seconds",
-            "default": 300
+            "default": 900
           },
           "rate_limit_policy": {
             "type": "string",

--- a/specs/106-gemini-429-cooldown-retry/plan.md
+++ b/specs/106-gemini-429-cooldown-retry/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Gemini 429 Cooldown Retry
+
+**Branch**: `106-gemini-429-cooldown-retry` | **Date**: 2026-03-28 | **Spec**: [`spec.md`](./spec.md)
+
+## Summary
+
+Terminate managed Gemini CLI runs as soon as live output proves the provider is capacity-rate-limited, map that terminal result into provider error code `429`, and let `MoonMind.AgentRun` re-enter the existing profile-slot cooldown path with a retry summary that surfaces in task details.
+
+## Technical Context
+
+**Language/Version**: Python 3.11
+**Primary Dependencies**: Temporal Python SDK, FastAPI/Pydantic, existing managed runtime supervisor/log streamer
+**Storage**: Managed run store JSON files, local runtime artifacts
+**Testing**: `./tools/test_unit.sh`
+**Target Platform**: Docker Compose local stack / Temporal workers
+**Project Type**: Backend workflow/runtime + Mission Control detail rendering via existing summary field
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Keeps cooldown behavior in workflow orchestration, not UI hacks.
+- II. One-Click Agent Deployment: PASS. No new external dependency.
+- III. Avoid Vendor Lock-In: PASS. Gemini-specific parsing is isolated to the Gemini strategy/runtime path.
+- IV. Own Your Data: PASS. Evidence remains in managed run logs/diagnostics and execution summaries.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill contract changes.
+- VI. Design for Deletion / Thick Contracts: PASS. Extends existing runtime parser/supervisor contracts instead of adding bespoke side channels.
+- VII. Powerful Runtime Configurability: PASS. Uses configurable cooldown values instead of hardcoded retry delay.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay in runtime strategy, supervisor, and workflow boundaries.
+- IX. Resilient by Default: PASS. Converts a livelock into a bounded cooldown retry with operator-visible reason.
+- X. Facilitate Continuous Improvement: PASS. Failure reason becomes visible in task details and diagnostics.
+- XI. Spec-Driven Development: PASS. This plan implements the attached spec.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. No migration backlog added to canonical docs.
+- XIII. Pre-Release / Compatibility Policy: PASS. No backward-compat wrapper; extends existing internal behavior directly.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/106-gemini-429-cooldown-retry/
+├── plan.md
+├── spec.md
+└── tasks.md
+```
+
+### Code
+
+```text
+moonmind/workflows/temporal/runtime/
+moonmind/workflows/temporal/workflows/
+api_service/api/routers/
+tests/unit/services/temporal/runtime/
+tests/unit/workflows/temporal/
+tests/integration/services/temporal/workflows/
+```
+
+## Implementation Strategy
+
+1. Add Gemini-specific live output parsing for capacity-exhausted 429 markers and expose stream events during supervision.
+2. Terminate the Gemini process early when those markers appear, then classify the run as a managed rate-limit failure using diagnostics-backed enrichment.
+3. Cache provider profile cooldown metadata in `MoonMind.AgentRun`, use it for retry delay, and publish a retry-specific `awaiting_slot` summary that the existing task details timeline already displays.
+4. Update provider profile create defaults to 900 seconds so new profiles inherit the requested 15-minute retry window by default.
+
+## Testing Strategy
+
+- Add supervisor/runtime tests proving live Gemini 429 output terminates the process and persists rate-limit diagnostics.
+- Add workflow-boundary tests proving `MoonMind.AgentRun` reports cooldown, releases/re-requests slot, and emits the retry summary.
+- Run targeted unit coverage through `./tools/test_unit.sh`.

--- a/specs/106-gemini-429-cooldown-retry/spec.md
+++ b/specs/106-gemini-429-cooldown-retry/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: Gemini 429 Cooldown Retry
+
+**Feature Branch**: `106-gemini-429-cooldown-retry`
+**Created**: 2026-03-28
+**Status**: Draft
+**Input**: User request: "Gemini 429 capacity failures should show in task details timeline and ideally retry 15 minutes later, configurable as a setting."
+
+## User Scenarios & Testing
+
+### User Story 1 - Capacity exhaustion is visible while the task waits to retry (Priority: P1)
+
+When a managed Gemini CLI run hits a provider 429 capacity error, the task details page should show that the task is waiting because Gemini capacity was exhausted and that a retry is scheduled after cooldown.
+
+**Why this priority**: Operators currently see an apparently stuck task instead of a meaningful waiting state.
+
+**Independent Test**: Trigger a managed Gemini run that emits a recognizable capacity-exhausted 429, then verify the execution enters `awaiting_slot` with a summary that mentions the 429/capacity condition and retry timing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed Gemini CLI task is running, **when** the live runtime output contains a Gemini capacity-exhausted 429 marker, **then** the workflow summary changes to an `awaiting_slot` reason that explains the capacity failure and scheduled retry.
+2. **Given** the task details UI renders a Temporal execution, **when** the execution is waiting on the Gemini cooldown retry, **then** the timeline/waiting detail shows that summary without requiring raw Temporal history browsing.
+
+---
+
+### User Story 2 - Capacity exhaustion stops the live retry loop and schedules a durable retry (Priority: P1)
+
+When Gemini CLI enters its own internal retry loop after a capacity 429, MoonMind should stop the live run promptly and hand control back to the workflow cooldown path.
+
+**Why this priority**: Without early termination, the workflow polls indefinitely and the built-in cooldown logic never activates.
+
+**Independent Test**: Run supervised Gemini output that emits a capacity-exhausted 429 marker, verify the supervisor terminates the process, the managed run is classified as failed with rate-limit metadata, and `MoonMind.AgentRun` reports cooldown + requests a new slot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed Gemini CLI process emits a capacity-exhausted 429 marker while still running, **when** the supervisor observes the live output, **then** it terminates the process instead of waiting for Gemini CLI to keep retrying internally.
+2. **Given** the terminated managed run is fetched by `MoonMind.AgentRun`, **when** the workflow inspects the result, **then** it recognizes provider error code `429`, reports cooldown, releases the slot, and re-requests a slot durably.
+
+---
+
+### User Story 3 - Retry delay is configurable through existing cooldown settings (Priority: P2)
+
+Operators should be able to change the retry delay without code changes.
+
+**Why this priority**: Different providers and profiles may require different cooldown windows.
+
+**Independent Test**: Set a non-default cooldown value for the provider profile used by a managed Gemini run, trigger a 429 capacity failure, and verify the scheduled retry summary and manager cooldown use that value.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider profile has `cooldown_after_429_seconds` configured, **when** Gemini capacity exhaustion occurs on that profile, **then** the workflow uses that configured delay instead of a hardcoded 300 seconds.
+2. **Given** a new provider profile is created through the API/UI defaults, **when** the operator does not override the cooldown, **then** the default cooldown value is 900 seconds (15 minutes).
+
+## Requirements
+
+### Functional Requirements
+
+- FR-001: Managed Gemini CLI runtime supervision MUST detect recognizable Gemini capacity-exhausted 429 output while the process is still running.
+- FR-002: On detection of a Gemini capacity-exhausted 429, supervision MUST stop the live Gemini process so the workflow can resume deterministic cooldown handling.
+- FR-003: Managed run result fetching MUST map the terminated Gemini capacity-exhausted run into provider error code `429`.
+- FR-004: `MoonMind.AgentRun` MUST use the configured cooldown duration for the assigned profile when handling managed-provider `429` retries.
+- FR-005: `MoonMind.AgentRun` MUST update the parent run summary with a waiting reason that mentions the capacity failure and scheduled retry timing before re-entering slot wait.
+- FR-006: The existing task details timeline/waiting surface MUST display that waiting reason without requiring a separate event store.
+- FR-007: New provider profiles MUST default `cooldown_after_429_seconds` to 900 seconds unless the operator sets another value.
+
+### Key Entities
+
+- Managed Gemini run record
+- Provider profile cooldown configuration
+- Parent execution summary / waiting reason
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- SC-001: A Gemini capacity-exhausted 429 no longer leaves the task in an unbounded `agent_runtime.status` poll loop.
+- SC-002: During cooldown wait, the task details timeline shows a human-readable reason and retry schedule.
+- SC-003: Boundary tests cover live-output detection, managed-run result mapping, and workflow cooldown retry behavior.

--- a/specs/106-gemini-429-cooldown-retry/tasks.md
+++ b/specs/106-gemini-429-cooldown-retry/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Gemini 429 Cooldown Retry
+
+## 1. Runtime Detection
+
+- [ ] 1.1 Add Gemini live-output parsing for capacity-exhausted 429 markers.
+- [ ] 1.2 Extend runtime streaming/supervision so Gemini 429 detection can terminate the process early.
+- [ ] 1.3 Ensure managed Gemini result enrichment maps those failures to provider error code `429`.
+
+## 2. Workflow Cooldown + Timeline
+
+- [ ] 2.1 Cache provider profile cooldown configuration in `MoonMind.AgentRun`.
+- [ ] 2.2 Replace the hardcoded managed 429 cooldown with the configured value.
+- [ ] 2.3 Emit a retry-specific `awaiting_slot` summary with scheduled retry timing so task details show the reason.
+
+## 3. Defaults and Validation
+
+- [ ] 3.1 Update new provider profile defaults to 900-second cooldown.
+- [ ] 3.2 Add/update unit and integration tests for supervisor detection and workflow retry behavior.
+- [ ] 3.3 Run `./tools/test_unit.sh` and fix regressions.

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -1,5 +1,6 @@
 import pytest
 import asyncio
+from datetime import datetime, timedelta
 
 from temporalio import workflow
 from temporalio.testing import WorkflowEnvironment
@@ -75,7 +76,7 @@ async def mock_auth_profile_list(request: dict) -> dict:
                 "runtime_env_overrides": {},
                 "api_key_env_var": None,
                 "max_parallel_runs": 1,
-                "cooldown_after_429_seconds": 300,
+                "cooldown_after_429_seconds": 900,
                 "rate_limit_policy": "pause_and_retry",
                 "max_lease_duration_seconds": 7200,
                 "enabled": True,
@@ -151,6 +152,8 @@ class MockAuthProfileManager:
         self._shutdown = False
         self.pending_requests = []
         self._leases: dict[str, str] = {}  # profile_id -> workflow_id
+        self.cooldown_reports: list[dict] = []
+        self.cooldowns: dict[str, str] = {}
 
     @workflow.signal
     def request_slot(self, payload: dict) -> None:
@@ -167,7 +170,12 @@ class MockAuthProfileManager:
 
     @workflow.signal
     def report_cooldown(self, payload: dict) -> None:
-        pass
+        self.cooldown_reports.append(dict(payload))
+        profile_id = payload.get("profile_id", "default-managed")
+        cooldown_seconds = int(payload.get("cooldown_seconds", 0))
+        self.cooldowns[profile_id] = (
+            workflow.now() + timedelta(seconds=cooldown_seconds)
+        ).isoformat()
 
     @workflow.signal
     def sync_profiles(self, payload: dict) -> None:
@@ -179,6 +187,8 @@ class MockAuthProfileManager:
         return {
             "leases": dict(self._leases),
             "pending_requests": self.pending_requests,
+            "cooldown_reports": list(self.cooldown_reports),
+            "cooldowns": dict(self.cooldowns),
         }
 
     @workflow.run
@@ -192,10 +202,69 @@ class MockAuthProfileManager:
                 req = self.pending_requests.pop(0)
                 if assign_slots:
                     profile_id = "default-managed"
+                    cooldown_until = self.cooldowns.get(profile_id)
+                    if cooldown_until is not None:
+                        cooldown_dt = datetime.fromisoformat(cooldown_until)
+                        if workflow.now() < cooldown_dt:
+                            self.pending_requests.insert(0, req)
+                            await workflow.sleep(
+                                (cooldown_dt - workflow.now()).total_seconds()
+                            )
+                            continue
                     self._leases[profile_id] = req["requester_workflow_id"]
                     handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
                     await handle.signal("slot_assigned", {"profile_id": profile_id})
         return {}
+
+
+@workflow.defn(name="TestAgentRunParent")
+class TestAgentRunParent:
+    def __init__(self) -> None:
+        self.state_changes: list[dict[str, str]] = []
+        self.profile_assignments: list[dict] = []
+
+    @workflow.signal
+    def child_state_changed(self, new_state: str, reason: str) -> None:
+        self.state_changes.append({"state": new_state, "reason": reason})
+
+    @workflow.signal
+    def profile_assigned(self, payload: dict) -> None:
+        self.profile_assignments.append(dict(payload))
+
+    @workflow.query
+    def get_state(self) -> dict:
+        return {
+            "state_changes": list(self.state_changes),
+            "profile_assignments": list(self.profile_assignments),
+        }
+
+    @workflow.run
+    async def run(self, request: AgentExecutionRequest) -> AgentRunResult:
+        return await workflow.execute_child_workflow(
+            MoonMindAgentRun.run,
+            request,
+            id=f"{workflow.info().workflow_id}:child",
+            task_queue="agent-run-task-queue",
+        )
+
+
+@_activity.defn(name="agent_runtime.status")
+async def mock_agent_runtime_status_rate_limited(request: dict) -> dict:
+    return {
+        "runId": request.get("run_id", "managed-rate-limit-run"),
+        "agentKind": "managed",
+        "agentId": request.get("agent_id", "gemini_cli"),
+        "status": "failed",
+    }
+
+
+@_activity.defn(name="agent_runtime.fetch_result")
+async def mock_agent_runtime_fetch_result_rate_limited(request: dict) -> dict:
+    return {
+        "summary": "Gemini API rate limit exceeded",
+        "failureClass": "integration_error",
+        "providerErrorCode": "429",
+    }
 
 
 @pytest.mark.asyncio
@@ -306,6 +375,88 @@ async def test_agent_run_workflow_cancellation():
                 assert "cancel" in exc_str or "cancel" in cause_str or isinstance(
                     exc_info.value.__cause__, asyncio.CancelledError
                 )
+
+
+@pytest.mark.asyncio
+async def test_agent_run_reports_managed_429_retry_summary_to_parent():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="mm.workflow",
+            activities=_WORKFLOW_QUEUE_ACTIVITIES,
+        ):
+            async with Worker(
+                env.client,
+                task_queue="agent-run-task-queue",
+                workflows=[MoonMindAgentRun, MockAuthProfileManager, TestAgentRunParent],
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                request = AgentExecutionRequest(
+                    agent_kind="managed",
+                    agent_id="gemini_cli",
+                    execution_profile_ref="default-managed",
+                    correlation_id="corr-429",
+                    idempotency_key="idem-429",
+                )
+
+                manager_id = "auth-profile-manager:gemini_cli"
+                await env.client.start_workflow(
+                    MockAuthProfileManager.run,
+                    {"runtime_id": "gemini_cli"},
+                    id=manager_id,
+                    task_queue="agent-run-task-queue",
+                )
+
+                parent_handle = await env.client.start_workflow(
+                    TestAgentRunParent.run,
+                    request,
+                    id="test-parent-managed-429",
+                    task_queue="agent-run-task-queue",
+                )
+                child_handle = env.client.get_workflow_handle(
+                    "test-parent-managed-429:child"
+                )
+                manager_handle = env.client.get_workflow_handle(manager_id)
+
+                parent_state = {}
+                for _ in range(30):
+                    parent_state = await parent_handle.query(TestAgentRunParent.get_state)
+                    if parent_state.get("profile_assignments"):
+                        break
+                    await asyncio.sleep(0.1)
+
+                await child_handle.signal(
+                    MoonMindAgentRun.completion_signal,
+                    {
+                        "summary": "Gemini API rate limit exceeded",
+                        "failureClass": "integration_error",
+                        "providerErrorCode": "429",
+                    },
+                )
+
+                manager_state = {}
+                for _ in range(30):
+                    parent_state = await parent_handle.query(TestAgentRunParent.get_state)
+                    manager_state = await manager_handle.query(MockAuthProfileManager.get_state)
+                    if manager_state.get("cooldown_reports") and any(
+                        "retry scheduled" in change["reason"].lower()
+                        for change in parent_state.get("state_changes", [])
+                    ):
+                        break
+                    await asyncio.sleep(0.1)
+
+                assert manager_state["cooldown_reports"]
+                assert manager_state["cooldown_reports"][-1]["cooldown_seconds"] == 900
+                assert any(
+                    "retry scheduled" in change["reason"].lower()
+                    and "900s cooldown" in change["reason"].lower()
+                    for change in parent_state["state_changes"]
+                )
+
+                await parent_handle.cancel()
+                with pytest.raises(WorkflowFailureError):
+                    await parent_handle.result()
 
 
 # --- External agent workflow path ---
@@ -589,4 +740,3 @@ async def test_cancellation_releases_auth_profile_slot():
                        manager_state_after.get("leases", {}).get("default-managed") != "test-workflow-cancel-slot", (
                     f"Slot was NOT released after cancellation. Manager state: {manager_state_after}"
                 )
-

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.output_parser import (
+    GeminiCliOutputParser,
     NdjsonOutputParser,
     ParsedOutput,
     PlainTextOutputParser,
@@ -155,6 +156,33 @@ async def test_stream_and_parse_detects_rate_limit(streamer):
 
     assert parsed.rate_limited
     assert len(parsed.error_messages) > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_and_parse_invokes_event_callback(streamer):
+    log_streamer, _ = streamer
+    stdout_reader = asyncio.StreamReader()
+    stdout_reader.feed_data(
+        b"Attempt 6 failed with status 429. Retrying with backoff...\n"
+    )
+    stdout_reader.feed_eof()
+    stderr_reader = asyncio.StreamReader()
+    stderr_reader.feed_eof()
+    seen_events: list[dict] = []
+
+    async def _callback(events: list[dict]) -> None:
+        seen_events.extend(events)
+
+    _, _, _, parsed = await log_streamer.stream_and_parse(
+        stdout_reader,
+        stderr_reader,
+        run_id="run-parse-gemini-callback",
+        parser=GeminiCliOutputParser(),
+        event_callback=_callback,
+    )
+
+    assert parsed.rate_limited
+    assert any(event.get("type") == "rate_limit" for event in seen_events)
 
 
 def test_diagnostics_includes_parsed_output(streamer):

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -101,7 +101,7 @@ async def test_stream_and_parse_with_plain_text_parser(streamer):
     stderr_reader.feed_data(b"Error: oops\n")
     stderr_reader.feed_eof()
 
-    log_refs, stdout, stderr, parsed = await log_streamer.stream_and_parse(
+    log_refs, stdout, stderr, parsed, events = await log_streamer.stream_and_parse(
         stdout_reader, stderr_reader,
         run_id="run-parse-plain", parser=PlainTextOutputParser(),
     )
@@ -129,7 +129,7 @@ async def test_stream_and_parse_with_ndjson_parser(streamer):
     stderr_reader = asyncio.StreamReader()
     stderr_reader.feed_eof()
 
-    log_refs, stdout, stderr, parsed = await log_streamer.stream_and_parse(
+    log_refs, stdout, stderr, parsed, events = await log_streamer.stream_and_parse(
         stdout_reader, stderr_reader,
         run_id="run-parse-ndjson", parser=NdjsonOutputParser(),
     )
@@ -149,7 +149,7 @@ async def test_stream_and_parse_detects_rate_limit(streamer):
     stderr_reader = asyncio.StreamReader()
     stderr_reader.feed_eof()
 
-    _, _, _, parsed = await log_streamer.stream_and_parse(
+    _, _, _, parsed, events = await log_streamer.stream_and_parse(
         stdout_reader, stderr_reader,
         run_id="run-parse-rl", parser=NdjsonOutputParser(),
     )
@@ -173,7 +173,7 @@ async def test_stream_and_parse_invokes_event_callback(streamer):
     async def _callback(events: list[dict]) -> None:
         seen_events.extend(events)
 
-    _, _, _, parsed = await log_streamer.stream_and_parse(
+    _, _, _, parsed, events = await log_streamer.stream_and_parse(
         stdout_reader,
         stderr_reader,
         run_id="run-parse-gemini-callback",
@@ -222,7 +222,7 @@ async def test_stream_and_parse_no_parser_uses_default(streamer):
     stderr_reader = asyncio.StreamReader()
     stderr_reader.feed_eof()
 
-    log_refs, stdout, stderr, parsed = await log_streamer.stream_and_parse(
+    log_refs, stdout, stderr, parsed, events = await log_streamer.stream_and_parse(
         stdout_reader, stderr_reader,
         run_id="run-parse-default",
     )

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -10,6 +10,7 @@ These tests specifically demonstrate:
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -295,6 +296,45 @@ async def test_supervise_nonzero_exit_classified_as_failed(tmp_path: Path):
 
     assert result.status == "failed"
     assert result.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_supervise_terminates_gemini_on_live_rate_limit(tmp_path: Path):
+    """Gemini rate-limit output should terminate the live process early."""
+    supervisor, store, storage = _make_supervisor(tmp_path)
+    run_id = "run-gemini-rate-limit"
+    _save_record(store, run_id)
+
+    process = await asyncio.create_subprocess_exec(
+        "python3",
+        "-c",
+        (
+            "import sys,time; "
+            "sys.stderr.write('Attempt 6 failed with status 429. Retrying with backoff...\\n'); "
+            "sys.stderr.write('reason: MODEL_CAPACITY_EXHAUSTED\\n'); "
+            "sys.stderr.flush(); "
+            "time.sleep(30)"
+        ),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    result = await asyncio.wait_for(
+        supervisor.supervise(
+            run_id=run_id,
+            process=process,
+            timeout_seconds=10,
+        ),
+        timeout=5,
+    )
+
+    assert result.status == "failed"
+    assert result.failure_class == "integration_error"
+    diagnostics = json.loads(
+        storage.resolve_storage_path(result.diagnostics_ref).read_text(encoding="utf-8")
+    )
+    assert diagnostics["parsed_output"]["rate_limited"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from moonmind.workflows.temporal.runtime.output_parser import (
+    GeminiCliOutputParser,
     NdjsonOutputParser,
     PlainTextOutputParser,
 )
@@ -187,6 +188,13 @@ class TestDefaultStrategyClassifyExit:
         assert status == "failed"
         assert failure == "execution_error"
 
+    def test_gemini_rate_limited(self) -> None:
+        s = GeminiCliStrategy()
+        stderr = "Error 429: Too many requests\nreason: MODEL_CAPACITY_EXHAUSTED"
+        status, failure = s.classify_exit(143, "", stderr)
+        assert status == "failed"
+        assert failure == "integration_error"
+
     def test_claude_success(self) -> None:
         s = ClaudeCodeStrategy()
         status, failure = s.classify_exit(0, "", "")
@@ -203,7 +211,7 @@ class TestDefaultStrategyClassifyExit:
 class TestDefaultOutputParser:
     def test_gemini_returns_plain_text(self) -> None:
         s = GeminiCliStrategy()
-        assert isinstance(s.create_output_parser(), PlainTextOutputParser)
+        assert isinstance(s.create_output_parser(), GeminiCliOutputParser)
 
     def test_claude_returns_plain_text(self) -> None:
         s = ClaudeCodeStrategy()
@@ -212,3 +220,24 @@ class TestDefaultOutputParser:
     def test_codex_returns_plain_text(self) -> None:
         s = CodexCliStrategy()
         assert isinstance(s.create_output_parser(), PlainTextOutputParser)
+
+
+class TestGeminiCliOutputParser:
+    def test_parse_stream_chunk_detects_capacity_rate_limit(self) -> None:
+        parser = GeminiCliOutputParser()
+        events = parser.parse_stream_chunk(
+            'Attempt 6 failed with status 429. Retrying with backoff...\n'
+        )
+        assert len(events) == 1
+        assert events[0]["type"] == "rate_limit"
+        assert events[0]["status_code"] == 429
+
+    def test_parse_detects_capacity_markers(self) -> None:
+        parser = GeminiCliOutputParser()
+        result = parser.parse(
+            "",
+            'message: No capacity available for model gemini-3.1-pro-preview\n'
+            'reason: MODEL_CAPACITY_EXHAUSTED\n',
+        )
+        assert result.rate_limited
+        assert any("capacity" in message.lower() for message in result.error_messages)

--- a/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
@@ -242,3 +242,60 @@ async def test_fetch_result_prefers_report_with_matching_run_workspace(
 
     assert result["failureClass"] == "integration_error"
     assert result["providerErrorCode"] == "quota_exhausted"
+
+
+async def test_fetch_result_uses_diagnostics_when_report_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report_dir = tmp_path / "reports"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(activity_runtime_module, "_GEMINI_ERROR_REPORT_DIR", report_dir)
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(tmp_path))
+
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    started_at = now - timedelta(minutes=3)
+    finished_at = now - timedelta(minutes=2)
+    run_id = "gemini-run-diagnostics-429"
+    diagnostics_ref = f"{run_id}/diagnostics.json"
+    diagnostics_path = tmp_path / "artifacts" / diagnostics_ref
+    diagnostics_path.parent.mkdir(parents=True, exist_ok=True)
+    diagnostics_path.write_text(
+        json.dumps(
+            {
+                "parsed_output": {
+                    "rate_limited": True,
+                    "error_messages": [
+                        "Attempt 6 failed with status 429. Retrying with backoff...",
+                        "reason: MODEL_CAPACITY_EXHAUSTED",
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    run_store.save(
+        ManagedRunRecord(
+            runId=run_id,
+            agentId="gemini_cli",
+            runtimeId="gemini_cli",
+            status="failed",
+            pid=1234,
+            exitCode=143,
+            startedAt=started_at,
+            finishedAt=finished_at,
+            diagnosticsRef=diagnostics_ref,
+            errorMessage="Process exited with code 143",
+            failureClass="integration_error",
+            workspacePath=f"/work/agent_jobs/workspaces/{run_id}/repo",
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result({"run_id": run_id})
+
+    assert result["failureClass"] == "integration_error"
+    assert result["providerErrorCode"] == "429"
+    assert "429" in result["summary"]


### PR DESCRIPTION
## What changed
This teaches managed Gemini runs to recognize provider 429 / capacity exhaustion as a first-class rate-limit condition instead of sitting in the internal provider retry loop until the run looks stuck.

It adds live Gemini output detection in the managed runtime supervisor, enriches managed fetch results from diagnostics when a standalone Gemini error report is missing, and updates `MoonMind.AgentRun` to surface the cooldown reason through the existing child state summary path so it shows up in the task details timeline.

It also makes the retry delay configurable through the auth profile `cooldown_after_429_seconds` setting and raises the default for newly created Gemini-capable profiles/UI forms to 900 seconds (15 minutes).

## Why
A managed Gemini run that hits `429` / `MODEL_CAPACITY_EXHAUSTED` can keep retrying inside the provider CLI, which leaves the workflow looking alive but not meaningfully progressing. Operators need to see that state in the task timeline, and the workflow should back off long enough for capacity to recover before requesting another slot.

## User impact
Gemini capacity failures now show up as an `awaiting_slot` retry reason in the task details timeline with the scheduled retry timestamp and cooldown duration. Managed runs release the current auth profile lease, report cooldown to the profile manager, and retry after the configured cooldown rather than thrashing every few seconds.

## Root cause
The runtime only classified Gemini 429s after the process fully exited and only when a separate Gemini error report file existed. When Gemini CLI stayed inside its own retry loop, the workflow stayed in a poll cycle and the UI never got a meaningful waiting reason.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/runtime/test_output_parser.py tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py tests/integration/services/temporal/workflows/test_agent_run.py`
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_auth_profile_manager.py tests/unit/api_service/api/routers/test_auth_profiles.py tests/unit/api_service/api/routers/test_oauth_sessions.py`