### PR TITLE
Fix empty runtime registry handling and threaded artifact writes

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,27 @@
 [
   {
-    "id": 4150745049,
+    "id": 4150920228,
     "disposition": "not-applicable",
-    "rationale": "Codex usage-limit notice is informational and does not describe a code defect in this PR."
+    "rationale": "Codex usage-limit notice is an informational bot comment and does not request a code change."
   },
   {
-    "id": 3006565445,
+    "id": 4027169265,
+    "disposition": "not-applicable",
+    "rationale": "Gemini review summary is informational; the actionable feedback was captured in the inline review comment."
+  },
+  {
+    "id": 3006660389,
     "disposition": "addressed",
-    "rationale": "Kept pagination visible on empty paginated pages and removed the extra empty-results disable guard for the Previous button."
+    "rationale": "Replaced the manual empty-registry JSON hashing path with a shared canonical registry digest helper."
   },
   {
-    "id": 4027089950,
-    "disposition": "not-applicable",
-    "rationale": "This review summary only restates the actionable pagination comment already tracked separately."
+    "id": 3006663916,
+    "disposition": "addressed",
+    "rationale": "Gated the conditional registry read behind a replay-stable Temporal patch and added an unpatched-history regression."
   },
   {
-    "id": 4027091119,
+    "id": 4027172243,
     "disposition": "not-applicable",
-    "rationale": "Copilot overview contained no requested change or defect report to address."
+    "rationale": "Copilot review summary is informational; the actionable feedback was captured in the inline review comment."
   }
 ]

--- a/moonmind/workflows/skills/skill_registry.py
+++ b/moonmind/workflows/skills/skill_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .tool_registry import ToolRegistryError as SkillRegistryError
 from .tool_registry import ToolRegistrySnapshot as SkillRegistrySnapshot
 from .tool_registry import (
+    compute_registry_digest,
     create_registry_snapshot,
     load_registry_snapshot_from_artifact,
 )
