### PR TITLE
Implement MoonMind.Run dependency gate

### DIFF
--- a/docs/tmp/011-TaskDependenciesPlan.md
+++ b/docs/tmp/011-TaskDependenciesPlan.md
@@ -2,7 +2,7 @@
 
 Status: In Progress  
 Owners: MoonMind Engineering  
-Last Updated: 2026-03-29  
+Last Updated: 2026-04-01  
 Related: `docs/Tasks/TaskDependencies.md`, `docs/Api/ExecutionsApiContract.md`, `docs/UI/MissionControlArchitecture.md`, `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
 
 ## Phase 0 - Spec Alignment ✅ COMPLETE
@@ -26,52 +26,55 @@ All Phase 0 requirements verified complete as of 2026-03-29 (spec `116-task-dep-
 
 All Phase 1 requirements verified complete as of 2026-03-29 (spec `117-task-dep-phase1`).
 
-## Phase 2 - `MoonMind.Run` Dependency Gate
+## Phase 2 - `MoonMind.Run` Dependency Gate ✅ COMPLETE
 
-- Parse `initialParameters.task.dependsOn` in `MoonMindRunWorkflow.run()` after `_initialize_from_payload()` and before entering `STATE_PLANNING`.
-  - The insertion point is `run.py` between the current `STATE_INITIALIZING` and `STATE_PLANNING` transitions (currently lines 413–414).
-- When `dependsOn` is present and non-empty:
-  - Set `mm_state` to `waiting_on_dependencies` and update memo/search attributes with dependency IDs.
-  - Wait on each prerequisite using Temporal external workflow handles:
-    ```python
-    handles = [
-        workflow.get_external_workflow_handle(dep_id)
-        for dep_id in depends_on
-    ]
-    await asyncio.gather(*(handle.result() for handle in handles))
-    ```
-  - Wrap the `gather` in a Temporal `CancellationScope` so cancellation of the dependent run interrupts the wait cleanly.
-  - Guard with `workflow.patched("dependency-gate-v1")` for replay safety.
-- When `dependsOn` is absent or empty, proceed directly to `planning` (current behavior — no change needed).
-- Fail the dependent run with a dependency-specific message when a prerequisite fails, is canceled, or is terminated (propagated via the `handle.result()` exception).
-- Preserve cancel semantics during the dependency wait: canceling the dependent run cancels only that run, not the prerequisites.
-- Pause/resume semantics: check `self._paused` after the dependency wait resolves, consistent with the existing pause gate pattern.
+- [x] Parse `initialParameters.task.dependsOn` in `MoonMindRunWorkflow.run()` after `_initialize_from_payload()` and before entering `STATE_PLANNING`.
+  - Insertion point: `run.py` between the current `STATE_INITIALIZING` and `STATE_PLANNING` transitions.
+- [x] Set `mm_state` to `waiting_on_dependencies` and update memo/search attributes with dependency IDs when `dependsOn` is present and non-empty.
+- [x] Wait on each prerequisite using Temporal external workflow handles.
+  ```python
+  handles = [
+      workflow.get_external_workflow_handle(dep_id)
+      for dep_id in depends_on
+  ]
+  await asyncio.gather(*(handle.result() for handle in handles))
+  ```
+- [x] Wrap the dependency wait in an interruptible cancellation boundary so cancellation of the dependent run interrupts the wait cleanly.
+  - Implementation note: the current `temporalio.workflow` SDK in this repo does not expose a `CancellationScope` API, so the workflow uses explicit task cancellation around the dependency wait to preserve the intended semantics.
+- [x] Guard the dependency gate with `workflow.patched("dependency-gate-v1")` for replay safety.
+- [x] Preserve current behavior by proceeding directly to `planning` when `dependsOn` is absent or empty.
+- [x] Fail the dependent run with a dependency-specific message when a prerequisite fails, is canceled, or is terminated.
+- [x] Preserve cancel semantics during the dependency wait so canceling the dependent run cancels only that run, not the prerequisites.
+- [x] Check `self._paused` after the dependency wait resolves, consistent with the existing pause gate pattern.
+
+All Phase 2 requirements verified complete as of 2026-04-01 (spec `123-task-dep-phase2`).
 
 ## Phase 3 - Finish Summary And Read Model Metadata
 
-- Extend `reports/run_summary.json` with dependency outcome data:
-  - declared dependency IDs
-  - whether a dependency wait occurred
-  - dependency wait duration
-  - resolution outcome (success vs dependency failure)
-  - failed dependency ID when applicable
-- Include dependency presence metadata in workflow memo (for list/detail surfaces).
-- Ensure execution serialization can surface dependency metadata cleanly for the detail page.
+- [ ] Extend `reports/run_summary.json` with declared dependency IDs.
+- [ ] Extend `reports/run_summary.json` with whether a dependency wait occurred.
+- [ ] Extend `reports/run_summary.json` with dependency wait duration.
+- [ ] Extend `reports/run_summary.json` with dependency resolution outcome.
+- [ ] Extend `reports/run_summary.json` with failed dependency ID when applicable.
+- [ ] Include dependency presence metadata in workflow memo for list and detail surfaces.
+- [ ] Ensure execution serialization can surface dependency metadata cleanly for the detail page.
 
 ## Phase 4 - Mission Control Create And Detail UX
 
-- Add a Dependencies section to `/tasks/new`.
-- Use execution search or list APIs to power a dependency picker for existing `MoonMind.Run` executions.
-- Enforce client-side validation for dependency count and duplicate entries.
-- Verify `waiting_on_dependencies` presentation in the task list.
-- Add a Dependencies panel to task detail with prerequisite links and current statuses.
-- Quick-view in task list shows titles of blocking tasks.
-- Add a lightweight downstream dependents view only if backend reverse lookup is feasible without blocking v1.
+- [ ] Add a Dependencies section to `/tasks/new`.
+- [ ] Use execution search or list APIs to power a dependency picker for existing `MoonMind.Run` executions.
+- [ ] Enforce client-side validation for dependency count and duplicate entries.
+- [ ] Verify `waiting_on_dependencies` presentation in the task list.
+- [ ] Add a Dependencies panel to task detail with prerequisite links and current statuses.
+- [ ] Show titles of blocking tasks in the task list quick view.
+- [ ] Add a lightweight downstream dependents view if backend reverse lookup is feasible without blocking v1.
 
 ## Phase 5 - Hardening And Rollout
 
-- Add integration coverage for chained execution, multi-dependency fan-in, failure propagation, and restart or replay safety.
-- Verify Continue-As-New behavior preserves dependency context.
-- Confirm list and detail pages remain performant with dependency metadata present.
-- Document operator guidance for dependency limits, failure semantics, and known v1 non-goals.
-
+- [ ] Add integration coverage for chained execution.
+- [ ] Add integration coverage for multi-dependency fan-in.
+- [ ] Add integration coverage for failure propagation.
+- [ ] Add integration coverage for restart or replay safety.
+- [ ] Verify Continue-As-New behavior preserves dependency context.
+- [ ] Confirm list and detail pages remain performant with dependency metadata present.
+- [ ] Document operator guidance for dependency limits, failure semantics, and known v1 non-goals.

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -534,14 +534,25 @@ class MoonMindRunWorkflow:
             return {"status": "canceled"}
 
         self._set_state(STATE_INITIALIZING, summary="Execution initialized.")
