### PR TITLE
[codex] Structure managed Gemini rate-limit results

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,167 +1,37 @@
 [
   {
-    "id": 4147576145,
+    "id": 4148277041,
     "disposition": "not-applicable",
-    "rationale": "Informational summary from bot, no action needed."
+    "rationale": "Codex usage limit warning, not an actionable review comment."
   },
   {
-    "id": 4147576250,
+    "id": 4025685035,
     "disposition": "not-applicable",
-    "rationale": "Informational usage warning from bot."
+    "rationale": "Bot review stating no feedback."
   },
   {
-    "id": 3004476246,
+    "id": 3004964461,
     "disposition": "addressed",
-    "rationale": "Refactored dict merge using dictionary comprehension to filter reserved keys before merging."
+    "rationale": "Removed unused imports AgentRunState and FailureClass."
   },
   {
-    "id": 3004476253,
+    "id": 3004964466,
     "disposition": "addressed",
-    "rationale": "Removed unused json import from plan_script.py."
+    "rationale": "Used AgentRunState and RuntimeFailureClass in ManagedRuntimeExitResult."
   },
   {
-    "id": 4025224334,
+    "id": 3004964471,
+    "disposition": "addressed",
+    "rationale": "Added runtime_id == 'gemini_cli' check for rate limit error message."
+  },
+  {
+    "id": 3004964480,
+    "disposition": "addressed",
+    "rationale": "Tightened parsed_output annotation to ParsedOutput | None."
+  },
+  {
+    "id": 4025686730,
     "disposition": "not-applicable",
-    "rationale": "Review summary from gemini-code-assist."
-  },
-  {
-    "id": 3004476542,
-    "disposition": "addressed",
-    "rationale": "Addressed by removing unused json import in plan_script.py."
-  },
-  {
-    "id": 3004478895,
-    "disposition": "addressed",
-    "rationale": "Addressed by removing unused json import in plan_script.py."
-  },
-  {
-    "id": 3004478902,
-    "disposition": "addressed",
-    "rationale": "Changed step IDs to step-1 and step-2 in plan_script.py."
-  },
-  {
-    "id": 3004478905,
-    "disposition": "addressed",
-    "rationale": "Filtered reserved keys in worker_runtime.py."
-  },
-  {
-    "id": 3004478910,
-    "disposition": "addressed",
-    "rationale": "Added unit test test_runtime_planner_multi_step_preserves_custom_keys."
-  },
-  {
-    "id": 4025226978,
-    "disposition": "not-applicable",
-    "rationale": "Review summary from copilot."
-  },
-  {
-    "id": 4147586544,
-    "disposition": "not-applicable",
-    "rationale": "Informational bot greeting."
-  },
-  {
-    "id": 4147688756,
-    "disposition": "not-applicable",
-    "rationale": "Informational greeting from jules bot."
-  },
-  {
-    "id": 4147689011,
-    "disposition": "not-applicable",
-    "rationale": "Informational usage limit message from codex bot."
-  },
-  {
-    "id": 4025366377,
-    "disposition": "not-applicable",
-    "rationale": "Overall code review summary from gemini-code-assist bot."
-  },
-  {
-    "id": 3004601024,
-    "disposition": "addressed",
-    "rationale": "Added tests for TemporalArtifactActivities covering the new Pydantic models, legacy dictionaries, and kwargs fallbacks."
-  },
-  {
-    "id": 3004601027,
-    "disposition": "addressed",
-    "rationale": "Refactored artifact_read validation, consolidating parameter access and narrowing the exception block."
-  },
-  {
-    "id": 3004601028,
-    "disposition": "addressed",
-    "rationale": "Refactored artifact_write_complete validation, consolidating parameter access and narrowing the exception block."
-  },
-  {
-    "id": 3004601511,
-    "disposition": "addressed",
-    "rationale": "Tightened the type hint of request for artifact_read by adding ArtifactReadInput."
-  },
-  {
-    "id": 3004601518,
-    "disposition": "addressed",
-    "rationale": "Narrowed exception scope to ValidationError instead of generic Exception in artifact_read."
-  },
-  {
-    "id": 3004601523,
-    "disposition": "addressed",
-    "rationale": "Tightened the type hint of request for artifact_write_complete by adding ArtifactWriteCompleteInput."
-  },
-  {
-    "id": 3004601525,
-    "disposition": "addressed",
-    "rationale": "Narrowed exception scope to ValidationError instead of generic Exception in artifact_write_complete."
-  },
-  {
-    "id": 4025366822,
-    "disposition": "not-applicable",
-    "rationale": "Suppressed low confidence comment by reviewer about legacy list payloads."
-  },
-  {
-    "id": 3004791140,
-    "disposition": "addressed",
-    "rationale": "Removed unused import TemporalArtifactValidationError."
-  },
-  {
-    "id": 4147632858,
-    "disposition": "not-applicable",
-    "rationale": "Informational greeting from jules bot."
-  },
-  {
-    "id": 4147632968,
-    "disposition": "not-applicable",
-    "rationale": "Informational message about Codex usage limit."
-  },
-  {
-    "id": 3004512513,
-    "disposition": "addressed",
-    "rationale": "Extracted mock_session fixture in test_temporal_service_pause_guard.py."
-  },
-  {
-    "id": 3004512516,
-    "disposition": "addressed",
-    "rationale": "Extracted mock_client_adapter fixture in test_temporal_service.py."
-  },
-  {
-    "id": 4025260170,
-    "disposition": "not-applicable",
-    "rationale": "Informational code review summary."
-  },
-  {
-    "id": 3004516642,
-    "disposition": "addressed",
-    "rationale": "Moved unittest.mock import to the top of test_temporal_service.py."
-  },
-  {
-    "id": 3004516645,
-    "disposition": "addressed",
-    "rationale": "Extracted mock_client_adapter fixture in test_temporal_service.py (duplicate suggestion)."
-  },
-  {
-    "id": 3004516651,
-    "disposition": "addressed",
-    "rationale": "Extracted mock_session fixture in test_temporal_service_pause_guard.py (duplicate suggestion)."
-  },
-  {
-    "id": 4025265860,
-    "disposition": "not-applicable",
-    "rationale": "Informational PR review overview."
+    "rationale": "Pull request overview summary, not actionable."
   }
 ]

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -365,6 +365,7 @@ class ManagedRunRecord(BaseModel):
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
     error_message: str | None = Field(None, alias="errorMessage")
     failure_class: FailureClass | None = Field(None, alias="failureClass")
