### PR TITLE
fix(runtime): skip CLAUDE.md write when it is a symlink

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/claude_code.py
+++ b/moonmind/workflows/temporal/runtime/strategies/claude_code.py
@@ -64,9 +64,20 @@ class ClaudeCodeStrategy(ManagedRuntimeStrategy):
         workspace_path: Path,
         request: Any,
     ) -> None:
-        """Write CLAUDE.md in the workspace."""
+        """Write CLAUDE.md in the workspace.
+
+        If CLAUDE.md already exists as a symlink (e.g. CLAUDE.md -> AGENTS.md),
+        skip writing — following the symlink would overwrite AGENTS.md and destroy
+        the project's coding standards.  Instructions are already passed via ``-p``
+        so CLAUDE.md can continue to provide project context through the symlink.
+
+        Only write CLAUDE.md when it does not yet exist, ensuring repos that have
+        no CLAUDE.md still receive task instructions as project context.
+        """
         if not getattr(request, "instruction_ref", None):
             return
 
         instruction_path = workspace_path / "CLAUDE.md"
+        if instruction_path.exists() or instruction_path.is_symlink():
+            return
         instruction_path.write_text(request.instruction_ref, encoding="utf-8")

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -168,6 +168,56 @@ class TestClaudeCodeBuildCommand:
         assert "claude-sonnet-4-6" in cmd
 
 
+# ---------------------------------------------------------------------------
+# ClaudeCodeStrategy.prepare_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodePrepareWorkspace:
+    @pytest.mark.asyncio
+    async def test_creates_claude_md_when_absent(self, tmp_path) -> None:
+        """When CLAUDE.md does not exist, it is created with the instruction ref."""
+        s = ClaudeCodeStrategy()
+        request = _make_request(instruction_ref="Do the task")
+        await s.prepare_workspace(tmp_path, request)
+        claude_md = tmp_path / "CLAUDE.md"
+        assert claude_md.is_file() and not claude_md.is_symlink()
+        assert claude_md.read_text() == "Do the task"
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_existing_regular_file(self, tmp_path) -> None:
+        """When CLAUDE.md already exists as a regular file, it is left unchanged."""
+        s = ClaudeCodeStrategy()
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text("existing project context")
+        request = _make_request(instruction_ref="New task instructions")
+        await s.prepare_workspace(tmp_path, request)
+        assert claude_md.read_text() == "existing project context"
+
+    @pytest.mark.asyncio
+    async def test_does_not_follow_symlink_to_agents_md(self, tmp_path) -> None:
+        """When CLAUDE.md is a symlink (e.g. -> AGENTS.md), it must not be followed.
+        AGENTS.md must remain intact after prepare_workspace runs."""
+        s = ClaudeCodeStrategy()
+        agents_md = tmp_path / "AGENTS.md"
+        agents_md.write_text("# Agent coding standards\n\nDo not break me.")
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.symlink_to("AGENTS.md")
+        request = _make_request(instruction_ref="Task instructions")
+        await s.prepare_workspace(tmp_path, request)
+        # AGENTS.md must be untouched
+        assert agents_md.read_text() == "# Agent coding standards\n\nDo not break me."
+        # CLAUDE.md symlink must still point to AGENTS.md
+        assert claude_md.is_symlink()
+
+    @pytest.mark.asyncio
+    async def test_no_op_without_instruction_ref(self, tmp_path) -> None:
+        """When instruction_ref is absent, nothing is written."""
+        s = ClaudeCodeStrategy()
+        request = _make_request()
+        await s.prepare_workspace(tmp_path, request)
+        assert not (tmp_path / "CLAUDE.md").exists()
+
 
 # ---------------------------------------------------------------------------
 # CodexCliStrategy


### PR DESCRIPTION
## Summary

- `ClaudeCodeStrategy.prepare_workspace()` was unconditionally writing task instructions to `CLAUDE.md`, which on this repo is a symlink → `AGENTS.md`
- Writing through the symlink overwrote `AGENTS.md` with the task instructions, destroying project coding standards
- Claude Code received the overwritten context and responded with no actionable work, completing in ~14 seconds with `proposals_submitted: 0`
- Fix: check `instruction_path.exists() or instruction_path.is_symlink()` before writing — instructions are already passed via `-p` so skipping is safe

## Test plan

- [x] `test_creates_claude_md_when_absent` — new file is written when CLAUDE.md does not exist
- [x] `test_does_not_overwrite_existing_regular_file` — existing regular CLAUDE.md is left unchanged
- [x] `test_does_not_follow_symlink_to_agents_md` — AGENTS.md remains intact when CLAUDE.md is a symlink
- [x] `test_no_op_without_instruction_ref` — nothing written when instruction_ref is absent
- [x] All 26 strategy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)