### PR TITLE
Sync .env token values into managed secrets on startup

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -175,6 +175,94 @@ def _initialize_contexts(app_state, app_settings):
     logger.info("Storage and service contexts initialized successfully.")
 
 
+async def _sync_env_managed_secrets() -> int:
+    """Seed or refresh managed secrets from environment values."""
+
+    def _read_value_from_dotenv(name: str) -> str | None:
+        from moonmind.config.paths import ENV_FILE
+        env_file = ENV_FILE
+
+        try:
+            if not env_file.exists():
+                return None
+            for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line.removeprefix("export ").strip()
+                if "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                if key.strip() != name:
+                    continue
+                value = value.strip()
+                if (value.startswith("\"") and value.endswith("\"")) or (
+                    value.startswith("'") and value.endswith("'")
+                ):
+                    return value[1:-1]
+                return value
+        except Exception:
+            logger.debug(
+                "Failed to read candidate managed secret from .env file",
+                slug=name,
+                env_file=str(env_file),
+                exc_info=True,
+            )
+            return None
+        return None
+
+    def _env_value(name: str) -> str | None:
+        return (
+            os.environ.get(name)
+            or _read_value_from_dotenv(name)
+        )
+
+    from api_service.services.secrets import SecretsService
+
+    github_token = (
+        _env_value("GITHUB_TOKEN")
+        or _env_value("GH_TOKEN")
+        or _env_value("GITHUB_PAT")
+    )
+    candidate_env_secrets = {
+        k: v
+        for k, v in {
+            "GITHUB_TOKEN": github_token,
+            "ATLASSIAN_API_KEY": _env_value("ATLASSIAN_API_KEY"),
+        }.items()
+        if v
+    }
+
+    if not candidate_env_secrets:
+        logger.debug("No managed secret values found in environment; skipping sync.")
+        return 0
+
+    try:
+        async with get_async_session_context() as session:
+            imported = await SecretsService.import_from_env(
+                session,
+                candidate_env_secrets,
+                overwrite_active=True,
+            )
+            if imported:
+                logger.info(
+                    "Synced managed secrets from environment on startup",
+                    slugs=sorted(candidate_env_secrets.keys()),
+                    imported_count=imported,
+                )
+            return imported
+    except Exception as exc:
+        # Keep startup resilient: this is convenience migration behavior, not a hard
+        # startup dependency.
+        logger.warning(
+            "Failed to sync managed secrets from environment during startup: %s",
+            exc,
+            exc_info=True,
+        )
+        return 0
+
+
 async def _initialize_oidc_provider(app: FastAPI):
     """Initializes the OIDC provider by fetching discovery documents if needed."""
     provider = settings.oidc.AUTH_PROVIDER
@@ -668,6 +756,7 @@ async def startup_event():
             exc,
         )
     await _sync_task_template_seed_catalog()
+    await _sync_env_managed_secrets()
 
     # Ensure default user and profile exist if auth is disabled
     if settings.oidc.AUTH_PROVIDER == "disabled":

--- a/api_service/services/secrets.py
+++ b/api_service/services/secrets.py
@@ -151,10 +151,17 @@ class SecretsService:
         return secret.ciphertext
 
     @classmethod
-    async def import_from_env(cls, db: AsyncSession, env_dict: dict[str, str]) -> int:
+    async def import_from_env(
+        cls,
+        db: AsyncSession,
+        env_dict: dict[str, str],
+        *,
+        overwrite_active: bool = False,
+    ) -> int:
         """
         Migrate legacy .env values.
-        Upserts missing values to ManagedSecrets, skipping existing active ones.
+        Upserts values to ManagedSecrets.
+        By default, existing active secrets are skipped.
         """
         imported_count = 0
         for key, value in env_dict.items():
@@ -162,21 +169,29 @@ class SecretsService:
             existing = result.scalar_one_or_none()
 
             if existing:
-                if existing.status == SecretStatus.ACTIVE:
+                if existing.status == SecretStatus.ACTIVE and not overwrite_active:
                     continue  # Skip overriding already active managed secrets