+    provider_error_code: str | None = Field(None, alias="providerErrorCode")
 
     @model_validator(mode="after")
     def _normalize(self) -> "ManagedRunRecord":

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -433,6 +433,7 @@ class ManagedAgentAdapter:
                     summary=summary,
                     output_refs=output_refs,
                     failure_class=failure_class,
+                    provider_error_code=record.provider_error_code,
                 )
         return AgentRunResult()
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3203,6 +3203,8 @@ class TemporalAgentRuntimeActivities:
             return result
         if record.status != "failed":
             return result
+        if result.provider_error_code:
+            return result
         if result.failure_class not in {None, "execution_error", "integration_error"}:
             return result
         if not cls._is_generic_process_exit_summary(result.summary):

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -9,11 +9,25 @@ using if/elif branching on ``runtime_id``.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from moonmind.workflows.temporal.runtime.output_parser import PlainTextOutputParser, RuntimeOutputParser
+from moonmind.workflows.temporal.runtime.output_parser import (
+    ParsedOutput,
+    PlainTextOutputParser,
+    RuntimeOutputParser,
+)
 from moonmind.workflows.temporal.runtime.self_heal import FailureClass, is_failure_retryable
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedRuntimeExitResult:
+    """Structured managed-runtime exit classification."""
+
+    status: str
+    failure_class: str | None
+    provider_error_code: str | None = None
 
 
 class ManagedRuntimeStrategy(ABC):
@@ -118,6 +132,25 @@ class ManagedRuntimeStrategy(ABC):
         if exit_code == 0:
             return "completed", None
         return "failed", "execution_error"
