### PR TITLE
Refresh architecture docs and add Jira integration design

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ MoonMind runs as a set of decoupled containers from a single `docker-compose.yam
 
 | Component | Role |
 | --- | --- |
-| **API Service** | FastAPI OpenAI-compatible endpoints, MCP server, and job queue API. |
+| **API Service** | FastAPI control plane for Mission Control, `/api/executions`, artifacts, templates, proposals, and MCP/context surfaces. |
 | **Temporal Server** | Durable execution engine with PostgreSQL persistence. |
 | **Worker Fleet** | Specialized isolated workers for orchestration, sandbox execution, LLM calls, and external integrations. |
 | **Mission Control** | Operational dashboard for managing tasks and reviewing artifacts. |

--- a/docs/ExternalAgents/ModelContextProtocol.md
+++ b/docs/ExternalAgents/ModelContextProtocol.md
@@ -1,6 +1,6 @@
 # Model Context Protocol in MoonMind
 
-This document describes how MoonMind exposes **agent-facing HTTP surfaces** related to the Model Context Protocol (MCP) ecosystem: a **context-style chat completion** endpoint and a small **MCP tool HTTP API** for discovery and invocation. Together they replace the older standalone `docs/CodexMcpToolsAdapter.md` guide; operational detail for Jules-specific behavior lives in [`docs/ExternalAgents/JulesAdapter.md`](ExternalAgents/JulesAdapter.md) (§ MCP tooling posture).
+This document describes how MoonMind exposes **agent-facing HTTP surfaces** related to the Model Context Protocol (MCP) ecosystem: a **context-style chat completion** endpoint and a small **MCP tool HTTP API** for discovery and invocation. Together they replace the older standalone `docs/CodexMcpToolsAdapter.md` guide; operational detail for Jules-specific behavior lives in [`docs/ExternalAgents/JulesAdapter.md`](JulesAdapter.md) (§ MCP tooling posture).
 
 MoonMind does **not** implement the full MCP streamable-HTTP or JSON-RPC transport on `/context`; that route is a **REST JSON** contract documented below. Tooling uses **JSON over HTTP** at `/mcp/*`, which clients such as Codex CLI can configure as an HTTP MCP tool server.
 
@@ -186,5 +186,5 @@ For tool use, the same host and port apply to `/mcp/tools` and `/mcp/tools/call`
 
 ## Related documentation
 
-- [`docs/ExternalAgents/JulesAdapter.md`](ExternalAgents/JulesAdapter.md) — Jules adapter, including MCP as an optional consumer surface.
-- [`docs/MoonMindArchitecture.md`](MoonMindArchitecture.md) — High-level mention of `/context` and agent integration.
+- [`docs/ExternalAgents/JulesAdapter.md`](JulesAdapter.md) — Jules adapter, including MCP as an optional consumer surface.
+- [`docs/MoonMindArchitecture.md`](../MoonMindArchitecture.md) — High-level mention of `/context` and agent integration.

--- a/docs/Memory/MemoryArchitecture.md
+++ b/docs/Memory/MemoryArchitecture.md
@@ -1,8 +1,10 @@
 # MoonMind Memory Architecture (Desired State)
 
 Status: Proposed
-Last Updated: 2026-02-16
-Scope: Chat, RAG, Mission Control (agent queue), Spec workflow, system
+Last Updated: 2026-04-02
+Scope: Chat, RAG, Mission Control (task and execution surfaces), Spec workflow, system
+
+This desired-state document now assumes MoonMind's current Temporal-first bridge architecture. Older queue/Celery terminology should be treated as historical only, not as the current execution substrate.
 
 ## 1) Goals
 
@@ -25,10 +27,10 @@ Non-goals:
 
 MoonMind already has the core primitives we will extend:
 
-- **Document retrieval (RAG)**: LlamaIndex + Qdrant powering chat and `/context`.
-- **Durable execution state**: Postgres tables for spec workflows, system runs, and agent queue jobs.
-- **Durable artifacts**: filesystem artifact roots for workflow runs and agent jobs.
-- **Background jobs**: Celery + RabbitMQ for orchestration and asynchronous processing.
+- **Document retrieval (RAG)**: LlamaIndex + Qdrant powering chat, `/context`, and related retrieval flows.
+- **Durable execution state**: Temporal-backed workflow executions plus Postgres-backed execution/projection records used by Mission Control and execution APIs.
+- **Durable artifacts and run evidence**: S3-compatible workflow artifacts plus managed-run observability artifacts and workspace-backed log spools.
+- **Background orchestration**: Temporal workflows and activities running across specialized worker fleets.
 
 This architecture does not replace these primitives. It adds a thin “memory layer” that:
 1) reads from them, and
@@ -54,8 +56,8 @@ MoonMind uses three orthogonal memory planes. Each plane has a clear purpose and
 **Question:** “What happened last time we tried something like this?”
 
 **Source of truth:**
-- Postgres run/job rows + lifecycle/event streams + timestamps.
-- Artifact store for logs/patches/test results.
+- Temporal-backed execution state plus Postgres execution/projection rows, timestamps, and related metadata.
+- Artifact storage and managed-run observability artifacts for logs, patches, diagnostics, and test results.
 
 **Derived retrieval indexes (not sources of truth):**
 - **Run Digests**: short structured summaries of intent/result/changes/decisions/gotchas/next steps.
@@ -63,7 +65,7 @@ MoonMind uses three orthogonal memory planes. Each plane has a clear purpose and
 
 **Storage:**
 - Digests and fix patterns are embedded and indexed in Qdrant (never raw logs).
-- Every digest links back to evidence: run/job IDs, commits/PRs, artifact paths.
+- Every digest links back to evidence: `workflowId`, `taskRunId` when applicable, commits/PRs, and artifact refs.
 
 ### Plane C — Long-Term Memory (Mem0)
 
@@ -109,21 +111,21 @@ Fail-open behavior:
 
 ## 5) Write Path: Turning Runs Into Memory
 
-Writeback is automatic, async-first, and idempotent by run/job ID.
+Writeback is automatic, async-first, and idempotent by execution identity (`workflowId`, and `taskRunId` for managed-run observability when applicable).
 
 ### 5.1 On run start
 - If linked to Beads: claim the work item with `run_ref`.
-- Record minimal start metadata in the existing run/job tables (baseline behavior).
+- Record minimal start metadata in the Temporal-backed execution row/projection and related run metadata.
 
 ### 5.2 During execution
-- Append events to existing run/job event streams (status transitions, key tool calls).
+- Persist lifecycle state through Temporal history, execution projections, and managed-run observability records as appropriate.
 - Store large outputs to artifacts (logs, patches, test output).
 
 ### 5.3 On run finish
 1) **Generate a Run Digest (Plane B index)**
 - Structured summary:
   - intent, outcome, key changes, key decisions, gotchas, next steps
-- Link to evidence (run/job id, commit/PR, artifact refs).
+- Link to evidence (`workflowId`, `taskRunId` when present, commit/PR, artifact refs).
 - Embed + upsert into Qdrant.
 
 2) **Update Fix Patterns (Plane B procedural memory)**
@@ -141,10 +143,10 @@ Writeback is automatic, async-first, and idempotent by run/job ID.
 ## 6) Storage Contracts
 
 ### 6.1 Sources of truth
-- **Postgres**: workflow runs, task states, system runs, agent queue jobs, event logs.
+- **Postgres**: Temporal-backed execution records/projections, workflow support tables, system runs, and related event metadata.
 - **Artifact store**:
-  - workflow artifacts under `var/artifacts/workflow_runs/<run_id>/`
-  - agent job artifacts under `var/artifacts/agent_jobs/<job_id>/`
+  - workflow artifacts under `var/artifacts/<scope>/<run_id>/`
+  - managed-run workspace and observability artifacts under `/work/agent_jobs/<job_id>/...` in worker containers
 - **Git**: code + Beads planning state.
 
 ### 6.2 Qdrant: retrieval indexes (not truth)
@@ -161,7 +163,7 @@ Payload keys (minimum):
 Required metadata on every Mem0 entry:
 - `namespace_id`, `repo`, `scope` (`project | team | user`)
 - `review_state` (`draft | approved | deprecated`)
-- `provenance` pointers (run/job IDs, commits, doc refs)
+- `provenance` pointers (`workflowId`, `taskRunId` when applicable, commits, doc refs)
 
 ## 7) Integration Surfaces
 

--- a/docs/Memory/MemoryArchitecture.md
+++ b/docs/Memory/MemoryArchitecture.md
@@ -145,8 +145,9 @@ Writeback is automatic, async-first, and idempotent by execution identity (`work
 ### 6.1 Sources of truth
 - **Postgres**: Temporal-backed execution records/projections, workflow support tables, system runs, and related event metadata.
 - **Artifact store**:
-  - workflow artifacts under `var/artifacts/<scope>/<run_id>/`
-  - managed-run workspace and observability artifacts under `/work/agent_jobs/<job_id>/...` in worker containers
+  - workflow artifacts default under `var/artifacts/workflows/<workflow_id>/` and may be relocated via `WORKFLOW_ARTIFACT_ROOT`
+  - local-dev Temporal artifact files default under `var/artifacts/temporal_artifacts/`
+  - managed-run workspace and observability files may exist under `/work/agent_jobs/<job_id>/...` in worker containers; treat that as runtime-local workspace layout rather than the primary durable artifact root
 - **Git**: code + Beads planning state.
 
 ### 6.2 Qdrant: retrieval indexes (not truth)

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -4,6 +4,8 @@ MoonMind is an open-source platform that orchestrates leading AI agents out of t
 
 This document is the top-level architectural overview. It covers the major subsystems, how they connect, and where to find deeper documentation. It reflects the **current and intended near-term** state of the project.
 
+> **Migration posture:** MoonMind is currently in a bridge state. Core execution is Temporal-native and live for major paths, while task-oriented product routes, compatibility APIs, and a few projection/read-model layers still remain around that execution core.
+
 ---
 
 ## Architecture at a Glance
@@ -36,7 +38,7 @@ flowchart LR
 
 Key layers:
 
-* **Control Plane** — API + Mission Control. Authenticates callers, starts workflows, exposes task-oriented surfaces, and serves the operator dashboard.
+* **Control Plane** — API + Mission Control. Authenticates callers, resolves task templates and agent-skill intent, starts workflows, exposes execution and task-oriented surfaces, and serves the operator dashboard.
 * **Execution Plane** — Temporal workers grouped by capability, not by agent brand. Workflows orchestrate; Activities execute side effects.
 * **Data Layer** — A single consolidated Postgres instance, Qdrant for vector retrieval, and MinIO for S3-compatible artifact storage.
 
@@ -48,10 +50,13 @@ Key layers:
 
 The FastAPI-based [API service](../api_service/) is MoonMind's central control plane:
 
-* **Workflow management** — starts Temporal workflows, sends signals/updates/cancellations, queries execution state.
-* **Task compatibility APIs** — exposes `/tasks/*` endpoints that map the user-facing "task" concept onto Temporal workflow executions.
+* **Execution lifecycle APIs** — exposes `/api/executions` for create/list/detail/update/signal/cancel and related Temporal-backed execution operations.
+* **Task-oriented product routes** — serves `/tasks/*` Mission Control routes and compatibility views that present workflow executions as tasks.
+* **Observability APIs** — exposes `/api/task-runs/*` for managed-run log, diagnostics, and live-follow surfaces.
 * **Artifact APIs** — manages artifact metadata, presigned upload/download grants, and artifact-to-execution linkage.
-* **RAG retrieval** — indexes and retrieves vectors via Qdrant for chat and the `/context` MCP endpoint.
+* **Task templates and presets** — serves the task step template catalog used by Mission Control submission flows.
+* **Agent skill resolution** — accepts task/step skill-selection intent and resolves it into immutable `ResolvedSkillSet` snapshot refs for execution.
+* **RAG retrieval** — indexes and retrieves vectors via Qdrant for chat, `/context`, and related retrieval surfaces.
 * **Task Proposals** — stores and surfaces agent-generated task proposals for human review before promotion to executing workflows.
 * **Auth** — optional OIDC via Keycloak, or disabled-auth mode for local development.
 
@@ -61,7 +66,7 @@ Mission Control is MoonMind's purpose-built operator dashboard — a thin, serve
 
 * **Task list** — unified view of workflow executions, with filtering, sorting, and pagination via Temporal Visibility.
 * **Task detail** — execution state, artifact browsing, timeline, and operator actions (pause, resume, cancel, approve, rerun).
-* **Task submission** — form wizard for creating new tasks with runtime/model selection, scheduling, and artifact upload.
+* **Task submission** — form wizard for creating new tasks with runtime/model selection, template expansion, skill selection, scheduling, and artifact upload.
 * **Proposals** — triage queue for reviewing, promoting, or dismissing agent-generated task proposals.
 
 > **Vocabulary rule:** The UI uses **task** as the primary term. "Workflow execution" is reserved for implementation docs and debug views. Temporal Task Queues are never presented as a user-facing queue product.
@@ -82,7 +87,7 @@ See: [Mission Control Architecture](UI/MissionControlArchitecture.md) · [Missio
 * **Schedules** for recurring and deferred task starts.
 * **Timers, retries, signals, updates** for resilient fire-and-forget execution.
 
-The Temporal server runs self-hosted in Docker Compose with PostgreSQL persistence and visibility. It is private-network only — no ports are exposed to the host by default.
+The Temporal server runs self-hosted in Docker Compose with PostgreSQL persistence and visibility. The baseline local compose file publishes `7233:7233` for host tooling and debugging, while workers and the API normally use the internal `temporal-internal` network alias.
 
 See: [Temporal Architecture](Temporal/TemporalArchitecture.md) · [Temporal Platform Foundation](Temporal/TemporalPlatformFoundation.md)
 
@@ -95,7 +100,8 @@ MoonMind keeps a small workflow type catalog:
 | `MoonMind.Run` | Root workflow for all task execution — direct commands, plan-driven execution, and external integrations. |
 | `MoonMind.AgentRun` | Child workflow for true agent-runtime execution (managed and external agents). Started per-step by `MoonMind.Run`. |
 | `MoonMind.ManifestIngest` | Manifest-driven ingestion with graph compilation, fan-out/fan-in, and aggregation. |
-| `MoonMindProviderProfileManagerWorkflow` | Manages provider-profile slot acquisition and release for managed runtimes. |
+| `MoonMind.ProviderProfileManager` | Manages provider-profile slot acquisition, release, and cooldown coordination for managed runtimes. |
+| `MoonMind.OAuthSession` | Manages browser and terminal OAuth session lifecycle for managed runtimes. |
 
 See: [Workflow Type Catalog](Temporal/WorkflowTypeCatalogAndLifecycle.md)
 
@@ -108,6 +114,7 @@ MoonMind's execution model is built on three domain concepts that Temporal does 
   * `agent_runtime` — dispatched as a child `MoonMind.AgentRun` workflow.
 * **Plan** — a DAG of tool invocations (Steps) with explicit dependencies, concurrency policy, and failure mode (`FAIL_FAST` or `CONTINUE`).
 * **Artifact** — large inputs/outputs stored outside workflow history, referenced by `ArtifactRef`.
+* **Agent skill context** — task/step skill-selection intent is resolved by the control plane into immutable `ResolvedSkillSet` refs before runtime launch.
 
 Plans are data, not code. They are validated, stored as artifacts, and interpreted deterministically by the plan executor inside `MoonMind.Run`. Planning itself is "just a tool" — an LLM activity that produces a plan artifact.
 
@@ -207,9 +214,29 @@ See: [Memory Architecture](Memory/MemoryArchitecture.md) · [Memory Research](Me
 
 ## Model Context Protocol
 
-MoonMind implements an MCP server endpoint at `POST /context`. This gives agent runtimes (OpenHands or others) a standardized interface to MoonMind's model routing, RAG, and policy layers — decoupling agent UX from specific model vendors.
+MoonMind exposes two agent-facing HTTP surfaces related to the MCP ecosystem:
 
-See: [Model Context Protocol](ModelContextProtocol.md)
+* **Context-style completion** — `POST /context` provides MoonMind-routed completion with optional RAG enrichment. This is a MoonMind REST JSON contract, not the full MCP streamable transport.
+* **HTTP MCP tools** — `GET /mcp/tools` and `POST /mcp/tools/call` expose tool discovery and invocation over JSON/HTTP for clients that can target an HTTP MCP tool server.
+
+Together these surfaces let agent runtimes consume MoonMind context, retrieval, and tool capabilities without binding directly to one model vendor.
+
+See: [Model Context Protocol](ExternalAgents/ModelContextProtocol.md)
+
+---
+
+## Observability
+
+MoonMind currently uses complementary product-facing and operational observability layers:
+
+* **Execution list/query/count** — Temporal Visibility is the source of truth for Temporal-backed execution list and filter behavior.
+* **Managed-run observability APIs** — `/api/task-runs/*` exposes artifact-backed logs, diagnostics, and SSE live follow for active managed runs.
+* **Mission Control detail views** — task detail pages combine execution state, artifacts, and observability refs into the operator-facing "what happened?" surface.
+* **Operational telemetry** — MoonMind now includes dedicated observability transport code and an OpenTelemetry design, but the OpenTelemetry subsystem is still an active draft rather than a fully locked architecture surface.
+
+Operational telemetry should complement, not replace, Temporal Visibility, Mission Control, or artifact-backed run evidence.
+
+See: [OpenTelemetry System](Observability/OpenTelemetrySystem.md) · [Managed and External Agent Execution Model](Temporal/ManagedAndExternalAgentExecutionModel.md) · [Task Runs API](Tasks/TaskRunsApi.md)
 
 ---
 

--- a/docs/MoonMindArchitecture.md
+++ b/docs/MoonMindArchitecture.md
@@ -52,7 +52,7 @@ The FastAPI-based [API service](../api_service/) is MoonMind's central control p
 
 * **Execution lifecycle APIs** — exposes `/api/executions` for create/list/detail/update/signal/cancel and related Temporal-backed execution operations.
 * **Task-oriented product routes** — serves `/tasks/*` Mission Control routes and compatibility views that present workflow executions as tasks.
-* **Observability APIs** — exposes `/api/task-runs/*` for managed-run log, diagnostics, and live-follow surfaces.
+* **Observability APIs** — exposes `/api/task-runs/*` for managed-run log, diagnostics, and live-follow surfaces. The underlying `task_runs` router is mounted under the app-level `/api` prefix, so the public path family remains `/api/task-runs/*`.
 * **Artifact APIs** — manages artifact metadata, presigned upload/download grants, and artifact-to-execution linkage.
 * **Task templates and presets** — serves the task step template catalog used by Mission Control submission flows.
 * **Agent skill resolution** — accepts task/step skill-selection intent and resolves it into immutable `ResolvedSkillSet` snapshot refs for execution.

--- a/docs/Tasks/TaskRunsApi.md
+++ b/docs/Tasks/TaskRunsApi.md
@@ -2,55 +2,53 @@
 
 Status: Active  
 Owners: MoonMind Engineering  
-Last Updated: 2026-04-01
+Last Updated: 2026-04-02
 
 ## 1. Purpose
 
-Define the REST API surface for creating, monitoring, and observing MoonMind task runs. The API acts as a translation layer between the Mission Control UI and the Temporal Workflow engine: incoming HTTP requests are normalized into the canonical task payload and dispatched as `MoonMind.Run` Temporal Workflow Executions.
+Define the REST API surfaces used to create, monitor, and observe MoonMind task runs in the Temporal-first architecture.
+
+MoonMind now splits this responsibility across:
+
+- **`/api/executions`** for Temporal-backed execution lifecycle operations
+- **`/api/task-runs`** for managed-run observability (logs, diagnostics, live follow)
+
+Mission Control still presents these executions as **tasks** in the product UI, but the active lifecycle API is execution-oriented.
 
 ## 2. API Surface
 
-Task runs are served by two routers:
+Task runs are served by two active router families:
 
-- **`/api/queue/jobs`** — Job lifecycle (create, list, detail, update, cancel, resubmit, events, artifacts, attachments).
-- **`/api/task-runs`** — Artifact-backed observability endpoints for Temporal-backed task runs.
+- **`/api/executions`** — Execution lifecycle for Temporal-backed work.
+- **`/api/task-runs`** — Artifact-backed managed-run observability.
 
-### 2.1 Job Lifecycle (`/api/queue/jobs`)
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/queue/jobs` | Create a new task run from canonical payload |
-| `POST` | `/api/queue/jobs/with-attachments` | Create with file attachments (multipart) |
-| `GET`  | `/api/queue/jobs` | List task runs (filterable by `type`, `limit`) |
-| `GET`  | `/api/queue/jobs/{jobId}` | Get task run detail |
-| `PUT`  | `/api/queue/jobs/{jobId}` | Update a queued task run before execution |
-| `POST` | `/api/queue/jobs/{jobId}/resubmit` | Clone a terminal task run into a new queued run |
-| `POST` | `/api/queue/jobs/{jobId}/cancel` | Cancel a running or queued task run |
-| `GET`  | `/api/queue/jobs/{jobId}/events` | List run events |
-| `GET`  | `/api/queue/jobs/{jobId}/events/stream` | SSE stream of run events |
-| `GET`  | `/api/queue/jobs/{jobId}/artifacts` | List run artifacts |
-| `GET`  | `/api/queue/jobs/{jobId}/artifacts/{artifactId}/download` | Download an artifact |
-| `GET`  | `/api/queue/jobs/{jobId}/attachments` | List run attachments |
-| `GET`  | `/api/queue/jobs/{jobId}/attachments/{attachmentId}/download` | Download an attachment |
-| `GET`  | `/api/queue/jobs/{jobId}/finish-summary` | Get completion summary |
-
-### 2.2 Worker Callbacks (`/api/queue`)
-
-These endpoints are authenticated with worker tokens and used by agent workers during execution.
+### 2.1 Execution Lifecycle (`/api/executions`)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/queue/jobs/claim` | Worker claims a queued job |
-| `POST` | `/api/queue/jobs/{jobId}/heartbeat` | Worker heartbeat while executing |
-| `POST` | `/api/queue/jobs/{jobId}/runtime-state` | Worker reports runtime state |
-| `POST` | `/api/queue/jobs/{jobId}/complete` | Worker marks job succeeded |
-| `POST` | `/api/queue/jobs/{jobId}/fail` | Worker marks job failed |
-| `POST` | `/api/queue/jobs/{jobId}/cancel/ack` | Worker acknowledges cancellation |
-| `POST` | `/api/queue/jobs/{jobId}/recover` | Worker requests recovery |
+| `POST` | `/api/executions` | Create/start a Temporal-backed execution |
+| `GET`  | `/api/executions` | List executions visible to the caller |
+| `GET`  | `/api/executions/{workflowId}` | Get execution detail |
+| `POST` | `/api/executions/{workflowId}/update` | Apply a workflow update such as input edits or rerun requests |
+| `POST` | `/api/executions/{workflowId}/signal` | Send an asynchronous workflow signal such as pause, resume, or approve |
+| `POST` | `/api/executions/{workflowId}/cancel` | Cancel or terminate an execution |
 
-### 2.3 Observability (`/api/task-runs`)
+### 2.2 Auxiliary Execution Routes (`/api/executions`)
 
-These endpoints expose read-only observability for Temporal-backed runs. The legacy `/live-session*` family used by terminal-session experiments is not part of the active Phase 6 API surface.
+These routes extend the main lifecycle surface for specific execution types:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/executions/{workflowId}/manifest-status` | Fetch manifest-run status summary |
+| `GET` | `/api/executions/{workflowId}/manifest-nodes` | Page manifest node state |
+| `POST` | `/api/executions/{workflowId}/integration` | Register/update integration monitoring state |
+| `POST` | `/api/executions/{workflowId}/integration/poll` | Record integration poll results |
+| `POST` | `/api/executions/{workflowId}/reschedule` | Change the scheduled time of a scheduled execution |
+| `POST` | `/api/executions/{workflowId}/rerun` | Create a fresh execution with the original parameters |
+
+### 2.3 Managed-Run Observability (`/api/task-runs`)
+
+These endpoints expose artifact-backed observability for managed runs. The legacy `/live-session*` family is not part of the active API.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -61,7 +59,22 @@ These endpoints expose read-only observability for Temporal-backed runs. The leg
 | `GET` | `/api/task-runs/{taskRunId}/logs/merged` | Read the merged log view or synthesized fallback |
 | `GET` | `/api/task-runs/{taskRunId}/diagnostics` | Read the diagnostics artifact |
 
-### 2.4 Observability Behavior
+## 3. Identity Model
+
+MoonMind currently uses three related identifiers around task runs:
+
+- **`workflowId`** — the canonical durable execution identifier for `/api/executions`
+- **`taskId`** — the task-oriented product identifier; for Temporal-backed work, `taskId == workflowId`
+- **`taskRunId`** — the managed-run observability record identifier used by `/api/task-runs`
+
+The normal control-plane flow is:
+
+1. Create or list work through `/api/executions`
+2. Use `workflowId` for lifecycle actions and detail fetches
+3. Read `taskRunId` from execution detail when managed-run observability is available
+4. Use `/api/task-runs/{taskRunId}` for logs, diagnostics, and live follow
+
+## 4. Observability Behavior
 
 These routes are artifact-first:
 
@@ -70,73 +83,13 @@ These routes are artifact-first:
 - `logs/stdout`, `logs/stderr`, and `logs/merged` remain available for historical and terminal runs.
 - `diagnostics` exposes the persisted supervision payload for postmortem inspection.
 
-Legacy live-session and terminal-handoff routes should be treated as deprecated migration references only. See [Live Logs](../ManagedAgents/LiveLogs.md) and [Live Task Management](../Temporal/LiveTaskManagement.md).
+Full log bodies and diagnostics come from managed-run artifact storage and spool files, not from workflow history or raw Temporal event history.
 
-## 3. Canonical Task Payload
+## 5. Request Model Posture
 
-Tasks submitted via `POST /api/queue/jobs` are normalized into the canonical payload shape defined in `moonmind.workflows.agent_queue.task_contract`. The contract supports three ingest formats (`task`, `codex_exec`, `codex_skill`), all of which are normalized into the same canonical structure.
+`POST /api/executions` is the active create surface. It accepts the execution-oriented request model and, during migration, may also normalize task-shaped compatibility payloads into the same Temporal-backed execution contract.
 
-```json
-{
-  "repository": "owner/repo",
-  "requiredCapabilities": ["git", "codex"],
-  "targetRuntime": "codex",
-  "auth": {
-    "repoAuthRef": null,
-    "publishAuthRef": null
-  },
-  "task": {
-    "instructions": "Implement feature and run tests",
-    "skill": {
-      "id": "auto",
-      "args": {}
-    },
-    "runtime": {
-      "mode": "codex",
-      "model": null,
-      "effort": null
-    },
-    "git": {
-      "startingBranch": null,
-      "targetBranch": null
-    },
-    "publish": {
-      "mode": "pr",
-      "prBaseBranch": null,
-      "commitMessage": null,
-      "prTitle": null,
-      "prBody": null
-    },
-    "proposeTasks": true,
-    "steps": [],
-    "container": null,
-    "proposalPolicy": null
-  }
-}
-```
-
-### 3.1 Key Payload Sections
-
-- **`task.runtime`** — Selects the agent runtime (`codex`, `gemini`, `claude`, `jules`) and optional model/effort overrides.
-- **`task.skill`** — Selects a skill from the skill catalog. `"auto"` lets the system pick based on instructions.
-- **`task.publish`** — Controls how results are published (`pr`, `branch`, `none`). Certain skills force specific publish modes.
-- **`task.steps`** — Optional ordered list of execution steps, each with its own instructions and optional skill override. Steps receive sequential IDs (`step-1`, `step-2`, …).
-- **`task.container`** — Optional custom container execution with `image`, `command`, `env`, and `timeout_seconds`. Mutually exclusive with `task.steps`.
-- **`task.proposalPolicy`** — Controls task proposal emission targets (`project`, `moonmind`) and per-target limits.
-- **`task.proposeTasks`** — Whether the worker should generate follow-up task proposals.
-- **`requiredCapabilities`** — Auto-populated from runtime, publish mode, skill requirements, and container settings.
-
-### 3.2 Legacy Format Support
-
-The contract includes backward-compatible normalization for:
-
-- **`codex_exec`** jobs — Flat payloads with top-level `instruction`, `publish`, and `codex` blocks.
-- **`codex_skill`** jobs — Payloads with `skillId` and `inputs` blocks from the older skill execution API.
-- **Top-level `targetRuntime`** — Lifted into `task.runtime.mode` during normalization.
-
-## 4. Temporal Dispatch
-
-Once the payload is normalized, the system creates a `MoonMind.Run` Temporal Workflow Execution. Activity execution is dispatched across specialized Temporal Task Queues grouped by worker fleet:
+Execution requests ultimately dispatch into `MoonMind.Run` or another allowed workflow type, then fan out across Temporal worker fleets grouped by capability and security boundary:
 
 | Fleet | Task Queue | Capabilities | Purpose |
 |-------|-----------|--------------|---------|
@@ -149,10 +102,16 @@ Once the payload is normalized, the system creates a `MoonMind.Run` Temporal Wor
 
 The `activity_catalog.py` module defines the full routing contract including per-activity timeout and retry policies.
 
-## 5. Related Documentation
+## 6. Legacy Queue Posture
 
+The legacy `/api/queue/jobs` lifecycle routes and `/api/queue` worker callback routes are historical migration references only. They are not the active task-run lifecycle API, and the execution router explicitly rejects falling back to the old queue substrate when Temporal submission is disabled.
+
+## 7. Related Documentation
+
+- [../Api/ExecutionsApiContract.md](../Api/ExecutionsApiContract.md) — Direct execution lifecycle contract
 - [TaskArchitecture.md](TaskArchitecture.md) — Overall task system design
-- [TasksStepSystem.md](TasksStepSystem.md) — Multi-step task execution
+- [../UI/MissionControlArchitecture.md](../UI/MissionControlArchitecture.md) — Task-oriented UI over execution APIs
 - [TaskProposalSystem.md](TaskProposalSystem.md) — Task proposal generation
 - [TaskCancellation.md](TaskCancellation.md) — Cancellation flow
-- [TemporalArchitecture.md](../Temporal/TemporalArchitecture.md) — Temporal infrastructure
+- [../ManagedAgents/LiveLogs.md](../ManagedAgents/LiveLogs.md) — Managed-run log and observability design
+- [../Temporal/TemporalArchitecture.md](../Temporal/TemporalArchitecture.md) — Temporal infrastructure

--- a/docs/Tasks/TaskRunsApi.md
+++ b/docs/Tasks/TaskRunsApi.md
@@ -15,6 +15,8 @@ MoonMind now splits this responsibility across:
 
 Mission Control still presents these executions as **tasks** in the product UI, but the active lifecycle API is execution-oriented.
 
+The public `/api/task-runs` path is intentional: the `task_runs` router itself uses `prefix="/task-runs"` and FastAPI mounts it under the app-level `/api` prefix.
+
 ## 2. API Surface
 
 Task runs are served by two active router families:
@@ -29,7 +31,7 @@ Task runs are served by two active router families:
 | `POST` | `/api/executions` | Create/start a Temporal-backed execution |
 | `GET`  | `/api/executions` | List executions visible to the caller |
 | `GET`  | `/api/executions/{workflowId}` | Get execution detail |
-| `POST` | `/api/executions/{workflowId}/update` | Apply a workflow update such as input edits or rerun requests |
+| `POST` | `/api/executions/{workflowId}/update` | Apply an in-place workflow update such as `UpdateInputs`, `SetTitle`, or `RequestRerun` (Continue-As-New on the same logical execution) |
 | `POST` | `/api/executions/{workflowId}/signal` | Send an asynchronous workflow signal such as pause, resume, or approve |
 | `POST` | `/api/executions/{workflowId}/cancel` | Cancel or terminate an execution |
 
@@ -44,7 +46,7 @@ These routes extend the main lifecycle surface for specific execution types:
 | `POST` | `/api/executions/{workflowId}/integration` | Register/update integration monitoring state |
 | `POST` | `/api/executions/{workflowId}/integration/poll` | Record integration poll results |
 | `POST` | `/api/executions/{workflowId}/reschedule` | Change the scheduled time of a scheduled execution |
-| `POST` | `/api/executions/{workflowId}/rerun` | Create a fresh execution with the original parameters |
+| `POST` | `/api/executions/{workflowId}/rerun` | Create a fresh execution with the original parameters and a new `workflowId` |
 
 ### 2.3 Managed-Run Observability (`/api/task-runs`)
 

--- a/docs/Tools/JiraIntegration.md
+++ b/docs/Tools/JiraIntegration.md
@@ -1,0 +1,721 @@
+# Jira Integration for Managed Agents
+
+Status: Recommended design
+Owners: MoonMind Engineering
+Last Updated: 2026-04-02
+
+## Purpose
+
+This document describes the recommended way to let MoonMind managed agents work with Jira Cloud without exposing the raw `ATLASSIAN_API_KEY` value inside the agent runtime.
+
+The design covers:
+
+- how to install the necessary runtime dependencies in the worker image
+- how to store and resolve Jira credentials securely
+- how to expose Jira operations as MoonMind tools
+- how to support issue creation, sub-task creation, edits, and workflow transitions
+- how to keep credentials out of workflow payloads, logs, artifacts, and general-purpose agent shells
+
+## Recommendation
+
+**Do not inject `ATLASSIAN_API_KEY` into the managed agent container as a normal environment variable.**
+
+Instead:
+
+1. Store Jira credentials as a SecretRef-backed secret.
+2. Resolve the secret only inside a trusted MoonMind-side Jira tool handler.
+3. Let the agent call a MoonMind Jira tool such as `jira.create_issue` or `jira.transition_issue`.
+4. Have the trusted tool handler call Jira Cloud REST APIs on the agent's behalf.
+
+This gives the agent the *capability* to work with Jira without giving it direct possession of the raw credential.
+
+## Why this is the right fit for MoonMind
+
+MoonMind is already moving toward a **Provider Profiles + SecretRefs + launch-time materialization** model rather than the older `auth_mode` / `api_key_ref` contract. The recent direction is:
+
+- Provider Profiles are the durable contract for managed runtime credentials.
+- SecretRefs are the mechanism for binding secrets.
+- Secret resolution should happen only at controlled execution boundaries.
+- Raw secrets should not appear in workflow payloads, profile rows, artifacts, logs, or test fixtures.
+- Generated files containing secrets should be ephemeral and not durably published.
+
+For Jira, the safest controlled boundary is **the Jira tool invocation itself**, not the general agent runtime.
+
+That means the recommended pattern is:
+
+- keep Jira credentials in the MoonMind secrets system
+- resolve them in a trusted backend or worker process only when a Jira tool is called
+- send the HTTPS request to Jira from that trusted code path
+- return a sanitized result to the agent
+
+This is better than placing the key in the agent environment, because managed agents often have bash, file-system, and code-execution capabilities.
+
+## Authentication modes
+
+Support two modes.
+
+### 1. Preferred production mode: service account + scoped API token
+
+Use an Atlassian **service account** and store its token in `ATLASSIAN_API_KEY`.
+
+Recommended supporting values:
+
+- `ATLASSIAN_AUTH_MODE=service_account_scoped`
+- `ATLASSIAN_API_KEY=<service-account-token>`
+- `ATLASSIAN_SERVICE_ACCOUNT_EMAIL=<service-account-email>`
+- `ATLASSIAN_CLOUD_ID=<atlassian-cloud-id>`
+
+Use the Platform API Gateway base URL:
+
+```text
+https://api.atlassian.com/ex/jira/${ATLASSIAN_CLOUD_ID}/rest/api/3
+```
+
+Why this mode is preferred:
+
+- separate non-human identity
+- explicit scopes
+- cleaner revocation and rotation
+- easier auditing
+- easier least-privilege setup
+
+Recommended scopes for standard issue work:
+
+- `read:jira-work`
+- `write:jira-work`
+
+Only add broader scopes such as `manage:jira-project` if the tool truly needs project-administration capabilities.
+
+### 2. Compatibility / local-dev mode: account email + API token
+
+If you already have an existing Atlassian API token and email address, support a compatibility mode.
+
+Suggested values:
+
+- `ATLASSIAN_AUTH_MODE=basic`
+- `ATLASSIAN_API_KEY=<api-token>`
+- `ATLASSIAN_EMAIL=<atlassian-account-email>`
+- `ATLASSIAN_SITE_URL=https://your-domain.atlassian.net`
+
+Use the site-local Jira base URL:
+
+```text
+${ATLASSIAN_SITE_URL}/rest/api/3
+```
+
+This mode is useful for simple local development and existing bot-style automation, but production should prefer a service account and scoped token when possible.
+
+## Security model
+
+### Never expose the raw secret to the managed agent shell
+
+The managed agent should **not** receive:
+
+- `ATLASSIAN_API_KEY`
+- a mounted `.env` file containing the Jira token
+- a config file containing the Jira token
+- a serialized workflow payload containing the Jira token
+
+The agent should only receive a tool capability such as:
+
+- `jira.create_issue`
+- `jira.create_subtask`
+- `jira.edit_issue`
+- `jira.get_transitions`
+- `jira.transition_issue`
+- `jira.add_comment`
+- `jira.search_issues`
+
+### Resolve secrets just in time
+
+When a Jira tool call is made:
+
+1. validate the tool input
+2. resolve SecretRefs into plaintext credentials in memory
+3. construct the Jira client
+4. make the request
+5. discard the plaintext secret
+6. return a sanitized result
+
+### Never persist plaintext secrets
+
+The Jira tool path must never write plaintext credentials into:
+
+- Temporal workflow payloads
+- run metadata
+- Provider Profile rows
+- artifacts
+- diagnostics
+- structured logs
+- exception text returned to the model
+
+### Redaction
+
+At minimum, redact:
+
+- `Authorization`
+- `ATLASSIAN_API_KEY`
+- any `email:token` basic-auth material
+- request dumps that accidentally include headers
+- serialized SecretRef resolution results
+
+## Dockerfile changes
+
+The Jira integration does **not** require a Jira CLI.
+
+The recommended implementation is a small Python client that calls Jira's REST API directly from trusted MoonMind code.
+
+### System packages
+
+Install HTTPS trust roots if they are not already present.
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+ && rm -rf /var/lib/apt/lists/*
+```
+
+Notes:
+
+- `ca-certificates` is required for reliable TLS to Atlassian Cloud.
+- `curl` is optional but useful for manual health checks and debugging.
+- Do **not** rely on `curl` as the agent-facing integration mechanism.
+
+### Python dependencies
+
+Prefer adding dependencies to the project's normal dependency file, then rebuilding the image.
+
+A minimal dependency set is:
+
+```dockerfile
+RUN pip install --no-cache-dir \
+    httpx \
+    tenacity
+```
+
+Recommended usage:
+
+- `httpx` for async HTTPS calls to Jira
+- `tenacity` for bounded retries on `429` and transient `5xx` responses
+
+### Why not install Forge MCP or a Jira CLI?
+
+Do **not** use the Forge MCP Server as the runtime mutation tool for this feature.
+
+The Forge MCP Server is intended to expose Atlassian and Forge **knowledge/context** to coding agents and IDEs. It is not the right primitive for a MoonMind-managed backend integration that needs to create or edit Jira issues from a trusted tool path.
+
+For MoonMind, the correct primitive is a **trusted server-side Jira tool** implemented in MoonMind itself.
+
+## Suggested code layout
+
+One clean layout would be:
+
+```text
+moonmind/
+  integrations/
+    jira/
+      __init__.py
+      auth.py
+      client.py
+      models.py
+      tool.py
+      adf.py
+      errors.py
+  workflows/
+    temporal/
+      activities/
+        jira_activities.py
+```
+
+Suggested responsibilities:
+
+- `auth.py` — convert resolved SecretRefs into auth headers and base URLs
+- `client.py` — low-level REST wrapper
+- `models.py` — request / response schemas
+- `tool.py` — tool dispatcher and policy checks
+- `adf.py` — convert plain text descriptions/comments into Atlassian Document Format when needed
+- `jira_activities.py` — optional Temporal activity wrapper if Jira calls should run through activity boundaries
+
+## Secret configuration
+
+### Local development
+
+For local development, it is acceptable to point SecretRefs at environment variables on the trusted API or worker process.
+
+#### Compatibility/basic-auth mode
+
+```bash
+ATLASSIAN_AUTH_MODE=basic
+ATLASSIAN_SITE_URL=https://your-domain.atlassian.net
+ATLASSIAN_EMAIL=bot@example.com
+ATLASSIAN_API_KEY=your-api-token
+```
+
+#### Preferred/service-account mode
+
+```bash
+ATLASSIAN_AUTH_MODE=service_account_scoped
+ATLASSIAN_CLOUD_ID=11111111-2222-3333-4444-555555555555
+ATLASSIAN_SERVICE_ACCOUNT_EMAIL=bot@serviceaccount.atlassian.com
+ATLASSIAN_API_KEY=your-service-account-token
+```
+
+### Production
+
+For production, store credentials in MoonMind's managed secrets system and bind them by SecretRef.
+
+Illustrative pseudo-configuration:
+
+```yaml
+jira_credentials:
+  auth_mode:
+    source: db_encrypted
+    secret_id: jira-auth-mode
+  api_key:
+    source: db_encrypted
+    secret_id: jira-api-key
+  email:
+    source: db_encrypted
+    secret_id: jira-email
+  cloud_id:
+    source: db_encrypted
+    secret_id: jira-cloud-id
+  site_url:
+    source: db_encrypted
+    secret_id: jira-site-url
+```
+
+Important:
+
+- this is **not** intended to be materialized into the agent's general environment
+- resolve these values inside the Jira tool handler only
+- if Mission Control surfaces this binding, show only presence/health, never the secret value
+
+## Tool surface
+
+Expose a narrow, explicit set of actions rather than a generic "execute arbitrary Jira HTTP request" tool.
+
+Recommended actions:
+
+- `jira.create_issue`
+- `jira.create_subtask`
+- `jira.edit_issue`
+- `jira.get_issue`
+- `jira.search_issues`
+- `jira.get_transitions`
+- `jira.transition_issue`
+- `jira.add_comment`
+
+Avoid a catch-all raw-request tool unless it is restricted to operators.
+
+## Jira client behavior
+
+### Base URL selection
+
+```python
+if auth_mode == "service_account_scoped":
+    base_url = f"https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3"
+else:
+    base_url = f"{site_url.rstrip('/')}/rest/api/3"
+```
+
+### Authorization header selection
+
+Service-account scoped token mode:
+
+```python
+headers = {
+    "Authorization": f"Bearer {api_key}",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+```
+
+Compatibility/basic-auth mode:
+
+```python
+basic = base64.b64encode(f"{email}:{api_key}".encode("utf-8")).decode("ascii")
+headers = {
+    "Authorization": f"Basic {basic}",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+}
+```
+
+### Timeouts and retries
+
+Recommended defaults:
+
+- connect timeout: 10 seconds
+- read timeout: 30 seconds
+- max retry attempts: 3
+- retry on: `429`, `502`, `503`, `504`
+- respect `Retry-After` when present
+
+### Logging
+
+Log:
+
+- action name
+- Jira issue key/id where available
+- project key where available
+- HTTP status code
+- Atlassian request ID headers if useful
+- retry count
+
+Do **not** log:
+
+- authorization headers
+- resolved secrets
+- raw request dumps containing credentials
+
+## Operation details
+
+### 1. Create issue
+
+Tool name:
+
+```text
+jira.create_issue
+```
+
+Suggested input:
+
+```json
+{
+  "projectKey": "ENG",
+  "issueTypeId": "10001",
+  "summary": "Add Jira integration",
+  "description": "Implement server-side Jira tool",
+  "fields": {
+    "priority": { "name": "High" }
+  }
+}
+```
+
+Implementation notes:
+
+- use `POST /issue`
+- support either a ready-made `fields` payload or a higher-level simplified input that MoonMind converts to Jira JSON
+- if a plain-text description is provided, convert it to Atlassian Document Format for multiline fields
+- use create-metadata endpoints to discover valid issue types and required fields before submission when needed
+
+### 2. Create sub-task
+
+Tool name:
+
+```text
+jira.create_subtask
+```
+
+Suggested input:
+
+```json
+{
+  "projectKey": "ENG",
+  "parentIssueKey": "ENG-123",
+  "issueTypeId": "10002",
+  "summary": "Wire SecretRef resolution",
+  "description": "Resolve Jira token at tool execution time"
+}
+```
+
+Implementation notes:
+
+- also use `POST /issue`
+- ensure `issueTypeId` refers to a sub-task issue type
+- ensure the request includes the parent issue key or ID
+
+### 3. Edit issue
+
+Tool name:
+
+```text
+jira.edit_issue
+```
+
+Suggested input:
+
+```json
+{
+  "issueKey": "ENG-123",
+  "fields": {
+    "summary": "Finalize Jira integration design"
+  },
+  "update": {}
+}
+```
+
+Implementation notes:
+
+- use `PUT /issue/{issueIdOrKey}`
+- **do not** attempt transitions here
+- retrieve edit metadata when field mutability is unclear
+
+### 4. Get transitions
+
+Tool name:
+
+```text
+jira.get_transitions
+```
+
+Suggested input:
+
+```json
+{
+  "issueKey": "ENG-123",
+  "expandFields": true
+}
+```
+
+Implementation notes:
+
+- use `GET /issue/{issueIdOrKey}/transitions`
+- if `expandFields` is true, request `expand=transitions.fields`
+- return transition IDs and names so the model can choose a valid transition
+
+### 5. Transition issue
+
+Tool name:
+
+```text
+jira.transition_issue
+```
+
+Suggested input:
+
+```json
+{
+  "issueKey": "ENG-123",
+  "transitionId": "31",
+  "fields": {
+    "resolution": { "name": "Done" }
+  }
+}
+```
+
+Implementation notes:
+
+- use `POST /issue/{issueIdOrKey}/transitions`
+- fetch available transitions first unless a validated transition ID is already supplied
+- if the transition screen has required fields, include them in `fields` or `update`
+
+### 6. Add comment
+
+Tool name:
+
+```text
+jira.add_comment
+```
+
+Suggested input:
+
+```json
+{
+  "issueKey": "ENG-123",
+  "body": "Implementation PR is ready for review"
+}
+```
+
+Implementation notes:
+
+- use the Jira comment endpoint
+- convert multiline text to Atlassian Document Format when needed
+
+## Metadata helpers
+
+The tool layer should expose or internally use metadata helpers so the agent does not guess issue types or required fields.
+
+Recommended helpers:
+
+- `jira.list_create_issue_types(projectKey)`
+- `jira.get_create_fields(projectKey, issueTypeId)`
+- `jira.get_edit_metadata(issueKey)`
+- `jira.get_transitions(issueKey)`
+
+Important:
+
+- do **not** build new logic on the deprecated `GET /issue/createmeta` endpoint
+- prefer the newer project-specific issue-type and field-metadata endpoints
+
+## Input validation rules
+
+The Jira tool wrapper should validate all inputs before making an API call.
+
+Examples:
+
+- `projectKey` must match an allowed project if MoonMind enforces project allowlists
+- `issueKey` must be non-empty and match a simple Jira key pattern
+- `transitionId` must be a string or integer-like value
+- `summary` must be present for issue creation
+- `parentIssueKey` must be present for sub-task creation
+- reject unknown top-level keys if strict mode is enabled
+
+## Example internal tool contract
+
+Illustrative shape:
+
+```json
+{
+  "tool": "jira.create_issue",
+  "parameters": {
+    "projectKey": "ENG",
+    "issueTypeId": "10001",
+    "summary": "Add Jira integration",
+    "description": "Implement MoonMind-side Jira tool",
+    "fields": {
+      "labels": ["automation", "moonmind"]
+    }
+  }
+}
+```
+
+The model should never send raw credentials. The backend already knows which Jira credential binding to use.
+
+## Example execution flow
+
+1. The agent decides it needs to create or modify a Jira issue.
+2. It invokes a Jira tool by name with structured parameters.
+3. MoonMind validates the call against the tool schema and policy.
+4. The trusted Jira tool handler resolves the bound SecretRefs.
+5. The handler constructs the correct base URL and auth header.
+6. The handler calls Jira REST.
+7. The handler redacts sensitive data from logs and returns a sanitized result.
+8. The managed agent sees only the result, never the raw secret.
+
+## Permissions and policy
+
+Use least privilege.
+
+Recommended policy defaults:
+
+- service account limited to the relevant Jira projects
+- minimal required scopes only
+- no project-admin scopes unless truly needed
+- optional allowlist of project keys inside MoonMind
+- optional allowlist of tool actions per agent/runtime
+
+Potential MoonMind-side policy knobs:
+
+```yaml
+jira_policy:
+  allowed_projects:
+    - ENG
+    - OPS
+  allowed_actions:
+    - create_issue
+    - create_subtask
+    - edit_issue
+    - get_transitions
+    - transition_issue
+    - add_comment
+  require_explicit_transition_lookup: true
+  deny_raw_http_mode: true
+```
+
+## Error handling
+
+Map Jira failures into clean, structured MoonMind errors.
+
+Examples:
+
+- `401` -> credential invalid / expired / wrong auth mode
+- `403` -> valid credential but missing permission or scope
+- `404` -> issue or project not found, or wrong Cloud ID / endpoint format
+- `429` -> rate limited; retry with backoff
+- `400` / `422` -> field validation or workflow/transition mismatch
+
+Avoid returning giant raw HTML or raw exception traces to the model.
+
+## Rate limiting
+
+The client should:
+
+- retry boundedly on `429`
+- honor `Retry-After`
+- surface a structured "rate_limited" result to orchestration when retries are exhausted
+- optionally mark the associated profile / tool credential as cooling down if MoonMind later unifies tool credentials with Provider Profile cooldown semantics
+
+## Operational notes
+
+### Token rotation
+
+Because Atlassian tokens now expire by default, track expiration metadata in MoonMind and rotate before expiry.
+
+Recommended operational behavior:
+
+- store token expiry alongside secret metadata when known
+- warn operators before expiration
+- allow replacing the secret without changing the tool contract
+- ensure new tool invocations use the new secret without mutating historical durable payloads
+
+### Health check
+
+Add a lightweight verification path such as:
+
+```text
+jira.verify_connection
+```
+
+This should:
+
+- resolve credentials
+- call a small safe endpoint such as project or user lookup
+- verify both auth and permissions
+- return a sanitized success/failure result
+
+## Testing checklist
+
+### Unit tests
+
+- auth header construction for both auth modes
+- base URL selection
+- SecretRef resolution wiring
+- redaction of secrets from logs and exceptions
+- plain-text-to-ADF conversion
+- input validation for each tool action
+
+### Integration tests
+
+- create issue
+- create sub-task
+- edit issue
+- get transitions
+- transition issue
+- add comment
+- `429` retry behavior
+- permission-denied behavior
+
+### Security regression tests
+
+- secret never appears in workflow payloads
+- secret never appears in run metadata
+- secret never appears in artifacts
+- secret never appears in structured logs
+- secret never appears in agent-visible stderr/stdout
+
+## What not to do
+
+Do **not**:
+
+- inject `ATLASSIAN_API_KEY` into the agent runtime's general environment
+- write a `.jira` or `.env` file with the token into the workspace
+- expose a raw "make arbitrary Jira HTTP call" tool to normal agents
+- use the deprecated `GET /issue/createmeta` endpoint for new work
+- try to change issue status through `Edit issue`
+- assume a transition exists by status name without checking the available transitions
+- rely on Forge MCP as the mutation path for managed agents
+
+## Bottom line
+
+The best MoonMind design is:
+
+- **SecretRef-backed Jira credentials**
+- **trusted MoonMind-side Jira tool execution**
+- **no raw Jira token in the managed agent shell**
+- **strongly typed Jira actions instead of arbitrary HTTP**
+- **bounded retries, redaction, and least-privilege credentials**
+
+This approach lines up with MoonMind's current move toward Provider Profiles, launch-only secret resolution, and strict avoidance of raw secrets in durable contracts.

--- a/docs/Tools/JiraIntegration.md
+++ b/docs/Tools/JiraIntegration.md
@@ -265,25 +265,15 @@ ATLASSIAN_API_KEY=your-service-account-token
 
 For production, store credentials in MoonMind's managed secrets system and bind them by SecretRef.
 
-Illustrative pseudo-configuration:
+Example using actual SecretRef syntax:
 
 ```yaml
 jira_credentials:
-  auth_mode:
-    source: db_encrypted
-    secret_id: jira-auth-mode
-  api_key:
-    source: db_encrypted
-    secret_id: jira-api-key
-  email:
-    source: db_encrypted
-    secret_id: jira-email
-  cloud_id:
-    source: db_encrypted
-    secret_id: jira-cloud-id
-  site_url:
-    source: db_encrypted
-    secret_id: jira-site-url
+  auth_mode: db://jira-auth-mode
+  api_key: db://jira-api-key
+  email: db://jira-email
+  cloud_id: db://jira-cloud-id
+  site_url: db://jira-site-url
 ```
 
 Important:
@@ -322,7 +312,7 @@ else:
 
 ### Authorization header selection
 
-Service-account scoped token mode:
+Service-account scoped token mode against `api.atlassian.com`:
 
 ```python
 headers = {
@@ -331,6 +321,8 @@ headers = {
     "Content-Type": "application/json",
 }
 ```
+
+If an HTTP client or shared auth helper prefers `email:token` formatting, Atlassian's service-account token docs also allow Basic auth against the same gateway using the service-account email plus token. MoonMind should pick one mode per client implementation and document it clearly rather than mixing both on one request path.
 
 Compatibility/basic-auth mode:
 

--- a/tools/auth-claude-volume.sh
+++ b/tools/auth-claude-volume.sh
@@ -157,36 +157,84 @@ cmd_check() {
 }
 
 # ---------------------------------------------------------------------------
-# --register: register the volume in the MoonMind auth profile API
+# --register: register the volume in the MoonMind provider profile API
 # ---------------------------------------------------------------------------
 cmd_register() {
   local API_URL="${MOONMIND_API_URL:-http://localhost:5000}"
   local PROFILE_ID="${CLAUDE_PROFILE_ID:-claude_anthropic}"
+  local CREATE_URL="${API_URL}/api/v1/provider-profiles"
+  local UPDATE_URL="${API_URL}/api/v1/provider-profiles/${PROFILE_ID}"
 
-  echo "Registering auth profile '${PROFILE_ID}' via ${API_URL}..."
+  echo "Registering provider profile '${PROFILE_ID}' via ${API_URL}..."
+
+  local create_payload
+  create_payload=$(cat <<EOF
+{
+  "profile_id": "${PROFILE_ID}",
+  "runtime_id": "claude_code",
+  "provider_id": "anthropic",
+  "provider_label": "Anthropic",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${CLAUDE_VOLUME_PATH}",
+  "account_label": "Claude OAuth Profile (${PROFILE_ID})",
+  "clear_env_keys": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
+
+  local update_payload
+  update_payload=$(cat <<EOF
+{
+  "provider_id": "anthropic",
+  "provider_label": "Anthropic",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${CLAUDE_VOLUME_PATH}",
+  "account_label": "Claude OAuth Profile (${PROFILE_ID})",
+  "clear_env_keys": ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
 
   local response
-  response=$(curl -sS -w "\n%{http_code}" -X POST "${API_URL}/api/v1/auth-profiles" \
+  response=$(curl -sS -w "\n%{http_code}" -X POST "${CREATE_URL}" \
     -H "Content-Type: application/json" \
-    -d '{
-      "profile_id": "'"${PROFILE_ID}"'",
-      "runtime_id": "claude_code",
-      "auth_mode": "oauth",
-      "volume_ref": "'"${VOLUME_NAME}"'",
-      "volume_mount_path": "'"${CLAUDE_VOLUME_PATH}"'",
-      "account_label": "Claude OAuth Profile ('"${PROFILE_ID}"')",
-      "max_parallel_runs": 1
-    }')
+    -d "${create_payload}")
 
   local status_code=$(echo "$response" | tail -n1)
   local body=$(echo "$response" | sed '$d')
 
   if [ "$status_code" -eq 201 ]; then
-    echo "Successfully registered profile '${PROFILE_ID}'."
+    echo "Successfully created provider profile '${PROFILE_ID}'."
   elif [ "$status_code" -eq 409 ]; then
-    echo "Profile '${PROFILE_ID}' already exists."
+    echo "Provider profile '${PROFILE_ID}' already exists; updating it..."
+
+    response=$(curl -sS -w "\n%{http_code}" -X PATCH "${UPDATE_URL}" \
+      -H "Content-Type: application/json" \
+      -d "${update_payload}")
+
+    status_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    if [ "$status_code" -eq 200 ]; then
+      echo "Successfully updated provider profile '${PROFILE_ID}'."
+    else
+      echo "Error updating provider profile (HTTP $status_code): $body" >&2
+      exit 1
+    fi
   else
-    echo "Error registering profile (HTTP $status_code): $body" >&2
+    echo "Error registering provider profile (HTTP $status_code): $body" >&2
     exit 1
   fi
 }

--- a/tools/auth-codex-volume.sh
+++ b/tools/auth-codex-volume.sh
@@ -209,36 +209,82 @@ cmd_check() {
 }
 
 # ---------------------------------------------------------------------------
-# --register: register the volume in the MoonMind auth profile API
+# --register: register the volume in the MoonMind provider profile API
 # ---------------------------------------------------------------------------
 cmd_register() {
   local API_URL="${MOONMIND_API_URL:-http://localhost:5000}"
   local PROFILE_ID="${CODEX_PROFILE_ID:-codex_default}"
+  local CREATE_URL="${API_URL}/api/v1/provider-profiles"
+  local UPDATE_URL="${API_URL}/api/v1/provider-profiles/${PROFILE_ID}"
 
-  echo "Registering auth profile '${PROFILE_ID}' via ${API_URL}..."
+  echo "Registering provider profile '${PROFILE_ID}' via ${API_URL}..."
+
+  local create_payload
+  create_payload=$(cat <<EOF
+{
+  "profile_id": "${PROFILE_ID}",
+  "runtime_id": "codex_cli",
+  "provider_id": "openai",
+  "provider_label": "OpenAI",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${CODEX_VOLUME_PATH}",
+  "account_label": "Codex OAuth Profile (${PROFILE_ID})",
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
+
+  local update_payload
+  update_payload=$(cat <<EOF
+{
+  "provider_id": "openai",
+  "provider_label": "OpenAI",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${CODEX_VOLUME_PATH}",
+  "account_label": "Codex OAuth Profile (${PROFILE_ID})",
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
 
   local response
-  response=$(curl -sS -w "\n%{http_code}" -X POST "${API_URL}/api/v1/auth-profiles" \
+  response=$(curl -sS -w "\n%{http_code}" -X POST "${CREATE_URL}" \
     -H "Content-Type: application/json" \
-    -d '{
-      "profile_id": "'"${PROFILE_ID}"'",
-      "runtime_id": "codex_cli",
-      "auth_mode": "oauth",
-      "volume_ref": "'"${VOLUME_NAME}"'",
-      "volume_mount_path": "'"${CODEX_VOLUME_PATH}"'",
-      "account_label": "Codex OAuth Profile ('"${PROFILE_ID}"')",
-      "max_parallel_runs": 1
-    }')
+    -d "${create_payload}")
 
   local status_code=$(echo "$response" | tail -n1)
   local body=$(echo "$response" | sed '$d')
 
   if [ "$status_code" -eq 201 ]; then
-    echo "Successfully registered profile '${PROFILE_ID}'."
+    echo "Successfully created provider profile '${PROFILE_ID}'."
   elif [ "$status_code" -eq 409 ]; then
-    echo "Profile '${PROFILE_ID}' already exists."
+    echo "Provider profile '${PROFILE_ID}' already exists; updating it..."
+
+    response=$(curl -sS -w "\n%{http_code}" -X PATCH "${UPDATE_URL}" \
+      -H "Content-Type: application/json" \
+      -d "${update_payload}")
+
+    status_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    if [ "$status_code" -eq 200 ]; then
+      echo "Successfully updated provider profile '${PROFILE_ID}'."
+    else
+      echo "Error updating provider profile (HTTP $status_code): $body" >&2
+      exit 1
+    fi
   else
-    echo "Error registering profile (HTTP $status_code): $body" >&2
+    echo "Error registering provider profile (HTTP $status_code): $body" >&2
     exit 1
   fi
 }

--- a/tools/auth-gemini-volume.sh
+++ b/tools/auth-gemini-volume.sh
@@ -165,36 +165,82 @@ cmd_check() {
 }
 
 # ---------------------------------------------------------------------------
-# --register: register the volume in the MoonMind auth profile API
+# --register: register the volume in the MoonMind provider profile API
 # ---------------------------------------------------------------------------
 cmd_register() {
   local API_URL="${MOONMIND_API_URL:-http://localhost:5000}"
   local PROFILE_ID="${GEMINI_PROFILE_ID:-gemini_default}"
-  
-  echo "Registering auth profile '${PROFILE_ID}' via ${API_URL}..."
-  
+  local CREATE_URL="${API_URL}/api/v1/provider-profiles"
+  local UPDATE_URL="${API_URL}/api/v1/provider-profiles/${PROFILE_ID}"
+
+  echo "Registering provider profile '${PROFILE_ID}' via ${API_URL}..."
+
+  local create_payload
+  create_payload=$(cat <<EOF
+{
+  "profile_id": "${PROFILE_ID}",
+  "runtime_id": "gemini_cli",
+  "provider_id": "google",
+  "provider_label": "Google",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${GEMINI_VOLUME_PATH}",
+  "account_label": "Gemini OAuth Profile (${PROFILE_ID})",
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
+
+  local update_payload
+  update_payload=$(cat <<EOF
+{
+  "provider_id": "google",
+  "provider_label": "Google",
+  "credential_source": "oauth_volume",
+  "runtime_materialization_mode": "oauth_home",
+  "volume_ref": "${VOLUME_NAME}",
+  "volume_mount_path": "${GEMINI_VOLUME_PATH}",
+  "account_label": "Gemini OAuth Profile (${PROFILE_ID})",
+  "max_parallel_runs": 1,
+  "cooldown_after_429_seconds": 900,
+  "rate_limit_policy": "backoff",
+  "enabled": true
+}
+EOF
+)
+
   local response
-  response=$(curl -sS -w "\n%{http_code}" -X POST "${API_URL}/api/v1/auth-profiles" \
+  response=$(curl -sS -w "\n%{http_code}" -X POST "${CREATE_URL}" \
     -H "Content-Type: application/json" \
-    -d '{
-      "profile_id": "'"${PROFILE_ID}"'",
-      "runtime_id": "gemini_cli",
-      "auth_mode": "oauth",
-      "volume_ref": "'"${VOLUME_NAME}"'",
-      "volume_mount_path": "'"${GEMINI_VOLUME_PATH}"'",
-      "account_label": "Gemini OAuth Profile ('"${PROFILE_ID}"')",
-      "max_parallel_runs": 1
-    }')
-    
+    -d "${create_payload}")
+
   local status_code=$(echo "$response" | tail -n1)
   local body=$(echo "$response" | sed '$d')
-  
+
   if [ "$status_code" -eq 201 ]; then
-    echo "Successfully registered profile '${PROFILE_ID}'."
+    echo "Successfully created provider profile '${PROFILE_ID}'."
   elif [ "$status_code" -eq 409 ]; then
-    echo "Profile '${PROFILE_ID}' already exists."
+    echo "Provider profile '${PROFILE_ID}' already exists; updating it..."
+
+    response=$(curl -sS -w "\n%{http_code}" -X PATCH "${UPDATE_URL}" \
+      -H "Content-Type: application/json" \
+      -d "${update_payload}")
+
+    status_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    if [ "$status_code" -eq 200 ]; then
+      echo "Successfully updated provider profile '${PROFILE_ID}'."
+    else
+      echo "Error updating provider profile (HTTP $status_code): $body" >&2
+      exit 1
+    fi
   else
-    echo "Error registering profile (HTTP $status_code): $body" >&2
+    echo "Error registering provider profile (HTTP $status_code): $body" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary
- refresh the top-level architecture docs to match the current Temporal-first bridge architecture
- update task-run and memory documentation to use `/api/executions`, `/api/task-runs`, current workflow names, and current observability/MCP posture
- add `docs/Tools/JiraIntegration.md` with the recommended managed-agent Jira integration design

## Testing
- not run (docs-only changes)