-        dependency_ids = self._dependency_ids_from_parameters(parameters)
-        if dependency_ids and workflow.patched(DEPENDENCY_GATE_PATCH):
-            await self._wait_for_dependencies(dependency_ids)
-            if self._cancel_requested:
-                await self._run_finalizing_stage(
-                    parameters=parameters, status="canceled", error=None
-                )
-                return {"status": "canceled"}
+        try:
+            dependency_ids = self._dependency_ids_from_parameters(parameters)
+            if dependency_ids and workflow.patched(DEPENDENCY_GATE_PATCH):
+                await self._wait_for_dependencies(dependency_ids)
+                if self._cancel_requested:
+                    await self._run_finalizing_stage(
+                        parameters=parameters, status="canceled", error=None
+                    )
+                    return {"status": "canceled"}
+        except ValueError as exc:
+            await self._run_finalizing_stage(
+                parameters=parameters, status="failed", error=str(exc)
+            )
+            self._close_status = CLOSE_STATUS_FAILED
+            self._set_state(STATE_FAILED, summary=str(exc))
+            raise exceptions.ApplicationError(
+                str(exc),
+                non_retryable=True,
+            ) from exc
         self._set_state(STATE_PLANNING, summary="Planning execution strategy.")
 
         # Pause until unpaused

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -101,6 +101,7 @@ RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
+DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
 )
@@ -180,6 +181,7 @@ class MoonMindRunWorkflow:
         self._awaiting_external: bool = False
         self._waiting_reason: Optional[str] = None
         self._attention_required: bool = False
+        self._dependency_workflow_ids: list[str] = []
 
         # Action flags
         self._cancel_requested = False
@@ -385,6 +387,85 @@ class MoonMindRunWorkflow:
             )
         return [payload_by_id[node_id] for node_id in ordered_node_ids]
 