-                else:
-                    existing.ciphertext = value
-                    existing.status = SecretStatus.ACTIVE
-                    existing.details.update({"imported_from": ".env", "migrated_at": datetime.now(timezone.utc).isoformat()})
-                    existing.updated_at = datetime.now(timezone.utc)
-                    imported_count += 1
+                now = datetime.now(timezone.utc)
+                existing.ciphertext = value
+                existing.status = SecretStatus.ACTIVE
+                details = dict(existing.details or {})
+                details.update(
+                    {"imported_from": ".env", "migrated_at": now.isoformat()}
+                )
+                existing.details = details
+                existing.updated_at = now
+                imported_count += 1
             else:
+                now = datetime.now(timezone.utc)
                 db.add(
                     ManagedSecret(
                         slug=key,
                         ciphertext=value,
                         status=SecretStatus.ACTIVE,
-                        details={"imported_from": ".env", "migrated_at": datetime.now(timezone.utc).isoformat()}
+                        details={
+                            "imported_from": ".env",
+                            "migrated_at": now.isoformat(),
+                        },
                     )
                 )
                 imported_count += 1

--- a/tests/integration/test_startup_secret_env_seeding.py
+++ b/tests/integration/test_startup_secret_env_seeding.py
@@ -1,0 +1,132 @@
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db import base as db_base
+from api_service.db.models import Base, ManagedSecret, SecretStatus
+from api_service.main import startup_event
+
+
+async def _seed_db(tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    db_base.DATABASE_URL = db_url
+    db_base.engine = create_async_engine(db_url, future=True)
+    db_base.async_session_maker = sessionmaker(
+        db_base.engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with db_base.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+@pytest.mark.asyncio
+async def test_startup_syncs_managed_secrets_from_env(monkeypatch, disabled_env_keys, tmp_path):
+    await _seed_db(tmp_path)
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-test-token")
+    monkeypatch.setenv("ATLASSIAN_API_KEY", "atl-token")
+
+    with (
+        patch("api_service.main._initialize_embedding_model"),
+        patch("api_service.main._initialize_vector_store"),
+        patch("api_service.main._initialize_contexts"),
+        patch("api_service.main._load_or_create_vector_index"),
+        patch("api_service.main._initialize_oidc_provider"),
+    ):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        github_secret = (
+            await session.execute(select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_TOKEN"))
+        ).scalar_one_or_none()
+        atlassian_secret = (
+            await session.execute(
+                select(ManagedSecret).where(ManagedSecret.slug == "ATLASSIAN_API_KEY")
+            )
+        ).scalar_one_or_none()
+
+    assert github_secret is not None
+    assert github_secret.status == SecretStatus.ACTIVE
+    assert github_secret.ciphertext == "ghp-test-token"
+    assert github_secret.details.get("imported_from") == ".env"
+    assert atlassian_secret is not None
+    assert atlassian_secret.status == SecretStatus.ACTIVE
+    assert atlassian_secret.ciphertext == "atl-token"
+    assert atlassian_secret.details.get("imported_from") == ".env"
+
+
+@pytest.mark.asyncio
+async def test_startup_updates_existing_env_managed_secret(monkeypatch, disabled_env_keys, tmp_path):
+    await _seed_db(tmp_path)
+
+    async with db_base.async_session_maker() as session:
+        existing_secret = ManagedSecret(
+            slug="GITHUB_TOKEN",
+            ciphertext="old-token",
+            status=SecretStatus.ACTIVE,
+            details={"imported_from": ".env", "migrated_at": "older"},
+        )
+        session.add(existing_secret)
+        await session.commit()
+
+    monkeypatch.setenv("GITHUB_TOKEN", "new-github-token")
+
+    with (
+        patch("api_service.main._initialize_embedding_model"),
+        patch("api_service.main._initialize_vector_store"),
+        patch("api_service.main._initialize_contexts"),
+        patch("api_service.main._load_or_create_vector_index"),
+        patch("api_service.main._initialize_oidc_provider"),
+    ):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        refreshed = (
+            await session.execute(select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_TOKEN"))
+        ).scalar_one()
+
+    assert refreshed.ciphertext == "new-github-token"
+    assert refreshed.details.get("migrated_at") is not None
+
+
+@pytest.mark.asyncio
+async def test_startup_syncs_managed_secrets_from_dotenv_file(
+    monkeypatch, disabled_env_keys, tmp_path
+):
+    await _seed_db(tmp_path)
+
+    dotenv_path = tmp_path / ".env"
+    dotenv_path.write_text(
+        "GITHUB_TOKEN=ghp-dotenv-token\nATLASSIAN_API_KEY=atl-dotenv-token\n"
+    )
+    monkeypatch.setattr("moonmind.config.paths.ENV_FILE", dotenv_path)
+
+    with (
+        patch("api_service.main._initialize_embedding_model"),
+        patch("api_service.main._initialize_vector_store"),
+        patch("api_service.main._initialize_contexts"),
+        patch("api_service.main._load_or_create_vector_index"),
+        patch("api_service.main._initialize_oidc_provider"),
+    ):
+        await startup_event()
+
+    async with db_base.async_session_maker() as session:
+        github_secret = (
+            await session.execute(
+                select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_TOKEN")
+            )
+        ).scalar_one_or_none()
+        atlassian_secret = (
+            await session.execute(
+                select(ManagedSecret).where(
+                    ManagedSecret.slug == "ATLASSIAN_API_KEY"
+                )
+            )
+        ).scalar_one_or_none()
+
+    assert github_secret is not None
+    assert github_secret.ciphertext == "ghp-dotenv-token"
+    assert atlassian_secret is not None
+    assert atlassian_secret.ciphertext == "atl-dotenv-token"

--- a/tests/unit/services/test_secrets.py
+++ b/tests/unit/services/test_secrets.py
@@ -129,7 +129,60 @@ async def test_import_from_env(mock_db_session):
     mock_db_session.execute.side_effect = mock_execute
     
     count = await SecretsService.import_from_env(mock_db_session, env_dict)
-    
+
     assert count == 2
     assert mock_db_session.add.call_count == 2
     mock_db_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_import_from_env_does_not_overwrite_active_by_default(mock_db_session):
+    active_secret = ManagedSecret(
+        slug="KEY_1",
+        ciphertext="old-value",
+        status=SecretStatus.ACTIVE,
+        details={"imported_from": ".env"},
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = active_secret
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    count = await SecretsService.import_from_env(
+        mock_db_session,
+        {"KEY_1": "new-value"},
+    )
+
+    assert count == 0
+    assert active_secret.ciphertext == "old-value"
+
+
+@pytest.mark.asyncio
+async def test_import_from_env_can_overwrite_active(mock_db_session):
+    active_secret = ManagedSecret(
+        slug="KEY_1",
+        ciphertext="old-value",
+        status=SecretStatus.ACTIVE,
+        details={"imported_from": ".env", "migrated_at": "earlier"},
+    )
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = active_secret
+
+    async def mock_execute(*args, **kwargs):
+        return mock_result
+
+    mock_db_session.execute.side_effect = mock_execute
+
+    count = await SecretsService.import_from_env(
+        mock_db_session,
+        {"KEY_1": "new-value"},
+        overwrite_active=True,
+    )
+
+    assert count == 1
+    assert active_secret.ciphertext == "new-value"


### PR DESCRIPTION
## Summary
- On API startup, automatically seed/update managed secrets from environment values for `GITHUB_TOKEN` (or `GH_TOKEN` / `GITHUB_PAT`) and `ATLASSIAN_API_KEY`.
- Added `.env` fallback support when env vars are not exported.
- Updated `SecretsService.import_from_env` with an explicit `overwrite_active` option (default preserves existing active secret values).
- Added unit/integration coverage for startup import/update and `.env` file fallback.

## Why
The first-run warning in the dashboard checks managed secrets, so plain `.env` credentials were not being recognized until manually created as managed secrets.

## Testing
- `./tools/test_unit.sh --python-only -- tests/unit/services/test_secrets.py tests/integration/test_startup_secret_env_seeding.py`
- Result: tests pass in those targeted suites.
- Note: full suite still requires npm in this environment to run frontend unit tests.