### PR TITLE
[codex] Fix task input artifact completion before submit

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,32 @@
 [
   {
-    "id": 3034176610,
+    "id": 3034605043,
     "disposition": "addressed",
-    "rationale": "Fixed _client_with_mock_service to override _get_temporal_service with a lambda returning the actual mock_service instance instead of a fresh AsyncMock. Removed unused _build_mock_temporal_service function."
+    "rationale": "Switched presigned artifact PUT headers to a single Headers object so signed content-type values are not duplicated."
   },
   {
-    "id": 3034173336,
+    "id": 4057512440,
+    "disposition": "not-applicable",
+    "rationale": "Top-level bot review summary only; the actionable feedback was captured in the inline review comments below."
+  },
+  {
+    "id": 3034606279,
     "disposition": "addressed",
-    "rationale": "Refactored _client_with_mock_service to accept optional monkeypatch parameter and use monkeypatch.setenv for environment variable management when available, making tests cleaner and more idiomatic to pytest."
+    "rationale": "Implemented canonical header construction for presigned uploads, preserving one content-type header and other required signed headers."
   },
   {
-    "id": 4057082355,
-    "disposition": "not-applicable",
-    "rationale": "Informational review summary from Gemini, no specific action required beyond the addressed review comment."
+    "id": 3034606297,
+    "disposition": "addressed",
+    "rationale": "Expanded the presigned upload test to include required signed headers and assert they are forwarded without duplication."
   },
   {
-    "id": 4057086102,
+    "id": 4057513529,
     "disposition": "not-applicable",
-    "rationale": "Informational review summary from Copilot, no specific action required beyond the addressed review comment."
+    "rationale": "Overview-only review comment; no separate remediation requested beyond the inline comments already addressed."
+  },
+  {
+    "id": 4057516246,
+    "disposition": "not-applicable",
+    "rationale": "Informational approval comment stating no additional feedback."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -590,10 +590,9 @@ describe("Task Create Entrypoint", () => {
     const uploadCall = fetchSpy.mock.calls
       .filter(([url]) => String(url) === "/api/artifacts/art-001/content")
       .at(-1);
-    expect(uploadCall?.[1]?.headers).toEqual(
-      expect.objectContaining({
-        "Content-Type": "application/json; charset=utf-8",
-      }),
+    const uploadHeaders = new Headers(uploadCall?.[1]?.headers);
+    expect(uploadHeaders.get("content-type")).toBe(
+      "application/json; charset=utf-8",
     );
     expect(JSON.parse(String(uploadCall?.[1]?.body))).toMatchObject({
       repository: "MoonLadderStudios/MoonMind",
@@ -647,7 +646,10 @@ describe("Task Create Entrypoint", () => {
                   "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload",
                 expires_at: "2026-04-02T00:00:00Z",
                 max_size_bytes: 100000,
-                required_headers: {},
+                required_headers: {
+                  "content-type": "text/plain",
+                  "x-amz-server-side-encryption": "AES256",
+                },
               },
             }),
           } as Response);
@@ -656,6 +658,9 @@ describe("Task Create Entrypoint", () => {
           url ===
           "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload"
         ) {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("content-type")).toBe("text/plain");
+          expect(headers.get("x-amz-server-side-encryption")).toBe("AES256");
           return Promise.resolve({
             ok: true,
             text: async () => "",

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1,353 +1,413 @@
-import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 
-import type { BootPayload } from '../boot/parseBootPayload';
-import { navigateTo } from '../lib/navigation';
-import { renderWithClient } from '../utils/test-utils';
-import { resolveObjectiveInstructions, TaskCreatePage } from './task-create';
+import type { BootPayload } from "../boot/parseBootPayload";
+import { navigateTo } from "../lib/navigation";
+import { renderWithClient } from "../utils/test-utils";
+import { resolveObjectiveInstructions, TaskCreatePage } from "./task-create";
 
-vi.mock('../lib/navigation', () => ({
+vi.mock("../lib/navigation", () => ({
   navigateTo: vi.fn(),
 }));
 
 const mockPayload: BootPayload = {
-  page: 'task-create',
-  apiBase: '/api',
+  page: "task-create",
+  apiBase: "/api",
   initialData: {
     dashboardConfig: {
       sources: {
         temporal: {
-          create: '/api/executions',
-          artifactCreate: '/api/artifacts',
+          create: "/api/executions",
+          artifactCreate: "/api/artifacts",
         },
       },
       system: {
-        defaultRepository: 'MoonLadderStudios/MoonMind',
-        defaultTaskRuntime: 'codex_cli',
-        defaultTaskModel: 'gpt-5.4',
-        defaultTaskEffort: 'medium',
-        defaultPublishMode: 'pr',
+        defaultRepository: "MoonLadderStudios/MoonMind",
+        defaultTaskRuntime: "codex_cli",
+        defaultTaskModel: "gpt-5.4",
+        defaultTaskEffort: "medium",
+        defaultPublishMode: "pr",
         defaultProposeTasks: false,
         defaultTaskModelByRuntime: {
-          codex_cli: 'gpt-5.4',
-          gemini_cli: 'gemini-2.5-pro',
-          claude_code: 'claude-3.7-sonnet',
+          codex_cli: "gpt-5.4",
+          gemini_cli: "gemini-2.5-pro",
+          claude_code: "claude-3.7-sonnet",
         },
         defaultTaskEffortByRuntime: {
-          codex_cli: 'medium',
-          gemini_cli: 'high',
-          claude_code: 'low',
+          codex_cli: "medium",
+          gemini_cli: "high",
+          claude_code: "low",
         },
-        supportedTaskRuntimes: ['codex_cli', 'gemini_cli', 'claude_code'],
+        supportedTaskRuntimes: ["codex_cli", "gemini_cli", "claude_code"],
         providerProfiles: {
-          list: '/api/v1/provider-profiles',
+          list: "/api/v1/provider-profiles",
         },
         taskTemplateCatalog: {
           enabled: true,
           templateSaveEnabled: true,
-          list: '/api/task-step-templates',
-          detail: '/api/task-step-templates/{slug}',
-          expand: '/api/task-step-templates/{slug}:expand',
-          saveFromTask: '/api/task-step-templates/save-from-task',
+          list: "/api/task-step-templates",
+          detail: "/api/task-step-templates/{slug}",
+          expand: "/api/task-step-templates/{slug}:expand",
+          saveFromTask: "/api/task-step-templates/save-from-task",
         },
       },
     },
   },
 };
 
-describe('Task Create Entrypoint', () => {
+describe("Task Create Entrypoint", () => {
   let fetchSpy: MockInstance;
   let executionResponseOverride: Response | null;
 
   beforeEach(() => {
-    window.history.pushState({}, 'Task Create', '/tasks/new');
+    window.history.pushState({}, "Task Create", "/tasks/new");
     vi.mocked(navigateTo).mockReset();
     executionResponseOverride = null;
-    fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.startsWith('/api/tasks/skills')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            items: { worker: ['speckit-orchestrate', 'pr-resolver'] },
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates?scope=personal')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            items: [],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates?scope=global')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            items: [
-              {
-                slug: 'speckit-demo',
-                scope: 'global',
-                title: 'Spec Kit Demo',
-                description: 'Seed a two-step planning flow.',
-                latestVersion: '1.2.3',
-                version: '1.2.3',
-              },
-              {
-                slug: 'objective-demo',
-                scope: 'global',
-                title: 'Objective Request Demo',
-                description: 'Use template inputs to derive the task objective.',
-                latestVersion: '2.0.0',
-                version: '2.0.0',
-              },
-            ],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates/speckit-demo?scope=global')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            slug: 'speckit-demo',
-            scope: 'global',
-            title: 'Spec Kit Demo',
-            description: 'Seed a two-step planning flow.',
-            latestVersion: '1.2.3',
-            version: '1.2.3',
-            inputs: [
-              {
-                name: 'feature_name',
-                label: 'Feature Name',
-                type: 'text',
-                required: true,
-              },
-            ],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates/objective-demo?scope=global')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            slug: 'objective-demo',
-            scope: 'global',
-            title: 'Objective Request Demo',
-            description: 'Use template inputs to derive the task objective.',
-            latestVersion: '2.0.0',
-            version: '2.0.0',
-            inputs: [
-              {
-                name: 'request',
-                label: 'Request',
-                type: 'text',
-                required: true,
-              },
-            ],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates/speckit-demo:expand?scope=global')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            steps: [
-              {
-                id: 'tpl:speckit-demo:1.2.3:01',
-                title: 'Clarify spec',
-                instructions: 'Clarify the {{ inputs.feature_name }} scope.',
-                skill: {
-                  id: 'speckit-clarify',
-                  args: { feature: 'Task Create' },
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith("/api/tasks/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: { worker: ["speckit-orchestrate", "pr-resolver"] },
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates?scope=personal")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [],
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/task-step-templates?scope=global")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [
+                {
+                  slug: "speckit-demo",
+                  scope: "global",
+                  title: "Spec Kit Demo",
+                  description: "Seed a two-step planning flow.",
+                  latestVersion: "1.2.3",
+                  version: "1.2.3",
                 },
-              },
-              {
-                id: 'tpl:speckit-demo:1.2.3:02',
-                title: 'Plan implementation',
-                instructions: 'Write a plan for the task builder recovery.',
-              },
-            ],
-            appliedTemplate: {
-              slug: 'speckit-demo',
-              version: '1.2.3',
-            },
-            warnings: [],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/task-step-templates/objective-demo:expand?scope=global')) {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            steps: [
-              {
-                id: 'tpl:objective-demo:2.0.0:01',
-                title: 'Clarify request',
-                instructions: '',
-                skill: {
-                  id: 'speckit-clarify',
-                  args: { mode: 'objective' },
+                {
+                  slug: "objective-demo",
+                  scope: "global",
+                  title: "Objective Request Demo",
+                  description:
+                    "Use template inputs to derive the task objective.",
+                  latestVersion: "2.0.0",
+                  version: "2.0.0",
                 },
+              ],
+            }),
+          } as Response);
+        }
+        if (
+          url.startsWith("/api/task-step-templates/speckit-demo?scope=global")
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              slug: "speckit-demo",
+              scope: "global",
+              title: "Spec Kit Demo",
+              description: "Seed a two-step planning flow.",
+              latestVersion: "1.2.3",
+              version: "1.2.3",
+              inputs: [
+                {
+                  name: "feature_name",
+                  label: "Feature Name",
+                  type: "text",
+                  required: true,
+                },
+              ],
+            }),
+          } as Response);
+        }
+        if (
+          url.startsWith("/api/task-step-templates/objective-demo?scope=global")
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              slug: "objective-demo",
+              scope: "global",
+              title: "Objective Request Demo",
+              description: "Use template inputs to derive the task objective.",
+              latestVersion: "2.0.0",
+              version: "2.0.0",
+              inputs: [
+                {
+                  name: "request",
+                  label: "Request",
+                  type: "text",
+                  required: true,
+                },
+              ],
+            }),
+          } as Response);
+        }
+        if (
+          url.startsWith(
+            "/api/task-step-templates/speckit-demo:expand?scope=global",
+          )
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              steps: [
+                {
+                  id: "tpl:speckit-demo:1.2.3:01",
+                  title: "Clarify spec",
+                  instructions: "Clarify the {{ inputs.feature_name }} scope.",
+                  skill: {
+                    id: "speckit-clarify",
+                    args: { feature: "Task Create" },
+                  },
+                },
+                {
+                  id: "tpl:speckit-demo:1.2.3:02",
+                  title: "Plan implementation",
+                  instructions: "Write a plan for the task builder recovery.",
+                },
+              ],
+              appliedTemplate: {
+                slug: "speckit-demo",
+                version: "1.2.3",
               },
-              {
-                id: 'tpl:objective-demo:2.0.0:02',
-                title: 'Review objective',
-                instructions: 'Review the resulting task objective.',
+              warnings: [],
+            }),
+          } as Response);
+        }
+        if (
+          url.startsWith(
+            "/api/task-step-templates/objective-demo:expand?scope=global",
+          )
+        ) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              steps: [
+                {
+                  id: "tpl:objective-demo:2.0.0:01",
+                  title: "Clarify request",
+                  instructions: "",
+                  skill: {
+                    id: "speckit-clarify",
+                    args: { mode: "objective" },
+                  },
+                },
+                {
+                  id: "tpl:objective-demo:2.0.0:02",
+                  title: "Review objective",
+                  instructions: "Review the resulting task objective.",
+                },
+              ],
+              appliedTemplate: {
+                slug: "objective-demo",
+                version: "2.0.0",
               },
-            ],
-            appliedTemplate: {
-              slug: 'objective-demo',
-              version: '2.0.0',
-            },
-            warnings: [],
-          }),
-        } as Response);
-      }
-      if (url.startsWith('/api/v1/provider-profiles')) {
-        const runtimeId = new URL(`http://localhost${url}`).searchParams.get('runtime_id');
-        const items =
-          runtimeId === 'gemini_cli'
-            ? [{ profile_id: 'profile:gemini-default', account_label: 'Gemini Default' }]
-            : runtimeId === 'claude_code'
-              ? [{ profile_id: 'profile:claude-default', account_label: 'Claude Default' }]
-              : [
-                  { profile_id: 'profile:codex-default', account_label: 'Codex Default' },
-                  { profile_id: 'profile:codex-secondary', account_label: 'Codex Secondary' },
-                ];
-        return Promise.resolve({
-          ok: true,
-          json: async () => items,
-        } as Response);
-      }
-      if (url === '/api/executions') {
-        if (executionResponseOverride) {
-          return Promise.resolve(executionResponseOverride);
+              warnings: [],
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          const runtimeId = new URL(`http://localhost${url}`).searchParams.get(
+            "runtime_id",
+          );
+          const items =
+            runtimeId === "gemini_cli"
+              ? [
+                  {
+                    profile_id: "profile:gemini-default",
+                    account_label: "Gemini Default",
+                  },
+                ]
+              : runtimeId === "claude_code"
+                ? [
+                    {
+                      profile_id: "profile:claude-default",
+                      account_label: "Claude Default",
+                    },
+                  ]
+                : [
+                    {
+                      profile_id: "profile:codex-default",
+                      account_label: "Codex Default",
+                    },
+                    {
+                      profile_id: "profile:codex-secondary",
+                      account_label: "Codex Secondary",
+                    },
+                  ];
+          return Promise.resolve({
+            ok: true,
+            json: async () => items,
+          } as Response);
+        }
+        if (url === "/api/executions") {
+          if (executionResponseOverride) {
+            return Promise.resolve(executionResponseOverride);
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:workflow-123",
+              runId: "run-123",
+              namespace: "moonmind",
+              redirectPath: "/tasks/mm:workflow-123?source=temporal",
+            }),
+          } as Response);
+        }
+        if (url === "/api/task-step-templates/save-from-task") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              slug: "saved-preset",
+              scope: "personal",
+              title: "Saved preset",
+              latestVersion: "1.0.0",
+            }),
+          } as Response);
+        }
+        if (url === "/api/artifacts") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              artifact_ref: {
+                artifact_id: "art-001",
+              },
+              upload: {
+                mode: "single",
+                upload_url: "/api/artifacts/art-001/content",
+                expires_at: "2026-04-02T00:00:00Z",
+                max_size_bytes: 100000,
+                required_headers: {},
+              },
+            }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/art-001/content") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ artifact_id: "art-001" }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/art-001/complete") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ artifact_id: "art-001" }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/art-001/links") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ artifact_id: "art-001" }),
+          } as Response);
         }
         return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            workflowId: 'mm:workflow-123',
-            runId: 'run-123',
-            namespace: 'moonmind',
-            redirectPath: '/tasks/mm:workflow-123?source=temporal',
-          }),
+          ok: false,
+          status: 404,
+          statusText: `Unhandled fetch for ${url} ${String(init?.method || "GET")}`,
+          text: async () => "Unhandled fetch",
         } as Response);
-      }
-      if (url === '/api/task-step-templates/save-from-task') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            slug: 'saved-preset',
-            scope: 'personal',
-            title: 'Saved preset',
-            latestVersion: '1.0.0',
-          }),
-        } as Response);
-      }
-      if (url === '/api/artifacts') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            artifact_ref: {
-              artifact_id: 'art-001',
-            },
-            upload: {
-              mode: 'single',
-              upload_url: '/api/artifacts/art-001/content',
-              expires_at: '2026-04-02T00:00:00Z',
-              max_size_bytes: 100000,
-              required_headers: {},
-            },
-          }),
-        } as Response);
-      }
-      if (url === '/api/artifacts/art-001/content') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ artifact_id: 'art-001' }),
-        } as Response);
-      }
-      if (url === '/api/artifacts/art-001/links') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ artifact_id: 'art-001' }),
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        statusText: `Unhandled fetch for ${url} ${String(init?.method || 'GET')}`,
-        text: async () => 'Unhandled fetch',
-      } as Response);
-    });
+      });
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
   });
 
-  it('submits the queue-shaped Temporal task payload and redirects on success', async () => {
+  it("submits the queue-shaped Temporal task payload and redirects on success", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const primaryStep = (await screen.findByText('Step 1 (Primary)')).closest('section');
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
     expect(primaryStep).not.toBeNull();
-    fireEvent.change(await screen.findByLabelText('Instructions'), {
-      target: { value: 'Run end-to-end regression flow.' },
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Run end-to-end regression flow." },
     });
     fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
-      target: { value: 'MoonLadderStudios/MoonMind' },
+      target: { value: "MoonLadderStudios/MoonMind" },
     });
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/), {
-      target: { value: 'speckit-orchestrate' },
-    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "speckit-orchestrate" },
+      },
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/executions',
+        "/api/executions",
         expect.objectContaining({
-          method: 'POST',
+          method: "POST",
         }),
       );
     });
 
-    const executionCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions').at(-1);
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
     const request = JSON.parse(String(executionCall?.[1]?.body));
     expect(request).toMatchObject({
-      type: 'task',
+      type: "task",
       priority: 0,
       maxAttempts: 3,
       payload: {
-        repository: 'MoonLadderStudios/MoonMind',
-        targetRuntime: 'codex_cli',
+        repository: "MoonLadderStudios/MoonMind",
+        targetRuntime: "codex_cli",
         task: {
-          instructions: 'Run end-to-end regression flow.',
+          instructions: "Run end-to-end regression flow.",
           tool: {
-            type: 'skill',
-            name: 'speckit-orchestrate',
-            version: '1.0',
+            type: "skill",
+            name: "speckit-orchestrate",
+            version: "1.0",
           },
           runtime: {
-            mode: 'codex_cli',
-            model: 'gpt-5.4',
-            effort: 'medium',
+            mode: "codex_cli",
+            model: "gpt-5.4",
+            effort: "medium",
           },
           publish: {
-            mode: 'pr',
+            mode: "pr",
           },
           proposeTasks: false,
         },
       },
     });
