### PR TITLE
⚡ Optimize Temporal execution sync with concurrent fetching

### DIFF
--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -243,9 +243,12 @@ async def map_temporal_state_to_projection(
 async def sync_execution_projection(
     session: AsyncSession,
     desc: WorkflowExecutionDescription,
+    *,
+    payload: dict[str, Any] | None = None,
 ) -> TemporalExecutionRecord:
     """Upsert the Temporal workflow state to the local projection database."""
-    payload = await map_temporal_state_to_projection(desc)
+    if payload is None:
+        payload = await map_temporal_state_to_projection(desc)
 
     projection = await session.get(TemporalExecutionRecord, desc.id)
     previous_version = int(projection.projection_version or 0) if projection else 0
@@ -342,26 +345,48 @@ async def sync_temporal_executions_safely(
 ) -> list[Any]:
     import asyncio
 
-    async def fetch_and_sync(item):
+    from moonmind.workflows.temporal.client import fetch_workflow_execution
+
+    async def fetch_and_map(item: Any) -> tuple[Any, WorkflowExecutionDescription, dict[str, Any]] | tuple[Any, None, None]:
         try:
-            return await fetch_and_sync_execution(session, item.workflow_id, client)
+            desc = await fetch_workflow_execution(client, item.workflow_id)
+            payload = await map_temporal_state_to_projection(desc)
+            return (item, desc, payload)
         except Exception as exc:
             logger.warning(
-                "Failed to sync execution %s from Temporal: %s",
+                "Failed to fetch execution %s from Temporal: %s",
                 item.workflow_id,
                 exc,
             )
-            return item
+            return (item, None, None)
+
+    # Concurrently fetch and map Temporal state for all items
+    results = await asyncio.gather(*(fetch_and_map(item) for item in items))
 
     updated_items = []
-    for item in items:
-        updated_items.append(await fetch_and_sync(item))
+    for item, desc, payload in results:
+        if desc is None or payload is None:
+            updated_items.append(item)
+            continue
+
+        try:
+            # Sequentially sync and commit mapped state to the database
+            updated_items.append(await sync_execution_projection(session, desc, payload=payload))
+        except Exception as exc:
+            logger.warning(
+                "Failed to sync mapped execution %s to DB: %s",
+                item.workflow_id,
+                exc,
+            )
+            updated_items.append(item)
+
     await session.commit()
     for obj in updated_items:
-        try:
-            await session.refresh(obj)
-        except Exception:
-            pass  # fallback to potentially stale but accessible attributes
+        if obj is not None and hasattr(obj, "workflow_id"):
+            try:
+                await session.refresh(obj)
+            except Exception:
+                pass  # fallback to potentially stale but accessible attributes
     return updated_items
 
 


### PR DESCRIPTION
Refactored `sync_temporal_executions_safely` to use `asyncio.gather` for fetching and mapping Temporal workflow state. Added an optional `payload` parameter to `sync_execution_projection` to support processing pre-mapped state.

Previously, the sync loop performed sequential asynchronous I/O for each item (fetching description, awaiting memo, and database operations). This was inefficient for large batches.

Benchmarking with 20 items and simulated latencies (100ms network, 50ms DB) showed a reduction in duration from ~3.0s to ~1.1s, an estimated **2.7x speedup**. The optimization parallelizes the network-bound Temporal fetches while preserving sequential database updates to ensure `AsyncSession` safety.

---
*PR created automatically by Jules for task [7082449614047205566](https://jules.google.com/task/7082449614047205566) started by @nsticco*