### PR TITLE
[codex] fix proposal submission routing

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1944,23 +1944,21 @@ class TemporalProposalActivities:
                 if isinstance(payload_node, Mapping):
                     target_repo = str(payload_node.get("repository") or "").strip()
                 
-                is_moonmind_target = bool(moonmind_repo) and target_repo.lower() == moonmind_repo.lower()
                 should_submit = False
-
-                if is_moonmind_target:
-                    severity = str(candidate.get("severity") or "medium")
-                    if effective_policy.severity_meets_floor(severity) and effective_policy.consume_moonmind_slot():
-                        should_submit = True
+                if effective_policy.consume_project_slot():
+                    should_submit = True
                 else:
-                    if effective_policy.consume_project_slot():
+                    severity = str(candidate.get("severity") or "medium")
+                    is_moonmind_repo = (
+                        bool(moonmind_repo)
+                        and target_repo.lower() == moonmind_repo.lower()
+                    )
+                    if (
+                        is_moonmind_repo
+                        and effective_policy.severity_meets_floor(severity)
+                        and effective_policy.consume_moonmind_slot()
+                    ):
                         should_submit = True
-                    else:
-                        severity = str(candidate.get("severity") or "medium")
-                        if bool(moonmind_repo) and effective_policy.severity_meets_floor(severity) and effective_policy.consume_moonmind_slot():
-                            is_moonmind_target = True
-                            should_submit = True
-                            if isinstance(payload_node, dict):
-                                payload_node["repository"] = moonmind_repo
 
                 if not should_submit:
                     continue

--- a/tests/unit/workflows/temporal/test_proposal_activities.py
+++ b/tests/unit/workflows/temporal/test_proposal_activities.py
@@ -247,6 +247,45 @@ class TestProposalSubmit(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["submitted_count"], 3)
         self.assertEqual(mock_service.create_proposal.await_count, 3)
 
+    async def test_moonmind_repo_candidate_still_submits_as_project_by_default(self) -> None:
+        mock_service = AsyncMock()
+
+        @contextlib.asynccontextmanager
+        async def factory():
+            yield mock_service
+
+        activities = TemporalProposalActivities(
+            proposal_service_factory=factory,
+        )
+        candidates = [
+            {
+                "title": "[run_quality] Follow-up: Fix proposal routing",
+                "summary": "Proposal should remain project-targeted for MoonMind repo runs.",
+                "category": "run_quality",
+                "tags": ["artifact_gap"],
+                "taskCreateRequest": {
+                    "payload": {"repository": "MoonLadderStudios/MoonMind"}
+                },
+            }
+        ]
+
+        result = await activities.proposal_submit(
+            {
+                "candidates": candidates,
+                "policy": {},
+                "origin": {},
+            }
+        )
+
+        self.assertEqual(result["generated_count"], 1)
+        self.assertEqual(result["submitted_count"], 1)
+        mock_service.create_proposal.assert_awaited_once()
+        call_kwargs = mock_service.create_proposal.await_args.kwargs
+        self.assertEqual(
+            call_kwargs["task_create_request"]["payload"]["repository"],
+            "MoonLadderStudios/MoonMind",
+        )
+
     async def test_service_factory_called(self) -> None:
         mock_service = AsyncMock()
         @contextlib.asynccontextmanager


### PR DESCRIPTION
## Summary
Fix proposal submission routing for MoonMind repo runs.

## What changed
- submit project proposals before applying MoonMind-specific run-quality routing
- stop treating every proposal targeting `MoonLadderStudios/MoonMind` as MoonMind-only backlog work
- add a regression test covering default project-target submission for MoonMind repo candidates

## Root cause
The Temporal `proposal.submit` path classified proposals by repository equality with the configured `moonmind_ci_repository`. In this repository, that caused normal follow-up proposals to bypass project submission and get filtered by the MoonMind severity gate, so they were generated but never inserted as open proposals.

## Impact
Open proposals can now be created and shown on the proposals page for normal runs in this repo.

## Validation
- `./tools/test_unit.sh`
