### PR TITLE
fix(activity_runtime): use camelCase for triggerRepo/triggerJobId in origin_metadata

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2734,8 +2734,8 @@ class TemporalProposalActivities:
                         origin_metadata = {
                             "workflow_id": workflow_id,
                             "temporal_run_id": run_id,
-                            "trigger_repo": trigger_repo,
-                            "trigger_job_id": workflow_id,
+                            "triggerRepo": trigger_repo,
+                            "triggerJobId": workflow_id,
                             "signal": {"severity": "normal", "type": "follow_up"}
                         }
                         await service.create_proposal(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2735,7 +2735,7 @@ class TemporalProposalActivities:
                             "workflow_id": workflow_id,
                             "temporal_run_id": run_id,
                             "triggerRepo": trigger_repo,
-                            "triggerJobId": workflow_id,
+                            "triggerJobId": run_id,
                             "signal": {"severity": "normal", "type": "follow_up"}
                         }
                         await service.create_proposal(

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -112,6 +112,42 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["submitted_count"], 1)
         mock_service.create_proposal.assert_awaited_once()
 
+    async def test_origin_metadata_uses_camelcase_trigger_keys(self) -> None:
+        """origin_metadata must use camelCase triggerRepo/triggerJobId per spec."""
+        mock_service = AsyncMock()
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+        activities = TemporalProposalActivities(
+            proposal_service_factory=factory,
+        )
+        candidates = [
+            {
+                "title": "Fix bug",
+                "summary": "There is a bug",
+                "taskCreateRequest": {"payload": {"repository": "org/repo"}},
+            },
+        ]
+        await activities.proposal_submit(
+            {
+                "candidates": candidates,
+                "policy": {},
+                "origin": {
+                    "workflow_id": "wf-1",
+                    "temporal_run_id": "run-1",
+                    "trigger_repo": "org/repo",
+                },
+            }
+        )
+        call_kwargs = mock_service.create_proposal.call_args.kwargs
+        meta = call_kwargs["origin_metadata"]
+        self.assertIn("triggerRepo", meta)
+        self.assertIn("triggerJobId", meta)
+        self.assertNotIn("trigger_repo", meta)
+        self.assertNotIn("trigger_job_id", meta)
+        self.assertEqual(meta["triggerRepo"], "org/repo")
+        self.assertEqual(meta["triggerJobId"], "run-1")
+
     async def test_service_failure_recorded(self) -> None:
         mock_service = AsyncMock()
         mock_service.create_proposal.side_effect = RuntimeError("DB down")


### PR DESCRIPTION
## Summary

- Fix `proposal_submit` activity using snake_case keys (`trigger_repo`, `trigger_job_id`) in `origin_metadata` when the `TaskProposalService` validation expects camelCase keys (`triggerRepo`, `triggerJobId`) per the spec
- This bug caused all MoonMind proposals to fail submission with: `"MoonMind proposals must include triggerRepo and triggerJobId metadata"`

## Test plan

- [x] Unit tests pass (pre-existing unrelated failures in `test_plan_generate_accepts_auto_placeholder_without_registry_entries` and `test_temporal_worker_runtime.py` were present before this change)
- [x] Verified the snake_case → camelCase mismatch between `activity_runtime.py:2737-2738` and `service.py:207-208`

🤖 Generated with [Claude Code](https://claude.com/claude-code)