### PR TITLE
New branches from the codex_cli managed agent are showing up with names like "auto-ad0bdd28". Fix this issue so that branches receive more meaningful 

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -28,7 +28,7 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
 
     @property
     def default_command_template(self) -> list[str]:
-        return ["codex", "exec", "--full-auto"]
+        return ["codex", "exec", "--sandbox", "danger-full-access"]
 
     def build_command(
         self,

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -236,7 +236,7 @@ class TestCodexCliProperties:
 
     def test_default_command_template(self) -> None:
         assert CodexCliStrategy().default_command_template == [
-            "codex", "exec", "--full-auto",
+            "codex", "exec", "--sandbox", "danger-full-access",
         ]
 
     def test_default_auth_mode(self) -> None:


### PR DESCRIPTION
Launching agent...