### PR TITLE
Fix Codex managed gh auth propagation

### DIFF
--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -387,6 +387,17 @@ class ManagedRuntimeLauncher:
         return store_token
 
     @staticmethod
+    def _runtime_requires_direct_github_env(runtime_id: str | None) -> bool:
+        """Return whether a managed runtime needs token env in addition to broker helpers.
+
+        Codex CLI shell-tool execution can bypass the workspace-local ``gh`` wrapper
+        during nested ``bash -lc`` command execution, so direct ``GH_TOKEN`` /
+        ``GITHUB_TOKEN`` env remains necessary for reliable GitHub CLI auth.
+        """
+
+        return str(runtime_id or "").strip() == "codex_cli"
+
+    @staticmethod
     def _write_executable_script(path: Path, content: str) -> str:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
@@ -745,8 +756,13 @@ class ManagedRuntimeLauncher:
                     socket_path=github_socket_path,
                 )
                 deferred_cleanup_paths.append(github_socket_path)
-                env_overrides.pop("GITHUB_TOKEN", None)
-                env_overrides.pop("GH_TOKEN", None)
+                if self._runtime_requires_direct_github_env(profile.runtime_id):
+                    env_overrides["GITHUB_TOKEN"] = github_token
+                    env_overrides["GH_TOKEN"] = github_token
+                    env_overrides.setdefault("GIT_TERMINAL_PROMPT", "0")
+                else:
+                    env_overrides.pop("GITHUB_TOKEN", None)
+                    env_overrides.pop("GH_TOKEN", None)
 
             if resolved_workspace_path is not None:
                 deferred_cleanup_paths.extend(

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -1083,6 +1083,83 @@ async def test_launch_resolves_github_token_from_managed_secrets_store_without_p
 
 
 @pytest.mark.asyncio
+async def test_launch_keeps_direct_github_env_for_codex_cli_managed_runs(
+    tmp_path, monkeypatch
+):
+    """Codex CLI managed runs keep token env because nested shell tools may bypass wrappers."""
+
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        command_template=["codex", "exec", "hello"],
+        env_overrides={},
+        passthrough_env_keys=[],
+        secret_refs={},
+    )
+    request = _make_request(
+        workspace_spec={"repository": str(tmp_path / "source-repo")},
+    )
+
+    source_repo = tmp_path / "source-repo"
+    subprocess.run(["git", "init", str(source_repo)], check=True, capture_output=True)
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 1004) -> None:
+            self.pid = pid
+            self.returncode = 0
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_env: dict[str, str] = {}
+
+    async def _fake_create_subprocess_exec(*_args, **kwargs):
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            captured_env.update(env)
+        return _FakeProcess()
+
+    async def _fake_store_token() -> str:
+        return "resolved-from-managed-secrets-table"
+
+    from moonmind.config.settings import settings as app_settings
+
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _fake_store_token,
+    )
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-github-managed-store-codex-1", request=request, profile=profile
+    )
+    await process.wait()
+
+    run_root = store.store_root.parent / "workspaces" / "run-github-managed-store-codex-1"
+    assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
+    assert captured_env["GITHUB_TOKEN"] == "resolved-from-managed-secrets-table"
+    assert captured_env["GH_TOKEN"] == "resolved-from-managed-secrets-table"
+    assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
+    assert (run_root / ".moonmind" / "bin" / "gh").exists()
+
+
+@pytest.mark.asyncio
 async def test_resolve_github_token_for_launch_propagates_cancellation_from_secret_ref(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- preserve direct `GH_TOKEN` / `GITHUB_TOKEN` env for `codex_cli` managed runs even when broker-backed GitHub auth is enabled
- keep the existing broker + wrapper path for other runtimes
- add launcher regression coverage for the Codex-specific behavior

## Root cause
The failing workflow was `mm:a7323962-caff-4a9c-8ef7-f168531e27ac` on April 3, 2026. The parent `MoonMind.Run` completed, but its child `MoonMind.AgentRun` (`mm:a7323962-caff-4a9c-8ef7-f168531e27ac:agent:node-1`) recorded a hidden runtime failure in the diagnostics for managed run `b2980b06-8175-44ce-aed8-535cb081ab3e`.

The key failure was:

`gh pr list --repo MoonLadderStudios/MoonMind --state open ...`

returning exit code 4 with:

`To get started with GitHub CLI, please run: gh auth login`

The managed launcher was resolving the GitHub token correctly, but once the per-run broker was enabled it removed `GH_TOKEN` / `GITHUB_TOKEN` from the launched process env and relied on the workspace-local `gh` wrapper instead. That works when subprocesses use the inherited wrapper path, but Codex shell-tool execution can bypass that wrapper during nested command execution, so `gh` lost auth inside the managed Codex run.

## Fix
For `codex_cli` managed runs, keep direct `GH_TOKEN` / `GITHUB_TOKEN` env in addition to the existing broker-backed helper setup. That preserves reliable `gh` auth for Codex shell tools without changing non-Codex runtime behavior.

## Verification
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py`