-    expect(request.payload.requiredCapabilities).toEqual(['codex_cli', 'git', 'gh']);
+    expect(request.payload.requiredCapabilities).toEqual([
+      "codex_cli",
+      "git",
+      "gh",
+    ]);
     await waitFor(() => {
-      expect(navigateTo).toHaveBeenCalledWith('/tasks/mm:workflow-123?source=temporal');
+      expect(navigateTo).toHaveBeenCalledWith(
+        "/tasks/mm:workflow-123?source=temporal",
+      );
     });
   });
 
-  it('defaults publish mode to none when selecting pr-resolver skills', async () => {
+  it("defaults publish mode to none when selecting pr-resolver skills", async () => {
     type MockInitialData = {
       dashboardConfig: {
         system: {
@@ -363,8 +423,9 @@ describe('Task Create Entrypoint', () => {
         dashboardConfig: {
           ...(mockPayload.initialData as MockInitialData).dashboardConfig,
           system: {
-            ...(mockPayload.initialData as MockInitialData).dashboardConfig.system,
-            defaultPublishMode: 'pr',
+            ...(mockPayload.initialData as MockInitialData).dashboardConfig
+              .system,
+            defaultPublishMode: "pr",
           },
         },
       },
@@ -372,399 +433,525 @@ describe('Task Create Entrypoint', () => {
 
     renderWithClient(<TaskCreatePage payload={payload} />);
 
-    const primaryStep = (await screen.findByText('Step 1 (Primary)')).closest('section');
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
     expect(primaryStep).not.toBeNull();
 
-    const publishSelect = screen.getByLabelText('Publish Mode') as HTMLSelectElement;
-    expect(publishSelect.value).toBe((payload.initialData as MockInitialData).dashboardConfig.system.defaultPublishMode);
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/), {
-      target: { value: 'pr-resolver' },
-    });
+    const publishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(publishSelect.value).toBe(
+      (payload.initialData as MockInitialData).dashboardConfig.system
+        .defaultPublishMode,
+    );
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "pr-resolver" },
+      },
+    );
     await waitFor(() => {
-      expect((screen.getByLabelText('Publish Mode') as HTMLSelectElement).value).toBe('none');
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
     });
 
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/), {
-      target: { value: 'batch-pr-resolver' },
-    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "batch-pr-resolver" },
+      },
+    );
     await waitFor(() => {
-      expect((screen.getByLabelText('Publish Mode') as HTMLSelectElement).value).toBe('none');
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
     });
   });
 
-  it('submits publish mode none when the selected primary skill is pr-resolver', async () => {
+  it("submits publish mode none when the selected primary skill is pr-resolver", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const primaryStep = (await screen.findByText('Step 1 (Primary)')).closest('section');
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
     expect(primaryStep).not.toBeNull();
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/), {
-      target: { value: 'pr-resolver' },
-    });
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText('Instructions'), {
-      target: { value: 'Resolve the current branch PR.' },
-    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "pr-resolver" },
+      },
+    );
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText("Instructions"),
+      {
+        target: { value: "Resolve the current branch PR." },
+      },
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith('/api/executions', expect.objectContaining({ method: 'POST' }));
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
     });
 
-    const executionCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions').at(-1);
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
     const request = JSON.parse(String(executionCall?.[1]?.body));
     expect(request.payload.task.publish).toMatchObject({
-      mode: 'none',
+      mode: "none",
     });
   });
 
-  it('renders the restored legacy create-task controls', async () => {
+  it("renders the restored legacy create-task controls", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    expect(await screen.findByPlaceholderText('owner/repo')).not.toBeNull();
-    expect(await screen.findByLabelText('Provider profile')).not.toBeNull();
-    expect(await screen.findByLabelText('Feature Request / Initial Instructions')).not.toBeNull();
-    expect(await screen.findByPlaceholderText('auto-generated unless starting branch is non-default')).not.toBeNull();
-    expect(await screen.findByDisplayValue('3')).not.toBeNull();
-    expect(screen.getByText('Task Presets (optional)')).not.toBeNull();
-    expect(screen.getByText('Schedule (optional)')).not.toBeNull();
+    expect(await screen.findByPlaceholderText("owner/repo")).not.toBeNull();
+    expect(await screen.findByLabelText("Provider profile")).not.toBeNull();
+    expect(
+      await screen.findByLabelText("Feature Request / Initial Instructions"),
+    ).not.toBeNull();
+    expect(
+      await screen.findByPlaceholderText(
+        "auto-generated unless starting branch is non-default",
+      ),
+    ).not.toBeNull();
+    expect(await screen.findByDisplayValue("3")).not.toBeNull();
+    expect(screen.getByText("Task Presets (optional)")).not.toBeNull();
+    expect(screen.getByText("Schedule (optional)")).not.toBeNull();
   });
 
-  it('updates provider-profile options when the selected runtime changes', async () => {
+  it("updates provider-profile options when the selected runtime changes", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const providerSelect = await screen.findByLabelText('Provider profile');
+    const providerSelect = await screen.findByLabelText("Provider profile");
     await waitFor(() => {
-      const labels = Array.from((providerSelect as HTMLSelectElement).options).map((option) => option.text);
-      expect(labels).toEqual(['Default (system chooses)', 'Codex Default', 'Codex Secondary']);
+      const labels = Array.from(
+        (providerSelect as HTMLSelectElement).options,
+      ).map((option) => option.text);
+      expect(labels).toEqual([
+        "Default (system chooses)",
+        "Codex Default",
+        "Codex Secondary",
+      ]);
     });
 
-    fireEvent.change(screen.getByLabelText('Runtime'), {
-      target: { value: 'gemini_cli' },
+    fireEvent.change(screen.getByLabelText("Runtime"), {
+      target: { value: "gemini_cli" },
     });
 
     await waitFor(() => {
-      const labels = Array.from((providerSelect as HTMLSelectElement).options).map((option) => option.text);
-      expect(labels).toEqual(['Default (system chooses)', 'Gemini Default']);
+      const labels = Array.from(
+        (providerSelect as HTMLSelectElement).options,
+      ).map((option) => option.text);
+      expect(labels).toEqual(["Default (system chooses)", "Gemini Default"]);
     });
   });
 
-  it('uploads oversized task input as a JSON artifact before submitting the execution', async () => {
+  it("uploads oversized task input as a JSON artifact before submitting the execution", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    fireEvent.change(await screen.findByLabelText('Instructions'), {
-      target: { value: 'Large instructions '.repeat(1000) },
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Large instructions ".repeat(1000) },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/artifacts',
-        expect.objectContaining({ method: 'POST' }),
+        "/api/artifacts",
+        expect.objectContaining({ method: "POST" }),
       );
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/artifacts/art-001/content',
-        expect.objectContaining({ method: 'PUT' }),
+        "/api/artifacts/art-001/content",
+        expect.objectContaining({ method: "PUT" }),
       );
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/artifacts/art-001/links',
-        expect.objectContaining({ method: 'POST' }),
+        "/api/artifacts/art-001/complete",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/artifacts/art-001/links",
+        expect.objectContaining({ method: "POST" }),
       );
     });
 
-    const executionCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions').at(-1);
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
     const request = JSON.parse(String(executionCall?.[1]?.body));
-    expect(request.payload.inputArtifactRef).toBe('art-001');
+    expect(request.payload.inputArtifactRef).toBe("art-001");
     expect(request.payload.task.instructions).toBeUndefined();
 
-    const uploadCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/artifacts/art-001/content').at(-1);
+    const uploadCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/artifacts/art-001/content")
+      .at(-1);
     expect(uploadCall?.[1]?.headers).toEqual(
       expect.objectContaining({
-        'Content-Type': 'application/json; charset=utf-8',
+        "Content-Type": "application/json; charset=utf-8",
       }),
     );
     expect(JSON.parse(String(uploadCall?.[1]?.body))).toMatchObject({
-      repository: 'MoonLadderStudios/MoonMind',
+      repository: "MoonLadderStudios/MoonMind",
       task: {
-        instructions: expect.stringContaining('Large instructions Large instructions'),
+        instructions: expect.stringContaining(
+          "Large instructions Large instructions",
+        ),
       },
     });
   });
 
-  it('uploads task input through the same-origin artifact content endpoint when the API returns a presigned storage URL', async () => {
+  it("uploads task input to the returned single-put URL and finalizes the artifact before task creation", async () => {
     const providerProfileItems = [
-      { profile_id: 'profile:codex-default', account_label: 'Codex Default' },
-      { profile_id: 'profile:codex-secondary', account_label: 'Codex Secondary' },
+      { profile_id: "profile:codex-default", account_label: "Codex Default" },
+      {
+        profile_id: "profile:codex-secondary",
+        account_label: "Codex Secondary",
+      },
     ];
 
-    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url.includes('/api/v1/provider-profiles')) {
+    fetchSpy.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/v1/provider-profiles")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => providerProfileItems,
+          } as Response);
+        }
+        if (url === "/api/executions") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:workflow-123",
+              runId: "run-123",
+              namespace: "moonmind",
+              redirectPath: "/tasks/mm:workflow-123?source=temporal",
+            }),
+          } as Response);
+        }
+        if (url === "/api/artifacts") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              artifact_ref: {
+                artifact_id: "art-001",
+              },
+              upload: {
+                mode: "single_put",
+                upload_url:
+                  "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload",
+                expires_at: "2026-04-02T00:00:00Z",
+                max_size_bytes: 100000,
+                required_headers: {},
+              },
+            }),
+          } as Response);
+        }
+        if (
+          url ===
+          "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload"
+        ) {
+          return Promise.resolve({
+            ok: true,
+            text: async () => "",
+          } as Response);
+        }
+        if (url === "/api/artifacts/art-001/complete") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ artifact_id: "art-001" }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/art-001/links") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ artifact_id: "art-001" }),
+          } as Response);
+        }
         return Promise.resolve({
-          ok: true,
-          json: async () => providerProfileItems,
+          ok: false,
+          status: 404,
+          statusText: `Unhandled fetch for ${url} ${String(init?.method || "GET")}`,
+          text: async () => "Unhandled fetch",
         } as Response);
-      }
-      if (url === '/api/executions') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            workflowId: 'mm:workflow-123',
-            runId: 'run-123',
-            namespace: 'moonmind',
-            redirectPath: '/tasks/mm:workflow-123?source=temporal',
-          }),
-        } as Response);
-      }
-      if (url === '/api/artifacts') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({
-            artifact_ref: {
-              artifact_id: 'art-001',
-            },
-            upload: {
-              mode: 'single_put',
-              upload_url: 'http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload',
-              expires_at: '2026-04-02T00:00:00Z',
-              max_size_bytes: 100000,
-              required_headers: {},
-            },
-          }),
-        } as Response);
-      }
-      if (url === '/api/artifacts/art-001/content') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ artifact_id: 'art-001' }),
-        } as Response);
-      }
-      if (url === '/api/artifacts/art-001/links') {
-        return Promise.resolve({
-          ok: true,
-          json: async () => ({ artifact_id: 'art-001' }),
-        } as Response);
-      }
-      return Promise.resolve({
-        ok: false,
-        status: 404,
-        statusText: `Unhandled fetch for ${url} ${String(init?.method || 'GET')}`,
-        text: async () => 'Unhandled fetch',
-      } as Response);
-    });
+      },
+    );
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    fireEvent.change(await screen.findByLabelText('Instructions'), {
-      target: { value: 'Large instructions '.repeat(1000) },
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Large instructions ".repeat(1000) },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/artifacts/art-001/content',
-        expect.objectContaining({ method: 'PUT' }),
+        "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload",
+        expect.objectContaining({ method: "PUT" }),
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/artifacts/art-001/complete",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
       );
     });
 
-    expect(
-      fetchSpy.mock.calls.some(([url]) =>
-        String(url) === 'http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload',
-      ),
-    ).toBe(false);
+    const presignedUploadIndex = fetchSpy.mock.calls.findIndex(
+      ([url]) =>
+        String(url) ===
+        "http://localhost:9000/moonmind-temporal-artifacts/demo-presigned-upload",
+    );
+    const completeIndex = fetchSpy.mock.calls.findIndex(
+      ([url]) => String(url) === "/api/artifacts/art-001/complete",
+    );
+    const executionIndex = fetchSpy.mock.calls.findIndex(
+      ([url]) => String(url) === "/api/executions",
+    );
+    expect(presignedUploadIndex).toBeGreaterThanOrEqual(0);
+    expect(completeIndex).toBeGreaterThan(presignedUploadIndex);
+    expect(executionIndex).toBeGreaterThan(completeIndex);
   });
 
