### PR TITLE
Remove dashboard runtime globals

### DIFF
--- a/api_service/templates/react_dashboard.html
+++ b/api_service/templates/react_dashboard.html
@@ -7,23 +7,6 @@
   <title>MoonMind Mission Control</title>
   <script>
     (() => {
-      if (
-        window.customElements &&
-        !window.__moonmind_customElementsDefineGuard
-      ) {
-        const originalDefine = window.customElements.define.bind(window.customElements);
-        window.customElements.define = function(name, constructor, options) {
-          if (
-            name === "mce-autosize-textarea" &&
-            window.customElements.get(name)
-          ) {
-            return;
-          }
-          return originalDefine(name, constructor, options);
-        };
-        window.__moonmind_customElementsDefineGuard = true;
-      }
-
       const key = "moonmind.theme";
       const root = document.documentElement;
       let stored = null;
@@ -45,7 +28,6 @@
       root.dataset.theme = mode;
     })();
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   {{ assets_html | safe }}
 </head>
 

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3034605043,
+    "id": 3034751817,
     "disposition": "addressed",
-    "rationale": "Switched presigned artifact PUT headers to a single Headers object so signed content-type values are not duplicated."
+    "rationale": "Changed the checklist's feature link from an absolute local path to the repo-relative ../spec.md target."
   },
   {
-    "id": 4057512440,
-    "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary only; the actionable feedback was captured in the inline review comments below."
-  },
-  {
-    "id": 3034606279,
+    "id": 3034751830,
     "disposition": "addressed",
-    "rationale": "Implemented canonical header construction for presigned uploads, preserving one content-type header and other required signed headers."
+    "rationale": "Unchecked the technology-agnostic checklist assertions and clarified the notes so the checklist now matches the spec's implementation-detail content."
   },
   {
-    "id": 3034606297,
-    "disposition": "addressed",
-    "rationale": "Expanded the presigned upload test to include required signed headers and assert they are forwarded without duplication."
-  },
-  {
-    "id": 4057513529,
+    "id": 4057656070,
     "disposition": "not-applicable",
-    "rationale": "Overview-only review comment; no separate remediation requested beyond the inline comments already addressed."
+    "rationale": "Informational review summary only; its actionable feedback is already represented by the inline review comments above."
   },
   {
-    "id": 4057516246,
+    "id": 4057666739,
     "disposition": "not-applicable",
-    "rationale": "Informational approval comment stating no additional feedback."
+    "rationale": "Positive review with no requested change."
   }
 ]

--- a/frontend/src/entrypoints/skills.test.tsx
+++ b/frontend/src/entrypoints/skills.test.tsx
@@ -55,14 +55,6 @@ describe('Skills Entrypoint', () => {
         text: async () => 'Unhandled fetch',
       } as Response);
     });
