### PR TITLE
Fix live log artifact path resolution

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -30,10 +30,12 @@ def _get_agent_runtime_store_root() -> str:
     )
 
 def _get_agent_runtime_artifacts_root() -> str:
-    return os.path.join(
-        os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs"),
-        "artifacts",
+    root = Path(
+        os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs")
     )
+    if root.name != "artifacts":
+        root = root / "artifacts"
+    return str(root)
 
 
 def _enum_value(value: object) -> object:

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -11,6 +11,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.schemas.agent_runtime_models import is_terminal_agent_run_state
 from moonmind.observability.transport import SpoolLogReader
@@ -30,12 +31,7 @@ def _get_agent_runtime_store_root() -> str:
     )
 
 def _get_agent_runtime_artifacts_root() -> str:
-    root = Path(
-        os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs")
-    )
-    if root.name != "artifacts":
-        root = root / "artifacts"
-    return str(root)
+    return str(managed_runtime_artifact_root())
 
 
 def _enum_value(value: object) -> object:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -24,6 +24,7 @@ from moonmind.schemas.manifest_ingest_models import CompiledManifestPlanModel
 from moonmind.schemas.temporal_activity_models import (
     PlanGenerateInput,
 )
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.adapters.managed_agent_adapter import ManagedAgentAdapter
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
@@ -127,10 +128,7 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
 
 
 def _managed_runtime_artifact_root() -> Path:
