### PR TITLE
[codex] Fix artifact upload completion retries

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,42 @@
 [
   {
-    "id": 3034751817,
+    "id": 3034926806,
     "disposition": "addressed",
-    "rationale": "Changed the checklist's feature link from an absolute local path to the repo-relative ../spec.md target."
+    "rationale": "Restricted single-put completion retries to visibility errors only and added a regression test for non-visibility storage failures."
   },
   {
-    "id": 3034751830,
+    "id": 3034926820,
     "disposition": "addressed",
-    "rationale": "Unchecked the technology-agnostic checklist assertions and clarified the notes so the checklist now matches the spec's implementation-detail content."
+    "rationale": "Restructured the frontend completion retries to use an explicit initial-attempt plus retry-schedule loop with valid indexes on every iteration."
   },
   {
-    "id": 4057656070,
-    "disposition": "not-applicable",
-    "rationale": "Informational review summary only; its actionable feedback is already represented by the inline review comments above."
+    "id": 3034926825,
+    "disposition": "addressed",
+    "rationale": "Frontend completion retries now require a 409 response with structured `detail.code` and message instead of matching on plain error text alone."
   },
   {
-    "id": 4057666739,
+    "id": 3034926829,
+    "disposition": "addressed",
+    "rationale": "Backend retry tests now monkeypatch the single-put retry delays to zero so the unit suite stays fast and deterministic."
+  },
+  {
+    "id": 3034926834,
+    "disposition": "addressed",
+    "rationale": "The UI retry test now overrides the retry delay schedule to near-zero values instead of waiting for wall-clock backoff intervals."
+  },
+  {
+    "id": 4057871862,
     "disposition": "not-applicable",
-    "rationale": "Positive review with no requested change."
+    "rationale": "This was an informational PR overview summary, not an actionable review request."
+  },
+  {
+    "id": 3034928185,
+    "disposition": "addressed",
+    "rationale": "The backend now logs `retry pending` only when another retry is actually scheduled."
+  },
+  {
+    "id": 4057873595,
+    "disposition": "not-applicable",
+    "rationale": "This was a summary review comment; the only actionable point in it was captured and addressed in the inline logging comment."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -725,6 +725,110 @@ describe("Task Create Entrypoint", () => {
     expect(executionIndex).toBeGreaterThan(completeIndex);
   });
 
+  it(
+    "retries transient artifact completion conflicts before creating the task",
+    async () => {
+      let completeAttempts = 0;
+
+      fetchSpy.mockImplementation(
+        (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.includes("/api/v1/provider-profiles")) {
+            return Promise.resolve({
+              ok: true,
+              json: async () => [],
+            } as Response);
+          }
+          if (url === "/api/artifacts") {
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                artifact_ref: {
+                  artifact_id: "art-001",
+                },
+                upload: {
+                  mode: "single_put",
+                  upload_url: "/api/artifacts/art-001/content",
+                  expires_at: "2026-04-02T00:00:00Z",
+                  max_size_bytes: 100000,
+                  required_headers: {},
+                },
+              }),
+            } as Response);
+          }
+          if (url === "/api/artifacts/art-001/content") {
+            return Promise.resolve({
+              ok: true,
+              text: async () => "",
+            } as Response);
+          }
+          if (url === "/api/artifacts/art-001/complete") {
+            completeAttempts += 1;
+            if (completeAttempts < 5) {
+              return Promise.resolve({
+                ok: false,
+                status: 409,
+                text: async () =>
+                  JSON.stringify({
+                    detail: {
+                      code: "artifact_state_error",
+                      message: "artifact upload is not complete",
+                    },
+                  }),
+              } as Response);
+            }
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({ artifact_id: "art-001" }),
+            } as Response);
+          }
+          if (url === "/api/artifacts/art-001/links") {
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({ artifact_id: "art-001" }),
+            } as Response);
+          }
+          if (url === "/api/executions") {
+            return Promise.resolve({
+              ok: true,
+              json: async () => ({
+                workflowId: "mm:workflow-123",
+                runId: "run-123",
+                namespace: "moonmind",
+                redirectPath: "/tasks/mm:workflow-123?source=temporal",
+              }),
+            } as Response);
+          }
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            statusText: `Unhandled fetch for ${url} ${String(init?.method || "GET")}`,
+            text: async () => "Unhandled fetch",
+          } as Response);
+        },
+      );
+
+      renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+      fireEvent.change(await screen.findByLabelText("Instructions"), {
+        target: { value: "Large instructions ".repeat(1000) },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+      await waitFor(
+        () => {
+          expect(completeAttempts).toBe(5);
+          expect(fetchSpy).toHaveBeenCalledWith(
+            "/api/executions",
+            expect.objectContaining({ method: "POST" }),
+          );
+        },
+        { timeout: 9000 },
+      );
+    },
+    10000,
+  );
+
   it("uploads oversized step instructions as a JSON artifact and strips inline step text", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -12,7 +12,11 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { BootPayload } from "../boot/parseBootPayload";
 import { navigateTo } from "../lib/navigation";
 import { renderWithClient } from "../utils/test-utils";
-import { resolveObjectiveInstructions, TaskCreatePage } from "./task-create";
+import {
+  ARTIFACT_COMPLETE_RETRY_DELAYS_MS,
+  resolveObjectiveInstructions,
+  TaskCreatePage,
+} from "./task-create";
 
 vi.mock("../lib/navigation", () => ({
   navigateTo: vi.fn(),
@@ -729,102 +733,120 @@ describe("Task Create Entrypoint", () => {
     "retries transient artifact completion conflicts before creating the task",
     async () => {
       let completeAttempts = 0;
+      const originalRetryDelays = [...ARTIFACT_COMPLETE_RETRY_DELAYS_MS];
 
-      fetchSpy.mockImplementation(
-        (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = String(input);
-          if (url.includes("/api/v1/provider-profiles")) {
-            return Promise.resolve({
-              ok: true,
-              json: async () => [],
-            } as Response);
-          }
-          if (url === "/api/artifacts") {
-            return Promise.resolve({
-              ok: true,
-              json: async () => ({
-                artifact_ref: {
-                  artifact_id: "art-001",
-                },
-                upload: {
-                  mode: "single_put",
-                  upload_url: "/api/artifacts/art-001/content",
-                  expires_at: "2026-04-02T00:00:00Z",
-                  max_size_bytes: 100000,
-                  required_headers: {},
-                },
-              }),
-            } as Response);
-          }
-          if (url === "/api/artifacts/art-001/content") {
-            return Promise.resolve({
-              ok: true,
-              text: async () => "",
-            } as Response);
-          }
-          if (url === "/api/artifacts/art-001/complete") {
-            completeAttempts += 1;
-            if (completeAttempts < 5) {
+      try {
+        ARTIFACT_COMPLETE_RETRY_DELAYS_MS.splice(
+          0,
+          ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length,
+          1,
+          1,
+          1,
+          1,
+          1,
+        );
+        fetchSpy.mockImplementation(
+          (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            if (url.includes("/api/v1/provider-profiles")) {
               return Promise.resolve({
-                ok: false,
-                status: 409,
-                text: async () =>
-                  JSON.stringify({
-                    detail: {
-                      code: "artifact_state_error",
-                      message: "artifact upload is not complete",
-                    },
-                  }),
+                ok: true,
+                json: async () => [],
+              } as Response);
+            }
+            if (url === "/api/artifacts") {
+              return Promise.resolve({
+                ok: true,
+                json: async () => ({
+                  artifact_ref: {
+                    artifact_id: "art-001",
+                  },
+                  upload: {
+                    mode: "single_put",
+                    upload_url: "/api/artifacts/art-001/content",
+                    expires_at: "2026-04-02T00:00:00Z",
+                    max_size_bytes: 100000,
+                    required_headers: {},
+                  },
+                }),
+              } as Response);
+            }
+            if (url === "/api/artifacts/art-001/content") {
+              return Promise.resolve({
+                ok: true,
+                text: async () => "",
+              } as Response);
+            }
+            if (url === "/api/artifacts/art-001/complete") {
+              completeAttempts += 1;
+              if (completeAttempts < 5) {
+                return Promise.resolve({
+                  ok: false,
+                  status: 409,
+                  text: async () =>
+                    JSON.stringify({
+                      detail: {
+                        code: "artifact_state_error",
+                        message: "artifact upload is not complete",
+                      },
+                    }),
+                } as Response);
+              }
+              return Promise.resolve({
+                ok: true,
+                json: async () => ({ artifact_id: "art-001" }),
+              } as Response);
+            }
+            if (url === "/api/artifacts/art-001/links") {
+              return Promise.resolve({
+                ok: true,
+                json: async () => ({ artifact_id: "art-001" }),
+              } as Response);
+            }
+            if (url === "/api/executions") {
+              return Promise.resolve({
+                ok: true,
+                json: async () => ({
+                  workflowId: "mm:workflow-123",
+                  runId: "run-123",
+                  namespace: "moonmind",
+                  redirectPath: "/tasks/mm:workflow-123?source=temporal",
+                }),
               } as Response);
             }
             return Promise.resolve({
-              ok: true,
-              json: async () => ({ artifact_id: "art-001" }),
+              ok: false,
+              status: 404,
+              statusText: `Unhandled fetch for ${url} ${String(init?.method || "GET")}`,
+              text: async () => "Unhandled fetch",
             } as Response);
-          }
-          if (url === "/api/artifacts/art-001/links") {
-            return Promise.resolve({
-              ok: true,
-              json: async () => ({ artifact_id: "art-001" }),
-            } as Response);
-          }
-          if (url === "/api/executions") {
-            return Promise.resolve({
-              ok: true,
-              json: async () => ({
-                workflowId: "mm:workflow-123",
-                runId: "run-123",
-                namespace: "moonmind",
-                redirectPath: "/tasks/mm:workflow-123?source=temporal",
-              }),
-            } as Response);
-          }
-          return Promise.resolve({
-            ok: false,
-            status: 404,
-            statusText: `Unhandled fetch for ${url} ${String(init?.method || "GET")}`,
-            text: async () => "Unhandled fetch",
-          } as Response);
-        },
-      );
+          },
+        );
 
-      renderWithClient(<TaskCreatePage payload={mockPayload} />);
+        renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-      fireEvent.change(await screen.findByLabelText("Instructions"), {
-        target: { value: "Large instructions ".repeat(1000) },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Create" }));
+        fireEvent.change(await screen.findByLabelText("Instructions"), {
+          target: { value: "Large instructions ".repeat(1000) },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-      await waitFor(
-        () => {
-          expect(completeAttempts).toBe(5);
-          expect(fetchSpy).toHaveBeenCalledWith(
-            "/api/executions",
-            expect.objectContaining({ method: "POST" }),
-          );
-        },
-        { timeout: 9000 },
-      );
+        await waitFor(
+          () => {
+            expect(completeAttempts).toBe(5);
+            expect(fetchSpy).toHaveBeenCalledWith(
+              "/api/executions",
+              expect.objectContaining({ method: "POST" }),
+            );
+          },
+          { timeout: 9000 },
+        );
+      } finally {
+        ARTIFACT_COMPLETE_RETRY_DELAYS_MS.splice(
+          0,
+          ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length,
+          ...originalRetryDelays,
+        );
+      }
     },
     10000,
   );

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7,7 +7,7 @@ import { navigateTo } from "../lib/navigation";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
-const ARTIFACT_COMPLETE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 2000];
+export const ARTIFACT_COMPLETE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 2000];
 const ARTIFACT_COMPLETE_RETRY_MESSAGE = "artifact upload is not complete";
 const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
@@ -105,6 +105,11 @@ interface ExecutionCreateResponse {
   namespace?: string;
   redirectPath?: string;
   definitionId?: string;
+}
+
+interface ResponseErrorDetail {
+  code: string | null;
+  message: string;
 }
 
 interface TaskTemplateInputDefinition {
@@ -555,35 +560,43 @@ export function resolveObjectiveInstructions(
   return "";
 }
 
+async function responseErrorDetail(
+  response: Response,
+  fallback: string,
+): Promise<ResponseErrorDetail> {
+  try {
+    const rawText = (await response.text()).trim();
+    if (!rawText) {
+      return { code: null, message: fallback };
+    }
+    try {
+      const payload = JSON.parse(rawText) as {
+        detail?: string | { code?: string; message?: string };
+      };
+      if (typeof payload.detail === "string" && payload.detail.trim()) {
+        return { code: null, message: payload.detail.trim() };
+      }
+      if (payload.detail && typeof payload.detail === "object") {
+        const detailCode = String(payload.detail.code || "").trim() || null;
+        const detailMessage = String(payload.detail.message || "").trim();
+        if (detailMessage) {
+          return { code: detailCode, message: detailMessage };
+        }
+      }
+    } catch {
+      return { code: null, message: rawText };
+    }
+  } catch {
+    return { code: null, message: fallback };
+  }
+  return { code: null, message: fallback };
+}
+
 async function responseErrorMessage(
   response: Response,
   fallback: string,
 ): Promise<string> {
-  try {
-    const rawText = (await response.text()).trim();
-    if (!rawText) {
-      return fallback;
-    }
-    try {
-      const payload = JSON.parse(rawText) as {
-        detail?: string | { message?: string };
-      };
-      if (typeof payload.detail === "string" && payload.detail.trim()) {
-        return payload.detail.trim();
-      }
-      if (payload.detail && typeof payload.detail === "object") {
-        const detailMessage = String(payload.detail.message || "").trim();
-        if (detailMessage) {
-          return detailMessage;
-        }
-      }
-    } catch {
-      return rawText;
-    }
-  } catch {
-    return fallback;
-  }
-  return fallback;
+  return (await responseErrorDetail(response, fallback)).message;
 }
 
 async function createInputArtifact(
@@ -703,11 +716,12 @@ async function createInputArtifact(
 
   const completeUrl = `/api/artifacts/${encodeURIComponent(artifactId)}/complete`;
   let completeError: Error | null = null;
-  for (
-    let attempt = 0;
-    attempt <= ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length;
-    attempt += 1
-  ) {
+  const completeRetryScheduleMs = [0, ...ARTIFACT_COMPLETE_RETRY_DELAYS_MS];
+  for (let attempt = 0; attempt < completeRetryScheduleMs.length; attempt += 1) {
+    const delayMs = completeRetryScheduleMs[attempt];
+    if (delayMs > 0) {
+      await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+    }
     let completeResponse: Response;
     try {
       completeResponse = await fetch(completeUrl, {
@@ -741,20 +755,19 @@ async function createInputArtifact(
       return { artifactId };
     }
 
-    const message = await responseErrorMessage(
+    const detail = await responseErrorDetail(
       completeResponse,
       "Failed to finalize task input artifact upload.",
     );
-    completeError = new Error(message);
+    completeError = new Error(detail.message);
     if (
-      !message.includes(ARTIFACT_COMPLETE_RETRY_MESSAGE) ||
-      attempt === ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length
+      completeResponse.status !== 409 ||
+      detail.code !== "artifact_state_error" ||
+      detail.message !== ARTIFACT_COMPLETE_RETRY_MESSAGE ||
+      attempt === completeRetryScheduleMs.length - 1
     ) {
       throw completeError;
     }
-    await new Promise((resolve) =>
-      window.setTimeout(resolve, ARTIFACT_COMPLETE_RETRY_DELAYS_MS[attempt]),
-    );
   }
 
   throw (

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -7,6 +7,8 @@ import { navigateTo } from "../lib/navigation";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
 const INLINE_TASK_INPUT_LIMIT_BYTES = 8_000;
+const ARTIFACT_COMPLETE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 2000];
+const ARTIFACT_COMPLETE_RETRY_MESSAGE = "artifact upload is not complete";
 const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
 const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
@@ -701,7 +703,11 @@ async function createInputArtifact(
 
   const completeUrl = `/api/artifacts/${encodeURIComponent(artifactId)}/complete`;
   let completeError: Error | null = null;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  for (
+    let attempt = 0;
+    attempt <= ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length;
+    attempt += 1
+  ) {
     let completeResponse: Response;
     try {
       completeResponse = await fetch(completeUrl, {
@@ -740,11 +746,14 @@ async function createInputArtifact(
       "Failed to finalize task input artifact upload.",
     );
     completeError = new Error(message);
-    if (!message.includes("artifact upload is not complete") || attempt === 2) {
+    if (
+      !message.includes(ARTIFACT_COMPLETE_RETRY_MESSAGE) ||
+      attempt === ARTIFACT_COMPLETE_RETRY_DELAYS_MS.length
+    ) {
       throw completeError;
     }
     await new Promise((resolve) =>
-      window.setTimeout(resolve, 200 * (attempt + 1)),
+      window.setTimeout(resolve, ARTIFACT_COMPLETE_RETRY_DELAYS_MS[attempt]),
     );
   }
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -717,8 +717,7 @@ async function createInputArtifact(
   const completeUrl = `/api/artifacts/${encodeURIComponent(artifactId)}/complete`;
   let completeError: Error | null = null;
   const completeRetryScheduleMs = [0, ...ARTIFACT_COMPLETE_RETRY_DELAYS_MS];
-  for (let attempt = 0; attempt < completeRetryScheduleMs.length; attempt += 1) {
-    const delayMs = completeRetryScheduleMs[attempt];
+  for (const [attempt, delayMs] of completeRetryScheduleMs.entries()) {
     if (delayMs > 0) {
       await new Promise((resolve) => window.setTimeout(resolve, delayMs));
     }

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -36,6 +36,7 @@ _CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _PREVIEW_MAX_BYTES = 16 * 1024
 _STREAM_CHUNK_BYTES = 64 * 1024
 _SINGLE_PUT_READ_RETRY_DELAYS_SECONDS = (0.1, 0.2, 0.4, 0.8, 1.6)
+_SINGLE_PUT_READ_RETRYABLE_S3_ERROR_CODES = {"404", "NoSuchKey", "NotFound"}
 
 
 class TemporalArtifactError(Exception):
@@ -60,6 +61,15 @@ class TemporalArtifactValidationError(TemporalArtifactError):
 
 class TemporalArtifactAuthorizationError(TemporalArtifactError):
     """Raised when principal is not permitted to access an artifact."""
+
+
+def _is_retryable_single_put_read_error(exc: Exception) -> bool:
+    if isinstance(exc, (FileNotFoundError, KeyError)):
+        return True
+    if isinstance(exc, ClientError):
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        return code in _SINGLE_PUT_READ_RETRYABLE_S3_ERROR_CODES
+    return False
 
 
 @dataclass(slots=True, frozen=True)
@@ -1449,10 +1459,8 @@ class TemporalArtifactService:
         artifact: db_models.TemporalArtifact,
     ) -> bytes:
         last_error: Exception | None = None
-        for attempt, delay_seconds in enumerate(
-            (0.0, *_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS),
-            start=1,
-        ):
+        attempt_delays = (0.0, *_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS)
+        for attempt, delay_seconds in enumerate(attempt_delays, start=1):
             if delay_seconds > 0:
                 await asyncio.sleep(delay_seconds)
             try:
@@ -1460,13 +1468,16 @@ class TemporalArtifactService:
                     None, self._store.read_bytes, artifact.storage_key
                 )
             except Exception as exc:
+                if not _is_retryable_single_put_read_error(exc):
+                    raise
                 last_error = exc
-                logger.debug(
-                    "Temporal artifact single-put completion read retry pending "
-                    "artifact_id=%s attempt=%s",
-                    artifact.artifact_id,
-                    attempt,
-                )
+                if attempt < len(attempt_delays):
+                    logger.debug(
+                        "Temporal artifact single-put completion read retry pending "
+                        "artifact_id=%s attempt=%s",
+                        artifact.artifact_id,
+                        attempt,
+                    )
         raise TemporalArtifactStateError(
             "artifact upload is not complete"
         ) from last_error

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 _CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _PREVIEW_MAX_BYTES = 16 * 1024
 _STREAM_CHUNK_BYTES = 64 * 1024
+_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS = (0.1, 0.2, 0.4, 0.8, 1.6)
 
 
 class TemporalArtifactError(Exception):
@@ -1399,14 +1400,7 @@ class TemporalArtifactService:
                 None, self._store.read_bytes, artifact.storage_key
             )
         else:
-            try:
-                payload = await asyncio.get_running_loop().run_in_executor(
-                    None, self._store.read_bytes, artifact.storage_key
-                )
-            except Exception as exc:
-                raise TemporalArtifactStateError(
-                    "artifact upload is not complete"
-                ) from exc
+            payload = await self._read_single_put_payload_with_retry(artifact)
 
         digest, actual_size = self._compute_digest_and_size(payload)
         if (
@@ -1449,6 +1443,33 @@ class TemporalArtifactService:
             artifact.artifact_id,
         )
         return artifact
+
+    async def _read_single_put_payload_with_retry(
+        self,
+        artifact: db_models.TemporalArtifact,
+    ) -> bytes:
+        last_error: Exception | None = None
+        for attempt, delay_seconds in enumerate(
+            (0.0, *_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS),
+            start=1,
+        ):
+            if delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
+            try:
+                return await asyncio.get_running_loop().run_in_executor(
+                    None, self._store.read_bytes, artifact.storage_key
+                )
+            except Exception as exc:
+                last_error = exc
+                logger.debug(
+                    "Temporal artifact single-put completion read retry pending "
+                    "artifact_id=%s attempt=%s",
+                    artifact.artifact_id,
+                    attempt,
+                )
+        raise TemporalArtifactStateError(
+            "artifact upload is not complete"
+        ) from last_error
 
     async def read(
         self,

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
+from botocore.exceptions import ClientError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -28,6 +29,7 @@ from moonmind.workflows.temporal.artifacts import (
     build_artifact_ref,
     generate_artifact_id,
 )
+from moonmind.workflows.temporal import artifacts as artifact_module
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -405,9 +407,15 @@ async def test_complete_rejects_undeclared_single_put_over_size_limit(
 
 async def test_complete_retries_single_put_reads_until_uploaded_bytes_are_visible(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Single-put completion should tolerate short storage visibility delays."""
 
+    monkeypatch.setattr(
+        artifact_module,
+        "_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS",
+        (0.0, 0.0, 0.0, 0.0, 0.0),
+    )
     async with temporal_db(tmp_path) as session_maker:
         async with session_maker() as session:
             store = _EventuallyVisibleMemoryStore(missing_read_count=3)
@@ -439,9 +447,15 @@ async def test_complete_retries_single_put_reads_until_uploaded_bytes_are_visibl
 
 async def test_complete_still_fails_when_single_put_bytes_never_appear(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Single-put completion should still return state error after retry budget."""
 
+    monkeypatch.setattr(
+        artifact_module,
+        "_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS",
+        (0.0, 0.0, 0.0, 0.0, 0.0),
+    )
     async with temporal_db(tmp_path) as session_maker:
         async with session_maker() as session:
             store = _EventuallyVisibleMemoryStore(missing_read_count=99)
@@ -457,6 +471,51 @@ async def test_complete_still_fails_when_single_put_bytes_never_appear(
             )
 
             with pytest.raises(TemporalArtifactStateError, match="not complete"):
+                await service.complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="user-1",
+                )
+
+
+async def test_complete_single_put_raises_non_visibility_read_error_immediately(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-put completion should not mask non-visibility storage failures."""
+
+    class _AccessDeniedReadStore(_MultipartMemoryStore):
+        def read_bytes(self, storage_key: str) -> bytes:
+            raise ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetObject",
+            )
+
+    monkeypatch.setattr(
+        artifact_module,
+        "_SINGLE_PUT_READ_RETRY_DELAYS_SECONDS",
+        (0.0, 0.0, 0.0, 0.0, 0.0),
+    )
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            store = _AccessDeniedReadStore()
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=store,
+                direct_upload_max_bytes=1024,
+            )
+            artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="text/plain",
+            )
+
+            store.write_bytes(
+                artifact.storage_key,
+                b"present but unreadable",
+                content_type="text/plain",
+            )
+
+            with pytest.raises(ClientError, match="AccessDenied"):
                 await service.complete(
                     artifact_id=artifact.artifact_id,
                     principal="user-1",

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -22,6 +22,7 @@ from moonmind.workflows.temporal.artifacts import (
     S3TemporalArtifactStore,
     TemporalArtifactRepository,
     TemporalArtifactService,
+    TemporalArtifactStateError,
     TemporalArtifactStore,
     TemporalArtifactValidationError,
     build_artifact_ref,
@@ -136,6 +137,21 @@ class _MultipartMemoryStore(TemporalArtifactStore):
     def put_part(self, upload_id: str, part_number: int, payload: bytes) -> str:
         self._uploads[upload_id][part_number] = payload
         return str(part_number)
+
+
+class _EventuallyVisibleMemoryStore(_MultipartMemoryStore):
+    """Store that hides uploaded bytes for a bounded number of initial reads."""
+
+    def __init__(self, missing_read_count: int) -> None:
+        super().__init__()
+        self._missing_read_count = missing_read_count
+        self.read_attempts = 0
+
+    def read_bytes(self, storage_key: str) -> bytes:
+        self.read_attempts += 1
+        if self.read_attempts <= self._missing_read_count:
+            raise KeyError(storage_key)
+        return super().read_bytes(storage_key)
 
 
 async def test_generate_artifact_id_uses_art_prefix_and_ulid_shape() -> None:
@@ -381,6 +397,66 @@ async def test_complete_rejects_undeclared_single_put_over_size_limit(
             )
 
             with pytest.raises(TemporalArtifactValidationError, match="max bytes"):
+                await service.complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="user-1",
+                )
+
+
+async def test_complete_retries_single_put_reads_until_uploaded_bytes_are_visible(
+    tmp_path: Path,
+) -> None:
+    """Single-put completion should tolerate short storage visibility delays."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            store = _EventuallyVisibleMemoryStore(missing_read_count=3)
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=store,
+                direct_upload_max_bytes=1024,
+            )
+            artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="text/plain",
+            )
+
+            store.write_bytes(
+                artifact.storage_key,
+                b"ready after retries",
+                content_type="text/plain",
+            )
+
+            completed = await service.complete(
+                artifact_id=artifact.artifact_id,
+                principal="user-1",
+            )
+
+            assert completed.status is TemporalArtifactStatus.COMPLETE
+            assert store.read_attempts == 4
+
+
+async def test_complete_still_fails_when_single_put_bytes_never_appear(
+    tmp_path: Path,
+) -> None:
+    """Single-put completion should still return state error after retry budget."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            store = _EventuallyVisibleMemoryStore(missing_read_count=99)
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=store,
+                direct_upload_max_bytes=1024,
+            )
+            artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="text/plain",
+            )
+
+            with pytest.raises(TemporalArtifactStateError, match="not complete"):
                 await service.complete(
                     artifact_id=artifact.artifact_id,
                     principal="user-1",


### PR DESCRIPTION
## What changed
This fixes task creation failures caused by transient artifact finalization conflicts during large-input uploads from the UI.

## Why it changed
The UI uploads oversized task input as an artifact, then calls `/api/artifacts/{artifact_id}/complete`. In some runs that completion call raced the underlying single-put object visibility and returned `409 artifact upload is not complete`, which surfaced to the user as a failed task submission.

## Root cause
Single-put artifact completion treated an immediate storage read miss as a terminal state error, and the UI only retried that specific conflict a few short times.

## Fix
- add bounded backend retry logic when completing single-put artifact uploads
- extend the UI retry window for the specific retryable `artifact upload is not complete` conflict
- add regression coverage for delayed artifact visibility and transient completion conflicts

## Impact
Users creating tasks with oversized input payloads should no longer hit spurious submission failures when artifact upload completion is briefly delayed.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py`