### PR TITLE
fix: correct MINIMAX secret ref and report no_pr_created status

### DIFF
--- a/api_service/migrations/versions/1a2b3c4d5e6f_fix_claude_minimax_secret_refs.py
+++ b/api_service/migrations/versions/1a2b3c4d5e6f_fix_claude_minimax_secret_refs.py
@@ -44,8 +44,14 @@ def upgrade() -> None:
     if isinstance(env_template, str):
         env_template = json.loads(env_template)
 
-    # Only apply if still in the broken state
-    if "anthropic_api_key" not in secret_refs:
+    # Only apply if still in the broken state:
+    # - legacy "anthropic_api_key" still present (original broken state), OR
+    # - ANTHROPIC_AUTH_TOKEN exists but lacks the env:// prefix (migration
+    #   was previously run but with the wrong value)
+    anthropic_auth_token = secret_refs.get("ANTHROPIC_AUTH_TOKEN", "")
+    if "anthropic_api_key" not in secret_refs and not (
+        isinstance(anthropic_auth_token, str) and anthropic_auth_token.startswith("env://")
+    ):
         return
 
     secret_refs.pop("anthropic_api_key", None)

--- a/api_service/migrations/versions/1a2b3c4d5e6f_fix_claude_minimax_secret_refs.py
+++ b/api_service/migrations/versions/1a2b3c4d5e6f_fix_claude_minimax_secret_refs.py
@@ -49,7 +49,7 @@ def upgrade() -> None:
         return
 
     secret_refs.pop("anthropic_api_key", None)
-    secret_refs["ANTHROPIC_AUTH_TOKEN"] = "MINIMAX_API_KEY"
+    secret_refs["ANTHROPIC_AUTH_TOKEN"] = "env://MINIMAX_API_KEY"
     env_template.pop("ANTHROPIC_AUTH_TOKEN", None)
 
     conn.execute(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -469,10 +469,19 @@ class MoonMindRunWorkflow:
         self._close_status = CLOSE_STATUS_COMPLETED
         self._set_state(STATE_COMPLETED, summary="Workflow completed successfully.")
 
-        output: RunWorkflowOutput = {
-            "status": "success",
-            "message": "Workflow completed successfully",
-        }
+        publish_mode = self._publish_mode(parameters)
+        # When publish mode is "pr" but no proposals were submitted, the
+        # workflow did not achieve its business objective.
+        if publish_mode == "pr" and self._proposals_submitted == 0:
+            output: RunWorkflowOutput = {
+                "status": "no_pr_created",
+                "message": "Workflow completed but no PR was created",
+            }
+        else:
+            output = {
+                "status": "success",
+                "message": "Workflow completed successfully",
+            }
         if self._proposals_generated > 0 or self._proposals_submitted > 0:
             output["proposals_generated"] = self._proposals_generated
             output["proposals_submitted"] = self._proposals_submitted
@@ -1645,7 +1654,8 @@ class MoonMindRunWorkflow:
             if status == "success":
                 publish_mode = self._publish_mode(parameters)
                 if publish_mode == "pr":
-                    code = "PUBLISHED_PR" # this is a simplification
+                    # Only mark as PUBLISHED_PR if proposals were actually submitted
+                    code = "PUBLISHED_PR" if self._proposals_submitted > 0 else "NO_PR_CREATED"
                 elif publish_mode == "branch":
                     code = "PUBLISHED_BRANCH"
                 elif publish_mode == "none":

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -163,6 +163,7 @@ class MoonMindRunWorkflow:
         self._title: Optional[str] = None
         self._summary: str = "Execution initialized."
         self._correlation_id: Optional[str] = None
+        self._pull_request_url: Optional[str] = None
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -470,13 +471,21 @@ class MoonMindRunWorkflow:
         self._set_state(STATE_COMPLETED, summary="Workflow completed successfully.")
 
         publish_mode = self._publish_mode(parameters)
-        # When publish mode is "pr" but no proposals were submitted, the
-        # workflow did not achieve its business objective.
-        if publish_mode == "pr" and self._proposals_submitted == 0:
-            output: RunWorkflowOutput = {
-                "status": "no_pr_created",
-                "message": "Workflow completed but no PR was created",
-            }
+        # When publish mode is "pr" but no PR was created (tracked via
+        # _pull_request_url from execution stage), the workflow did not
+        # achieve its business objective. Guard with workflow.patched for
+        # replay safety on in-flight executions.
+        if workflow.patched("run-workflow-pr-status-v1"):
+            if publish_mode == "pr" and self._pull_request_url is None:
+                output: RunWorkflowOutput = {
+                    "status": "no_pr_created",
+                    "message": "Workflow completed but no PR was created",
+                }
+            else:
+                output = {
+                    "status": "success",
+                    "message": "Workflow completed successfully",
+                }
         else:
             output = {
                 "status": "success",
@@ -957,6 +966,8 @@ class MoonMindRunWorkflow:
                         raise ValueError(
                             f"publishMode 'pr' requested; native PR creation failed: {e}"
                         ) from e
+        # Persist the PR URL so the workflow output can determine if a PR was created.
+        self._pull_request_url = pull_request_url
         self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 
@@ -1654,8 +1665,12 @@ class MoonMindRunWorkflow:
             if status == "success":
                 publish_mode = self._publish_mode(parameters)
                 if publish_mode == "pr":
-                    # Only mark as PUBLISHED_PR if proposals were actually submitted
-                    code = "PUBLISHED_PR" if self._proposals_submitted > 0 else "NO_PR_CREATED"
+                    # Guard with workflow.patched for replay safety.
+                    if workflow.patched("run-workflow-pr-status-v1"):
+                        # Use explicit PR URL tracking from execution stage
+                        code = "PUBLISHED_PR" if self._pull_request_url else "NO_PR_CREATED"
+                    else:
+                        code = "PUBLISHED_PR"
                 elif publish_mode == "branch":
                     code = "PUBLISHED_BRANCH"
                 elif publish_mode == "none":


### PR DESCRIPTION
## Summary

- **Fix MINIMAX secret ref**: Migration `1a2b3c4d5e6f_fix_claude_minimax_secret_refs` was setting `secret_refs["ANTHROPIC_AUTH_TOKEN"] = "MINIMAX_API_KEY"` but the secret resolver expects `"env://MINIMAX_API_KEY"` to read from the environment variable. Without this prefix, it looks for a non-existent database secret, causing the MiniMax provider profile to fail credential resolution.
- **Report meaningful PR status**: The `MoonMind.Run` workflow was returning `status: "success"` even when `publishMode: "pr"` and `proposals_submitted: 0` (no PR created). Now returns `status: "no_pr_created"` and finish summary code `NO_PR_CREATED` in this case.

## Root Cause

When `MINIMAX_API_KEY` is set in `.env`, the agent should use it to authenticate with MiniMax. However, the `claude_minimax` provider profile's `secret_refs` was `{"ANTHROPIC_AUTH_TOKEN": "MINIMAX_API_KEY"}` (missing `env://` prefix). The secret resolver interpreted this as a database secret slug rather than an environment variable reference, found no matching secret, and the agent ran without credentials — producing `push_status: "no_commits"`.

## Test plan

- [x] Unit tests pass (8 run workflow tests)
- [x] Review migration SQL for correctness
- [ ] Apply to existing database: `UPDATE managed_agent_provider_profiles SET secret_refs = '{"ANTHROPIC_AUTH_TOKEN": "env://MINIMAX_API_KEY"}'::jsonb WHERE profile_id = 'claude_minimax';`

🤖 Generated with [Claude Code](https://claude.com/claude-code)