-    root = Path(os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs"))
-    if root.name != "artifacts":
-        root = root / "artifacts"
-    return root
+    return managed_runtime_artifact_root()
 
 
 class TemporalActivityRuntimeError(RuntimeError):

--- a/moonmind/workflows/temporal/runtime/paths.py
+++ b/moonmind/workflows/temporal/runtime/paths.py
@@ -1,0 +1,19 @@
+"""Helpers for managed-runtime filesystem layout."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def managed_runtime_artifact_root() -> Path:
+    """Return the normalized artifact root for managed-runtime files.
+
+    ``MOONMIND_AGENT_RUNTIME_ARTIFACTS`` may point either at the agent-jobs
+    root or directly at its ``artifacts`` directory.
+    """
+
+    root = Path(os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs"))
+    if root.name != "artifacts":
+        root = root / "artifacts"
+    return root

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -77,6 +77,7 @@ from moonmind.workflows.temporal.workflows.oauth_session import (
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 
 logger = logging.getLogger(__name__)
@@ -462,10 +463,7 @@ def _build_agent_runtime_deps() -> tuple[ManagedRunStore, ManagedRunSupervisor, 
         os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
         "managed_runs",
     )
-    artifact_root = os.path.join(
-        os.environ.get("MOONMIND_AGENT_RUNTIME_ARTIFACTS", "/work/agent_jobs"),
-        "artifacts",
-    )
+    artifact_root = str(managed_runtime_artifact_root())
     os.makedirs(store_root, exist_ok=True)
     os.makedirs(artifact_root, exist_ok=True)
 

--- a/tests/integration/temporal/test_managed_runtime_live_logs.py
+++ b/tests/integration/temporal/test_managed_runtime_live_logs.py
@@ -488,5 +488,15 @@ async def test_long_running_launch_is_visible_through_observability_routes(
         final = await asyncio.wait_for(supervise_task, timeout=10)
         assert final.status == "completed"
         assert store.find_latest_for_workflow("mm:wf-live-1") is not None
+
+        with TestClient(app) as client:
+            stdout_response = client.get(f"/api/task-runs/{run_id}/logs/stdout")
+            assert stdout_response.status_code == 200
+            assert "alpha" in stdout_response.text
+            assert "omega" in stdout_response.text
+
+            diagnostics_response = client.get(f"/api/task-runs/{run_id}/diagnostics")
+            assert diagnostics_response.status_code == 200
+            assert '"stdout"' in diagnostics_response.text
     finally:
         app.dependency_overrides.clear()

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -278,19 +278,28 @@ def test_stream_task_run_log_returns_file_response(
     assert response.content == b"mock_log_data"
 
 
-def test_stream_task_run_log_uses_agent_jobs_root_for_default_artifact_layout(
+@pytest.mark.parametrize(
+    ("env_root_name", "artifact_root_name"),
+    [
+        ("agent_jobs", "artifacts"),
+        ("artifacts", "."),
+    ],
+)
+def test_stream_task_run_log_uses_supported_artifact_root_layouts(
     client: tuple[TestClient, AsyncMock],
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
+    env_root_name: str,
+    artifact_root_name: str,
 ) -> None:
     test_client, _ = client
-    agent_jobs_root = tmp_path / "agent_jobs"
-    artifacts_root = agent_jobs_root / "artifacts"
+    env_root = tmp_path / env_root_name
+    artifacts_root = env_root if artifact_root_name == "." else env_root / artifact_root_name
     run_dir = artifacts_root / "run"
     run_dir.mkdir(parents=True)
     expected_content = "stdout from durable artifact\n"
     (run_dir / "stdout.log").write_text(expected_content, encoding="utf-8")
-    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(agent_jobs_root))
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(env_root))
 
     mock_record = MagicMock()
     mock_record.stdout_artifact_ref = "run/stdout.log"
@@ -547,19 +556,28 @@ def test_get_task_run_diagnostics_returns_file_response(
     assert response.content == b'{"mock":"diag"}'
 
 
-def test_get_task_run_diagnostics_uses_agent_jobs_root_for_default_artifact_layout(
+@pytest.mark.parametrize(
+    ("env_root_name", "artifact_root_name"),
+    [
+        ("agent_jobs", "artifacts"),
+        ("artifacts", "."),
+    ],
+)
+def test_get_task_run_diagnostics_uses_supported_artifact_root_layouts(
     client: tuple[TestClient, AsyncMock],
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
+    env_root_name: str,
+    artifact_root_name: str,
 ) -> None:
     test_client, _ = client
-    agent_jobs_root = tmp_path / "agent_jobs"
-    artifacts_root = agent_jobs_root / "artifacts"
+    env_root = tmp_path / env_root_name
+    artifacts_root = env_root if artifact_root_name == "." else env_root / artifact_root_name
     run_dir = artifacts_root / "run"
     run_dir.mkdir(parents=True)
     expected_content = '{"kind":"diagnostics"}'
     (run_dir / "diagnostics.json").write_text(expected_content, encoding="utf-8")
-    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(agent_jobs_root))
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(env_root))
 
     mock_record = MagicMock()
     mock_record.diagnostics_ref = "run/diagnostics.json"

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -278,6 +278,30 @@ def test_stream_task_run_log_returns_file_response(
     assert response.content == b"mock_log_data"
 
 
+def test_stream_task_run_log_uses_agent_jobs_root_for_default_artifact_layout(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, _ = client
+    agent_jobs_root = tmp_path / "agent_jobs"
+    artifacts_root = agent_jobs_root / "artifacts"
+    run_dir = artifacts_root / "run"
+    run_dir.mkdir(parents=True)
+    expected_content = "stdout from durable artifact\n"
+    (run_dir / "stdout.log").write_text(expected_content, encoding="utf-8")
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(agent_jobs_root))
+
+    mock_record = MagicMock()
+    mock_record.stdout_artifact_ref = "run/stdout.log"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stdout")
+
+    assert response.status_code == 200
+    assert response.text == expected_content
+
+
 # ---------------------------------------------------------------------------
 # Merged-tail (artifact-backed and synthesized)
 # ---------------------------------------------------------------------------
@@ -521,6 +545,30 @@ def test_get_task_run_diagnostics_returns_file_response(
     assert mock_file_response.call_args[1]["media_type"] == "application/json"
     assert response.status_code == 200
     assert response.content == b'{"mock":"diag"}'
+
+
+def test_get_task_run_diagnostics_uses_agent_jobs_root_for_default_artifact_layout(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, _ = client
+    agent_jobs_root = tmp_path / "agent_jobs"
+    artifacts_root = agent_jobs_root / "artifacts"
+    run_dir = artifacts_root / "run"
+    run_dir.mkdir(parents=True)
+    expected_content = '{"kind":"diagnostics"}'
+    (run_dir / "diagnostics.json").write_text(expected_content, encoding="utf-8")
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(agent_jobs_root))
+
+    mock_record = MagicMock()
+    mock_record.diagnostics_ref = "run/diagnostics.json"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{uuid4()}/diagnostics")
+
+    assert response.status_code == 200
+    assert response.text == expected_content
 
 # ---------------------------------------------------------------------------
 # SSE Live Streaming (Phase 3)

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -8,6 +8,7 @@ from moonmind.workflows.temporal.worker_runtime import (
     MoonMindAgentRun,
     MoonMindManifestIngest,
     MoonMindRun,
+    _build_agent_runtime_deps,
     _enforce_codex_config_for_managed_fleet,
     _build_runtime_planner,
     _build_runtime_activities,
@@ -165,6 +166,22 @@ def test_runtime_planner_requires_selector_for_pr_resolver_without_instructions(
             parameters={},
             snapshot=snapshot,
         )
+
+
+def test_build_agent_runtime_deps_uses_artifacts_env_without_double_nesting(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    artifacts_root = tmp_path / "artifacts"
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+
+    store, supervisor, _launcher = _build_agent_runtime_deps()
+
+    assert store.store_root == tmp_path / "managed_runs"
+    assert supervisor._log_streamer._storage._root == artifacts_root
+    assert artifacts_root.is_dir()
+    assert not (artifacts_root / "artifacts").exists()
 
 
 def _make_snapshot():


### PR DESCRIPTION
## Summary
- normalize task-run artifact root resolution so observability APIs read from the same gent_jobs/artifacts layout used by managed runtime writers
- add router regression tests for stdout and diagnostics retrieval when MOONMIND_AGENT_RUNTIME_ARTIFACTS points at the agent-jobs root
- extend the live-logs integration test to verify completed-run stdout and diagnostics remain readable through the API

## Testing
- ash ./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_task_runs.py tests/integration/temporal/test_managed_runtime_live_logs.py