-    // Provide the global marked surface that the template normally loads.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).marked = {
-      parse(markdown: string) {
-        const [heading = '', ...rest] = markdown.split('\n');
-        return `<h1>${heading.replace(/^#\s*/, '')}</h1><p>${rest.join(' ').trim()}</p>`;
-      },
-    };
   });
 
   afterEach(() => {
@@ -118,12 +110,6 @@ describe('Skills Entrypoint', () => {
   });
 
   it('sanitizes rendered markdown before injecting preview HTML', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).marked = {
-      parse() {
-        return '<h1>Unsafe</h1><p><img src="x" onerror="alert(1)"></p><a href="javascript:alert(1)">click</a>';
-      },
-    };
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.startsWith('/api/tasks/skills?includeContent=true')) {

--- a/frontend/src/entrypoints/skills.tsx
+++ b/frontend/src/entrypoints/skills.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { marked } from 'marked';
 
 import { mountPage } from '../boot/mountPage';
 import type { BootPayload } from '../boot/parseBootPayload';
@@ -90,12 +91,7 @@ function sanitizeHtml(html: string): string {
 }
 
 function renderMarkdown(markdown: string): string {
-  if (window.marked && typeof window.marked.parse === 'function') {
-    return sanitizeHtml(window.marked.parse(markdown));
-  }
-  return sanitizeHtml(
-    `<pre>${markdown.replace(/[&<>]/g, (value) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[value] || value))}</pre>`,
-  );
+  return sanitizeHtml(marked.parse(markdown, { async: false }));
 }
 
 export function SkillsPage({ payload: _payload }: { payload: BootPayload }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
+        "marked": "^17.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "zod": "^4.3.6"
@@ -3027,6 +3028,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+      "integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
+    "marked": "^17.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "zod": "^4.3.6"

--- a/specs/126-remove-runtime-globals/checklists/requirements.md
+++ b/specs/126-remove-runtime-globals/checklists/requirements.md
@@ -2,13 +2,13 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-04-03
-**Feature**: [spec.md](/home/nsticco/MoonMind/specs/126-remove-runtime-globals/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 
-- [X] No implementation details (languages, frameworks, APIs)
+- [ ] No implementation details (languages, frameworks, APIs)
 - [X] Focused on user value and business needs
-- [X] Written for non-technical stakeholders
+- [ ] Written for non-technical stakeholders
 - [X] All mandatory sections completed
 
 ## Requirement Completeness
@@ -16,7 +16,7 @@
 - [X] No [NEEDS CLARIFICATION] markers remain
 - [X] Requirements are testable and unambiguous
 - [X] Success criteria are measurable
-- [X] Success criteria are technology-agnostic (no implementation details)
+- [ ] Success criteria are technology-agnostic (no implementation details)
 - [X] All acceptance scenarios are defined
 - [X] Edge cases are identified
 - [X] Scope is clearly bounded
@@ -27,8 +27,8 @@
 - [X] All functional requirements have clear acceptance criteria
 - [X] User scenarios cover primary flows
 - [X] Feature meets measurable outcomes defined in Success Criteria
-- [X] No implementation details leak into specification
+- [ ] No implementation details leak into specification
 
 ## Notes
 
-- Spec is ready for planning. Runtime deliverables are explicit: frontend runtime code cleanup plus validation tests/build checks.
+- Spec is ready for planning, but the spec intentionally carries implementation details from the scoped runtime cleanup request, so the technology-agnostic checklist items remain unchecked.

--- a/specs/126-remove-runtime-globals/checklists/requirements.md
+++ b/specs/126-remove-runtime-globals/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: remove-runtime-globals
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](/home/nsticco/MoonMind/specs/126-remove-runtime-globals/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Spec is ready for planning. Runtime deliverables are explicit: frontend runtime code cleanup plus validation tests/build checks.

--- a/specs/126-remove-runtime-globals/plan.md
+++ b/specs/126-remove-runtime-globals/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: remove-runtime-globals
+
+**Branch**: `126-remove-runtime-globals` | **Date**: 2026-04-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/126-remove-runtime-globals/spec.md`
+
+## Summary
+
+Remove the last React dashboard template globals by bundling markdown parsing through the frontend module graph, deleting the template CDN script, and removing the stale page-boot `customElements.define` monkeypatch that no longer corresponds to any in-repo `mce-autosize-textarea` registration path.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React 19, HTML template, npm package metadata  
+**Primary Dependencies**: Vite frontend build, React Query, packaged markdown parser, Vitest  
+**Storage**: N/A  
+**Testing**: `npm run ui:typecheck`, `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx`, `npm run ui:build:check`, `./tools/test_unit.sh`  
+**Target Platform**: Backend-served Mission Control web UI  
+**Project Type**: Web application with FastAPI-hosted HTML shell and Vite entrypoints  
+**Performance Goals**: Preserve current page boot/render behavior with no additional network fetches for parser globals  
+**Constraints**: Remove compatibility code instead of preserving globals, keep markdown sanitization intact, avoid changing unrelated dashboard boot behavior  
+**Scale/Scope**: One entrypoint (`skills.tsx`), one shared HTML template, associated frontend tests, and package metadata/lockfile
+
+## Constitution Check
+
+- **II. One-Click Agent Deployment**: PASS. The cleanup stays within the existing repo-managed frontend build and does not add deployment prerequisites.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The skills page keeps working while removing hidden runtime coupling to the HTML shell.
+- **VI. Design for Deletion / Thin Scaffolding**: PASS. This feature deletes stale compatibility scaffolding instead of extending it.
+- **VII. Powerful Runtime Configurability**: PASS. No runtime configuration behavior changes; hidden globals are removed rather than made configurable.
+- **VIII. Modular and Extensible Architecture**: PASS. Markdown parsing and any element-registration logic stay with the module that owns them.
+- **IX. Resilient by Default**: PASS. Verification covers the affected entrypoint, build path, and full unit suite to catch regressions.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Cleanup requirements and validation are captured before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. No canonical docs need migration prose for this targeted runtime cleanup.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. Dead globals are removed outright; no backward-compat wrapper is retained.
+
+## Scope
+
+### In Scope
+
+- Add the markdown parser as a real frontend dependency and import it in `frontend/src/entrypoints/skills.tsx`
+- Remove `window.marked` usage and the `marked` CDN script from `api_service/templates/react_dashboard.html`
+- Remove the `mce-autosize-textarea` `customElements.define` monkeypatch from `react_dashboard.html`
+- Update tests so the skills entrypoint no longer depends on a template-provided parser global
+- Regenerate package lock/build artifacts required by the dependency change
+
+### Out of Scope
+
+- Changing markdown sanitization policy or supported HTML tags beyond what this cleanup requires
+- Introducing a new rich-text editor or custom element system
+- Refactoring unrelated dashboard boot logic, theme initialization, or page layout
+
+## Research Summary
+
+- The only in-repo references to `window.marked` are in `frontend/src/entrypoints/skills.tsx`, its test file, and the shared dashboard template script tag.
+- A repo-wide search, including unignored files, found no in-repo owner or dependency reference for `mce-autosize-textarea`; the only references are the template monkeypatch and built output that still reflects current source.
+- Because no active registration path exists in source or lockfile, the safest cleanup is to delete the global monkeypatch rather than relocate it.
+
+## Structure Decision
+
+- Keep markdown rendering ownership inside `frontend/src/entrypoints/skills.tsx` by importing the packaged parser there and preserving the existing `sanitizeHtml()` post-processing.
+- Keep the shared HTML shell limited to generic boot concerns (theme initialization and asset injection), with no page-specific globals.
+- Treat the `mce-autosize-textarea` guard as dead compatibility code and delete it from the template because there is no owning module to move it into.
+- Update the skills entrypoint test setup to exercise direct parser imports instead of stubbing `window.marked`.
+
+## Verification Plan
+
+1. Run `npm run ui:typecheck`.
+2. Run `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx`.
+3. Run `npm run ui:build:check`.
+4. Run `./tools/test_unit.sh`.

--- a/specs/126-remove-runtime-globals/quickstart.md
+++ b/specs/126-remove-runtime-globals/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: remove-runtime-globals
+
+1. Install frontend dependencies so the packaged markdown parser is available:
+   ```bash
+   npm install
+   ```
+2. Verify the affected entrypoint still typechecks:
+   ```bash
+   npm run ui:typecheck
+   ```
+3. Run the focused skills entrypoint test:
+   ```bash
+   npm run ui:test -- frontend/src/entrypoints/skills.test.tsx
+   ```
+4. Verify the production bundle and manifest path:
+   ```bash
+   npm run ui:build:check
+   ```
+5. Run the repo unit-test gate before finalizing:
+   ```bash
+   ./tools/test_unit.sh
+   ```

--- a/specs/126-remove-runtime-globals/research.md
+++ b/specs/126-remove-runtime-globals/research.md
@@ -1,0 +1,25 @@
+# Research: remove-runtime-globals
+
+## Decision 1: Bundle markdown parsing through the frontend module graph
+
+- **Decision**: Add `marked` as a normal frontend dependency and import it directly in `frontend/src/entrypoints/skills.tsx`.
+- **Rationale**: The skills page is the only consumer, and using a direct import removes hidden coupling between the React entrypoint and `react_dashboard.html`.
+- **Alternatives considered**:
+  - Keep the template CDN script and `window.marked`: rejected because it preserves a global compatibility path the user explicitly wants removed.
+  - Add a local markdown parser wrapper module first: rejected as unnecessary indirection for a single consumer.
+
+## Decision 2: Preserve sanitization after markdown parsing
+
+- **Decision**: Continue running the rendered HTML through the existing `sanitizeHtml()` function after markdown conversion.
+- **Rationale**: The current behavior already strips unsafe elements and attributes, and this cleanup should not widen the allowed HTML surface.
+- **Alternatives considered**:
+  - Trust the parser output directly: rejected because it would weaken the current safety posture.
+  - Replace the sanitizer as part of this cleanup: rejected because it would broaden scope beyond removing globals.
+
+## Decision 3: Delete the `mce-autosize-textarea` global monkeypatch
+
+- **Decision**: Remove the template-level `customElements.define` override entirely.
+- **Rationale**: Repo-wide search found no source-owned registration path, no package reference, and no other runtime code referring to `mce-autosize-textarea`, so the monkeypatch appears to be dead compatibility code.
+- **Alternatives considered**:
+  - Move the guard into an owning module: rejected because no owning module exists in the current codebase.
+  - Keep the monkeypatch defensively: rejected because it preserves global behavior for a non-existent path and conflicts with the repo's delete-don't-deprecate policy.

--- a/specs/126-remove-runtime-globals/spec.md
+++ b/specs/126-remove-runtime-globals/spec.md
@@ -1,0 +1,60 @@
+# Feature Specification: remove-runtime-globals
+
+**Feature Branch**: `126-remove-runtime-globals`
+**Created**: 2026-04-03
+**Status**: In Progress
+**Input**: User description: "Remove the global runtime exceptions. Put marked in package.json, import it in skills.tsx, and delete the CDN script from react_dashboard.html. Then track down why mce-autosize-textarea needed a global customElements.define monkeypatch and move that guard into the module that actually owns the element registration or remove the duplicate registration path entirely."
+
+## User Scenarios & Testing
+
+### User Story 1 - Skills preview runs without template globals (Priority: P1)
+
+Frontend maintainers need the skills page to render markdown through the normal module graph so Mission Control does not depend on a page-template global parser.
+
+**Why this priority**: The current template-level parser global hides a leftover compatibility path and makes the skills entrypoint depend on runtime HTML state instead of its own imports.
+
+**Independent Test**: The skills page renders markdown previews correctly when loaded through the React entrypoint, and the shared dashboard template no longer injects a markdown-parser global.
+
+**Acceptance Scenarios**:
+
+1. **Given** the skills page loads through `react_dashboard.html`, **When** the entrypoint renders skill markdown, **Then** it uses its bundled dependency path and the template does not inject a parser CDN script.
+2. **Given** skill markdown contains unsafe HTML or links, **When** the preview renders, **Then** the existing sanitization behavior remains enforced.
+
+---
+
+### User Story 2 - Custom element registration is owned by the registering module (Priority: P1)
+
+Frontend maintainers need custom element registration behavior to live with the code that registers the element so Mission Control no longer patches `customElements.define` globally at page boot.
+
+**Why this priority**: A page-template monkeypatch for one element name is strong evidence of stale compatibility code and broadens the runtime blast radius of a narrow registration problem.
+
+**Independent Test**: Mission Control pages boot without a template-level `customElements.define` override, and any remaining duplicate-registration guard exists only in the module that owns the element registration.
+
+**Acceptance Scenarios**:
+
+1. **Given** Mission Control boots any React dashboard page, **When** the page template executes, **Then** it does not replace `window.customElements.define`.
+2. **Given** the owning module attempts to register an already-registered custom element, **When** that path still exists, **Then** the guard is scoped to that module and only suppresses the duplicate registration for that element.
+
+### Edge Cases
+
+- Invalid or empty markdown still renders a safe preview instead of breaking the skills page.
+- Dashboard pages that do not use the skills preview or the custom element continue to boot without relying on removed globals.
+- If no live duplicate-registration path exists for `mce-autosize-textarea`, the cleanup removes the dead compatibility branch instead of relocating it.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Mission Control skill markdown rendering MUST use a dependency managed by the frontend build instead of a parser exposed as a page-template global.
+- **FR-002**: `api_service/templates/react_dashboard.html` MUST NOT inject a markdown parser CDN script for the React dashboard.
+- **FR-003**: `api_service/templates/react_dashboard.html` MUST NOT override `window.customElements.define` to special-case `mce-autosize-textarea`.
+- **FR-004**: If duplicate custom element registration protection is still required, it MUST live in the module that owns the registration path and MUST scope the guard to that registration flow only.
+- **FR-005**: If no active duplicate registration path exists for `mce-autosize-textarea`, the dead compatibility code MUST be removed entirely rather than preserved behind a global guard.
+- **FR-006**: Frontend verification MUST cover the skills markdown rendering path and confirm the cleanup does not regress Mission Control boot/build behavior.
+
+## Success Criteria
+
+- **SC-001**: The skills entrypoint imports its markdown parser directly and no longer references a parser on `window`.
+- **SC-002**: `react_dashboard.html` contains neither the marked CDN script nor a `customElements.define` monkeypatch.
+- **SC-003**: The skills entrypoint tests continue to pass with no test setup that fakes a template-provided parser global.
+- **SC-004**: Frontend typecheck, targeted UI tests, and build verification pass after the cleanup.

--- a/specs/126-remove-runtime-globals/speckit_analyze_report.md
+++ b/specs/126-remove-runtime-globals/speckit_analyze_report.md
@@ -1,0 +1,33 @@
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| A0 | Alignment | LOW | spec.md, plan.md, tasks.md | No cross-artifact inconsistencies or uncovered requirements were detected in the current artifact set. | Proceed to implementation and keep verification aligned with the listed commands. |
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --- | --- | --- | --- |
+| bundled-markdown-parser | Yes | T002, T003, T005 | Dependency, entrypoint import, and frontend test coverage are explicit. |
+| remove-template-parser-cdn | Yes | T004, T007 | Runtime template removal plus route-shell assertion coverage. |
+| remove-global-custom-elements-monkeypatch | Yes | T006, T007 | Runtime template cleanup plus backend shell assertion coverage. |
+| local-registration-guard-only-if-needed | Yes | T006 | Research concluded no owning module exists, so deletion is the compliant path. |
+| remove-dead-duplicate-registration-path | Yes | T006 | Cleanup removes the dead compatibility code entirely. |
+| verification-covers-runtime-cleanup | Yes | T005, T007, T008, T009, T010 | Frontend, backend, build, unit-suite, and diff-scope validation are all represented. |
+
+**Metrics:**
+
+- Total Requirements: 6
+- Total Tasks: 10
+- Coverage %: 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+**Next Actions**
+
+- Proceed to implementation.
+- Preserve the current markdown sanitization behavior while replacing the parser import path.
+- Keep a backend `tests/` file in the final diff so runtime scope validation continues to pass.
+
+Safe to Implement: YES

--- a/specs/126-remove-runtime-globals/tasks.md
+++ b/specs/126-remove-runtime-globals/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: remove-runtime-globals
+
+**Input**: Design documents from `/specs/126-remove-runtime-globals/`
+**Prerequisites**: plan.md, spec.md, research.md, quickstart.md
+
+## Phase 1: Setup
+
+- [X] T001 Confirm the remaining global runtime paths and record the feature artifacts in `specs/126-remove-runtime-globals/spec.md`, `specs/126-remove-runtime-globals/plan.md`, `specs/126-remove-runtime-globals/research.md`, `specs/126-remove-runtime-globals/quickstart.md`, and `specs/126-remove-runtime-globals/tasks.md`
+
+## Phase 2: User Story 1 - Skills preview runs without template globals (Priority: P1)
+
+**Goal**: Make the skills entrypoint own markdown parsing instead of relying on a template global.
+
+**Independent Test**: The skills page still renders markdown previews safely, and the shared dashboard template no longer injects the parser CDN script.
+
+- [X] T002 [US1] Add the packaged markdown parser dependency in `package.json` and `package-lock.json`
+- [X] T003 [US1] Import the parser directly in `frontend/src/entrypoints/skills.tsx` and remove the `window.marked` fallback path
+- [X] T004 [US1] Remove the marked CDN script from `api_service/templates/react_dashboard.html`
+- [X] T005 [US1] Update `frontend/src/entrypoints/skills.test.tsx` so the skills preview tests exercise direct parser imports instead of a template global
+
+## Phase 3: User Story 2 - Custom element registration is owned locally (Priority: P1)
+
+**Goal**: Delete the stale global custom-element compatibility hook from the shared dashboard shell.
+
+**Independent Test**: The shared dashboard shell renders without a `customElements.define` monkeypatch, and route tests confirm the removed globals stay removed.
+
+- [X] T006 [US2] Remove the `mce-autosize-textarea` `customElements.define` monkeypatch from `api_service/templates/react_dashboard.html`
+- [X] T007 [US2] Add dashboard shell assertions in `tests/unit/api/routers/test_task_dashboard.py` proving `react_dashboard.html` no longer injects the marked CDN script or custom-elements monkeypatch
+
+## Phase 4: Validation
+
+- [X] T008 Run `npm run ui:typecheck`, `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx`, and `npm run ui:build:check`
+- [X] T009 Run `./tools/test_unit.sh`
+- [X] T010 Run `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -172,6 +172,8 @@ def test_static_sub_routes_render_react_shell(client: TestClient) -> None:
         assert "task-dashboard-config" not in response.text
         assert "/static/task_dashboard/dashboard.js" not in response.text
         assert 'id="dashboard-alerts-root"' in response.text
+        assert "marked.min.js" not in response.text
+        assert "__moonmind_customElementsDefineGuard" not in response.text
 
     for path in (
         "/tasks/list",
@@ -187,6 +189,8 @@ def test_static_sub_routes_render_react_shell(client: TestClient) -> None:
         assert 'type="module"' in response.text
         assert "/static/task_dashboard/dist/assets/" in response.text
         assert 'id="dashboard-alerts-root"' in response.text
+        assert "marked.min.js" not in response.text
+        assert "__moonmind_customElementsDefineGuard" not in response.text
 
 
 def test_react_shell_uses_vite_dev_server_assets_when_configured(


### PR DESCRIPTION
## Summary
- add `marked` as a packaged frontend dependency and import it directly in the skills entrypoint
- remove the `marked` CDN script and the `mce-autosize-textarea` `customElements.define` monkeypatch from `react_dashboard.html`
- update frontend and backend tests plus Spec Kit artifacts for feature `126-remove-runtime-globals`

## Verification
- `npm run ui:typecheck`
- `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx`
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_task_dashboard.py`
- `npm run ui:build:check`
- `./tools/test_unit.sh`
- `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`