### PR TITLE
[codex] Fix task run observability volume mount

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       - ./moonmind:/app/moonmind:ro
       - ./.agents:/app/.agents:ro
       - ./keycloak:/app/keycloak:ro # Mount keycloak configs if needed by api, or remove if only for keycloak service
+      - agent_workspaces:/work/agent_jobs:ro
       - workflow_workspaces:/work/runs:ro
     command: sh /app/api_service/entrypoint.sh
     networks:

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -45,3 +45,22 @@ def test_docker_compose_has_temporal_worker_auto_start_configured():
         assert (
             "sleep" not in command_var
         ), f"Worker '{fleet}' must not be configured to sleep. Found: {command_var}"
+
+
+def test_api_service_mounts_agent_runtime_workspace_volume():
+    """Mission Control observability must read managed-run records from agent_workspaces."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    api_service = services.get("api")
+    assert isinstance(api_service, dict), "api service is missing from docker-compose.yaml"
+
+    volumes = api_service.get("volumes", [])
+    assert isinstance(volumes, list), "api service volumes must be a list"
+    assert (
+        "agent_workspaces:/work/agent_jobs:ro" in volumes
+    ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -61,6 +61,19 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
 
     volumes = api_service.get("volumes", [])
     assert isinstance(volumes, list), "api service volumes must be a list"
+    
+    found_mount = False
+    for v in volumes:
+        if isinstance(v, str):
+            parts = v.split(":")
+            if len(parts) >= 2 and parts[0] == "agent_workspaces" and parts[1] == "/work/agent_jobs":
+                found_mount = True
+                break
+        elif isinstance(v, dict):
+            if v.get("source") == "agent_workspaces" and v.get("target") == "/work/agent_jobs":
+                found_mount = True
+                break
+
     assert (
-        "agent_workspaces:/work/agent_jobs:ro" in volumes
+        found_mount
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"


### PR DESCRIPTION
## What changed
- mounted `agent_workspaces` into the `api` service at `/work/agent_jobs`
- added a compose regression test to ensure Mission Control can read managed-run records from the shared runtime workspace volume

## Why
Mission Control task-run observability was reading from `/work/agent_jobs/managed_runs`, but the `api` container did not mount the `agent_workspaces` volume. Managed runs and spool files existed in the worker volume, but the API saw an empty local path and returned `404` for observability summary and log routes.

## Impact
- task-run observability summary can resolve real managed runs
- merged/stdout/stderr log endpoints can read existing managed-run artifacts and spool-backed logs
- compose drift that removes this mount will now fail a test

## Root cause
The agent-runtime worker and workflow workers mounted `agent_workspaces`, but the `api` service only mounted `workflow_workspaces`. Observability routes depended on the managed runtime store under `/work/agent_jobs`, so the API could not see the run records it was supposed to serve.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/test_local_dev.py tests/integration/temporal/test_compose_foundation.py`
- recreated `api` with `docker compose up -d api`
- confirmed the API could load managed run `6642276e-181e-4e54-b44d-868cf77213b1`
- confirmed `/api/task-runs/6642276e-181e-4e54-b44d-868cf77213b1/observability-summary` returned `200`
- confirmed `/api/task-runs/6642276e-181e-4e54-b44d-868cf77213b1/logs/merged` returned `200`