### PR TITLE
The batch-pr-resolver is supposed to submit pr-resolver tasks to MoonMind using the SAME provider profile and model selection settings used when creating the task for batch-pr-resolver. It should NOT use the default runtime and model, which is what it seems to be doing right now.

### DIFF
--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -281,7 +281,10 @@ def _load_parent_runtime_selection(
             runtime_config.get("effort") or runtime_node.get("effort")
         )
         provider_profile = _runtime_text(
-            runtime_config.get("providerProfile") or runtime_node.get("providerProfile")
+            runtime_config.get("providerProfile")
+            or runtime_config.get("profileId")
+            or runtime_node.get("providerProfile")
+            or runtime_node.get("profileId")
         )
         return RuntimeSelection(
             mode=mode, model=model, effort=effort, provider_profile=provider_profile

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1150,8 +1150,11 @@ async def _create_execution_from_task_request(
     )
     raw_profile_id = str(
         runtime_payload.get("profileId")
+        or runtime_payload.get("providerProfile")
         or task_payload.get("profileId")
+        or task_payload.get("providerProfile")
         or payload.get("profileId")
+        or payload.get("providerProfile")
         or ""
     ).strip() or None
     # Preserve the original requested model byte-for-byte (Compatibility Policy:

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -4182,6 +4182,15 @@ class CodexWorker:
             )
             runtime_model = str(runtime.get("model") or "").strip() or None
             runtime_effort = str(runtime.get("effort") or "").strip() or None
+            runtime_provider_profile = (
+                str(
+                    runtime.get("providerProfile")
+                    or runtime.get("profileId")
+                    or canonical_payload.get("profileId")
+                    or ""
+                ).strip()
+                or None
+            )
 
             repository = str(canonical_payload.get("repository") or "").strip()
             if not repository:
@@ -4296,6 +4305,8 @@ class CodexWorker:
                     "mode": runtime_mode,
                     "model": runtime_model,
                     "effort": runtime_effort,
