### PR TITLE
Install bubblewrap in my Dockerfile so that my Codex CLI managed agent does not keep producing warnings based on this analysis:

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -263,6 +263,7 @@ COPY --from=tooling-builder /usr/local/lib/node_modules/@anthropic-ai/claude-cod
 RUN apt-get update && \
     apt-get install -y \
         build-essential \
+        bubblewrap \
         pkg-config \
         libcairo2-dev \
         libffi-dev \


### PR DESCRIPTION
Launching agent...