### PR TITLE
[codex] Fix task create upload and Vite asset paths

### DIFF
--- a/api_service/api/routers/temporal_artifacts.py
+++ b/api_service/api/routers/temporal_artifacts.py
@@ -174,6 +174,7 @@ async def _resolve_principal(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_artifact(
+    request: Request,
     payload: CreateArtifactRequest,
     principal: str = Depends(_resolve_principal),
     service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
@@ -194,11 +195,15 @@ async def create_artifact(
         _raise_temporal_artifact_http(exc)
         raise
 
+    upload_url = upload.upload_url
+    if upload_url and upload_url.startswith("/"):
+        upload_url = str(request.base_url).rstrip("/") + upload_url
+
     return CreateArtifactResponse(
         artifact_ref=ArtifactRefModel(**asdict(build_artifact_ref(artifact))),
         upload={
             "mode": upload.mode,
-            "upload_url": upload.upload_url,
+            "upload_url": upload_url,
             "upload_id": upload.upload_id,
             "expires_at": upload.expires_at,
             "max_size_bytes": upload.max_size_bytes,

--- a/frontend/src/vite-base.ts
+++ b/frontend/src/vite-base.ts
@@ -1,0 +1,3 @@
+export function missionControlViteBase(command: string): string {
+  return command === "build" ? "/static/task_dashboard/dist/" : "/";
+}

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -1,9 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import config from "../vite.config";
+import viteConfig from "../vite.config";
 
 describe("vite.config", () => {
-  it("serves built Mission Control chunks from the mounted static dist root", () => {
+  it("serves built Mission Control chunks from the mounted static dist root", async () => {
+    const config = await viteConfig({
+      command: "build",
+      mode: "test",
+      isSsrBuild: false,
+      isPreview: false,
+    });
+
     expect(config.base).toBe("/static/task_dashboard/dist/");
+  });
+
+  it("keeps dev-server asset URLs at the Vite root during local HMR", async () => {
+    const config = await viteConfig({
+      command: "serve",
+      mode: "test",
+      isSsrBuild: false,
+      isPreview: false,
+    });
+
+    expect(config.base).toBe("/");
   });
 });

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -1,27 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import viteConfig from "../vite.config";
+import { missionControlViteBase } from "./vite-base";
 
 describe("vite.config", () => {
-  it("serves built Mission Control chunks from the mounted static dist root", async () => {
-    const config = await viteConfig({
-      command: "build",
-      mode: "test",
-      isSsrBuild: false,
-      isPreview: false,
-    });
-
-    expect(config.base).toBe("/static/task_dashboard/dist/");
+  it("serves built Mission Control chunks from the mounted static dist root", () => {
+    expect(missionControlViteBase("build")).toBe("/static/task_dashboard/dist/");
   });
 
-  it("keeps dev-server asset URLs at the Vite root during local HMR", async () => {
-    const config = await viteConfig({
-      command: "serve",
-      mode: "test",
-      isSsrBuild: false,
-      isPreview: false,
-    });
-
-    expect(config.base).toBe("/");
+  it("keeps dev-server asset URLs at the Vite root during local HMR", () => {
+    expect(missionControlViteBase("serve")).toBe("/");
   });
 });

--- a/frontend/src/vite-config.test.ts
+++ b/frontend/src/vite-config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import config from "../vite.config";
+
+describe("vite.config", () => {
+  it("serves built Mission Control chunks from the mounted static dist root", () => {
+    expect(config.base).toBe("/static/task_dashboard/dist/");
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
 export default defineConfig({
+  base: '/static/task_dashboard/dist/',
   plugins: [react()],
   root: resolve(__dirname, 'src'),
   build: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import { missionControlViteBase } from './src/vite-base';
 
 export default defineConfig(({ command }) => ({
-  base: command === 'build' ? '/static/task_dashboard/dist/' : '/',
+  base: missionControlViteBase(command),
   plugins: [react()],
   root: resolve(__dirname, 'src'),
   build: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
-export default defineConfig({
-  base: '/static/task_dashboard/dist/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/static/task_dashboard/dist/' : '/',
   plugins: [react()],
   root: resolve(__dirname, 'src'),
   build: {
@@ -20,4 +20,4 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
   },
-});
+}));

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -252,15 +252,6 @@ class TemporalArtifactStore:
     def delete(self, storage_key: str) -> None:
         raise NotImplementedError
 
-    def presign_single_upload(
-        self,
-        *,
-        storage_key: str,
-        content_type: str | None,
-        expires_in_seconds: int,
-    ) -> tuple[str, dict[str, str]]:
-        raise NotImplementedError
-
     def create_multipart_upload(
         self,
         *,
@@ -377,16 +368,6 @@ class LocalTemporalArtifactStore(TemporalArtifactStore):
 
     def delete(self, storage_key: str) -> None:
         self.resolve_storage_key(storage_key).unlink(missing_ok=True)
-
-    def presign_single_upload(
-        self,
-        *,
-        storage_key: str,
-        content_type: str | None,
-        expires_in_seconds: int,
-    ) -> tuple[str, dict[str, str]]:
-        _ = storage_key, content_type, expires_in_seconds
-        return "", {}
 
     def presign_download(
         self,
@@ -549,29 +530,6 @@ class S3TemporalArtifactStore(TemporalArtifactStore):
 
     def delete(self, storage_key: str) -> None:
         self._client.delete_object(Bucket=self._bucket, Key=storage_key)
-
-    def presign_single_upload(
-        self,
-        *,
-        storage_key: str,
-        content_type: str | None,
-        expires_in_seconds: int,
-    ) -> tuple[str, dict[str, str]]:
-        params: dict[str, Any] = {
-            "Bucket": self._bucket,
-            "Key": storage_key,
-        }
-        required_headers: dict[str, str] = {}
-        if content_type:
-            params["ContentType"] = content_type
-            required_headers["content-type"] = content_type
-        url = self._client.generate_presigned_url(
-            "put_object",
-            Params=params,
-            ExpiresIn=expires_in_seconds,
-            HttpMethod="PUT",
-        )
-        return self._rewrite_presigned_url(url), required_headers
 
     def create_multipart_upload(
         self,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -1204,14 +1204,7 @@ class TemporalArtifactService:
                 ),
             )
         else:
-            if self._store.backend is db_models.TemporalArtifactStorageBackend.S3:
-                upload_url, required_headers = self._store.presign_single_upload(
-                    storage_key=storage_key,
-                    content_type=content_type,
-                    expires_in_seconds=self._presign_ttl_seconds,
-                )
-            else:
-                upload_url = f"/api/artifacts/{artifact_id}/content"
+            upload_url = f"/api/artifacts/{artifact_id}/content"
 
         artifact = await self._repository.create_artifact(
             artifact_id=artifact_id,

--- a/tests/unit/api/routers/test_temporal_artifacts.py
+++ b/tests/unit/api/routers/test_temporal_artifacts.py
@@ -134,7 +134,10 @@ def test_create_artifact_returns_upload_descriptor() -> None:
         assert response.status_code == 201
         body = response.json()
         assert body["artifact_ref"]["artifact_id"] == artifact.artifact_id
-        assert body["upload"]["upload_url"].endswith(f"/{artifact.artifact_id}/content")
+        assert (
+            body["upload"]["upload_url"]
+            == f"http://testserver/api/artifacts/{artifact.artifact_id}/content"
+        )
 
 
 def test_upload_content_maps_validation_to_413() -> None:

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -272,6 +272,30 @@ async def test_create_write_read_and_list_for_execution(tmp_path: Path) -> None:
             assert [item.artifact_id for item in listed] == [artifact.artifact_id]
 
 
+async def test_create_uses_same_origin_content_endpoint_for_small_s3_uploads(
+    tmp_path: Path,
+) -> None:
+    """Small S3-backed uploads should stay on the API content route."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=_MultipartMemoryStore(),
+                direct_upload_max_bytes=1024,
+            )
+
+            artifact, upload = await service.create(
+                principal="user-1",
+                content_type="text/plain",
+                size_bytes=11,
+            )
+
+            assert upload.mode == "single_put"
+            assert upload.upload_url == f"/api/artifacts/{artifact.artifact_id}/content"
+
+
 async def test_compute_preview_redacts_token_like_pairs(tmp_path: Path) -> None:
     """Preview activity should redact token/password assignments."""
 

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -90,12 +90,6 @@ class _MultipartMemoryStore(TemporalArtifactStore):
     def delete(self, storage_key: str) -> None:
         self._objects.pop(storage_key, None)
 
-    def presign_single_upload(
-        self, *, storage_key: str, content_type, expires_in_seconds: int
-    ):
-        _ = content_type, expires_in_seconds
-        return f"https://example.test/upload/{storage_key}", {}
-
     def create_multipart_upload(self, *, storage_key: str, content_type=None) -> str:
         _ = content_type
         upload_id = f"upload-{storage_key}"


### PR DESCRIPTION
## Summary
- set the Mission Control Vite `base` to `/static/task_dashboard/dist/` so lazy-loaded chunks resolve under the mounted static path instead of root-relative `/assets/...`
- route small single-put artifact uploads back through `/api/artifacts/{artifact_id}/content` instead of browser-direct MinIO presigned URLs
- add regression coverage for the Vite base config and same-origin single-upload artifact behavior

## Root Cause
Task creation was failing for two separate reasons:
1. the rebuilt Mission Control bundle emitted lazy imports to `/assets/...`, which produced 404s because FastAPI serves bundles from `/static/task_dashboard/dist/assets/...`
2. small task-input artifact uploads were going directly from the browser to MinIO; in the failing dashboard path the object never became readable at completion time, so `/api/artifacts/{id}/complete` correctly returned `409 artifact upload is not complete`

## Impact
- `/tasks/new` and other lazy-loaded Mission Control pages now load follow-on chunks from the correct static prefix
- task-create artifact uploads use the API content endpoint for small payloads, avoiding the broken browser-to-MinIO path
- the regressions are covered by focused tests so future bundle or artifact changes fail loudly

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- rebuilt the frontend with `npm run ui:build`
- restarted `moonmind-api-1`
- live smoke-checked artifact create/upload/complete against `http://127.0.0.1:5000`