@@ -15,6 +16,7 @@ from .tool_registry import validate_tool_registry as validate_skill_registry
 __all__ = [
     "SkillRegistryError",
     "SkillRegistrySnapshot",
+    "compute_registry_digest",
     "create_registry_snapshot",
     "load_registry_snapshot_from_artifact",
     "load_skill_registry",

--- a/moonmind/workflows/skills/tool_registry.py
+++ b/moonmind/workflows/skills/tool_registry.py
@@ -85,6 +85,12 @@ def _digest_registry_doc(payload: Mapping[str, Any]) -> str:
     return f"{REGISTRY_DIGEST_PREFIX}{hashlib.sha256(encoded).hexdigest()}"
 
 
+def compute_registry_digest(*, skills: tuple[ToolDefinition, ...]) -> str:
+    """Compute the canonical digest for a registry snapshot payload."""
+
+    return _digest_registry_doc(_canonical_registry_doc(skills))
+
+
 def validate_tool_registry(skills: tuple[ToolDefinition, ...]) -> None:
     """Validate a registry payload after it has been parsed."""
 
@@ -158,7 +164,7 @@ def create_registry_snapshot(
 
     validate_tool_registry(skills)
     canonical = _canonical_registry_doc(skills)
-    digest = _digest_registry_doc(canonical)
+    digest = compute_registry_digest(skills=skills)
 
     artifact = artifact_store.put_json(
         canonical,
@@ -194,6 +200,7 @@ def load_registry_snapshot_from_artifact(
 __all__ = [
     "ToolRegistryError",
     "ToolRegistrySnapshot",
+    "compute_registry_digest",
     "create_registry_snapshot",
     "load_registry_snapshot_from_artifact",
     "load_tool_registry",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -52,9 +52,9 @@ from moonmind.workflows.skills.skill_plan_contracts import (
     SkillResult,
     parse_plan_definition,
 )
-from moonmind.workflows.skills.tool_plan_contracts import REGISTRY_DIGEST_PREFIX
 from moonmind.workflows.skills.skill_registry import (
     SkillRegistrySnapshot,
+    compute_registry_digest,
     create_registry_snapshot,
     parse_skill_registry,
 )
@@ -347,12 +347,7 @@ def _temporal_snapshot_from_payload(
 
     if isinstance(raw_skills, list) and not raw_skills:
         skills = ()
-        encoded = json.dumps(
-            {"schema_version": "1.0", "tools": [], "skills": []},
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode("utf-8")
-        digest = f"{REGISTRY_DIGEST_PREFIX}{hashlib.sha256(encoded).hexdigest()}"
+        digest = compute_registry_digest(skills=skills)
     else:
         skills = parse_skill_registry(payload)
         digest_only = create_registry_snapshot(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -52,6 +52,7 @@ from moonmind.workflows.skills.skill_plan_contracts import (
     SkillResult,
     parse_plan_definition,
 )
+from moonmind.workflows.skills.tool_plan_contracts import REGISTRY_DIGEST_PREFIX
 from moonmind.workflows.skills.skill_registry import (
     SkillRegistrySnapshot,
     create_registry_snapshot,
@@ -336,13 +337,32 @@ def _temporal_snapshot_from_payload(
     *,
     artifact_locator: str,
 ) -> SkillRegistrySnapshot:
-    skills = parse_skill_registry(payload)
-    digest_only = create_registry_snapshot(
-        skills=skills,
-        artifact_store=InMemoryArtifactStore(),
-    )
+    raw_skills: Any
+    if "tools" in payload:
+        raw_skills = payload.get("tools")
+    elif "skills" in payload:
+        raw_skills = payload.get("skills")
+    else:
+        raw_skills = payload
+
+    if isinstance(raw_skills, list) and not raw_skills:
+        skills = ()
+        encoded = json.dumps(
+            {"schema_version": "1.0", "tools": [], "skills": []},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        digest = f"{REGISTRY_DIGEST_PREFIX}{hashlib.sha256(encoded).hexdigest()}"
+    else:
+        skills = parse_skill_registry(payload)
+        digest_only = create_registry_snapshot(
+            skills=skills,
+            artifact_store=InMemoryArtifactStore(),
+        )
+        digest = digest_only.digest
+
     return SkillRegistrySnapshot(
-        digest=digest_only.digest,
+        digest=digest,
         artifact_ref=artifact_locator,
         skills=skills,
     )

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import secrets
+import threading
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -409,15 +410,24 @@ class S3TemporalArtifactStore(TemporalArtifactStore):
             )
 
         self._bucket = bucket.strip()
-        self._client = boto3.client(
-            "s3",
-            endpoint_url=endpoint_url.strip(),
-            aws_access_key_id=access_key_id.strip(),
-            aws_secret_access_key=secret_access_key.strip(),
-            region_name=region_name.strip() or "us-east-1",
-            use_ssl=bool(use_ssl),
-        )
+        self._client_kwargs = {
+            "service_name": "s3",
+            "endpoint_url": endpoint_url.strip(),
+            "aws_access_key_id": access_key_id.strip(),
+            "aws_secret_access_key": secret_access_key.strip(),
+            "region_name": region_name.strip() or "us-east-1",
+            "use_ssl": bool(use_ssl),
+        }
+        self._client_local = threading.local()
         self._ensure_bucket_exists()
+
+    @property
+    def _client(self):
+        client = getattr(self._client_local, "client", None)
+        if client is None:
+            client = boto3.client(**self._client_kwargs)
+            self._client_local.client = client
+        return client
 
     @property
     def backend(self) -> db_models.TemporalArtifactStorageBackend:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -606,8 +606,11 @@ class MoonMindRunWorkflow:
         require_pull_request_url = publish_mode == "pr" and self._integration is None
         pull_request_url: str | None = None
         skill_definitions_by_key: dict[tuple[str, str], Any] = {}
+        requires_registry_lookup = any(
+            node.tool_type == "skill" for node in plan_definition.nodes
+        )
 
-        if registry_snapshot_ref:
+        if registry_snapshot_ref and requires_registry_lookup:
             registry_payload = await execute_typed_activity(
                 "artifact.read",
                 ArtifactReadInput(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -95,6 +95,8 @@ _GITHUB_PR_URL_PATTERN = re.compile(
 INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 # Replay-stable patch id for parent-initiated defensive slot release on child terminal state.
 RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release-1"
+# Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
+RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
 )
@@ -609,8 +611,14 @@ class MoonMindRunWorkflow:
         requires_registry_lookup = any(
             node.tool_type == "skill" for node in plan_definition.nodes
         )
+        if workflow.patched(RUN_CONDITIONAL_REGISTRY_READ_PATCH):
+            should_read_registry = bool(
+                registry_snapshot_ref and requires_registry_lookup
+            )
+        else:
+            should_read_registry = bool(registry_snapshot_ref)
 
-        if registry_snapshot_ref and requires_registry_lookup:
+        if should_read_registry:
             registry_payload = await execute_typed_activity(
                 "artifact.read",
                 ArtifactReadInput(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -471,6 +471,55 @@ async def test_default_skill_registry_payload_auto_placeholder_filtered():
     assert ("auto", "1.0") not in keyset
 
 
+async def test_plan_generate_accepts_auto_placeholder_without_registry_entries(
+    tmp_path: Path,
+):
+    from moonmind.workflows.temporal.worker_runtime import _build_runtime_planner
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            planner = TemporalPlanActivities(
+                artifact_service=service,
+                planner=_build_runtime_planner(),
+            )
+
+            result = await planner.plan_generate(
+                principal="user-1",
+                parameters={
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "claude",
+                    "model": "MiniMax-M2.7",
+                    "instructions": "Move the pagination control next to next/prev buttons.",
+                    "task": {
+                        "tool": {"type": "skill", "name": "auto", "version": "1.0"},
+                        "skill": {"name": "auto", "version": "1.0"},
+                        "runtime": {"mode": "claude", "model": "MiniMax-M2.7"},
+                        "instructions": "Move the pagination control next to next/prev buttons.",
+                    },
+                },
+            )
+
+            _artifact, payload = await service.read(
+                artifact_id=result.plan_ref.artifact_id,
+                principal="user-1",
+            )
+            plan_payload = json.loads(payload.decode("utf-8"))
+            registry_ref = plan_payload["metadata"]["registry_snapshot"]["artifact_ref"]
+
+            _registry_artifact, registry_payload_raw = await service.read(
+                artifact_id=registry_ref,
+                principal="user-1",
+            )
+            registry_payload = json.loads(registry_payload_raw.decode("utf-8"))
+
+            assert plan_payload["nodes"][0]["tool"]["type"] == "agent_runtime"
+            assert registry_payload == {"skills": []}
+
+
 async def test_default_registry_payload_uses_extended_timeouts_for_pr_resolver():
     payload = _default_registry_skill_payload(name="pr-resolver", version="1.0")
     policies = payload.get("policies", {})

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from api_service.db.models import (
 from moonmind.workflows.temporal.artifacts import (
     ExecutionRef,
     LocalTemporalArtifactStore,
+    S3TemporalArtifactStore,
     TemporalArtifactRepository,
     TemporalArtifactService,
     TemporalArtifactStore,
@@ -153,6 +155,53 @@ async def test_local_store_rejects_traversal_storage_key(tmp_path: Path) -> None
     store = LocalTemporalArtifactStore(tmp_path)
     with pytest.raises(TemporalArtifactValidationError):
         store.resolve_storage_key("../escape.txt")
+
+
+async def test_s3_store_uses_thread_local_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """S3 store should allocate one boto3 client per thread."""
+
+    created_clients: list[object] = []
+
+    class _DummyS3Client:
+        def __init__(self, index: int) -> None:
+            self.index = index
+
+        def head_bucket(self, *, Bucket: str) -> None:
+            _ = Bucket
+
+    def _fake_boto3_client(service_name: str, **kwargs: object) -> _DummyS3Client:
+        assert service_name == "s3"
+        assert kwargs["endpoint_url"] == "http://example.test:9000"
+        client = _DummyS3Client(len(created_clients))
+        created_clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.artifacts.boto3.client",
+        _fake_boto3_client,
+    )
+
+    store = S3TemporalArtifactStore(
+        endpoint_url="http://example.test:9000",
+        bucket="bucket-1",
+        access_key_id="access",
+        secret_access_key="secret",
+        region_name="us-east-1",
+        use_ssl=False,
+    )
+
+    main_thread_client = store._client
+    assert store._client is main_thread_client
+
+    other_thread_client = await asyncio.get_running_loop().run_in_executor(
+        None,
+        lambda: store._client,
+    )
+
+    assert other_thread_client is not main_thread_client
+    assert len(created_clients) == 2
 
 
 async def test_create_write_read_and_list_for_execution(tmp_path: Path) -> None:

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -303,6 +303,116 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
     assert captured[2][1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 
+@pytest.mark.asyncio
+async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        normalized = _normalize_payload(payload)
+        captured.append((activity_type, normalized))
+        if activity_type == "artifact.read":
+            artifact_ref = normalized.get("artifact_ref")
+            if artifact_ref == "artifact://registry/empty":
+                raise AssertionError(
+                    "agent_runtime-only plans should not read the empty registry snapshot"
+                )
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Runtime Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/empty",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "step-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "claude",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "instructions": "Adjust the dashboard pagination control.",
+                                "runtime": {"mode": "claude", "model": "MiniMax-M2.7"},
+                                "repository": "MoonLadderStudios/MoonMind",
+                            },
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Agent finished",
+            "metadata": {"push_status": "not_requested"},
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    artifact_reads = [
+        payload["artifact_ref"]
+        for activity_type, payload in captured
+        if activity_type == "artifact.read"
+    ]
+    assert artifact_reads == ["art_plan_1"]
+
+
 def test_build_agent_execution_request_includes_bundle_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1113,4 +1223,3 @@ async def test_run_proposals_stage_uses_task_proposal_policy(
     assert "workflow_id" in captured_origin
     assert "temporal_run_id" in captured_origin
     assert "trigger_repo" in captured_origin
-

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -7,6 +7,7 @@ import pytest
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
+
 def _normalize_payload(payload: Any) -> dict[str, Any]:
     if isinstance(payload, dict):
         return payload
@@ -411,6 +412,138 @@ async def test_run_execution_stage_skips_empty_registry_for_agent_runtime_only_p
         if activity_type == "artifact.read"
     ]
     assert artifact_reads == ["art_plan_1"]
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_preserves_registry_read_for_unpatched_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        normalized = _normalize_payload(payload)
+        captured.append((activity_type, normalized))
+        if activity_type == "artifact.read":
+            artifact_ref = normalized.get("artifact_ref")
+            if artifact_ref == "artifact://registry/empty":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "repo.run_tests",
+                                "version": "1.0.0",
+                                "description": "Run tests",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.skill.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 3},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Runtime Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/empty",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "step-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "claude",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "instructions": "Adjust the dashboard pagination control.",
+                                "runtime": {"mode": "claude", "model": "MiniMax-M2.7"},
+                                "repository": "MoonLadderStudios/MoonMind",
+                            },
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Agent finished",
+            "metadata": {"push_status": "not_requested"},
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: False)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    artifact_reads = [
+        payload["artifact_ref"]
+        for activity_type, payload in captured
+        if activity_type == "artifact.read"
+    ]
+    assert artifact_reads == ["art_plan_1", "artifact://registry/empty"]
 
 
 def test_build_agent_execution_request_includes_bundle_metadata(


### PR DESCRIPTION
## Summary
- accept empty registry snapshots generated from the uto placeholder instead of failing plan.generate
- skip registry artifact reads for agent-runtime-only plans that do not execute skill nodes
- give the S3 temporal artifact store a thread-local boto3 client so executor-thread writes persist reliably
- add workflow-boundary regressions for the empty-registry plan path and the threaded S3 client behavior

## Verification
- ash ./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_run_artifacts.py tests/unit/workflows/temporal/test_artifacts.py

## Runtime validation
- reset workflow mm:c40d3ae7-77b8-4b30-89a5-962d74e77fcc after deploying the worker changes
- the workflow no longer fails in planning or artifact read and is currently waiting on an auth/profile slot in child workflow scheduling