### PR TITLE
🔒 Restrict CORS allowed origins and fix credentialed request vulnerability

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -385,7 +385,7 @@ else:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=list(settings.security.CORS_ALLOWED_ORIGINS),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1205,6 +1205,32 @@ class SecuritySettings(BaseSettings):
     ENCRYPTION_MASTER_KEY: Optional[str] = Field(
         None, alias="ENCRYPTION_MASTER_KEY"
     )
+    CORS_ALLOWED_ORIGINS: Annotated[tuple[str, ...], NoDecode] = Field(
+        ("http://localhost:3000", "http://localhost:5000"),
+        validation_alias=AliasChoices("CORS_ALLOWED_ORIGINS", "ALLOWED_ORIGINS"),
+        description="Allowed origins for CORS (comma-separated).",
+    )
+
+    @field_validator("CORS_ALLOWED_ORIGINS", mode="before")
+    @classmethod
+    def _split_cors_origins(cls, value: Optional[str | Sequence[str]]) -> tuple[str, ...]:
+        """Allow comma-delimited strings for CORS origins."""
+        if value is None:
+            return ("http://localhost:3000", "http://localhost:5000")
+
+        if isinstance(value, str):
+            raw_items: Sequence[object] = value.split(",")
+        elif isinstance(value, Sequence) and not isinstance(
+            value, (bytes, bytearray, str)
+        ):
+            raw_items = value
+        else:
+            raw_items = (value,)
+
+        items = [str(item).strip() for item in raw_items if str(item).strip()]
+        if not items:
+            return ("http://localhost:3000", "http://localhost:5000")
+        return tuple(dict.fromkeys(items))
 
     model_config = SettingsConfigDict(populate_by_name=True, env_prefix="")
 

--- a/tests/unit/api_service/test_cors.py
+++ b/tests/unit/api_service/test_cors.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi.testclient import TestClient
+from api_service.main import app
+from moonmind.config.settings import settings
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+def test_cors_allowed_origin(client):
+    # Test with an origin that is in the default allowed list
+    allowed_origin = "http://localhost:3000"
+    response = client.get("/healthz", headers={"Origin": allowed_origin})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == allowed_origin
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+def test_cors_disallowed_origin(client):
+    # Test with an origin that is NOT in the allowed list
+    disallowed_origin = "http://malicious-site.com"
+    response = client.get("/healthz", headers={"Origin": disallowed_origin})
+    assert response.status_code == 200
+    # FastAPI's CORSMiddleware typically doesn't include the header if origin not allowed
+    assert "access-control-allow-origin" not in response.headers
+
+def test_cors_preflight_allowed(client):
+    allowed_origin = "http://localhost:5000"
+    response = client.options(
+        "/healthz",
+        headers={
+            "Origin": allowed_origin,
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "X-Requested-With",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == allowed_origin
+    assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+def test_cors_preflight_disallowed(client):
+    disallowed_origin = "http://another-malicious-site.com"
+    response = client.options(
+        "/healthz",
+        headers={
+            "Origin": disallowed_origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    # CORSMiddleware returns 400 for invalid preflight? No, it returns 200 but without CORS headers or 400 depending on version/config
+    # Actually, standard CORSMiddleware returns a simple response without CORS headers if origin not allowed.
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
🎯 **What:** Fixed an overly permissive CORS policy in `api_service/main.py` where `allow_origins=["*"]` was used in conjunction with `allow_credentials=True`.

⚠️ **Risk:** Allowing all origins (`*`) while also allowing credentials is a security risk that can enable cross-origin attacks. Furthermore, modern browsers reject such configurations for credentialed requests, potentially breaking functionality for legitimate clients.

🛡️ **Solution:** 
- Introduced a new `CORS_ALLOWED_ORIGINS` setting in `moonmind/config/settings.py` (within `SecuritySettings`).
- Configured a default whitelist of `http://localhost:3000` and `http://localhost:5000` to support local development.
- Updated the `CORSMiddleware` in `api_service/main.py` to use this whitelist.
- Added a new test suite `tests/unit/api_service/test_cors.py` to verify that the middleware correctly enforces the origin whitelist for both standard and preflight requests.

---
*PR created automatically by Jules for task [7300082382012898631](https://jules.google.com/task/7300082382012898631) started by @nsticco*