### PR TITLE
feat: support providerProfile inheritance in batch-pr-resolver

### DIFF
--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -36,6 +36,7 @@ class RuntimeSelection:
     mode: str | None = None
     model: str | None = None
     effort: str | None = None
+    provider_profile: str | None = None
 
 
 def _run_command(cmd: list[str]) -> str:
@@ -279,7 +280,12 @@ def _load_parent_runtime_selection(
         effort = _runtime_text(
             runtime_config.get("effort") or runtime_node.get("effort")
         )
-        return RuntimeSelection(mode=mode, model=model, effort=effort)
+        provider_profile = _runtime_text(
+            runtime_config.get("providerProfile") or runtime_node.get("providerProfile")
+        )
+        return RuntimeSelection(
+            mode=mode, model=model, effort=effort, provider_profile=provider_profile
+        )
     return None
 
 
@@ -293,15 +299,19 @@ def _resolve_runtime_selection(args: argparse.Namespace) -> RuntimeSelection:
     )
     runtime_model = _runtime_text(args.runtime_model)
     runtime_effort = _runtime_text(args.runtime_effort)
+    runtime_provider_profile = _runtime_text(getattr(args, "runtime_provider_profile", None))
     if runtime_model is None and inherited is not None:
         runtime_model = inherited.model
     if runtime_effort is None and inherited is not None:
         runtime_effort = inherited.effort
+    if runtime_provider_profile is None and inherited is not None:
+        runtime_provider_profile = inherited.provider_profile
 
     return RuntimeSelection(
         mode=runtime_mode,
         model=runtime_model,
         effort=runtime_effort,
+        provider_profile=runtime_provider_profile,
     )
 
 
@@ -325,6 +335,8 @@ def _build_queue_request(
         runtime_payload["model"] = runtime.model
     if runtime.effort:
         runtime_payload["effort"] = runtime.effort
+    if runtime.provider_profile:
+        runtime_payload["providerProfile"] = runtime.provider_profile
 
     payload_dict: dict[str, Any] = {
         "repository": repo,
@@ -415,6 +427,11 @@ def _parse_args() -> argparse.Namespace:
         "--runtime-effort",
         default=None,
         help="Explicit runtime effort for queued pr-resolver tasks.",
+    )
+    parser.add_argument(
+        "--runtime-provider-profile",
+        default=None,
+        help="Explicit runtime provider profile for queued pr-resolver tasks.",
     )
     parser.add_argument("--merge-method", default="squash")
     parser.add_argument("--max-iterations", type=int, default=3)
@@ -635,6 +652,7 @@ async def main() -> int:
             "mode": runtime.mode,
             "model": runtime.model,
             "effort": runtime.effort,
+            "providerProfile": runtime.provider_profile,
         },
         "requested": len(open_prs),
         "created": len(created),

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -232,13 +232,14 @@ class TaskRuntimeSelection(BaseModel):
     )
     model: str | None = Field(None, alias="model")
     effort: str | None = Field(None, alias="effort")
+    provider_profile: str | None = Field(None, alias="providerProfile")
 
     @field_validator("mode", mode="before")
     @classmethod
     def _normalize_mode(cls, value: object) -> str | None:
         return _normalize_runtime_value(value, field_name="task.runtime.mode")
 
-    @field_validator("model", "effort", mode="before")
+    @field_validator("model", "effort", "provider_profile", mode="before")
     @classmethod
     def _normalize_optional_strings(cls, value: object) -> str | None:
         return _clean_optional_str(value)

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -69,7 +69,7 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
         "MoonLadderStudios/MoonMind",
         pr_number=42,
         branch="feature/example",
-        runtime=runtime_selection(mode="codex", model="gpt-5-codex", effort="high"),
+        runtime=runtime_selection(mode="codex", model="gpt-5-codex", effort="high", provider_profile="test-profile"),
         merge_method="squash",
         max_iterations=3,
         priority=0,
@@ -84,6 +84,7 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["runtime"]["mode"] == "codex"
     assert task["runtime"]["model"] == "gpt-5-codex"
     assert task["runtime"]["effort"] == "high"
+    assert task["runtime"]["providerProfile"] == "test-profile"
     assert task["publish"]["mode"] == "none"
     assert git["startingBranch"] == "feature/example"
     assert git["targetBranch"] == "feature/example"
