### PR TITLE
fix(build): ignore UI dist in Docker context to restore layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .git
 .gitignore
 .github
-__pycache__/
+**/__pycache__/
 *.pyc
 *.pyo
 *.pyd
@@ -10,12 +10,12 @@ __pycache__/
 .ruff_cache/
 .venv/
 venv/
-node_modules/
+**/node_modules/
 **/dist/
-build/
+**/build/
 coverage/
-.env
-.env.*
+**/.env
+**/.env.*
 *.log
 *.log*
 var/

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,7 @@ __pycache__/
 .venv/
 venv/
 node_modules/
-dist/
+**/dist/
 build/
 coverage/
 .env

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 3012286515,
+    "disposition": "addressed",
+    "rationale": "Made node_modules, build, __pycache__, and .env patterns recursive by adding **/ prefixes."
+  },
+  {
+    "id": 4033396041,
+    "disposition": "not-applicable",
+    "rationale": "High-level summary of the code review suggestions."
+  },
+  {
+    "id": 4033400379,
+    "disposition": "not-applicable",
+    "rationale": "Copilot contextual summary of the PR."
+  }
+]


### PR DESCRIPTION
Correctly ignores `api_service/static/task_dashboard/dist/` so that local runner UI builds do not permanently bust the Docker layer cache for `frontend-builder`.