### PR TITLE
[codex] Fix workflow GitHub auth and workspace git trust

### DIFF
--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1254,6 +1254,13 @@ class GitHubSettings(BaseSettings):
     """GitHub settings"""
 
     github_token: Optional[str] = Field(None, alias="GITHUB_TOKEN")
+    github_token_secret_ref: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices(
+            "GITHUB_TOKEN_SECRET_REF",
+            "WORKFLOW_GITHUB_TOKEN_SECRET_REF",
+        ),
+    )
     github_repos: Optional[str] = Field(
         None, alias="GITHUB_REPOS"
     )  # Comma-delimited string of repositories

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -57,13 +57,29 @@ class GitHubService:
     """Thin wrapper around the GitHub REST API for pull-request operations.
 
     This service is stateless and safe to share across activity invocations.
-    Authentication is resolved from an explicit token or ``GITHUB_TOKEN`` env.
+    Authentication is resolved from an explicit token, ``GITHUB_TOKEN`` /
+    ``GH_TOKEN`` env vars, or the configured secret reference.
     """
 
     def __init__(self, *, timeout: float = 30.0) -> None:
         self._timeout = timeout
 
     # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _missing_auth_summary(action: str) -> str:
+        return (
+            "GitHub auth is not configured; set GITHUB_TOKEN or GH_TOKEN, "
+            f"or configure GITHUB_TOKEN_SECRET_REF / WORKFLOW_GITHUB_TOKEN_SECRET_REF to {action}."
+        )
+
+    @staticmethod
+    def _secret_ref_resolution_summary() -> str:
+        return (
+            "GitHub token secret reference could not be resolved. "
+            "Ensure GITHUB_TOKEN or GH_TOKEN is set, or configure "
+            "GITHUB_TOKEN_SECRET_REF / WORKFLOW_GITHUB_TOKEN_SECRET_REF; see logs for details."
+        )
 
     @staticmethod
     def parse_github_pr_url(pr_url: str) -> tuple[str, str, str] | None:
@@ -81,7 +97,11 @@ class GitHubService:
         explicit_token: str | None = None,
     ) -> tuple[str, str | None]:
         """Resolve a GitHub token from explicit input, env, or secret ref."""
-        token = str(explicit_token or os.environ.get("GITHUB_TOKEN", "")).strip()
+        token = str(
+            explicit_token
+            or os.environ.get("GITHUB_TOKEN", "")
+            or os.environ.get("GH_TOKEN", "")
+        ).strip()
         if token:
             return token, None
 
@@ -98,12 +118,12 @@ class GitHubService:
 
         try:
             return await resolve_managed_api_key_reference(secret_ref), None
-        except Exception as exc:
+        except Exception:
             logger.warning(
                 "Failed to resolve GitHub token secret ref",
                 exc_info=True,
             )
-            return "", f"GITHUB token secret ref could not be resolved: {exc}"
+            return "", GitHubService._secret_ref_resolution_summary()
 
     @staticmethod
     def _github_headers(token: str) -> dict[str, str]:
@@ -131,8 +151,7 @@ class GitHubService:
         if not token:
             return CreatePRResult(
                 created=False,
-                summary=resolution_error
-                or "GITHUB_TOKEN is not configured; cannot create PR.",
+                summary=resolution_error or self._missing_auth_summary("create a PR"),
             )
 
         api_url = f"https://api.github.com/repos/{repo}/pulls"
@@ -206,8 +225,7 @@ class GitHubService:
             return MergePRResult(
                 pr_url=pr_url,
                 merged=False,
-                summary=resolution_error
-                or "GITHUB_TOKEN is not configured; cannot merge PR.",
+                summary=resolution_error or self._missing_auth_summary("merge a PR"),
             )
 
         api_url = (
@@ -288,7 +306,7 @@ class GitHubService:
             return (
                 False,
                 resolution_error
-                or "GITHUB_TOKEN is not configured; cannot update PR base.",
+                or self._missing_auth_summary("update a PR base branch"),
             )
 
         api_url = (

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -77,9 +77,33 @@ class GitHubService:
         return match.group(1), match.group(2), match.group(3)
 
     @staticmethod
-    def resolve_github_token(explicit_token: str | None = None) -> str:
-        """Return a GitHub token from the explicit arg or ``GITHUB_TOKEN`` env."""
-        return (explicit_token or os.environ.get("GITHUB_TOKEN", "")).strip()
+    async def resolve_github_token(
+        explicit_token: str | None = None,
+    ) -> tuple[str, str | None]:
+        """Resolve a GitHub token from explicit input, env, or secret ref."""
+        token = str(explicit_token or os.environ.get("GITHUB_TOKEN", "")).strip()
+        if token:
+            return token, None
+
+        from moonmind.config.settings import settings
+        from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+            resolve_managed_api_key_reference,
+        )
+
+        secret_ref = str(
+            getattr(settings.github, "github_token_secret_ref", "") or ""
+        ).strip()
+        if not secret_ref:
+            return "", None
+
+        try:
+            return await resolve_managed_api_key_reference(secret_ref), None
+        except Exception as exc:
+            logger.warning(
+                "Failed to resolve GitHub token secret ref",
+                exc_info=True,
+            )
+            return "", f"GITHUB token secret ref could not be resolved: {exc}"
 
     @staticmethod
     def _github_headers(token: str) -> dict[str, str]:
@@ -103,11 +127,12 @@ class GitHubService:
     ) -> CreatePRResult:
         """Create a GitHub pull request via REST API."""
 
-        token = self.resolve_github_token(github_token)
+        token, resolution_error = await self.resolve_github_token(github_token)
         if not token:
             return CreatePRResult(
                 created=False,
-                summary="GITHUB_TOKEN is not configured; cannot create PR.",
+                summary=resolution_error
+                or "GITHUB_TOKEN is not configured; cannot create PR.",
             )
 
         api_url = f"https://api.github.com/repos/{repo}/pulls"
@@ -176,12 +201,13 @@ class GitHubService:
             )
 
         owner, repo, pr_number = parsed