@@ -170,7 +171,7 @@ def test_load_parent_runtime_selection_prefers_runtime_config(tmp_path: Path):
         (
             "{"
             '"runtime":"codex",'
-            '"runtimeConfig":{"mode":"gemini","model":"gemini-2.5-pro","effort":"medium"}'
+            '"runtimeConfig":{"mode":"gemini","model":"gemini-2.5-pro","effort":"medium","providerProfile":"inherited-profile"}'
             "}"
         ),
         encoding="utf-8",
@@ -181,6 +182,7 @@ def test_load_parent_runtime_selection_prefers_runtime_config(tmp_path: Path):
     assert runtime.mode == "gemini"
     assert runtime.model == "gemini-2.5-pro"
     assert runtime.effort == "medium"
+    assert runtime.provider_profile == "inherited-profile"
 
 
 def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
@@ -191,7 +193,7 @@ def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
     task_context.write_text(
         (
             "{"
-            '"runtimeConfig":{"mode":"claude","model":"claude-3.7-sonnet","effort":"low"}'
+            '"runtimeConfig":{"mode":"claude","model":"claude-3.7-sonnet","effort":"low","providerProfile":"inherited-profile"}'
             "}"
         ),
         encoding="utf-8",
@@ -204,6 +206,7 @@ def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
             "runtime_mode": None,
             "runtime_model": None,
             "runtime_effort": None,
+            "runtime_provider_profile": None,
         },
     )()
 
@@ -211,6 +214,7 @@ def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
     assert runtime.mode == "claude"
     assert runtime.model == "claude-3.7-sonnet"
     assert runtime.effort == "low"
+    assert runtime.provider_profile == "inherited-profile"
 
 
 def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Path):
@@ -219,7 +223,7 @@ def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Pat
 
     task_context = tmp_path / "task_context.json"
     task_context.write_text(
-        ('{"runtimeConfig":{"mode":"codex","model":"gpt-5-codex","effort":"low"}}'),
+        ('{"runtimeConfig":{"mode":"codex","model":"gpt-5-codex","effort":"low","providerProfile":"inherited-profile"}}'),
         encoding="utf-8",
     )
     args = type(
@@ -230,6 +234,7 @@ def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Pat
             "runtime_mode": "gemini",
             "runtime_model": "gemini-2.5-pro",
             "runtime_effort": "high",
+            "runtime_provider_profile": "explicit-profile",
         },
     )()
 
@@ -237,6 +242,7 @@ def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Pat
     assert runtime.mode == "gemini"
     assert runtime.model == "gemini-2.5-pro"
     assert runtime.effort == "high"
+    assert runtime.provider_profile == "explicit-profile"
 
 
 def test_resolve_runtime_selection_defaults_to_none_without_inheritance(monkeypatch: Any):
@@ -253,6 +259,7 @@ def test_resolve_runtime_selection_defaults_to_none_without_inheritance(monkeypa
             "runtime_mode": None,
             "runtime_model": None,
             "runtime_effort": None,
+            "runtime_provider_profile": None,
         },
     )()
 
@@ -260,6 +267,7 @@ def test_resolve_runtime_selection_defaults_to_none_without_inheritance(monkeypa
     assert runtime.mode is None
     assert runtime.model is None
     assert runtime.effort is None
+    assert runtime.provider_profile is None
 
 
 def test_resolve_runtime_selection_uses_default_runtime_env(monkeypatch: Any):
@@ -276,6 +284,7 @@ def test_resolve_runtime_selection_uses_default_runtime_env(monkeypatch: Any):
             "runtime_mode": None,
             "runtime_model": None,
             "runtime_effort": None,
+            "runtime_provider_profile": None,
         },
     )()
 
@@ -283,6 +292,7 @@ def test_resolve_runtime_selection_uses_default_runtime_env(monkeypatch: Any):
     assert runtime.mode == "claude"
     assert runtime.model is None
     assert runtime.effort is None
+    assert runtime.provider_profile is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This ensures that if a user manually selects a `providerProfile` when kicking off a `batch-pr-resolver` task, that profile gets seamlessly handed off to all the child `pr-resolver` tasks it generates, instead of them falling back to a default.

---
*PR created automatically by Jules for task [9382610166883830644](https://jules.google.com/task/9382610166883830644) started by @nsticco*