### PR TITLE
[codex] fix batch pr-resolver runtime inheritance

### DIFF
--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -19,6 +19,10 @@ Create one queue task per open pull request so each PR branch can be resolved by
 - `priority` (number, optional): Queue job priority. Default `0`.
 - `mergeMethod` (string, optional): Merge method passed to `pr-resolver`. Default `squash`.
 - `maxIterations` (number, optional): `pr-resolver` loop cap. Default `3`.
+- `runtimeMode` (string, optional): Runtime to stamp onto each queued `pr-resolver` task. When omitted, the helper falls back to inherited task context or deployment defaults.
+- `runtimeModel` (string, optional): Explicit model override to stamp onto each queued `pr-resolver` task.
+- `runtimeEffort` (string, optional): Explicit effort override to stamp onto each queued `pr-resolver` task.
+- `runtimeProviderProfile` (string, optional): Explicit provider-profile override to stamp onto each queued `pr-resolver` task.
 
 ## Workflow
 
@@ -32,7 +36,11 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
   --max-attempts 3 \
   --priority 0 \
   --merge-method squash \
-  --max-iterations 3
+  --max-iterations 3 \
+  --runtime-mode <runtime_mode> \
+  --runtime-model <model> \
+  --runtime-effort <effort> \
+  --runtime-provider-profile <profile_id>
 ```
 
 2. Map inputs to flags:
@@ -44,6 +52,12 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
    - `priority` -> `--priority`
    - `mergeMethod` -> `--merge-method`
    - `maxIterations` -> `--max-iterations`
+   - `runtimeMode` -> `--runtime-mode`
+   - `runtimeModel` -> `--runtime-model`
+   - `runtimeEffort` -> `--runtime-effort`
+   - `runtimeProviderProfile` -> `--runtime-provider-profile`
+
+   Always forward the parent task's explicit runtime selection fields when they are present so the queued `pr-resolver` tasks reuse the same runtime, model, effort, and provider profile instead of falling back to the deployment default runtime.
 
 3. For each open PR in the target repo:
    - Skip PRs identified as cross-repository (`isCrossRepository=true`) or whose head is not on `owner/repo`.

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -3843,24 +3843,37 @@ class CodexWorker:
             runtime_mode = str(
                 runtime.get("mode") or canonical_payload.get("targetRuntime") or ""
             ).strip()
-            runtime_model = runtime.get("model")
-            runtime_effort = runtime.get("effort")
+            runtime_model = (
+                str(runtime.get("model")).strip()
+                if runtime.get("model") is not None
+                else ""
+            )
+            runtime_effort = (
+                str(runtime.get("effort")).strip()
+                if runtime.get("effort") is not None
+                else ""
+            )
             runtime_provider_profile = (
                 runtime.get("providerProfile")
                 or runtime.get("profileId")
                 or canonical_payload.get("profileId")
             )
+            runtime_provider_profile = (
+                str(runtime_provider_profile).strip()
+                if runtime_provider_profile is not None
+                else ""
+            )
 
             if runtime_mode:
                 effective_args.setdefault("runtimeMode", runtime_mode)
-            if runtime_model is not None and str(runtime_model).strip():
-                effective_args.setdefault("runtimeModel", str(runtime_model))
-            if runtime_effort is not None and str(runtime_effort).strip():
-                effective_args.setdefault("runtimeEffort", str(runtime_effort))
-            if runtime_provider_profile is not None and str(runtime_provider_profile).strip():
+            if runtime_model:
+                effective_args.setdefault("runtimeModel", runtime_model)
+            if runtime_effort:
+                effective_args.setdefault("runtimeEffort", runtime_effort)
+            if runtime_provider_profile:
                 effective_args.setdefault(
                     "runtimeProviderProfile",
-                    str(runtime_provider_profile),
+                    runtime_provider_profile,
                 )
             return effective_args
 
@@ -3898,13 +3911,11 @@ class CodexWorker:
                 if explicit_step_skill:
                     effective_skill_id = explicit_step_skill
                     step_skill_args_node = step_skill.get("args")
-                    effective_skill_args = (
-                        _augment_skill_args(
-                            effective_skill_id,
-                            step_skill_args_node,
-                        )
+                    effective_skill_args = _augment_skill_args(
+                        effective_skill_id,
+                        step_skill_args_node
                         if isinstance(step_skill_args_node, Mapping)
-                        else {}
+                        else {},
                     )
                 else:
                     effective_skill_id = task_skill_id

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -3830,6 +3830,40 @@ class CodexWorker:
             else {}
         )
 
+        def _augment_skill_args(
+            skill_id: str, skill_args: Mapping[str, Any]
+        ) -> dict[str, Any]:
+            effective_args = dict(skill_args)
+            if skill_id != "batch-pr-resolver":
+                return effective_args
+
+            runtime_node = task.get("runtime")
+            runtime = runtime_node if isinstance(runtime_node, Mapping) else {}
+
+            runtime_mode = str(
+                runtime.get("mode") or canonical_payload.get("targetRuntime") or ""
+            ).strip()
+            runtime_model = runtime.get("model")
+            runtime_effort = runtime.get("effort")
+            runtime_provider_profile = (
+                runtime.get("providerProfile")
+                or runtime.get("profileId")
+                or canonical_payload.get("profileId")
+            )
+
+            if runtime_mode:
+                effective_args.setdefault("runtimeMode", runtime_mode)
+            if runtime_model is not None and str(runtime_model).strip():
+                effective_args.setdefault("runtimeModel", str(runtime_model))
+            if runtime_effort is not None and str(runtime_effort).strip():
+                effective_args.setdefault("runtimeEffort", str(runtime_effort))
+            if runtime_provider_profile is not None and str(runtime_provider_profile).strip():
+                effective_args.setdefault(
+                    "runtimeProviderProfile",
+                    str(runtime_provider_profile),
+                )
+            return effective_args
+
         raw_steps = task.get("steps")
         if not isinstance(raw_steps, list) or not raw_steps:
             return [
@@ -3840,7 +3874,9 @@ class CodexWorker:
                     instructions=None,
                     effective_skill_id=task_skill_id,
                     effective_skill_args=(
-                        dict(task_skill_args) if task_skill_id != "auto" else {}
+                        _augment_skill_args(task_skill_id, task_skill_args)
+                        if task_skill_id != "auto"
+                        else {}
                     ),
                     has_step_instructions=False,
                 )
@@ -3863,16 +3899,25 @@ class CodexWorker:
                     effective_skill_id = explicit_step_skill
                     step_skill_args_node = step_skill.get("args")
                     effective_skill_args = (
-                        dict(step_skill_args_node)
+                        _augment_skill_args(
+                            effective_skill_id,
+                            step_skill_args_node,
+                        )
                         if isinstance(step_skill_args_node, Mapping)
                         else {}
                     )
                 else:
                     effective_skill_id = task_skill_id
-                    effective_skill_args = dict(task_skill_args)
+                    effective_skill_args = _augment_skill_args(
+                        effective_skill_id,
+                        task_skill_args,
+                    )
             else:
                 effective_skill_id = task_skill_id
-                effective_skill_args = dict(task_skill_args)
+                effective_skill_args = _augment_skill_args(
+                    effective_skill_id,
+                    task_skill_args,
+                )
 
             if not effective_skill_id:
                 effective_skill_id = "auto"

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -889,15 +889,19 @@ async def test_run_once_passes_runtime_inheritance_args_to_batch_pr_resolver_ski
             "targetRuntime": "codex",
             "task": {
                 "instructions": "Queue PR resolver jobs.",
-                "skill": {
-                    "id": "batch-pr-resolver",
-                    "args": {"repo": "MoonLadderStudios/MoonMind"},
-                },
+                "skill": {"id": "auto"},
+                "steps": [
+                    {
+                        "id": "queue-prs",
+                        "instructions": "Queue PR resolver jobs.",
+                        "skill": {"id": "batch-pr-resolver"},
+                    }
+                ],
                 "runtime": {
-                    "mode": "codex",
-                    "model": "gpt-5-codex",
-                    "effort": "high",
-                    "providerProfile": "codex-provider-profile",
+                    "mode": " codex ",
+                    "model": " gpt-5-codex ",
+                    "effort": " high ",
+                    "providerProfile": " codex-provider-profile ",
                 },
                 "git": {"startingBranch": "main", "targetBranch": None},
                 "publish": {"mode": "none"},

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -878,6 +878,58 @@ async def test_run_once_writes_runtime_config_into_task_context(tmp_path: Path) 
     assert runtime_config["profileId"] == "codex-provider-profile"
 
 
+async def test_run_once_passes_runtime_inheritance_args_to_batch_pr_resolver_skill(
+    tmp_path: Path,
+) -> None:
+    job = ClaimedJob(
+        id=uuid4(),
+        type="task",
+        payload={
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetRuntime": "codex",
+            "task": {
+                "instructions": "Queue PR resolver jobs.",
+                "skill": {
+                    "id": "batch-pr-resolver",
+                    "args": {"repo": "MoonLadderStudios/MoonMind"},
+                },
+                "runtime": {
+                    "mode": "codex",
+                    "model": "gpt-5-codex",
+                    "effort": "high",
+                    "providerProfile": "codex-provider-profile",
+                },
+                "git": {"startingBranch": "main", "targetBranch": None},
+                "publish": {"mode": "none"},
+            },
+        },
+    )
+    queue = FakeQueueClient(jobs=[job])
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="queued", error_message=None)
+    )
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    processed = await worker.run_once()
+
+    assert processed is True
+    assert handler.calls == ["codex_skill:batch-pr-resolver:True"]
+    payload = handler.skill_payloads[0]
+    inputs = payload["inputs"]
+    assert inputs["runtimeMode"] == "codex"
+    assert inputs["runtimeModel"] == "gpt-5-codex"
+    assert inputs["runtimeEffort"] == "high"
+    assert inputs["runtimeProviderProfile"] == "codex-provider-profile"
+
+
 async def test_run_once_skips_empty_artifacts(tmp_path: Path) -> None:
     """Zero-byte artifacts should be skipped to avoid upload validation failures."""
 


### PR DESCRIPTION
## Summary
- propagate the parent task runtime selection into `batch-pr-resolver` skill args before step execution
- document the runtime inheritance args in the `batch-pr-resolver` skill contract and map them to the helper script flags
- add a worker regression test that locks the `batch-pr-resolver` payload contract for runtime/model/effort/provider-profile inheritance

## Root cause
`batch-pr-resolver` child tasks were falling back to the deployment default runtime because the parent task's explicit runtime selection was not being forwarded into the skill invocation boundary consistently. That left the helper script dependent on fallback task-context discovery instead of receiving the runtime settings directly.

## Impact
- `batch-pr-resolver` now reuses the same runtime, provider profile, model, and effort when it enqueues `pr-resolver` tasks
- queued `pr-resolver` tasks should no longer default to Gemini when the parent batch task was submitted with Codex

## Validation
- Added a unit regression test covering worker payload propagation for `batch-pr-resolver`
- Tests not run in this PR creation pass
