### PR TITLE
[codex] Fix managed Codex sandbox defaults

### DIFF
--- a/api_service/config.template.toml
+++ b/api_service/config.template.toml
@@ -1,6 +1,8 @@
 # Managed by MoonMind automation
 approval_policy = "never"
-sandbox_mode = "workspace-write"
+# Managed Codex runs are already container-sandboxed by MoonMind, so avoid
+# nested bubblewrap requirements inside the worker container.
+sandbox_mode = "danger-full-access"
 
 [sandbox_workspace_write]
 network_access = true

--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -97,7 +97,7 @@ class ManagedRuntimeStrategy(ABC):
     @property
     @abstractmethod
     def default_command_template(self) -> list[str]:
-        """e.g. ['gemini'] or ['codex', 'exec', '--full-auto']"""
+        """e.g. ['gemini'] or ['codex', 'exec']"""
 
     @property
     def default_auth_mode(self) -> str:
@@ -309,7 +309,7 @@ Checkboxes reflect **implementation in the repo** as of **2026-03-22**. Run `./t
 - [x] Implement `CodexCliStrategy`
   - [x] `build_command`: former `codex_cli` branch
   - [x] `shape_environment`: Codex home/config keys — **wired via launcher**
-  - [x] `default_command_template`: `["codex", "exec", "--full-auto"]`
+  - [x] `default_command_template`: `["codex", "exec"]`
   - [x] `prepare_workspace`: RAG context injection via `ContextInjectionService`
 - [x] Remove all per-runtime `if/elif` branching from `launcher.py:build_command()`
 - [x] Remove `_runtime_env_keys` hardcoded list from `launcher.py`

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -22,13 +22,24 @@ _CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
 class CodexCliStrategy(ManagedRuntimeStrategy):
     """Strategy for launching ``codex`` CLI runs."""
 
+    _MANAGED_POLICY_FLAGS = frozenset({
+        "--full-auto",
+        "--dangerously-bypass-approvals-and-sandbox",
+    })
+    _MANAGED_POLICY_FLAGS_WITH_VALUE = frozenset({
+        "-a",
+        "--ask-for-approval",
+        "-s",
+        "--sandbox",
+    })
+
     @property
     def runtime_id(self) -> str:
         return "codex_cli"
 
     @property
     def default_command_template(self) -> list[str]:
-        return ["codex", "exec", "--full-auto"]
+        return ["codex", "exec"]
 
     def build_command(
         self,
@@ -43,7 +54,7 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
         Codex CLI uses ``-m`` for model and does NOT support
         ``--effort``.  Prompt is a positional argument.
         """
-        cmd = list(profile.command_template)
+        cmd = self._sanitize_command_template(profile.command_template)
 
         model = self.get_model(profile, request)
         if model:
@@ -53,6 +64,24 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             cmd.append(request.instruction_ref)
 
         return cmd
+
+    @classmethod
+    def _sanitize_command_template(cls, command_template: list[str]) -> list[str]:
+        """Drop sandbox/approval flags so managed policy comes only from config."""
+
+        sanitized: list[str] = []
+        skip_next = False
+        for part in command_template:
+            if skip_next:
+                skip_next = False
+                continue
+            if part in cls._MANAGED_POLICY_FLAGS:
+                continue
+            if part in cls._MANAGED_POLICY_FLAGS_WITH_VALUE:
+                skip_next = True
+                continue
+            sanitized.append(part)
+        return sanitized
 
     def shape_environment(
         self,

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -71,6 +71,9 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
 
         sanitized: list[str] = []
         skip_next = False
+        managed_policy_flags = (
+            cls._MANAGED_POLICY_FLAGS | cls._MANAGED_POLICY_FLAGS_WITH_VALUE
+        )
         for part in command_template:
             if skip_next:
                 skip_next = False
@@ -79,6 +82,8 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
                 continue
             if part in cls._MANAGED_POLICY_FLAGS_WITH_VALUE:
                 skip_next = True
+                continue
+            if any(part.startswith(flag + "=") for flag in managed_policy_flags):
                 continue
             sanitized.append(part)
         return sanitized

--- a/tests/unit/api_service/scripts/test_ensure_codex_config.py
+++ b/tests/unit/api_service/scripts/test_ensure_codex_config.py
@@ -27,7 +27,7 @@ def test_ensure_codex_config_enforces_network_defaults_and_preserves_custom_keys
         template_path,
         """
 approval_policy = "never"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 
 [sandbox_workspace_write]
 network_access = true
@@ -57,7 +57,7 @@ network_access = false
     assert result.path == target_path
     rendered = toml.load(target_path)
     assert rendered["approval_policy"] == "never"
-    assert rendered["sandbox_mode"] == "workspace-write"
+    assert rendered["sandbox_mode"] == "danger-full-access"
     assert rendered["sandbox_workspace_write"]["network_access"] is True
 
     # Ensure non-enforced user values survive.
@@ -74,7 +74,7 @@ def test_ensure_codex_config_replaces_invalid_nested_shape(tmp_path, monkeypatch
         template_path,
         """
 approval_policy = "never"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 
 [sandbox_workspace_write]
 network_access = true
@@ -107,7 +107,7 @@ def test_ensure_codex_config_requires_workspace_network_key(
         template_path,
         """
 approval_policy = "never"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 """.strip()
         + "\n",
     )

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -81,7 +81,7 @@ def test_build_command_codex_cli():
     launcher = ManagedRuntimeLauncher(store)
     profile = _make_profile(
         runtime_id="codex_cli",
-        command_template=["codex", "exec", "--full-auto"],
+        command_template=["codex", "exec"],
         default_model="gpt-5.3-codex",
         default_effort="high",
     )
@@ -91,7 +91,7 @@ def test_build_command_codex_cli():
     )
 
     cmd = launcher.build_command(profile, request)
-    assert cmd[:3] == ["codex", "exec", "--full-auto"]
+    assert cmd[:2] == ["codex", "exec"]
     assert "-m" in cmd
     assert "o3" in cmd
     # Codex does not support --effort or --model (long form)

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -236,7 +236,7 @@ class TestCodexCliProperties:
 
     def test_default_command_template(self) -> None:
         assert CodexCliStrategy().default_command_template == [
-            "codex", "exec", "--full-auto",
+            "codex", "exec",
         ]
 
     def test_default_auth_mode(self) -> None:
@@ -247,30 +247,30 @@ class TestCodexCliBuildCommand:
     def test_basic_prompt(self) -> None:
         s = CodexCliStrategy()
         profile = _make_profile(
-            command_template=["codex", "exec", "--full-auto"],
+            command_template=["codex", "exec"],
         )
         request = _make_request(instruction_ref="Fix the bug")
         cmd = s.build_command(profile, request)
         # When no profile default_model set, codex_cli runtime default applies.
-        assert cmd == ["codex", "exec", "--full-auto", "-m", "gpt-5.4", "Fix the bug"]
+        assert cmd == ["codex", "exec", "-m", "gpt-5.4", "Fix the bug"]
 
     def test_with_model(self) -> None:
         s = CodexCliStrategy()
         profile = _make_profile(
-            command_template=["codex", "exec", "--full-auto"],
+            command_template=["codex", "exec"],
             default_model="o3-mini",
         )
         request = _make_request(instruction_ref="Hello")
         cmd = s.build_command(profile, request)
         assert cmd == [
-            "codex", "exec", "--full-auto",
+            "codex", "exec",
             "-m", "o3-mini", "Hello",
         ]
 
     def test_model_from_params(self) -> None:
         s = CodexCliStrategy()
         profile = _make_profile(
-            command_template=["codex", "exec", "--full-auto"],
+            command_template=["codex", "exec"],
             default_model="o3-mini",
         )
         request = _make_request(
@@ -281,15 +281,32 @@ class TestCodexCliBuildCommand:
         assert "-m" in cmd
         assert "gpt-4.1" in cmd
 
+    def test_strips_managed_policy_flags_from_legacy_template(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=[
+                "codex",
+                "exec",
+                "--full-auto",
+                "--sandbox",
+                "workspace-write",
+                "--ask-for-approval",
+                "on-request",
+            ],
+        )
+        request = _make_request(instruction_ref="Go")
+        cmd = s.build_command(profile, request)
+        assert cmd == ["codex", "exec", "-m", "gpt-5.4", "Go"]
+
     def test_no_prompt(self) -> None:
         s = CodexCliStrategy()
         profile = _make_profile(
-            command_template=["codex", "exec", "--full-auto"],
+            command_template=["codex", "exec"],
         )
         request = _make_request()
         cmd = s.build_command(profile, request)
         # No instruction_ref but runtime default model still applies.
-        assert cmd == ["codex", "exec", "--full-auto", "-m", "gpt-5.4"]
+        assert cmd == ["codex", "exec", "-m", "gpt-5.4"]
 
 
 class TestCodexCliShapeEnvironment:

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -292,6 +292,8 @@ class TestCodexCliBuildCommand:
                 "workspace-write",
                 "--ask-for-approval",
                 "on-request",
+                "--sandbox=danger-full-access",
+                "--ask-for-approval=never",
             ],
         )
         request = _make_request(instruction_ref="Go")


### PR DESCRIPTION
## Summary
- stop the managed `codex_cli` runtime from inheriting `--full-auto` / `workspace-write` behavior
- enforce `sandbox_mode = "danger-full-access"` in the managed Codex config template used by worker startup
- sanitize legacy Codex command templates so persisted profiles cannot reintroduce approval or sandbox flags

## Root cause
Managed Codex runs were still using the old `--full-auto` launch shape. In Codex CLI `0.118.0`, that expands to `--sandbox workspace-write`, which requires bubblewrap and unprivileged user namespaces. Inside the managed worker container, that caused shell tool invocations to fail immediately with `bwrap: No permissions to create a new namespace`, which broke `batch-pr-resolver` when run through the `codex_cli` runtime.

## Impact
Managed Codex runs now rely on MoonMind's external container sandbox rather than trying to nest Codex's Linux bubblewrap sandbox inside the worker container. Existing provider profiles that still carry legacy Codex sandbox or approval flags are normalized at launch so they follow the managed policy consistently.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api_service/scripts/test_ensure_codex_config.py tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/services/temporal/runtime/test_launcher.py`
