### PR TITLE
[codex] Fix proposal runtime normalization

### DIFF
--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import re
+from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any, Mapping, Sequence
 from uuid import UUID
@@ -48,6 +49,10 @@ _MOONMIND_SIGNAL_TAGS = frozenset(
         "artifact_gap",
     }
 )
+_PROPOSAL_RUNTIME_MODE_ALIASES = {
+    "codex_cli": "codex",
+    "claude_code": "claude",
+}
 
 
 class TaskProposalError(RuntimeError):
@@ -330,7 +335,7 @@ class TaskProposalService:
     ) -> tuple[dict[str, Any], str]:
         """Validate proposal payload shape without applying runtime defaults."""
 
-        payload_for_validation = dict(payload)
+        payload_for_validation = self._normalize_proposal_runtime_payload(payload)
         task_node = payload_for_validation.get("task")
         task = dict(task_node) if isinstance(task_node, Mapping) else {}
         if not task:
@@ -373,6 +378,45 @@ class TaskProposalService:
             )
         return normalized_payload, repository
 
+    @classmethod
+    def _normalize_proposal_runtime_mode(cls, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        lowered = value.strip().lower()
+        if not lowered:
+            return value
+        return _PROPOSAL_RUNTIME_MODE_ALIASES.get(lowered, lowered)
+
+    @classmethod
+    def _normalize_proposal_runtime_payload(
+        cls, payload: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Normalize proposal runtime ids to the task contract vocabulary."""
+
+        normalized = deepcopy(dict(payload))
+
+        for key in ("targetRuntime", "target_runtime", "runtime"):
+            if key in normalized:
+                normalized[key] = cls._normalize_proposal_runtime_mode(
+                    normalized.get(key)
+                )
+
+        task_node = normalized.get("task")
+        if not isinstance(task_node, Mapping):
+            return normalized
+
+        task = dict(task_node)
+        runtime_node = task.get("runtime")
+        if isinstance(runtime_node, Mapping):
+            runtime = dict(runtime_node)
+            if "mode" in runtime:
+                runtime["mode"] = cls._normalize_proposal_runtime_mode(
+                    runtime.get("mode")
+                )
+            task["runtime"] = runtime
+        normalized["task"] = task
+        return normalized
+
     def _prepare_task_create_request(
         self,
         request: dict[str, Any],
@@ -414,7 +458,10 @@ class TaskProposalService:
             )
         if apply_runtime_defaults:
             try:
-                parsed = CanonicalTaskPayload.model_validate(payload)
+                normalized_payload_input = self._normalize_proposal_runtime_payload(
+                    payload
+                )
+                parsed = CanonicalTaskPayload.model_validate(normalized_payload_input)
                 normalized_payload = parsed.model_dump(by_alias=True, exclude_none=True)
             except ValidationError as exc:
                 raise TaskProposalValidationError(f"Invalid task payload: {exc}") from exc

--- a/moonmind/workflows/task_proposals/service.py
+++ b/moonmind/workflows/task_proposals/service.py
@@ -388,6 +388,16 @@ class TaskProposalService:
         return _PROPOSAL_RUNTIME_MODE_ALIASES.get(lowered, lowered)
 
     @classmethod
+    def _normalize_proposal_runtime_mapping(
+        cls, runtime_node: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        runtime = dict(runtime_node)
+        for key in ("mode", "targetRuntime", "target_runtime"):
+            if key in runtime:
+                runtime[key] = cls._normalize_proposal_runtime_mode(runtime.get(key))
+        return runtime
+
+    @classmethod
     def _normalize_proposal_runtime_payload(
         cls, payload: Mapping[str, Any]
     ) -> dict[str, Any]:
@@ -406,14 +416,14 @@ class TaskProposalService:
             return normalized
 
         task = dict(task_node)
-        runtime_node = task.get("runtime")
-        if isinstance(runtime_node, Mapping):
-            runtime = dict(runtime_node)
-            if "mode" in runtime:
-                runtime["mode"] = cls._normalize_proposal_runtime_mode(
-                    runtime.get("mode")
-                )
-            task["runtime"] = runtime
+        for key in ("targetRuntime", "target_runtime", "runtime"):
+            if key not in task:
+                continue
+            value = task.get(key)
+            if key == "runtime" and isinstance(value, Mapping):
+                task["runtime"] = cls._normalize_proposal_runtime_mapping(value)
+                continue
+            task[key] = cls._normalize_proposal_runtime_mode(value)
         normalized["task"] = task
         return normalized
 

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -189,6 +189,65 @@ async def test_create_proposal_normalizes_managed_runtime_ids() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_field", ["targetRuntime", "target_runtime", "runtime"])
+async def test_create_proposal_normalizes_legacy_task_runtime_fields(
+    runtime_field: str,
+) -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.QUEUE,
+        origin_id=None,
+        origin_metadata={},
+        task_create_request={},
+    )
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+    service._emit_notification = AsyncMock()
+
+    await service.create_proposal(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["Auth"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Add regression coverage",
+                    runtime_field: "claude_code",
+                },
+            },
+        },
+        origin_source="queue",
+        origin_id=None,
+        origin_metadata={},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+    )
+
+    kwargs = repo.create_proposal.await_args.kwargs
+    assert kwargs["task_create_request"]["payload"]["task"]["runtime"]["mode"] == "claude"
+
+
+@pytest.mark.asyncio
 async def test_create_proposal_enforces_moonmind_metadata() -> None:
     repo = AsyncMock()
     service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
@@ -480,6 +539,54 @@ async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> Non
     assert final_request["payload"]["targetRuntime"] == "codex"
     assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
 
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_mode_field", ["targetRuntime", "target_runtime"])
+async def test_promote_proposal_override_normalizes_runtime_mapping_aliases(
+    runtime_mode_field: str,
+) -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Refactor logic",
+                    "runtime": {"mode": "gemini_cli"},
+                }
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    override_request = {
+        "type": "task",
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "Refactor logic",
+                "runtime": {runtime_mode_field: "claude_code"},
+            },
+        },
+    }
+
+    updated_proposal, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+        task_create_request_override=override_request,
+    )
+
+    repo.commit.assert_awaited()
+    assert updated_proposal.status is TaskProposalStatus.PROMOTED
+    assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
 
 
 

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -131,6 +131,64 @@ async def test_create_proposal_accepts_enum_origin_source() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_proposal_normalizes_managed_runtime_ids() -> None:
+    repo = AsyncMock()
+    record = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        title="Add tests",
+        summary="Add follow-up",
+        category="tests",
+        tags=["tests"],
+        repository="Moon/Repo",
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        origin_source=TaskProposalOriginSource.QUEUE,
+        origin_id=None,
+        origin_metadata={},
+        task_create_request={},
+    )
+    repo.create_proposal.return_value = record
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+    service._emit_notification = AsyncMock()
+
+    await service.create_proposal(
+        title="Add Tests",
+        summary="Ensure coverage",
+        category="Tests",
+        tags=["Auth"],
+        task_create_request={
+            "type": "task",
+            "priority": 0,
+            "maxAttempts": 3,
+            "payload": {
+                "repository": "Moon/Repo",
+                "targetRuntime": "codex_cli",
+                "task": {
+                    "instructions": "Add regression coverage",
+                    "runtime": {"mode": "claude_code"},
+                },
+            },
+        },
+        origin_source="queue",
+        origin_id=None,
+        origin_metadata={},
+        proposed_by_worker_id="worker-1",
+        proposed_by_user_id=None,
+    )
+
+    kwargs = repo.create_proposal.await_args.kwargs
+    assert kwargs["task_create_request"]["payload"]["targetRuntime"] == "codex"
+    assert kwargs["task_create_request"]["payload"]["task"]["runtime"]["mode"] == "claude"
+
+
+@pytest.mark.asyncio
 async def test_create_proposal_enforces_moonmind_metadata() -> None:
     repo = AsyncMock()
     service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
@@ -374,6 +432,53 @@ async def test_promote_proposal_applies_runtime_override() -> None:
     assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
     assert updated_proposal.task_create_request["payload"]["task"]["runtime"]["mode"] == "gemini_cli"
 
+
+@pytest.mark.asyncio
+async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Refactor logic",
+                    "runtime": {"mode": "gemini_cli"},
+                }
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    override_request = {
+        "type": "task",
+        "payload": {
+            "repository": "Moon/Repo",
+            "targetRuntime": "codex_cli",
+            "task": {
+                "instructions": "Refactor logic",
+                "runtime": {"mode": "claude_code"},
+            },
+        },
+    }
+
+    updated_proposal, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+        task_create_request_override=override_request,
+    )
+
+    repo.commit.assert_awaited()
+    assert updated_proposal.status is TaskProposalStatus.PROMOTED
+    assert final_request["payload"]["targetRuntime"] == "codex"
+    assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
 
 
 

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -6,10 +6,19 @@ import unittest
 import contextlib
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import uuid4
+from datetime import UTC, datetime
+from types import SimpleNamespace
 
+from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalProposalActivities,
 )
+from moonmind.workflows.task_proposals.models import (
+    TaskProposalOriginSource,
+    TaskProposalStatus,
+)
+from moonmind.workflows.task_proposals.service import TaskProposalService
 
 
 class TestProposalGenerate(unittest.IsolatedAsyncioTestCase):
@@ -344,3 +353,69 @@ class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
         stamped = call_kwargs["task_create_request"]
         self.assertNotIn("task", stamped["payload"])
 
+    async def test_managed_runtime_ids_are_normalized_before_submission(self) -> None:
+        repo = AsyncMock()
+        record = SimpleNamespace(
+            id=uuid4(),
+            status=TaskProposalStatus.OPEN,
+            title="Fix bug",
+            summary="Bug in module X",
+            category="tests",
+            tags=["tests"],
+            repository="org/repo",
+            proposed_by_worker_id="worker-1",
+            proposed_by_user_id=None,
+            promoted_at=None,
+            promoted_by_user_id=None,
+            decided_by_user_id=None,
+            decision_note=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            origin_source=TaskProposalOriginSource.WORKFLOW,
+            origin_id=None,
+            origin_metadata={},
+            task_create_request={},
+        )
+        repo.create_proposal.return_value = record
+        service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+        service._emit_notification = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def mock_factory():
+            yield service
+
+        activities = TemporalProposalActivities(
+            proposal_service_factory=mock_factory,
+        )
+        candidates = [
+            {
+                "title": "Fix bug",
+                "summary": "Bug in module X",
+                "taskCreateRequest": {
+                    "type": "task",
+                    "payload": {
+                        "repository": "org/repo",
+                        "targetRuntime": "codex_cli",
+                        "task": {
+                            "instructions": "fix it",
+                            "runtime": {"mode": "claude_code"},
+                        },
+                    }
+                },
+            },
+        ]
+
+        result = await activities.proposal_submit(
+            {
+                "candidates": candidates,
+                "policy": {},
+                "origin": {"workflow_id": "wf-1", "temporal_run_id": "run-1"},
+            }
+        )
+
+        self.assertEqual(result["submitted_count"], 1)
+        self.assertEqual(result["errors"], [])
+        call_kwargs = repo.create_proposal.await_args.kwargs
+        stamped = call_kwargs["task_create_request"]
+        self.assertEqual(stamped["payload"]["targetRuntime"], "codex")
+        self.assertEqual(stamped["payload"]["task"]["runtime"]["mode"], "claude")

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -398,7 +398,7 @@ class TestProposalSubmitRuntimeStamping(unittest.IsolatedAsyncioTestCase):
                         "targetRuntime": "codex_cli",
                         "task": {
                             "instructions": "fix it",
-                            "runtime": {"mode": "claude_code"},
+                            "runtime": "claude_code",
                         },
                     }
                 },


### PR DESCRIPTION
## Summary
- normalize proposal task payload runtimes before `CanonicalTaskPayload` validation
- apply the same normalization when reviewers promote proposals with override payloads
- add regression coverage for proposal creation, submit activity, and promotion overrides

## Root Cause
Workflow-generated proposals were copying managed runtime ids like `codex_cli` and `claude_code` into `taskCreateRequest`. The proposal service validates those payloads against the task contract, which currently accepts `codex` and `claude`, so proposal submission was generating candidates but rejecting them before persistence.

## Impact
New proposals generated from current managed runtime executions can now be stored and later promoted instead of failing validation with `task.runtime.mode` errors.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/task_proposals/test_service.py tests/unit/workflows/temporal/test_proposal_activities.py`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_proposals.py tests/unit/workflows/temporal/workflows/test_run_proposals.py`