+    def _dependency_ids_from_parameters(self, parameters: Mapping[str, Any]) -> list[str]:
+        task_payload = parameters.get("task")
+        if task_payload is None:
+            return []
+        if not isinstance(task_payload, Mapping):
+            raise ValueError("initialParameters.task must be an object when provided")
+
+        depends_on = task_payload.get("dependsOn")
+        if depends_on is None:
+            return []
+        if not isinstance(depends_on, list):
+            raise ValueError(
+                "initialParameters.task.dependsOn must be a list when provided"
+            )
+
+        normalized: list[str] = []
+        for dep_id in depends_on:
+            if not isinstance(dep_id, str):
+                raise ValueError(
+                    "initialParameters.task.dependsOn entries must be strings"
+                )
+            candidate = dep_id.strip()
+            if candidate and candidate not in normalized:
+                normalized.append(candidate)
+        return normalized
+
+    async def _await_dependency_result(self, dependency_id: str) -> None:
+        handle = workflow.get_external_workflow_handle(dependency_id)
+        try:
+            await handle.result()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            raise ValueError(
+                f"Dependency '{dependency_id}' did not complete successfully: {exc}"
+            ) from exc
+
+    async def _await_dependency_results(self, dependency_ids: list[str]) -> None:
+        await asyncio.gather(
+            *(self._await_dependency_result(dep_id) for dep_id in dependency_ids)
+        )
+
+    async def _wait_for_dependencies(self, dependency_ids: list[str]) -> None:
+        if not dependency_ids:
+            return
+
+        self._dependency_workflow_ids = list(dependency_ids)
+        self._waiting_reason = "dependency_wait"
+        self._set_state(
+            STATE_WAITING_ON_DEPENDENCIES,
+            summary=f"Waiting on {len(dependency_ids)} prerequisite execution(s).",
+        )
+
+        dependency_task = asyncio.create_task(
+            self._await_dependency_results(dependency_ids)
+        )
+        cancel_task = asyncio.create_task(
+            workflow.wait_condition(lambda: self._cancel_requested)
+        )
+
+        try:
+            done, pending = await asyncio.wait(
+                {dependency_task, cancel_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            if cancel_task in done:
+                dependency_task.cancel()
+                await asyncio.gather(dependency_task, return_exceptions=True)
+                return
+
+            cancel_task.cancel()
+            await asyncio.gather(cancel_task, return_exceptions=True)
+            await dependency_task
+        finally:
+            self._waiting_reason = None
+            self._update_search_attributes()
+            self._update_memo()
+
     @workflow.run
     async def run(self, input_payload: RunWorkflowInput) -> RunWorkflowOutput:
         try:
@@ -453,6 +534,14 @@ class MoonMindRunWorkflow:
             return {"status": "canceled"}
 
         self._set_state(STATE_INITIALIZING, summary="Execution initialized.")
+        dependency_ids = self._dependency_ids_from_parameters(parameters)
+        if dependency_ids and workflow.patched(DEPENDENCY_GATE_PATCH):
+            await self._wait_for_dependencies(dependency_ids)
+            if self._cancel_requested:
+                await self._run_finalizing_stage(
+                    parameters=parameters, status="canceled", error=None
+                )
+                return {"status": "canceled"}
         self._set_state(STATE_PLANNING, summary="Planning execution strategy.")
 
         # Pause until unpaused
@@ -2042,6 +2131,8 @@ class MoonMindRunWorkflow:
             memo_dict["logs_artifact_ref"] = self._logs_ref
         if self._summary_ref:
             memo_dict["summary_artifact_ref"] = self._summary_ref
+        if self._dependency_workflow_ids:
+            memo_dict["dependency_workflow_ids"] = list(self._dependency_workflow_ids)
 
         try:
             workflow.upsert_memo(memo_dict)

--- a/specs/123-task-dep-phase2/checklists/requirements.md
+++ b/specs/123-task-dep-phase2/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
 **Created**: 2026-04-01  
-**Feature**: [spec.md](/d:/code/MoonMind/specs/123-task-dep-phase2/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/123-task-dep-phase2/checklists/requirements.md
+++ b/specs/123-task-dep-phase2/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-01  
+**Feature**: [spec.md](/d:/code/MoonMind/specs/123-task-dep-phase2/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- [X] Source document requirements are mapped into functional requirements and runtime validation expectations.

--- a/specs/123-task-dep-phase2/contracts/requirements-traceability.md
+++ b/specs/123-task-dep-phase2/contracts/requirements-traceability.md
@@ -1,0 +1,13 @@
+# Requirements Traceability: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+| Requirement | Source Requirement | Planned Implementation Surface | Validation Strategy |
+|-------------|--------------------|-------------------------------|--------------------|
+| FR-001 | DOC-REQ-001 | `moonmind/workflows/temporal/workflows/run.py` pre-planning dependency parsing | Workflow-boundary test proves dependency parsing occurs before planning |
+| FR-002, FR-003 | DOC-REQ-002 | `moonmind/workflows/temporal/workflows/run.py` waiting state transition and memo metadata | Workflow-boundary + direct unit tests assert `waiting_on_dependencies`, `dependency_wait`, and memo dependency IDs |
+| FR-004 | DOC-REQ-003 | `moonmind/workflows/temporal/workflows/run.py` external handle wait helper | Workflow-boundary test asserts planning runs only after dependency handles resolve |
+| FR-005 | DOC-REQ-004 | `moonmind/workflows/temporal/workflows/run.py` interruptible dependency wait | Workflow-boundary test cancels dependent run during wait and asserts the wait is interrupted cleanly |
+| FR-006, FR-010 | DOC-REQ-005 | `moonmind/workflows/temporal/workflows/run.py` patched/unpatched branch and `tests/unit/workflows/temporal/workflows/test_run_scheduling.py` | Compatibility test covers both patched and unpatched paths |
+| FR-007 | DOC-REQ-006 | `moonmind/workflows/temporal/workflows/run.py` legacy direct-to-planning path | Workflow-boundary test with empty dependencies confirms direct planning path |
+| FR-008, FR-010 | DOC-REQ-007 | `moonmind/workflows/temporal/workflows/run.py` dependency-specific failure handling and `tests/unit/workflows/temporal/workflows/test_run_signals_updates.py` | Direct unit test simulates failed prerequisite and `./tools/test_unit.sh` validates degraded outcomes |
+| FR-005 | DOC-REQ-008 | `moonmind/workflows/temporal/workflows/run.py` cancel-safe dependency wait path | Workflow-boundary test confirms dependent-run cancellation does not mutate prerequisite workflows |
+| FR-009 | DOC-REQ-009 | `moonmind/workflows/temporal/workflows/run.py` post-wait pause gate | Workflow-boundary test confirms pause gate is honored after dependencies resolve |

--- a/specs/123-task-dep-phase2/data-model.md
+++ b/specs/123-task-dep-phase2/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+## Overview
+
+Phase 2 does not introduce a new database entity. It extends the runtime state carried by `MoonMindRunWorkflow` while it enforces prerequisite execution dependencies before planning.
+
+## Workflow-Local Fields
+
+| Field | Type | Source | Purpose |
+|------|------|--------|---------|
+| `dependsOn` | `list[str]` | `initialParameters.task.dependsOn` | Declared prerequisite workflow IDs persisted during Phase 1 |
+| `_state` | `str` | workflow lifecycle | Includes `waiting_on_dependencies` while blocked on prerequisites |
+| `_waiting_reason` | `str | None` | workflow-local state | Set to `dependency_wait` while dependency gating is active |
+| `_paused` | `bool` | workflow-local state | Existing operator pause flag that must still gate planning after dependencies resolve |
+| `_cancel_requested` | `bool` | workflow-local state | Existing cancellation flag used to interrupt dependency waiting cleanly |
+
+## Memo / Visibility Fields
+
+| Field | Carrier | Value |
+|------|---------|-------|
+| `mm_state` | Search Attribute | `waiting_on_dependencies` while dependency wait is active |
+| `waiting_reason` | Memo helper path | `dependency_wait` while dependency wait is active |
+| `dependency_workflow_ids` | Memo | Declared dependency IDs for list/detail inspection |
+
+## State Transitions
+
+```mermaid
+stateDiagram-v2
+  [*] --> initializing
+  initializing --> waiting_on_dependencies : dependsOn present and patched
+  waiting_on_dependencies --> planning : all dependencies completed
+  initializing --> planning : no dependencies or unpatched history
+  waiting_on_dependencies --> failed : dependency failed/canceled/terminated/not-found
+  waiting_on_dependencies --> canceled : dependent run canceled
+```
+
+## Failure Model
+
+| Failure input | Workflow outcome | Notes |
+|--------------|------------------|-------|
+| Dependency handle raises workflow failure | `failed` | Message should identify dependency failure cause |
+| Dependency handle raises canceled/terminated style failure | `failed` | Dependency did not complete successfully |
+| Dependent run canceled while waiting | `canceled` | Cancellation stops only the dependent run |
+| Unpatched replay history | legacy path | Skip dependency gate to preserve existing workflow behavior |

--- a/specs/123-task-dep-phase2/plan.md
+++ b/specs/123-task-dep-phase2/plan.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+**Branch**: `123-task-dep-phase2` | **Date**: 2026-04-01 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/123-task-dep-phase2/spec.md`
+
+## Summary
+
+Phase 2 implements the missing runtime dependency gate inside `MoonMindRunWorkflow.run()`. The workflow will inspect `initialParameters.task.dependsOn` after payload initialization, enter `waiting_on_dependencies` when dependencies exist, wait on prerequisite workflow handles inside a cancellation scope, and only proceed to planning when all prerequisites complete successfully. The implementation is test-driven and centered on workflow-boundary coverage for the patched path, replay-safe legacy path, and dependency-failure/cancel outcomes.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Temporal Python SDK, pytest  
+**Storage**: Temporal workflow state, Search Attributes, Memo, existing artifact outputs  
+**Testing**: pytest via `./tools/test_unit.sh`  
+**Target Platform**: Linux worker container running Temporal workflows  
+**Project Type**: Single Python monorepo  
+**Performance Goals**: Dependency gating should add no polling loop and should block only on prerequisite workflow completion or cancellation.  
+**Constraints**: Preserve replay safety for in-flight executions, add workflow-boundary tests, do not introduce new internal compatibility aliases, and keep metadata within the existing Visibility schema.  
+**Scale/Scope**: One workflow file, one or two unit-test files, and feature-spec artifacts for this phase.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Orchestrate, Don't Recreate | PASS | Uses Temporal-native external workflow handles rather than bespoke polling or parallel orchestration code. |
+| II. One-Click Agent Deployment | PASS | No infrastructure or operator bootstrap changes. |
+| III. Avoid Vendor Lock-In | PASS | Uses Temporal workflow semantics already central to the platform. |
+| IV. Own Your Data | PASS | Dependency metadata stays in operator-controlled workflow memo/search attributes and run artifacts. |
+| V. Skills Are First-Class | N/A | Not a skill system change. |
+| VI. Bittersweet Lesson | PASS | Thin orchestration addition behind stable workflow contracts; no new runtime scaffolding layers. |
+| VII. Runtime Configurability | PASS | Dependencies come from request payload data already persisted in `initialParameters`. |
+| VIII. Modular Architecture | PASS | Keeps dependency wait logic localized to `MoonMindRunWorkflow` lifecycle boundaries. |
+| IX. Resilient by Default | PASS | Adds durable dependency waiting, failure propagation, and replay-safe patching with boundary tests. |
+| X. Continuous Improvement | PASS | Improves runtime observability through waiting metadata without changing operator flow shape. |
+| XI. Spec-Driven Development | PASS | This feature spec/plan/tasks drive the Phase 2 runtime implementation. |
+| XII. Canonical Documentation | PASS | Sequencing stays in `docs/tmp`; canonical docs already describe the target behavior. |
+| XIII. Pre-Release Velocity | PASS | No compatibility aliases; only a replay-safe patch guard for in-flight workflow histories. |
+
+## Phase 0: Research Findings
+
+See [research.md](research.md) for the detailed decision log. Key decisions:
+
+1. Use `workflow.get_external_workflow_handle(dep_id).result()` and `asyncio.gather(...)` rather than polling activities.
+2. Guard the new dependency gate with `workflow.patched("dependency-gate-v1")` so unpatched histories preserve legacy `initializing -> planning` behavior.
+3. Reuse the existing visibility model: `mm_state=waiting_on_dependencies`, `waitingReason=dependency_wait`, dependency IDs stored in workflow memo, and no new search attributes in Phase 2.
+4. Cover the feature at the workflow boundary with unit tests that exercise the patched path, the legacy unpatched path, and degraded dependency outcomes.
+
+## Phase 1: Design & Contracts
+
+### Source Code Layout
+
+```text
+moonmind/workflows/temporal/workflows/run.py
+tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+
+specs/123-task-dep-phase2/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── requirements-traceability.md
+└── tasks.md
+```
+
+**Structure Decision**: Keep the implementation in the existing `MoonMindRunWorkflow` module and add workflow-boundary tests alongside the current run workflow tests. No new package or abstraction layer is justified for this phase.
+
+### Design Notes
+
+#### Workflow insertion point
+
+- Add dependency parsing immediately after `_initialize_from_payload()` and before the first transition to `STATE_PLANNING`.
+- Preserve current behavior for runs with no dependencies or for unpatched replay histories.
+
+#### Waiting behavior
+
+- Introduce a small helper to normalize dependency IDs from `parameters.get("task", {}).get("dependsOn")`.
+- Introduce a helper that:
+  - stores dependency IDs on workflow state,
+  - sets `_waiting_reason = "dependency_wait"`,
+  - transitions to `STATE_WAITING_ON_DEPENDENCIES`,
+  - awaits dependency handles inside `workflow.CancellationScope()`,
+  - converts dependency exceptions into a dependency-specific `ValueError`.
+
+#### Metadata behavior
+
+- Keep queryable state in the existing registered schema:
+  - `mm_state = waiting_on_dependencies`
+  - `waiting_reason = dependency_wait`
+- Store compact dependency IDs in memo only, because the current visibility contract explicitly avoids new ad hoc search attributes in v1.
+
+#### Replay and cancellation safety
+
+- Patched path: run dependency gate.
+- Unpatched path: skip dependency gate entirely to preserve existing histories.
+- Cancellation during wait should interrupt the scope and let normal cancel/finalize logic run without signaling prerequisite workflows.
+
+### Planned Artifacts
+
+- [data-model.md](data-model.md): workflow-local dependency gate fields and state transitions
+- [contracts/requirements-traceability.md](contracts/requirements-traceability.md): `DOC-REQ-*` to FR/test mapping
+- [quickstart.md](quickstart.md): deterministic validation path for patched/unpatched/failure cases
+
+## Complexity Tracking
+
+No Constitution violations. No complexity tracking required.

--- a/specs/123-task-dep-phase2/quickstart.md
+++ b/specs/123-task-dep-phase2/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+## Goal
+
+Validate that `MoonMind.Run` enforces dependency waiting before planning, preserves replay compatibility, and fails clearly when prerequisites do not complete successfully.
+
+## Prerequisites
+
+- Repo checked out on branch `123-task-dep-phase2`
+- Unit-test environment available through `./tools/test_unit.sh`
+
+## Validation Steps
+
+1. Run targeted workflow tests while iterating:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+```
+
+2. Run the full required unit-test command before completion:
+
+```bash
+./tools/test_unit.sh
+```
+
+3. Confirm the new workflow-boundary tests cover:
+   - dependency-aware runs entering `waiting_on_dependencies`
+   - empty/unpatched paths skipping the dependency gate
+   - failed or canceled prerequisites producing dependency-specific failure
+   - dependent-run cancellation during dependency wait
+
+## Expected Results
+
+- Dependency-aware workflow tests pass.
+- Legacy/unpatched compatibility tests pass.
+- Existing run workflow tests remain green.
+- No direct `pytest` invocation is required outside the project test wrapper.

--- a/specs/123-task-dep-phase2/research.md
+++ b/specs/123-task-dep-phase2/research.md
@@ -1,0 +1,40 @@
+# Research: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+## Decision 1: Use Temporal external workflow handles for prerequisite waiting
+
+- **Decision**: Wait on dependencies with `workflow.get_external_workflow_handle(dep_id)` and `await asyncio.gather(*(handle.result() ...))`.
+- **Rationale**: This matches the canonical design in `docs/Tasks/TaskDependencies.md` and avoids introducing polling activities or extra persistence just to observe prerequisite completion.
+- **Alternatives considered**:
+  - Poll execution state through activities: rejected because it duplicates Temporal orchestration semantics and adds avoidable latency/history churn.
+  - Signal-based prerequisite completion fan-out: rejected because it requires broader contract changes and more moving parts than Phase 2 needs.
+
+## Decision 2: Guard the dependency gate with a replay-stable patch id
+
+- **Decision**: Use `workflow.patched("dependency-gate-v1")` around the new pre-planning behavior.
+- **Rationale**: Existing histories currently transition straight from `initializing` to `planning`. The patch guard preserves that path for unpatched histories while allowing new runs to use the dependency gate safely.
+- **Alternatives considered**:
+  - Replace behavior without patching: rejected because it risks replay divergence for in-flight runs.
+  - Introduce a second workflow type/version: rejected because the change is local and Temporal patching already solves the replay problem.
+
+## Decision 3: Keep dependency IDs in memo, not new search attributes
+
+- **Decision**: Expose dependency IDs through workflow memo and use existing search attributes only for state transitions (`mm_state`, `mm_updated_at`, existing owner/repo fields).
+- **Rationale**: `docs/Temporal/VisibilityAndUiQueryModel.md` defines a tight v1 search-attribute set and explicitly warns against ad hoc additions. Phase 2 needs state visibility, not new query surfaces.
+- **Alternatives considered**:
+  - Add `mm_dependency_ids` search attribute: rejected because it would expand the visibility contract ahead of the planned Phase 3/4 work.
+  - Skip dependency metadata entirely: rejected because the phase plan explicitly calls for dependency IDs in workflow metadata.
+
+## Decision 4: Reuse existing waiting metadata contract
+
+- **Decision**: Set `waitingReason` to `dependency_wait` via the existing `_waiting_reason` memo/search update path.
+- **Rationale**: The visibility model already defines `dependency_wait` as an allowed waiting reason, so the implementation can integrate with current list/detail semantics without inventing a new field.
+- **Alternatives considered**:
+  - Leave `waiting_reason` unset: rejected because blocked runs would be less diagnosable in UI and tests.
+  - Add a dependency-specific status alias: rejected by the pre-release compatibility policy.
+
+## Decision 5: Prefer workflow-boundary unit tests over isolated helper-only tests
+
+- **Decision**: Add tests around `MoonMindRunWorkflow.run()` orchestration, plus any focused helper tests only where needed.
+- **Rationale**: The AGENTS guidance requires boundary coverage for workflow contract changes, including compatibility coverage for in-flight histories and degraded provider/runtime inputs.
+- **Alternatives considered**:
+  - Unit-test only a private helper: rejected because it would miss the replay/cancel/state-transition contract at the workflow boundary.

--- a/specs/123-task-dep-phase2/spec.md
+++ b/specs/123-task-dep-phase2/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+**Feature Branch**: `123-task-dep-phase2`  
+**Created**: 2026-04-01  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 2 of docs/tmp/011-TaskDependenciesPlan.md using test-driven development"
+
+## Source Document Requirements
+
+Extracted from `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 and `docs/Tasks/TaskDependencies.md` section 5.
+
+| Requirement ID | Source Citation | Requirement Summary |
+|----------------|----------------|---------------------|
+| DOC-REQ-001 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 1 | `MoonMindRunWorkflow.run()` MUST parse `initialParameters.task.dependsOn` after `_initialize_from_payload()` and before entering `planning`. |
+| DOC-REQ-002 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 2 | When dependencies are present, the workflow MUST set `mm_state` to `waiting_on_dependencies` and expose dependency IDs in memo/search metadata. |
+| DOC-REQ-003 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 3 and `docs/Tasks/TaskDependencies.md` §5.2 | The workflow MUST wait on each prerequisite using Temporal external workflow handles and block until all prerequisites complete successfully. |
+| DOC-REQ-004 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 4 | Dependency waiting MUST be wrapped in a Temporal `CancellationScope` so cancellation interrupts the wait cleanly. |
+| DOC-REQ-005 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 5 | The dependency gate MUST be guarded by `workflow.patched("dependency-gate-v1")` for replay safety. |
+| DOC-REQ-006 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 6 and `docs/Tasks/TaskDependencies.md` §5.1 | If `dependsOn` is absent or empty, the workflow MUST proceed directly from `initializing` to `planning`. |
+| DOC-REQ-007 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 7 and `docs/Tasks/TaskDependencies.md` §5.4 | If a prerequisite fails, is canceled, or is terminated, the dependent run MUST fail with a dependency-specific message. |
+| DOC-REQ-008 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 8 and `docs/Tasks/TaskDependencies.md` §5.3 | Canceling the dependent run during dependency wait MUST cancel only the dependent run, not prerequisite runs. |
+| DOC-REQ-009 | `docs/tmp/011-TaskDependenciesPlan.md` Phase 2 bullet 9 | After dependency wait resolves, the workflow MUST re-check `self._paused` before entering planning, consistent with the existing pause gate. |
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Dependent run waits before planning (Priority: P1)
+
+An operator submits a `MoonMind.Run` execution with `initialParameters.task.dependsOn`, and the workflow blocks in `waiting_on_dependencies` until every prerequisite completes successfully before entering planning.
+
+**Why this priority**: This is the core runtime behavior for the feature. Without it, Phase 1 validation has no effect at execution time.
+
+**Independent Test**: Start the workflow with dependencies in a workflow test environment, assert it enters `waiting_on_dependencies`, resolves prerequisite handles, and only then runs the planning stage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run with a non-empty `initialParameters.task.dependsOn`, **When** the workflow starts, **Then** it transitions from `initializing` to `waiting_on_dependencies` before `planning`.
+2. **Given** all prerequisite workflows complete successfully, **When** the dependency gate resolves, **Then** the run continues into planning and execution without failing.
+3. **Given** `initialParameters.task.dependsOn` is absent or empty, **When** the workflow starts, **Then** it skips the dependency gate and proceeds directly to planning.
+
+---
+
+### User Story 2 - Dependency failures fail the dependent run clearly (Priority: P1)
+
+An operator can see a dependent run fail with a dependency-specific reason if any prerequisite fails, is canceled, is terminated, or cannot be awaited successfully at runtime.
+
+**Why this priority**: Failure propagation is a correctness and operability requirement. Silent hangs or generic failures would make dependencies unsafe to use.
+
+**Independent Test**: Simulate failed or canceled prerequisite handles and assert the dependent workflow finalizes as failed with a dependency-specific error message naming the dependency when possible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a prerequisite workflow fails, **When** the dependency gate awaits it, **Then** the dependent run finalizes as failed with a dependency-specific error.
+2. **Given** a prerequisite workflow is canceled or terminated, **When** the dependency gate awaits it, **Then** the dependent run finalizes as failed with a dependency-specific error.
+3. **Given** dependency waiting fails after create-time validation because the target cannot be resolved at runtime, **When** the workflow handles the error, **Then** it fails instead of waiting indefinitely.
+
+---
+
+### User Story 3 - Dependency waiting remains replay-safe and cancel-safe (Priority: P2)
+
+An operator can cancel the dependent run while it is waiting on prerequisites, and in-flight or replayed workflows remain safe because the dependency gate is patch-guarded and isolated inside a cancellation scope.
+
+**Why this priority**: Temporal workflow changes must preserve replay safety and cancel behavior for in-flight executions.
+
+**Independent Test**: Verify patched and unpatched paths behave correctly in workflow-boundary tests, and that canceling the dependent run interrupts the wait without signaling or canceling prerequisite workflows.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run waiting on dependencies, **When** the dependent workflow is canceled, **Then** the dependency wait is interrupted and only the dependent run transitions to canceled.
+2. **Given** an in-flight workflow history without the patch marker, **When** the workflow replays, **Then** it follows the legacy no-gate path and remains replay-safe.
+3. **Given** a dependency wait resolves while the workflow is paused, **When** the gate exits, **Then** the workflow honors the existing pause gate before entering planning.
+
+---
+
+### Edge Cases
+
+- What happens when `dependsOn` is present but normalizes to an empty list? The workflow treats it as absent and skips the dependency gate.
+- What happens when all prerequisites already completed successfully before the dependent workflow starts? The external workflow `result()` calls resolve immediately and the workflow moves straight to the pause/planning gate.
+- What happens when memo or search-attribute upserts for dependency metadata fail in tests because attributes are not registered? The workflow logs the warning and continues, consistent with existing visibility update behavior.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `MoonMindRunWorkflow.run()` MUST read `initialParameters.task.dependsOn` immediately after payload initialization and before entering planning. (DOC-REQ-001)
+- **FR-002**: When the normalized dependency list is non-empty, the workflow MUST transition to `waiting_on_dependencies` before awaiting prerequisites. (DOC-REQ-002)
+- **FR-003**: When dependencies are present, the workflow MUST expose dependency identifiers through compact workflow metadata used by memo and visibility surfaces. (DOC-REQ-002)
+- **FR-004**: The workflow MUST await every dependency through Temporal external workflow handles and continue only after all dependencies complete successfully. (DOC-REQ-003)
+- **FR-005**: Dependency waiting MUST execute inside a Temporal `CancellationScope` so canceling the dependent workflow interrupts the wait without mutating prerequisite workflows. (DOC-REQ-004, DOC-REQ-008)
+- **FR-006**: The dependency-gate behavior MUST be guarded by `workflow.patched("dependency-gate-v1")`, while the unpatched path preserves pre-Phase-2 behavior for replay compatibility. (DOC-REQ-005)
+- **FR-007**: When `dependsOn` is absent or empty, the workflow MUST skip the dependency gate and proceed directly from `initializing` to `planning`. (DOC-REQ-006)
+- **FR-008**: If any prerequisite fails, is canceled, is terminated, or cannot be awaited successfully at runtime, the dependent workflow MUST fail with a dependency-specific error message. (DOC-REQ-007)
+- **FR-009**: After dependency waiting resolves successfully, the workflow MUST honor the existing pause gate before entering planning. (DOC-REQ-009)
+- **FR-010**: Workflow-boundary tests MUST cover the patched dependency gate path, the legacy unpatched compatibility path, and at least one degraded dependency outcome. (DOC-REQ-005, DOC-REQ-007)
+- **FR-011**: Existing run workflow tests unrelated to dependency gating MUST continue to pass without behavioral regressions.
+
+### Key Entities
+
+- **Dependency Gate**: The pre-planning workflow stage that inspects `initialParameters.task.dependsOn`, exposes dependency metadata, and waits on prerequisite workflow completion.
+- **Prerequisite Execution Handle**: A Temporal external workflow handle returned by `workflow.get_external_workflow_handle(dep_id)` and awaited through `result()`.
+- **Dependency Failure Outcome**: The dependency-specific workflow error surfaced when a prerequisite does not complete successfully.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A dependency-aware `MoonMind.Run` enters `waiting_on_dependencies` before planning and only reaches planning after all prerequisite handles succeed.
+- **SC-002**: A run with no dependencies follows the existing `initializing -> planning` path with no dependency-wait side effects.
+- **SC-003**: A failed or canceled prerequisite causes the dependent workflow to fail with a dependency-specific message instead of hanging or returning a generic error.
+- **SC-004**: Canceling a dependent workflow while it is waiting interrupts the wait and does not cancel prerequisite workflows.
+- **SC-005**: Workflow-boundary tests cover patched, unpatched, and degraded dependency outcomes and pass via `./tools/test_unit.sh`.

--- a/specs/123-task-dep-phase2/tasks.md
+++ b/specs/123-task-dep-phase2/tasks.md
@@ -1,0 +1,138 @@
+# Tasks: Task Dependencies Phase 2 - MoonMind.Run Dependency Gate
+
+**Input**: Design documents from `specs/123-task-dep-phase2/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/requirements-traceability.md`
+
+**Tests**: Test-driven development is required for this feature. Each user story starts with failing workflow-boundary tests before runtime code changes.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the runtime scope and the concrete files that own the dependency gate.
+
+- [X] T001 Audit `moonmind/workflows/temporal/workflows/run.py`, `tests/unit/workflows/temporal/workflows/test_run_scheduling.py`, and `tests/unit/workflows/temporal/workflows/test_run_signals_updates.py` against `specs/123-task-dep-phase2/spec.md` and `docs/tmp/011-TaskDependenciesPlan.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish failing test coverage before changing workflow runtime code.
+
+- [X] T002 [P] Add shared dependency-gate test helpers in `tests/unit/workflows/temporal/workflows/test_run_scheduling.py` for dependency-aware workflow start paths and planning/execution call ordering
+- [X] T003 [P] Add direct unit-test scaffolding in `tests/unit/workflows/temporal/workflows/test_run_signals_updates.py` for dependency metadata, external workflow handle doubles, and dependency failure simulation
+
+**Checkpoint**: Dependency-gate test harness is ready. User-story tests can now be written first and made to fail.
+
+---
+
+## Phase 3: User Story 1 - Dependent run waits before planning (Priority: P1) 🎯 MVP
+
+**Goal**: Dependency-aware runs enter `waiting_on_dependencies`, expose dependency metadata, and only reach planning after prerequisite success.
+
+**Independent Test**: Run the scheduling workflow tests and verify that dependency-aware runs wait before planning while runs without dependencies still go straight to planning.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [X] T004 [P] [US1] Add failing workflow-boundary tests in `tests/unit/workflows/temporal/workflows/test_run_scheduling.py` for patched dependency gating, planning-after-dependencies ordering, and empty-dependency bypass (DOC-REQ-001, DOC-REQ-002, DOC-REQ-003, DOC-REQ-006, DOC-REQ-009)
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Implement dependency parsing, `waiting_on_dependencies` state transition, `dependency_wait` metadata, memo dependency IDs, successful external-handle waiting, and post-wait pause gating in `moonmind/workflows/temporal/workflows/run.py` (DOC-REQ-001, DOC-REQ-002, DOC-REQ-003, DOC-REQ-006, DOC-REQ-009)
+
+### Validation for User Story 1
+
+- [X] T006 [US1] Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_scheduling.py` to validate the patched wait path and no-dependency bypass behavior (DOC-REQ-001, DOC-REQ-002, DOC-REQ-003, DOC-REQ-006, DOC-REQ-009)
+
+**Checkpoint**: Dependency-aware runs now block before planning and dependency-free runs preserve the direct planning path.
+
+---
+
+## Phase 4: User Story 2 - Dependency failures fail the dependent run clearly (Priority: P1)
+
+**Goal**: Failed, canceled, terminated, or otherwise unsuccessful prerequisites fail the dependent run with dependency-specific messaging.
+
+**Independent Test**: Run direct dependency-gate tests that simulate failed prerequisite handles and confirm dependency-specific workflow failure.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Add failing dependency-outcome tests in `tests/unit/workflows/temporal/workflows/test_run_signals_updates.py` for failed/canceled prerequisite handles and dependency-specific failure messaging (DOC-REQ-003, DOC-REQ-007)
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Implement dependency failure classification and dependency-specific error propagation in `moonmind/workflows/temporal/workflows/run.py` (DOC-REQ-003, DOC-REQ-007)
+
+### Validation for User Story 2
+
+- [X] T009 [US2] Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_signals_updates.py` to validate degraded dependency outcomes and failure messaging (DOC-REQ-003, DOC-REQ-007)
+
+**Checkpoint**: Unsuccessful prerequisites fail dependents deterministically instead of hanging.
+
+---
+
+## Phase 5: User Story 3 - Dependency waiting remains replay-safe and cancel-safe (Priority: P2)
+
+**Goal**: The dependency gate is replay-safe for in-flight histories and cancel-safe for dependent runs waiting on prerequisites.
+
+**Independent Test**: Run workflow tests that exercise the patched path, legacy unpatched path, and dependent-run cancellation during dependency wait.
+
+### Tests for User Story 3
+
+- [X] T010 [P] [US3] Add failing workflow-boundary tests in `tests/unit/workflows/temporal/workflows/test_run_scheduling.py` for `workflow.patched(\"dependency-gate-v1\")`, cancellation-scope interruption, and legacy unpatched compatibility (DOC-REQ-004, DOC-REQ-005, DOC-REQ-008)
+
+### Implementation for User Story 3
+
+- [X] T011 [US3] Implement the patch-guarded dependency wait branch and cancellation-scope handling in `moonmind/workflows/temporal/workflows/run.py` without mutating prerequisite workflows (DOC-REQ-004, DOC-REQ-005, DOC-REQ-008)
+
+### Validation for User Story 3
+
+- [X] T012 [US3] Run `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_scheduling.py` to validate patched, unpatched, and cancel-during-wait behavior (DOC-REQ-004, DOC-REQ-005, DOC-REQ-008)
+
+**Checkpoint**: Dependency waiting is replay-safe for existing histories and cancel-safe for dependent runs.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Close the phase tracker and run the full regression gate.
+
+- [X] T013 Update `docs/tmp/011-TaskDependenciesPlan.md` to mark Phase 2 items complete and leave later phases open
+- [X] T014 Run `./tools/test_unit.sh` for full regression coverage and confirm no unrelated run workflow regressions remain (FR-010, FR-011)
+
+---
+
+## Dependencies & Execution Order
+
+- T001 must complete before new test work starts.
+- T002 and T003 can run in parallel after T001.
+- T004 must complete before T005, and T005 before T006.
+- T007 must complete before T008, and T008 before T009.
+- T010 must complete before T011, and T011 before T012.
+- T013 and T014 depend on all user-story implementation and validation tasks completing.
+
+---
+
+## Implementation Strategy
+
+1. Establish shared harnesses for dependency-gate testing.
+2. Implement the success path first (US1) so the runtime behavior exists end-to-end.
+3. Add explicit failure propagation (US2).
+4. Finish replay/cancel safety and compatibility behavior (US3).
+5. Update the phase tracker and run the full unit-test gate.
+
+---
+
+## Notes
+
+- Runtime code changes are limited to `moonmind/workflows/temporal/workflows/run.py`.
+- Validation must use `./tools/test_unit.sh`; do not invoke `pytest` directly.
+- Every `DOC-REQ-*` is covered by at least one implementation task and one validation task.

--- a/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
@@ -1,11 +1,16 @@
-import pytest
 from datetime import datetime, timedelta, timezone
+import asyncio
+
+import pytest
 
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    DEPENDENCY_GATE_PATCH,
+    MoonMindRunWorkflow,
+)
 
 async def fake_execute_activity(activity_name, *args, **kwargs):
     if activity_name == "artifact.read":
@@ -174,3 +179,217 @@ async def test_run_workflow_invalid_scheduled_for(mock_run_environment):
                 await handle.result()
             
             assert "Invalid scheduled_for format" in str(excinfo.value.cause)
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_waits_on_dependencies_before_planning(
+    mock_run_environment,
+    monkeypatch,
+):
+    call_order: list[tuple[str, str | tuple[str, ...]]] = []
+
+    class _ImmediateHandle:
+        def __init__(self, workflow_id: str) -> None:
+            self._workflow_id = workflow_id
+
+        async def result(self) -> None:
+            call_order.append(("dependency", self._workflow_id))
+
+    async def fake_planning_stage(*args, **kwargs):
+        call_order.append(("planning", "started"))
+        return "ref-123"
+
+    async def fake_execution_stage(*args, **kwargs):
+        call_order.append(("execution", "started"))
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _ImmediateHandle(workflow_id),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_run_planning_stage", fake_planning_stage)
+    monkeypatch.setattr(MoonMindRunWorkflow, "_run_execution_stage", fake_execution_stage)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-dep-order",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-1", "dep-2"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-dep-order",
+                task_queue="test-task-queue-dep-order",
+            )
+
+            result = await handle.result()
+
+    assert result["status"] == "success"
+    dependency_indexes = [
+        idx for idx, call in enumerate(call_order) if call[0] == "dependency"
+    ]
+    planning_index = next(
+        idx for idx, call in enumerate(call_order) if call[0] == "planning"
+    )
+    assert dependency_indexes
+    assert max(dependency_indexes) < planning_index
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_dependency_pause_gate_blocks_planning_until_resume(
+    mock_run_environment,
+    monkeypatch,
+):
+    dependency_released = asyncio.Event()
+    planning_started = asyncio.Event()
+
+    class _BlockingHandle:
+        async def result(self) -> None:
+            await dependency_released.wait()
+
+    async def fake_planning_stage(*args, **kwargs):
+        planning_started.set()
+        return "ref-123"
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _BlockingHandle(),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_run_planning_stage", fake_planning_stage)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-dep-pause",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-1"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-dep-pause",
+                task_queue="test-task-queue-dep-pause",
+            )
+
+            await asyncio.sleep(0.1)
+            await handle.execute_update("Pause")
+            dependency_released.set()
+            await asyncio.sleep(0.1)
+
+            status = await handle.query("get_status")
+            assert status.get("paused") is True
+            assert planning_started.is_set() is False
+
+            await handle.execute_update("Resume")
+            result = await handle.result()
+
+    assert result["status"] == "success"
+    assert planning_started.is_set() is True
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_dependency_cancel_interrupts_wait(
+    mock_run_environment,
+    monkeypatch,
+):
+    dependency_started = asyncio.Event()
+    keep_waiting = asyncio.Event()
+
+    class _BlockingHandle:
+        async def result(self) -> None:
+            dependency_started.set()
+            await keep_waiting.wait()
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _BlockingHandle(),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-dep-cancel",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-1"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-dep-cancel",
+                task_queue="test-task-queue-dep-cancel",
+            )
+
+            await asyncio.wait_for(dependency_started.wait(), timeout=5)
+            await handle.execute_update("Cancel")
+            result = await handle.result()
+
+    assert result["status"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_dependency_gate_unpatched_skips_wait(
+    mock_run_environment,
+    monkeypatch,
+):
+    handle_calls: list[str] = []
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: handle_calls.append(workflow_id),
+    )
+    monkeypatch.setattr(workflow, "patched", lambda _patch_id: False)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-dep-unpatched",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-1"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-dep-unpatched",
+                task_queue="test-task-queue-dep-unpatched",
+            )
+
+            result = await handle.result()
+
+    assert result["status"] == "success"
+    assert handle_calls == []