-        token = self.resolve_github_token(github_token)
+        token, resolution_error = await self.resolve_github_token(github_token)
         if not token:
             return MergePRResult(
                 pr_url=pr_url,
                 merged=False,
-                summary="GITHUB_TOKEN is not configured; cannot merge PR.",
+                summary=resolution_error
+                or "GITHUB_TOKEN is not configured; cannot merge PR.",
             )
 
         api_url = (
@@ -257,11 +283,12 @@ class GitHubService:
             return False, f"Could not parse PR URL: {pr_url}"
 
         owner, repo, pr_number = parsed
-        token = self.resolve_github_token(github_token)
+        token, resolution_error = await self.resolve_github_token(github_token)
         if not token:
             return (
                 False,
-                "GITHUB_TOKEN is not configured; cannot update PR base.",
+                resolution_error
+                or "GITHUB_TOKEN is not configured; cannot update PR base.",
             )
 
         api_url = (

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3298,6 +3298,19 @@ class TemporalAgentRuntimeActivities:
             return None
 
     @staticmethod
+    def _workspace_git_command(workspace: str, *args: str) -> list[str]:
+        """Build a git command that trusts the run workspace explicitly."""
+        resolved_workspace = str(Path(workspace).resolve())
+        return [
+            "git",
+            "-c",
+            f"safe.directory={resolved_workspace}",
+            "-C",
+            resolved_workspace,
+            *args,
+        ]
+
+    @staticmethod
     def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:
         """Best-effort run discriminator for Gemini error reports."""
         try:
@@ -3346,7 +3359,9 @@ class TemporalAgentRuntimeActivities:
         workspace = record.workspace_path
         try:
             branch_proc = await _asyncio.create_subprocess_exec(
-                "git", "-C", workspace, "rev-parse", "--abbrev-ref", "HEAD",
+                *self._workspace_git_command(
+                    workspace, "rev-parse", "--abbrev-ref", "HEAD",
+                ),
                 stdout=_asyncio.subprocess.PIPE,
                 stderr=_asyncio.subprocess.PIPE,
             )
@@ -3376,7 +3391,9 @@ class TemporalAgentRuntimeActivities:
                 }
 
             push_proc = await _asyncio.create_subprocess_exec(
-                "git", "-C", workspace, "push", "-u", "origin", current_branch,
+                *self._workspace_git_command(
+                    workspace, "push", "-u", "origin", current_branch,
+                ),
                 stdout=_asyncio.subprocess.PIPE,
                 stderr=_asyncio.subprocess.PIPE,
             )
@@ -3406,8 +3423,12 @@ class TemporalAgentRuntimeActivities:
             base_ref = f"origin/{target_branch or 'main'}"
             try:
                 count_proc = await _asyncio.create_subprocess_exec(
-                    "git", "-C", workspace,
-                    "rev-list", "--count", f"{base_ref}..{current_branch}",
+                    *self._workspace_git_command(
+                        workspace,
+                        "rev-list",
+                        "--count",
+                        f"{base_ref}..{current_branch}",
+                    ),
                     stdout=_asyncio.subprocess.PIPE,
                     stderr=_asyncio.subprocess.PIPE,
                 )
@@ -3480,7 +3501,9 @@ class TemporalAgentRuntimeActivities:
         try:
             # Get the current branch in the workspace
             branch_result = subprocess.run(
-                ["git", "-C", workspace, "rev-parse", "--abbrev-ref", "HEAD"],
+                self._workspace_git_command(
+                    workspace, "rev-parse", "--abbrev-ref", "HEAD",
+                ),
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -3526,7 +3549,9 @@ class TemporalAgentRuntimeActivities:
         import subprocess
 
         result = subprocess.run(
-            ["git", "-C", workspace, "remote", "get-url", "origin"],
+            TemporalAgentRuntimeActivities._workspace_git_command(
+                workspace, "remote", "get-url", "origin",
+            ),
             capture_output=True,
             text=True,
             timeout=10,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2923,6 +2923,8 @@ class TemporalAgentRuntimeActivities:
             except Exception as e:
                 logger.error("Supervisor failed for run %s", run_id, exc_info=True)
                 return
+            finally:
+                await self._run_launcher.cleanup_run_support(run_id)
 
 
 
@@ -3311,6 +3313,21 @@ class TemporalAgentRuntimeActivities:
         ]
 
     @staticmethod
+    def _workspace_command_env(workspace: str) -> dict[str, str]:
+        """Build a subprocess env that exposes workspace-local command shims."""
+        env = dict(os.environ)
+        support_bin = Path(workspace).resolve().parent / ".moonmind" / "bin"
+        if support_bin.exists():
+            existing_path = str(env.get("PATH") or "").strip()
+            env["PATH"] = (
+                f"{support_bin}{os.pathsep}{existing_path}"
+                if existing_path
+                else str(support_bin)
+            )
+        env.setdefault("GIT_TERMINAL_PROMPT", "0")
+        return env
+
+    @staticmethod
     def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:
         """Best-effort run discriminator for Gemini error reports."""
         try:
@@ -3527,6 +3544,7 @@ class TemporalAgentRuntimeActivities:
                 text=True,
                 timeout=30,
                 cwd=workspace,
+                env=self._workspace_command_env(workspace),
             )
             if pr_result.returncode != 0:
                 return None

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -33,10 +33,12 @@ class GitHubAuthBrokerHandle:
         try:
             await self.serve_task
         except asyncio.CancelledError:
+            # Task cancellation is expected here during shutdown.
             pass
         try:
             os.remove(self.socket_path)
         except OSError:
+            # Socket removal is best-effort cleanup; shutdown should continue.
             pass
 
 
@@ -57,10 +59,12 @@ class GitHubAuthBrokerManager:
         await self.stop(run_id)
 
         path = Path(socket_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        path.parent.chmod(0o700)
         try:
             path.unlink()
         except FileNotFoundError:
+            # It's fine if the socket file does not exist yet.
             pass
 
         async def _handle_client(
@@ -100,6 +104,7 @@ class GitHubAuthBrokerManager:
                     pass
 
         server = await asyncio.start_unix_server(_handle_client, path=str(path))
+        os.chmod(path, 0o600)
         serve_task = asyncio.create_task(server.serve_forever())
         handle = GitHubAuthBrokerHandle(
             run_id=run_id,

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -1,0 +1,228 @@
+"""Broker GitHub credentials to local helper scripts without writing PATs to disk."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import socket
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+_BROKER_SOCKET_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(slots=True)
+class GitHubAuthBrokerHandle:
+    """Per-run in-memory GitHub token broker."""
+
+    run_id: str
+    socket_path: str
+    server: asyncio.AbstractServer
+    serve_task: asyncio.Task[None]
+    token: str
+
+    async def close(self) -> None:
+        """Stop serving broker requests and remove the socket."""
+        self.server.close()
+        await self.server.wait_closed()
+        self.serve_task.cancel()
+        try:
+            await self.serve_task
+        except asyncio.CancelledError:
+            pass
+        try:
+            os.remove(self.socket_path)
+        except OSError:
+            pass
+
+
+class GitHubAuthBrokerManager:
+    """Owns per-run GitHub auth brokers inside the worker process."""
+
+    def __init__(self) -> None:
+        self._handles: dict[str, GitHubAuthBrokerHandle] = {}
+
+    async def start(
+        self,
+        *,
+        run_id: str,
+        token: str,
+        socket_path: str,
+    ) -> GitHubAuthBrokerHandle:
+        """Start or replace a broker for one managed run."""
+        await self.stop(run_id)
+
+        path = Path(socket_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+
+        async def _handle_client(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            try:
+                request_line = await asyncio.wait_for(
+                    reader.readline(),
+                    timeout=_BROKER_SOCKET_TIMEOUT_SECONDS,
+                )
+                request = json.loads(request_line.decode("utf-8"))
+                command = str(request.get("command") or "").strip()
+                if command == "ping":
+                    response: dict[str, Any] = {"ok": True}
+                elif command == "github_token":
+                    response = {"ok": True, "token": token}
+                else:
+                    response = {"ok": False, "error": f"unsupported command: {command}"}
+                writer.write((json.dumps(response) + "\n").encode("utf-8"))
+                await writer.drain()
+            except Exception as exc:  # noqa: BLE001
+                try:
+                    writer.write(
+                        (
+                            json.dumps({"ok": False, "error": str(exc)[:200]}) + "\n"
+                        ).encode("utf-8")
+                    )
+                    await writer.drain()
+                except Exception:  # noqa: BLE001
+                    pass
+            finally:
+                writer.close()
+                try:
+                    await writer.wait_closed()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        server = await asyncio.start_unix_server(_handle_client, path=str(path))
+        serve_task = asyncio.create_task(server.serve_forever())
+        handle = GitHubAuthBrokerHandle(
+            run_id=run_id,
+            socket_path=str(path),
+            server=server,
+            serve_task=serve_task,
+            token=token,
+        )
+        self._handles[run_id] = handle
+        await wait_for_broker_socket(str(path))
+        return handle
+
+    async def stop(self, run_id: str) -> None:
+        """Stop the broker for one managed run when present."""
+        handle = self._handles.pop(run_id, None)
+        if handle is None:
+            return
+        await handle.close()
+
+
+async def wait_for_broker_socket(socket_path: str) -> None:
+    """Poll until the broker socket exists and answers ping."""
+    deadline = asyncio.get_running_loop().time() + _BROKER_SOCKET_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+    while asyncio.get_running_loop().time() < deadline:
+        if not Path(socket_path).exists():
+            await asyncio.sleep(0.05)
+            continue
+        try:
+            if await _async_request(socket_path, command="ping") == "":
+                return
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            await asyncio.sleep(0.05)
+            continue
+    raise RuntimeError(
+        f"Timed out waiting for GitHub auth broker socket at {socket_path}"
+    ) from last_error
+
+
+async def _async_request(socket_path: str, *, command: str) -> str:
+    """Fetch one broker response using asyncio Unix sockets."""
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+    try:
+        payload = json.dumps({"command": command}).encode("utf-8") + b"\n"
+        writer.write(payload)
+        await writer.drain()
+        response = await asyncio.wait_for(
+            reader.readline(),
+            timeout=_BROKER_SOCKET_TIMEOUT_SECONDS,
+        )
+        if not response:
+            raise RuntimeError("GitHub auth broker returned no response")
+        parsed = json.loads(response.decode("utf-8").strip())
+        if not parsed.get("ok"):
+            raise RuntimeError(str(parsed.get("error") or "broker request failed"))
+        return str(parsed.get("token") or "")
+    finally:
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def request_github_token(socket_path: str, *, command: str = "github_token") -> str:
+    """Fetch the GitHub token from the broker over a local Unix socket."""
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(_BROKER_SOCKET_TIMEOUT_SECONDS)
+    try:
+        client.connect(socket_path)
+        payload = json.dumps({"command": command}).encode("utf-8") + b"\n"
+        client.sendall(payload)
+
+        response = bytearray()
+        while True:
+            chunk = client.recv(4096)
+            if not chunk:
+                break
+            response.extend(chunk)
+            if b"\n" in chunk:
+                break
+        if not response:
+            raise RuntimeError("GitHub auth broker returned no response")
+        parsed = json.loads(response.decode("utf-8").strip())
+        if not parsed.get("ok"):
+            raise RuntimeError(str(parsed.get("error") or "broker request failed"))
+        return str(parsed.get("token") or "")
+    finally:
+        client.close()
+
+
+def run_gh_wrapper(*, socket_path: str, real_gh_path: str) -> int:
+    """Exec the real gh binary with a token fetched from the local broker."""
+    token = request_github_token(socket_path)
+    env = dict(os.environ)
+    env["GH_TOKEN"] = token
+    env["GITHUB_TOKEN"] = token
+    os.execvpe(real_gh_path, [real_gh_path, *sys.argv[1:]], env)
+    return 0
+
+
+def run_git_credential_helper(*, socket_path: str) -> int:
+    """Respond to git credential-helper requests with brokered GitHub auth."""
+    operation = str(sys.argv[1] if len(sys.argv) > 1 else "").strip().lower()
+    if operation not in {"get", "fill"}:
+        return 0
+
+    request: dict[str, str] = {}
+    for raw_line in sys.stdin:
+        line = raw_line.rstrip("\n")
+        if not line:
+            break
+        key, _, value = line.partition("=")
+        request[key] = value
+
+    host = str(request.get("host") or "").strip().lower()
+    protocol = str(request.get("protocol") or "").strip().lower()
+    if host != "github.com" or (protocol and protocol != "https"):
+        return 0
+
+    token = request_github_token(socket_path)
+    sys.stdout.write("username=x-access-token\n")
+    sys.stdout.write(f"password={token}\n\n")
+    sys.stdout.flush()
+    return 0

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -10,6 +10,7 @@ import shlex
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from moonmind.schemas.agent_runtime_models import (
     AgentExecutionRequest,
@@ -19,6 +20,7 @@ from moonmind.schemas.agent_runtime_models import (
 )
 from moonmind.utils.logging import SecretRedactor
 
+from .github_auth_broker import GitHubAuthBrokerManager
 from .store import ManagedRunStore
 
 _OWNER_REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -32,6 +34,7 @@ class ManagedRuntimeLauncher:
     def __init__(self, store: ManagedRunStore) -> None:
         self._store = store
         self._logger = logging.getLogger(__name__)
+        self._github_auth_brokers = GitHubAuthBrokerManager()
 
     @staticmethod
     def _extract_workspace_branch(workspace_spec: dict[str, object] | None) -> str | None:
@@ -354,29 +357,50 @@ class ManagedRuntimeLauncher:
             return None
 
     @staticmethod
+    def _write_executable_script(path: Path, content: str) -> str:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o700)
+        return str(path)
+
+    @staticmethod
+    def _render_gh_wrapper_script(*, socket_path: str, real_gh_path: str) -> str:
+        return (
+            "#!/usr/bin/env python3\n"
+            "from moonmind.workflows.temporal.runtime.github_auth_broker import run_gh_wrapper\n"
+            "\n"
+            "if __name__ == \"__main__\":\n"
+            f"    raise SystemExit(run_gh_wrapper(socket_path={socket_path!r}, real_gh_path={real_gh_path!r}))\n"
+        )
+
+    @staticmethod
+    def _render_git_credential_helper_script(*, socket_path: str) -> str:
+        return (
+            "#!/usr/bin/env python3\n"
+            "from moonmind.workflows.temporal.runtime.github_auth_broker import run_git_credential_helper\n"
+            "\n"
+            "if __name__ == \"__main__\":\n"
+            f"    raise SystemExit(run_git_credential_helper(socket_path={socket_path!r}))\n"
+        )
+
+    @staticmethod
     def _persist_gh_config(
         env: dict[str, str],
         workspace_path: str | None,
         *,
         support_root: str | None = None,
-    ) -> None:
+        github_socket_path: str | None = None,
+        real_gh_path: str | None = None,
+    ) -> list[str]:
         """Persist workspace-scoped git/gh support config for managed runs.
 
-        The generated support files give agent subprocesses a stable git view
-        of the workspace even when they sanitize environment variables before
-        spawning tool commands. In particular this writes:
-
-        - ``GH_CONFIG_DIR`` hosts config when a GitHub token is available
-        - ``GIT_CONFIG_GLOBAL`` with ``safe.directory`` for the workspace
-        - optional credential-helper and git identity settings
-        - optional repo-local credential helper for tools that ignore
-          ``GIT_CONFIG_GLOBAL`` but still read ``.git/config``
+        The generated support files give agent subprocesses a stable git/gh view
+        of the workspace without writing plaintext GitHub credentials to disk.
         """
         if not workspace_path:
-            return
+            return []
 
         resolved_workspace = str(Path(workspace_path).resolve())
-        token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
         git_name = str(
             env.get("GIT_AUTHOR_NAME") or env.get("GIT_COMMITTER_NAME") or ""
         ).strip()
@@ -385,87 +409,88 @@ class ManagedRuntimeLauncher:
         ).strip()
 
         support_dir = Path(support_root or workspace_path) / ".moonmind"
-        gh_dir = support_dir / "gh"
+        bin_dir = support_dir / "bin"
         git_config_path = support_dir / "gitconfig"
-        cred_store_path = gh_dir / "git-credentials"
+        cleanup_paths: list[str] = []
+        git_helper_path: Path | None = None
 
-        try:
-            support_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            logger.debug("Failed to create managed runtime git support dir", exc_info=True)
-            return
+        support_dir.mkdir(parents=True, exist_ok=True)
+        cleanup_paths.append(str(git_config_path))
 
-        if token:
-            try:
-                gh_dir.mkdir(parents=True, exist_ok=True)
-                hosts_path = gh_dir / "hosts.yml"
-                hosts_path.write_text(
-                    f"github.com:\n"
-                    f"  oauth_token: {token}\n"
-                    f"  git_protocol: https\n",
-                    encoding="utf-8",
+        if github_socket_path:
+            git_helper_path = bin_dir / "git-credential-moonmind"
+            cleanup_paths.append(
+                ManagedRuntimeLauncher._write_executable_script(
+                    git_helper_path,
+                    ManagedRuntimeLauncher._render_git_credential_helper_script(
+                        socket_path=github_socket_path,
+                    ),
                 )
-                hosts_path.chmod(0o600)
-                cred_store_path.write_text(
-                    f"https://x-access-token:{token}@github.com\n",
-                    encoding="utf-8",
+            )
+            if real_gh_path:
+                cleanup_paths.append(
+                    ManagedRuntimeLauncher._write_executable_script(
+                        bin_dir / "gh",
+                        ManagedRuntimeLauncher._render_gh_wrapper_script(
+                            socket_path=github_socket_path,
+                            real_gh_path=real_gh_path,
+                        ),
+                    )
                 )
-                cred_store_path.chmod(0o600)
-                env["GH_CONFIG_DIR"] = str(gh_dir)
-                env.setdefault("GIT_TERMINAL_PROMPT", "0")
-            except OSError:
-                logger.debug("Failed to persist gh config", exc_info=True)
-                token = ""
+            existing_path = str(env.get("PATH") or "").strip()
+            env["PATH"] = (
+                f"{bin_dir}{os.pathsep}{existing_path}" if existing_path else str(bin_dir)
+            )
+            env.setdefault("GIT_TERMINAL_PROMPT", "0")
 
-        try:
-            git_config_lines = [
-                "# moonmind-managed-git-config\n",
-                "[safe]\n",
-                f"\tdirectory = {resolved_workspace}\n",
-            ]
-            if token:
-                git_config_lines.extend(
-                    [
-                        "[credential]\n",
-                        f'\thelper = store --file="{cred_store_path}"\n',
-                    ]
-                )
-            if git_name or git_email:
-                git_config_lines.append("[user]\n")
-                if git_name:
-                    git_config_lines.append(f"\tname = {git_name}\n")
-                if git_email:
-                    git_config_lines.append(f"\temail = {git_email}\n")
-            git_config_path.write_text("".join(git_config_lines), encoding="utf-8")
-            git_config_path.chmod(0o600)
-            env["GIT_CONFIG_GLOBAL"] = str(git_config_path)
-        except OSError:
-            logger.debug("Failed to persist git global config", exc_info=True)
+        git_config_lines = [
+            "# moonmind-managed-git-config\n",
+            "[safe]\n",
+            f"\tdirectory = {resolved_workspace}\n",
+        ]
+        if git_helper_path is not None:
+            git_helper_command = shlex.quote(str(git_helper_path))
+            git_config_lines.extend(
+                [
+                    "[credential]\n",
+                    f"\thelper = !{git_helper_command}\n",
+                ]
+            )
+        if git_name or git_email:
+            git_config_lines.append("[user]\n")
+            if git_name:
+                git_config_lines.append(f"\tname = {git_name}\n")
+            if git_email:
+                git_config_lines.append(f"\temail = {git_email}\n")
+        git_config_path.write_text("".join(git_config_lines), encoding="utf-8")
+        git_config_path.chmod(0o600)
+        env["GIT_CONFIG_GLOBAL"] = str(git_config_path)
 
-        try:
-            if not token:
-                return
-            repo_git_config_path = Path(workspace_path) / ".git" / "config"
-            if not repo_git_config_path.exists():
-                return
+        if git_helper_path is None:
+            return cleanup_paths
 
-            # Append credential helper config to .git/config if not already
-            # present.  We check for our marker to avoid duplicating on
-            # idempotent re-launches.
-            marker = "# moonmind-credential-helper"
-            existing_config = repo_git_config_path.read_text(encoding="utf-8")
-            if marker not in existing_config:
-                credential_section = (
-                    f"\n{marker}\n"
-                    f"[credential]\n"
-                    f'\thelper = store --file="{cred_store_path}"\n'
-                )
-                repo_git_config_path.write_text(
-                    existing_config + credential_section,
-                    encoding="utf-8",
-                )
-        except OSError:
-            logger.debug("Failed to persist git credential config", exc_info=True)
+        repo_git_config_path = Path(workspace_path) / ".git" / "config"
+        if not repo_git_config_path.exists():
+            return cleanup_paths
+
+        marker = "# moonmind-credential-helper"
+        existing_config = repo_git_config_path.read_text(encoding="utf-8")
+        if marker not in existing_config:
+            git_helper_command = shlex.quote(str(git_helper_path))
+            credential_section = (
+                f"\n{marker}\n"
+                f"[credential]\n"
+                f"\thelper = !{git_helper_command}\n"
+            )
+            repo_git_config_path.write_text(
+                existing_config + credential_section,
+                encoding="utf-8",
+            )
+        return cleanup_paths
+
+    async def cleanup_run_support(self, run_id: str) -> None:
+        """Stop any in-memory runtime support services for the run."""
+        await self._github_auth_brokers.stop(run_id)
 
     def build_command(
         self,
@@ -616,23 +641,11 @@ class ManagedRuntimeLauncher:
         if strategy is not None:
             env_overrides = strategy.shape_environment(env_overrides, profile)
 
-        github_token = await self._resolve_github_token_for_launch(env_overrides)
-        if github_token:
-            env_overrides.setdefault("GITHUB_TOKEN", github_token)
-            env_overrides.setdefault("GH_TOKEN", github_token)
-
         for key in profile.passthrough_env_keys:
             value = os.environ.get(key)
             if value is None or not str(value).strip():
                 continue
             env_overrides[key] = value
-
-        if resolved_workspace_path is not None:
-            self._persist_gh_config(
-                env_overrides,
-                resolved_workspace_path,
-                support_root=str(run_root),
-            )
 
         from moonmind.config.settings import settings as _mm_settings
         _git_name = str(_mm_settings.workflow.git_user_name or "").strip() or None
@@ -644,52 +657,86 @@ class ManagedRuntimeLauncher:
             env_overrides.setdefault("GIT_AUTHOR_EMAIL", _git_email)
             env_overrides.setdefault("GIT_COMMITTER_EMAIL", _git_email)
 
-        # The claude CLI refuses --dangerously-skip-permissions when running as root
-        # (security restriction). For claude_code runtime, drop to the app user.
-        _run_as_root = os.geteuid() == 0
-        _is_claude_code = profile.runtime_id == "claude_code"
-        _needs_priv_drop = _run_as_root and _is_claude_code
+        github_token = await self._resolve_github_token_for_launch(env_overrides)
+        cleanup_paths: list[str] = list(materializer.generated_files)
+        github_socket_path: str | None = None
+        real_gh_path = shutil.which("gh")
+        process: asyncio.subprocess.Process
+        try:
+            if github_token and run_root is not None:
+                github_socket_path = str(run_root / ".moonmind" / "github-auth.sock")
+                await self._github_auth_brokers.start(
+                    run_id=run_id,
+                    token=github_token,
+                    socket_path=github_socket_path,
+                )
+                cleanup_paths.append(github_socket_path)
+                env_overrides.pop("GITHUB_TOKEN", None)
+                env_overrides.pop("GH_TOKEN", None)
 
-        # Transfer the full run workspace root to the app user so it can write
-        # both the repo checkout and support files materialized alongside it
-        # (for example .moonmind/GH_CONFIG_DIR and active skill projections).
-        # Chowning only the repo subtree leaves root-owned support paths behind
-        # and the dropped user can hang or fail before producing any output.
-        if _needs_priv_drop and resolved_workspace_path is not None:
-            ownership_root = self._resolve_workspace_ownership_root(
-                resolved_workspace_path=resolved_workspace_path,
-                run_id=run_id,
-            )
-            await self._run_checked_command(
-                "chown", "-R", "app:app", ownership_root,
-            )
+            if resolved_workspace_path is not None:
+                cleanup_paths.extend(
+                    self._persist_gh_config(
+                        env_overrides,
+                        resolved_workspace_path,
+                        support_root=str(run_root),
+                        github_socket_path=github_socket_path,
+                        real_gh_path=real_gh_path,
+                    )
+                )
 
-        if _needs_priv_drop:
-            # runuser -u does not rewrite HOME/USER/LOGNAME for us when we pass
-            # an explicit env block, so seed the target-user login context
-            # explicitly before launching Claude Code.
-            env_overrides["HOME"] = "/home/app"
-            env_overrides["USER"] = "app"
-            env_overrides["LOGNAME"] = "app"
-            # Use runuser with env= so secrets do not appear in process argv.
-            process = await asyncio.create_subprocess_exec(
-                "runuser", "-u", "app", "--",
-                *cmd,
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env_overrides,
-                cwd=resolved_workspace_path,
-            )
-        else:
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env_overrides,
-                cwd=resolved_workspace_path,
-            )
+            # The claude CLI refuses --dangerously-skip-permissions when running as root
+            # (security restriction). For claude_code runtime, drop to the app user.
+            _run_as_root = os.geteuid() == 0
+            _is_claude_code = profile.runtime_id == "claude_code"
+            _needs_priv_drop = _run_as_root and _is_claude_code
+
+            # Transfer the full run workspace root to the app user so it can write
+            # both repo files and launcher support artifacts beside the repo.
+            # Chowning only the repo subtree leaves root-owned support paths behind.
+            if _needs_priv_drop and resolved_workspace_path is not None:
+                ownership_root = self._resolve_workspace_ownership_root(
+                    resolved_workspace_path=resolved_workspace_path,
+                    run_id=run_id,
+                )
+                await self._run_checked_command(
+                    "chown", "-R", "app:app", ownership_root,
+                )
+
+            if _needs_priv_drop:
+                # runuser -u does not rewrite HOME/USER/LOGNAME for us when we pass
+                # an explicit env block, so seed the target-user login context
+                # explicitly before launching Claude Code.
+                env_overrides["HOME"] = "/home/app"
+                env_overrides["USER"] = "app"
+                env_overrides["LOGNAME"] = "app"
+                # Use runuser with env= so secrets do not appear in process argv.
+                process = await asyncio.create_subprocess_exec(
+                    "runuser", "-u", "app", "--",
+                    *cmd,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env_overrides,
+                    cwd=resolved_workspace_path,
+                )
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env_overrides,
+                    cwd=resolved_workspace_path,
+                )
+        except Exception:
+            await self.cleanup_run_support(run_id)
+            for path in cleanup_paths:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            raise
 
         record = ManagedRunRecord(
             run_id=run_id,
@@ -702,4 +749,4 @@ class ManagedRuntimeLauncher:
             live_stream_capable=bool(resolved_workspace_path),
         )
         self._store.save(record)
-        return record, process, materializer.generated_files
+        return record, process, cleanup_paths

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -400,6 +400,11 @@ class ManagedRuntimeLauncher:
         )
 
     @staticmethod
+    def _format_git_config_value(value: str) -> str:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+
+    @staticmethod
     def _persist_gh_config(
         env: dict[str, str],
         workspace_path: str | None,
@@ -462,7 +467,10 @@ class ManagedRuntimeLauncher:
         git_config_lines = [
             "# moonmind-managed-git-config\n",
             "[safe]\n",
-            f"\tdirectory = {resolved_workspace}\n",
+            (
+                "\tdirectory = "
+                f"{ManagedRuntimeLauncher._format_git_config_value(resolved_workspace)}\n"
+            ),
         ]
         if git_helper_path is not None:
             git_helper_command = shlex.quote(str(git_helper_path))
@@ -754,7 +762,11 @@ class ManagedRuntimeLauncher:
                 try:
                     os.remove(path)
                 except OSError:
-                    pass
+                    self._logger.debug(
+                        "Best-effort cleanup failed for support path %s",
+                        path,
+                        exc_info=True,
+                    )
             raise
 
         record = ManagedRunRecord(

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
 import shlex
 import shutil
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -65,6 +67,20 @@ class ManagedRuntimeLauncher:
     def _workspace_root() -> Path:
         root = os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
         return Path(root).resolve() / "workspaces"
+
+    @staticmethod
+    def _build_github_socket_path(*, run_id: str, support_root: str | None) -> str:
+        """Keep broker sockets on a short path to avoid AF_UNIX length limits."""
+        socket_root = Path("/tmp")
+        if not socket_root.is_dir():
+            socket_root = Path(tempfile.gettempdir())
+        socket_root = socket_root / "mm-gh"
+
+        material = run_id
+        if support_root:
+            material = f"{Path(support_root).resolve()}::{run_id}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+        return str(socket_root / f"{digest}.sock")
 
     def _resolve_workspace_ownership_root(
         self,
@@ -664,7 +680,10 @@ class ManagedRuntimeLauncher:
         process: asyncio.subprocess.Process
         try:
             if github_token and run_root is not None:
-                github_socket_path = str(run_root / ".moonmind" / "github-auth.sock")
+                github_socket_path = self._build_github_socket_path(
+                    run_id=run_id,
+                    support_root=str(run_root),
+                )
                 await self._github_auth_brokers.start(
                     run_id=run_id,
                     token=github_token,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -328,72 +328,139 @@ class ManagedRuntimeLauncher:
         return str(repo_path)
 
     @staticmethod
+    async def _resolve_github_token_for_launch(env: dict[str, str]) -> str | None:
+        token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
+        if token:
+            return token
+
+        from moonmind.config.settings import settings as _mm_settings
+        from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+            resolve_managed_api_key_reference,
+        )
+
+        secret_ref = str(
+            getattr(_mm_settings.github, "github_token_secret_ref", "") or ""
+        ).strip()
+        if not secret_ref:
+            return None
+
+        try:
+            return await resolve_managed_api_key_reference(secret_ref)
+        except Exception:
+            logger.warning(
+                "Failed to resolve GitHub token secret ref for managed runtime launch",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
     def _persist_gh_config(
         env: dict[str, str],
         workspace_path: str | None,
         *,
         support_root: str | None = None,
     ) -> None:
-        """Write ``gh`` file-based auth so ``gh`` works even when AI CLIs
-        strip secret env vars from tool-call subprocesses.
+        """Persist workspace-scoped git/gh support config for managed runs.
 
-        Sets ``GH_CONFIG_DIR`` in *env* to a per-workspace directory
-        containing ``hosts.yml`` with the GitHub token.
+        The generated support files give agent subprocesses a stable git view
+        of the workspace even when they sanitize environment variables before
+        spawning tool commands. In particular this writes:
 
-        Also injects a git credential helper into the workspace's
-        ``.git/config`` so that ``git push`` can authenticate even when
-        env vars like ``GITHUB_TOKEN`` are stripped from tool-call
-        subprocesses (e.g. Claude Code, Gemini CLI).  Writing into
-        ``.git/config`` is robust because git always reads this file
-        regardless of the subprocess environment.
+        - ``GH_CONFIG_DIR`` hosts config when a GitHub token is available
+        - ``GIT_CONFIG_GLOBAL`` with ``safe.directory`` for the workspace
+        - optional credential-helper and git identity settings
+        - optional repo-local credential helper for tools that ignore
+          ``GIT_CONFIG_GLOBAL`` but still read ``.git/config``
         """
-        token = env.get("GITHUB_TOKEN") or env.get("GH_TOKEN")
-        if not token or not workspace_path:
+        if not workspace_path:
             return
-        gh_root = Path(support_root or workspace_path)
-        gh_dir = gh_root / ".moonmind" / "gh"
+
+        resolved_workspace = str(Path(workspace_path).resolve())
+        token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
+        git_name = str(
+            env.get("GIT_AUTHOR_NAME") or env.get("GIT_COMMITTER_NAME") or ""
+        ).strip()
+        git_email = str(
+            env.get("GIT_AUTHOR_EMAIL") or env.get("GIT_COMMITTER_EMAIL") or ""
+        ).strip()
+
+        support_dir = Path(support_root or workspace_path) / ".moonmind"
+        gh_dir = support_dir / "gh"
+        git_config_path = support_dir / "gitconfig"
+        cred_store_path = gh_dir / "git-credentials"
+
         try:
-            gh_dir.mkdir(parents=True, exist_ok=True)
-            hosts_path = gh_dir / "hosts.yml"
-            hosts_path.write_text(
-                f"github.com:\n"
-                f"  oauth_token: {token}\n"
-                f"  git_protocol: https\n",
-                encoding="utf-8",
-            )
-            hosts_path.chmod(0o600)
-            env["GH_CONFIG_DIR"] = str(gh_dir)
+            support_dir.mkdir(parents=True, exist_ok=True)
         except OSError:
-            logger.debug("Failed to persist gh config", exc_info=True)
+            logger.debug("Failed to create managed runtime git support dir", exc_info=True)
             return
 
-        # Inject git credential helper into .git/config so git push works
-        # even when the AI CLI strips env vars from tool-call subprocesses.
-        try:
-            git_config_path = Path(workspace_path) / ".git" / "config"
-            if not git_config_path.exists():
-                return
+        if token:
+            try:
+                gh_dir.mkdir(parents=True, exist_ok=True)
+                hosts_path = gh_dir / "hosts.yml"
+                hosts_path.write_text(
+                    f"github.com:\n"
+                    f"  oauth_token: {token}\n"
+                    f"  git_protocol: https\n",
+                    encoding="utf-8",
+                )
+                hosts_path.chmod(0o600)
+                cred_store_path.write_text(
+                    f"https://x-access-token:{token}@github.com\n",
+                    encoding="utf-8",
+                )
+                cred_store_path.chmod(0o600)
+                env["GH_CONFIG_DIR"] = str(gh_dir)
+                env.setdefault("GIT_TERMINAL_PROMPT", "0")
+            except OSError:
+                logger.debug("Failed to persist gh config", exc_info=True)
+                token = ""
 
-            # Write a git-credential-store file with the token
-            cred_store_path = gh_dir / "git-credentials"
-            cred_store_path.write_text(
-                f"https://x-access-token:{token}@github.com\n",
-                encoding="utf-8",
-            )
-            cred_store_path.chmod(0o600)
+        try:
+            git_config_lines = [
+                "# moonmind-managed-git-config\n",
+                "[safe]\n",
+                f"\tdirectory = {resolved_workspace}\n",
+            ]
+            if token:
+                git_config_lines.extend(
+                    [
+                        "[credential]\n",
+                        f'\thelper = store --file="{cred_store_path}"\n',
+                    ]
+                )
+            if git_name or git_email:
+                git_config_lines.append("[user]\n")
+                if git_name:
+                    git_config_lines.append(f"\tname = {git_name}\n")
+                if git_email:
+                    git_config_lines.append(f"\temail = {git_email}\n")
+            git_config_path.write_text("".join(git_config_lines), encoding="utf-8")
+            git_config_path.chmod(0o600)
+            env["GIT_CONFIG_GLOBAL"] = str(git_config_path)
+        except OSError:
+            logger.debug("Failed to persist git global config", exc_info=True)
+
+        try:
+            if not token:
+                return
+            repo_git_config_path = Path(workspace_path) / ".git" / "config"
+            if not repo_git_config_path.exists():
+                return
 
             # Append credential helper config to .git/config if not already
             # present.  We check for our marker to avoid duplicating on
             # idempotent re-launches.
             marker = "# moonmind-credential-helper"
-            existing_config = git_config_path.read_text(encoding="utf-8")
+            existing_config = repo_git_config_path.read_text(encoding="utf-8")
             if marker not in existing_config:
                 credential_section = (
                     f"\n{marker}\n"
                     f"[credential]\n"
                     f'\thelper = store --file="{cred_store_path}"\n'
                 )
-                git_config_path.write_text(
+                repo_git_config_path.write_text(
                     existing_config + credential_section,
                     encoding="utf-8",
                 )
@@ -548,6 +615,11 @@ class ManagedRuntimeLauncher:
 
         if strategy is not None:
             env_overrides = strategy.shape_environment(env_overrides, profile)
+
+        github_token = await self._resolve_github_token_for_launch(env_overrides)
+        if github_token:
+            env_overrides.setdefault("GITHUB_TOKEN", github_token)
+            env_overrides.setdefault("GH_TOKEN", github_token)
 
         for key in profile.passthrough_env_keys:
             value = os.environ.get(key)

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -16,7 +16,8 @@ from moonmind.workflows.temporal.runtime.github_auth_broker import (
 @pytest.mark.asyncio
 async def test_github_auth_broker_serves_token_and_cleans_socket():
     manager = GitHubAuthBrokerManager()
-    socket_path = Path("/tmp") / f"mm-gh-broker-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock"
+    socket_dir = Path("/tmp") / f"mm-gh-broker-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    socket_path = socket_dir / "github-auth.sock"
 
     await manager.start(
         run_id="run-1",
@@ -29,6 +30,8 @@ async def test_github_auth_broker_serves_token_and_cleans_socket():
         == "ghp_testtoken123"
     )
     assert Path(socket_path).exists()
+    assert (socket_dir.stat().st_mode & 0o777) == 0o700
+    assert (socket_path.stat().st_mode & 0o777) == 0o600
 
     await manager.stop("run-1")
 

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
+import uuid
 
 import pytest
 
@@ -12,9 +14,9 @@ from moonmind.workflows.temporal.runtime.github_auth_broker import (
 
 
 @pytest.mark.asyncio
-async def test_github_auth_broker_serves_token_and_cleans_socket(tmp_path):
+async def test_github_auth_broker_serves_token_and_cleans_socket():
     manager = GitHubAuthBrokerManager()
-    socket_path = tmp_path / "github-auth.sock"
+    socket_path = Path("/tmp") / f"mm-gh-broker-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock"
 
     await manager.start(
         run_id="run-1",

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from moonmind.workflows.temporal.runtime.github_auth_broker import (
+    GitHubAuthBrokerManager,
+    request_github_token,
+)
+
+
+@pytest.mark.asyncio
+async def test_github_auth_broker_serves_token_and_cleans_socket(tmp_path):
+    manager = GitHubAuthBrokerManager()
+    socket_path = tmp_path / "github-auth.sock"
+
+    await manager.start(
+        run_id="run-1",
+        token="ghp_testtoken123",
+        socket_path=str(socket_path),
+    )
+
+    assert (
+        await asyncio.to_thread(request_github_token, str(socket_path))
+        == "ghp_testtoken123"
+    )
+    assert Path(socket_path).exists()
+
+    await manager.stop("run-1")
+
+    assert not Path(socket_path).exists()

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -213,22 +213,33 @@ async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch)
     assert captured_env["GITHUB_TOKEN"] == "ghp-legacy"
 
 
-def test_persist_gh_config_writes_hosts_yml(tmp_path):
+def test_persist_gh_config_writes_broker_helpers_without_plaintext_token(tmp_path):
     env = {"GITHUB_TOKEN": "ghp_testtoken123", "PATH": "/usr/bin"}
-    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
-    hosts = tmp_path / ".moonmind" / "gh" / "hosts.yml"
+    ManagedRuntimeLauncher._persist_gh_config(
+        env,
+        str(tmp_path),
+        github_socket_path="/tmp/github-auth.sock",
+        real_gh_path="/usr/bin/gh",
+    )
+    gh_wrapper = tmp_path / ".moonmind" / "bin" / "gh"
+    git_helper = tmp_path / ".moonmind" / "bin" / "git-credential-moonmind"
     gitconfig = tmp_path / ".moonmind" / "gitconfig"
-    assert hosts.exists()
+    assert gh_wrapper.exists()
+    assert git_helper.exists()
     assert gitconfig.exists()
-    content = hosts.read_text()
-    assert "ghp_testtoken123" in content
-    assert "github.com" in content
-    assert env["GH_CONFIG_DIR"] == str(tmp_path / ".moonmind" / "gh")
     assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
-    assert (hosts.stat().st_mode & 0o777) == 0o600
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["PATH"].startswith(str(tmp_path / ".moonmind" / "bin"))
+    assert "GH_CONFIG_DIR" not in env
+    assert (gh_wrapper.stat().st_mode & 0o777) == 0o700
+    assert (git_helper.stat().st_mode & 0o777) == 0o700
     gitconfig_text = gitconfig.read_text(encoding="utf-8")
     assert "[safe]" in gitconfig_text
+    assert "[credential]" in gitconfig_text
     assert f"\tdirectory = {tmp_path.resolve()}" in gitconfig_text
+    assert "ghp_testtoken123" not in gh_wrapper.read_text(encoding="utf-8")
+    assert "ghp_testtoken123" not in git_helper.read_text(encoding="utf-8")
+    assert "ghp_testtoken123" not in gitconfig_text
 
 
 def test_persist_gh_config_writes_safe_directory_without_token(tmp_path):
@@ -242,12 +253,14 @@ def test_persist_gh_config_writes_safe_directory_without_token(tmp_path):
     )
     assert "GH_CONFIG_DIR" not in env
     assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+    assert "[credential]" not in gitconfig.read_text(encoding="utf-8")
 
 
 def test_persist_gh_config_skips_without_workspace():
-    env = {"GITHUB_TOKEN": "ghp_test"}
+    env = {"PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(env, None)
     assert "GH_CONFIG_DIR" not in env
+    assert "GIT_CONFIG_GLOBAL" not in env
 
 
 def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
@@ -261,33 +274,34 @@ def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
         encoding="utf-8",
     )
 
-    env = {"GITHUB_TOKEN": "test-support-root-token", "PATH": "/usr/bin"}
+    env = {"PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(
         env,
         str(repo_root),
         support_root=str(run_root),
+        github_socket_path="/tmp/github-auth.sock",
+        real_gh_path="/usr/bin/gh",
     )
 
-    hosts = run_root / ".moonmind" / "gh" / "hosts.yml"
-    cred_store = run_root / ".moonmind" / "gh" / "git-credentials"
+    gh_wrapper = run_root / ".moonmind" / "bin" / "gh"
+    git_helper = run_root / ".moonmind" / "bin" / "git-credential-moonmind"
     gitconfig = run_root / ".moonmind" / "gitconfig"
-    assert hosts.exists()
-    assert cred_store.exists()
+    assert gh_wrapper.exists()
+    assert git_helper.exists()
     assert gitconfig.exists()
     assert not (repo_root / ".moonmind").exists()
-    assert env["GH_CONFIG_DIR"] == str(run_root / ".moonmind" / "gh")
     assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+    assert env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
 
     updated_config = git_config.read_text()
-    assert str(cred_store) in updated_config
+    assert str(git_helper) in updated_config
     assert f"\tdirectory = {repo_root.resolve()}" in gitconfig.read_text(
         encoding="utf-8"
     )
 
 
 def test_persist_gh_config_writes_git_credential_helper(tmp_path):
-    """When a .git/config exists, _persist_gh_config injects a credential
-    helper pointing to a git-credentials store file."""
+    """When a .git/config exists, _persist_gh_config injects a broker helper."""
     git_dir = tmp_path / ".git"
     git_dir.mkdir()
     git_config = git_dir / "config"
@@ -296,26 +310,22 @@ def test_persist_gh_config_writes_git_credential_helper(tmp_path):
         encoding="utf-8",
     )
 
-    env = {"GITHUB_TOKEN": "test-cred-store-token", "PATH": "/usr/bin"}
-    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
+    env = {"PATH": "/usr/bin"}
+    ManagedRuntimeLauncher._persist_gh_config(
+        env,
+        str(tmp_path),
+        github_socket_path="/tmp/github-auth.sock",
+    )
 
-    # gh hosts.yml should still be written
-    assert (tmp_path / ".moonmind" / "gh" / "hosts.yml").exists()
-
-    # git-credentials store file should contain the token
-    cred_store = tmp_path / ".moonmind" / "gh" / "git-credentials"
-    assert cred_store.exists()
-    cred_content = cred_store.read_text()
-    assert "test-cred-store-token" in cred_content
-    assert "github.com" in cred_content
-    assert (cred_store.stat().st_mode & 0o777) == 0o600
+    git_helper = tmp_path / ".moonmind" / "bin" / "git-credential-moonmind"
+    assert git_helper.exists()
+    assert (git_helper.stat().st_mode & 0o777) == 0o700
 
     # .git/config should have the credential helper section
     updated_config = git_config.read_text()
     assert "# moonmind-credential-helper" in updated_config
     assert "[credential]" in updated_config
-    assert "store --file=" in updated_config
-    assert str(cred_store) in updated_config
+    assert str(git_helper) in updated_config
 
 
 def test_persist_gh_config_git_credential_idempotent(tmp_path):
@@ -325,9 +335,17 @@ def test_persist_gh_config_git_credential_idempotent(tmp_path):
     git_config = git_dir / "config"
     git_config.write_text("[core]\n\tbare = false\n", encoding="utf-8")
 
-    env = {"GITHUB_TOKEN": "test-idempotent-token", "PATH": "/usr/bin"}
-    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
-    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
+    env = {"PATH": "/usr/bin"}
+    ManagedRuntimeLauncher._persist_gh_config(
+        env,
+        str(tmp_path),
+        github_socket_path="/tmp/github-auth.sock",
+    )
+    ManagedRuntimeLauncher._persist_gh_config(
+        env,
+        str(tmp_path),
+        github_socket_path="/tmp/github-auth.sock",
+    )
 
     updated_config = git_config.read_text()
     assert updated_config.count("# moonmind-credential-helper") == 1
@@ -335,13 +353,15 @@ def test_persist_gh_config_git_credential_idempotent(tmp_path):
 
 
 def test_persist_gh_config_skips_git_cred_without_git_dir(tmp_path):
-    """When no .git/config exists, global git config still carries credentials."""
-    env = {"GITHUB_TOKEN": "test-no-gitdir-token", "PATH": "/usr/bin"}
-    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
+    """When no .git/config exists, global git config still carries the helper."""
+    env = {"PATH": "/usr/bin"}
+    ManagedRuntimeLauncher._persist_gh_config(
+        env,
+        str(tmp_path),
+        github_socket_path="/tmp/github-auth.sock",
+    )
 
-    # gh config should still be written
-    assert (tmp_path / ".moonmind" / "gh" / "hosts.yml").exists()
-    assert (tmp_path / ".moonmind" / "gh" / "git-credentials").exists()
+    assert (tmp_path / ".moonmind" / "bin" / "git-credential-moonmind").exists()
     gitconfig = tmp_path / ".moonmind" / "gitconfig"
     assert "[credential]" in gitconfig.read_text(encoding="utf-8")
 
@@ -353,16 +373,17 @@ def test_persist_gh_config_quotes_helper_path_when_store_has_spaces(tmp_path):
     git_config = git_dir / "config"
     git_config.write_text("[core]\n\tbare = false\n", encoding="utf-8")
 
-    env = {"GITHUB_TOKEN": "test-space-path-token", "PATH": "/usr/bin"}
+    env = {"PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(
         env,
         str(run_root / "repo"),
         support_root=str(run_root),
+        github_socket_path="/tmp/github-auth.sock",
     )
 
     updated_config = git_config.read_text(encoding="utf-8")
-    assert 'helper = store --file="' in updated_config
-    assert str(run_root / ".moonmind" / "gh" / "git-credentials") in updated_config
+    assert "helper = !" in updated_config
+    assert str(run_root / ".moonmind" / "bin" / "git-credential-moonmind") in updated_config
 
 
 def test_persist_gh_config_writes_git_identity_to_global_config(tmp_path):
@@ -788,6 +809,10 @@ async def test_launch_materializes_managed_api_key_target_env(tmp_path, monkeypa
         _fake_create_subprocess_exec,
     )
     monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
+    )
+    monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
         _fake_resolve,
     )
@@ -861,6 +886,10 @@ async def test_launch_resolves_github_token_from_secret_ref_setting(
         _fake_create_subprocess_exec,
     )
     monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
+    )
+    monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
         _fake_resolve,
     )
@@ -870,12 +899,16 @@ async def test_launch_resolves_github_token_from_secret_ref_setting(
     )
     await process.wait()
 
-    assert captured_env["GITHUB_TOKEN"] == "resolved-github-token"
-    assert captured_env["GH_TOKEN"] == "resolved-github-token"
+    run_root = store.store_root.parent / "workspaces" / "run-github-secret-ref-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert "GITHUB_TOKEN" not in captured_env
+    assert "GH_TOKEN" not in captured_env
+    assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     gitconfig = Path(captured_env["GIT_CONFIG_GLOBAL"])
     assert gitconfig.exists()
     assert "[credential]" in gitconfig.read_text(encoding="utf-8")
+    assert "resolved-github-token" not in gitconfig.read_text(encoding="utf-8")
+    assert (run_root / ".moonmind" / "bin" / "gh").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -217,19 +217,31 @@ def test_persist_gh_config_writes_hosts_yml(tmp_path):
     env = {"GITHUB_TOKEN": "ghp_testtoken123", "PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
     hosts = tmp_path / ".moonmind" / "gh" / "hosts.yml"
+    gitconfig = tmp_path / ".moonmind" / "gitconfig"
     assert hosts.exists()
+    assert gitconfig.exists()
     content = hosts.read_text()
     assert "ghp_testtoken123" in content
     assert "github.com" in content
     assert env["GH_CONFIG_DIR"] == str(tmp_path / ".moonmind" / "gh")
+    assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
     assert (hosts.stat().st_mode & 0o777) == 0o600
+    gitconfig_text = gitconfig.read_text(encoding="utf-8")
+    assert "[safe]" in gitconfig_text
+    assert f"\tdirectory = {tmp_path.resolve()}" in gitconfig_text
 
 
-def test_persist_gh_config_skips_without_token(tmp_path):
+def test_persist_gh_config_writes_safe_directory_without_token(tmp_path):
     env = {"PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
-    assert not (tmp_path / ".moonmind" / "gh").exists()
+    gitconfig = tmp_path / ".moonmind" / "gitconfig"
+    assert gitconfig.exists()
+    assert "[safe]" in gitconfig.read_text(encoding="utf-8")
+    assert f"\tdirectory = {tmp_path.resolve()}" in gitconfig.read_text(
+        encoding="utf-8"
+    )
     assert "GH_CONFIG_DIR" not in env
+    assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
 
 
 def test_persist_gh_config_skips_without_workspace():
@@ -258,13 +270,19 @@ def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
 
     hosts = run_root / ".moonmind" / "gh" / "hosts.yml"
     cred_store = run_root / ".moonmind" / "gh" / "git-credentials"
+    gitconfig = run_root / ".moonmind" / "gitconfig"
     assert hosts.exists()
     assert cred_store.exists()
+    assert gitconfig.exists()
     assert not (repo_root / ".moonmind").exists()
     assert env["GH_CONFIG_DIR"] == str(run_root / ".moonmind" / "gh")
+    assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
 
     updated_config = git_config.read_text()
     assert str(cred_store) in updated_config
+    assert f"\tdirectory = {repo_root.resolve()}" in gitconfig.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_persist_gh_config_writes_git_credential_helper(tmp_path):
@@ -317,14 +335,15 @@ def test_persist_gh_config_git_credential_idempotent(tmp_path):
 
 
 def test_persist_gh_config_skips_git_cred_without_git_dir(tmp_path):
-    """When no .git/config exists, only gh hosts.yml should be written."""
+    """When no .git/config exists, global git config still carries credentials."""
     env = {"GITHUB_TOKEN": "test-no-gitdir-token", "PATH": "/usr/bin"}
     ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
 
     # gh config should still be written
     assert (tmp_path / ".moonmind" / "gh" / "hosts.yml").exists()
-    # But no git-credentials file since there's no .git/config
-    assert not (tmp_path / ".moonmind" / "gh" / "git-credentials").exists()
+    assert (tmp_path / ".moonmind" / "gh" / "git-credentials").exists()
+    gitconfig = tmp_path / ".moonmind" / "gitconfig"
+    assert "[credential]" in gitconfig.read_text(encoding="utf-8")
 
 
 def test_persist_gh_config_quotes_helper_path_when_store_has_spaces(tmp_path):
@@ -344,6 +363,22 @@ def test_persist_gh_config_quotes_helper_path_when_store_has_spaces(tmp_path):
     updated_config = git_config.read_text(encoding="utf-8")
     assert 'helper = store --file="' in updated_config
     assert str(run_root / ".moonmind" / "gh" / "git-credentials") in updated_config
+
+
+def test_persist_gh_config_writes_git_identity_to_global_config(tmp_path):
+    env = {
+        "PATH": "/usr/bin",
+        "GIT_AUTHOR_NAME": "Nate Sticco",
+        "GIT_AUTHOR_EMAIL": "nsticco@gmail.com",
+    }
+
+    ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
+
+    gitconfig = tmp_path / ".moonmind" / "gitconfig"
+    text = gitconfig.read_text(encoding="utf-8")
+    assert "[user]" in text
+    assert "\tname = Nate Sticco" in text
+    assert "\temail = nsticco@gmail.com" in text
 
 
 @pytest.mark.asyncio
@@ -765,6 +800,82 @@ async def test_launch_materializes_managed_api_key_target_env(tmp_path, monkeypa
     assert captured_env["ANTHROPIC_AUTH_TOKEN"] == "resolved-minimax-token"
     assert "MANAGED_API_KEY_REF" not in captured_env
     assert "MANAGED_API_KEY_TARGET_ENV" not in captured_env
+
+
+@pytest.mark.asyncio
+async def test_launch_resolves_github_token_from_secret_ref_setting(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    profile = _make_profile(
+        runtime_id="claude_code",
+        command_template=["claude", "-p", "hello"],
+        env_overrides={},
+        passthrough_env_keys=[],
+        secret_refs={},
+    )
+    request = _make_request(
+        workspace_spec={"repository": str(tmp_path / "source-repo")},
+    )
+
+    source_repo = tmp_path / "source-repo"
+    subprocess.run(["git", "init", str(source_repo)], check=True, capture_output=True)
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 1002) -> None:
+            self.pid = pid
+            self.returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_env: dict[str, str] = {}
+
+    async def _fake_create_subprocess_exec(*_args, **kwargs):
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            captured_env.update(env)
+        return _FakeProcess()
+
+    async def _fake_resolve(secret_name: str) -> str:
+        assert secret_name == "db://github-pat"
+        return "resolved-github-token"
+
+    from moonmind.config.settings import settings as app_settings
+
+    monkeypatch.setattr(
+        app_settings.github,
+        "github_token_secret_ref",
+        "db://github-pat",
+    )
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
+        _fake_resolve,
+    )
+
+    _record, process, _cleanup = await launcher.launch(
+        run_id="run-github-secret-ref-1", request=request, profile=profile
+    )
+    await process.wait()
+
+    assert captured_env["GITHUB_TOKEN"] == "resolved-github-token"
+    assert captured_env["GH_TOKEN"] == "resolved-github-token"
+    assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
+    gitconfig = Path(captured_env["GIT_CONFIG_GLOBAL"])
+    assert gitconfig.exists()
+    assert "[credential]" in gitconfig.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -236,7 +236,7 @@ def test_persist_gh_config_writes_broker_helpers_without_plaintext_token(tmp_pat
     gitconfig_text = gitconfig.read_text(encoding="utf-8")
     assert "[safe]" in gitconfig_text
     assert "[credential]" in gitconfig_text
-    assert f"\tdirectory = {tmp_path.resolve()}" in gitconfig_text
+    assert f'\tdirectory = "{tmp_path.resolve()}"' in gitconfig_text
     assert "ghp_testtoken123" not in gh_wrapper.read_text(encoding="utf-8")
     assert "ghp_testtoken123" not in git_helper.read_text(encoding="utf-8")
     assert "ghp_testtoken123" not in gitconfig_text
@@ -248,7 +248,7 @@ def test_persist_gh_config_writes_safe_directory_without_token(tmp_path):
     gitconfig = tmp_path / ".moonmind" / "gitconfig"
     assert gitconfig.exists()
     assert "[safe]" in gitconfig.read_text(encoding="utf-8")
-    assert f"\tdirectory = {tmp_path.resolve()}" in gitconfig.read_text(
+    assert f'\tdirectory = "{tmp_path.resolve()}"' in gitconfig.read_text(
         encoding="utf-8"
     )
     assert "GH_CONFIG_DIR" not in env
@@ -307,7 +307,7 @@ def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
 
     updated_config = git_config.read_text()
     assert str(git_helper) in updated_config
-    assert f"\tdirectory = {repo_root.resolve()}" in gitconfig.read_text(
+    assert f'\tdirectory = "{repo_root.resolve()}"' in gitconfig.read_text(
         encoding="utf-8"
     )
 
@@ -401,8 +401,8 @@ def test_persist_gh_config_quotes_helper_path_when_store_has_spaces(tmp_path):
 def test_persist_gh_config_writes_git_identity_to_global_config(tmp_path):
     env = {
         "PATH": "/usr/bin",
-        "GIT_AUTHOR_NAME": "Nate Sticco",
-        "GIT_AUTHOR_EMAIL": "nsticco@gmail.com",
+        "GIT_AUTHOR_NAME": "Test User",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
     }
 
     ManagedRuntimeLauncher._persist_gh_config(env, str(tmp_path))
@@ -410,8 +410,8 @@ def test_persist_gh_config_writes_git_identity_to_global_config(tmp_path):
     gitconfig = tmp_path / ".moonmind" / "gitconfig"
     text = gitconfig.read_text(encoding="utf-8")
     assert "[user]" in text
-    assert "\tname = Nate Sticco" in text
-    assert "\temail = nsticco@gmail.com" in text
+    assert "\tname = Test User" in text
+    assert "\temail = test@example.com" in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -263,6 +263,18 @@ def test_persist_gh_config_skips_without_workspace():
     assert "GIT_CONFIG_GLOBAL" not in env
 
 
+def test_build_github_socket_path_stays_short_for_long_workspace_paths(tmp_path):
+    support_root = tmp_path / ("nested-" * 12) / ("workspace-" * 8)
+    socket_path = ManagedRuntimeLauncher._build_github_socket_path(
+        run_id="run-github-secret-ref-1",
+        support_root=str(support_root),
+    )
+
+    assert len(socket_path.encode("utf-8")) < 80
+    assert str(support_root) not in socket_path
+    assert socket_path.endswith(".sock")
+
+
 def test_persist_gh_config_uses_support_root_for_repo_workspace(tmp_path):
     run_root = tmp_path / "run-1"
     repo_root = run_root / "repo"

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -159,6 +159,7 @@ async def test_agent_runtime_launch_binds_workflow_id_to_task_run_before_launch(
     mock_launcher.launch = AsyncMock(
         return_value=(SimpleNamespace(model_dump=lambda mode="json": {"status": "launching"}), None, [])
     )
+    mock_launcher.cleanup_run_support = AsyncMock()
     mock_supervisor = MagicMock()
 
     activities = TemporalAgentRuntimeActivities(
@@ -195,3 +196,54 @@ async def test_agent_runtime_launch_binds_workflow_id_to_task_run_before_launch(
         "6f8b6bf7-6e0c-4d71-9b08-18d489f17a8d",
     )
     assert result == {"status": "launching"}
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_launch_cleans_launcher_support_after_supervision():
+    class _FakeProcess:
+        stdout = None
+        stderr = None
+
+    launch_record = SimpleNamespace(model_dump=lambda mode="json": {"status": "launching"})
+    mock_launcher = MagicMock()
+    mock_launcher.launch = AsyncMock(
+        return_value=(launch_record, _FakeProcess(), ["/tmp/cleanup.file"])
+    )
+    mock_launcher.cleanup_run_support = AsyncMock()
+    mock_supervisor = MagicMock()
+    mock_supervisor.supervise = AsyncMock(return_value=SimpleNamespace(status="completed"))
+
+    activities = TemporalAgentRuntimeActivities(
+        run_launcher=mock_launcher,
+        run_supervisor=mock_supervisor,
+    )
+
+    payload = {
+        "run_id": "run-cleanup-1",
+        "request": {
+            "agentKind": "managed",
+            "agentId": "codex_cli",
+            "executionProfileRef": "default",
+            "correlationId": "corr-1",
+            "idempotencyKey": "idem-1",
+        },
+        "profile": {
+            "runtimeId": "codex_cli",
+            "commandTemplate": ["codex", "exec"],
+            "defaultModel": "gpt-5.3-codex",
+            "defaultEffort": "medium",
+            "defaultTimeoutSeconds": 3600,
+            "workspaceMode": "tempdir",
+            "envOverrides": {},
+        },
+    }
+
+    result = await activities.agent_runtime_launch(payload)
+    assert result == {"status": "launching"}
+
+    assert len(activities._supervision_tasks) == 1
+    [task] = list(activities._supervision_tasks)
+    await task
+
+    mock_supervisor.supervise.assert_awaited_once()
+    mock_launcher.cleanup_run_support.assert_awaited_once_with("run-cleanup-1")

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
@@ -55,6 +56,33 @@ def _make_subprocess_result(
     return subprocess.CompletedProcess(
         args=[], returncode=returncode, stdout=stdout, stderr=stderr,
     )
+
+
+def test_detect_pr_url_uses_workspace_command_shims(tmp_path):
+    store = _make_mock_store(workspace_path=str(tmp_path / "run-1" / "repo"))
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    workspace = Path(str(store.load.return_value.workspace_path))
+    (workspace.parent / ".moonmind" / "bin").mkdir(parents=True)
+
+    calls: list[dict[str, object]] = []
+
+    def _mock_run(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        if len(calls) == 1:
+            return _make_subprocess_result(stdout="feature/test-branch\n")
+        if len(calls) == 2:
+            return _make_subprocess_result(stdout="https://github.com/o/r.git\n")
+        return _make_subprocess_result(stdout='[{"url":"https://github.com/o/r/pull/1"}]\n')
+
+    with patch("subprocess.run", side_effect=_mock_run):
+        pr_url = activities._detect_pr_url_from_workspace("run-1")
+
+    assert pr_url == "https://github.com/o/r/pull/1"
+    assert len(calls) == 3
+    gh_call = calls[2]
+    gh_env = gh_call["kwargs"]["env"]
+    assert isinstance(gh_env, dict)
+    assert gh_env["PATH"].startswith(str(workspace.parent / ".moonmind" / "bin"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -168,6 +168,43 @@ class TestPushWorkspaceBranch:
         assert "push_error" not in result
 
     @pytest.mark.asyncio
+    async def test_push_marks_workspace_safe_for_git_commands(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        recorded_calls: list[tuple[object, ...]] = []
+        workspace = "/work/agent_jobs/run-1/repo"
+
+        async def _mock_exec(*args, **kwargs):
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            command = list(args)
+            if "rev-parse" in command:
+                proc.communicate = AsyncMock(return_value=(b"feature/safe-branch\n", b""))
+                proc.returncode = 0
+            elif "push" in command:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        assert len(recorded_calls) == 3
+        for call in recorded_calls:
+            command = list(call)
+            assert command[:5] == [
+                "git",
+                "-c",
+                f"safe.directory={workspace}",
+                "-C",
+                workspace,
+            ]
+
+    @pytest.mark.asyncio
     async def test_push_failure(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -72,6 +72,50 @@ async def test_create_pr_missing_token(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_pr_uses_secret_ref_when_env_missing(monkeypatch):
+    """Secret-ref fallback should be used when raw env token is absent."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_mock_response(201, {"html_url": "https://github.com/o/r/pull/43"})
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    from moonmind.config.settings import settings as app_settings
+
+    monkeypatch.setattr(
+        app_settings.github,
+        "github_token_secret_ref",
+        "db://github-pat",
+    )
+
+    async def _fake_resolve(secret_ref: str) -> str:
+        assert secret_ref == "db://github-pat"
+        return "resolved-gh-token"
+
+    with (
+        patch(
+            "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+        patch(
+            "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
+            side_effect=_fake_resolve,
+        ),
+    ):
+        svc = GitHubService()
+        result = await svc.create_pull_request(
+            repo="o/r", head="feature", base="main", title="T", body="B",
+        )
+
+    assert result.created is True
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer resolved-gh-token"
+
+
+@pytest.mark.asyncio
 async def test_create_pr_http_error(monkeypatch):
     """HTTP 422 from GitHub should return created=False."""
     monkeypatch.setenv("GITHUB_TOKEN", "ghp_fake_token")

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -60,6 +60,7 @@ async def test_create_pr_success(monkeypatch):
 async def test_create_pr_missing_token(monkeypatch):
     """Missing GITHUB_TOKEN should return created=False gracefully."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     svc = GitHubService()
     result = await svc.create_pull_request(
@@ -68,13 +69,40 @@ async def test_create_pr_missing_token(monkeypatch):
 
     assert isinstance(result, CreatePRResult)
     assert result.created is False
-    assert "GITHUB_TOKEN" in result.summary
+    assert "GitHub auth is not configured" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_create_pr_uses_gh_token_fallback(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_fallback_token")
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(
+        return_value=_mock_response(201, {"html_url": "https://github.com/o/r/pull/44"})
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        svc = GitHubService()
+        result = await svc.create_pull_request(
+            repo="o/r", head="feature", base="main", title="T", body="B",
+        )
+
+    assert result.created is True
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["headers"]["Authorization"] == "Bearer ghp_fallback_token"
 
 
 @pytest.mark.asyncio
 async def test_create_pr_uses_secret_ref_when_env_missing(monkeypatch):
     """Secret-ref fallback should be used when raw env token is absent."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(
@@ -180,6 +208,7 @@ async def test_merge_pr_invalid_url():
 async def test_merge_pr_missing_token(monkeypatch):
     """Missing GITHUB_TOKEN should return merged=False."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     svc = GitHubService()
     result = await svc.merge_pull_request(
@@ -187,7 +216,7 @@ async def test_merge_pr_missing_token(monkeypatch):
     )
 
     assert result.merged is False
-    assert "GITHUB_TOKEN" in result.summary
+    assert "GitHub auth is not configured" in result.summary
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fix workflow GitHub publish handling so managed runs can authenticate cleanly and git trusts per-run workspaces.

## What changed
- add workspace-scoped git support config in the managed runtime launcher
- write `safe.directory` into generated git config to prevent dubious ownership failures
- persist git credential helper and git identity in launcher-managed config
- allow native PR activities to resolve GitHub auth from a secret ref when raw `GITHUB_TOKEN` is absent
- add regression coverage for launcher auth/trust config, PR token resolution, and post-run push behavior

## Root cause
The failing workflow's child agent run completed, but the post-run push step failed because git refused to operate on the job workspace due to dubious ownership. Separately, native PR creation still depended on raw env token lookup instead of the newer secret-ref path.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_launcher.py`
- `./tools/test_unit.sh --python-only tests/unit/workflows/adapters/test_github_service.py`
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/test_fetch_result_push.py`