-  it('uploads oversized step instructions as a JSON artifact and strips inline step text', async () => {
+  it("uploads oversized step instructions as a JSON artifact and strips inline step text", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    fireEvent.change(await screen.findByLabelText('Instructions'), {
-      target: { value: 'Primary objective' },
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Primary objective" },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Add Step' }));
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
 
     const stepTextarea = await screen.findByPlaceholderText(
-      'Step-specific instructions (leave blank to continue from the task objective).',
+      "Step-specific instructions (leave blank to continue from the task objective).",
     );
     fireEvent.change(stepTextarea, {
-      target: { value: 'Long step instructions '.repeat(1000) },
+      target: { value: "Long step instructions ".repeat(1000) },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/artifacts',
-        expect.objectContaining({ method: 'POST' }),
+        "/api/artifacts",
+        expect.objectContaining({ method: "POST" }),
       );
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/executions',
-        expect.objectContaining({ method: 'POST' }),
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
       );
     });
 
-    const executionCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions').at(-1);
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
     const request = JSON.parse(String(executionCall?.[1]?.body));
-    expect(request.payload.inputArtifactRef).toBe('art-001');
-    expect(request.payload.task.instructions).toBe('Primary objective');
+    expect(request.payload.inputArtifactRef).toBe("art-001");
+    expect(request.payload.task.instructions).toBe("Primary objective");
     expect(request.payload.task.steps).toEqual([
       {
-        instructions: 'Primary objective',
+        instructions: "Primary objective",
       },
       {},
     ]);
 
-    const uploadCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/artifacts/art-001/content').at(-1);
+    const uploadCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/artifacts/art-001/content")
+      .at(-1);
     expect(JSON.parse(String(uploadCall?.[1]?.body))).toMatchObject({
-      repository: 'MoonLadderStudios/MoonMind',
+      repository: "MoonLadderStudios/MoonMind",
       task: {
-        instructions: 'Primary objective',
+        instructions: "Primary objective",
         steps: expect.arrayContaining([
           expect.objectContaining({
-            instructions: 'Primary objective',
+            instructions: "Primary objective",
           }),
           expect.objectContaining({
-            instructions: expect.stringContaining('Long step instructions Long step instructions'),
+            instructions: expect.stringContaining(
+              "Long step instructions Long step instructions",
+            ),
           }),
         ]),
       },
     });
   });
 
-  it('applies a preset into task steps and submits them', async () => {
+  it("applies a preset into task steps and submits them", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const presetSelect = await screen.findByLabelText('Preset');
+    const presetSelect = await screen.findByLabelText("Preset");
     await waitFor(() => {
       expect(
         Array.from((presetSelect as HTMLSelectElement).options).some(
-          (option) => option.text === 'Spec Kit Demo (Global)',
+          (option) => option.text === "Spec Kit Demo (Global)",
         ),
       ).toBe(true);
     });
 
     fireEvent.change(presetSelect, {
-      target: { value: 'global::::speckit-demo' },
+      target: { value: "global::::speckit-demo" },
     });
 
-    fireEvent.change(screen.getByLabelText('Feature Request / Initial Instructions'), {
-      target: { value: 'Task Create' },
-    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
 
-    await screen.findByDisplayValue('Clarify the {{ inputs.feature_name }} scope.');
-    await screen.findByDisplayValue('Write a plan for the task builder recovery.');
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+    await screen.findByDisplayValue(
+      "Write a plan for the task builder recovery.",
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/executions',
+        "/api/executions",
         expect.objectContaining({
-          method: 'POST',
+          method: "POST",
         }),
       );
     });
 
-    const executionCall = fetchSpy.mock.calls.filter(([url]) => String(url) === '/api/executions').at(-1);
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
     const request = JSON.parse(String(executionCall?.[1]?.body));
-    expect(request.payload.task.instructions).toBe('Task Create');
+    expect(request.payload.task.instructions).toBe("Task Create");
     expect(request.payload.task.steps).toEqual([
       {
-        id: 'tpl:speckit-demo:1.2.3:01',
-        title: 'Clarify spec',
-        instructions: 'Clarify the {{ inputs.feature_name }} scope.',
+        id: "tpl:speckit-demo:1.2.3:01",
+        title: "Clarify spec",
+        instructions: "Clarify the {{ inputs.feature_name }} scope.",
         tool: {
-          type: 'skill',
-          name: 'speckit-clarify',
-          version: '1.0',
-          inputs: { feature: 'Task Create' },
+          type: "skill",
+          name: "speckit-clarify",
+          version: "1.0",
+          inputs: { feature: "Task Create" },
         },
         skill: {
-          id: 'speckit-clarify',
-          args: { feature: 'Task Create' },
+          id: "speckit-clarify",
+          args: { feature: "Task Create" },
         },
       },
       {
-        id: 'tpl:speckit-demo:1.2.3:02',
-        title: 'Plan implementation',
-        instructions: 'Write a plan for the task builder recovery.',
+        id: "tpl:speckit-demo:1.2.3:02",
+        title: "Plan implementation",
+        instructions: "Write a plan for the task builder recovery.",
       },
     ]);
     expect(request.payload.task.appliedStepTemplates).toEqual([
       expect.objectContaining({
-        slug: 'speckit-demo',
-        version: '1.2.3',
+        slug: "speckit-demo",
+        version: "1.2.3",
       }),
     ]);
   });
 
-  it('derives the task objective from feature-request template input aliases', () => {
+  it("derives the task objective from feature-request template input aliases", () => {
     expect(
-      resolveObjectiveInstructions('', '', [
+      resolveObjectiveInstructions("", "", [
         {
-          slug: 'objective-demo',
-          version: '2.0.0',
-          appliedAt: '2026-04-03T00:00:00Z',
+          slug: "objective-demo",
+          version: "2.0.0",
+          appliedAt: "2026-04-03T00:00:00Z",
           inputs: {
-            request: 'Restore the legacy Create Task objective handling.',
+            request: "Restore the legacy Create Task objective handling.",
           },
           stepIds: [],
           capabilities: [],
         },
       ]),
-    ).toBe('Restore the legacy Create Task objective handling.');
+    ).toBe("Restore the legacy Create Task objective handling.");
   });
 
-  it('surfaces plain-text execution errors without reading the response body twice', async () => {
-    executionResponseOverride = new Response('Plaintext execution failure.', {
+  it("surfaces plain-text execution errors without reading the response body twice", async () => {
+    executionResponseOverride = new Response("Plaintext execution failure.", {
       status: 400,
-      statusText: 'Bad Request',
+      statusText: "Bad Request",
       headers: {
-        'Content-Type': 'text/plain',
+        "Content-Type": "text/plain",
       },
     });
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    fireEvent.change(await screen.findByLabelText('Instructions'), {
-      target: { value: 'Run end-to-end regression flow.' },
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Run end-to-end regression flow." },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
-      expect(screen.getByText('Plaintext execution failure.')).not.toBeNull();
+      expect(screen.getByText("Plaintext execution failure.")).not.toBeNull();
     });
   });
 
-  it('blocks preset saves when step skill args are invalid JSON', async () => {
+  it("blocks preset saves when step skill args are invalid JSON", async () => {
     const promptSpy = vi
-      .spyOn(window, 'prompt')
-      .mockImplementationOnce(() => 'Saved preset title')
-      .mockImplementationOnce(() => 'Saved preset description');
+      .spyOn(window, "prompt")
+      .mockImplementationOnce(() => "Saved preset title")
+      .mockImplementationOnce(() => "Saved preset description");
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const primaryStep = (await screen.findByText('Step 1 (Primary)')).closest('section');
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
     expect(primaryStep).not.toBeNull();
 
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText('Instructions'), {
-      target: { value: 'Capture the current draft as a preset.' },
-    });
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/), {
-      target: { value: 'pr-resolver' },
-    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText("Instructions"),
+      {
+        target: { value: "Capture the current draft as a preset." },
+      },
+    );
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "pr-resolver" },
+      },
+    );
     await waitFor(() => {
-      expect(within(primaryStep as HTMLElement).getByLabelText(/Skill Args \(optional JSON object\)/)).not.toBeNull();
+      expect(
+        within(primaryStep as HTMLElement).getByLabelText(
+          /Skill Args \(optional JSON object\)/,
+        ),
+      ).not.toBeNull();
     });
-    fireEvent.change(within(primaryStep as HTMLElement).getByLabelText(/Skill Args \(optional JSON object\)/), {
-      target: { value: '{"broken":' },
-    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(
+        /Skill Args \(optional JSON object\)/,
+      ),
+      {
+        target: { value: '{"broken":' },
+      },
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: /Save Current Steps as Preset/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Save Current Steps as Preset/ }),
+    );
 
     await waitFor(() => {
-      expect(screen.getByText('Step 1 Skill Args must be valid JSON object text.')).not.toBeNull();
+      expect(
+        screen.getByText("Step 1 Skill Args must be valid JSON object text."),
+      ).not.toBeNull();
     });
-    expect(fetchSpy.mock.calls.some(([url]) => String(url) === '/api/task-step-templates/save-from-task')).toBe(false);
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url]) => String(url) === "/api/task-step-templates/save-from-task",
+      ),
+    ).toBe(false);
 
     promptSpy.mockRestore();
   });

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -663,12 +663,13 @@ async function createInputArtifact(
 
   let uploadResponse: Response;
   try {
+    const uploadHeaders = new Headers(requiredHeaders);
+    if (!uploadHeaders.has("content-type")) {
+      uploadHeaders.set("content-type", "application/json; charset=utf-8");
+    }
     uploadResponse = await fetch(uploadUrl, {
       method: "PUT",
-      headers: {
-        ...requiredHeaders,
-        "Content-Type": "application/json; charset=utf-8",
-      },
+      headers: uploadHeaders,
       body,
     });
   } catch (error) {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1,18 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
-import { mountPage } from '../boot/mountPage';
-import type { BootPayload } from '../boot/parseBootPayload';
-import { navigateTo } from '../lib/navigation';
+import { mountPage } from "../boot/mountPage";
+import type { BootPayload } from "../boot/parseBootPayload";
+import { navigateTo } from "../lib/navigation";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
-const SKILL_OPTIONS_DATALIST_ID = 'queue-skill-options';
-const MODEL_OPTIONS_DATALIST_ID = 'queue-model-options';
-const EFFORT_OPTIONS_DATALIST_ID = 'queue-effort-options';
+const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
+const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
+const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const PR_RESOLVER_SKILLS = new Set(['pr-resolver', 'batch-pr-resolver']);
-const PROPOSE_TASKS_PREFERENCE_KEY = 'moonmind.task-create.propose-tasks';
+const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
+const PROPOSE_TASKS_PREFERENCE_KEY = "moonmind.task-create.propose-tasks";
 
 function readProposeTasksPreference(defaultValue: boolean): boolean {
   try {
@@ -20,10 +20,10 @@ function readProposeTasksPreference(defaultValue: boolean): boolean {
     if (raw === null) {
       return defaultValue;
     }
-    if (raw === 'true' || raw === '1') {
+    if (raw === "true" || raw === "1") {
       return true;
     }
-    if (raw === 'false' || raw === '0') {
+    if (raw === "false" || raw === "0") {
       return false;
     }
   } catch {
@@ -34,14 +34,17 @@ function readProposeTasksPreference(defaultValue: boolean): boolean {
 
 function writeProposeTasksPreference(value: boolean): void {
   try {
-    window.localStorage.setItem(PROPOSE_TASKS_PREFERENCE_KEY, value ? 'true' : 'false');
+    window.localStorage.setItem(
+      PROPOSE_TASKS_PREFERENCE_KEY,
+      value ? "true" : "false",
+    );
   } catch {
     // Ignore localStorage write failures to keep task submission behavior unaffected.
   }
 }
 
-type TemplateScope = 'global' | 'personal';
-type ScheduleMode = 'immediate' | 'once' | 'deferred_minutes' | 'recurring';
+type TemplateScope = "global" | "personal";
+type ScheduleMode = "immediate" | "once" | "deferred_minutes" | "recurring";
 
 interface DashboardConfig {
   sources?: {
@@ -105,7 +108,15 @@ interface ExecutionCreateResponse {
 interface TaskTemplateInputDefinition {
   name: string;
   label: string;
-  type: 'text' | 'textarea' | 'markdown' | 'enum' | 'boolean' | 'user' | 'team' | 'repo_path';
+  type:
+    | "text"
+    | "textarea"
+    | "markdown"
+    | "enum"
+    | "boolean"
+    | "user"
+    | "team"
+    | "repo_path";
   required?: boolean;
   default?: unknown;
   options?: string[];
@@ -196,17 +207,27 @@ interface AppliedTemplateState {
 }
 
 function readDashboardConfig(payload: BootPayload): DashboardConfig {
-  const raw = payload.initialData as { dashboardConfig?: DashboardConfig } | undefined;
+  const raw = payload.initialData as
+    | { dashboardConfig?: DashboardConfig }
+    | undefined;
   return raw?.dashboardConfig ?? {};
 }
 
-function templateKey(scope: TemplateScope, slug: string, scopeRef?: string | null): string {
-  return `${scope}::${String(scopeRef || '').trim()}::${slug}`;
+function templateKey(
+  scope: TemplateScope,
+  slug: string,
+  scopeRef?: string | null,
+): string {
+  return `${scope}::${String(scopeRef || "").trim()}::${slug}`;
 }
 
-function interpolatePath(template: string, replacements: Record<string, string>): string {
+function interpolatePath(
+  template: string,
+  replacements: Record<string, string>,
+): string {
   return Object.entries(replacements).reduce(
-    (value, [key, replacement]) => value.replaceAll(`{${key}}`, encodeURIComponent(replacement)),
+    (value, [key, replacement]) =>
+      value.replaceAll(`{${key}}`, encodeURIComponent(replacement)),
     template,
   );
 }
@@ -217,7 +238,7 @@ function withQueryParams(
 ): string {
   const searchParams = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') {
+    if (value !== undefined && value !== null && value !== "") {
       searchParams.set(key, value);
     }
   });
@@ -225,27 +246,30 @@ function withQueryParams(
   if (!serialized) {
     return baseUrl;
   }
-  return `${baseUrl}${baseUrl.includes('?') ? '&' : '?'}${serialized}`;
+  return `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}${serialized}`;
 }
 
-function createStepStateEntry(index: number, overrides: Partial<StepState> = {}): StepState {
+function createStepStateEntry(
+  index: number,
+  overrides: Partial<StepState> = {},
+): StepState {
   return {
     localId: `step-${index}`,
-    id: '',
-    title: '',
-    instructions: '',
-    skillId: '',
-    skillArgs: '',
-    skillRequiredCapabilities: '',
-    templateStepId: '',
-    templateInstructions: '',
+    id: "",
+    title: "",
+    instructions: "",
+    skillId: "",
+    skillArgs: "",
+    skillRequiredCapabilities: "",
+    templateStepId: "",
+    templateInstructions: "",
     ...overrides,
   };
 }
 
 function hasExplicitSkillSelection(skillId: string): boolean {
   const normalized = skillId.trim().toLowerCase();
-  return normalized !== '' && normalized !== 'auto';
+  return normalized !== "" && normalized !== "auto";
 }
 
 function isResolverSkill(skillId: string): boolean {
@@ -253,39 +277,50 @@ function isResolverSkill(skillId: string): boolean {
 }
 
 function shouldShowSkillArgs(step: StepState | null | undefined): boolean {
-  return hasExplicitSkillSelection(String(step?.skillId || ''));
+  return hasExplicitSkillSelection(String(step?.skillId || ""));
 }
 
 function parseCapabilitiesCsv(value: string): string[] {
   return Array.from(
     new Set(
       value
-        .split(',')
+        .split(",")
         .map((item) => item.trim().toLowerCase())
         .filter(Boolean),
     ),
   );
 }
 
-function stringifySkillArgs(args: Record<string, unknown> | null | undefined): string {
-  if (!args || typeof args !== 'object' || Array.isArray(args) || Object.keys(args).length === 0) {
-    return '';
+function stringifySkillArgs(
+  args: Record<string, unknown> | null | undefined,
+): string {
+  if (
+    !args ||
+    typeof args !== "object" ||
+    Array.isArray(args) ||
+    Object.keys(args).length === 0
+  ) {
+    return "";
   }
   try {
     return JSON.stringify(args, null, 2);
   } catch {
-    return '[unserializable skill args]';
+    return "[unserializable skill args]";
   }
 }
 
 function extractCapabilityCsv(value: unknown): string {
   if (!Array.isArray(value)) {
-    return '';
+    return "";
   }
   return value
-    .map((item) => String(item || '').trim().toLowerCase())
+    .map((item) =>
+      String(item || "")
+        .trim()
+        .toLowerCase(),
+    )
     .filter(Boolean)
-    .join(',');
+    .join(",");
 }
 
 function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
@@ -306,9 +341,11 @@ function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
 function validatePrimaryStepSubmission(
   primaryStep: StepState | null,
   options: { additionalStepsCount?: number } = {},
-): { ok: true; value: { instructions: string; skillId: string } } | { ok: false; error: string } {
+):
+  | { ok: true; value: { instructions: string; skillId: string } }
+  | { ok: false; error: string } {
   if (!primaryStep) {
-    return { ok: false, error: 'Add at least one step before submitting.' };
+    return { ok: false, error: "Add at least one step before submitting." };
   }
   const instructions = primaryStep.instructions.trim();
   const skillId = primaryStep.skillId.trim();
@@ -316,7 +353,8 @@ function validatePrimaryStepSubmission(
   if (!instructions && additionalStepsCount > 0) {
     return {
       ok: false,
-      error: 'Primary step instructions are required when additional steps are provided.',
+      error:
+        "Primary step instructions are required when additional steps are provided.",
     };
   }
   if (instructions || hasExplicitSkillSelection(skillId)) {
@@ -324,7 +362,7 @@ function validatePrimaryStepSubmission(
   }
   return {
     ok: false,
-    error: 'Primary step requires instructions or an explicit skill selection.',
+    error: "Primary step requires instructions or an explicit skill selection.",
   };
 }
 
@@ -336,27 +374,37 @@ function isValidRepositoryInput(value: string): boolean {
   if (OWNER_REPO_PATTERN.test(candidate)) {
     return true;
   }
-  if (candidate.startsWith('http://') || candidate.startsWith('https://')) {
+  if (candidate.startsWith("http://") || candidate.startsWith("https://")) {
     try {
       const parsed = new URL(candidate);
-      return Boolean(parsed.hostname) && Boolean(parsed.pathname) && parsed.pathname !== '/' && !parsed.username && !parsed.password;
+      return (
+        Boolean(parsed.hostname) &&
+        Boolean(parsed.pathname) &&
+        parsed.pathname !== "/" &&
+        !parsed.username &&
+        !parsed.password
+      );
     } catch {
       return false;
     }
   }
-  return candidate.startsWith('git@');
+  return candidate.startsWith("git@");
 }
 
 function scopeLabel(scope: TemplateScope): string {
-  return scope === 'personal' ? 'Personal' : 'Global';
+  return scope === "personal" ? "Personal" : "Global";
 }
 
 function preferredTemplate(items: TemplateOption[]): TemplateOption | null {
-  const preferredGlobal = items.find((item) => item.slug === 'speckit-orchestrate' && item.scope === 'global');
+  const preferredGlobal = items.find(
+    (item) => item.slug === "speckit-orchestrate" && item.scope === "global",
+  );
   if (preferredGlobal) {
     return preferredGlobal;
   }
-  const preferredAny = items.find((item) => item.slug === 'speckit-orchestrate');
+  const preferredAny = items.find(
+    (item) => item.slug === "speckit-orchestrate",
+  );
   if (preferredAny) {
     return preferredAny;
   }
@@ -374,7 +422,10 @@ function formatAttachmentBytes(value: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function validateAttachmentFiles(files: File[], policy: AttachmentPolicy): {
+function validateAttachmentFiles(
+  files: File[],
+  policy: AttachmentPolicy,
+): {
   ok: boolean;
   errors: string[];
   totalBytes: number;
@@ -385,18 +436,24 @@ function validateAttachmentFiles(files: File[], policy: AttachmentPolicy): {
   }
   let totalBytes = 0;
   files.forEach((file) => {
-    const type = String(file.type || '').trim().toLowerCase();
+    const type = String(file.type || "")
+      .trim()
+      .toLowerCase();
     if (!policy.allowedContentTypes.includes(type)) {
-      errors.push(`Unsupported file type for ${file.name || 'attachment'}.`);
+      errors.push(`Unsupported file type for ${file.name || "attachment"}.`);
     }
     const sizeBytes = Math.max(0, Number(file.size) || 0);
     if (sizeBytes > policy.maxBytes) {
-      errors.push(`${file.name || 'attachment'} exceeds ${formatAttachmentBytes(policy.maxBytes)}.`);
+      errors.push(
+        `${file.name || "attachment"} exceeds ${formatAttachmentBytes(policy.maxBytes)}.`,
+      );
     }
     totalBytes += sizeBytes;
   });
   if (totalBytes > policy.totalBytes) {
-    errors.push(`Total attachment size exceeds ${formatAttachmentBytes(policy.totalBytes)}.`);
+    errors.push(
+      `Total attachment size exceeds ${formatAttachmentBytes(policy.totalBytes)}.`,
+    );
   }
   return { ok: errors.length === 0, errors, totalBytes };
 }
@@ -412,31 +469,36 @@ function deriveRequiredCapabilities(args: {
     new Set(
       [
         args.runtimeMode,
-        'git',
-        ...(args.publishMode === 'pr' ? ['gh'] : []),
+        "git",
+        ...(args.publishMode === "pr" ? ["gh"] : []),
         ...args.taskSkillRequiredCapabilities,
         ...args.stepSkillRequiredCapabilities,
-        ...args.templateCapabilities.map((item) => item.trim().toLowerCase()).filter(Boolean),
+        ...args.templateCapabilities
+          .map((item) => item.trim().toLowerCase())
+          .filter(Boolean),
       ].filter(Boolean),
     ),
   );
 }
 
-function mapExpandedStepToState(index: number, step: ExpandedStepPayload): StepState {
+function mapExpandedStepToState(
+  index: number,
+  step: ExpandedStepPayload,
+): StepState {
   const tool = step.tool || step.skill || {};
   const inlineInputs =
-    tool.inputs && typeof tool.inputs === 'object'
+    tool.inputs && typeof tool.inputs === "object"
       ? tool.inputs
-      : tool.args && typeof tool.args === 'object'
+      : tool.args && typeof tool.args === "object"
         ? tool.args
         : {};
-  const stepId = String(step.id || '').trim();
-  const instructions = String(step.instructions || '').trim();
+  const stepId = String(step.id || "").trim();
+  const instructions = String(step.instructions || "").trim();
   return createStepStateEntry(index, {
     id: stepId,
-    title: String(step.title || '').trim(),
+    title: String(step.title || "").trim(),
     instructions,
-    skillId: String(tool.name || tool.id || '').trim(),
+    skillId: String(tool.name || tool.id || "").trim(),
     skillArgs: stringifySkillArgs(inlineInputs),
     skillRequiredCapabilities: extractCapabilityCsv(tool.requiredCapabilities),
     templateStepId: stepId,
@@ -445,12 +507,19 @@ function mapExpandedStepToState(index: number, step: ExpandedStepPayload): StepS
 }
 
 function normalizeTemplateInputKey(rawKey: string): string {
-  return rawKey.trim().toLowerCase().replaceAll(/[^a-z0-9]/g, '');
+  return rawKey
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, "");
 }
 
 function isFeatureRequestInputKey(rawKey: string): boolean {
   const normalizedKey = normalizeTemplateInputKey(rawKey);
-  return normalizedKey === 'featurerequest' || normalizedKey === 'feature' || normalizedKey === 'request';
+  return (
+    normalizedKey === "featurerequest" ||
+    normalizedKey === "feature" ||
+    normalizedKey === "request"
+  );
 }
 
 export function resolveObjectiveInstructions(
@@ -470,29 +539,38 @@ export function resolveObjectiveInstructions(
     if (!candidate) {
       continue;
     }
-    const value = Object.entries(candidate.inputs || {}).find(([rawKey, rawValue]) => {
-      return isFeatureRequestInputKey(rawKey) && String(rawValue || '').trim();
-    });
+    const value = Object.entries(candidate.inputs || {}).find(
+      ([rawKey, rawValue]) => {
+        return (
+          isFeatureRequestInputKey(rawKey) && String(rawValue || "").trim()
+        );
+      },
+    );
     if (value) {
-      return String(value[1] || '').trim();
+      return String(value[1] || "").trim();
     }
   }
-  return '';
+  return "";
 }
 
-async function responseErrorMessage(response: Response, fallback: string): Promise<string> {
+async function responseErrorMessage(
+  response: Response,
+  fallback: string,
+): Promise<string> {
   try {
     const rawText = (await response.text()).trim();
     if (!rawText) {
       return fallback;
     }
     try {
-      const payload = JSON.parse(rawText) as { detail?: string | { message?: string } };
-      if (typeof payload.detail === 'string' && payload.detail.trim()) {
+      const payload = JSON.parse(rawText) as {
+        detail?: string | { message?: string };
+      };
+      if (typeof payload.detail === "string" && payload.detail.trim()) {
         return payload.detail.trim();
       }
-      if (payload.detail && typeof payload.detail === 'object') {
-        const detailMessage = String(payload.detail.message || '').trim();
+      if (payload.detail && typeof payload.detail === "object") {
+        const detailMessage = String(payload.detail.message || "").trim();
         if (detailMessage) {
           return detailMessage;
         }
@@ -514,113 +592,202 @@ async function createInputArtifact(
   let createResponse: Response;
   try {
     createResponse = await fetch(createEndpoint, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
+        "Content-Type": "application/json",
+        Accept: "application/json",
       },
       body: JSON.stringify({
-        content_type: 'application/json; charset=utf-8',
+        content_type: "application/json; charset=utf-8",
         size_bytes: new TextEncoder().encode(body).length,
         metadata: {
-          label: 'Submitted Task Input',
+          label: "Submitted Task Input",
           repository: repository || null,
-          source: 'task-dashboard-submit',
+          source: "task-dashboard-submit",
         },
       }),
     });
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      console.error('[TaskCreate] Network failure during artifact creation.', {
+    if (error instanceof TypeError && error.message === "Failed to fetch") {
+      console.error("[TaskCreate] Network failure during artifact creation.", {
         endpoint: createEndpoint,
-        possibleCauses: 'API service unreachable, CORS block, or network issue.',
+        possibleCauses:
+          "API service unreachable, CORS block, or network issue.",
       });
       throw new Error(
         `Failed to reach the artifact creation API (endpoint: ${createEndpoint}). ` +
-          'The API service may be unreachable or a CORS policy is blocking the request.',
+          "The API service may be unreachable or a CORS policy is blocking the request.",
         { cause: error },
       );
     }
     throw error;
   }
   if (!createResponse.ok) {
-    throw new Error(await responseErrorMessage(createResponse, 'Failed to create input artifact.'));
+    throw new Error(
+      await responseErrorMessage(
+        createResponse,
+        "Failed to create input artifact.",
+      ),
+    );
   }
   const created = (await createResponse.json()) as {
     artifact_ref?: { artifact_id?: string };
-    upload?: { mode?: string; upload_url?: string };
+    upload?: {
+      mode?: string;
+      upload_url?: string;
+      required_headers?: Record<string, string>;
+    };
   };
-  const artifactId = String(created.artifact_ref?.artifact_id || '').trim();
-  const uploadMode = String(created.upload?.mode || 'single_put').trim().toLowerCase();
+  const artifactId = String(created.artifact_ref?.artifact_id || "").trim();
+  const uploadMode = String(created.upload?.mode || "single_put")
+    .trim()
+    .toLowerCase();
   if (!artifactId) {
-    throw new Error('Artifact upload details were incomplete.');
+    throw new Error("Artifact upload details were incomplete.");
   }
-  if (uploadMode === 'multipart') {
+  if (uploadMode === "multipart") {
     throw new Error(
-      'Task input artifact is too large for the current browser submission flow. ' +
-        'Reduce the submitted instructions or task step payload and retry.',
+      "Task input artifact is too large for the current browser submission flow. " +
+        "Reduce the submitted instructions or task step payload and retry.",
     );
   }
 
-  const uploadUrl = `/api/artifacts/${encodeURIComponent(artifactId)}/content`;
+  const uploadUrl =
+    String(created.upload?.upload_url || "").trim() ||
+    `/api/artifacts/${encodeURIComponent(artifactId)}/content`;
+  const requiredHeaders =
+    created.upload?.required_headers &&
+    typeof created.upload.required_headers === "object"
+      ? created.upload.required_headers
+      : {};
 
   let uploadResponse: Response;
   try {
     uploadResponse = await fetch(uploadUrl, {
-      method: 'PUT',
+      method: "PUT",
       headers: {
-        'Content-Type': 'application/json; charset=utf-8',
+        ...requiredHeaders,
+        "Content-Type": "application/json; charset=utf-8",
       },
       body,
     });
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      console.error('[TaskCreate] Network failure during artifact content upload.', {
-        uploadUrl,
-        possibleCauses: 'API service unreachable, CORS block, or network issue.',
-      });
+    if (error instanceof TypeError && error.message === "Failed to fetch") {
+      console.error(
+        "[TaskCreate] Network failure during artifact content upload.",
+        {
+          uploadUrl,
+          possibleCauses:
+            "API service unreachable, CORS block, or network issue.",
+        },
+      );
       throw new Error(
         `Failed to upload artifact content (upload URL: ${uploadUrl}). ` +
-          'The API service may be unreachable or a CORS policy is blocking the request.',
+          "The API service may be unreachable or a CORS policy is blocking the request.",
         { cause: error },
       );
     }
     throw error;
   }
   if (!uploadResponse.ok) {
-    throw new Error(await responseErrorMessage(uploadResponse, 'Failed to upload task input artifact content.'));
+    throw new Error(
+      await responseErrorMessage(
+        uploadResponse,
+        "Failed to upload task input artifact content.",
+      ),
+    );
   }
 
-  return { artifactId };
+  const completeUrl = `/api/artifacts/${encodeURIComponent(artifactId)}/complete`;
+  let completeError: Error | null = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let completeResponse: Response;
+    try {
+      completeResponse = await fetch(completeUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ parts: [] }),
+      });
+    } catch (error) {
+      if (error instanceof TypeError && error.message === "Failed to fetch") {
+        console.error(
+          "[TaskCreate] Network failure during artifact completion.",
+          {
+            endpoint: completeUrl,
+            artifactId,
+            possibleCauses:
+              "API service unreachable, CORS block, or network issue.",
+          },
+        );
+        throw new Error(
+          `Failed to finalize artifact upload (endpoint: ${completeUrl}). ` +
+            "The API service may be unreachable or a CORS policy is blocking the request.",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+    if (completeResponse.ok) {
+      return { artifactId };
+    }
+
+    const message = await responseErrorMessage(
+      completeResponse,
+      "Failed to finalize task input artifact upload.",
+    );
+    completeError = new Error(message);
+    if (!message.includes("artifact upload is not complete") || attempt === 2) {
+      throw completeError;
+    }
+    await new Promise((resolve) =>
+      window.setTimeout(resolve, 200 * (attempt + 1)),
+    );
+  }
+
+  throw (
+    completeError ?? new Error("Failed to finalize task input artifact upload.")
+  );
 }
 
 function utf8ByteLength(value: string): number {
   return new TextEncoder().encode(value).length;
 }
 
-function stripOversizedInlineInstructions(requestBody: Record<string, unknown>): void {
+function stripOversizedInlineInstructions(
+  requestBody: Record<string, unknown>,
+): void {
   const payload = requestBody.payload;
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return;
   }
 
   const payloadRecord = payload as Record<string, unknown>;
   const task = payloadRecord.task;
-  if (!task || typeof task !== 'object' || Array.isArray(task)) {
+  if (!task || typeof task !== "object" || Array.isArray(task)) {
     return;
   }
 
   const taskRecord = task as Record<string, unknown>;
   const steps = Array.isArray(taskRecord.steps) ? taskRecord.steps : [];
 
-  const fitsInlineLimit = () => utf8ByteLength(JSON.stringify(requestBody)) <= INLINE_TASK_INPUT_LIMIT_BYTES;
+  const fitsInlineLimit = () =>
+    utf8ByteLength(JSON.stringify(requestBody)) <=
+    INLINE_TASK_INPUT_LIMIT_BYTES;
   if (fitsInlineLimit()) {
     return;
   }
 
   for (let index = steps.length - 1; index >= 1; index -= 1) {
     const step = steps[index];
-    if (!step || typeof step !== 'object' || Array.isArray(step) || !('instructions' in step)) {
+    if (
+      !step ||
+      typeof step !== "object" ||
+      Array.isArray(step) ||
+      !("instructions" in step)
+    ) {
       continue;
     }
     delete (step as Record<string, unknown>).instructions;
@@ -629,7 +796,7 @@ function stripOversizedInlineInstructions(requestBody: Record<string, unknown>):
     }
   }
 
-  if ('instructions' in taskRecord) {
+  if ("instructions" in taskRecord) {
     delete taskRecord.instructions;
     if (fitsInlineLimit()) {
       return;
@@ -638,7 +805,12 @@ function stripOversizedInlineInstructions(requestBody: Record<string, unknown>):
 
   for (let index = 0; index < steps.length; index += 1) {
     const step = steps[index];
-    if (!step || typeof step !== 'object' || Array.isArray(step) || !('instructions' in step)) {
+    if (
+      !step ||
+      typeof step !== "object" ||
+      Array.isArray(step) ||
+      !("instructions" in step)
+    ) {
       continue;
     }
     delete (step as Record<string, unknown>).instructions;
@@ -648,10 +820,13 @@ function stripOversizedInlineInstructions(requestBody: Record<string, unknown>):
   }
 }
 
-async function linkInputArtifact(artifactId: string, execution: ExecutionCreateResponse): Promise<void> {
-  const workflowId = String(execution.workflowId || '').trim();
-  const runId = String(execution.runId || execution.temporalRunId || '').trim();
-  const namespace = String(execution.namespace || '').trim();
+async function linkInputArtifact(
+  artifactId: string,
+  execution: ExecutionCreateResponse,
+): Promise<void> {
+  const workflowId = String(execution.workflowId || "").trim();
+  const runId = String(execution.runId || execution.temporalRunId || "").trim();
+  const namespace = String(execution.namespace || "").trim();
   if (!artifactId || !workflowId || !runId || !namespace) {
     return;
   }
@@ -659,36 +834,42 @@ async function linkInputArtifact(artifactId: string, execution: ExecutionCreateR
   let response: Response;
   try {
     response = await fetch(linkEndpoint, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
+        "Content-Type": "application/json",
+        Accept: "application/json",
       },
       body: JSON.stringify({
         namespace,
         workflow_id: workflowId,
         run_id: runId,
-        link_type: 'input.instructions',
-        label: 'Submitted Task Input',
+        link_type: "input.instructions",
+        label: "Submitted Task Input",
       }),
     });
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      console.error('[TaskCreate] Network failure during artifact linking.', {
+    if (error instanceof TypeError && error.message === "Failed to fetch") {
+      console.error("[TaskCreate] Network failure during artifact linking.", {
         endpoint: linkEndpoint,
         artifactId,
-        possibleCauses: 'API service unreachable, CORS block, or network issue.',
+        possibleCauses:
+          "API service unreachable, CORS block, or network issue.",
       });
       throw new Error(
         `Failed to reach the artifact linking API (endpoint: ${linkEndpoint}). ` +
-          'The API service may be unreachable or a CORS policy is blocking the request.',
+          "The API service may be unreachable or a CORS policy is blocking the request.",
         { cause: error },
       );
     }
     throw error;
   }
   if (!response.ok) {
-    throw new Error(await responseErrorMessage(response, 'Failed to link input artifact to execution.'));
+    throw new Error(
+      await responseErrorMessage(
+        response,
+        "Failed to link input artifact to execution.",
+      ),
+    );
   }
 }
 
@@ -718,27 +899,48 @@ function CloseIcon() {
 
 export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const dashboardConfig = readDashboardConfig(payload);
-  const temporalCreateEndpoint = String(dashboardConfig.sources?.temporal?.create || '/api/executions');
-  const artifactCreateEndpoint = String(dashboardConfig.sources?.temporal?.artifactCreate || '/api/artifacts');
+  const temporalCreateEndpoint = String(
+    dashboardConfig.sources?.temporal?.create || "/api/executions",
+  );
+  const artifactCreateEndpoint = String(
+    dashboardConfig.sources?.temporal?.artifactCreate || "/api/artifacts",
+  );
   const providerProfilesEndpoint = String(
-    dashboardConfig.system?.providerProfiles?.list || '/api/v1/provider-profiles',
+    dashboardConfig.system?.providerProfiles?.list ||
+      "/api/v1/provider-profiles",
   );
   const taskTemplateCatalog = dashboardConfig.system?.taskTemplateCatalog;
   const taskTemplateCatalogEnabled = Boolean(taskTemplateCatalog?.enabled);
-  const taskTemplateSaveEnabled = Boolean(taskTemplateCatalog?.templateSaveEnabled);
-  const taskTemplateListEndpoint = String(taskTemplateCatalog?.list || '/api/task-step-templates');
-  const taskTemplateDetailEndpoint = String(taskTemplateCatalog?.detail || '/api/task-step-templates/{slug}');
-  const taskTemplateExpandEndpoint = String(taskTemplateCatalog?.expand || '/api/task-step-templates/{slug}:expand');
+  const taskTemplateSaveEnabled = Boolean(
+    taskTemplateCatalog?.templateSaveEnabled,
+  );
+  const taskTemplateListEndpoint = String(
+    taskTemplateCatalog?.list || "/api/task-step-templates",
+  );
+  const taskTemplateDetailEndpoint = String(
+    taskTemplateCatalog?.detail || "/api/task-step-templates/{slug}",
+  );
+  const taskTemplateExpandEndpoint = String(
+    taskTemplateCatalog?.expand || "/api/task-step-templates/{slug}:expand",
+  );
   const taskTemplateSaveEndpoint = String(
-    taskTemplateCatalog?.saveFromTask || '/api/task-step-templates/save-from-task',
+    taskTemplateCatalog?.saveFromTask ||
+      "/api/task-step-templates/save-from-task",
   );
 
   const attachmentPolicy = useMemo<AttachmentPolicy>(() => {
     const config = dashboardConfig.system?.attachmentPolicy;
     const allowedContentTypes =
-      Array.isArray(config?.allowedContentTypes) && config.allowedContentTypes.length > 0
-        ? config.allowedContentTypes.map((item) => String(item || '').trim().toLowerCase()).filter(Boolean)
-        : ['image/png', 'image/jpeg', 'image/webp'];
+      Array.isArray(config?.allowedContentTypes) &&
+      config.allowedContentTypes.length > 0
+        ? config.allowedContentTypes
+            .map((item) =>
+              String(item || "")
+                .trim()
+                .toLowerCase(),
+            )
+            .filter(Boolean)
+        : ["image/png", "image/jpeg", "image/webp"];
     return {
       enabled: Boolean(config?.enabled),
       maxCount: Math.max(1, Number(config?.maxCount) || 10),
@@ -748,48 +950,69 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     };
   }, [dashboardConfig.system?.attachmentPolicy]);
 
-  const defaultRuntime = String(dashboardConfig.system?.defaultTaskRuntime || 'codex_cli');
-  const defaultRepository = String(dashboardConfig.system?.defaultRepository || '');
-  const defaultPublishMode = String(dashboardConfig.system?.defaultPublishMode || 'pr');
-  const defaultProposeTasks = Boolean(dashboardConfig.system?.defaultProposeTasks);
-  const defaultTaskModelByRuntime = dashboardConfig.system?.defaultTaskModelByRuntime || {};
-  const defaultTaskEffortByRuntime = dashboardConfig.system?.defaultTaskEffortByRuntime || {};
-  const supportedTaskRuntimes = dashboardConfig.system?.supportedTaskRuntimes || [
-    'codex_cli',
-    'gemini_cli',
-    'claude_code',
-  ];
+  const defaultRuntime = String(
+    dashboardConfig.system?.defaultTaskRuntime || "codex_cli",
+  );
+  const defaultRepository = String(
+    dashboardConfig.system?.defaultRepository || "",
+  );
+  const defaultPublishMode = String(
+    dashboardConfig.system?.defaultPublishMode || "pr",
+  );
+  const defaultProposeTasks = Boolean(
+    dashboardConfig.system?.defaultProposeTasks,
+  );
+  const defaultTaskModelByRuntime =
+    dashboardConfig.system?.defaultTaskModelByRuntime || {};
+  const defaultTaskEffortByRuntime =
+    dashboardConfig.system?.defaultTaskEffortByRuntime || {};
+  const supportedTaskRuntimes = dashboardConfig.system
+    ?.supportedTaskRuntimes || ["codex_cli", "gemini_cli", "claude_code"];
 
   const [steps, setSteps] = useState<StepState[]>([createStepStateEntry(1)]);
   const [nextStepNumber, setNextStepNumber] = useState(2);
   const [runtime, setRuntime] = useState(defaultRuntime);
   const [model, setModel] = useState(
-    String(defaultTaskModelByRuntime[defaultRuntime] || dashboardConfig.system?.defaultTaskModel || ''),
+    String(
+      defaultTaskModelByRuntime[defaultRuntime] ||
+        dashboardConfig.system?.defaultTaskModel ||
+        "",
+    ),
   );
   const [modelManualOverride, setModelManualOverride] = useState(false);
   const [effort, setEffort] = useState(
-    String(defaultTaskEffortByRuntime[defaultRuntime] || dashboardConfig.system?.defaultTaskEffort || ''),
+    String(
+      defaultTaskEffortByRuntime[defaultRuntime] ||
+        dashboardConfig.system?.defaultTaskEffort ||
+        "",
+    ),
   );
   const [repository, setRepository] = useState(defaultRepository);
-  const [providerProfile, setProviderProfile] = useState('');
-  const [startingBranch, setStartingBranch] = useState('');
-  const [targetBranch, setTargetBranch] = useState('');
+  const [providerProfile, setProviderProfile] = useState("");
+  const [startingBranch, setStartingBranch] = useState("");
+  const [targetBranch, setTargetBranch] = useState("");
   const [publishMode, setPublishMode] = useState(defaultPublishMode);
   const [priority, setPriority] = useState(0);
   const [maxAttempts, setMaxAttempts] = useState(3);
-  const [proposeTasks, setProposeTasks] = useState(() => readProposeTasksPreference(defaultProposeTasks));
+  const [proposeTasks, setProposeTasks] = useState(() =>
+    readProposeTasksPreference(defaultProposeTasks),
+  );
   const isInitialMount = useRef(true);
-  const [scheduleMode, setScheduleMode] = useState<ScheduleMode>('immediate');
-  const [scheduledFor, setScheduledFor] = useState('');
-  const [scheduleDeferredMinutes, setScheduleDeferredMinutes] = useState('');
-  const [scheduleCron, setScheduleCron] = useState('');
-  const [scheduleTimezone, setScheduleTimezone] = useState('UTC');
-  const [scheduleName, setScheduleName] = useState('');
-  const [templateFeatureRequest, setTemplateFeatureRequest] = useState('');
-  const [selectedPresetKey, setSelectedPresetKey] = useState('');
+  const [scheduleMode, setScheduleMode] = useState<ScheduleMode>("immediate");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [scheduleDeferredMinutes, setScheduleDeferredMinutes] = useState("");
+  const [scheduleCron, setScheduleCron] = useState("");
+  const [scheduleTimezone, setScheduleTimezone] = useState("UTC");
+  const [scheduleName, setScheduleName] = useState("");
+  const [templateFeatureRequest, setTemplateFeatureRequest] = useState("");
+  const [selectedPresetKey, setSelectedPresetKey] = useState("");
   const [templateMessage, setTemplateMessage] = useState<string | null>(null);
-  const [appliedTemplates, setAppliedTemplates] = useState<AppliedTemplateState[]>([]);
-  const [selectedAttachmentFiles, setSelectedAttachmentFiles] = useState<File[]>([]);
+  const [appliedTemplates, setAppliedTemplates] = useState<
+    AppliedTemplateState[]
+  >([]);
+  const [selectedAttachmentFiles, setSelectedAttachmentFiles] = useState<
+    File[]
+  >([]);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -798,17 +1021,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const prevProviderProfileRef = useRef(providerProfile);
 
   const providerProfilesQuery = useQuery({
-    queryKey: ['task-create', 'provider-profiles', runtime],
+    queryKey: ["task-create", "provider-profiles", runtime],
     queryFn: async (): Promise<ProviderProfile[]> => {
-      const separator = providerProfilesEndpoint.includes('?') ? '&' : '?';
+      const separator = providerProfilesEndpoint.includes("?") ? "&" : "?";
       const response = await fetch(
         `${providerProfilesEndpoint}${separator}runtime_id=${encodeURIComponent(runtime)}`,
         {
-          headers: { Accept: 'application/json' },
+          headers: { Accept: "application/json" },
         },
       );
       if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, 'Failed to load provider profiles.'));
+        throw new Error(
+          await responseErrorMessage(
+            response,
+            "Failed to load provider profiles.",
+          ),
+        );
       }
       return (await response.json()) as ProviderProfile[];
     },
@@ -824,7 +1052,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
 
     if (runtimeChanged) {
-      setProviderProfile('');
+      setProviderProfile("");
       prevRuntimeRef.current = runtime;
     }
 
@@ -832,19 +1060,33 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       prevProviderProfileRef.current = providerProfile;
     }
 
-    setEffort(String(defaultTaskEffortByRuntime[runtime] || dashboardConfig.system?.defaultTaskEffort || ''));
+    setEffort(
+      String(
+        defaultTaskEffortByRuntime[runtime] ||
+          dashboardConfig.system?.defaultTaskEffort ||
+          "",
+      ),
+    );
 
     if (modelManualOverride && !runtimeChanged && !profileChanged) {
       return;
     }
 
-    const profileIdForModel = runtimeChanged ? '' : providerProfile;
+    const profileIdForModel = runtimeChanged ? "" : providerProfile;
     const profiles = providerProfilesQuery.data || [];
-    const selectedProfile = profiles.find((p) => p.profile_id === profileIdForModel);
+    const selectedProfile = profiles.find(
+      (p) => p.profile_id === profileIdForModel,
+    );
     if (selectedProfile?.default_model) {
       setModel(selectedProfile.default_model);
     } else {
-      setModel(String(defaultTaskModelByRuntime[runtime] || dashboardConfig.system?.defaultTaskModel || ''));
+      setModel(
+        String(
+          defaultTaskModelByRuntime[runtime] ||
+            dashboardConfig.system?.defaultTaskModel ||
+            "",
+        ),
+      );
     }
   }, [
     dashboardConfig.system?.defaultTaskEffort,
@@ -858,9 +1100,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   ]);
 
   useEffect(() => {
-    const primarySkill = String(steps[0]?.skillId || '').trim().toLowerCase();
+    const primarySkill = String(steps[0]?.skillId || "")
+      .trim()
+      .toLowerCase();
     if (isResolverSkill(primarySkill)) {
-      setPublishMode('none');
+      setPublishMode("none");
     }
   }, [steps[0]?.skillId]);
 
@@ -873,13 +1117,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }, [proposeTasks]);
 
   const skillsQuery = useQuery({
-    queryKey: ['task-create', 'skills'],
+    queryKey: ["task-create", "skills"],
     queryFn: async (): Promise<string[]> => {
-      const response = await fetch('/api/tasks/skills', {
-        headers: { Accept: 'application/json' },
+      const response = await fetch("/api/tasks/skills", {
+        headers: { Accept: "application/json" },
       });
       if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, 'Failed to load skills.'));
+        throw new Error(
+          await responseErrorMessage(response, "Failed to load skills."),
+        );
       }
       const data = (await response.json()) as SkillsResponse;
       return data.items?.worker || [];
@@ -887,18 +1133,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   });
 
   const templateOptionsQuery = useQuery({
-    queryKey: ['task-create', 'task-template-catalog', taskTemplateListEndpoint],
+    queryKey: [
+      "task-create",
+      "task-template-catalog",
+      taskTemplateListEndpoint,
+    ],
     enabled: taskTemplateCatalogEnabled,
     queryFn: async (): Promise<TemplateCatalogResult> => {
-      const scopes: TemplateScope[] = ['global', 'personal'];
+      const scopes: TemplateScope[] = ["global", "personal"];
       const results = await Promise.all(
         scopes.map(async (scope) => {
           try {
-            const response = await fetch(withQueryParams(taskTemplateListEndpoint, { scope }), {
-              headers: { Accept: 'application/json' },
-            });
+            const response = await fetch(
+              withQueryParams(taskTemplateListEndpoint, { scope }),
+              {
+                headers: { Accept: "application/json" },
+              },
+            );
             if (!response.ok) {
-              throw new Error(await responseErrorMessage(response, 'Failed to load presets.'));
+              throw new Error(
+                await responseErrorMessage(response, "Failed to load presets."),
+              );
             }
             const data = (await response.json()) as TaskTemplateListResponse;
             const items = (data.items || []).map((item) => ({
@@ -912,8 +1167,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         }),
       );
       return {
-        items: results.flatMap((result) => result.items).sort((left, right) => left.title.localeCompare(right.title)),
-        failedScopes: results.filter((result) => result.failed).map((result) => result.scope),
+        items: results
+          .flatMap((result) => result.items)
+          .sort((left, right) => left.title.localeCompare(right.title)),
+        failedScopes: results
+          .filter((result) => result.failed)
+          .map((result) => result.scope),
       };
     },
   });
@@ -924,7 +1183,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!taskTemplateCatalogEnabled || templateItems.length === 0) {
       return;
     }
-    const selectedStillExists = templateItems.some((item) => item.key === selectedPresetKey);
+    const selectedStillExists = templateItems.some(
+      (item) => item.key === selectedPresetKey,
+    );
     if (selectedStillExists) {
       return;
     }
@@ -952,12 +1213,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       Array.from(
         new Set(
           [
-            String(defaultTaskModelByRuntime[runtime] || ''),
-            String(dashboardConfig.system?.defaultTaskModel || ''),
+            String(defaultTaskModelByRuntime[runtime] || ""),
+            String(dashboardConfig.system?.defaultTaskModel || ""),
           ].filter(Boolean),
         ),
       ),
-    [dashboardConfig.system?.defaultTaskModel, defaultTaskModelByRuntime, runtime],
+    [
+      dashboardConfig.system?.defaultTaskModel,
+      defaultTaskModelByRuntime,
+      runtime,
+    ],
   );
 
   const effortOptions = useMemo(
@@ -965,16 +1230,20 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       Array.from(
         new Set(
           [
-            'low',
-            'medium',
-            'high',
-            'xhigh',
-            String(defaultTaskEffortByRuntime[runtime] || ''),
-            String(dashboardConfig.system?.defaultTaskEffort || ''),
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            String(defaultTaskEffortByRuntime[runtime] || ""),
+            String(dashboardConfig.system?.defaultTaskEffort || ""),
           ].filter(Boolean),
         ),
       ),
-    [dashboardConfig.system?.defaultTaskEffort, defaultTaskEffortByRuntime, runtime],
+    [
+      dashboardConfig.system?.defaultTaskEffort,
+      defaultTaskEffortByRuntime,
+      runtime,
+    ],
   );
 
   const presetStatusText = useMemo(() => {
@@ -982,19 +1251,25 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return templateMessage;
     }
     if (templateOptionsQuery.isLoading) {
-      return 'Loading presets...';
+      return "Loading presets...";
     }
     if (templateOptionsQuery.isError) {
-      return 'Failed to load presets.';
+      return "Failed to load presets.";
     }
     if (templateItems.length === 0) {
-      return 'No presets available for your account.';
+      return "No presets available for your account.";
     }
     if ((templateOptionsQuery.data?.failedScopes || []).length > 0) {
-      return `Loaded ${templateItems.length} presets (missing scopes: ${(templateOptionsQuery.data?.failedScopes || []).join(', ')}).`;
+      return `Loaded ${templateItems.length} presets (missing scopes: ${(templateOptionsQuery.data?.failedScopes || []).join(", ")}).`;
     }
     return `Loaded ${templateItems.length} presets.`;
-  }, [templateItems, templateMessage, templateOptionsQuery.data?.failedScopes, templateOptionsQuery.isError, templateOptionsQuery.isLoading]);
+  }, [
+    templateItems,
+    templateMessage,
+    templateOptionsQuery.data?.failedScopes,
+    templateOptionsQuery.isError,
+    templateOptionsQuery.isLoading,
+  ]);
 
   function updateStep(localId: string, updates: Partial<StepState>) {
     setSteps((current) =>
@@ -1004,15 +1279,18 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         }
         const nextStep = { ...step, ...updates };
         if (
-          Object.prototype.hasOwnProperty.call(updates, 'instructions') &&
+          Object.prototype.hasOwnProperty.call(updates, "instructions") &&
           nextStep.templateStepId &&
           nextStep.id === nextStep.templateStepId &&
           nextStep.instructions !== nextStep.templateInstructions
         ) {
-          nextStep.id = '';
+          nextStep.id = "";
         }
-        if (Object.prototype.hasOwnProperty.call(updates, 'skillId') && !shouldShowSkillArgs(nextStep)) {
-          nextStep.skillArgs = '';
+        if (
+          Object.prototype.hasOwnProperty.call(updates, "skillId") &&
+          !shouldShowSkillArgs(nextStep)
+        ) {
+          nextStep.skillArgs = "";
         }
         return nextStep;
       }),
@@ -1027,7 +1305,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function moveStep(index: number, direction: -1 | 1) {
     setSteps((current) => {
       const nextIndex = index + direction;
-      if (index < 0 || index >= current.length || nextIndex < 0 || nextIndex >= current.length) {
+      if (
+        index < 0 ||
+        index >= current.length ||
+        nextIndex < 0 ||
+        nextIndex >= current.length
+      ) {
         return current;
       }
       const updated = current.slice();
@@ -1043,90 +1326,113 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }
 
   function removeStep(index: number) {
-    setSteps((current) => current.filter((_, currentIndex) => currentIndex !== index));
+    setSteps((current) =>
+      current.filter((_, currentIndex) => currentIndex !== index),
+    );
   }
 
-  function resolveTemplateInputs(inputs: TaskTemplateInputDefinition[]): { values: Record<string, unknown>; assumptions: string[] } {
+  function resolveTemplateInputs(inputs: TaskTemplateInputDefinition[]): {
+    values: Record<string, unknown>;
+    assumptions: string[];
+  } {
     const values: Record<string, unknown> = {};
     const assumptions: string[] = [];
-    const primaryInstructions = String(steps[0]?.instructions || '').trim();
+    const primaryInstructions = String(steps[0]?.instructions || "").trim();
     const explicitFeatureRequest = templateFeatureRequest.trim();
     const repositoryValue = repository.trim();
 
     inputs.forEach((definition) => {
-      const name = String(definition.name || '').trim();
+      const name = String(definition.name || "").trim();
       const label = String(definition.label || name).trim() || name;
       if (!name) {
         return;
       }
       const required = Boolean(definition.required);
-      const inputType = String(definition.type || '').toLowerCase();
+      const inputType = String(definition.type || "").toLowerCase();
       const options = Array.isArray(definition.options)
-        ? definition.options.map((option) => String(option).trim()).filter(Boolean)
+        ? definition.options
+            .map((option) => String(option).trim())
+            .filter(Boolean)
         : [];
       const key = name.toLowerCase();
       const isFeatureRequestKey = isFeatureRequestInputKey(name);
 
       let value: unknown = null;
-      let valueSource = '';
+      let valueSource = "";
       const remembered = templateInputMemoryRef.current[name];
       const defaultValue = definition.default;
 
       if (isFeatureRequestKey && explicitFeatureRequest) {
         value = explicitFeatureRequest;
-        valueSource = 'manual';
-      } else if (remembered !== undefined && remembered !== null && String(remembered).trim() !== '') {
+        valueSource = "manual";
+      } else if (
+        remembered !== undefined &&
+        remembered !== null &&
+        String(remembered).trim() !== ""
+      ) {
         value = remembered;
-        valueSource = 'memory';
-      } else if (defaultValue !== undefined && defaultValue !== null && String(defaultValue).trim() !== '') {
+        valueSource = "memory";
+      } else if (
+        defaultValue !== undefined &&
+        defaultValue !== null &&
+        String(defaultValue).trim() !== ""
+      ) {
         value = defaultValue;
-        valueSource = 'default';
-      } else if (key.includes('instruction') || isFeatureRequestKey) {
+        valueSource = "default";
+      } else if (key.includes("instruction") || isFeatureRequestKey) {
         value = explicitFeatureRequest || primaryInstructions;
-        valueSource = 'draft';
-      } else if (key.includes('repo')) {
+        valueSource = "draft";
+      } else if (key.includes("repo")) {
         value = repositoryValue;
-        valueSource = 'draft';
-      } else if (inputType === 'enum') {
-        value = options[0] || '';
-        valueSource = 'assumed';
-      } else if (inputType === 'boolean') {
+        valueSource = "draft";
+      } else if (inputType === "enum") {
+        value = options[0] || "";
+        valueSource = "assumed";
+      } else if (inputType === "boolean") {
         value = false;
-        valueSource = 'assumed';
+        valueSource = "assumed";
       }
 
-      const hasValue = value !== null && value !== undefined && String(value).trim() !== '';
+      const hasValue =
+        value !== null && value !== undefined && String(value).trim() !== "";
       if (!hasValue && required) {
-        if (inputType === 'enum' && options.length > 0) {
+        if (inputType === "enum" && options.length > 0) {
           value = options[0];
-        } else if (inputType === 'boolean') {
+        } else if (inputType === "boolean") {
           value = false;
         } else if (explicitFeatureRequest || primaryInstructions) {
           value = explicitFeatureRequest || primaryInstructions;
         } else {
-          value = `auto-${key.replaceAll(/[^a-z0-9]+/g, '-').replaceAll(/^-+|-+$/g, '') || 'value'}`;
+          value = `auto-${key.replaceAll(/[^a-z0-9]+/g, "-").replaceAll(/^-+|-+$/g, "") || "value"}`;
         }
-        valueSource = 'assumed';
+        valueSource = "assumed";
       }
 
-      if (value === null || value === undefined || String(value).trim() === '') {
+      if (
+        value === null ||
+        value === undefined ||
+        String(value).trim() === ""
+      ) {
         return;
       }
 
       let normalized: unknown;
-      if (inputType === 'boolean') {
+      if (inputType === "boolean") {
         normalized = Boolean(value);
       } else {
         normalized = String(value).trim();
       }
-      if (inputType === 'enum') {
+      if (inputType === "enum") {
         const candidate = String(normalized).trim();
-        normalized = options.length > 0 && !options.includes(candidate) ? options[0] : candidate;
+        normalized =
+          options.length > 0 && !options.includes(candidate)
+            ? options[0]
+            : candidate;
       }
 
       values[name] = normalized;
       templateInputMemoryRef.current[name] = normalized;
-      if (valueSource === 'assumed' || valueSource === 'draft') {
+      if (valueSource === "assumed" || valueSource === "draft") {
         assumptions.push(label);
       }
     });
@@ -1137,11 +1443,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   async function handleApplyPreset() {
     if (isApplyingPreset) return;
     if (!selectedPreset) {
-      setTemplateMessage('Choose a preset first.');
+      setTemplateMessage("Choose a preset first.");
       return;
     }
     setIsApplyingPreset(true);
-    setTemplateMessage('Applying preset...');
+    setTemplateMessage("Applying preset...");
 
     try {
       const scopeParams = {
@@ -1150,52 +1456,75 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       };
       const detailResponse = await fetch(
         withQueryParams(
-          interpolatePath(taskTemplateDetailEndpoint, { slug: selectedPreset.slug }),
+          interpolatePath(taskTemplateDetailEndpoint, {
+            slug: selectedPreset.slug,
+          }),
           scopeParams,
         ),
         {
-          headers: { Accept: 'application/json' },
+          headers: { Accept: "application/json" },
         },
       );
       if (!detailResponse.ok) {
-        throw new Error(await responseErrorMessage(detailResponse, 'Failed to load preset details.'));
+        throw new Error(
+          await responseErrorMessage(
+            detailResponse,
+            "Failed to load preset details.",
+          ),
+        );
       }
       const detail = (await detailResponse.json()) as TaskTemplateDetail;
-      const { values: inputs, assumptions } = resolveTemplateInputs(detail.inputs || []);
+      const { values: inputs, assumptions } = resolveTemplateInputs(
+        detail.inputs || [],
+      );
       const expandResponse = await fetch(
         withQueryParams(
-          interpolatePath(taskTemplateExpandEndpoint, { slug: selectedPreset.slug }),
+          interpolatePath(taskTemplateExpandEndpoint, {
+            slug: selectedPreset.slug,
+          }),
           scopeParams,
         ),
         {
-          method: 'POST',
+          method: "POST",
           headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
+            "Content-Type": "application/json",
+            Accept: "application/json",
           },
           body: JSON.stringify({
-            version: detail.version || detail.latestVersion || selectedPreset.latestVersion || '1.0.0',
+            version:
+              detail.version ||
+              detail.latestVersion ||
+              selectedPreset.latestVersion ||
+              "1.0.0",
             inputs,
             options: { enforceStepLimit: true },
           }),
         },
       );
       if (!expandResponse.ok) {
-        throw new Error(await responseErrorMessage(expandResponse, 'Failed to apply preset.'));
+        throw new Error(
+          await responseErrorMessage(expandResponse, "Failed to apply preset."),
+        );
       }
-      const expanded = (await expandResponse.json()) as TaskTemplateExpandResponse;
+      const expanded =
+        (await expandResponse.json()) as TaskTemplateExpandResponse;
       const expandedSteps = (expanded.steps || []).map((step, index) =>
         mapExpandedStepToState(nextStepNumber + index, step),
       );
-      const replaceEmptyDefault = steps.length === 1 && isEmptyStepStateEntry(steps[0]);
+      const replaceEmptyDefault =
+        steps.length === 1 && isEmptyStepStateEntry(steps[0]);
 
       setSteps((current) => {
         if (replaceEmptyDefault) {
-          return expandedSteps.length > 0 ? expandedSteps : [createStepStateEntry(nextStepNumber)];
+          return expandedSteps.length > 0
+            ? expandedSteps
+            : [createStepStateEntry(nextStepNumber)];
         }
         return [...current, ...expandedSteps];
       });
-      setNextStepNumber((current) => current + Math.max(expandedSteps.length, 1));
+      setNextStepNumber(
+        (current) => current + Math.max(expandedSteps.length, 1),
+      );
       if (expandedSteps.length > 0) {
         const appliedTemplate = expanded.appliedTemplate || {};
         setAppliedTemplates((current) => [
@@ -1203,27 +1532,38 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           {
             slug: String(appliedTemplate.slug || selectedPreset.slug),
             version: String(
-              appliedTemplate.version || detail.version || selectedPreset.latestVersion || '1.0.0',
+              appliedTemplate.version ||
+                detail.version ||
+                selectedPreset.latestVersion ||
+                "1.0.0",
             ),
             inputs:
-              appliedTemplate.inputs && typeof appliedTemplate.inputs === 'object'
+              appliedTemplate.inputs &&
+              typeof appliedTemplate.inputs === "object"
                 ? appliedTemplate.inputs
                 : inputs,
             stepIds: Array.isArray(appliedTemplate.stepIds)
               ? appliedTemplate.stepIds
               : expandedSteps.map((step) => step.id).filter(Boolean),
-            appliedAt: String(appliedTemplate.appliedAt || '').trim() || new Date().toISOString(),
-            capabilities: Array.isArray(expanded.capabilities) ? expanded.capabilities : [],
+            appliedAt:
+              String(appliedTemplate.appliedAt || "").trim() ||
+              new Date().toISOString(),
+            capabilities: Array.isArray(expanded.capabilities)
+              ? expanded.capabilities
+              : [],
           },
         ]);
       }
       const autoFillSuffix =
         assumptions.length > 0
-          ? ` Auto-filled ${assumptions.length} input(s): ${assumptions.join(', ')}.`
-          : '';
-      setTemplateMessage(`Applied preset '${selectedPreset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`);
+          ? ` Auto-filled ${assumptions.length} input(s): ${assumptions.join(", ")}.`
+          : "";
+      setTemplateMessage(
+        `Applied preset '${selectedPreset.title}' (${expandedSteps.length} steps).${autoFillSuffix}`,
+      );
     } catch (error) {
-      const failure = error instanceof Error ? error : new Error('Failed to apply preset.');
+      const failure =
+        error instanceof Error ? error : new Error("Failed to apply preset.");
       setTemplateMessage(`Failed to apply preset: ${failure.message}`);
     } finally {
       setIsApplyingPreset(false);
@@ -1234,13 +1574,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!taskTemplateSaveEnabled) {
       return;
     }
-    const title = window.prompt('Preset title', '');
+    const title = window.prompt("Preset title", "");
     if (title === null || !title.trim()) {
-      setTemplateMessage('Preset save cancelled.');
+      setTemplateMessage("Preset save cancelled.");
       return;
     }
     const description =
-      window.prompt('Preset description', `Saved from queue draft: ${title}`) || '';
+      window.prompt("Preset description", `Saved from queue draft: ${title}`) ||
+      "";
 
     const presetSteps: Record<string, unknown>[] = [];
     for (let index = 0; index < steps.length; index += 1) {
@@ -1255,25 +1596,33 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const blueprint: Record<string, unknown> = { instructions };
       const skillId = step.skillId.trim();
       const caps = parseCapabilitiesCsv(step.skillRequiredCapabilities);
-      const skillArgsRaw = shouldShowSkillArgs(step) ? step.skillArgs.trim() : '';
+      const skillArgsRaw = shouldShowSkillArgs(step)
+        ? step.skillArgs.trim()
+        : "";
       if (skillId || skillArgsRaw || caps.length > 0) {
         let skillArgs: Record<string, unknown> = {};
         if (skillArgsRaw) {
           try {
             const parsed = JSON.parse(skillArgsRaw) as unknown;
-            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-              throw new Error('Skill args must be an object.');
+            if (
+              !parsed ||
+              typeof parsed !== "object" ||
+              Array.isArray(parsed)
+            ) {
+              throw new Error("Skill args must be an object.");
             }
             skillArgs = parsed as Record<string, unknown>;
           } catch {
-            setTemplateMessage(`Step ${index + 1} Skill Args must be valid JSON object text.`);
+            setTemplateMessage(
+              `Step ${index + 1} Skill Args must be valid JSON object text.`,
+            );
             return;
           }
         }
         const normalizedTool = {
-          type: 'skill',
-          name: skillId || 'auto',
-          version: '1.0',
+          type: "skill",
+          name: skillId || "auto",
+          version: "1.0",
           inputs: skillArgs,
           ...(caps.length > 0 ? { requiredCapabilities: caps } : {}),
         };
@@ -1288,20 +1637,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
 
     if (presetSteps.length === 0) {
-      setTemplateMessage('Add at least one step with instructions before saving.');
+      setTemplateMessage(
+        "Add at least one step with instructions before saving.",
+      );
       return;
     }
 
-    setTemplateMessage('Saving preset...');
+    setTemplateMessage("Saving preset...");
     try {
       const response = await fetch(taskTemplateSaveEndpoint, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
+          "Content-Type": "application/json",
+          Accept: "application/json",
         },
         body: JSON.stringify({
-          scope: 'personal',
+          scope: "personal",
           title: title.trim(),
           description: description.trim() || title.trim(),
           steps: presetSteps,
@@ -1310,13 +1661,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         }),
       });
       if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, 'Failed to save preset.'));
+        throw new Error(
+          await responseErrorMessage(response, "Failed to save preset."),
+        );
       }
       const created = (await response.json()) as { title?: string };
       setTemplateMessage(`Saved preset '${created.title || title.trim()}'.`);
       await templateOptionsQuery.refetch();
     } catch (error) {
-      const failure = error instanceof Error ? error : new Error('Failed to save preset.');
+      const failure =
+        error instanceof Error ? error : new Error("Failed to save preset.");
       setTemplateMessage(`Failed to save preset: ${failure.message}`);
     }
   }
@@ -1343,47 +1697,55 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
     const normalizedRepository = repository.trim() || defaultRepository;
     if (!normalizedRepository) {
-      setSubmitMessage('Repository is required because no system default repository is configured.');
+      setSubmitMessage(
+        "Repository is required because no system default repository is configured.",
+      );
       return;
     }
     if (!isValidRepositoryInput(normalizedRepository)) {
-      setSubmitMessage('Repository must be owner/repo, https://<host>/<path>, or git@<host>:<path> (token-free).');
+      setSubmitMessage(
+        "Repository must be owner/repo, https://<host>/<path>, or git@<host>:<path> (token-free).",
+      );
       return;
     }
 
     const normalizedRuntime = runtime.trim().toLowerCase();
     if (!supportedTaskRuntimes.includes(normalizedRuntime)) {
-      setSubmitMessage(`Runtime must be one of: ${supportedTaskRuntimes.join(', ')}.`);
+      setSubmitMessage(
+        `Runtime must be one of: ${supportedTaskRuntimes.join(", ")}.`,
+      );
       return;
     }
 
     const normalizedPublishMode = publishMode.trim().toLowerCase();
-    if (!['none', 'branch', 'pr'].includes(normalizedPublishMode)) {
-      setSubmitMessage('Publish mode must be one of: none, branch, pr.');
+    if (!["none", "branch", "pr"].includes(normalizedPublishMode)) {
+      setSubmitMessage("Publish mode must be one of: none, branch, pr.");
       return;
     }
 
     if (!Number.isInteger(priority)) {
-      setSubmitMessage('Priority must be an integer.');
+      setSubmitMessage("Priority must be an integer.");
       return;
     }
     if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
-      setSubmitMessage('Max Attempts must be an integer >= 1.');
+      setSubmitMessage("Max Attempts must be an integer >= 1.");
       return;
     }
 
-    const primarySkillId = primaryValidation.value.skillId.trim() || 'auto';
-    const primarySkillArgsRaw = shouldShowSkillArgs(primaryStep) ? String(primaryStep?.skillArgs || '').trim() : '';
+    const primarySkillId = primaryValidation.value.skillId.trim() || "auto";
+    const primarySkillArgsRaw = shouldShowSkillArgs(primaryStep)
+      ? String(primaryStep?.skillArgs || "").trim()
+      : "";
     const taskSkillRequiredCapabilities = parseCapabilitiesCsv(
-      String(primaryStep?.skillRequiredCapabilities || ''),
+      String(primaryStep?.skillRequiredCapabilities || ""),
     );
 
     let primarySkillArgs: Record<string, unknown> = {};
     if (primarySkillArgsRaw) {
       try {
         const parsed = JSON.parse(primarySkillArgsRaw) as unknown;
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          throw new Error('Skill args must be an object.');
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("Skill args must be an object.");
         }
         primarySkillArgs = parsed as Record<string, unknown>;
       } catch {
@@ -1395,23 +1757,32 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
 
     const primaryStepTool = {
-      type: 'skill',
+      type: "skill",
       name: primarySkillId,
-      version: '1.0',
-      ...(Object.keys(primarySkillArgs).length > 0 ? { inputs: primarySkillArgs } : {}),
-      ...(taskSkillRequiredCapabilities.length > 0 ? { requiredCapabilities: taskSkillRequiredCapabilities } : {}),
+      version: "1.0",
+      ...(Object.keys(primarySkillArgs).length > 0
+        ? { inputs: primarySkillArgs }
+        : {}),
+      ...(taskSkillRequiredCapabilities.length > 0
+        ? { requiredCapabilities: taskSkillRequiredCapabilities }
+        : {}),
     };
     const primaryStepSkill = {
       id: primarySkillId,
       args: primarySkillArgs,
-      ...(taskSkillRequiredCapabilities.length > 0 ? { requiredCapabilities: taskSkillRequiredCapabilities } : {}),
+      ...(taskSkillRequiredCapabilities.length > 0
+        ? { requiredCapabilities: taskSkillRequiredCapabilities }
+        : {}),
     };
     const primaryStepHasSkillOverride =
       hasExplicitSkillSelection(primarySkillId) ||
       Object.keys(primarySkillArgs).length > 0 ||
       taskSkillRequiredCapabilities.length > 0;
 
-    const additionalSteps: Array<{ sourceIndex: number; payload: Record<string, unknown> }> = [];
+    const additionalSteps: Array<{
+      sourceIndex: number;
+      payload: Record<string, unknown>;
+    }> = [];
     const stepSkillRequiredCapabilities: string[] = [];
     for (let index = 1; index < steps.length; index += 1) {
       const step = steps[index];
@@ -1420,8 +1791,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       }
       const stepInstructions = step.instructions.trim();
       const stepSkillId = step.skillId.trim();
-      const stepSkillArgsRaw = shouldShowSkillArgs(step) ? step.skillArgs.trim() : '';
-      const stepSkillCaps = parseCapabilitiesCsv(step.skillRequiredCapabilities);
+      const stepSkillArgsRaw = shouldShowSkillArgs(step)
+        ? step.skillArgs.trim()
+        : "";
+      const stepSkillCaps = parseCapabilitiesCsv(
+        step.skillRequiredCapabilities,
+      );
       const hasStepContent =
         Boolean(stepInstructions) ||
         Boolean(stepSkillId) ||
@@ -1435,12 +1810,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (stepSkillArgsRaw) {
         try {
           const parsed = JSON.parse(stepSkillArgsRaw) as unknown;
-          if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-            throw new Error('Step skill args must be an object.');
+          if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new Error("Step skill args must be an object.");
           }
           stepSkillArgs = parsed as Record<string, unknown>;
         } catch {
-          setSubmitMessage(`Step ${index + 1} Skill Args must be valid JSON object text.`);
+          setSubmitMessage(
+            `Step ${index + 1} Skill Args must be valid JSON object text.`,
+          );
           return;
         }
       }
@@ -1454,61 +1831,78 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       }
       if (stepSkillId || stepSkillArgsRaw || stepSkillCaps.length > 0) {
         stepPayload.tool = {
-          type: 'skill',
+          type: "skill",
           name: stepSkillId || primarySkillId,
-          version: '1.0',
+          version: "1.0",
           inputs: stepSkillArgs,
-          ...(stepSkillCaps.length > 0 ? { requiredCapabilities: stepSkillCaps } : {}),
+          ...(stepSkillCaps.length > 0
+            ? { requiredCapabilities: stepSkillCaps }
+            : {}),
         };
         stepPayload.skill = {
           id: stepSkillId || primarySkillId,
           args: stepSkillArgs,
-          ...(stepSkillCaps.length > 0 ? { requiredCapabilities: stepSkillCaps } : {}),
+          ...(stepSkillCaps.length > 0
+            ? { requiredCapabilities: stepSkillCaps }
+            : {}),
         };
         stepSkillRequiredCapabilities.push(...stepSkillCaps);
       }
       additionalSteps.push({ sourceIndex: index, payload: stepPayload });
     }
 
-    const additionalStepValidation = validatePrimaryStepSubmission(primaryStep, {
-      additionalStepsCount: additionalSteps.length,
-    });
+    const additionalStepValidation = validatePrimaryStepSubmission(
+      primaryStep,
+      {
+        additionalStepsCount: additionalSteps.length,
+      },
+    );
     if (!additionalStepValidation.ok) {
       setSubmitMessage(additionalStepValidation.error);
       return;
     }
 
     const includePrimaryStepForObjectiveOverride =
-      Boolean(primaryInstructions) && objectiveInstructions !== primaryInstructions;
+      Boolean(primaryInstructions) &&
+      objectiveInstructions !== primaryInstructions;
     const hasTemplateBoundStep = steps.some((step) => Boolean(step.id.trim()));
     const includeExplicitSteps =
-      additionalSteps.length > 0 || includePrimaryStepForObjectiveOverride || hasTemplateBoundStep;
+      additionalSteps.length > 0 ||
+      includePrimaryStepForObjectiveOverride ||
+      hasTemplateBoundStep;
 
     const normalizedSteps = includeExplicitSteps
       ? [
           {
             sourceIndex: 0,
             payload: {
-              ...(primaryInstructions ? { instructions: primaryInstructions } : {}),
-              ...(primaryStepHasSkillOverride ? { tool: primaryStepTool, skill: primaryStepSkill } : {}),
+              ...(primaryInstructions
+                ? { instructions: primaryInstructions }
+                : {}),
+              ...(primaryStepHasSkillOverride
+                ? { tool: primaryStepTool, skill: primaryStepSkill }
+                : {}),
             },
           },
           ...additionalSteps,
-        ]
-          .map((entry) => {
-            const sourceStep = steps[entry.sourceIndex];
-            if (!sourceStep) {
-              return entry.payload;
-            }
-            return {
-              ...(sourceStep.id.trim() ? { id: sourceStep.id.trim() } : {}),
-              ...(sourceStep.title.trim() ? { title: sourceStep.title.trim() } : {}),
-              ...entry.payload,
-            };
-          })
+        ].map((entry) => {
+          const sourceStep = steps[entry.sourceIndex];
+          if (!sourceStep) {
+            return entry.payload;
+          }
+          return {
+            ...(sourceStep.id.trim() ? { id: sourceStep.id.trim() } : {}),
+            ...(sourceStep.title.trim()
+              ? { title: sourceStep.title.trim() }
+              : {}),
+            ...entry.payload,
+          };
+        })
       : [];
 
-    const templateCapabilities = appliedTemplates.flatMap((entry) => entry.capabilities || []);
+    const templateCapabilities = appliedTemplates.flatMap(
+      (entry) => entry.capabilities || [],
+    );
     const mergedCapabilities = deriveRequiredCapabilities({
       runtimeMode: normalizedRuntime,
       publishMode: normalizedPublishMode,
@@ -1523,8 +1917,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       instructions: objectiveInstructions,
       tool: normalizedTaskTool,
       skill: primaryStepSkill,
-      ...(hasExplicitSkillSelection(primarySkillId) ? { skills: [primarySkillId] } : {}),
-      ...(Object.keys(primarySkillArgs).length > 0 ? { inputs: primarySkillArgs } : {}),
+      ...(hasExplicitSkillSelection(primarySkillId)
+        ? { skills: [primarySkillId] }
+        : {}),
+      ...(Object.keys(primarySkillArgs).length > 0
+        ? { inputs: primarySkillArgs }
+        : {}),
       proposeTasks,
       runtime: {
         mode: normalizedRuntime,
@@ -1538,74 +1936,94 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       ...(startingBranch.trim() || targetBranch.trim()
         ? {
             git: {
-              ...(startingBranch.trim() ? { startingBranch: startingBranch.trim() } : {}),
-              ...(targetBranch.trim() ? { targetBranch: targetBranch.trim() } : {}),
+              ...(startingBranch.trim()
+                ? { startingBranch: startingBranch.trim() }
+                : {}),
+              ...(targetBranch.trim()
+                ? { targetBranch: targetBranch.trim() }
+                : {}),
             },
           }
         : {}),
       ...(normalizedSteps.length > 0 ? { steps: normalizedSteps } : {}),
-      ...(appliedTemplates.length > 0 ? { appliedStepTemplates: appliedTemplates } : {}),
+      ...(appliedTemplates.length > 0
+        ? { appliedStepTemplates: appliedTemplates }
+        : {}),
     };
 
     const requestBody: Record<string, unknown> = {
-      type: 'task',
+      type: "task",
       priority,
       maxAttempts,
       payload: {
         repository: normalizedRepository,
-        ...(mergedCapabilities.length > 0 ? { requiredCapabilities: mergedCapabilities } : {}),
+        ...(mergedCapabilities.length > 0
+          ? { requiredCapabilities: mergedCapabilities }
+          : {}),
         targetRuntime: normalizedRuntime,
         task: taskPayload,
       },
     };
 
-    if (scheduleMode === 'once') {
+    if (scheduleMode === "once") {
       if (!scheduledFor.trim()) {
-        setSubmitMessage('Scheduled time is required for deferred scheduling.');
+        setSubmitMessage("Scheduled time is required for deferred scheduling.");
         return;
       }
       const scheduleDate = new Date(scheduledFor);
       if (Number.isNaN(scheduleDate.getTime()) || scheduleDate <= new Date()) {
-        setSubmitMessage('Scheduled time must be a valid future date.');
+        setSubmitMessage("Scheduled time must be a valid future date.");
         return;
       }
       (requestBody.payload as Record<string, unknown>).schedule = {
-        mode: 'once',
+        mode: "once",
         scheduledFor: scheduleDate.toISOString(),
       };
-    } else if (scheduleMode === 'deferred_minutes') {
+    } else if (scheduleMode === "deferred_minutes") {
       const deferredMinutes = Number(scheduleDeferredMinutes.trim());
-      if (!Number.isFinite(deferredMinutes) || !Number.isInteger(deferredMinutes) || deferredMinutes <= 0) {
-        setSubmitMessage('A valid positive whole number of minutes is required for deferred scheduling.');
+      if (
+        !Number.isFinite(deferredMinutes) ||
+        !Number.isInteger(deferredMinutes) ||
+        deferredMinutes <= 0
+      ) {
+        setSubmitMessage(
+          "A valid positive whole number of minutes is required for deferred scheduling.",
+        );
         return;
       }
       if (deferredMinutes > 525600) {
-        setSubmitMessage('Deferred minutes cannot exceed 525 600 (one year).');
+        setSubmitMessage("Deferred minutes cannot exceed 525 600 (one year).");
         return;
       }
       (requestBody.payload as Record<string, unknown>).schedule = {
-        mode: 'once',
-        scheduledFor: new Date(Date.now() + deferredMinutes * 60_000).toISOString(),
+        mode: "once",
+        scheduledFor: new Date(
+          Date.now() + deferredMinutes * 60_000,
+        ).toISOString(),
       };
-    } else if (scheduleMode === 'recurring') {
+    } else if (scheduleMode === "recurring") {
       if (!scheduleCron.trim()) {
-        setSubmitMessage('Cron expression is required for recurring scheduling.');
+        setSubmitMessage(
+          "Cron expression is required for recurring scheduling.",
+        );
         return;
       }
       (requestBody.payload as Record<string, unknown>).schedule = {
-        mode: 'recurring',
+        mode: "recurring",
         cron: scheduleCron.trim(),
-        timezone: scheduleTimezone.trim() || 'UTC',
-        name: scheduleName.trim() || 'Inline schedule',
+        timezone: scheduleTimezone.trim() || "UTC",
+        name: scheduleName.trim() || "Inline schedule",
       };
     }
 
     if (attachmentPolicy.enabled && selectedAttachmentFiles.length > 0) {
       if (!attachmentValidation.ok) {
-        setSubmitMessage(attachmentValidation.errors.join(' '));
+        setSubmitMessage(attachmentValidation.errors.join(" "));
         return;
       }
-      setSubmitMessage('Attachments are not supported for Temporal task submission yet. Remove attachments and retry.');
+      setSubmitMessage(
+        "Attachments are not supported for Temporal task submission yet. Remove attachments and retry.",
+      );
       return;
     }
 
@@ -1624,57 +2042,67 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           normalizedRepository,
         );
         inputArtifactRef = artifact.artifactId;
-        (requestBody.payload as Record<string, unknown>).inputArtifactRef = inputArtifactRef;
+        (requestBody.payload as Record<string, unknown>).inputArtifactRef =
+          inputArtifactRef;
         stripOversizedInlineInstructions(requestBody);
       }
 
       const response = await fetch(temporalCreateEndpoint, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
+          "Content-Type": "application/json",
+          Accept: "application/json",
         },
         body: JSON.stringify(requestBody),
       });
       if (!response.ok) {
-        throw new Error(await responseErrorMessage(response, 'Failed to create task.'));
+        throw new Error(
+          await responseErrorMessage(response, "Failed to create task."),
+        );
       }
       const created = (await response.json()) as ExecutionCreateResponse;
       if (inputArtifactRef) {
         await linkInputArtifact(inputArtifactRef, created);
       }
       const redirectPath =
-        String(created.redirectPath || '').trim() ||
+        String(created.redirectPath || "").trim() ||
         (created.definitionId
           ? `/tasks/schedules/${encodeURIComponent(created.definitionId)}`
           : created.workflowId
             ? `/tasks/${encodeURIComponent(created.workflowId)}?source=temporal`
-            : '');
+            : "");
       if (!redirectPath) {
-        throw new Error('Task was created but no redirect path was returned.');
+        throw new Error("Task was created but no redirect path was returned.");
       }
       navigateTo(redirectPath);
     } catch (error) {
-      const failure = error instanceof Error ? error : new Error('Failed to create task.');
+      const failure =
+        error instanceof Error ? error : new Error("Failed to create task.");
       // Detect network-level fetch failures (TypeError: "Failed to fetch")
       // and log additional diagnostics to help troubleshoot.
-      if (failure instanceof TypeError && failure.message === 'Failed to fetch') {
-        console.error('[TaskCreate] Network-level fetch failure during task creation.', {
-          endpoint: temporalCreateEndpoint,
-          errorName: failure.name,
-          errorMessage: failure.message,
-          possibleCauses: [
-            'API service may be unreachable or not running',
-            'CORS policy is blocking the request (check browser devtools Network tab for CORS errors)',
-            'Network connectivity issue or proxy misconfiguration',
-            'TLS/SSL certificate error (if using HTTPS)',
-          ].join('; '),
-        });
+      if (
+        failure instanceof TypeError &&
+        failure.message === "Failed to fetch"
+      ) {
+        console.error(
+          "[TaskCreate] Network-level fetch failure during task creation.",
+          {
+            endpoint: temporalCreateEndpoint,
+            errorName: failure.name,
+            errorMessage: failure.message,
+            possibleCauses: [
+              "API service may be unreachable or not running",
+              "CORS policy is blocking the request (check browser devtools Network tab for CORS errors)",
+              "Network connectivity issue or proxy misconfiguration",
+              "TLS/SSL certificate error (if using HTTPS)",
+            ].join("; "),
+          },
+        );
         setSubmitMessage(
-          'Failed to reach the task creation API. ' +
-          `Endpoint: ${temporalCreateEndpoint}. ` +
-          'This usually means the API service is unreachable, a CORS policy is blocking the request, ' +
-          'or there is a network connectivity issue. Check the browser console for more details.',
+          "Failed to reach the task creation API. " +
+            `Endpoint: ${temporalCreateEndpoint}. ` +
+            "This usually means the API service is unreachable, a CORS policy is blocking the request, " +
+            "or there is a network connectivity issue. Check the browser console for more details.",
         );
       } else {
         setSubmitMessage(failure.message);
@@ -1690,7 +2118,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         <h2 className="page-title">Create Task</h2>
       </div>
 
-      <form id="queue-submit-form" className="queue-submit-form" onSubmit={handleSubmit}>
+      <form
+        id="queue-submit-form"
+        className="queue-submit-form"
+        onSubmit={handleSubmit}
+      >
         <section className="queue-steps-section stack">
           <div id="queue-steps-list" className="stack">
             <datalist id={SKILL_OPTIONS_DATALIST_ID}>
@@ -1712,13 +2144,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
             {steps.map((step, index) => {
               const isPrimaryStep = index === 0;
-              const stepLabel = isPrimaryStep ? ' (Primary)' : '';
+              const stepLabel = isPrimaryStep ? " (Primary)" : "";
               const showSkillArgsField = shouldShowSkillArgs(step);
               return (
-                <section key={step.localId} className="card stack queue-step-section" data-step-index={index}>
+                <section
+                  key={step.localId}
+                  className="card stack queue-step-section"
+                  data-step-index={index}
+                >
                   <div className="queue-step-header">
                     <strong>{`Step ${index + 1}${stepLabel}`}</strong>
-                    <div className="queue-step-controls" role="group" aria-label={`Step ${index + 1} controls`}>
+                    <div
+                      className="queue-step-controls"
+                      role="group"
+                      aria-label={`Step ${index + 1} controls`}
+                    >
                       <button
                         type="button"
                         className="queue-step-icon-button"
@@ -1768,11 +2208,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       data-step-index={String(index)}
                       placeholder={
                         isPrimaryStep
-                          ? 'Describe the task to execute against the repository.'
-                          : 'Step-specific instructions (leave blank to continue from the task objective).'
+                          ? "Describe the task to execute against the repository."
+                          : "Step-specific instructions (leave blank to continue from the task objective)."
                       }
                       value={step.instructions}
-                      onChange={(event) => updateStep(step.localId, { instructions: event.target.value })}
+                      onChange={(event) =>
+                        updateStep(step.localId, {
+                          instructions: event.target.value,
+                        })
+                      }
                     />
                   </label>
 
@@ -1786,15 +2230,19 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         value={step.skillId}
                         placeholder={
                           isPrimaryStep
-                            ? 'auto (default), speckit-orchestrate, ...'
-                            : 'inherit primary step skill'
+                            ? "auto (default), speckit-orchestrate, ..."
+                            : "inherit primary step skill"
                         }
-                        onChange={(event) => updateStep(step.localId, { skillId: event.target.value })}
+                        onChange={(event) =>
+                          updateStep(step.localId, {
+                            skillId: event.target.value,
+                          })
+                        }
                       />
                       <span className="small">
                         {isPrimaryStep
-                          ? 'Primary step must include instructions or an explicit skill.'
-                          : 'Leave skill blank to inherit primary step defaults.'}
+                          ? "Primary step must include instructions or an explicit skill."
+                          : "Leave skill blank to inherit primary step defaults."}
                       </span>
                     </label>
 
@@ -1806,14 +2254,20 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         value={step.skillRequiredCapabilities}
                         placeholder="docker,qdrant,unity"
                         onChange={(event) =>
-                          updateStep(step.localId, { skillRequiredCapabilities: event.target.value })
+                          updateStep(step.localId, {
+                            skillRequiredCapabilities: event.target.value,
+                          })
                         }
                       />
                     </label>
                   </div>
 
                   <label
-                    className={showSkillArgsField ? 'queue-step-skill-args-field' : 'queue-step-skill-args-field hidden'}
+                    className={
+                      showSkillArgsField
+                        ? "queue-step-skill-args-field"
+                        : "queue-step-skill-args-field hidden"
+                    }
                     data-skill-args-index={String(index)}
                   >
                     Skill Args (optional JSON object)
@@ -1823,7 +2277,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       data-step-index={String(index)}
                       placeholder='{"notes":"optional context"}'
                       value={step.skillArgs}
-                      onChange={(event) => updateStep(step.localId, { skillArgs: event.target.value })}
+                      onChange={(event) =>
+                        updateStep(step.localId, {
+                          skillArgs: event.target.value,
+                        })
+                      }
                     />
                   </label>
                 </section>
@@ -1867,15 +2325,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 id="queue-template-feature-request"
                 placeholder="Describe the feature request this preset should execute."
                 value={templateFeatureRequest}
-                onChange={(event) => setTemplateFeatureRequest(event.target.value)}
+                onChange={(event) =>
+                  setTemplateFeatureRequest(event.target.value)
+                }
               />
             </label>
             <div className="actions">
-              <button type="button" id="queue-template-apply" onClick={handleApplyPreset} aria-disabled={isApplyingPreset} aria-busy={isApplyingPreset}>
+              <button
+                type="button"
+                id="queue-template-apply"
+                onClick={handleApplyPreset}
+                aria-disabled={isApplyingPreset}
+                aria-busy={isApplyingPreset}
+              >
                 Apply
               </button>
               {taskTemplateSaveEnabled ? (
-                <button type="button" id="queue-template-save-current" onClick={handleSaveCurrentStepsAsPreset}>
+                <button
+                  type="button"
+                  id="queue-template-save-current"
+                  onClick={handleSaveCurrentStepsAsPreset}
+                >
                   Save Current Steps as Preset
                 </button>
               ) : null}
@@ -1888,7 +2358,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
         <label>
           Runtime
-          <select name="runtime" value={runtime} onChange={(event) => setRuntime(event.target.value)}>
+          <select
+            name="runtime"
+            value={runtime}
+            onChange={(event) => setRuntime(event.target.value)}
+          >
             {supportedTaskRuntimes.map((runtimeOption) => (
               <option key={runtimeOption} value={runtimeOption}>
                 {runtimeOption}
@@ -1899,7 +2373,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
         <div
           id="queue-provider-profile-wrap"
-          className={providerOptions.length > 0 ? '' : 'hidden'}
+          className={providerOptions.length > 0 ? "" : "hidden"}
           hidden={providerOptions.length === 0}
         >
           <label>
@@ -1918,7 +2392,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             </select>
           </label>
           <p className="small" id="queue-auth-profile-hint">
-            {providerProfilesQuery.isError ? 'Failed to load provider profiles.' : ''}
+            {providerProfilesQuery.isError
+              ? "Failed to load provider profiles."
+              : ""}
           </p>
         </div>
 
@@ -1933,7 +2409,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               onChange={(event) => {
                 const next = event.target.value;
                 setModel(next);
-                setModelManualOverride(next !== '');
+                setModelManualOverride(next !== "");
               }}
             />
           </label>
@@ -1960,8 +2436,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           <span className="small">
             {defaultRepository
               ? `Leave blank to use default repository: ${defaultRepository}. `
-              : 'Set a repository in this form (no system default repository is configured). '}
-            Accepted formats: owner/repo, https://&lt;host&gt;/&lt;path&gt;, or git@&lt;host&gt;:&lt;path&gt; (token-free).
+              : "Set a repository in this form (no system default repository is configured). "}
+            Accepted formats: owner/repo, https://&lt;host&gt;/&lt;path&gt;, or
+            git@&lt;host&gt;:&lt;path&gt; (token-free).
           </span>
         </label>
 
@@ -1988,7 +2465,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
         <label>
           Publish Mode
-          <select name="publishMode" value={publishMode} onChange={(event) => setPublishMode(event.target.value)}>
+          <select
+            name="publishMode"
+            value={publishMode}
+            onChange={(event) => setPublishMode(event.target.value)}
+          >
             <option value="pr">pr</option>
             <option value="branch">branch</option>
             <option value="none">none</option>
@@ -2002,10 +2483,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               <input
                 type="file"
                 id="queue-attachments-input"
-                accept={attachmentPolicy.allowedContentTypes.join(',')}
+                accept={attachmentPolicy.allowedContentTypes.join(",")}
                 multiple
                 onChange={(event) =>
-                  setSelectedAttachmentFiles(Array.from(event.currentTarget.files || []))
+                  setSelectedAttachmentFiles(
+                    Array.from(event.currentTarget.files || []),
+                  )
                 }
               />
             </label>
@@ -2014,11 +2497,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 ? `Up to ${attachmentPolicy.maxCount} files, ${formatAttachmentBytes(attachmentPolicy.maxBytes)} each, ${formatAttachmentBytes(attachmentPolicy.totalBytes)} total.`
                 : attachmentValidation.ok
                   ? `${selectedAttachmentFiles.length} attachment(s) selected (${formatAttachmentBytes(attachmentValidation.totalBytes)} total).`
-                  : attachmentValidation.errors.join(' ')}
+                  : attachmentValidation.errors.join(" ")}
             </p>
             <ul className="list" id="queue-attachments-list">
               {selectedAttachmentFiles.map((file) => (
-                <li key={`${file.name}-${file.size}`}>{`${file.name} (${formatAttachmentBytes(file.size)})`}</li>
+                <li
+                  key={`${file.name}-${file.size}`}
+                >{`${file.name} (${formatAttachmentBytes(file.size)})`}</li>
               ))}
             </ul>
           </section>
@@ -2065,23 +2550,34 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           <summary>
             <strong>Schedule (optional)</strong>
           </summary>
-          <div className="stack" style={{ marginTop: '0.75rem' }}>
+          <div className="stack" style={{ marginTop: "0.75rem" }}>
             <label>
               Schedule Mode
               <select
                 name="scheduleMode"
                 id="schedule-mode-select"
                 value={scheduleMode}
-                onChange={(event) => setScheduleMode(event.target.value as ScheduleMode)}
+                onChange={(event) =>
+                  setScheduleMode(event.target.value as ScheduleMode)
+                }
               >
                 <option value="immediate">Immediate</option>
-                <option value="once">Deferred (run once at a specific time)</option>
-                <option value="deferred_minutes">Deferred (run in N minutes)</option>
-                <option value="recurring">Recurring (create a cron schedule)</option>
+                <option value="once">
+                  Deferred (run once at a specific time)
+                </option>
+                <option value="deferred_minutes">
+                  Deferred (run in N minutes)
+                </option>
+                <option value="recurring">
+                  Recurring (create a cron schedule)
+                </option>
               </select>
             </label>
 
-            <div id="schedule-once-fields" className={scheduleMode === 'once' ? '' : 'hidden'}>
+            <div
+              id="schedule-once-fields"
+              className={scheduleMode === "once" ? "" : "hidden"}
+            >
               <label>
                 Scheduled For
                 <input
@@ -2096,7 +2592,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
             <div
               id="schedule-deferred-minutes-fields"
-              className={scheduleMode === 'deferred_minutes' ? '' : 'hidden'}
+              className={scheduleMode === "deferred_minutes" ? "" : "hidden"}
             >
               <label>
                 Minutes from now
@@ -2108,12 +2604,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   step="1"
                   placeholder="e.g. 15"
                   value={scheduleDeferredMinutes}
-                  onChange={(event) => setScheduleDeferredMinutes(event.target.value)}
+                  onChange={(event) =>
+                    setScheduleDeferredMinutes(event.target.value)
+                  }
                 />
               </label>
             </div>
 
-            <div id="schedule-recurring-fields" className={scheduleMode === 'recurring' ? 'stack' : 'hidden'}>
+            <div
+              id="schedule-recurring-fields"
+              className={scheduleMode === "recurring" ? "stack" : "hidden"}
+            >
               <label>
                 Cron Expression
                 <input
@@ -2146,16 +2647,25 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         </details>
 
         <div className="actions">
-          <button type="submit" className="queue-submit-primary" aria-disabled={isSubmitting} aria-busy={isSubmitting}>
+          <button
+            type="submit"
+            className="queue-submit-primary"
+            aria-disabled={isSubmitting}
+            aria-busy={isSubmitting}
+          >
             Create
           </button>
         </div>
 
         <p
           id="queue-submit-message"
-          className={submitMessage ? 'queue-submit-message notice error' : 'queue-submit-message small'}
+          className={
+            submitMessage
+              ? "queue-submit-message notice error"
+              : "queue-submit-message small"
+          }
         >
-          {submitMessage || ''}
+          {submitMessage || ""}
         </p>
       </form>
     </div>

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -290,6 +290,7 @@ class MoonMindAgentRun:
         runtime_id: str,
         *,
         request_slot: bool = True,
+        execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Signal the auth-profile-manager; auto-start it on first failure.
@@ -307,6 +308,8 @@ class MoonMindAgentRun:
             "requester_workflow_id": workflow.info().workflow_id,
             "runtime_id": runtime_id,
         }
+        if execution_profile_ref:
+            signal_payload["execution_profile_ref"] = execution_profile_ref
         if profile_selector:
             signal_payload["profile_selector"] = profile_selector
         if not request_slot:
@@ -337,6 +340,7 @@ class MoonMindAgentRun:
         manager_id: str,
         runtime_id: str,
         *,
+        execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
     ) -> workflow.ExternalWorkflowHandle:
         """Terminate a stuck manager, start a fresh one, and re-request a slot.
@@ -359,6 +363,8 @@ class MoonMindAgentRun:
             "requester_workflow_id": workflow.info().workflow_id,
             "runtime_id": runtime_id,
         }
+        if execution_profile_ref:
+            signal_payload["execution_profile_ref"] = execution_profile_ref
         if profile_selector:
             signal_payload["profile_selector"] = profile_selector
         await manager_handle.signal("request_slot", signal_payload)
@@ -659,6 +665,7 @@ class MoonMindAgentRun:
                         manager_id,
                         runtime_id,
                         request_slot=True,
+                        execution_profile_ref=request.execution_profile_ref,
                         profile_selector=request.profile_selector.model_dump(by_alias=True, exclude_none=True),
                     )
                     profile_count = await self._sync_manager_profiles(
@@ -671,6 +678,18 @@ class MoonMindAgentRun:
                             type="ProfileResolutionError",
                             non_retryable=True,
                         )
+                    if request.execution_profile_ref:
+                        requested_profile_id = str(request.execution_profile_ref).strip()
+                        if (
+                            requested_profile_id
+                            and self._profile_snapshots
+                            and requested_profile_id not in self._profile_snapshots
+                        ):
+                            raise ApplicationError(
+                                f"Provider profile '{requested_profile_id}' not found for runtime_id='{runtime_id}'",
+                                type="ProfileResolutionError",
+                                non_retryable=True,
+                            )
 
                     # Wait for an auth profile slot.
                     # Awaiting time does not count against the execution timeout;
@@ -725,6 +744,7 @@ class MoonMindAgentRun:
                                 manager_handle = await self._reset_and_request_slot(
                                     manager_id, 
                                     runtime_id,
+                                    execution_profile_ref=request.execution_profile_ref,
                                     profile_selector=request.profile_selector.model_dump(by_alias=True, exclude_none=True),
                                 )
                                 await self._sync_manager_profiles(
@@ -794,6 +814,11 @@ class MoonMindAgentRun:
                             "requester_workflow_id": wf_id,
                             "runtime_id": kw.get("runtime_id", runtime_id),
                         }
+                        exact_profile_id = kw.get(
+                            "execution_profile_ref", request.execution_profile_ref
+                        )
+                        if exact_profile_id:
+                            payload["execution_profile_ref"] = exact_profile_id
                         if request.profile_selector:
                             payload["profile_selector"] = request.profile_selector.model_dump(by_alias=True, exclude_none=True)
                         await manager_handle.signal("request_slot", payload)

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -79,6 +79,7 @@ class SlotRequestPayload(TypedDict):
 
     requester_workflow_id: str
     runtime_id: str
+    execution_profile_ref: str | None
 
 
 class SlotReleasePayload(TypedDict):
@@ -202,6 +203,7 @@ class PendingRequest:
 
     requester_workflow_id: str
     runtime_id: str
+    execution_profile_ref: str | None = None
     profile_selector: Optional[dict[str, Any]] = None
 
 
@@ -268,6 +270,7 @@ class MoonMindProviderProfileManagerWorkflow:
             PendingRequest(
                 requester_workflow_id=payload["requester_workflow_id"],
                 runtime_id=payload.get("runtime_id", self._runtime_id or ""),
+                execution_profile_ref=payload.get("execution_profile_ref"),
                 profile_selector=payload.get("profile_selector"),
             )
         )
@@ -331,6 +334,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 {
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
+                    "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                 }
                 for r in self._pending_requests
@@ -425,6 +429,7 @@ class MoonMindProviderProfileManagerWorkflow:
             PendingRequest(
                 requester_workflow_id=req.get("requester_workflow_id", ""),
                 runtime_id=req.get("runtime_id", ""),
+                execution_profile_ref=req.get("execution_profile_ref"),
                 profile_selector=req.get("profile_selector"),
             )
             for req in pending_data
@@ -531,7 +536,10 @@ class MoonMindProviderProfileManagerWorkflow:
                     leases_changed = True
                 continue
 
-            profile = self._find_available_profile(req.profile_selector)
+            profile = self._find_available_profile(
+                selector=req.profile_selector,
+                execution_profile_ref=req.execution_profile_ref,
+            )
             if profile and profile.reserve(req.requester_workflow_id, now):
                 leases_changed = True
                 try:
@@ -554,8 +562,37 @@ class MoonMindProviderProfileManagerWorkflow:
         if leases_changed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
             await self._sync_leases_to_db()
 
-    def _find_available_profile(self, selector: Optional[dict[str, Any]] = None) -> Optional[ProfileSlotState]:
+    def _find_available_profile(
+        self,
+        selector: Optional[dict[str, Any]] = None,
+        execution_profile_ref: str | None = None,
+    ) -> Optional[ProfileSlotState]:
         """Find the best available profile matching the selector."""
+        exact_profile_id = str(execution_profile_ref or "").strip()
+        if exact_profile_id:
+            exact_profile = self._profiles.get(exact_profile_id)
+            if exact_profile is None or not exact_profile.is_available():
+                return None
+
+            if selector:
+                if selector.get("providerId") and exact_profile.provider_id != selector.get("providerId"):
+                    return None
+                if (
+                    selector.get("runtimeMaterializationMode")
+                    and exact_profile.runtime_materialization_mode != selector.get("runtimeMaterializationMode")
+                ):
+                    return None
+
+                tags_any = selector.get("tagsAny", [])
+                if tags_any and not set(tags_any).intersection(set(exact_profile.tags)):
+                    return None
+
+                tags_all = selector.get("tagsAll", [])
+                if tags_all and not set(tags_all).issubset(set(exact_profile.tags)):
+                    return None
+
+            return exact_profile
+
         eligible_profiles: list[ProfileSlotState] = []
         for profile in self._profiles.values():
             if not profile.is_available():
@@ -714,6 +751,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 {
                     "requester_workflow_id": r.requester_workflow_id,
                     "runtime_id": r.runtime_id,
+                    "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
                 }
                 for r in self._pending_requests

--- a/tests/integration/services/temporal/workflows/test_agent_run.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run.py
@@ -35,7 +35,7 @@ async def mock_cancel(request: dict) -> AgentRunStatus:
 
 @_activity.defn(name="provider_profile.list")
 async def mock_provider_profile_list(request: dict) -> dict:
-    """Return a single default managed profile."""
+    """Return managed profiles for exact-profile and selector routing tests."""
     return {
         "profiles": [
             {
@@ -53,19 +53,36 @@ async def mock_provider_profile_list(request: dict) -> dict:
                 "rate_limit_policy": "pause_and_retry",
                 "max_lease_duration_seconds": 7200,
                 "enabled": True,
-            }
+            },
+            {
+                "profile_id": "explicit-openai-profile",
+                "runtime_id": request.get("runtime_id", "test-agent"),
+                "provider_id": "openai",
+                "auth_mode": "volume",
+                "volume_ref": "test-volume",
+                "volume_mount_path": "/tmp/auth",
+                "account_label": "openai",
+                "api_key_ref": None,
+                "runtime_env_overrides": {},
+                "api_key_env_var": None,
+                "max_parallel_runs": 1,
+                "cooldown_after_429_seconds": 900,
+                "rate_limit_policy": "pause_and_retry",
+                "max_lease_duration_seconds": 7200,
+                "enabled": True,
+            },
         ]
     }
 
 
 @_activity.defn(name="provider_profile.ensure_manager")
 async def mock_provider_profile_ensure_manager(request: dict) -> dict:
-    return {"started": True, "workflow_id": f"auth-profile-manager:{request.get('runtime_id', 'test')}"}
+    return {"started": True, "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'test')}"}
 
 
 @_activity.defn(name="provider_profile.reset_manager")
 async def mock_provider_profile_reset_manager(request: dict) -> dict:
-    return {"reset": True, "workflow_id": f"auth-profile-manager:{request.get('runtime_id', 'test')}"}
+    return {"reset": True, "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'test')}"}
 
 
 # Collect all activities that need to be registered on the main task queue.
@@ -174,7 +191,11 @@ class MockProviderProfileManager:
             while self.pending_requests:
                 req = self.pending_requests.pop(0)
                 if assign_slots:
-                    profile_id = "default-managed"
+                    profile_id = (
+                        req.get("execution_profile_ref")
+                        or req.get("profile_id")
+                        or "default-managed"
+                    )
                     cooldown_until = self.cooldowns.get(profile_id)
                     if cooldown_until is not None:
                         cooldown_dt = datetime.fromisoformat(cooldown_until)
@@ -242,6 +263,7 @@ async def mock_agent_runtime_fetch_result_rate_limited(request: dict) -> dict:
 
 @pytest.mark.asyncio
 async def test_agent_run_workflow():
+    _managed_launch_requests.clear()
     async with await WorkflowEnvironment.start_time_skipping() as env:
         # Main agent-run worker.
         async with Worker(
@@ -262,7 +284,7 @@ async def test_agent_run_workflow():
                 # Start dummy manager
                 runtime_mapping = {"gemini_cli": "gemini_cli", "claude": "claude_code", "codex": "codex_cli"}
                 runtime_id = runtime_mapping.get(request.agent_id, request.agent_id)
-                manager_id = f"auth-profile-manager:{runtime_id}"
+                manager_id = f"provider-profile-manager:{runtime_id}"
                 await env.client.start_workflow(
                     MockProviderProfileManager.run,
                     {"runtime_id": request.agent_id},
@@ -288,8 +310,8 @@ async def test_agent_run_workflow():
                 assert result.summary == "Success"
 
 
-@pytest.mark.asyncio
 async def test_agent_run_workflow_cancellation():
+    _managed_launch_requests.clear()
     async with await WorkflowEnvironment.start_time_skipping() as env:
         async with Worker(
             env.client,
@@ -309,7 +331,7 @@ async def test_agent_run_workflow_cancellation():
                 # Start dummy manager
                 runtime_mapping = {"gemini_cli": "gemini_cli", "claude": "claude_code", "codex": "codex_cli"}
                 runtime_id = runtime_mapping.get(request.agent_id, request.agent_id)
-                manager_id = f"auth-profile-manager:{runtime_id}"
+                manager_id = f"provider-profile-manager:{runtime_id}"
                 await env.client.start_workflow(
                     MockProviderProfileManager.run,
                     {"runtime_id": request.agent_id, "assign_slots": False},
@@ -357,7 +379,7 @@ async def test_agent_run_reports_managed_429_retry_summary_to_parent():
                     idempotency_key="idem-429",
                 )
 
-                manager_id = "auth-profile-manager:gemini_cli"
+                manager_id = "provider-profile-manager:gemini_cli"
                 await env.client.start_workflow(
                     MockProviderProfileManager.run,
                     {"runtime_id": "gemini_cli"},
@@ -436,7 +458,7 @@ async def test_agent_run_binds_managed_launch_to_parent_workflow_for_new_histori
                     idempotency_key="idem-parent-bind",
                 )
 
-                manager_id = "auth-profile-manager:test-agent"
+                manager_id = "provider-profile-manager:test-agent"
                 await env.client.start_workflow(
                     MockProviderProfileManager.run,
                     {"runtime_id": "test-agent"},
@@ -693,7 +715,7 @@ async def test_cancellation_releases_provider_profile_slot():
                 # Start dummy manager that assigns slots
                 runtime_mapping = {"gemini_cli": "gemini_cli", "claude": "claude_code", "codex": "codex_cli"}
                 runtime_id = runtime_mapping.get(request.agent_id, request.agent_id)
-                manager_id = f"auth-profile-manager:{runtime_id}"
+                manager_id = f"provider-profile-manager:{runtime_id}"
                 manager_handle = await env.client.start_workflow(
                     MockProviderProfileManager.run,
                     {"runtime_id": request.agent_id, "assign_slots": True},

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -290,6 +290,53 @@ class TestProviderProfileManagerHelpers:
         # Test finding unknown
         assert wf._find_available_profile({"providerId": "openai"}) is None
 
+    def test_find_available_profile_honors_exact_profile_ref(self):
+        wf = self._make_workflow()
+        wf._profiles["openai-profile"] = ProfileSlotState(
+            profile_id="openai-profile",
+            max_parallel_runs=5,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            provider_id="openai",
+            priority=50,
+        )
+        wf._profiles["openrouter-profile"] = ProfileSlotState(
+            profile_id="openrouter-profile",
+            max_parallel_runs=5,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            provider_id="openrouter",
+            priority=200,
+        )
+
+        best = wf._find_available_profile(
+            execution_profile_ref="openai-profile",
+        )
+        assert best is not None
+        assert best.profile_id == "openai-profile"
+
+    def test_find_available_profile_exact_ref_requires_available_profile(self):
+        wf = self._make_workflow()
+        wf._profiles["busy-profile"] = ProfileSlotState(
+            profile_id="busy-profile",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            current_leases=["wf-1"],
+        )
+
+        assert (
+            wf._find_available_profile(execution_profile_ref="busy-profile")
+            is None
+        )
+        assert (
+            wf._find_available_profile(execution_profile_ref="missing-profile")
+            is None
+        )
+
     def test_find_available_profile_sorts_by_priority(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -110,3 +110,73 @@ class TestEnsureManagerAutoStart:
             f"All request_slot signals must go through _ensure_manager_and_signal "
             f"for auto-start fallback."
         )
+
+    def test_ensure_manager_propagates_exact_execution_profile_ref(self):
+        """Managed runs with an explicit profile must pass it into slot acquisition."""
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        tree = ast.parse(source)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr == "_ensure_manager_and_signal"
+            ):
+                continue
+
+            execution_profile_kw = [
+                kw for kw in node.keywords if kw.arg == "execution_profile_ref"
+            ]
+            assert len(execution_profile_kw) == 1, (
+                "_ensure_manager_and_signal must receive execution_profile_ref "
+                "so exact provider-profile selections are preserved."
+            )
+            kw_value = execution_profile_kw[0].value
+            assert isinstance(kw_value, ast.Attribute), (
+                "execution_profile_ref should be forwarded from request.execution_profile_ref"
+            )
+            assert kw_value.attr == "execution_profile_ref"
+            return
+
+        raise AssertionError(
+            "Could not find _ensure_manager_and_signal call in MoonMindAgentRun.run"
+        )
+
+    def test_manager_signal_payload_carries_execution_profile_ref(self):
+        """The auto-start helper must include execution_profile_ref in request_slot payloads."""
+        source = textwrap.dedent(
+            inspect.getsource(MoonMindAgentRun._ensure_manager_and_signal)
+        )
+        tree = ast.parse(source)
+
+        found_guard = False
+        found_payload_write = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.If):
+                test = node.test
+                if isinstance(test, ast.Name) and test.id == "execution_profile_ref":
+                    found_guard = True
+                    for child in node.body:
+                        if not isinstance(child, ast.Assign):
+                            continue
+                        for target in child.targets:
+                            if not isinstance(target, ast.Subscript):
+                                continue
+                            if not (
+                                isinstance(target.value, ast.Name)
+                                and target.value.id == "signal_payload"
+                            ):
+                                continue
+                            slice_node = target.slice
+                            if isinstance(slice_node, ast.Constant) and slice_node.value == "execution_profile_ref":
+                                found_payload_write = True
+        assert found_guard, (
+            "_ensure_manager_and_signal must guard on execution_profile_ref "
+            "before shaping the request_slot payload."
+        )
+        assert found_payload_write, (
+            "_ensure_manager_and_signal must include signal_payload['execution_profile_ref'] "
+            "so the ProviderProfileManager can honor exact profile selections."
+        )


### PR DESCRIPTION
## Summary
Fix the task-create artifact flow so oversized task input is only submitted to `/api/executions` after the artifact is actually readable.

## What changed
- use the server-provided `upload_url` and required headers for single-put artifact uploads
- explicitly finalize uploaded task-input artifacts via `/api/artifacts/{artifact_id}/complete` before task creation
- add a short retry for transient "artifact upload is not complete" races
- update create-page tests to cover both local `/content` uploads and presigned single-put uploads, and to verify finalize-before-submit ordering

## Root cause
The create page treated an oversized input artifact as ready immediately after uploading bytes. In environments where the artifact had not yet transitioned from `pending_upload` to `complete`, task creation failed validation with `inputArtifactRef must reference a readable artifact`.

## Validation
- `./tools/test_unit.sh`