+
+    def classify_result(
+        self,
+        *,
+        exit_code: int | None,
+        stdout: str,
+        stderr: str,
+        parsed_output: ParsedOutput | None = None,
+    ) -> ManagedRuntimeExitResult:
+        """Return structured exit metadata for one managed runtime process."""
+        status, failure_class = self.classify_exit(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        return ManagedRuntimeExitResult(
+            status=status,
+            failure_class=failure_class,
+        )
 
     def create_output_parser(self) -> RuntimeOutputParser:
         """Factory for the runtime's stream parser.

--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from moonmind.schemas.agent_runtime_models import (
+    AgentRunState,
+    FailureClass as RuntimeFailureClass,
+)
 from moonmind.workflows.temporal.runtime.output_parser import (
     ParsedOutput,
     PlainTextOutputParser,
@@ -25,8 +29,8 @@ from moonmind.workflows.temporal.runtime.self_heal import FailureClass, is_failu
 class ManagedRuntimeExitResult:
     """Structured managed-runtime exit classification."""
 
-    status: str
-    failure_class: str | None
+    status: AgentRunState
+    failure_class: RuntimeFailureClass | None
     provider_error_code: str | None = None
 
 

--- a/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/gemini_cli.py
@@ -6,9 +6,11 @@ from typing import Any
 
 from moonmind.workflows.temporal.runtime.output_parser import (
     GeminiCliOutputParser,
+    ParsedOutput,
     RuntimeOutputParser,
 )
 from moonmind.workflows.temporal.runtime.strategies.base import (
+    ManagedRuntimeExitResult,
     ManagedRuntimeStrategy,
 )
 
@@ -87,6 +89,28 @@ class GeminiCliStrategy(ManagedRuntimeStrategy):
         if exit_code == 0:
             return "completed", None
         return "failed", "execution_error"
+
+    def classify_result(
+        self,
+        *,
+        exit_code: int | None,
+        stdout: str,
+        stderr: str,
+        parsed_output: ParsedOutput | None = None,
+    ) -> ManagedRuntimeExitResult:
+        parsed = parsed_output or self.create_output_parser().parse(stdout, stderr)
+        if parsed.rate_limited:
+            return ManagedRuntimeExitResult(
+                status="failed",
+                failure_class="integration_error",
+                provider_error_code="429",
+            )
+        if exit_code == 0:
+            return ManagedRuntimeExitResult(status="completed", failure_class=None)
+        return ManagedRuntimeExitResult(
+            status="failed",
+            failure_class="execution_error",
+        )
 
     def create_output_parser(self) -> RuntimeOutputParser:
         return GeminiCliOutputParser()

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -28,6 +28,7 @@ from moonmind.schemas.agent_runtime_models import (
 from .log_streamer import RuntimeLogStreamer
 from .store import ManagedRunStore
 from .strategies import get_strategy
+from .strategies.base import ManagedRuntimeExitResult
 
 HEARTBEAT_INTERVAL = 30  # seconds
 GRACEFUL_TERMINATE_WAIT_SECONDS = (
@@ -146,19 +147,25 @@ class ManagedRunSupervisor:
             )
 
             # Classify exit
-            status, failure_class = self._classify_exit(
+            exit_result = self._classify_exit(
                 runtime_id=runtime_id,
                 exit_code=exit_code,
                 timed_out=timed_out,
                 stdout=stdout_content,
                 stderr=stderr_content,
+                parsed_output=parsed_output,
             )
+            status = exit_result.status
+            failure_class = exit_result.failure_class
 
             error_message = None
             if status == "failed":
-                error_message = f"Process exited with code {exit_code}"
-                if parsed_output.error_messages:
-                    error_message += f": {parsed_output.error_messages[0]}"
+                if exit_result.provider_error_code == "429":
+                    error_message = "Gemini API rate limit exceeded"
+                else:
+                    error_message = f"Process exited with code {exit_code}"
+                    if parsed_output.error_messages:
+                        error_message += f": {parsed_output.error_messages[0]}"
             elif status == "timed_out":
                 error_message = (
                     f"Process timed out after {timeout_seconds}s"
@@ -172,6 +179,7 @@ class ManagedRunSupervisor:
                 diagnostics_ref=diagnostics_ref,
                 log_artifact_ref=log_refs.get("stdout"),
                 failure_class=failure_class,
+                provider_error_code=exit_result.provider_error_code,
                 error_message=error_message,
             )
 
@@ -344,26 +352,35 @@ class ManagedRunSupervisor:
         timed_out: bool,
         stdout: str,
         stderr: str,
-    ) -> tuple[AgentRunState, FailureClass | None]:
+        parsed_output: Any | None = None,
+    ) -> ManagedRuntimeExitResult:
         """Classify process exit into a run state and optional failure class."""
+
         if timed_out:
-            return "timed_out", "execution_error"
+            return ManagedRuntimeExitResult(
+                status="timed_out",
+                failure_class="execution_error",
+            )
 
         if runtime_id:
             strategy = get_strategy(runtime_id)
             if strategy:
-                # strategy.classify_exit returns (status, failure_class)
-                status, failure_class = strategy.classify_exit(
+                return strategy.classify_result(
                     exit_code=exit_code,
                     stdout=stdout,
                     stderr=stderr,
+                    parsed_output=parsed_output,
                 )
-                # Map to AgentRunState if needed, or assume strategy returns one
-                return status, failure_class
 
         if exit_code == 0:
-            return "completed", None
-        return "failed", "execution_error"
+            return ManagedRuntimeExitResult(
+                status="completed",
+                failure_class=None,
+            )
+        return ManagedRuntimeExitResult(
+            status="failed",
+            failure_class="execution_error",
+        )
 
     @staticmethod
     def _resolve_effective_exit_code(
@@ -427,6 +444,7 @@ class ManagedRunSupervisor:
             "summary": summary,
             "output_refs": output_refs,
             "failure_class": record.failure_class,
+            "provider_error_code": record.provider_error_code,
         }
 
     @staticmethod

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -20,8 +20,6 @@ logger = logging.getLogger(__name__)
 CompletionCallback = Callable[[dict[str, Any]], Awaitable[None]]
 
 from moonmind.schemas.agent_runtime_models import (
-    AgentRunState,
-    FailureClass,
     ManagedRunRecord,
 )
 
@@ -29,6 +27,7 @@ from .log_streamer import RuntimeLogStreamer
 from .store import ManagedRunStore
 from .strategies import get_strategy
 from .strategies.base import ManagedRuntimeExitResult
+from .output_parser import ParsedOutput
 
 HEARTBEAT_INTERVAL = 30  # seconds
 GRACEFUL_TERMINATE_WAIT_SECONDS = (
@@ -160,7 +159,7 @@ class ManagedRunSupervisor:
 
             error_message = None
             if status == "failed":
-                if exit_result.provider_error_code == "429":
+                if runtime_id == "gemini_cli" and exit_result.provider_error_code == "429":
                     error_message = "Gemini API rate limit exceeded"
                 else:
                     error_message = f"Process exited with code {exit_code}"
@@ -352,7 +351,7 @@ class ManagedRunSupervisor:
         timed_out: bool,
         stdout: str,
         stderr: str,
-        parsed_output: Any | None = None,
+        parsed_output: ParsedOutput | None = None,
     ) -> ManagedRuntimeExitResult:
         """Classify process exit into a run state and optional failure class."""
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -94,12 +94,19 @@ INTEGRATIONS_STATUS_TIMEOUT = timedelta(seconds=60)
 WORKFLOW_TASK_QUEUE = "mm.workflow"
 STREAMING_EXTERNAL_HEARTBEAT_TIMEOUT = timedelta(seconds=120)
 MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
+MANAGED_429_CONTINUE_AS_NEW_PATCH_ID = "agent-run-managed-429-continue-as-new-v1"
 
 # How long to wait for a slot_assigned signal before assuming the manager is
 # stuck (e.g. nondeterminism error) and resetting it.
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
 _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
+_MAX_AGENT_RUN_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
+_MAX_MANAGED_429_RETRIES_BEFORE_CONTINUE_AS_NEW = 25
+_INTERNAL_REQUEST_STATE_KEY = "__moonmind_temporal_internal"
+_INTERNAL_MANAGED_429_RETRY_COUNT_KEY = "managed_429_retry_count"
+_INTERNAL_MANAGED_429_WAITING_REASON_KEY = "managed_429_waiting_reason"
+_INTERNAL_MANAGED_429_SLOT_WAIT_TIMEOUT_KEY = "managed_429_slot_wait_timeout_seconds"
 
 
 @activity.defn(name="integration.get_activity_route")
@@ -188,6 +195,7 @@ class MoonMindAgentRun:
         self._profile_snapshots: dict[str, dict[str, Any]] = {}
         self._awaiting_slot_reason_override: str | None = None
         self._slot_wait_timeout_override_seconds: int | None = None
+        self._managed_429_retry_count = 0
 
     async def _get_route_info(self, activity_name: str, fallback_queue: str, fallback_timeout: timedelta) -> tuple[str, timedelta, timedelta, RetryPolicy | None, timedelta | None]:
         if activity_name in self._route_cache:
@@ -303,6 +311,79 @@ class MoonMindAgentRun:
         return (
             f"Gemini capacity exhausted for {runtime_id}{profile_fragment}; retry scheduled for "
             f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
+        )
+
+    @staticmethod
+    def _request_internal_state(request: AgentExecutionRequest) -> dict[str, Any]:
+        params = request.parameters or {}
+        raw_state = params.get(_INTERNAL_REQUEST_STATE_KEY)
+        if isinstance(raw_state, dict):
+            return dict(raw_state)
+        return {}
+
+    def _restore_internal_request_state(self, request: AgentExecutionRequest) -> None:
+        internal_state = self._request_internal_state(request)
+        raw_retry_count = internal_state.get(_INTERNAL_MANAGED_429_RETRY_COUNT_KEY, 0)
+        try:
+            retry_count = int(raw_retry_count)
+        except (TypeError, ValueError):
+            retry_count = 0
+        self._managed_429_retry_count = max(retry_count, 0)
+
+        waiting_reason = internal_state.get(_INTERNAL_MANAGED_429_WAITING_REASON_KEY)
+        if isinstance(waiting_reason, str) and waiting_reason.strip():
+            self._awaiting_slot_reason_override = waiting_reason.strip()
+
+        raw_wait_timeout = internal_state.get(_INTERNAL_MANAGED_429_SLOT_WAIT_TIMEOUT_KEY)
+        try:
+            wait_timeout = int(raw_wait_timeout)
+        except (TypeError, ValueError):
+            wait_timeout = 0
+        if wait_timeout > 0:
+            self._slot_wait_timeout_override_seconds = wait_timeout
+
+    @staticmethod
+    def _request_with_internal_state(
+        request: AgentExecutionRequest,
+        *,
+        retry_count: int,
+        waiting_reason: str | None,
+        slot_wait_timeout_seconds: int | None,
+    ) -> AgentExecutionRequest:
+        params = dict(request.parameters or {})
+        raw_internal_state = params.get(_INTERNAL_REQUEST_STATE_KEY)
+        internal_state = (
+            dict(raw_internal_state)
+            if isinstance(raw_internal_state, dict)
+            else {}
+        )
+        internal_state[_INTERNAL_MANAGED_429_RETRY_COUNT_KEY] = max(retry_count, 0)
+        if waiting_reason:
+            internal_state[_INTERNAL_MANAGED_429_WAITING_REASON_KEY] = waiting_reason
+        else:
+            internal_state.pop(_INTERNAL_MANAGED_429_WAITING_REASON_KEY, None)
+        if slot_wait_timeout_seconds and slot_wait_timeout_seconds > 0:
+            internal_state[_INTERNAL_MANAGED_429_SLOT_WAIT_TIMEOUT_KEY] = (
+                slot_wait_timeout_seconds
+            )
+        else:
+            internal_state.pop(_INTERNAL_MANAGED_429_SLOT_WAIT_TIMEOUT_KEY, None)
+        params[_INTERNAL_REQUEST_STATE_KEY] = internal_state
+        return request.model_copy(update={"parameters": params})
+
+    def _should_continue_as_new_after_managed_429(self) -> bool:
+        if not workflow.patched(MANAGED_429_CONTINUE_AS_NEW_PATCH_ID):
+            return False
+        if workflow.info().is_continue_as_new_suggested():
+            return True
+        if (
+            workflow.info().get_current_history_length()
+            >= _MAX_AGENT_RUN_EVENTS_BEFORE_CONTINUE_AS_NEW
+        ):
+            return True
+        return (
+            self._managed_429_retry_count
+            >= _MAX_MANAGED_429_RETRIES_BEFORE_CONTINUE_AS_NEW
         )
 
 
@@ -672,6 +753,7 @@ class MoonMindAgentRun:
     @workflow.run
     async def run(self, request: AgentExecutionRequest) -> AgentRunResult:
         self.agent_kind = request.agent_kind
+        self._restore_internal_request_state(request)
 
         timeout_seconds = (
             DEFAULT_EXTERNAL_TIMEOUT_SECONDS
@@ -1403,6 +1485,16 @@ class MoonMindAgentRun:
                             cooldown_seconds + 60,
                             _SLOT_WAIT_TIMEOUT_SECONDS,
                         )
+                        self._managed_429_retry_count += 1
+                        if self._should_continue_as_new_after_managed_429():
+                            workflow.continue_as_new(
+                                self._request_with_internal_state(
+                                    request,
+                                    retry_count=self._managed_429_retry_count,
+                                    waiting_reason=waiting_reason,
+                                    slot_wait_timeout_seconds=self._slot_wait_timeout_override_seconds,
+                                )
+                            )
                         self.completion_event.clear()
                         self.final_result = None
                         self._assigned_profile_id = None

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -6,6 +6,7 @@ from temporalio import workflow
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 from temporalio.client import WorkflowFailureError
+from temporalio.service import RPCError
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -453,6 +454,109 @@ async def test_agent_run_reports_managed_429_retry_summary_to_parent():
                     and "900s cooldown" in change["reason"].lower()
                     for change in parent_state["state_changes"]
                 )
+
+                await parent_handle.cancel()
+                with pytest.raises(WorkflowFailureError):
+                    await parent_handle.result()
+
+
+@pytest.mark.asyncio
+async def test_agent_run_managed_429_can_continue_as_new_after_retry_threshold():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="mm.workflow",
+            activities=_WORKFLOW_QUEUE_ACTIVITIES,
+        ):
+            async with Worker(
+                env.client,
+                task_queue="agent-run-task-queue",
+                workflows=[MoonMindAgentRun, MockAuthProfileManager, TestAgentRunParent],
+                activities=_COMMON_AGENT_RUN_ACTIVITIES,
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                request = AgentExecutionRequest(
+                    agent_kind="managed",
+                    agent_id="gemini_cli",
+                    execution_profile_ref="default-managed",
+                    correlation_id="corr-429-continue-as-new",
+                    idempotency_key="idem-429-continue-as-new",
+                    parameters={
+                        "__moonmind_temporal_internal": {
+                            "managed_429_retry_count": 24,
+                        }
+                    },
+                )
+
+                manager_id = "auth-profile-manager:gemini_cli"
+                await env.client.start_workflow(
+                    MockAuthProfileManager.run,
+                    {"runtime_id": "gemini_cli"},
+                    id=manager_id,
+                    task_queue="agent-run-task-queue",
+                )
+
+                parent_handle = await env.client.start_workflow(
+                    TestAgentRunParent.run,
+                    request,
+                    id="test-parent-managed-429-continue-as-new",
+                    task_queue="agent-run-task-queue",
+                )
+                child_handle = env.client.get_workflow_handle(
+                    "test-parent-managed-429-continue-as-new:child"
+                )
+                manager_handle = env.client.get_workflow_handle(manager_id)
+
+                original_run_id = ""
+                for _ in range(30):
+                    try:
+                        description = await child_handle.describe()
+                    except RPCError:
+                        await asyncio.sleep(0.1)
+                        continue
+                    original_run_id = description.run_id
+                    parent_state = await parent_handle.query(TestAgentRunParent.get_state)
+                    if parent_state.get("profile_assignments"):
+                        break
+                    await asyncio.sleep(0.1)
+
+                assert original_run_id
+
+                await child_handle.signal(
+                    MoonMindAgentRun.completion_signal,
+                    {
+                        "summary": "Gemini API rate limit exceeded",
+                        "failureClass": "integration_error",
+                        "providerErrorCode": "429",
+                    },
+                )
+
+                new_run_id = original_run_id
+                parent_state = {}
+                manager_state = {}
+                for _ in range(40):
+                    try:
+                        description = await child_handle.describe()
+                    except RPCError:
+                        await asyncio.sleep(0.1)
+                        continue
+                    new_run_id = description.run_id
+                    parent_state = await parent_handle.query(TestAgentRunParent.get_state)
+                    manager_state = await manager_handle.query(MockAuthProfileManager.get_state)
+                    if (
+                        new_run_id != original_run_id
+                        and manager_state.get("cooldown_reports")
+                        and any(
+                            "retry scheduled" in change["reason"].lower()
+                            for change in parent_state.get("state_changes", [])
+                        )
+                    ):
+                        break
+                    await asyncio.sleep(0.1)
+
+                assert new_run_id != original_run_id
+                assert manager_state["cooldown_reports"]
+                assert manager_state["cooldown_reports"][-1]["cooldown_seconds"] == 900
 
                 await parent_handle.cancel()
                 with pytest.raises(WorkflowFailureError):

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -331,6 +331,8 @@ async def test_supervise_terminates_gemini_on_live_rate_limit(tmp_path: Path):
 
     assert result.status == "failed"
     assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "429"
+    assert result.error_message == "Gemini API rate limit exceeded"
     diagnostics = json.loads(
         storage.resolve_storage_path(result.diagnostics_ref).read_text(encoding="utf-8")
     )

--- a/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py
@@ -90,6 +90,37 @@ async def test_fetch_result_maps_gemini_quota_report_to_integration_error(
     assert "exhausted your capacity" in result["summary"].lower()
 
 
+async def test_fetch_result_returns_structured_provider_error_from_record(
+    tmp_path: Path,
+) -> None:
+    run_store = ManagedRunStore(tmp_path / "run_store")
+    now = datetime.now(tz=UTC)
+    run_store.save(
+        ManagedRunRecord(
+            runId="gemini-run-structured-429",
+            agentId="gemini_cli",
+            runtimeId="gemini_cli",
+            status="failed",
+            pid=1234,
+            exitCode=1,
+            startedAt=now - timedelta(minutes=2),
+            finishedAt=now - timedelta(minutes=1),
+            errorMessage="Gemini API rate limit exceeded",
+            failureClass="integration_error",
+            providerErrorCode="429",
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(run_store=run_store)
+    result = await activities.agent_runtime_fetch_result(
+        {"run_id": "gemini-run-structured-429"}
+    )
+
+    assert result["failureClass"] == "integration_error"
+    assert result["providerErrorCode"] == "429"
+    assert result["summary"] == "Gemini API rate limit exceeded"
+
+
 async def test_fetch_result_keeps_non_generic_failure_summary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What changed
This follow-up removes the last Gemini 429-specific dependence on post-hoc result enrichment for the normal managed-runtime path.

The managed runtime supervisor now emits a structured exit classification that includes `providerErrorCode` when Gemini exits due to a detected rate-limit condition. That value is persisted on `ManagedRunRecord`, returned by the managed adapter, and surfaced directly by `agent_runtime.fetch_result`.

The existing diagnostics/error-report parsing remains in place only as a fallback for older runs and edge cases where the runtime record does not already contain structured provider error metadata.

## Why
The previous fix made Gemini 429 cooldown handling operationally correct, but the canonical result still depended on reconstructing rate-limit semantics from diagnostics or Gemini error-report files during `fetch_result`. That works, but it is not the cleanest contract boundary.

Structured provider error propagation is a better fit for Temporal and for our managed runtime abstraction: the activity/supervisor determines the failure reason once, persists it durably, and later workflow/activity consumers read the typed result directly.

## Impact
Managed Gemini runs now carry `providerErrorCode=429` as part of the stored managed run record. Fetching results for those runs no longer has to infer the 429 from logs in the normal case.

This keeps the workflow-owned cooldown/timeline behavior unchanged while making the underlying runtime result path cleaner and less heuristic.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/runtime/test_output_parser.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py tests/integration/services/temporal/workflows/test_agent_run.py`
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/workflows/temporal/test_agent_runtime_fetch_result.py`