### PR TITLE
🧪 [testing] Improve error handling coverage for JiraStoryPlanner

### DIFF
--- a/tests/unit/planning/test_jira_story_planner.py
+++ b/tests/unit/planning/test_jira_story_planner.py
@@ -1,6 +1,6 @@
 import hashlib
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from requests.exceptions import HTTPError
@@ -139,8 +139,10 @@ def test_call_llm_invalid_json(monkeypatch):
     with patch(
         "moonmind.planning.jira_story_planner.get_google_model", return_value=mock_model
     ):
-        with pytest.raises(JiraStoryPlannerError):
+        with pytest.raises(JiraStoryPlannerError) as excinfo:
             planner._call_llm(prompt)
+
+    assert "Invalid JSON from LLM" in str(excinfo.value)
 
 
 def test_call_llm_json_code_block(monkeypatch):
@@ -439,3 +441,78 @@ def test_plan_logs_metrics(monkeypatch, caplog):
     assert record.prompt_hash == expected_hash
     assert record.created_issue_keys == ["PROJ-1"]
     assert isinstance(record.latency, float)
+
+
+def test_call_llm_story_validation_error(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+    prompt = planner._build_prompt("plan")
+
+    # Valid JSON array, but objects miss required 'description' and 'issue_type'
+    response_text = '[{"summary": "Missing fields"}]'
+    mock_model = MagicMock()
+    mock_model.generate_content.return_value = _mock_gemini_response(response_text)
+
+    with patch(
+        "moonmind.planning.jira_story_planner.get_google_model", return_value=mock_model
+    ):
+        with pytest.raises(JiraStoryPlannerError) as excinfo:
+            planner._call_llm(prompt)
+
+    assert "Story validation failed" in str(excinfo.value)
+
+
+def test_call_llm_no_text(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+    prompt = planner._build_prompt("plan")
+
+    mock_model = MagicMock()
+    # Mock response with candidates but no text parts
+    response_mock = MagicMock()
+    candidate_mock = MagicMock()
+    candidate_mock.content.parts = []
+    response_mock.candidates = [candidate_mock]
+    # Ensure hasattr(response, "text") is False or it returns None
+    del response_mock.text
+
+    mock_model.generate_content.return_value = response_mock
+
+    with patch(
+        "moonmind.planning.jira_story_planner.get_google_model", return_value=mock_model
+    ):
+        with pytest.raises(JiraStoryPlannerError) as excinfo:
+            planner._call_llm(prompt)
+
+    assert "LLM returned no text content" in str(excinfo.value)
+
+
+def test_call_llm_extraction_error(monkeypatch):
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "key")
+    monkeypatch.setenv("ATLASSIAN_USERNAME", "user")
+    monkeypatch.setenv("ATLASSIAN_URL", "https://example.atlassian.net")
+
+    planner = JiraStoryPlanner(plan_text="plan", jira_project_key="PROJ")
+    prompt = planner._build_prompt("plan")
+
+    mock_model = MagicMock()
+    # Mock response that raises an exception when candidates is accessed
+    response_mock = MagicMock()
+    type(response_mock).candidates = PropertyMock(
+        side_effect=Exception("Extraction failed")
+    )
+    mock_model.generate_content.return_value = response_mock
+
+    with patch(
+        "moonmind.planning.jira_story_planner.get_google_model", return_value=mock_model
+    ):
+        with pytest.raises(JiraStoryPlannerError) as excinfo:
+            planner._call_llm(prompt)
+
+    assert "Invalid LLM response format" in str(excinfo.value)


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
This PR improves the test coverage for error handling paths in `moonmind/planning/jira_story_planner.py`, specifically within the `_call_llm` method. It ensures that both JSON parsing errors and Pydantic validation errors are correctly caught, logged, and re-raised as `JiraStoryPlannerError`.

### 📊 Coverage: What scenarios are now tested
- **JSON Parsing Failure:** Updated `test_call_llm_invalid_json` to verify the "Invalid JSON from LLM" error message.
- **Pydantic Validation Failure:** Added `test_call_llm_story_validation_error` to verify the "Story validation failed" error path when the LLM returns valid JSON that does not match the `StoryDraft` schema.
- **Empty Response:** Added `test_call_llm_no_text` to verify the handling of LLM responses with no text content.
- **Malformed Response Structure:** Added `test_call_llm_extraction_error` to verify the handling of unexpected LLM response object structures.

### ✨ Result: The improvement in test coverage
The `_call_llm` method's exception handling paths are now explicitly verified, increasing the reliability of the planning system when dealing with unpredictable LLM outputs.

---
*PR created automatically by Jules for task [15494851512740486949](https://jules.google.com/task/15494851512740486949) started by @nsticco*