--- a/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_scheduling.py
@@ -292,10 +292,20 @@ async def test_run_workflow_dependency_pause_gate_blocks_planning_until_resume(
                 task_queue="test-task-queue-dep-pause",
             )
 
-            await asyncio.sleep(0.1)
+            for _ in range(50):
+                status = await handle.query("get_status")
+                if status.get("state") == "waiting_on_dependencies":
+                    break
+                await asyncio.sleep(0.01)
+
             await handle.execute_update("Pause")
             dependency_released.set()
-            await asyncio.sleep(0.1)
+
+            for _ in range(50):
+                status = await handle.query("get_status")
+                if status.get("paused") is True:
+                    break
+                await asyncio.sleep(0.01)
 
             status = await handle.query("get_status")
             assert status.get("paused") is True
@@ -393,3 +403,69 @@ async def test_run_workflow_dependency_gate_unpatched_skips_wait(
 
     assert result["status"] == "success"
     assert handle_calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_handles_failed_dependency_with_degraded_outcome(
+    mock_run_environment,
+    monkeypatch,
+):
+    call_order: list[tuple[str, str | tuple[str, ...]]] = []
+
+    class _FailingHandle:
+        def __init__(self, workflow_id: str) -> None:
+            self._workflow_id = workflow_id
+
+        async def result(self) -> None:
+            call_order.append(("dependency", self._workflow_id))
+            raise RuntimeError("dependency failed")
+
+    async def fake_planning_stage(*args, **kwargs):
+        call_order.append(("planning", "started"))
+        return "ref-should-not-be-used"
+
+    async def fake_execution_stage(*args, **kwargs):
+        call_order.append(("execution", "started"))
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _FailingHandle(workflow_id),
+    )
+    monkeypatch.setattr(
+        workflow,
+        "patched",
+        lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
+    )
+    monkeypatch.setattr(MoonMindRunWorkflow, "_run_planning_stage", fake_planning_stage)
+    monkeypatch.setattr(MoonMindRunWorkflow, "_run_execution_stage", fake_execution_stage)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="test-task-queue-dep-failure",
+            workflows=[MoonMindRunWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindRunWorkflow.run,
+                {
+                    "workflow_type": "MoonMind.Run",
+                    "initial_parameters": {"task": {"dependsOn": ["dep-1"]}},
+                    "plan_artifact_ref": "ref-123",
+                },
+                id="test-wf-dep-failure",
+                task_queue="test-task-queue-dep-failure",
+            )
+
+            from temporalio.client import WorkflowFailureError
+            try:
+                await handle.result()
+                assert False, "Workflow should have failed"
+            except WorkflowFailureError as exc:
+                assert "dependency failed" in str(exc.cause)
+
+    dependency_calls = [c for c in call_order if c[0] == "dependency"]
+    planning_calls = [c for c in call_order if c[0] == "planning"]
+    assert dependency_calls
+    assert not planning_calls

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -388,7 +388,7 @@ async def test_wait_for_dependencies_records_dependency_metadata(monkeypatch):
         (),
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
     )
