### PR TITLE
[codex] Fix Mission Control Vite CSS loading

### DIFF
--- a/api_service/ui_assets.py
+++ b/api_service/ui_assets.py
@@ -95,6 +95,62 @@ def _verify_asset_paths(dist_root: Path, asset_info: Dict[str, Any]) -> None:
             )
 
 
+def _walk_manifest_imports(
+    manifest: Dict[str, Any], manifest_key: str, seen: set[str] | None = None
+) -> list[tuple[str, Dict[str, Any]]]:
+    if seen is None:
+        seen = set()
+    if manifest_key in seen:
+        return []
+
+    asset_info = manifest.get(manifest_key)
+    if not isinstance(asset_info, dict):
+        raise AssetFileMissingError(
+            f"Manifest import {manifest_key!r} is missing or invalid."
+        )
+
+    seen.add(manifest_key)
+    ordered_assets: list[tuple[str, Dict[str, Any]]] = []
+    imports = asset_info.get("imports") or []
+    if not isinstance(imports, list):
+        raise AssetFileMissingError(
+            f"Manifest entry {manifest_key!r} has a non-list 'imports' field."
+        )
+
+    for import_key in imports:
+        if not isinstance(import_key, str):
+            raise AssetFileMissingError(
+                f"Manifest entry {manifest_key!r} contains a non-string import key."
+            )
+        ordered_assets.extend(_walk_manifest_imports(manifest, import_key, seen))
+
+    ordered_assets.append((manifest_key, asset_info))
+    return ordered_assets
+
+
+def _collect_css_files(
+    manifest: Dict[str, Any], manifest_key: str
+) -> list[str]:
+    css_files: list[str] = []
+    seen_css: set[str] = set()
+
+    for _, asset_info in _walk_manifest_imports(manifest, manifest_key):
+        css_entries = asset_info.get("css") or []
+        if not isinstance(css_entries, list):
+            raise AssetFileMissingError("Manifest entry 'css' must be a list when present.")
+        for css_file in css_entries:
+            if not isinstance(css_file, str):
+                raise AssetFileMissingError(
+                    "Manifest CSS entry must be a string path."
+                )
+            if css_file in seen_css:
+                continue
+            seen_css.add(css_file)
+            css_files.append(css_file)
+
+    return css_files
+
+
 def ui_assets(entrypoint: str) -> str:
     """Return HTML tags to load the Vite bundle for a Mission Control entrypoint.
 
@@ -136,14 +192,15 @@ def ui_assets(entrypoint: str) -> str:
 
     dist_root = _dist_root_for_manifest(manifest_path)
     try:
-        _verify_asset_paths(dist_root, asset_info)
+        for _, imported_asset_info in _walk_manifest_imports(manifest, manifest_key):
+            _verify_asset_paths(dist_root, imported_asset_info)
     except AssetFileMissingError:
         if lenient:
             return f"<!-- Vite manifest references missing files for {entrypoint} -->"
         raise
 
     js_file = asset_info["file"]
-    css_files = asset_info.get("css") or []
+    css_files = _collect_css_files(manifest, manifest_key)
 
     tags: list[str] = []
     tags.append(

--- a/tests/api_service/test_ui_assets_strict.py
+++ b/tests/api_service/test_ui_assets_strict.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from api_service.ui_assets import (
+    AssetFileMissingError,
     EntrypointMissingError,
     ManifestNotFoundError,
     ui_assets,
@@ -54,3 +55,78 @@ def test_ui_assets_lenient_returns_comment_when_entrypoint_missing(
     monkeypatch.setenv("MOONMIND_LENIENT_UI_ASSETS", "1")
     html = ui_assets("tasks-list")
     assert "manifest entry not found" in html
+
+
+def test_ui_assets_includes_css_from_imported_chunks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dist_root = tmp_path / "dist"
+    manifest_dir = dist_root / ".vite"
+    assets_dir = dist_root / "assets"
+    manifest_dir.mkdir(parents=True)
+    assets_dir.mkdir()
+
+    manifest = dist_root / ".vite" / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "entrypoints/tasks-list.tsx": {
+                    "file": "assets/tasks-list.js",
+                    "imports": ["_mountPage-shared.js"],
+                },
+                "_mountPage-shared.js": {
+                    "file": "assets/mountPage.js",
+                    "css": ["assets/mountPage.css"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (assets_dir / "tasks-list.js").write_text("console.log('entry');", encoding="utf-8")
+    (assets_dir / "mountPage.js").write_text("console.log('shared');", encoding="utf-8")
+    (assets_dir / "mountPage.css").write_text("body { color: red; }", encoding="utf-8")
+
+    monkeypatch.setenv("VITE_MANIFEST_PATH", str(manifest))
+    monkeypatch.delenv("MOONMIND_LENIENT_UI_ASSETS", raising=False)
+
+    html = ui_assets("tasks-list")
+
+    assert 'src="/static/task_dashboard/dist/assets/tasks-list.js"' in html
+    assert 'href="/static/task_dashboard/dist/assets/mountPage.css"' in html
+
+
+def test_ui_assets_strict_raises_when_imported_chunk_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dist_root = tmp_path / "dist"
+    manifest_dir = dist_root / ".vite"
+    assets_dir = dist_root / "assets"
+    manifest_dir.mkdir(parents=True)
+    assets_dir.mkdir()
+
+    manifest = dist_root / ".vite" / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "entrypoints/tasks-list.tsx": {
+                    "file": "assets/tasks-list.js",
+                    "imports": ["_mountPage-shared.js"],
+                },
+                "_mountPage-shared.js": {
+                    "file": "assets/mountPage.js",
+                    "css": ["assets/mountPage.css"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (assets_dir / "tasks-list.js").write_text("console.log('entry');", encoding="utf-8")
+    (assets_dir / "mountPage.css").write_text("body { color: red; }", encoding="utf-8")
+
+    monkeypatch.setenv("VITE_MANIFEST_PATH", str(manifest))
+    monkeypatch.delenv("MOONMIND_LENIENT_UI_ASSETS", raising=False)
+
+    with pytest.raises(AssetFileMissingError):
+        ui_assets("tasks-list")


### PR DESCRIPTION
## Summary
- fix Mission Control Vite asset rendering to include CSS declared on imported manifest chunks
- validate imported chunk files during strict asset resolution so incomplete bundles still fail loudly
- add regression coverage for the shared-chunk CSS case introduced by the TypeScript cutover

## Root Cause
The recent Mission Control TypeScript cutover moved the shared stylesheet onto the common `mountPage` chunk. The server-side Vite asset renderer only emitted CSS listed directly on each entrypoint, so pages loaded their JavaScript and markup without the shared stylesheet. That stripped the outer layout styling and dark-mode presentation.

## Impact
Mission Control pages now load the shared CSS again, restoring route shell styling and dark mode after the Vite bundle is resolved from the manifest.

## Validation
- `./tools/test_unit.sh tests/api_service/test_ui_assets_strict.py tests/api_service/test_ui_assets.py tests/api_service/test_task_dashboard_ui_assets_errors.py`