+                    "providerProfile": runtime_provider_profile,
+                    "profileId": runtime_provider_profile,
                 },
                 "skill": {
                     "id": (

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -257,6 +257,16 @@ def _build_runtime_planner():
         if isinstance(effort, str) and effort.strip():
             runtime_node["effort"] = effort.strip()
 
+        profile_id = (
+            runtime_payload.get("profileId")
+            or runtime_payload.get("providerProfile")
+            or parameter_payload.get("profileId")
+        )
+        if isinstance(profile_id, str) and profile_id.strip():
+            normalized_profile_id = profile_id.strip()
+            runtime_node["profileId"] = normalized_profile_id
+            runtime_node["providerProfile"] = normalized_profile_id
+
         exec_profile_ref = (
             runtime_payload.get("executionProfileRef")
             or runtime_payload.get("execution_profile_ref")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1349,6 +1349,10 @@ class MoonMindRunWorkflow:
         execution_profile_ref = str(
             node_inputs.get("executionProfileRef")
             or runtime_block.get("executionProfileRef")
+            or node_inputs.get("profileId")
+            or runtime_block.get("profileId")
+            or node_inputs.get("providerProfile")
+            or runtime_block.get("providerProfile")
             or f"default:{agent_id}"
         )
         wf_info = workflow.info()

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -844,6 +844,7 @@ async def test_run_once_writes_runtime_config_into_task_context(tmp_path: Path) 
                     "mode": "codex",
                     "model": "gpt-5-codex",
                     "effort": "high",
+                    "providerProfile": "codex-provider-profile",
                 },
                 "git": {"startingBranch": "main", "targetBranch": None},
                 "publish": {"mode": "none"},
@@ -873,6 +874,8 @@ async def test_run_once_writes_runtime_config_into_task_context(tmp_path: Path) 
     assert runtime_config["mode"] == "codex"
     assert runtime_config["model"] == "gpt-5-codex"
     assert runtime_config["effort"] == "high"
+    assert runtime_config["providerProfile"] == "codex-provider-profile"
+    assert runtime_config["profileId"] == "codex-provider-profile"
 
 
 async def test_run_once_skips_empty_artifacts(tmp_path: Path) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -19,6 +19,7 @@ from api_service.api.routers.executions import (
     router,
 )
 from api_service.auth_providers import get_current_user
+from api_service.db.base import get_async_session
 from api_service.db.models import MoonMindWorkflowState, TemporalWorkflowType
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal import (
@@ -444,6 +445,49 @@ def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
         "startingBranch": "feature/resolve-pr",
         "targetBranch": "codex/pr-resolver",
     }
+
+
+def test_create_task_shaped_execution_accepts_provider_profile_alias() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.create_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(
+            return_value=SimpleNamespace(
+                default_model="gpt-5-codex",
+            )
+        )
+    )
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=False)
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions",
+            json={
+                "type": "task",
+                "payload": {
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "targetRuntime": "codex",
+                    "task": {
+                        "instructions": "Fix failing Temporal run.",
+                        "runtime": {
+                            "mode": "codex",
+                            "providerProfile": "codex-provider-profile",
+                        },
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    initial_parameters = mock_service.create_execution.await_args.kwargs["initial_parameters"]
+    assert initial_parameters["profileId"] == "codex-provider-profile"
+    assert initial_parameters["model"] == "gpt-5-codex"
+    assert initial_parameters["modelSource"] == "provider_profile_default"
+    app.dependency_overrides.clear()
 
 
 def test_create_task_shaped_execution_preserves_task_title_and_publish_overrides(

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -185,6 +185,29 @@ def test_load_parent_runtime_selection_prefers_runtime_config(tmp_path: Path):
     assert runtime.provider_profile == "inherited-profile"
 
 
+def test_load_parent_runtime_selection_accepts_profile_id_fallback(tmp_path: Path):
+    module = _load_module()
+    load_parent_runtime_selection = module["_load_parent_runtime_selection"]
+
+    task_context = tmp_path / "task_context.json"
+    task_context.write_text(
+        (
+            "{"
+            '"runtime":"codex",'
+            '"runtimeConfig":{"mode":"codex","model":"gpt-5-codex","effort":"high","profileId":"profile-from-id"}'
+            "}"
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = load_parent_runtime_selection(str(task_context))
+    assert runtime is not None
+    assert runtime.mode == "codex"
+    assert runtime.model == "gpt-5-codex"
+    assert runtime.effort == "high"
+    assert runtime.provider_profile == "profile-from-id"
+
+
 def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
     module = _load_module()
     resolve_runtime_selection = module["_resolve_runtime_selection"]

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -75,6 +75,32 @@ def test_runtime_planner_preserves_execution_profile_ref_snake_case():
     )
 
 
+def test_runtime_planner_promotes_profile_id_to_runtime_node():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Use the pinned Codex provider profile.",
+                "runtime": {
+                    "mode": "codex",
+                    "providerProfile": "codex-provider-profile",
+                },
+            }
+        },
+        parameters={"profileId": "codex-provider-profile"},
+        snapshot=snapshot,
+    )
+
+    runtime_node = plan["nodes"][0]["inputs"]["runtime"]
+    assert runtime_node["profileId"] == "codex-provider-profile"
+    assert runtime_node["providerProfile"] == "codex-provider-profile"
+
+
 def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -191,3 +191,30 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.resolved_skillset_ref, "skills:snap:12345")
+
+    def test_build_agent_execution_request_uses_provider_profile_as_execution_profile_ref(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex",
+                        "providerProfile": "codex-provider-profile",
+                    },
+                },
+                node_id="node-profile",
+                tool_name="pr-resolver",
+            )
+
+        self.assertEqual(request.agent_id, "codex")
+        self.assertEqual(request.execution_profile_ref, "codex-provider-profile")


### PR DESCRIPTION
The batch-pr-resolver is supposed to submit pr-resolver tasks to MoonMind using the SAME provider profile and model selection settings used when creating the task for batch-pr-resolver. It should NOT use the default runtime and model, which is what it seems to be doing right now.