### PR TITLE
fix: make task proposal titles unique by appending short workflow id

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2597,9 +2597,14 @@ class TemporalProposalActivities:
         # Derive a concise title from the first line of instructions.
         first_line = instructions.splitlines()[0].strip()
         title_prefix = "Follow-up: "
+
+        # Make the title unique and distinct from the parent workflow by appending a short ID.
+        short_id = workflow_id.split("-")[-1] if "-" in workflow_id else workflow_id[-8:]
+        run_suffix = f" ({short_id})" if short_id else ""
+
         max_title_len = 200
-        title_body = first_line[: max_title_len - len(title_prefix)]
-        title = f"{title_prefix}{title_body}"
+        title_body = first_line[: max_title_len - len(title_prefix) - len(run_suffix)]
+        title = f"{title_prefix}{title_body}{run_suffix}"
 
         summary = (
             f"Automatic follow-up proposal generated from workflow {workflow_id}. "

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2602,9 +2602,13 @@ class TemporalProposalActivities:
         short_id = workflow_id.split("-")[-1] if "-" in workflow_id else workflow_id[-8:]
         run_suffix = f" ({short_id})" if short_id else ""
 
-        max_title_len = 200
-        title_body = first_line[: max_title_len - len(title_prefix) - len(run_suffix)]
+        max_title_len = 180
+        budget = max(0, max_title_len - len(title_prefix) - len(run_suffix))
+        title_body = first_line[:budget]
         title = f"{title_prefix}{title_body}{run_suffix}"
+        
+        if len(title) > max_title_len:
+            title = title[:max_title_len]
 
         summary = (
             f"Automatic follow-up proposal generated from workflow {workflow_id}. "

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -23,6 +23,46 @@ class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
         result = await activities.proposal_generate(None)
         self.assertEqual(result, [])
 
+    async def test_proposal_generate_title_formatting(self) -> None:
+        activities = TemporalProposalActivities()
+
+        # Test normal instructions with varying workflow IDs
+        req_normal = {
+            "workflow_id": "test-wf-12345",
+            "parameters": {"instructions": "Implement feature X"}
+        }
+        res_normal = await activities.proposal_generate(req_normal)
+        self.assertEqual(len(res_normal), 1)
+        self.assertEqual(
+            res_normal[0]["title"],
+            "[run_quality] Follow-up: Implement feature X (12345)"
+        )
+
+        req_uuid = {
+            "workflow_id": "8e3b0e11-4a1d-40c9-94fc-0d3f2a1b9c8e",
+            "parameters": {"instructions": "Fix bug in Y"}
+        }
+        res_uuid = await activities.proposal_generate(req_uuid)
+        self.assertEqual(
+            res_uuid[0]["title"],
+            "[run_quality] Follow-up: Fix bug in Y (0d3f2a1b9c8e)"
+        )
+
+        # Test extremely long instructions (truncation)
+        long_instr = "A" * 300
+        req_long = {
+            "workflow_id": "very-long-id-12345678",
+            "parameters": {"instructions": long_instr}
+        }
+        res_long = await activities.proposal_generate(req_long)
+        title = res_long[0]["title"]
+        # Max length of internally generated title is 180 (excluding '[run_quality] ' prefix added later)
+        # So the candidate["title"] should be len("[run_quality] ") + 180 = 14 + 180 = 194
+        self.assertTrue(len(title) <= 194)
+        self.assertTrue(title.endswith("(12345678)"))
+        self.assertTrue(title.startswith("[run_quality] Follow-up: AAA"))
+
+
 
 class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
     async def test_empty_candidates_returns_zeroes(self) -> None:

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -58,9 +58,9 @@ class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
         title = res_long[0]["title"]
         # Max length of internally generated title is 180 (excluding '[run_quality] ' prefix added later)
         # So the candidate["title"] should be len("[run_quality] ") + 180 = 14 + 180 = 194
-        self.assertTrue(len(title) <= 194)
-        self.assertTrue(title.endswith("(12345678)"))
-        self.assertTrue(title.startswith("[run_quality] Follow-up: AAA"))
+        self.assertLessEqual(len(title), 194)
+        self.assertEqual(title[-10:], "(12345678)")
+        self.assertEqual(title[:28], "[run_quality] Follow-up: AAA")
 
 
 


### PR DESCRIPTION
Fixes issue where task proposals generated identical titles as the workflow run.