-    monkeypatch.setattr(workflow, "info", workflow_info)
+    monkeypatch.setattr(workflow, "info", lambda: workflow_info())
     monkeypatch.setattr(
         workflow,
         "logger",
@@ -437,7 +437,7 @@ async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypa
         (),
         {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
     )
-    monkeypatch.setattr(workflow, "info", workflow_info)
+    monkeypatch.setattr(workflow, "info", lambda: workflow_info())
     monkeypatch.setattr(
         workflow,
         "logger",

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest.mock import AsyncMock
+from datetime import datetime, timezone
 
 import pytest
 
@@ -7,7 +8,10 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 
 from temporalio import workflow
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    STATE_WAITING_ON_DEPENDENCIES,
+    MoonMindRunWorkflow,
+)
 
 
 async def fake_execute_activity(activity_name, *args, **kwargs):
@@ -353,3 +357,92 @@ def test_update_inputs_extracts_clarification_message_from_parameters_patch():
     )
 
     assert message == "Use the Workers page copy for now."
+
+
+@pytest.mark.asyncio
+async def test_wait_for_dependencies_records_dependency_metadata(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._owner_id = "owner-1"
+    workflow_instance._owner_type = "user"
+    memo_updates: list[dict[str, object]] = []
+
+    class _Handle:
+        async def result(self) -> None:
+            return None
+
+    async def fake_wait_condition(predicate, timeout=None):
+        while not predicate():
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _Handle(),
+    )
+    monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
+    )
+    monkeypatch.setattr(workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        workflow,
+        "logger",
+        type("Logger", (), {"warning": lambda *a, **k: None, "info": lambda *a, **k: None})(),
+    )
+
+    await workflow_instance._wait_for_dependencies(["dep-1", "dep-2"])
+
+    assert workflow_instance._state == STATE_WAITING_ON_DEPENDENCIES
+    assert workflow_instance._dependency_workflow_ids == ["dep-1", "dep-2"]
+    assert workflow_instance._waiting_reason is None
+    assert any(
+        memo.get("waiting_reason") == "dependency_wait" for memo in memo_updates
+    )
+    assert any(
+        memo.get("dependency_workflow_ids") == ["dep-1", "dep-2"]
+        for memo in memo_updates
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._owner_id = "owner-1"
+    workflow_instance._owner_type = "user"
+
+    class _Handle:
+        async def result(self) -> None:
+            raise RuntimeError("prerequisite failed")
+
+    async def fake_wait_condition(predicate, timeout=None):
+        while not predicate():
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        workflow,
+        "get_external_workflow_handle",
+        lambda workflow_id: _Handle(),
+    )
+    monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: None)
+    monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
+    )
+    monkeypatch.setattr(workflow, "info", workflow_info)
+    monkeypatch.setattr(
+        workflow,
+        "logger",
+        type("Logger", (), {"warning": lambda *a, **k: None, "info": lambda *a, **k: None})(),
+    )
+
+    with pytest.raises(ValueError, match="dep-1"):
+        await workflow_instance._wait_for_dependencies(["dep-1"])


### PR DESCRIPTION
## Summary
- add the Phase 2 dependency gate to MoonMind.Run before planning, with replay-safe patch gating and dependency metadata in memo
- add workflow-boundary tests for dependency wait ordering, pause/cancel behavior, legacy unpatched compatibility, and dependency failure propagation
- add the Speckit artifacts for Phase 2 and mark docs/tmp/011-TaskDependenciesPlan.md Phase 2 complete

## Testing
- ./tools/test_unit.sh --python-only --no-xdist -- tests/unit/workflows/temporal/workflows/test_run_scheduling.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py tests/unit/specs/test_doc_req_traceability.py
- ./tools/test_unit.sh
- .specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main

## Notes
- The current 	emporalio.workflow SDK in this repo does not expose a CancellationScope API, so the dependency wait uses explicit task cancellation to preserve the intended cancel semantics.