### PR TITLE
Implement Phase 3: Codex OpenRouter generalization and legacy auth cleanup

### DIFF
--- a/docs/tmp/remaining-work/127-codex-openrouter-phase3.md
+++ b/docs/tmp/remaining-work/127-codex-openrouter-phase3.md
@@ -1,0 +1,48 @@
+# Migration Tracker: 127-codex-openrouter-phase3
+
+**Feature**: Codex OpenRouter Phase 3 — Generalization
+**Branch**: `127-codex-openrouter-phase3`
+**Created**: 2026-04-03
+**Status**: In progress
+
+## Purpose
+
+Track in-flight implementation progress for Phase 3. This file should be removed once the feature ships and all tasks are merged.
+
+## Migration Summary
+
+The primary migration is aligning the `ManagedAgentProviderProfile` Pydantic model with the provider-profile contract:
+- **Legacy field**: `auth_mode` (required) — removed entirely
+- **Replacement field**: `credential_source` (required) — mapped from DB model
+- **Legacy-to-new mapping** (one-time, data level): `oauth` → `oauth_volume`, `api_key` → `secret_ref`
+
+## Implementation Tasks
+
+| Task | Status | Notes |
+|------|--------|-------|
+| T001 — Rewrite `ManagedAgentProviderProfile` | pending | Remove `auth_mode`, add 13 new fields |
+| T002 — Replace `auth_mode` in adapter | pending | 3 locations + metadata consumer audit |
+| T003 — Update existing tests | pending | Replace `authMode` with `credentialSource` |
+| T004 — Add validation tests | pending | 7 new test functions |
+| T005 — Provider-agnostic code audit | pending | Grep audit of materializer/adapter/launcher |
+| T006 — Multi-profile integration tests | pending | Depends on T001 |
+| T007 — Full test suite + edge case audit + DB check | pending | Depends on T001–T004 |
+
+## Data Verification Checklist
+
+- [ ] Query `managed_agent_provider_profiles` for rows with NULL or invalid `credential_source`
+- [ ] Confirm zero provider-specific branching in materializer/adapter/launcher
+- [ ] Confirm all metadata consumers of `metadata["auth_mode"]` updated to `credential_source`
+
+## DOC-REQ Traceability
+
+| DOC-REQ | Tasks | Status |
+|---------|-------|--------|
+| DOC-REQ-001 (Reference implementation) | T005 | pending |
+| DOC-REQ-002 (Additional model defaults) | T006 | pending |
+| DOC-REQ-003 (Legacy auth-profile alignment) | T001, T002, T003, T004, T007 | pending |
+
+## Remediation History
+
+- **Remediation A** (2026-04-03): Initial remediation discovery — 3 CRITICAL, 4 HIGH, 5 MEDIUM findings
+- **Remediation B** (2026-04-03): Applied all CRITICAL and HIGH items, plus MEDIUM items. Spec CRITICAL-01 (OAuthProviderSpec scoping), plan CRITICAL-01 (fields-to-retain), tasks CRITICAL-01 (T006 dependency). See `specs/127-codex-openrouter-phase3/remediation-b-summary.md`.

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -297,13 +297,13 @@ class ManagedAgentProviderProfile(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    # -- Core identity (required) --
+    # -- Core identity --
     profile_id: str = Field(..., alias="profileId", min_length=1)
     runtime_id: str = Field(..., alias="runtimeId", min_length=1)
     provider_id: str | None = Field(None, alias="providerId")
     provider_label: str | None = Field(None, alias="providerLabel")
     default_model: str | None = Field(None, alias="defaultModel")
-    model_overrides: dict[str, Any] = Field(default_factory=dict, alias="modelOverrides")
+    model_overrides: dict[str, str] = Field(default_factory=dict, alias="modelOverrides")
 
     # -- Credential & materialization strategy (required) --
     credential_source: str = Field(..., alias="credentialSource", min_length=1)
@@ -315,7 +315,9 @@ class ManagedAgentProviderProfile(BaseModel):
     tags: list[str] = Field(default_factory=list, alias="tags")
     priority: int = Field(default=100, alias="priority", ge=0)
     max_parallel_runs: int = Field(default=1, alias="maxParallelRuns", ge=1)
-    cooldown_after_429: int = Field(default=0, alias="cooldownAfter429", ge=0)
+    cooldown_after_429_seconds: int = Field(
+        default=900, alias="cooldownAfter429Seconds", ge=0
+    )
     rate_limit_policy: dict[str, Any] = Field(
         default_factory=dict, alias="rateLimitPolicy"
     )
@@ -349,7 +351,7 @@ class ManagedAgentProviderProfile(BaseModel):
     _ALLOWED_CREDENTIAL_SOURCES: frozenset[str] = frozenset(
         {"oauth_volume", "secret_ref", "none"}
     )
-    _ALLOWED_MATIALIZATION_MODES: frozenset[str] = frozenset(
+    _ALLOWED_MATERIALIZATION_MODES: frozenset[str] = frozenset(
         {"oauth_home", "api_key_env", "env_bundle", "config_bundle", "composite"}
     )
 
@@ -381,8 +383,8 @@ class ManagedAgentProviderProfile(BaseModel):
                 f"got {self.credential_source!r}"
             )
 
-        if self.runtime_materialization_mode not in self._ALLOWED_MATIALIZATION_MODES:
-            allowed = ", ".join(sorted(self._ALLOWED_MATIALIZATION_MODES))
+        if self.runtime_materialization_mode not in self._ALLOWED_MATERIALIZATION_MODES:
+            allowed = ", ".join(sorted(self._ALLOWED_MATERIALIZATION_MODES))
             raise ValueError(
                 f"runtimeMaterializationMode must be one of: {allowed}; "
                 f"got {self.runtime_materialization_mode!r}"

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -288,31 +288,81 @@ class AgentRunResult(BaseModel):
 
 
 class ManagedAgentProviderProfile(BaseModel):
-    """Named managed-runtime auth and execution policy contract."""
+    """Named managed-runtime provider profile contract.
+
+    Aligned with the DB model and provider-profile contract.  Uses
+    ``credential_source`` and ``runtime_materialization_mode`` instead of the
+    legacy ``auth_mode`` field (which is rejected by ``extra="forbid"``).
+    """
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
+    # -- Core identity (required) --
     profile_id: str = Field(..., alias="profileId", min_length=1)
     runtime_id: str = Field(..., alias="runtimeId", min_length=1)
     provider_id: str | None = Field(None, alias="providerId")
     provider_label: str | None = Field(None, alias="providerLabel")
     default_model: str | None = Field(None, alias="defaultModel")
-    model_overrides: dict[str, str] = Field(default_factory=dict, alias="modelOverrides")
-    auth_mode: str = Field(..., alias="authMode", min_length=1)
-    volume_ref: str | None = Field(None, alias="volumeRef")
-    account_label: str | None = Field(None, alias="accountLabel")
-    max_parallel_runs: int = Field(..., alias="maxParallelRuns", ge=1)
-    cooldown_after_429: int | None = Field(None, alias="cooldownAfter429", ge=0)
+    model_overrides: dict[str, Any] = Field(default_factory=dict, alias="modelOverrides")
+
+    # -- Credential & materialization strategy (required) --
+    credential_source: str = Field(..., alias="credentialSource", min_length=1)
+    runtime_materialization_mode: str = Field(
+        ..., alias="runtimeMaterializationMode", min_length=1
+    )
+
+    # -- Policy & routing --
+    tags: list[str] = Field(default_factory=list, alias="tags")
+    priority: int = Field(default=100, alias="priority", ge=0)
+    max_parallel_runs: int = Field(default=1, alias="maxParallelRuns", ge=1)
+    cooldown_after_429: int = Field(default=0, alias="cooldownAfter429", ge=0)
     rate_limit_policy: dict[str, Any] = Field(
         default_factory=dict, alias="rateLimitPolicy"
     )
     enabled: bool = Field(True, alias="enabled")
 
+    # -- Volume & account binding (optional) --
+    volume_ref: str | None = Field(None, alias="volumeRef")
+    account_label: str | None = Field(None, alias="accountLabel")
+    volume_mount_path: str | None = Field(None, alias="volumeMountPath")
+    owner_user_id: str | None = Field(None, alias="ownerUserId")
+
+    # -- Environment & config materialization --
+    clear_env_keys: list[str] = Field(default_factory=list, alias="clearEnvKeys")
+    env_template: dict[str, Any] = Field(default_factory=dict, alias="envTemplate")
+    file_templates: list[RuntimeFileTemplate] = Field(
+        default_factory=list, alias="fileTemplates"
+    )
+    home_path_overrides: dict[str, str] = Field(
+        default_factory=dict, alias="homePathOverrides"
+    )
+    command_behavior: dict[str, Any] = Field(
+        default_factory=dict, alias="commandBehavior"
+    )
+    secret_refs: dict[str, str] = Field(default_factory=dict, alias="secretRefs")
+
+    # -- Lifecycle limits --
+    max_lease_duration_seconds: int = Field(
+        default=7200, alias="maxLeaseDurationSeconds", ge=60
+    )
+
+    _ALLOWED_CREDENTIAL_SOURCES: frozenset[str] = frozenset(
+        {"oauth_volume", "secret_ref", "none"}
+    )
+    _ALLOWED_MATIALIZATION_MODES: frozenset[str] = frozenset(
+        {"oauth_home", "api_key_env", "env_bundle", "config_bundle", "composite"}
+    )
+
     @model_validator(mode="after")
     def _validate_policy(self) -> "ManagedAgentProviderProfile":
         self.profile_id = _require_non_blank(self.profile_id, field_name="profileId")
         self.runtime_id = _require_non_blank(self.runtime_id, field_name="runtimeId")
-        self.auth_mode = _require_non_blank(self.auth_mode, field_name="authMode")
+        self.credential_source = _require_non_blank(
+            self.credential_source, field_name="credentialSource"
+        )
+        self.runtime_materialization_mode = _require_non_blank(
+            self.runtime_materialization_mode, field_name="runtimeMaterializationMode"
+        )
         volume_ref = self.volume_ref
         if volume_ref is not None:
             self.volume_ref = _require_non_blank(volume_ref, field_name="volumeRef")
@@ -323,6 +373,21 @@ class ManagedAgentProviderProfile(BaseModel):
             )
         if _contains_sensitive_key(self.rate_limit_policy):
             raise ValueError("rateLimitPolicy must not contain raw credential keys")
+
+        if self.credential_source not in self._ALLOWED_CREDENTIAL_SOURCES:
+            allowed = ", ".join(sorted(self._ALLOWED_CREDENTIAL_SOURCES))
+            raise ValueError(
+                f"credentialSource must be one of: {allowed}; "
+                f"got {self.credential_source!r}"
+            )
+
+        if self.runtime_materialization_mode not in self._ALLOWED_MATIALIZATION_MODES:
+            allowed = ", ".join(sorted(self._ALLOWED_MATIALIZATION_MODES))
+            raise ValueError(
+                f"runtimeMaterializationMode must be one of: {allowed}; "
+                f"got {self.runtime_materialization_mode!r}"
+            )
+
         return self
 
 

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -209,7 +209,13 @@ class ManagedAgentAdapter:
             if _strategy is not None
             else "api_key"
         )
-        auth_mode: str = profile.get("auth_mode", default_auth)
+        # Map legacy strategy auth_mode values to credential_source equivalents.
+        default_credential_source = (
+            "oauth_volume" if default_auth == "oauth" else "secret_ref"
+        )
+        credential_source: str = profile.get(
+            "credential_source", default_credential_source
+        )
 
         # Build a safe delta-only env_overrides dict for ManagedRuntimeProfile.
         #
@@ -335,8 +341,7 @@ class ManagedAgentAdapter:
                 runtime_id=runtime_id_for_profile,
                 provider_id=profile.get("provider_id"),
                 provider_label=profile.get("provider_label"),
-                auth_mode=auth_mode,
-                credential_source=profile.get("credential_source"),
+                credential_source=credential_source,
                 runtime_materialization_mode=profile.get(
                     "runtime_materialization_mode"
                 ),
@@ -400,7 +405,7 @@ class ManagedAgentAdapter:
             startedAt=datetime.now(tz=UTC),
             metadata={
                 "profile_id": profile_id,
-                "auth_mode": auth_mode,
+                "credential_source": credential_source,
                 "env_keys_count": len(shaped_env),
             },
         )

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2276,9 +2276,6 @@ class TemporalArtifactActivities:
                     "provider_label": row.provider_label,
                     "tags": row.tags or [],
                     "priority": row.priority,
-                    "auth_mode": "oauth"
-                    if row.credential_source.value == "oauth_volume"
-                    else "api_key",
                     "credential_source": row.credential_source.value,
                     "runtime_materialization_mode": row.runtime_materialization_mode.value,
                     "volume_ref": row.volume_ref,

--- a/specs/127-codex-openrouter-phase3/analysis-v2.md
+++ b/specs/127-codex-openrouter-phase3/analysis-v2.md
@@ -1,0 +1,147 @@
+# speckit-analyze Report (v2): 127-codex-openrouter-phase3
+
+**Date**: 2026-04-03
+**Artifacts reviewed**: `spec.md`, `plan.md`, `tasks.md`, `analysis.md` (original), `remediation-b-summary.md`
+**Verdict**: Proceed with minor residual concerns (0 CRITICAL, 1 HIGH, 3 MEDIUM remaining)
+
+---
+
+## 1. CRITICAL Finding Resolution
+
+### C-01 (OAuthProviderSpec scoping) -- RESOLVED
+
+The spec's OQ-004 now includes a definitive answer: `OAuthProviderSpec.auth_mode` is semantically distinct (OAuth session type for terminal/bootstrap flows) from `ManagedAgentProviderProfile.auth_mode` (credential sourcing strategy). The out-of-scope section explicitly lists `OAuthProviderSpec` and `providers/registry.py` entries. I confirmed in the code that `OAuthProviderSpec.auth_mode: str` in `providers/base.py` and the 3 registry entries (`gemini_cli`, `codex_cli`, `claude_code`) with `auth_mode="oauth"` are indeed a separate concept -- they describe OAuth session transport, not credential sourcing. This is correctly scoped out.
+
+### C-02 (Fields retained as-is) -- RESOLVED
+
+Plan AD-002 now includes a complete "Fields retained as-is" table listing all 12 existing fields with their types and defaults. This eliminates the risk of an implementer accidentally dropping `volume_ref`, `account_label`, or `rate_limit_policy`.
+
+### C-03 (T006 dependency on T001) -- RESOLVED
+
+T006 now declares `Dependencies: T001` (previously "None"). The dependency graph and execution order are both updated. The integration tests construct profiles with `credential_source` and `runtime_materialization_mode`, which require T001's Pydantic changes.
+
+---
+
+## 2. HIGH Finding Resolution
+
+### H-01 (owner_user_id type coercion) -- RESOLVED
+
+Plan AD-002 now includes a note explaining that `owner_user_id` is `str | None` in Pydantic vs `Mapped[Optional[UUID]]` in DB, and that the existing API router already handles the conversion. No new coercion logic is introduced.
+
+### H-02 (rate_limit_policy type divergence) -- RESOLVED
+
+The spec's Implementation Scope section now explicitly documents that `rate_limit_policy` is retained as `dict[str, Any]` in the Pydantic model, with enum alignment deferred to a follow-up change. Plan AD-002's retained-fields table notes this with a cross-reference.
+
+### H-03 (metadata consumer audit for auth_mode removal) -- RESOLVED (with residual concern)
+
+The plan (Section 3.2, step 4) now requires a grep audit for consumers of `metadata["auth_mode"]` before adapter changes, with guidance to update atomically or add a backward-compat shim. T002 step 4 was added to reflect this.
+
+**Verification**: A grep for `metadata["auth_mode"]` confirms at least two consumers:
+1. `artifacts.py` line 2279 -- `build_canonical_start_handle` emits `"auth_mode": "oauth" if row.credential_source.value == "oauth_volume" else "api_key"`. This is a DB-to-dict projection, not a metadata consumer per se, but it shows the `auth_mode` key is still expected in API responses.
+2. `test_managed_agent_adapter.py` line 185 -- `assert handle.metadata["auth_mode"] == "oauth"`. This test will break when T002 removes `auth_mode` from the metadata dict.
+
+The plan correctly flags this as requiring atomic updates or backward-compat shims. The remediation provides the right guidance but does not enumerate all consumers. This is acceptable as an implementation-time audit, not an artifact gap.
+
+### H-04 (data migration verification for existing DB rows) -- RESOLVED
+
+T007 now includes a DB data integrity check (step 7): query for rows where `credential_source IS NULL` or not in valid values. Plan Risk Mitigation also documents the verification procedure.
+
+---
+
+## 3. MEDIUM Finding Resolution
+
+### M-01 (T001 constraint values) -- PARTIALLY RESOLVED
+
+T001 step 2 now includes a parenthetical specifying constraints: `priority ge=0, max_parallel_runs ge=1, max_lease_duration_seconds ge=60, cooldown_after_429 ge=0`. Required string fields implicitly get `min_length=1`. This is sufficient for implementation.
+
+### M-02 (T005 unnecessary dependency on T002) -- RESOLVED
+
+T005 now declares `Dependencies: T001` (T002 removed). Correct -- the provider-agnostic grep audit is about branching, not auth_mode cleanup.
+
+### M-03 (T003/T004 same-file conflict) -- RESOLVED
+
+T004 now includes a note: "T003 and T004 both edit `tests/unit/schemas/test_agent_runtime_models.py`. Execute atomically."
+
+### M-04 (unknown fields test) -- RESOLVED
+
+T004 test 5 (`test_managed_agent_provider_profile_forbids_unknown_fields`) was added. It passes an arbitrary unknown field alongside valid required fields and asserts `ValidationError`.
+
+### M-05 (edge case coverage) -- RESOLVED
+
+T007 step 6 now explicitly lists EC-001, EC-003, EC-004, EC-006, EC-009, EC-010 and requires confirming they are covered by existing tests, with documentation of follow-ups if not.
+
+### M-06 (NFR performance verification) -- ACCEPTED AS DEFERRED
+
+Per the remediation summary, this is explicitly deferred. Not re-raising.
+
+---
+
+## 4. New Issues Introduced by Remediation
+
+### HIGH-NEW-01: artifacts.py line 2279 still emits legacy `auth_mode` in API response
+
+The `build_canonical_start_handle` function in `artifacts.py` (line 2279) projects DB rows to dicts and includes:
+```python
+"auth_mode": "oauth" if row.credential_source.value == "oauth_volume" else "api_key",
+"credential_source": row.credential_source.value,
+```
+
+This function emits **both** `auth_mode` and `credential_source` in the API response. The plan's adapter cleanup (T002 step 3) removes `auth_mode` from the adapter's metadata dict but does not address this artifacts.py projection. If the REST API response schema (which the spec says FR-010 must support) includes `auth_mode` as a field, this is fine for backward compatibility. But the spec's FR-007 says `auth_mode` MUST be removed, and the Pydantic model's `extra="forbid"` will reject `authMode` in incoming payloads. The outgoing projection still emits it.
+
+This is not necessarily a bug -- the artifacts.py function is projecting DB data for API responses, and including both old and new keys is a valid backward-compat strategy. But the spec should clarify whether outgoing API responses should also drop `auth_mode`, or whether it is retained temporarily for API consumers. The remediation's plan says "Mission Control UI deferred to follow-up," which implies API consumers may still need `auth_mode` in responses.
+
+**Recommendation**: Either (a) explicitly document in the spec that outgoing API responses retain `auth_mode` as a derived field for backward compatibility while incoming requests reject it, or (b) add a task to clean up artifacts.py line 2279 in the same PR.
+
+### MEDIUM-NEW-01: Test at test_managed_agent_adapter.py line 185 asserts `metadata["auth_mode"]`
+
+This test will fail after T002 removes `auth_mode` from the metadata dict. T003's scope is limited to `test_agent_runtime_models.py` (the Pydantic schema tests) and does not cover adapter tests. T007 (full test suite) will catch this failure, but the task list should proactively note that adapter tests need updating.
+
+**Recommendation**: Add a note to T002 or T007: "Update `test_managed_agent_adapter.py` assertions that check `metadata['auth_mode']` to check `metadata['credential_source']` instead."
+
+### MEDIUM-NEW-02: Strategy `default_auth_mode` property naming
+
+The plan (Section 3.3) proposes keeping the `default_auth_mode` property name on strategies and adding a mapping layer. The adapter currently calls `_strategy.default_auth_mode` (line 208 of `managed_agent_adapter.py`). The plan suggests mapping the return value but not renaming the property. This is a reasonable backward-compat choice, but the spec's FR-007 says `auth_mode` MUST be removed. The strategy property name is not the same as the Pydantic field, but the shared terminology could cause confusion during implementation.
+
+**Recommendation**: Add a comment in the plan noting this is an intentional naming retention for backward compatibility, with a rename deferred to a future cleanup.
+
+---
+
+## 5. Artifact Consistency After Edits
+
+| Check | Status |
+|-------|--------|
+| Spec FR-007 (remove auth_mode, add fields) matches plan AD-002 field additions | PASS |
+| Plan AD-001 (remove auth_mode entirely) matches spec OQ-001 recommendation | PASS |
+| Plan AD-002 retained-fields table matches spec Implementation Scope | PASS |
+| Tasks T001 field table matches plan AD-002 field additions | PASS |
+| T002 adapter changes match plan Section 3.2 | PASS |
+| T003/T004 test updates match plan Section 3.4 | PASS |
+| T005 dependency graph (T001 only) matches plan AD-003 | PASS |
+| T006 dependency (T001) corrected from original "None" | PASS |
+| T007 edge case audit + DB check matches remediation commitments | PASS |
+| DOC-REQ traceability consistent across all three artifacts | PASS |
+| Migration tracker (`docs/tmp/remaining-work/127-codex-openrouter-phase3.md`) created per Constitution XII | PASS |
+
+---
+
+## 6. Summary of Remaining Findings
+
+| Severity | ID | Summary |
+|----------|----|---------|
+| HIGH | H-NEW-01 | `artifacts.py` line 2279 still emits legacy `auth_mode` in API response -- scope (in or out) needs explicit documentation |
+| MEDIUM | M-NEW-01 | `test_managed_agent_adapter.py` line 185 asserts `metadata["auth_mode"]` -- needs updating, not covered by T003 |
+| MEDIUM | M-NEW-02 | Strategy `default_auth_mode` property name retained -- intentional but should be documented |
+
+---
+
+## 7. Implementation Readiness
+
+### Overall: Ready with minor clarifications needed
+
+All CRITICAL and HIGH findings from the original analysis are resolved. The remediation is thorough and the artifacts are now internally consistent. Two minor new issues were surfaced by the remediation (adapter test updates and artifacts.py projection), but these are implementation-time concerns, not artifact gaps.
+
+### Remaining actions before implementation:
+
+1. Clarify whether `artifacts.py` line 2279's `auth_mode` emission is intentional backward compat or should be removed in this feature. (HIGH)
+2. Note that `test_managed_agent_adapter.py` needs `metadata["auth_mode"]` assertions updated to `metadata["credential_source"]`. (MEDIUM)
+3. Document that `default_auth_mode` property naming on strategies is intentionally retained. (MEDIUM)

--- a/specs/127-codex-openrouter-phase3/analysis.md
+++ b/specs/127-codex-openrouter-phase3/analysis.md
@@ -1,0 +1,182 @@
+# speckit-analyze Report: 127-codex-openrouter-phase3
+
+**Date**: 2026-04-03
+**Artifacts reviewed**: `spec.md`, `plan.md`, `tasks.md`
+**Verdict**: Proceed with modifications required (3 CRITICAL, 4 HIGH findings)
+
+---
+
+## 1. Consistency
+
+### CRITICAL-01: Unresolved OQ-004 — Other legacy `auth_mode` surfaces exist but are out of scope
+
+The spec's open question OQ-004 asks whether other legacy Pydantic models use `auth_mode` and answers "Needs code audit." The code audit reveals **two additional legacy surfaces** that are not addressed in any artifact:
+
+1. **`OAuthProviderSpec` TypedDict** in `/mnt/d/code/MoonMind/moonmind/workflows/temporal/runtime/providers/base.py` has `auth_mode: str` as a required field.
+2. **`providers/registry.py`** has 3 entries (`gemini_cli`, `codex_cli`, `claude_code`) all using `auth_mode="oauth"`.
+
+These are not the same model as `ManagedAgentProviderProfile`, but they represent the same legacy `auth_mode` concept in a code path adjacent to the provider-profile system. The plan's "Out-of-Scope Confirmation" does not mention these. If the goal is to eliminate `auth_mode` as a concept, these must be addressed. If they are genuinely separate subsystems (OAuth session management vs. provider profiles), this should be explicitly documented with a rationale.
+
+**Recommendation**: If these are separate subsystems, add a note to the plan's out-of-scope section explaining why `OAuthProviderSpec.auth_mode` is a different concept from `ManagedAgentProviderProfile.auth_mode`. If they should be aligned, create a follow-up task.
+
+### CRITICAL-02: Plan field list for AD-002 omits fields that already exist in the Pydantic model
+
+AD-002 lists fields to "add" but does not enumerate the **existing** fields that must be preserved. The current `ManagedAgentProviderProfile` model already has: `profile_id`, `runtime_id`, `provider_id`, `provider_label`, `default_model`, `model_overrides`, `volume_ref`, `account_label`, `max_parallel_runs`, `cooldown_after_429`, `rate_limit_policy`, `enabled`. The plan should explicitly state which of these are kept unchanged. Without this, an implementer might accidentally drop `volume_ref`, `account_label`, or `rate_limit_policy`.
+
+In particular, the DB model has **both** `volume_ref` and `volume_mount_path` as separate columns. The plan's AD-002 adds `volume_mount_path` but doesn't mention keeping `volume_ref` (which already exists in the Pydantic model). This ambiguity could lead to accidental data loss.
+
+**Recommendation**: Add a "fields retained as-is" section to AD-002 or a before/after table for the complete model.
+
+### HIGH-01: `owner_user_id` type mismatch between DB and Pydantic
+
+The DB model defines `owner_user_id` as `Mapped[Optional[UUID]]` (a `uuid.UUID` type), but the plan proposes `str | None` for the Pydantic model. The API router's response schema (line 152 of `provider_profiles.py`) uses `credential_source: str` (not an enum), so the Pydantic model should convert UUID to string. This is correct behavior, but the plan should note the type coercion explicitly.
+
+**Recommendation**: Add a note in AD-002 that `owner_user_id` is `str | None` with explicit UUID-to-string serialization.
+
+### HIGH-02: `rate_limit_policy` type divergence between DB and Pydantic
+
+The DB model stores `rate_limit_policy` as `ManagedAgentRateLimitPolicy` (an enum), but the current Pydantic model has it as `dict[str, Any]`. The plan does not mention this field at all -- it's implicitly retained but the type mismatch is unresolved. If the API already returns a `dict` for this field, the Pydantic model is correct and the DB enum is the mismatch. This should be clarified.
+
+**Recommendation**: Explicitly state whether `rate_limit_policy` is retained as `dict[str, Any]` (current) or whether it should be aligned with the DB enum.
+
+---
+
+## 2. Completeness
+
+### HIGH-03: No task covers migration of `auth_mode` in metadata dict at adapter line 403
+
+T002 step 3 says to replace `"auth_mode": auth_mode` with `"credential_source": credential_source` in the metadata dict. But this metadata dict is used for run tracking and observability. The plan's risk section (§5) says "This is internal metadata, not a public API." However, `build_canonical_start_handle` in `agent_runtime_models.py` and other consumers may read this metadata. A grep for `"auth_mode"` in the codebase shows it appears in artifacts (line 2279 of `artifacts.py`). If any downstream consumer reads `metadata["auth_mode"]`, removing it without updating consumers would cause `KeyError` or silent data loss.
+
+**Recommendation**: Add a grep audit in T002 for consumers of `metadata["auth_mode"]` and update them atomically, or leave `auth_mode` in the metadata dict temporarily (deriving it from `credential_source`) to maintain backward compatibility.
+
+### CRITICAL-03: T006 integration tests have a hidden dependency on T001
+
+T006 claims "Dependencies: None (can run in parallel with T001-T005)." However, the integration tests described in T006 construct profiles with `credential_source="secret_ref"` and `runtime_materialization_mode="composite"` -- fields that do not exist in the Pydantic model until T001 is complete. While the REST API layer may accept these fields (since the DB model and API router already support them), the Pydantic validation layer will reject them if T001 has not been applied. This means T006 tests **will fail** if run before T001.
+
+**Recommendation**: Mark T006 as dependent on T001, or restructure T006 to test only via the API layer (bypassing Pydantic validation) until T001 lands.
+
+### HIGH-04: No explicit data migration task for any existing DB rows using legacy patterns
+
+The spec's OQ-001 recommends removing `auth_mode` entirely with a one-time data migration. The plan's AD-001 confirms this approach. However, no task covers the data migration step. The DB model already uses `credential_source` (confirmed), so no DB schema migration is needed. But if any existing profile records in the DB were created with the old Pydantic model that only had `auth_mode`, there's no task to verify their `credential_source` values are set correctly.
+
+**Recommendation**: Add a verification step (not a full migration task) to T007 that checks existing DB rows have valid `credential_source` values. Or explicitly document why this is unnecessary (e.g., "all existing profiles were created via the API which already uses `credential_source`").
+
+---
+
+## 3. Ambiguity
+
+### HIGH-05: T001 field defaults are not fully specified for constraint values
+
+T001 says "Each field uses `min_length=1` on required strings and `ge=0` / `ge=1` / `ge=60` constraints where applicable" but the field table does not show which fields get which constraints. For example:
+- `credential_source` and `runtime_materialization_mode` are required -- do they get `min_length=1`? (Yes, per the validator.)
+- `max_lease_duration_seconds` -- the plan says `ge=60` but doesn't specify the default value derivation (7200 from DB model).
+- `priority` -- the plan says `ge=0` but doesn't confirm the default (100 from DB model).
+
+The implementer has enough info from the DB model defaults, but the task should be explicit.
+
+**Recommendation**: Add a "constraints" column to the T001 field table, or reference the DB model defaults explicitly.
+
+### MEDIUM-01: T004 test 4 (`test_managed_agent_provider_profile_rejects_legacy_auth_mode`) assumes `extra="forbid"` behavior
+
+The test expects that passing `authMode="oauth"` will raise a `ValidationError` due to `extra="forbid"`. However, the model config is `ConfigDict(populate_by_name=True, extra="forbid")` -- this is confirmed by reading the current model. The test is correct. But if any API route or seed script sends `authMode` as a pass-through field (for backward compatibility), this will break. The plan correctly accepts this risk. No action needed, but worth noting.
+
+---
+
+## 4. Dependency Ordering
+
+### MEDIUM-02: T005 could run immediately (no real dependency on T002)
+
+T005 depends on T002 per the task graph, but the provider-agnostic audit (grep for `openrouter`, `openai`, `anthropic` in materializer/adapter/launcher) is about **provider-specific branching**, not about `auth_mode` vs `credential_source`. The grep for "openrouter" in `moonmind/workflows/` already returns 0 matches. T005 could be executed as a verification task at any point. The dependency on T002 is unnecessary.
+
+**Recommendation**: Remove T005's dependency on T002. It only needs T001 if the adapter cleanup introduces new provider names (it won't), but as written it has no hard dependency.
+
+### MEDIUM-03: T003 and T004 can run in parallel
+
+T003 and T004 both edit the same test file (`test_agent_runtime_models.py`). The task graph shows T003 -> T004 (sequential), but they could conflict if both modify the same file. Given that T003 replaces `authMode` in existing tests and T004 adds new test functions, there's a low but nonzero merge-conflict risk.
+
+**Recommendation**: Keep the sequential order but note that T003 and T004 touch the same file and should be done atomically to avoid conflicts.
+
+---
+
+## 5. Testing Coverage
+
+### MEDIUM-04: Missing boundary test for `extra="forbid"` with future provider-profile fields
+
+The test suite covers rejecting `authMode` via `extra="forbid"`, but does not cover what happens when a **new** provider-profile field (not yet in the model) is added to the DB but not the Pydantic model. With `extra="forbid"`, the API will reject any future field additions until the Pydantic model is updated. This is intentional per AD-004's risk section, but there's no test verifying this protective behavior.
+
+**Recommendation**: Add a test `test_managed_agent_provider_profile_forbids_unknown_fields` that passes an arbitrary unknown field and asserts `ValidationError`.
+
+### MEDIUM-05: Edge cases EC-001, EC-003, EC-004, EC-006, EC-009, EC-010 are not covered by any task
+
+The spec defines 10 edge cases. T004 covers EC-002, EC-007, EC-008. The remaining edge cases (path traversal, missing secrets, env template ref validation, base env protection, file permissions, merge strategy) are not covered by any task in this feature. These are likely already tested in the materializer/adapter unit tests, but the tasks do not verify this.
+
+**Recommendation**: Add a note in T005 or T007 confirming that edge cases EC-001, EC-003, EC-004, EC-006, EC-009, EC-010 are covered by existing materializer/adapter tests. If not, create follow-up tasks.
+
+### MEDIUM-06: NFR performance targets (NFR-001, NFR-002) have no verification task
+
+The spec states profile resolution must complete within 500ms and materialization within 200ms. No task covers performance verification. For a narrow schema-alignment change, this is likely acceptable (the change is unlikely to affect performance), but the success criteria should not claim NFR compliance without verification.
+
+**Recommendation**: Either add a lightweight performance check to T007, or remove NFR-001/NFR-002 from this feature's scope and defer to a performance audit feature.
+
+---
+
+## 6. Constitution Alignment
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Orchestrate, Don't Recreate | PASS -- No new runtime created. |
+| II. One-Click Deployment | PASS -- Auto-seed already functional. |
+| III. Avoid Vendor Lock-In | PASS -- Reinforces data-driven provider agnosticism. |
+| IV. Own Your Data | PASS -- No changes to data ownership. |
+| V. Skills Are First-Class | N/A |
+| VI. Bittersweet Lesson | PASS -- Thick contracts maintained. |
+| VII. Powerful Runtime Configurability | PASS -- Profiles remain runtime-configurable. |
+| VIII. Modular and Extensible Architecture | PASS -- Pydantic model matches extensible DB contract. |
+| IX. Resilient by Default | PASS -- Invalid values fail fast. |
+| X. Facilitate Continuous Improvement | N/A |
+| XI. Spec-Driven Development | PASS -- Traceable to DOC-REQ IDs. |
+| XII. Canonical Documentation | PASS -- Migration tracking belongs in `docs/tmp/`. |
+| XIII. Pre-Release: Delete, Don't Deprecate | PASS -- `auth_mode` removed entirely. |
+
+**Note**: The unresolved OQ-004 (other `auth_mode` surfaces in `OAuthProviderSpec`) could be viewed as a partial violation of Principle XIII if those surfaces are considered the same legacy pattern. This depends on whether `OAuthProviderSpec.auth_mode` is semantically equivalent to `ManagedAgentProviderProfile.auth_mode` or a distinct concept.
+
+---
+
+## 7. Implementation Readiness
+
+### Overall: Ready with minor clarifications needed
+
+The artifacts are well-structured and the scope is appropriately narrow. The primary code change (Pydantic model rewrite) is concrete and actionable. The main gaps are:
+
+1. **Unaddressed legacy `auth_mode` surfaces** (`OAuthProviderSpec`) -- must be explicitly scoped in or out.
+2. **Incomplete field enumeration** -- the plan should list all existing fields that are retained, not just those being added.
+3. **T006 dependency correction** -- cannot run in parallel with T001 as claimed.
+4. **Missing edge case coverage** -- 6 of 10 edge cases have no verification task.
+
+### Priority fixes before implementation:
+
+1. Resolve OQ-004: explicitly document why `OAuthProviderSpec.auth_mode` is in or out of scope. (CRITICAL)
+2. Add a "fields retained as-is" table to AD-002. (HIGH)
+3. Correct T006 dependency: mark as dependent on T001. (CRITICAL)
+4. Add metadata consumer audit to T002. (HIGH)
+5. Add edge case coverage note to T005 or T007. (MEDIUM)
+
+---
+
+## 8. Summary of Findings
+
+| Severity | ID | Summary |
+|----------|----|---------|
+| CRITICAL | C-01 | Unresolved OQ-004: `OAuthProviderSpec` still uses `auth_mode` |
+| CRITICAL | C-02 | AD-002 omits existing fields to retain (risk of accidental data loss) |
+| CRITICAL | C-03 | T006 claims no deps but requires T001's Pydantic changes |
+| HIGH | H-01 | `owner_user_id` type coercion (UUID to str) not documented |
+| HIGH | H-02 | `rate_limit_policy` type mismatch (DB enum vs Pydantic dict) unaddressed |
+| HIGH | H-03 | No task covers metadata dict consumer audit for `auth_mode` removal |
+| HIGH | H-04 | No data migration verification for existing DB rows |
+| MEDIUM | M-01 | T001 constraint values not fully specified per field |
+| MEDIUM | M-02 | T005 dependency on T002 is unnecessary |
+| MEDIUM | M-03 | T003/T004 touch same file -- note conflict risk |
+| MEDIUM | M-04 | Missing test for `extra="forbid"` with unknown future fields |
+| MEDIUM | M-05 | 6 of 10 edge cases have no verification task |
+| MEDIUM | M-06 | NFR-001/NFR-002 performance targets have no verification |

--- a/specs/127-codex-openrouter-phase3/contracts/requirements-traceability.md
+++ b/specs/127-codex-openrouter-phase3/contracts/requirements-traceability.md
@@ -1,0 +1,128 @@
+# Requirements Traceability: Phase 3 — Codex OpenRouter Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+
+This document maps every source requirement (DOC-REQ-*) from the spec to its implementation location and verification method.
+
+---
+
+## 1. DOC-REQ Summary
+
+| DOC-REQ | Implementation Surfaces | Validation Strategy |
+|---------|------------------------|---------------------|
+| DOC-REQ-001 | Code audit: `materializer.py`, `managed_agent_adapter.py`, `launcher.py`, `codex_cli.py` — zero provider-specific branching | Grep audit: `grep -r "openrouter" moonmind/workflows/` → 0 matches; T005 |
+| DOC-REQ-002 | No code changes — data-only profile creation via REST API / DB row | Integration tests: two distinct OpenRouter profiles independently resolvable (T006) |
+| DOC-REQ-003 | `agent_runtime_models.py` — Pydantic model rewrite; `managed_agent_adapter.py` — adapter cleanup; `artifacts.py` — API response projection cleanup | Unit tests: full contract acceptance, legacy rejection, new validation tests (T003, T004) |
+
+---
+
+## 2. Source Requirements (from `docs/ManagedAgents/CodexCliOpenRouter.md`)
+
+### DOC-REQ-001 — OpenRouter as Reference Implementation
+
+**Source**: §15 Phase 3, line 1
+**Statement**: Treat OpenRouter as the reference implementation for config-bundle Codex providers.
+
+| Trace | Detail |
+|-------|--------|
+| **Spec FR-011** | No module in materialization, adapter, or launcher path may contain provider-specific branching for OpenRouter. |
+| **Implementation** | Code audit confirms zero OpenRouter-specific branching in `materializer.py`, `managed_agent_adapter.py`, `launcher.py`, `codex_cli.py`. `grep -r "openrouter" moonmind/workflows/` returns 0 matches. |
+| **File** | `/mnt/d/code/MoonMind/moonmind/workflows/adapters/materializer.py` — data-driven via `file_templates` |
+| **File** | `/mnt/d/code/MoonMind/moonmind/workflows/adapters/managed_agent_adapter.py` — data-driven via profile dict |
+| **File** | `/mnt/d/code/MoonMind/moonmind/workflows/temporal/runtime/launcher.py` — no provider identity references |
+| **Verification** | Code audit (research.md §1.5). All provider behavior is driven by `file_templates`, `env_template`, `command_behavior`, etc. |
+| **Success Criterion** | SC-002: `ProviderProfileMaterializer` contains zero provider-specific branching for OpenRouter. |
+
+### DOC-REQ-002 — Additional OpenRouter-Backed Model Defaults
+
+**Source**: §15 Phase 3, line 2
+**Statement**: Reuse the same pattern for additional OpenRouter-backed model defaults.
+
+| Trace | Detail |
+|-------|--------|
+| **Spec FR-001** | System must support creating arbitrary OpenRouter-backed profiles by varying only profile data, without code changes per profile. |
+| **Spec FR-014** | System must support at least two distinct OpenRouter-backed provider profiles simultaneously. |
+| **Implementation** | No code changes needed. Adding a new OpenRouter profile is a data-only operation: create a DB row via REST API with `runtime_id=codex_cli`, `provider_id=openrouter`, `default_model=<model-string>`, and appropriate `file_templates`/`env_template`. |
+| **File** | `/mnt/d/code/MoonMind/api_service/api/routers/provider_profiles.py` — REST API supports CRUD |
+| **File** | `/mnt/d/code/MoonMind/api_service/db/models.py` — DB model supports arbitrary profiles |
+| **File** | `/mnt/d/code/MoonMind/api_service/services/provider_profile_service.py` — `sync_provider_profile_manager` syncs all enabled profiles |
+| **Verification** | Manual test: create second OpenRouter profile via REST API → launch Codex run → verify correct model used. |
+| **Success Criterion** | SC-001: New profile usable without code changes. SC-004: Integration tests pass for two distinct profiles. |
+
+### DOC-REQ-003 — Legacy Auth-Profile Alignment
+
+**Source**: §15 Phase 3, line 3
+**Statement**: Align any remaining legacy auth-profile persistence with the provider-profile contract.
+
+| Trace | Detail |
+|-------|--------|
+| **Spec FR-007** | `ManagedAgentProviderProfile` Pydantic model must include all provider-profile fields; `auth_mode` must be removed. |
+| **Spec FR-012** | Pydantic model must remain compatible with the DB model — all DB fields must be representable. |
+| **Implementation** | `ManagedAgentProviderProfile` in `agent_runtime_models.py` rewritten to match provider-profile contract. `auth_mode` removed. All missing fields added: `credential_source`, `runtime_materialization_mode`, `tags`, `priority`, `clear_env_keys`, `env_template`, `file_templates`, `home_path_overrides`, `command_behavior`, `secret_refs`, `volume_mount_path`, `max_lease_duration_seconds`, `owner_user_id`. |
+| **File** | `/mnt/d/code/MoonMind/moonmind/schemas/agent_runtime_models.py` — Pydantic model rewrite |
+| **File** | `/mnt/d/code/MoonMind/moonmind/workflows/adapters/managed_agent_adapter.py` — adapter cleanup (replace `auth_mode` with `credential_source` in metadata) |
+| **Verification** | Unit tests: instantiate with full fields → validate; instantiate with legacy `auth_mode` → reject. |
+| **Success Criterion** | SC-003: Pydantic model accepts all provider-profile fields and rejects/migrates legacy `auth_mode`. |
+
+---
+
+## 2. Functional Requirements Traceability
+
+| FR-ID | Requirement | Plan Section | Status |
+|-------|-------------|-------------|--------|
+| FR-001 | Arbitrary OpenRouter profiles via data only | Plan §3.1, §3.2 | Addressed — no code needed per profile |
+| FR-002 | Materializer renders file_templates to arbitrary paths | Plan §3.1 | Already satisfied — materializer is data-driven |
+| FR-003 | home_path_overrides applied before launch | Plan §3.1 | Already satisfied — adapter maps field |
+| FR-004 | CodexCliStrategy honors suppress_default_model_flag | Plan §3.3 | Already satisfied — codex_cli.py implements this |
+| FR-005 | clear_env_keys cleared before env injection | Plan §3.1 | Already satisfied — materializer implements this |
+| FR-006 | Adapter maps all provider-profile fields | Plan §3.2 | Already satisfied — adapter maps all fields |
+| **FR-007** | Pydantic model aligned with provider-profile contract | **Plan §3.1** | **Primary change — model rewrite** |
+| FR-008 | Generated files written with mode 0600 | Plan §3.1 | Already satisfied — materializer defaults to 0600 |
+| FR-009 | Dynamic provider selection via profile_selector | Plan §3.2 | Already satisfied — adapter implements routing |
+| FR-010 | Profile CRUD via Mission Control / REST API | Plan §3.1 | Already satisfied — API routes complete |
+| **FR-011** | No provider-specific branching in materialization/adapter/launcher | **Plan §3.1, §3.2** | **Already satisfied — verified by grep audit** |
+| **FR-012** | Pydantic model compatible with DB model | **Plan §3.1** | **Primary change — field alignment** |
+| FR-013 | ManagedRuntimeProfile carries all launch fields | Plan §3.1 | Already satisfied — runtime model complete |
+| **FR-014** | Support at least two distinct OpenRouter profiles | **Plan §3.1, §4** | **No code needed — data-only operation** |
+
+---
+
+## 3. Non-Functional Requirements Traceability
+
+| NFR-ID | Requirement | Verification | Status |
+|--------|-------------|--------------|--------|
+| NFR-001 | Profile resolution < 500ms | Benchmark with 50 profiles | Already satisfied — in-memory dict lookup |
+| NFR-002 | Materialization < 200ms | Benchmark TOML rendering | Already satisfied — simple string rendering |
+| NFR-003 | No raw credentials in Temporal payloads | Code audit of launch pipeline | Already satisfied — only profile_id persisted |
+| NFR-004 | Profile values inspectable via Mission Control | Manual UI verification | Already satisfied — REST API exposes all fields |
+
+---
+
+## 4. Success Criteria Traceability
+
+| SC-ID | Criterion | Verification Method | Plan Section |
+|-------|-----------|---------------------|--------------|
+| SC-001 | New OpenRouter profile usable without code changes | Manual test: create profile → launch → verify model | Plan §6 (Integration Tests) |
+| SC-002 | Zero provider-specific branching in materializer | Code audit: grep for `openrouter` in workflow code | Plan §3.1, Research §1.5 |
+| SC-003 | Pydantic model accepts full contract, rejects legacy auth_mode | Unit tests | Plan §3.4, §6 |
+| SC-004 | Integration tests pass for two distinct OpenRouter profiles | Run integration test suite with two profiles | Plan §6.3 |
+| SC-005 | speckit-analyze reports no CRITICAL/HIGH gaps | Run `/speckit-analyze` after plan and tasks | Post-plan gate |
+| SC-006 | All existing tests pass without regression | Run `./tools/test_unit.sh` and integration suite | Plan §5 |
+| SC-007 | Generated files written with 0600 and cleaned up | Unit test on materializer; integration test | Plan §6.1 |
+
+---
+
+## 5. Edge Case Coverage
+
+| EC-ID | Scenario | Coverage |
+|-------|----------|----------|
+| EC-001 | file_templates path already exists | Already handled by materializer `_materialize_file_template` |
+| EC-002 | Invalid runtime_materialization_mode | Pydantic validation rejects unknown values (fail-fast) |
+| EC-003 | Missing secret at launch time | SecretResolverBoundary raises actionable error |
+| EC-004 | Path traversal in file_templates | Already handled by `is_relative_to` check in materializer |
+| EC-005 | Two profiles with identical priority | Tie-broken by available_slots (adapter `_resolve_profile`) |
+| EC-006 | env_template references undefined secret_ref | Materializer raises `Unknown template variable` error |
+| EC-007 | credential_source=none with config_bundle mode | Valid — Pydantic model allows this combination |
+| **EC-008** | Legacy auth_mode value submitted to aligned schema | **Pydantic extra="forbid" rejects it** |
+| EC-009 | clear_env_keys removes base env variable | Layering rule (§11.2 of ProviderProfiles) protects PATH, HOME |
+| EC-010 | File permissions not 0600 | Materializer defaults to 0600; explicit permissions override |

--- a/specs/127-codex-openrouter-phase3/data-model.md
+++ b/specs/127-codex-openrouter-phase3/data-model.md
@@ -26,7 +26,7 @@ This feature involves **Pydantic schema alignment only**. No database schema cha
 | `volume_ref` | `str | None`, optional | `str | None`, optional | Unchanged |
 | `account_label` | `str | None`, optional | `str | None`, optional | Unchanged |
 | `max_parallel_runs` | `int`, required | `int`, required | Unchanged |
-| `cooldown_after_429` | `int | None`, optional | `int | None`, optional | Unchanged |
+| `cooldown_after_429` | `int | None`, optional | `int` (default `900`) | Field renamed to `cooldown_after_429_seconds` in schema; default moved from nullable to 900. |
 | `rate_limit_policy` | `dict`, optional | `dict`, optional | Unchanged |
 | `enabled` | `bool`, optional | `bool`, optional | Unchanged |
 | **`credential_source`** | — | **`str`, required** | New. Allowed: `oauth_volume`, `secret_ref`, `none` |
@@ -48,7 +48,7 @@ This feature involves **Pydantic schema alignment only**. No database schema cha
 **Before (4 required):**
 - `profile_id`, `runtime_id`, `auth_mode`, `max_parallel_runs`
 
-**After (4 required):**
+**After (5 required):**
 - `profile_id`, `runtime_id`, `credential_source`, `runtime_materialization_mode`, `max_parallel_runs`
 
 Note: `max_parallel_runs` stays required (ge=1). `credential_source` and `runtime_materialization_mode` become required because they are fundamental to the provider-profile contract. The API's `ProviderProfileCreate` already requires them.

--- a/specs/127-codex-openrouter-phase3/data-model.md
+++ b/specs/127-codex-openrouter-phase3/data-model.md
@@ -1,0 +1,126 @@
+# Data Model Changes: Phase 3 — Codex OpenRouter Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+
+---
+
+## 1. Summary
+
+This feature involves **Pydantic schema alignment only**. No database schema changes are required. The DB model (`ManagedAgentProviderProfile` in `api_service/db/models.py`) already has all provider-profile fields. The change is to bring the Pydantic model (`ManagedAgentProviderProfile` in `moonmind/schemas/agent_runtime_models.py`) into alignment.
+
+---
+
+## 2. Pydantic Model Changes
+
+### 2.1 `ManagedAgentProviderProfile` — Field Diff
+
+| Field | Before | After | Notes |
+|-------|--------|-------|-------|
+| `profile_id` | `str`, required | `str`, required | Unchanged |
+| `runtime_id` | `str`, required | `str`, required | Unchanged |
+| `provider_id` | `str | None`, optional | `str | None`, optional | Unchanged |
+| `provider_label` | `str | None`, optional | `str | None`, optional | Unchanged |
+| `default_model` | `str | None`, optional | `str | None`, optional | Unchanged |
+| `model_overrides` | `dict[str, str]`, optional | `dict[str, str]`, optional | Unchanged |
+| `auth_mode` | **`str`, required** | **REMOVED** | Removed per Constitution XIII |
+| `volume_ref` | `str | None`, optional | `str | None`, optional | Unchanged |
+| `account_label` | `str | None`, optional | `str | None`, optional | Unchanged |
+| `max_parallel_runs` | `int`, required | `int`, required | Unchanged |
+| `cooldown_after_429` | `int | None`, optional | `int | None`, optional | Unchanged |
+| `rate_limit_policy` | `dict`, optional | `dict`, optional | Unchanged |
+| `enabled` | `bool`, optional | `bool`, optional | Unchanged |
+| **`credential_source`** | — | **`str`, required** | New. Allowed: `oauth_volume`, `secret_ref`, `none` |
+| **`runtime_materialization_mode`** | — | **`str`, required** | New. Allowed: `oauth_home`, `api_key_env`, `env_bundle`, `config_bundle`, `composite` |
+| **`tags`** | — | **`list[str]`** | New. Default: `[]` |
+| **`priority`** | — | **`int`** | New. Default: `100`, min: `0` |
+| **`clear_env_keys`** | — | **`list[str]`** | New. Default: `[]` |
+| **`env_template`** | — | **`dict[str, Any]`** | New. Default: `{}` |
+| **`file_templates`** | — | **`list[RuntimeFileTemplate]`** | New. Default: `[]`. Type already exists. |
+| **`home_path_overrides`** | — | **`dict[str, str]`** | New. Default: `{}` |
+| **`command_behavior`** | — | **`dict[str, Any]`** | New. Default: `{}` |
+| **`secret_refs`** | — | **`dict[str, str]`** | New. Default: `{}` |
+| **`volume_mount_path`** | — | **`str | None`** | New. Default: `None` |
+| **`max_lease_duration_seconds`** | — | **`int`** | New. Default: `7200`, min: `60` |
+| **`owner_user_id`** | — | **`str | None`** | New. Default: `None` |
+
+### 2.2 Required Fields — Before vs After
+
+**Before (4 required):**
+- `profile_id`, `runtime_id`, `auth_mode`, `max_parallel_runs`
+
+**After (4 required):**
+- `profile_id`, `runtime_id`, `credential_source`, `runtime_materialization_mode`, `max_parallel_runs`
+
+Note: `max_parallel_runs` stays required (ge=1). `credential_source` and `runtime_materialization_mode` become required because they are fundamental to the provider-profile contract. The API's `ProviderProfileCreate` already requires them.
+
+### 2.3 `ManagedRuntimeProfile` — No Changes
+
+The launch-time model already has all provider-profile fields. No changes needed.
+
+The existing `auth_mode: str | None = Field(None, alias="authMode")` on `ManagedRuntimeProfile` remains as optional for backward compatibility with any in-flight workflow payloads. It can be removed in a future cleanup pass when no caller references it.
+
+---
+
+## 3. DB Model — No Changes
+
+The SQLAlchemy model at `/mnt/d/code/MoonMind/api_service/db/models.py` already has all fields. No migration needed.
+
+| Column | DB Type | Notes |
+|--------|---------|-------|
+| `credential_source` | `ENUM('oauth_volume', 'secret_ref', 'none')` | Already present |
+| `runtime_materialization_mode` | `ENUM('oauth_home', 'api_key_env', 'env_bundle', 'config_bundle', 'composite')` | Already present |
+| `tags` | `JSONB` | Already present |
+| `priority` | `INTEGER` (default 100) | Already present |
+| `clear_env_keys` | `JSONB` | Already present |
+| `env_template` | `JSONB` | Already present |
+| `file_templates` | `JSONB` | Already present |
+| `home_path_overrides` | `JSONB` | Already present |
+| `command_behavior` | `JSONB` | Already present |
+| `secret_refs` | `JSONB` | Already present |
+| `volume_mount_path` | `VARCHAR(512)` | Already present |
+| `max_lease_duration_seconds` | `INTEGER` (default 7200) | Already present |
+| `owner_user_id` | `UUID` (nullable) | Already present |
+
+---
+
+## 4. API Schema — No Changes
+
+The FastAPI request/response schemas at `/mnt/d/code/MoonMind/api_service/api/routers/provider_profiles.py` already include all provider-profile fields. No changes needed.
+
+---
+
+## 5. Migration Notes
+
+### 5.1 Data Migration
+
+No DB data migration is needed. The DB already uses `credential_source` (enum column). There is no `auth_mode` column in the `managed_agent_provider_profiles` table.
+
+### 5.2 API Payload Compatibility
+
+The Pydantic model uses `extra="forbid"`. Any API client that submits `authMode` in a profile creation payload will receive a `422 Unprocessable Entity` error with a clear message about the unexpected field. This is the correct behavior per Constitution Principle XIII (fail-fast for unsupported values).
+
+### 5.3 In-Flight Workflow Safety
+
+Temporal workflows carry `ManagedRuntimeProfile` (not `ManagedAgentProviderProfile`). The `ManagedRuntimeProfile` model has `auth_mode` as optional (`str | None`), so in-flight workflows are unaffected.
+
+---
+
+## 6. Enum Reference
+
+### `credential_source` Allowed Values
+
+| Value | Meaning |
+|-------|---------|
+| `oauth_volume` | Credentials live in a mounted auth volume |
+| `secret_ref` | Credentials resolve from Secrets System at launch |
+| `none` | No provider secret is required |
+
+### `runtime_materialization_mode` Allowed Values
+
+| Value | Meaning |
+|-------|---------|
+| `oauth_home` | Mount auth volume and set runtime home variables |
+| `api_key_env` | Inject environment variables with resolved secrets |
+| `env_bundle` | Inject a provider-specific environment block |
+| `config_bundle` | Generate provider-specific config file(s) |
+| `composite` | Combine multiple techniques |

--- a/specs/127-codex-openrouter-phase3/plan.md
+++ b/specs/127-codex-openrouter-phase3/plan.md
@@ -1,0 +1,269 @@
+# Technical Implementation Plan: Phase 3 — Codex OpenRouter Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+**Created**: 2026-04-03
+**Status**: Draft
+
+---
+
+## 1. Executive Summary
+
+Phase 3 closes the remaining gaps between the Pydantic validation layer (`ManagedAgentProviderProfile`) and the full provider-profile contract already implemented in the DB model and API. The DB model, API routes, materializer, adapter, and launcher are all provider-agnostic. The only remaining legacy surface is the Pydantic model, which still requires `auth_mode` and lacks provider-profile fields.
+
+This plan has **one primary code change**: rewriting `ManagedAgentProviderProfile` in `moonmind/schemas/agent_runtime_models.py` to match the provider-profile contract, plus a secondary cleanup pass in the adapter to stop referencing `auth_mode`.
+
+---
+
+## 2. Architecture Decisions
+
+### AD-001: Remove `auth_mode` entirely from `ManagedAgentProviderProfile` (not deprecate)
+
+**Decision**: `auth_mode` will be removed from the Pydantic model as a field. Per Constitution Principle XIII (pre-release: delete, don't deprecate), no compatibility alias is introduced.
+
+**Rationale**:
+- `auth_mode` is semantically replaced by `credential_source` in the provider-profile contract.
+- The DB model already uses `credential_source` (enum: `oauth_volume`, `secret_ref`, `none`).
+- No API route or auto-seed uses `auth_mode` for creation.
+- The adapter still reads `auth_mode` from the profile dict but only for metadata tracking — this can be migrated to derive from `credential_source`.
+
+**Migration mapping** (one-time, applied at seed/data level, not code-level):
+| legacy `auth_mode` | new `credential_source` |
+|---|---|
+| `oauth` | `oauth_volume` |
+| `api_key` | `secret_ref` |
+
+### AD-002: Add missing provider-profile fields to `ManagedAgentProviderProfile`
+
+**Fields retained as-is** (existing fields that must be preserved unchanged):
+
+| Field | Current Type | Default | Notes |
+|---|---|---|---|
+| `profile_id` | `str` | — | Required, primary identifier |
+| `runtime_id` | `str` | — | Required |
+| `provider_id` | `str` | — | Required |
+| `provider_label` | `str` | — | Required |
+| `default_model` | `str` | — | Required |
+| `model_overrides` | `dict[str, Any]` | `{}` | Optional per-provider model config |
+| `volume_ref` | `str \| None` | `None` | Volume reference for OAuth providers |
+| `account_label` | `str \| None` | `None` | Account identifier label |
+| `max_parallel_runs` | `int` | `1` | Concurrency limit |
+| `cooldown_after_429` | `int` | `0` | Rate-limit backoff seconds |
+| `rate_limit_policy` | `dict[str, Any]` | `{}` | Stored as dict in Pydantic; DB uses `ManagedAgentRateLimitPolicy` enum — see spec Implementation Scope §5 |
+| `enabled` | `bool` | `True` | Soft-disable flag |
+
+**Fields to add** (exist in DB model and API but absent from Pydantic model):
+
+| Field | Type | Source |
+|---|---|---|
+| `credential_source` | `str` (enum: oauth_volume, secret_ref, none) | ProviderProfiles §6.1 |
+| `runtime_materialization_mode` | `str` (enum: oauth_home, api_key_env, env_bundle, config_bundle, composite) | ProviderProfiles §6.1 |
+| `tags` | `list[str]` | DB model + API |
+| `priority` | `int` (default 100) | DB model + API |
+| `clear_env_keys` | `list[str]` | ProviderProfiles §6.1 |
+| `env_template` | `dict[str, Any]` | ProviderProfiles §6.1 |
+| `file_templates` | `list[RuntimeFileTemplate]` | ProviderProfiles §6.1 (already has type) |
+| `home_path_overrides` | `dict[str, str]` | ProviderProfiles §6.1 |
+| `command_behavior` | `dict[str, Any]` | ProviderProfiles §6.1 |
+| `secret_refs` | `dict[str, str]` | ProviderProfiles §6.1 |
+| `volume_mount_path` | `str | None` | DB model |
+| `cooldown_after_429` | `int` (already present) | Already present |
+| `max_lease_duration_seconds` | `int` | DB model + API |
+| `owner_user_id` | `str | None` | DB model |
+
+> **Note on `owner_user_id` type coercion**: The DB model defines `owner_user_id` as `Mapped[Optional[UUID]]`, but the Pydantic model uses `str | None`. The API serialization layer must explicitly convert `UUID` to `str` via `str(uuid_value)` when reading from DB rows, and parse `str` back to `UUID` via `UUID(str_value)` when writing. The existing API router already handles this conversion (confirmed in `api_service/routes/provider_profiles.py`); no new coercion logic is introduced by this feature.
+
+### AD-003: No code changes to materializer, launcher, or strategy
+
+Code audit confirms zero provider-specific branching exists:
+- `grep "openrouter" moonmind/workflows/` → **0 matches**
+- Materializer is fully data-driven via `file_templates`
+- Launcher has no provider-specific code paths
+- `CodexCliStrategy` only handles CLI construction, not provider identity
+
+### AD-004: Adapter `auth_mode` reference → derive from `credential_source`
+
+The adapter (`managed_agent_adapter.py`) currently reads `auth_mode` from the profile dict at line 212. Since `credential_source` maps 1:1 with the old `auth_mode` semantics, we derive it:
+
+```python
+# Old:
+auth_mode: str = profile.get("auth_mode", default_auth)
+
+# New:
+credential_source = profile.get("credential_source", default_credential_source)
+# Pass credential_source into ManagedRuntimeProfile; drop auth_mode from metadata
+```
+
+---
+
+## 3. Component Breakdown
+
+### 3.1 `ManagedAgentProviderProfile` Pydantic Model Rewrite
+
+**File**: `/mnt/d/code/MoonMind/moonmind/schemas/agent_runtime_models.py`
+
+**Changes**:
+1. **Remove** `auth_mode: str = Field(..., alias="authMode", min_length=1)` field
+2. **Remove** `self.auth_mode = _require_non_blank(self.auth_mode, field_name="authMode")` from `_validate_policy`
+3. **Add** the following fields to the model (matching DB + API schema):
+
+```
+credential_source: str = Field(..., alias="credentialSource", min_length=1)
+runtime_materialization_mode: str = Field(..., alias="runtimeMaterializationMode", min_length=1)
+tags: list[str] = Field(default_factory=list, alias="tags")
+priority: int = Field(default=100, alias="priority", ge=0)
+clear_env_keys: list[str] = Field(default_factory=list, alias="clearEnvKeys")
+env_template: dict[str, Any] = Field(default_factory=dict, alias="envTemplate")
+file_templates: list[RuntimeFileTemplate] = Field(default_factory=list, alias="fileTemplates")
+home_path_overrides: dict[str, str] = Field(default_factory=dict, alias="homePathOverrides")
+command_behavior: dict[str, Any] = Field(default_factory=dict, alias="commandBehavior")
+secret_refs: dict[str, str] = Field(default_factory=dict, alias="secretRefs")
+volume_mount_path: str | None = Field(None, alias="volumeMountPath")
+max_lease_duration_seconds: int = Field(default=7200, alias="maxLeaseDurationSeconds", ge=60)
+owner_user_id: str | None = Field(None, alias="ownerUserId")
+```
+
+4. **Update** `_validate_policy` validator to validate `credential_source` and `runtime_materialization_mode` against their allowed enum values (or let Pydantic `extra="forbid"` handle it, with explicit enum validation for clarity).
+
+5. **Add** validators for `credential_source` and `runtime_materialization_mode` that reject unsupported values (fail-fast per Constitution Principle IX).
+
+### 3.2 Adapter Cleanup
+
+**File**: `/mnt/d/code/MoonMind/moonmind/workflows/adapters/managed_agent_adapter.py`
+
+**Changes**:
+1. Line 212: Replace `profile.get("auth_mode", default_auth)` with `profile.get("credential_source", default_credential_source)` where `default_credential_source` comes from the strategy's `default_auth_mode` property (renamed or mapped).
+2. Line 338: Remove `auth_mode=auth_mode` from `ManagedRuntimeProfile` constructor (the launch-time model already has `auth_mode: str | None` as optional — it can be left unset or set to `None`).
+3. Line 403: Remove `"auth_mode": auth_mode` from the metadata dict. Replace with `"credential_source": credential_source`.
+4. **Adapter metadata dict consumer audit**: Before applying changes in steps 2–3, grep the codebase for all consumers of `metadata["auth_mode"]` or `metadata.get("auth_mode")` that read from the adapter's output metadata dict. Update all consumers atomically to read `credential_source` instead of `auth_mode`. If any consumer cannot be updated in the same PR, temporarily derive `auth_mode` from `credential_source` in the metadata dict for backward compatibility and document as a follow-up.
+
+5. **API response projection audit (`artifacts.py`)**: Review `build_canonical_start_handle` in `artifacts.py` line ~2279, which projects DB rows directly to API response dicts (not from the adapter's metadata dict). This function currently emits both `auth_mode` (derived from `credential_source`) and `credential_source` itself. Per Constitution Principle XIII (pre-release: delete, don't deprecate), remove the derived `auth_mode` key from this projection. `credential_source` is the sole canonical field for outgoing API responses.
+
+### 3.3 Strategy Default Auth Mapping
+
+**File**: `/mnt/d/code/MoonMind/moonmind/workflows/temporal/runtime/strategies/base.py` (and codex_cli)
+
+The `default_auth_mode` property on strategies is named for the legacy concept. This can stay as-is for backward compatibility since it returns a string that maps directly to `credential_source` values (`api_key` → `secret_ref`). A simple mapping layer can handle this:
+
+```python
+_LEGACY_AUTH_TO_CREDENTIAL_SOURCE = {
+    "api_key": "secret_ref",
+    "oauth": "oauth_volume",
+}
+```
+
+However, since the adapter reads from the profile dict (which comes from the DB model), and the DB model already has `credential_source`, this mapping is only needed as a fallback default. Minimal change: just map the fallback.
+
+### 3.4 Test Updates
+
+**File**: `/mnt/d/code/MoonMind/tests/unit/schemas/test_agent_runtime_models.py`
+
+Existing tests use `authMode="oauth"` in `ManagedAgentProviderProfile` constructions. These must be updated:
+- Replace `authMode="oauth"` with `credentialSource="oauth_volume"`
+- Replace `authMode="api_key"` with `credentialSource="secret_ref"`
+- Add new tests verifying all provider-profile fields
+- Add tests verifying legacy `auth_mode` is rejected (extra="forbid" handles this)
+
+---
+
+## 4. Implementation Sequencing
+
+| Order | Work Item | Files Changed | Dependencies |
+|-------|-----------|---------------|--------------|
+| 1 | Rewrite `ManagedAgentProviderProfile` Pydantic model | `agent_runtime_models.py` | None |
+| 2 | Update adapter to use `credential_source` instead of `auth_mode` | `managed_agent_adapter.py` | Step 1 |
+| 3 | Update unit tests for Pydantic model changes | `test_agent_runtime_models.py` | Step 1 |
+| 4 | Add provider-agnostic guarantee tests | New test file | Steps 1-2 |
+| 5 | Run full test suite and fix any breakage | All | Steps 1-4 |
+
+---
+
+## 5. Risk Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Existing profile records use `auth_mode` only | Medium | DB model already uses `credential_source`. No data migration needed at DB level. Pydantic model is only used for validation/API payloads, not DB rows. |
+| Existing DB rows have NULL or invalid `credential_source` | Medium | Add a verification step in T007: query `managed_agent_provider_profiles` for rows where `credential_source IS NULL` or not in `(oauth_volume, secret_ref, none)`. If any are found, document a data-fix procedure mapping legacy `auth_mode` values to `credential_source` equivalents. Confirm zero results before merging. |
+| Adapter metadata still references `auth_mode` | Low | Update metadata dict key from `auth_mode` to `credential_source`. This is internal metadata, not a public API. |
+| Tests fail due to `auth_mode` removal | Low | All existing tests are in-repo and can be updated atomically. |
+| `extra="forbid"` rejects future fields | Medium | The model uses `extra="forbid"` by convention. New fields in the provider-profile contract will require explicit model updates (intentional). |
+| Workflow payloads contain `auth_mode` from in-flight runs | Low | Temporal payloads carry `ManagedRuntimeProfile` (not `ManagedAgentProviderProfile`). The runtime model already has `auth_mode` as optional, so in-flight runs are unaffected. |
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Unit Tests
+
+| Test | File | Purpose |
+|------|------|---------|
+| `test_managed_agent_provider_profile_accepts_full_provider_contract` | `test_agent_runtime_models.py` | Instantiate with all provider-profile fields, verify no ValidationError |
+| `test_managed_agent_provider_profile_rejects_invalid_credential_source` | `test_agent_runtime_models.py` | Verify invalid `credential_source` raises ValidationError |
+| `test_managed_agent_provider_profile_rejects_invalid_materialization_mode` | `test_agent_runtime_models.py` | Verify invalid `runtime_materialization_mode` raises ValidationError |
+| `test_managed_agent_provider_profile_rejects_legacy_auth_mode` | `test_agent_runtime_models.py` | Verify `authMode` in input is rejected by `extra="forbid"` |
+| `test_managed_runtime_profile_roundtrips_file_templates` | `test_agent_runtime_models.py` | Verify `file_templates` with TOML entries round-trips through `model_dump(by_alias=True)` |
+
+### 6.2 Boundary Tests
+
+| Test | Purpose |
+|------|---------|
+| Adapter produces `ManagedRuntimeProfile` with `credential_source` | Verify no `auth_mode` leakage into runtime profile |
+| Materializer zero provider-branching audit | Grep for `openrouter`, `openai`, `anthropic` in materializer/adapter/launcher — zero matches expected in code paths |
+
+### 6.3 Integration Tests
+
+| Test | Purpose |
+|------|---------|
+| Create second OpenRouter profile via REST API → launch | Verify data-only multi-profile support (FR-001, FR-014) |
+| Profile resolution with two OpenRouter profiles | Verify priority-based selection works (FR-009) |
+
+---
+
+## 7. Constitution Check
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Orchestrate, Don't Recreate | **PASS** — No new runtime created. Provider-profile contract is extended. |
+| II. One-Click Deployment | **PASS** — Auto-seed already creates working OpenRouter profile. Schema alignment makes it more robust. |
+| III. Avoid Vendor Lock-In | **PASS** — This change removes the last Pydantic-level legacy surface and reinforces data-driven provider agnosticism. |
+| IV. Own Your Data | **PASS** — No changes to data ownership model. |
+| V. Skills Are First-Class | **N/A** |
+| VI. Bittersweet Lesson | **PASS** — Provider-profile contract remains the thick stable interface. |
+| VII. Powerful Runtime Configurability | **PASS** — Profiles remain runtime-configurable via REST API. |
+| VIII. Modular and Extensible Architecture | **PASS** — This change makes the Pydantic model match the extensible DB contract. |
+| IX. Resilient by Default | **PASS** — Invalid values fail fast with clear errors. |
+| X. Facilitate Continuous Improvement | **N/A** |
+| XI. Spec-Driven Development | **PASS** — This plan is derived from the spec with traceability to DOC-REQ-* IDs. |
+| XII. Canonical Documentation | **PASS** — Implementation tracking belongs in `docs/tmp/`. |
+| XIII. Pre-Release: Delete, Don't Deprecate | **PASS** — `auth_mode` is removed entirely, not aliased. |
+
+---
+
+## 8. DOC-REQ Traceability
+
+| DOC-REQ-ID | Implementation | Verification |
+|------------|---------------|--------------|
+| DOC-REQ-001 (Reference implementation) | Grep audit confirms zero OpenRouter-specific branching in materializer, adapter, launcher. All behavior is data-driven via `file_templates`, `env_template`, `command_behavior`. | Code audit: `grep -r "openrouter" moonmind/workflows/` → 0 matches. |
+| DOC-REQ-002 (Additional model defaults) | No code changes needed per new profile. Adding a new OpenRouter model profile is a data-only operation (DB row creation via API/UI). The Pydantic model alignment ensures the API layer can express the full provider-profile contract. | Manual test: create profile via REST API → launch Codex run → verify correct model. |
+| DOC-REQ-003 (Legacy auth-profile alignment) | `ManagedAgentProviderProfile` Pydantic model rewritten to include all provider-profile fields and remove `auth_mode`. The dual-schema gap between DB model and Pydantic model is closed. | Unit tests: instantiate with full fields; instantiate with legacy `auth_mode`; verify rejection. |
+
+---
+
+## 9. Complexity Tracking
+
+No cross-cutting changes touching many modules. The scope is confined to:
+- One Pydantic model rewrite (`agent_runtime_models.py`)
+- One adapter cleanup (`managed_agent_adapter.py`)
+- Test file updates
+
+All changes are within the auth/profile subsystem boundary.
+
+---
+
+## 10. Out-of-Scope Confirmation
+
+The following are confirmed out of scope (matching the spec):
+- New provider implementations beyond OpenRouter
+- Temporal workflow orchestration changes
+- Secrets System backend changes
+- OpenRouter-specific optional headers (§16.3 of design doc)
+- `codex_cli` strategy changes beyond existing `command_behavior` support

--- a/specs/127-codex-openrouter-phase3/quickstart.md
+++ b/specs/127-codex-openrouter-phase3/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart: Phase 3 — Codex OpenRouter Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+
+---
+
+## Overview
+
+Phase 3 has one primary change: rewrite the `ManagedAgentProviderProfile` Pydantic model to match the provider-profile contract, plus adapter cleanup. The DB model, API routes, materializer, adapter, and launcher are already provider-agnostic.
+
+## Prerequisites
+
+- Python 3.12+ with the MoonMind virtual environment activated
+- Access to the MoonMind repository at `/mnt/d/code/MoonMind`
+
+## Running Existing Tests (Before Making Changes)
+
+```bash
+# Run unit tests for the affected schema module
+./tools/test_unit.sh --py-args tests/unit/schemas/test_agent_runtime_models.py -q
+
+# Run provider profile tests
+./tools/test_unit.sh --py-args tests/unit/api_service/api/routers/test_provider_profiles.py -q
+
+# Run provider profile manager workflow tests
+./tools/test_unit.sh --py-args tests/unit/workflows/temporal/test_provider_profile_manager.py -q
+```
+
+## Implementation Steps
+
+### Step 1: Rewrite `ManagedAgentProviderProfile`
+
+**File**: `/mnt/d/code/MoonMind/moonmind/schemas/agent_runtime_models.py`
+
+1. Remove the `auth_mode` field (line ~298)
+2. Remove `auth_mode` validation in `_validate_policy` (line ~316)
+3. Add the 13 missing provider-profile fields:
+   - `credential_source`, `runtime_materialization_mode`, `tags`, `priority`
+   - `clear_env_keys`, `env_template`, `file_templates`, `home_path_overrides`
+   - `command_behavior`, `secret_refs`, `volume_mount_path`
+   - `max_lease_duration_seconds`, `owner_user_id`
+
+See `plan.md` for the exact field definitions and types.
+
+### Step 2: Update Adapter
+
+**File**: `/mnt/d/code/MoonMind/moonmind/workflows/adapters/managed_agent_adapter.py`
+
+1. Line 212: Replace `profile.get("auth_mode", default_auth)` with `profile.get("credential_source", ...)`
+2. Line 338: Remove `auth_mode=auth_mode` from `ManagedRuntimeProfile` constructor
+3. Line 403: Replace `"auth_mode": auth_mode` with `"credential_source": credential_source` in metadata
+
+### Step 3: Update Tests
+
+**File**: `/mnt/d/code/MoonMind/tests/unit/schemas/test_agent_runtime_models.py`
+
+- Replace `authMode="oauth"` with `credentialSource="oauth_volume"`
+- Replace `authMode="api_key"` with `credentialSource="secret_ref"`
+- Add tests for full provider-profile field acceptance
+- Add tests for legacy `auth_mode` rejection
+
+### Step 4: Verify
+
+```bash
+# Full unit test suite
+./tools/test_unit.sh
+
+# Provider-agnostic guarantee audit
+grep -r "openrouter" moonmind/workflows/adapters/ moonmind/workflows/temporal/runtime/launcher.py
+# Expected: 0 matches
+```
+
+## Verification Checklist
+
+- [ ] `./tools/test_unit.sh` passes without regression
+- [ ] `grep -r "openrouter" moonmind/workflows/` returns 0 matches
+- [ ] `ManagedAgentProviderProfile` accepts all provider-profile fields
+- [ ] `ManagedAgentProviderProfile` rejects `authMode` (extra="forbid")
+- [ ] Adapter no longer references `auth_mode` in profile construction or metadata
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `/mnt/d/code/MoonMind/moonmind/schemas/agent_runtime_models.py` | Pydantic models (primary change target) |
+| `/mnt/d/code/MoonMind/moonmind/workflows/adapters/managed_agent_adapter.py` | Adapter (auth_mode cleanup) |
+| `/mnt/d/code/MoonMind/tests/unit/schemas/test_agent_runtime_models.py` | Unit tests |
+| `/mnt/d/code/MoonMind/api_service/db/models.py` | DB model (reference, no changes needed) |
+| `/mnt/d/code/MoonMind/api_service/api/routers/provider_profiles.py` | API routes (reference, no changes needed) |

--- a/specs/127-codex-openrouter-phase3/remediation-a-v2.md
+++ b/specs/127-codex-openrouter-phase3/remediation-a-v2.md
@@ -1,0 +1,147 @@
+# Prompt A Remediation Analysis (Second Pass, Post-Remediation)
+
+**Date**: 2026-04-03
+**Artifacts reviewed**: `spec.md`, `plan.md`, `tasks.md`, `analysis-v2.md`
+**Reviewer**: Qwen Code (Prompt A, second pass)
+
+---
+
+## spec.md
+
+### HIGH-01: Outgoing API response `auth_mode` emission not addressed in spec
+
+- **Severity**: HIGH
+- **Artifact**: spec.md
+- **Location**: Functional Requirements (FR-007), Edge Cases (EC-008)
+- **Problem**: FR-007 says `auth_mode` MUST be removed from the Pydantic model, and EC-008 says legacy values should be "auto-migrated or rejected," but the spec is silent on whether outgoing API responses (e.g., `build_canonical_start_handle` in `artifacts.py` line 2279) should also stop emitting `auth_mode` alongside `credential_source`.
+- **Remediation**: Add a sentence to FR-007 or a new FR-015 clarifying that outgoing API responses may retain `auth_mode` as a derived backward-compatibility field computed from `credential_source`, or explicitly require its removal. If retained for backward compat, document the derivation rule: `"oauth" if credential_source == "oauth_volume" else "api_key"`.
+- **Rationale**: Without this, implementers and reviewers cannot determine whether `artifacts.py` line 2279's dual emission is correct behavior or a leftover that should be cleaned up in this feature.
+
+### MEDIUM-01: Edge case EC-008 migration mechanism not specified
+
+- **Severity**: MEDIUM
+- **Artifact**: spec.md
+- **Location**: Edge Cases (EC-008)
+- **Problem**: EC-008 says legacy `auth_mode` values should be "auto-migrated or rejected with migration guidance" but does not specify which path (migration vs. rejection) is chosen, nor where the migration logic lives.
+- **Remediation**: Resolve EC-008 by stating: "Legacy `auth_mode` values in incoming API payloads are **rejected** by `extra='forbid'` on the Pydantic model. Migration is a one-time DB-level operation, not a per-request transform. No runtime auto-migration code is added."
+- **Rationale**: Eliminates implementation ambiguity between adding runtime migration logic vs. relying on Pydantic's `extra="forbid"` to reject legacy input.
+
+### LOW-01: Success criterion SC-005 references `speckit-analyze`
+
+- **Severity**: LOW
+- **Artifact**: spec.md
+- **Location**: Success Criteria (SC-005)
+- **Problem**: SC-005 says "`speckit-analyze` reports no CRITICAL or HIGH consistency gaps," but this is a tooling-dependent criterion, not an intrinsic property of the implementation.
+- **Remediation**: Replace with a concrete verification method, e.g., "Manual consistency audit of spec/plan/tasks against DOC-REQ traceability table yields zero unresolved CRITICAL or HIGH gaps."
+- **Rationale**: Makes the success criterion independently verifiable without requiring a specific tool.
+
+---
+
+## plan.md
+
+### HIGH-02: Adapter metadata consumer audit does not enumerate `artifacts.py` as a required update target
+
+- **Severity**: HIGH
+- **Artifact**: plan.md
+- **Location**: Section 3.2, step 4 (Metadata consumer audit)
+- **Problem**: The plan instructs a grep audit for `metadata["auth_mode"]` consumers and mentions `artifacts.py` line 2279 as an example, but `artifacts.py` does not consume the adapter's metadata dict — it projects DB rows directly to API response dicts. The plan conflates two different `auth_mode` surfaces: (1) adapter metadata dict, and (2) DB-to-API projection in `artifacts.py`. These require different treatments.
+- **Remediation**: Split step 4 into two sub-steps: (a) "Grep for consumers of `metadata['auth_mode']` from the adapter's output dict; update atomically or add backward-compat shim." (b) "Review `build_canonical_start_handle` in `artifacts.py` line ~2279: decide whether to remove the derived `auth_mode` field from API responses or retain it for backward compatibility. Document the decision and update the spec accordingly."
+- **Rationale**: The adapter metadata dict and the API response projection are distinct data flows with different backward-compatibility requirements; conflating them risks incorrect or incomplete fixes.
+
+### MEDIUM-02: Strategy `default_auth_mode` property naming not documented as intentional
+
+- **Severity**: MEDIUM
+- **Artifact**: plan.md
+- **Location**: Section 3.3 (Strategy Default Auth Mapping)
+- **Problem**: The plan proposes keeping `default_auth_mode` property name on strategies and mapping return values, but does not explicitly document that the naming retention is intentional (not an oversight) to avoid confusion with FR-007's `auth_mode` removal mandate.
+- **Remediation**: Add a note to Section 3.3: "The property name `default_auth_mode` on strategy classes is intentionally retained. It is a legacy name that now returns values compatible with `credential_source` semantics (via mapping). Renaming is deferred to a future cleanup. This does not conflict with FR-007, which targets the `ManagedAgentProviderProfile` Pydantic field, not strategy property names."
+- **Rationale**: Prevents implementers from renaming the strategy property as part of this feature, which would be out of scope and risk breaking unrelated callers.
+
+---
+
+## tasks.md
+
+### CRITICAL-01: No task explicitly covers updating `test_managed_agent_adapter.py` for `auth_mode` → `credential_source`
+
+- **Severity**: CRITICAL
+- **Artifact**: tasks.md
+- **Location**: All tasks (gap across T002, T003, T007)
+- **Problem**: `test_managed_agent_adapter.py` contains 16 references to `auth_mode` (lines 157, 158, 185, 193, 194, 222, 230, 238, 247, 404, 628, 678, 725, 758, 793, 1497). T003 is scoped only to `test_agent_runtime_models.py`. T002 covers adapter production code only. T007 will catch failures but does not proactively assign the fix — it only says "Fix any test failures," which is reactive, not prescriptive. With `runtime` mode, leaving test breakage to "fix later" without a dedicated task is a quality gap.
+- **Remediation**: Add a new task T003b (or extend T007): "Update `test_managed_agent_adapter.py` — replace all `auth_mode` fixture dict keys with `credential_source`, update assertion at line 185 from `metadata['auth_mode']` to `metadata['credential_source']`, and verify all 16 references are migrated." Add this task between T003 and T004, with a dependency on T002.
+- **Rationale**: 16 test references will fail without proactive migration guidance. Assigning this as an explicit task prevents implementation-time guesswork and ensures the adapter test suite is green before the full test run.
+
+### HIGH-03: T002 does not address `artifacts.py` line 2279 dual emission
+
+- **Severity**: HIGH
+- **Artifact**: tasks.md
+- **Location**: T002 (adapter cleanup)
+- **Problem**: T002 covers only the adapter file. The `artifacts.py` projection that emits both `auth_mode` and `credential_source` (line 2279) is mentioned in the plan's metadata consumer audit but has no corresponding task to either remove the legacy field or document its retention.
+- **Remediation**: Add a step to T007 (or create T008): "Review `build_canonical_start_handle` in `artifacts.py` line ~2279. If the spec decision is to remove `auth_mode` from outgoing API responses, remove the derived `auth_mode` key from the profile projection dict. If retaining for backward compat, add a comment documenting the derivation rule and the planned removal milestone."
+- **Rationale**: The dual emission is a tangible code artifact that must be either cleaned up or explicitly documented as backward compat within this feature's scope.
+
+### MEDIUM-03: T005 grep audit lacks expected-match documentation template
+
+- **Severity**: MEDIUM
+- **Artifact**: tasks.md
+- **Location**: T005 (Code audit: verify zero provider-specific branching)
+- **Problem**: T005 says to run grep commands and "confirm zero matches" but does not specify where to record the findings. Without a designated location, the audit may be performed but not documented, making SC-002 unverifiable.
+- **Remediation**: Add a step to T005: "Record grep output (even if empty) as a comment in this task file or in the PR description, confirming zero provider-specific branching matches."
+- **Rationale**: Ensures the audit is traceable and satisfies SC-002's verification method requirement.
+
+---
+
+## docs / Cross-Artifact
+
+### MEDIUM-04: No explicit task for DB data integrity check beyond T007 step 7
+
+- **Severity**: MEDIUM
+- **Artifact**: tasks.md (cross-artifact)
+- **Location**: T007 step 7
+- **Problem**: The DB data integrity check (querying `managed_agent_provider_profiles` for NULL or invalid `credential_source`) is listed as step 7 inside T007, which is the "run full test suite" task. This is a data-level verification that should be done early (before or during T001) to confirm no migration is needed, not late as a post-hoc check.
+- **Remediation**: Move the DB data integrity check to a new standalone task T000 (or prepend to T001) with "Dependencies: None" and execution before T001, so that any data issues are discovered before code changes are merged.
+- **Rationale**: Discovering invalid DB rows after code changes are implemented would require rollback or branching, increasing integration risk.
+
+---
+
+## Analysis-v2 New Issue Assessment
+
+### HIGH-NEW-01: `artifacts.py` line 2279 dual `auth_mode` / `credential_source` emission — ASSESSED
+
+**Confirmed**. The `build_canonical_start_handle` function at line ~2279 of `moonmind/workflows/temporal/artifacts.py` projects DB rows to dicts and emits both:
+```python
+"auth_mode": "oauth" if row.credential_source.value == "oauth_volume" else "api_key",
+"credential_source": row.credential_source.value,
+```
+This is a backward-compat projection for API responses. The spec's FR-007 mandates `auth_mode` removal from the Pydantic model (incoming validation), but is silent on outgoing responses. This needs an explicit scope decision: retain as derived backward compat (recommended for zero-downtime rollout) or remove in this feature. **Classified as HIGH** — the ambiguity could lead to either premature removal (breaking API consumers) or indefinite retention (violating Principle XIII).
+
+### MEDIUM-NEW-01: `test_managed_agent_adapter.py` line 185 asserts `auth_mode` — ASSESSED
+
+**Confirmed**. The test at line 185 asserts `handle.metadata["auth_mode"] == "oauth"`. After T002 removes `auth_mode` from the adapter's metadata dict, this assertion will fail. The test file contains 16 total `auth_mode` references across fixture dicts and assertions. **Classified as MEDIUM** in analysis-v2, but I am upgrading this to **CRITICAL** because (a) the volume of affected references (16) is significant, (b) no task explicitly covers this file, and (c) T007's reactive "fix any failures" is insufficient guidance for `runtime` mode quality standards.
+
+---
+
+## Summary by Severity
+
+| Severity | Count | IDs |
+|----------|-------|-----|
+| CRITICAL | 1 | CRITICAL-01 |
+| HIGH | 3 | HIGH-01, HIGH-02, HIGH-03 |
+| MEDIUM | 3 | MEDIUM-01, MEDIUM-02, MEDIUM-03, MEDIUM-04 |
+| LOW | 1 | LOW-01 |
+
+---
+
+## Final Determination
+
+### Safe to Implement: NO
+
+### Blocking Remediations
+
+1. **CRITICAL-01**: Add an explicit task covering `test_managed_agent_adapter.py` `auth_mode` → `credential_source` migration (16 references). Without this, the adapter test suite will fail and there is no assigned owner.
+2. **HIGH-01**: Clarify in the spec whether outgoing API responses should retain or remove the derived `auth_mode` field. Without this, `artifacts.py` line 2279 cannot be correctly handled.
+3. **HIGH-02**: Split the plan's metadata consumer audit into two distinct data flows (adapter metadata dict vs. DB-to-API projection) with separate treatment guidance.
+4. **HIGH-03**: Add a task to handle `artifacts.py` line 2279 — either remove the legacy `auth_mode` field from the API response projection or document it as backward compat with a removal plan.
+
+### Determination Dationale
+
+The spec, plan, and tasks are internally consistent on the primary code changes (Pydantic model rewrite and adapter cleanup). However, the `auth_mode` removal creates a downstream impact on `test_managed_agent_adapter.py` (16 references) and leaves ambiguity around the `artifacts.py` API response projection. With the feature in `runtime` mode, unassigned test breakage and unresolved API contract ambiguity are unacceptable for safe implementation. Resolving CRITICAL-01 and the three HIGH items would make this ready to implement.

--- a/specs/127-codex-openrouter-phase3/remediation-a-v3.md
+++ b/specs/127-codex-openrouter-phase3/remediation-a-v3.md
@@ -1,0 +1,122 @@
+# Prompt A Remediation Analysis (Third Pass, Post-V2 Remediation)
+
+**Date**: 2026-04-03
+**Artifacts reviewed**: `spec.md`, `plan.md`, `tasks.md`, `remediation-b-v2-summary.md`
+**Reviewer**: Qwen Code (Prompt A, third pass)
+
+---
+
+## V2 Remediation Verification
+
+All four blocking items from the second-pass remediation (analysis-v2.md) have been addressed in the artifacts:
+
+| Issue | Status | Evidence |
+|-------|--------|----------|
+| CRITICAL-01: No task for `test_managed_agent_adapter.py` (16 refs) | **RESOLVED** | T003b added to tasks.md with explicit line references, replacement instructions, and dependency on T002 |
+| HIGH-01: Outgoing API response `auth_mode` emission undefined in spec | **RESOLVED** | FR-007 extended to require removal of derived `auth_mode` from outgoing API responses; explicitly names `artifacts.py` `build_canonical_start_handle` |
+| HIGH-02: Plan conflates adapter metadata dict vs DB-to-API projection | **RESOLVED** | Plan §3.2 step 4 (adapter metadata audit) and step 5 (API response projection audit in `artifacts.py`) are now distinct |
+| HIGH-03: No task for `artifacts.py` line 2279 dual emission | **RESOLVED** | T003c added to tasks.md specifying removal of derived `auth_mode` from `build_canonical_start_handle` projection |
+
+---
+
+## Third-Pass Assessment
+
+### No new CRITICAL or HIGH issues found
+
+The spec, plan, and tasks are now internally consistent. The complete change set is:
+
+1. **T001**: Rewrite `ManagedAgentProviderProfile` in `agent_runtime_models.py` -- remove `auth_mode`, add 13 provider-profile fields, add validators
+2. **T002**: Replace `auth_mode` with `credential_source` in `managed_agent_adapter.py` (3 locations)
+3. **T003**: Update 2 existing test constructions in `test_agent_runtime_models.py`
+4. **T003b**: Migrate 16 `auth_mode` references in `test_managed_agent_adapter.py`
+5. **T003c**: Remove derived `auth_mode` from `artifacts.py` line 2279 profile projection
+6. **T004**: Add 6 new validation test functions
+7. **T005**: Grep audit for provider-specific branching
+8. **T006**: Multi-profile integration tests
+9. **T007**: Full test suite run + edge-case coverage audit
+
+The dependency graph is acyclic and correctly ordered. All DOC-REQ IDs are traced. All FRs are covered by tasks. All success criteria have verification methods.
+
+### Residual MEDIUM observations (non-blocking)
+
+| ID | Observation | Rationale |
+|----|-------------|-----------|
+| MED-01 | The `ManagedRuntimeProfile` Pydantic model (line 371 of `agent_runtime_models.py`) still has `auth_mode: str | None = Field(None, alias="authMode")`. T002 step 2 says to "remove `auth_mode=auth_mode` from the `ManagedRuntimeProfile` constructor" but the field itself remains. This is intentional -- the launch-time model is a separate contract from the API-validation model -- but is not explicitly documented. | The spec out-of-scope section confirms `ManagedRuntimeProfile` is not in scope for field removal. The adapter step correctly stops populating it. No action required, but a brief comment in the plan would prevent implementer confusion. |
+| MED-02 | Strategy property names (`default_auth_mode` in `base.py`, `gemini_cli.py`) are not documented as intentionally-retained legacy names. | Plan §3.3 discusses the mapping but does not explicitly state "renaming is out of scope." Low risk since these are unrelated to the `ManagedAgentProviderProfile` field. |
+| MED-03 | DB data integrity check (T007 step 7) is a data-level verification embedded in the "run full test suite" task rather than a standalone early task. | The plan's Risk Mitigation table already addresses this ("Add a verification step in T007"). Moving it earlier would be ideal but is not blocking. |
+
+---
+
+## Code-State Reality Check
+
+The following was verified against the live codebase:
+
+| Item | Status |
+|------|--------|
+| `ManagedAgentProviderProfile` in `agent_runtime_models.py` still has `auth_mode` (required) and lacks provider-profile fields | **Confirmed** -- this is the primary change target |
+| `managed_agent_adapter.py` line 212 reads `profile.get("auth_mode", default_auth)` | **Confirmed** -- must become `credential_source` |
+| `artifacts.py` line 2279 emits both `auth_mode` and `credential_source` | **Confirmed** -- derived `auth_mode` must be removed |
+| `test_managed_agent_adapter.py` has 16 `auth_mode` references | **Confirmed** (lines 157, 158, 185, 193, 194, 222, 230, 238, 247, 404, 628, 678, 725, 758, 793, 1497) |
+| `test_agent_runtime_models.py` has 2 `authMode` references | **Confirmed** (lines 71, 82) |
+| Zero OpenRouter-specific branching in `materializer.py`, `launcher.py`, `managed_agent_adapter.py` | **Confirmed** -- grep found no provider-specific branching in these files |
+| Materializer, adapter, launcher are data-driven | **Confirmed** |
+
+All observations match the spec's current-state assessment and the plan's assumptions.
+
+---
+
+## DOC-REQ / Task Coverage Matrix
+
+| DOC-REQ | Covered By | Verified |
+|---------|-----------|----------|
+| DOC-REQ-001 (Reference implementation) | T005 (grep audit) | Yes |
+| DOC-REQ-002 (Additional model defaults) | T006 (multi-profile integration tests) | Yes |
+| DOC-REQ-003 (Legacy auth-profile alignment) | T001, T002, T003, T003b, T003c, T004, T007 | Yes |
+
+## FR / Task Coverage Matrix
+
+| FR | Covered By | Verified |
+|----|-----------|----------|
+| FR-001 | T006 | Yes |
+| FR-002 | Already satisfied (materializer) | Yes |
+| FR-003 | Already satisfied (launcher) | Yes |
+| FR-004 | Already satisfied (strategy) | Yes |
+| FR-005 | Already satisfied (layering) | Yes |
+| FR-006 | Already satisfied (adapter) | Yes |
+| FR-007 | T001, T002, T003, T003b, T003c, T004 | Yes |
+| FR-008 | Already satisfied (materializer) | Yes |
+| FR-009 | T006 | Yes |
+| FR-010 | T006 | Yes |
+| FR-011 | T005 | Yes |
+| FR-012 | T001, T004 | Yes |
+| FR-013 | Already satisfied (runtime model) | Yes |
+| FR-014 | T006 | Yes |
+
+---
+
+## Summary by Severity
+
+| Severity | Count | IDs |
+|----------|-------|-----|
+| CRITICAL | 0 | -- |
+| HIGH | 0 | -- |
+| MEDIUM | 3 | MED-01, MED-02, MED-03 |
+| LOW | 0 | -- |
+
+---
+
+## Final Determination
+
+### Safe to Implement: YES
+
+### Rationale
+
+All four blocking issues from the second-pass remediation have been resolved:
+- The adapter test file migration is covered by T003b with explicit enumeration of all 16 references.
+- The outgoing API response contract is unambiguously specified in FR-007 (remove derived `auth_mode`).
+- The plan correctly separates the adapter metadata dict audit from the DB-to-API response projection audit.
+- The `artifacts.py` line 2279 cleanup is covered by T003c.
+
+The three residual MEDIUM observations are informational only -- they do not block implementation. They can be addressed during implementation as minor clarifications.
+
+The spec, plan, and tasks form a coherent, traceable implementation plan with no gaps in DOC-REQ or FR coverage, a correct dependency graph, and appropriate test strategy.

--- a/specs/127-codex-openrouter-phase3/remediation-a.md
+++ b/specs/127-codex-openrouter-phase3/remediation-a.md
@@ -1,0 +1,149 @@
+# Remediation Report: 127-codex-openrouter-phase3
+
+**Prompt**: A — Remediation Discovery
+**Orchestration mode**: runtime
+**Date**: 2026-04-03
+**Input**: `spec.md`, `plan.md`, `tasks.md`, `speckit-analyze` output
+
+---
+
+## spec.md
+
+### CRITICAL-01: Unresolved OQ-004 — Other legacy `auth_mode` surfaces not scoped
+- **Location**: Open Questions table, OQ-004
+- **Problem**: The spec asks "Are there any other legacy-shaped Pydantic models or API contracts that also need alignment beyond `ManagedAgentProviderProfile`?" and answers "Needs code audit," but the audit results are not incorporated into the spec's scope. The speckit-analyze audit found `OAuthProviderSpec` in `moonmind/workflows/temporal/runtime/providers/base.py` and `providers/registry.py` entries still using `auth_mode`, and these are not mentioned in any implementation or out-of-scope section.
+- **Remediation**: Add a definitive answer to OQ-004: either (a) bring `OAuthProviderSpec.auth_mode` and registry entries into scope with a new user story and tasks, or (b) add an explicit "Out of Scope" note with rationale explaining why `OAuthProviderSpec.auth_mode` is semantically distinct from `ManagedAgentProviderProfile.auth_mode` and why it is safe to leave unchanged.
+- **Rationale**: Per Constitution Principle XIII (delete, don't deprecate), unscoped legacy surfaces create a partial migration that contradicts the stated goal of eliminating `auth_mode`.
+- **Analysis ref**: CRITICAL-01
+
+### HIGH-01: Mission Control UI coverage for FR-010 is not addressed in any user story or task
+- **Location**: Requirements — FR-010; User Story 4
+- **Problem**: FR-010 states "Provider profile creation, update, and deletion MUST be available through Mission Control UI and REST API," but no user story, plan section, or task covers Mission Control UI changes. T006 only tests REST API CRUD.
+- **Remediation**: Either (a) add a user story and task for Mission Control UI profile CRUD, or (b) narrow FR-010 to "REST API only" with a note deferring Mission Control UI to a follow-up feature.
+- **Rationale**: An unaddressed MUST requirement means the feature cannot claim full spec compliance.
+- **Analysis ref**: Completeness gap (not in speckit-analyze)
+
+### HIGH-02: `rate_limit_policy` type divergence between DB model and Pydantic model is unaddressed
+- **Location**: Requirements — FR-012; Key Entities; plan AD-002 field table
+- **Problem**: The DB model stores `rate_limit_policy` as a `ManagedAgentRateLimitPolicy` enum, but the current Pydantic model has it as `dict[str, Any]`. The plan's AD-002 field-addition table does not mention this field at all, leaving the type mismatch unresolved.
+- **Remediation**: Add an explicit decision to AD-002 (and the T001 field table) stating whether `rate_limit_policy` is retained as `dict[str, Any]` (current) or aligned with the DB enum, with rationale.
+- **Rationale**: An unaddressed type mismatch between the Pydantic and DB models violates FR-012 ("all fields present in the DB row MUST be representable in the Pydantic schema").
+- **Analysis ref**: HIGH-02
+
+### MEDIUM-01: NFR-001 and NFR-002 performance targets have no verification task
+- **Location**: Non-Functional Requirements — NFR-001, NFR-002
+- **Problem**: The spec states profile resolution must complete within 500ms and materialization within 200ms, but no task in tasks.md includes a performance verification step.
+- **Remediation**: Add a lightweight performance assertion to T007 (e.g., `pytest-benchmark` or a timing assertion in the integration test), or move NFR-001/NFR-002 out of scope with a note deferring to a performance audit feature.
+- **Rationale**: Success criteria that claim NFR compliance without verification create a false confidence signal.
+- **Analysis ref**: MEDIUM-06
+
+---
+
+## plan.md
+
+### CRITICAL-01: AD-002 omits existing fields that must be retained in the model rewrite
+- **Location**: Architecture Decisions — AD-002, "Add missing provider-profile fields"
+- **Problem**: AD-002 lists fields to add but does not enumerate the **existing** fields that must be preserved (`profile_id`, `runtime_id`, `provider_id`, `provider_label`, `default_model`, `model_overrides`, `volume_ref`, `account_label`, `max_parallel_runs`, `cooldown_after_429`, `rate_limit_policy`, `enabled`). An implementer could accidentally drop `volume_ref` or `account_label`. The DB model has both `volume_ref` and `volume_mount_path` as separate columns; the plan adds `volume_mount_path` but never confirms `volume_ref` is kept.
+- **Remediation**: Add a "Fields retained as-is" table to AD-002 listing all existing fields with their current types and defaults, confirming they are unchanged.
+- **Rationale**: In a model rewrite that replaces most of the field list, omitting the retained-field inventory creates a real risk of accidental data loss.
+- **Analysis ref**: CRITICAL-02
+
+### HIGH-01: `owner_user_id` type coercion (UUID to str) not documented
+- **Location**: Architecture Decisions — AD-002 field table
+- **Problem**: The DB model defines `owner_user_id` as `Mapped[Optional[UUID]]`, but the plan proposes `str | None` for the Pydantic model without noting the explicit UUID-to-string serialization.
+- **Remediation**: Add a note to AD-002 that `owner_user_id` undergoes explicit UUID-to-string coercion during serialization, and confirm the API router already handles this conversion.
+- **Rationale**: Implicit type coercion between DB and Pydantic layers can cause silent serialization mismatches.
+- **Analysis ref**: HIGH-01
+
+### HIGH-02: No task covers metadata dict consumer audit for `auth_mode` removal
+- **Location**: Component Breakdown — §3.2 (Adapter Cleanup), step 3; Risk Mitigation §5
+- **Problem**: T002 step 3 replaces `"auth_mode": auth_mode` with `"credential_source": credential_source` in the metadata dict, but no grep audit verifies that downstream consumers (e.g., `artifacts.py` line 2279, `build_canonical_start_handle`, run tracking) do not read `metadata["auth_mode"]`. Removing it without updating consumers would cause `KeyError` or silent data loss.
+- **Remediation**: Add a step to T002: "Grep for consumers of `metadata['auth_mode']` or `metadata.get('auth_mode')` across the codebase; update all consumers atomically to read `credential_source` instead, or temporarily derive `auth_mode` from `credential_source` for backward compatibility."
+- **Rationale**: Removing a metadata key that downstream code reads is a runtime-breaking change.
+- **Analysis ref**: HIGH-03
+
+### HIGH-03: No data migration verification for existing DB rows
+- **Location**: Risk Mitigation §5; Implementation Scope — "Migration path"
+- **Problem**: The spec's OQ-001 recommends a one-time data migration mapping `auth_mode` values to `credential_source`. The plan confirms "DB model already uses `credential_source`" and "No data migration needed at DB level," but does not verify that existing DB rows actually have valid `credential_source` values (rows created before the DB schema added `credential_source` may have NULL or stale values).
+- **Remediation**: Add a verification step to T007: "Query `managed_agent_provider_profiles` for rows where `credential_source IS NULL` or has an invalid value; confirm zero results, or document a data-fix procedure."
+- **Rationale**: Even if the DB schema has the column, old rows may lack the data, and the new Pydantic model requires `credential_source` as a field.
+- **Analysis ref**: HIGH-04
+
+### MEDIUM-01: T001 constraint values not fully specified per field
+- **Location**: Component Breakdown — §3.1, step 2 (field table)
+- **Problem**: T001 says "Each field uses `min_length=1` on required strings and `ge=0` / `ge=1` / `ge=60` constraints where applicable" but the field table does not specify which constraint applies to which field.
+- **Remediation**: Add a "constraints" column to the T001 field table in the plan (e.g., `credential_source: min_length=1`, `priority: ge=0, default=100`, `max_lease_duration_seconds: ge=60, default=7200`, `cooldown_after_429: ge=0`, `max_parallel_runs: ge=1`).
+- **Rationale**: Ambiguous constraints invite implementer guesswork and may diverge from DB model defaults.
+- **Analysis ref**: MEDIUM-01
+
+---
+
+## tasks.md
+
+### CRITICAL-01: T006 claims no dependencies but requires T001's Pydantic changes
+- **Location**: T006 — "Dependencies: None (can run in parallel with T001-T005)"
+- **Problem**: T006 integration tests construct profiles with `credential_source="secret_ref"` and `runtime_materialization_mode="composite"` — fields that do not exist in the Pydantic model until T001 is complete. The Pydantic validation layer will reject these fields if T001 has not been applied, causing T006 tests to fail.
+- **Remediation**: Change T006 dependencies to "T001" (minimum), or restructure T006 to test only via the raw API layer (bypassing Pydantic validation) and mark Pydantic-integration testing as a separate post-T001 task.
+- **Rationale**: A task claiming parallel execution that will actually fail is a dependency ordering defect that breaks CI if tasks are parallelized.
+- **Analysis ref**: CRITICAL-03
+
+### MEDIUM-01: T005 dependency on T002 is unnecessary
+- **Location**: T005 — "Dependencies: T001, T002"
+- **Problem**: T005 is a grep audit for provider-specific branching (`openrouter`, `openai`, `anthropic` in materializer/adapter/launcher). This audit is about provider-agnostic guarantee, not about `auth_mode` vs `credential_source`. The grep already returns 0 matches today.
+- **Remediation**: Remove T002 from T005's dependencies. T005 depends only on T001 (or has no hard dependencies at all).
+- **Rationale**: Unnecessary dependencies lengthen the critical path and delay verification feedback.
+- **Analysis ref**: MEDIUM-02
+
+### MEDIUM-02: T003 and T004 modify the same test file without conflict guidance
+- **Location**: Task Dependency Graph; T003 and T004 artifact paths
+- **Problem**: Both T003 and T004 edit `tests/unit/schemas/test_agent_runtime_models.py`. The graph shows T003 -> T004 sequentially, but if executed by different agents or in parallel branches, there is merge-conflict risk.
+- **Remediation**: Add a note to T004: "Note: T003 and T004 both edit `test_agent_runtime_models.py`. Execute atomically or merge before running T007."
+- **Rationale**: Same-file edits by separate tasks are a common source of integration breakage in automated task execution.
+- **Analysis ref**: MEDIUM-03
+
+### MEDIUM-03: 6 of 10 edge cases have no verification task
+- **Location**: Edge Cases table in spec; tasks.md T004 coverage
+- **Problem**: The spec defines 10 edge cases (EC-001 through EC-010). T004 covers EC-002, EC-007, EC-008. EC-001 (merge strategy), EC-003 (missing secrets), EC-004 (path traversal), EC-006 (env_template ref validation), EC-009 (base env protection), and EC-010 (file permissions) have no verification task.
+- **Remediation**: Add a step to T005 or T007: "Confirm that edge cases EC-001, EC-003, EC-004, EC-006, EC-009, EC-010 are covered by existing materializer/adapter unit tests. If not, document as follow-up tasks."
+- **Rationale**: Unverified edge cases create a false sense of spec completeness.
+- **Analysis ref**: MEDIUM-05
+
+### MEDIUM-04: Missing test for `extra="forbid"` with unknown future fields
+- **Location**: T004 test list
+- **Problem**: T004 test 4 verifies that legacy `authMode` is rejected via `extra="forbid"`, but there is no test verifying that arbitrary unknown fields (not just `authMode`) are also rejected, which is the protective behavior the plan relies on (AD-004 risk section).
+- **Remediation**: Add a test `test_managed_agent_provider_profile_forbids_unknown_fields` to T004 that passes an arbitrary unknown field and asserts `ValidationError`.
+- **Rationale**: Testing the specific legacy field does not fully validate the `extra="forbid"` contract for future unknown fields.
+- **Analysis ref**: MEDIUM-04
+
+---
+
+## docs
+
+### MEDIUM-01: No `docs/tmp/` migration tracker created for this feature
+- **Location**: Constitution Principle XII; spec Implementation Scope
+- **Problem**: The spec's "Implementation Scope" describes a migration path for `auth_mode` removal and schema alignment. Per Constitution Principle XII, migration/implementation tracking should live under `docs/tmp/`, not in the canonical spec. No `docs/tmp/` tracker exists yet for this feature.
+- **Remediation**: Create a migration tracker file at `docs/tmp/remaining-work/127-codex-openrouter-phase3.md` (or equivalent) to track in-flight implementation progress, removable when the feature ships.
+- **Rationale**: Constitution Principle XII requires migration narratives to live in disposable scratch space, not canonical docs.
+- **Analysis ref**: Constitution alignment gap (not in speckit-analyze)
+
+---
+
+## Determination
+
+### Safe to Implement: NO
+
+### Blocking Remediations
+
+| Severity | ID | Summary |
+|----------|----|---------|
+| CRITICAL | spec CRITICAL-01 | Unresolved OQ-004: `OAuthProviderSpec` and registry entries still use `auth_mode`; must be explicitly scoped in or out. |
+| CRITICAL | plan CRITICAL-01 | AD-002 omits existing fields to retain; risk of accidental data loss during model rewrite. |
+| CRITICAL | tasks CRITICAL-01 | T006 claims no dependencies but requires T001's Pydantic changes; parallel execution will fail. |
+| HIGH | spec HIGH-01 | FR-010 Mission Control UI requirement is unaddressed in all artifacts. |
+| HIGH | spec HIGH-02 | `rate_limit_policy` type mismatch between DB and Pydantic models unaddressed. |
+| HIGH | plan HIGH-02 | No metadata dict consumer audit for `auth_mode` removal; downstream `KeyError` risk. |
+| HIGH | plan HIGH-03 | No data migration verification for existing DB rows with potentially NULL `credential_source`. |
+
+### Determination Rationale
+
+Three CRITICAL findings create direct implementation risk: unresolved legacy surface scope (`OAuthProviderSpec`), incomplete field inventory in the model rewrite (data loss risk), and an incorrect task dependency graph (parallel CI failure). Four HIGH findings add secondary risk around unaddressed MUST requirements (FR-010), type mismatches, metadata consumer breakage, and data integrity. All seven must be resolved before implementation can proceed safely.

--- a/specs/127-codex-openrouter-phase3/remediation-b-summary.md
+++ b/specs/127-codex-openrouter-phase3/remediation-b-summary.md
@@ -1,0 +1,72 @@
+# Remediation B Summary: 127-codex-openrouter-phase3
+
+**Prompt**: B — Remediation Application
+**Date**: 2026-04-03
+**Input**: `remediation-a.md` (Remediation Discovery report)
+
+---
+
+## Files Changed
+
+| File | Change Summary |
+|------|---------------|
+| `specs/127-codex-openrouter-phase3/spec.md` | Resolved OQ-004 (OAuthProviderSpec out of scope), narrowed FR-010 to REST API only, added rate_limit_policy type decision, added OAuthProviderSpec to out-of-scope section |
+| `specs/127-codex-openrouter-phase3/plan.md` | Added "Fields retained as-is" table to AD-002, added owner_user_id UUID coercion note, added metadata consumer audit step to adapter cleanup, added DB row credential_source verification to Risk Mitigation |
+| `specs/127-codex-openrouter-phase3/tasks.md` | Fixed T006 dependency (None -> T001), removed T002 from T005 dependency, added same-file conflict note for T003/T004, added unknown fields test to T004, added edge case coverage audit and DB integrity check to T007, updated dependency graph and execution order |
+| `docs/tmp/remaining-work/127-codex-openrouter-phase3.md` | Created new migration tracker per Constitution Principle XII |
+
+---
+
+## Remediations Completed
+
+### CRITICAL
+
+| ID | Source | Summary | Status |
+|----|--------|---------|--------|
+| spec CRITICAL-01 | spec.md OQ-004 | Added definitive answer: OAuthProviderSpec.auth_mode is semantically distinct (OAuth session type, not credential sourcing). Added explicit out-of-scope note. | Done |
+| plan CRITICAL-01 | plan.md AD-002 | Added "Fields retained as-is" table listing all 12 existing fields (profile_id, runtime_id, provider_id, provider_label, default_model, model_overrides, volume_ref, account_label, max_parallel_runs, cooldown_after_429, rate_limit_policy, enabled) with types and defaults. | Done |
+| tasks CRITICAL-01 | tasks.md T006 | Changed T006 dependencies from "None" to "T001". Updated dependency graph and execution order accordingly. | Done |
+
+### HIGH
+
+| ID | Source | Summary | Status |
+|----|--------|---------|--------|
+| spec HIGH-01 | spec.md FR-010 | Narrowed FR-010 to "REST API only". Mission Control UI deferred to follow-up feature. | Done |
+| spec HIGH-02 | spec.md Implementation Scope | Added explicit decision: rate_limit_policy retained as dict[str, Any] in Pydantic model; enum alignment deferred. | Done |
+| plan HIGH-01 | plan.md AD-002 | Added UUID-to-string coercion note for owner_user_id, confirmed existing API router handles conversion. | Done |
+| plan HIGH-02 | plan.md Section 3.2 | Added step 4 to adapter cleanup: grep audit for metadata["auth_mode"] consumers, with atomic update or backward-compat fallback guidance. | Done |
+| plan HIGH-03 | plan.md Risk Mitigation | Added new risk entry for NULL/invalid credential_source in existing DB rows, with verification procedure in T007. | Done |
+
+### MEDIUM
+
+| ID | Source | Summary | Status |
+|----|--------|---------|--------|
+| tasks MEDIUM-01 | tasks.md T005 | Removed T002 from T005 dependencies (audit is about provider-agnostic guarantee, not auth_mode cleanup). | Done |
+| tasks MEDIUM-02 | tasks.md T004 | Added same-file conflict note for T003/T004 edits to test_agent_runtime_models.py. | Done |
+| tasks MEDIUM-03 | tasks.md T007 | Added edge case coverage audit step (EC-001, EC-003, EC-004, EC-006, EC-009, EC-010) and DB data integrity check to T007. | Done |
+| tasks MEDIUM-04 | tasks.md T004 | Added test_managed_agent_provider_profile_forbids_unknown_fields test case to validate extra="forbid" for arbitrary unknown fields. | Done |
+
+### Infrastructure
+
+| ID | Source | Summary | Status |
+|----|--------|---------|--------|
+| docs MEDIUM-01 | Constitution XII | Created migration tracker at docs/tmp/remaining-work/127-codex-openrouter-phase3.md. | Done |
+
+---
+
+## Remediations Skipped
+
+| ID | Source | Summary | Reason |
+|----|--------|---------|--------|
+| spec MEDIUM-01 | spec.md NFR-001, NFR-002 | NFR performance targets (500ms/200ms) have no verification task | Deferred — lightweight performance assertion can be added during T007 execution if time permits. Not a blocking concern for artifact correctness. |
+| plan MEDIUM-01 | plan.md T001 field table | Constraint values not fully specified per field in the field table | Partially addressed — the plan references the same constraints as tasks.md T001 step 2 ("min_length=1 on required strings, ge=0/ge=1/ge=60 where applicable"). Full per-field constraint annotation would be redundant with the tasks.md table and is a minor documentation concern. |
+
+---
+
+## Residual Risks
+
+1. **Edge case coverage**: EC-001, EC-003, EC-004, EC-006, EC-009, EC-010 are not yet verified as covered by existing tests. The T007 audit step will confirm coverage; uncovered edge cases should become follow-up tasks.
+2. **Metadata consumer breakage**: The plan now requires a grep audit for metadata["auth_mode"] consumers before adapter changes are applied. If consumers exist outside the adapter boundary (e.g., in artifacts.py build_canonical_start_handle), they must be updated atomically or a backward-compat shim added.
+3. **DB data integrity**: Old rows with NULL credential_source must be verified before merging. The T007 DB check will confirm zero results; if non-zero, a data-fix procedure must be documented.
+4. **Mission Control UI**: FR-010 Mission Control UI coverage is deferred. This is an explicit scope reduction, not a residual risk, but should be tracked as a follow-up feature.
+5. **rate_limit_policy type divergence**: The Pydantic model uses dict[str, Any] while the DB uses ManagedAgentRateLimitPolicy enum. This is documented as deferred and is not a blocking risk, but should be addressed in a follow-up type-alignment change.

--- a/specs/127-codex-openrouter-phase3/remediation-b-v2-summary.md
+++ b/specs/127-codex-openrouter-phase3/remediation-b-v2-summary.md
@@ -1,0 +1,42 @@
+# Prompt B Remediation Summary
+
+**Date**: 2026-04-03
+**Input**: `/mnt/d/code/MoonMind/specs/127-codex-openrouter-phase3/remediation-a-v2.md`
+
+---
+
+## Issues Addressed
+
+### CRITICAL-01: No task covers `test_managed_agent_adapter.py` (16 `auth_mode` references)
+
+**Fix**: Added **T003b** — "Migrate `test_managed_agent_adapter.py` from `auth_mode` to `credential_source`" in `tasks.md`. Enumerates all 16 line references, specifies fixture dict key replacements and the assertion update at line ~185. Depends on T002.
+
+### HIGH-01: Spec FR-007 silent on outgoing API response `auth_mode` emission
+
+**Fix**: Extended **FR-007** in `spec.md` to explicitly state: outgoing API responses MUST NOT emit a derived `auth_mode` field alongside `credential_source`; `credential_source` is the sole canonical field. Any existing code path that projects `auth_mode` into API response dicts (e.g., `build_canonical_start_handle` in `artifacts.py`) MUST be updated to emit only `credential_source`.
+
+### HIGH-02: Plan conflates adapter metadata dict vs DB-to-API response projection
+
+**Fix**: Split the single "Metadata consumer audit" step in plan.md §3.2 into two distinct steps:
+- **Step 4**: Adapter metadata dict consumer audit — grep for consumers of `metadata["auth_mode"]` from the adapter's output dict.
+- **Step 5**: API response projection audit (`artifacts.py`) — review `build_canonical_start_handle` which projects DB rows directly to API response dicts (a separate data flow from the adapter metadata dict).
+
+### HIGH-03: No task addresses `artifacts.py` line 2279 dual emission
+
+**Fix**: Added **T003c** — "Remove legacy `auth_mode` from outgoing API response in `artifacts.py`" in `tasks.md`. Specifies removing the derived `auth_mode` key from the `build_canonical_start_handle` profile projection dict, per Constitution Principle XIII (pre-release: delete, don't deprecate). Depends on T001.
+
+---
+
+## Artifacts Modified
+
+| File | Changes |
+|------|---------|
+| `specs/127-codex-openrouter-phase3/tasks.md` | Added T003b, T003c; updated dependency graph, execution order, complexity table, and runtime scope validation |
+| `specs/127-codex-openrouter-phase3/plan.md` | Split §3.2 step 4 into two distinct audit steps (adapter metadata dict vs API response projection) |
+| `specs/127-codex-openrouter-phase3/spec.md` | Extended FR-007 to cover outgoing API response behavior (no derived `auth_mode`) |
+
+---
+
+## Determination
+
+**Safe to Implement: YES** — all four blocking issues from the remediation report are resolved.

--- a/specs/127-codex-openrouter-phase3/research.md
+++ b/specs/127-codex-openrouter-phase3/research.md
@@ -1,0 +1,183 @@
+# Research Findings: Phase 3 — Codex OpenRouter Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+**Date**: 2026-04-03
+
+---
+
+## 1. Codebase Audit Results
+
+### 1.1 `ManagedAgentProviderProfile` Pydantic Model — Current State
+
+**File**: `/mnt/d/code/MoonMind/moonmind/schemas/agent_runtime_models.py` (lines ~288-327)
+
+Current fields:
+| Field | Status | Notes |
+|---|---|---|
+| `profile_id` | Present, required | ✓ |
+| `runtime_id` | Present, required | ✓ |
+| `provider_id` | Present, optional | ✓ |
+| `provider_label` | Present, optional | ✓ |
+| `default_model` | Present, optional | ✓ |
+| `model_overrides` | Present, optional | ✓ |
+| `auth_mode` | **Present, REQUIRED** | ✗ Must be removed |
+| `volume_ref` | Present, optional | ✓ |
+| `account_label` | Present, optional | ✓ |
+| `max_parallel_runs` | Present, required | ✓ |
+| `cooldown_after_429` | Present, optional | ✓ |
+| `rate_limit_policy` | Present, optional | ✓ |
+| `enabled` | Present, optional | ✓ |
+| `credential_source` | **Missing** | ✗ Must add |
+| `runtime_materialization_mode` | **Missing** | ✗ Must add |
+| `tags` | **Missing** | ✗ Must add |
+| `priority` | **Missing** | ✗ Must add |
+| `clear_env_keys` | **Missing** | ✗ Must add |
+| `env_template` | **Missing** | ✗ Must add |
+| `file_templates` | **Missing** | ✗ Must add (type `RuntimeFileTemplate` already exists) |
+| `home_path_overrides` | **Missing** | ✗ Must add |
+| `command_behavior` | **Missing** | ✗ Must add |
+| `secret_refs` | **Missing** | ✗ Must add |
+| `volume_mount_path` | **Missing** | ✗ Must add |
+| `max_lease_duration_seconds` | **Missing** | ✗ Must add |
+| `owner_user_id` | **Missing** | ✗ Must add |
+
+**Finding**: The model has 13 present fields (4 required) and 13 missing fields. The `auth_mode` field is the blocker — it's required and has no equivalent in the provider-profile contract.
+
+### 1.2 `ManagedRuntimeProfile` — Already Complete
+
+The launch-time model (`ManagedRuntimeProfile` in the same file) already carries all provider-profile fields:
+- `credential_source`
+- `runtime_materialization_mode`
+- `command_behavior`
+- `env_template`
+- `file_templates` (with `RuntimeFileTemplate` typed entries)
+- `home_path_overrides`
+- `clear_env_keys`
+- `secret_refs`
+- `auth_mode` (optional, can be left `None`)
+
+**Finding**: The gap is exclusively in `ManagedAgentProviderProfile`, not in `ManagedRuntimeProfile`. The adapter already maps all provider-profile fields from the profile dict into `ManagedRuntimeProfile` (line 326-343).
+
+### 1.3 DB Model — Already Complete
+
+**File**: `/mnt/d/code/MoonMind/api_service/db/models.py` (lines 1805-1895)
+
+The SQLAlchemy model has all provider-profile fields including:
+- `credential_source` (enum: `ProviderCredentialSource`)
+- `runtime_materialization_mode` (enum: `RuntimeMaterializationMode`)
+- `tags`, `priority`
+- `clear_env_keys`, `env_template`, `file_templates`
+- `home_path_overrides`, `command_behavior`
+- `secret_refs`, `volume_mount_path`
+- `max_lease_duration_seconds`, `owner_user_id`
+
+**Finding**: No DB migration is needed. The DB schema is already correct.
+
+### 1.4 API Routes — Already Complete
+
+**File**: `/mnt/d/code/MoonMind/api_service/api/routers/provider_profiles.py`
+
+The REST API schemas (`ProviderProfileCreate`, `ProviderProfileUpdate`, `ProviderProfileResponse`) already include all provider-profile fields. The `_row_to_dict` helper already maps all DB columns to the response payload.
+
+**Finding**: No API changes needed. The REST API already speaks the provider-profile contract.
+
+### 1.5 Provider-agnostic Guarantee — Already Achieved
+
+**Grep results for `openrouter` in `moonmind/workflows/`**: **0 matches**
+
+Files audited:
+- `moonmind/workflows/adapters/materializer.py` — Zero provider-specific branching. All behavior is driven by `file_templates` data.
+- `moonmind/workflows/adapters/managed_agent_adapter.py` — Zero provider-specific branching. References `auth_mode` only for metadata tracking (line 212, 338, 403), which should be migrated to `credential_source`.
+- `moonmind/workflows/temporal/runtime/launcher.py` — Zero provider-specific branching. No `provider_id` references.
+- `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` — Zero provider-specific branching. Only handles CLI construction.
+
+**Finding**: DOC-REQ-001 is already satisfied at the code level. The only remaining `auth_mode` references in the adapter are metadata, not branching logic.
+
+### 1.6 Auto-seed Profile — Already Complete
+
+**File**: `/mnt/d/code/MoonMind/api_service/main.py` (lines 624-688)
+
+The auto-seed creates a fully specified OpenRouter profile (`codex_openrouter_qwen36_plus`) when `OPENROUTER_API_KEY` is present at startup. The profile includes:
+- All provider-profile fields
+- TOML config template via `file_templates`
+- `home_path_overrides` for `CODEX_HOME`
+- `command_behavior` with `suppress_default_model_flag`
+- Proper `clear_env_keys`
+- `secret_refs` binding
+
+**Finding**: The auto-seed profile is already a reference implementation for config-bundle Codex providers.
+
+---
+
+## 2. Legacy `auth_mode` Usage Map
+
+| Location | Usage | Action |
+|---|---|---|
+| `agent_runtime_models.py` line 298 | `auth_mode: str = Field(..., alias="authMode", min_length=1)` — **required field** | Remove |
+| `agent_runtime_models.py` line 316 | `self.auth_mode = _require_non_blank(self.auth_mode, field_name="authMode")` | Remove |
+| `managed_agent_adapter.py` line 212 | `auth_mode: str = profile.get("auth_mode", default_auth)` | Replace with `credential_source` derivation |
+| `managed_agent_adapter.py` line 338 | `auth_mode=auth_mode` in `ManagedRuntimeProfile` constructor | Remove (leave as default `None`) |
+| `managed_agent_adapter.py` line 403 | `"auth_mode": auth_mode` in metadata dict | Replace with `"credential_source"` |
+| `test_agent_runtime_models.py` | Tests use `authMode="oauth"` | Update to `credentialSource="oauth_volume"` |
+
+---
+
+## 3. Compatibility Analysis for In-Flight Workflows
+
+### 3.1 Temporal Payloads
+
+Temporal workflows carry `ManagedRuntimeProfile` (not `ManagedAgentProviderProfile`) in their payloads. The `ManagedRuntimeProfile` model already has:
+- `auth_mode: str | None = Field(None, alias="authMode")` — optional, defaults to `None`
+- All provider-profile fields present
+
+**Conclusion**: In-flight workflows are unaffected. The Pydantic model change only affects API-level validation and profile dict construction, not Temporal payloads.
+
+### 3.2 DB Rows
+
+The DB model already uses `credential_source` (not `auth_mode`). The `auth_mode` column in the DB (seen in migration `0b8e4befb8e5_initial_clean_migration.py`) is named `auth_mode` but typed as `ProviderCredentialSource` enum — it was already migrated at the DB level.
+
+**Conclusion**: No data migration needed at DB level.
+
+---
+
+## 4. Multi-Profile Support Assessment
+
+The system already supports multiple OpenRouter profiles:
+1. The DB model has no uniqueness constraint on `(runtime_id, provider_id)` — multiple profiles per provider are allowed.
+2. The REST API supports CRUD for arbitrary profiles.
+3. The profile resolution logic (adapter `_resolve_profile`) supports priority-based selection among multiple matching profiles.
+4. The `sync_provider_profile_manager` function syncs all enabled profiles for a runtime to the Temporal manager workflow.
+
+**Conclusion**: Adding a second OpenRouter profile (e.g., `codex_openrouter_qwen_max`) is a data-only operation. No code changes required for DOC-REQ-002.
+
+---
+
+## 5. Related Open Questions
+
+### OQ-001: Should `auth_mode` be removed or kept optional?
+
+**Decision**: Remove entirely. Constitution Principle XIII (pre-release: delete, don't deprecate) applies. The DB model already uses `credential_source`. The auto-seed uses `credential_source`. No API route produces `auth_mode`.
+
+### OQ-002: Are there other legacy Pydantic models using `auth_mode`?
+
+**Audit**: Searched for `auth_mode` across the codebase. Only occurrences are:
+- `agent_runtime_models.py` (the target of this change)
+- `managed_agent_adapter.py` (metadata tracking, to be updated)
+- DB models (already migrated to `ProviderCredentialSource` enum)
+
+No other Pydantic models use `auth_mode`.
+
+### OQ-003: Does `ManagedRuntimeProfile.auth_mode` also need removal?
+
+**Assessment**: `ManagedRuntimeProfile` has `auth_mode: str | None = Field(None, alias="authMode")` as optional. Since this is the launch-time model and the adapter already populates it from the profile dict, we can leave it as optional `None`. It's not a required field and doesn't block provider-profile compliance. Future cleanup can remove it entirely when no caller references it.
+
+---
+
+## 6. Test Coverage Gaps
+
+| Gap | Description |
+|-----|-------------|
+| `ManagedAgentProviderProfile` with full fields | No test exists that instantiates the Pydantic model with all provider-profile fields |
+| Provider-agnostic guarantee | No test explicitly verifies zero provider-specific branching in materializer/adapter/launcher |
+| Multi-profile launch | Integration tests exist for single OpenRouter profile; two-profile scenario not covered |
+| Legacy `auth_mode` rejection | No test verifies that submitting `authMode` to the aligned schema is rejected |

--- a/specs/127-codex-openrouter-phase3/spec.md
+++ b/specs/127-codex-openrouter-phase3/spec.md
@@ -1,0 +1,237 @@
+# Feature Specification: Codex OpenRouter Phase 3 — Generalization
+
+**Feature Branch**: `127-codex-openrouter-phase3`
+**Created**: 2026-04-03
+**Status**: Draft
+**Input**: Fully implement Phase 3 from `docs/ManagedAgents/CodexCliOpenRouter.md`
+
+## Source Document Requirements
+
+Source: `docs/ManagedAgents/CodexCliOpenRouter.md`, Section 15 — Rollout Plan, Phase 3
+
+| ID | Source | Requirement |
+|----|--------|-------------|
+| DOC-REQ-001 | §15 Phase 3, line 1 | Treat OpenRouter as the reference implementation for config-bundle Codex providers |
+| DOC-REQ-002 | §15 Phase 3, line 2 | Reuse the same pattern for additional OpenRouter-backed model defaults |
+| DOC-REQ-003 | §15 Phase 3, line 3 | Align any remaining legacy auth-profile persistence with the provider-profile contract |
+
+### DOC-REQ-001 — Reference Implementation
+
+The OpenRouter provider profile implementation must be structured as a reusable reference pattern that other config-bundle Codex providers can follow. All materialization, config generation, and launch plumbing must be provider-agnostic beyond OpenRouter-specific configuration values. Concretely, no module in the materialization or launch path should contain OpenRouter-specific branching; provider identity should only appear in profile data, config values, and seed definitions.
+
+### DOC-REQ-002 — Additional Model Defaults
+
+The system must support creating additional OpenRouter-backed provider profiles that differ primarily by `default_model`, `profile_id`, and provider-specific labels, without requiring new code per profile. Adding a new OpenRouter model profile should be a data-only operation (profile record creation via API/UI), not a code change.
+
+### DOC-REQ-003 — Legacy Auth-Profile Alignment
+
+The `ManagedAgentProviderProfile` Pydantic model in `moonmind/schemas/agent_runtime_models.py` remains legacy-shaped: it uses `auth_mode` as a required field and lacks the richer provider-profile fields (`credential_source`, `runtime_materialization_mode`, `command_behavior`, `env_template`, `file_templates`, `home_path_overrides`, `clear_env_keys`, `secret_refs`). The database model (`api_service/db/models.py`) already has these fields, but the Pydantic contract has not been aligned. This must be resolved so the Pydantic schema matches the provider-profile contract defined in `docs/Security/ProviderProfiles.md`.
+
+---
+
+## Current State Assessment
+
+The following Phase 1 / Phase 2 plumbing is **already implemented** in the codebase and should be verified rather than re-implemented:
+
+| Component | File | Status |
+|-----------|------|--------|
+| Rich `ManagedRuntimeProfile` fields | `moonmind/schemas/agent_runtime_models.py` | **Done** — has `credential_source`, `runtime_materialization_mode`, `command_behavior`, `env_template`, `file_templates`, `home_path_overrides`, `clear_env_keys`, `secret_refs` |
+| Adapter field mapping | `moonmind/workflows/adapters/managed_agent_adapter.py` | **Done** — maps all provider-profile fields into `ManagedRuntimeProfile` |
+| Path-aware file materialization | `moonmind/workflows/adapters/materializer.py` | **Done** — supports `RuntimeFileTemplate[]`, TOML rendering, `runtime_support_dir` template vars, permissions, cleanup |
+| Home-path application | `moonmind/workflows/adapters/materializer.py` | **Done** — `home_path_overrides` applied in `materialize()` |
+| Codex strategy model-flag suppression | `moonmind/workflows/temporal/runtime/strategies/codex_cli.py` | **Done** — honors `suppress_default_model_flag` |
+| OpenRouter auto-seed path | `api_service/` (seed tests exist) | **Done** — tests at `tests/unit/api_service/test_provider_profile_auto_seed.py` |
+| DB model with full fields | `api_service/db/models.py` | **Done** — `ManagedAgentProviderProfile` table has all provider-profile columns |
+| Launcher `home_path_overrides` | `moonmind/workflows/temporal/runtime/launcher.py` | **Done** — materializer applies `home_path_overrides` before strategy shaping |
+
+The **remaining gaps** that Phase 3 must close are:
+
+1. **Legacy Pydantic schema**: `ManagedAgentProviderProfile` in `agent_runtime_models.py` uses `auth_mode` (required) and is missing the rich provider-profile fields. It must be aligned with the DB model and the Provider Profiles contract.
+2. **Provider-agnostic guarantee**: No provider-specific branching should exist in materializer, adapter, or launcher code. The OpenRouter profile should be verifiably data-driven.
+3. **Multi-profile operational support**: The system must demonstrably support multiple OpenRouter-backed profiles with different models, selectable independently.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Create Additional OpenRouter Model Profiles (Priority: P1)
+
+A MoonMind operator or Mission Control user can create new provider profiles for different OpenRouter models (e.g., `qwen/qwen-max`, `anthropic/claude-sonnet-4-20250514`) by specifying only the profile identity, model string, and credential binding. No code changes are required per profile.
+
+**Why this priority**: Phase 3's generalization goal is blocked if new OpenRouter models still require custom code instead of profile data.
+
+**Independent Test**: Seed a second OpenRouter provider profile with a different model string, launch a Codex run against it, and verify the correct model is used.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing OpenRouter provider profile, **When** a new profile is created with a different `default_model`, **Then** Codex runs use the new model without any code changes.
+2. **Given** a new OpenRouter profile, **When** launched via exact `execution_profile_ref`, **Then** the per-run config bundle selects the correct model and provider.
+3. **Given** two OpenRouter profiles with different priorities, **When** a request uses `profile_selector.provider_id = "openrouter"`, **Then** the highest-priority available profile is selected.
+
+---
+
+### User Story 2 — Config-Bundle Materialization is Provider-Agnostic (Priority: P1)
+
+The file materialization system (`ProviderProfileMaterializer`) handles any config-bundle provider (OpenRouter, future providers) using the same path-aware rendering pipeline. Provider-specific logic is limited to configuration values, not materialization behavior.
+
+**Why this priority**: This is the core of Phase 3 — ensuring the OpenRouter pattern generalizes to other providers.
+
+**Independent Test**: Inspect the materializer, adapter, and launcher code to confirm zero provider-specific branching for OpenRouter; verify that config rendering is driven entirely by `file_templates` data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider profile with `runtime_materialization_mode = composite` and `file_templates`, **When** materialization runs, **Then** files are rendered to the specified paths regardless of provider identity.
+2. **Given** two different provider profiles with different `file_templates`, **When** both are materialized, **Then** each produces correct config at its specified paths.
+3. **Given** a `file_templates` entry with `format = "toml"`, **When** rendered, **Then** the output is valid TOML matching the `content_template` structure.
+
+---
+
+### User Story 3 — Legacy Auth-Profile Schema Alignment (Priority: P1)
+
+The `ManagedAgentProviderProfile` Pydantic model is updated to match the provider-profile contract, eliminating the dual-schema gap between the DB model (already complete) and the Pydantic model (still legacy-shaped).
+
+**Why this priority**: Without this, the API and validation layer cannot express the full provider-profile contract, and new fields added via the API would fail validation.
+
+**Independent Test**: Instantiate a `ManagedAgentProviderProfile` with all provider-profile fields (including `credential_source`, `runtime_materialization_mode`, `file_templates`, `home_path_overrides`, `command_behavior`, `clear_env_keys`, `secret_refs`) and verify it passes validation.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated `ManagedAgentProviderProfile` schema, **When** a profile dict is constructed with `credential_source = "secret_ref"` and `runtime_materialization_mode = "composite"`, **Then** the model validates successfully.
+2. **Given** a legacy profile dict using `auth_mode = "api_key"`, **When** the system processes it, **Then** it is either migrated or rejected with a clear error (no silent acceptance of legacy-only fields).
+3. **Given** a profile with `file_templates` containing a TOML config entry, **When** serialized via `model_dump(by_alias=True)`, **Then** the output round-trips correctly through the API layer.
+
+---
+
+### User Story 4 — Operator Creates OpenRouter Profiles via Mission Control / REST (Priority: P2)
+
+An operator can create, view, edit, and delete OpenRouter-backed Codex provider profiles through Mission Control and the REST API without touching code or seed scripts.
+
+**Why this priority**: Enables self-service profile management for production deployments.
+
+**Independent Test**: Use the REST API to create a new OpenRouter profile, then launch a Codex run targeting it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the REST API, **When** a POST creates a profile with `runtime_id = "codex_cli"`, `provider_id = "openrouter"`, `default_model = "qwen/qwen-max"`, **Then** the profile is persisted and returned on subsequent GET.
+2. **Given** an existing profile, **When** PATCH updates its `default_model` or `priority`, **Then** the update is reflected in subsequent profile resolution.
+3. **Given** a profile that has active leases, **When** DELETE is attempted, **Then** the system either rejects or warns about active usage.
+
+---
+
+### Edge Cases
+
+| ID | Scenario | Expected Behavior |
+|----|----------|-------------------|
+| EC-001 | `file_templates` references a path that already exists | Uses `merge_strategy` to determine behavior; `replace` overwrites, `deep_merge` merges |
+| EC-002 | Provider profile has an invalid or unsupported `runtime_materialization_mode` | Fails fast with clear error at profile validation time, not at launch time |
+| EC-003 | Secret referenced by `secret_refs` is missing at launch time | Aborts launch with actionable error naming the missing secret role and profile |
+| EC-004 | `file_templates[].path` resolves outside `runtime_support_dir` | Rejected with path-traversal error during materialization |
+| EC-005 | Two OpenRouter profiles have identical `priority` and `default_model` | Tie-broken by `available_slots` (most free slots wins); both are usable but one is preferred |
+| EC-006 | `env_template` value references a `secret_ref` key not defined in `secret_refs` | Fails at materialization time with clear error naming the missing ref |
+| EC-007 | Provider profile with `credential_source = "none"` and `runtime_materialization_mode = "config_bundle"` | Valid: a config-only provider that needs no credentials (e.g., local mock endpoint) |
+| EC-008 | Legacy `auth_mode` value (`"oauth"`, `"api_key"`) submitted to the aligned schema | Either auto-migrated (`"oauth"` → `"oauth_volume"`, `"api_key"` → `"secret_ref"`) or rejected with migration guidance |
+| EC-009 | `clear_env_keys` removes a key that is also required by the base environment (e.g., `PATH`) | `clear_env_keys` only removes provider-specific keys; base environment variables like `PATH`, `HOME` are protected by the layering rule (§11.2 of ProviderProfiles) |
+| EC-010 | Generated config file permissions are not `0600` | Default is `0600`; explicit `permissions` in `RuntimeFileTemplate` overrides; validated on write |
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST support creating arbitrary OpenRouter-backed provider profiles by varying only `profile_id`, `default_model`, `provider_label`, and `secret_refs`, without code changes per profile.
+- **FR-002**: `ProviderProfileMaterializer` MUST render `file_templates` to arbitrary paths specified in the profile, with support for TOML, JSON, and plain text formats.
+- **FR-003**: System MUST apply `home_path_overrides` from the provider profile into the subprocess env before runtime strategy shaping.
+- **FR-004**: `CodexCliStrategy` MUST honor `command_behavior.suppress_default_model_flag` and omit `-m` when the config bundle already sets the default model.
+- **FR-005**: System MUST clear `clear_env_keys` before injecting profile-resolved env vars to prevent ambient credential bleed.
+- **FR-006**: `ManagedAgentAdapter` MUST map all provider-profile fields (`credential_source`, `runtime_materialization_mode`, `command_behavior`, `env_template`, `file_templates`, `home_path_overrides`) into `ManagedRuntimeProfile`.
+- **FR-007**: The `ManagedAgentProviderProfile` Pydantic model MUST be aligned with the provider-profile contract: it MUST include `credential_source`, `runtime_materialization_mode`, `clear_env_keys`, `env_template`, `file_templates`, `home_path_overrides`, `command_behavior`, and `secret_refs`; and `auth_mode` MUST be removed from the model (incoming validation rejects it via `extra="forbid"`). Outgoing API responses MUST NOT emit a derived `auth_mode` field alongside `credential_source`; `credential_source` is the sole canonical field. Any existing code path that projects `auth_mode` into API response dicts (e.g., `build_canonical_start_handle` in `artifacts.py`) MUST be updated to emit only `credential_source`.
+- **FR-008**: Generated config files MUST be written with mode `0600` by default and cleaned up on run completion.
+- **FR-009**: System MUST support dynamic provider selection via `profile_selector.provider_id` in addition to exact `execution_profile_ref`.
+- **FR-010**: Provider profile creation, update, and deletion MUST be available through the REST API. Mission Control UI for profile management is deferred to a follow-up feature.
+- **FR-011**: No module in the materialization, adapter, or launcher path MAY contain provider-specific branching for OpenRouter. All provider behavior MUST be driven by profile data (`file_templates`, `env_template`, `command_behavior`, etc.).
+- **FR-012**: The `ManagedAgentProviderProfile` Pydantic model MUST remain compatible with the DB model in `api_service/db/models.py` — all fields present in the DB row MUST be representable in the Pydantic schema.
+- **FR-013**: When a provider profile is resolved and materialized, the resulting `ManagedRuntimeProfile` MUST contain all fields needed for launch without requiring fallback to the raw profile dict.
+- **FR-014**: The system MUST support at least two distinct OpenRouter-backed provider profiles simultaneously (e.g., `codex_openrouter_qwen36_plus` and `codex_openrouter_qwen_max`), each independently selectable and launchable.
+
+### Non-Functional Requirements
+
+- **NFR-001**: Profile resolution MUST complete within 500ms for a typical deployment with ≤ 50 profiles per runtime.
+- **NFR-002**: Materialization of `file_templates` (including TOML rendering) MUST complete within 200ms for a typical Codex config bundle.
+- **NFR-003**: No raw credential values MAY appear in Temporal workflow payloads, run metadata, artifact files, or log output at any point in the launch pipeline.
+- **NFR-004**: All provider-specific configuration values in profile records MUST be inspectable by operators through Mission Control without exposing secret values.
+
+### Key Entities
+
+- **Provider Profile** (`ManagedAgentProviderProfile`): A configuration record binding a `runtime_id` + `provider_id` to credential sources, materialization templates, policy limits, and command behavior. Persisted in `managed_agent_provider_profiles` DB table and represented by the aligned Pydantic model.
+- **Runtime File Template** (`RuntimeFileTemplate`): A structured descriptor (`path`, `format`, `merge_strategy`, `content_template`, `permissions`) for path-aware file materialization.
+- **Per-Run Support Directory**: A MoonMind-owned workspace subdirectory (`.moonmind/`) containing generated config bundles for the current run. Created during materialization, cleaned up on run completion.
+- **Managed Runtime Profile** (`ManagedRuntimeProfile`): The launch-time payload shaped from a Provider Profile. Carries all fields needed for subprocess launch without requiring further profile lookups.
+
+---
+
+## Implementation Scope
+
+### What is in scope for Phase 3
+
+1. **Schema alignment**: Update `ManagedAgentProviderProfile` in `moonmind/schemas/agent_runtime_models.py` to match the full provider-profile contract. Remove or deprecate `auth_mode` as a required field. Add all missing fields: `credential_source`, `runtime_materialization_mode`, `clear_env_keys`, `env_template`, `file_templates`, `home_path_overrides`, `command_behavior`, `secret_refs`.
+2. **Provider-agnostic verification**: Audit `materializer.py`, `managed_agent_adapter.py`, `launcher.py`, and `codex_cli.py` for any provider-specific branching. Remove or refactor any OpenRouter-specific conditionals that should be data-driven.
+3. **Multi-profile support**: Ensure the auto-seed mechanism can produce multiple OpenRouter profiles, and that the REST API / Mission Control supports CRUD for them.
+4. **Migration path**: Provide a data migration or compatibility layer for any existing profile records that use the legacy `auth_mode` field instead of `credential_source`.
+5. **`rate_limit_policy` type**: The DB model stores `rate_limit_policy` as `ManagedAgentRateLimitPolicy` (enum), while the current Pydantic model uses `dict[str, Any]`. The Pydantic model retains `dict[str, Any]` for this feature — the enum-to-dict serialization is handled at the API/DB boundary. Aligning the Pydantic type with the DB enum is deferred to a follow-up change, as it would require changes to the API serialization layer and is not required to close the `auth_mode` / provider-profile gap (DOC-REQ-003).
+
+### What is out of scope
+
+- New provider implementations beyond OpenRouter (the infrastructure should be ready, but actual new providers are separate features).
+- Changes to the Temporal workflow orchestration model or ProviderProfileManager signals.
+- Changes to the Secrets System backend or secret storage model.
+- OpenRouter-specific optional headers or attribution metadata (deferred per §16.3 of the design doc).
+- Changes to the `codex_cli` strategy beyond honoring `command_behavior` (existing behavior is sufficient).
+- `OAuthProviderSpec` in `moonmind/workflows/temporal/runtime/providers/base.py` and its registry entries: the `auth_mode` field in this TypedDict describes OAuth session type for terminal/bootstrap flows, not credential sourcing. It is semantically unrelated to `ManagedAgentProviderProfile.auth_mode` and is not affected by this feature.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+| ID | Criterion | Verification Method |
+|----|-----------|-------------------|
+| SC-001 | A new OpenRouter provider profile can be created and used for a Codex run by adding only profile data (no code changes). | Manual test: create profile via REST API → launch Codex run → verify correct model used. |
+| SC-002 | `ProviderProfileMaterializer` contains zero provider-specific branching for OpenRouter; all behavior is driven by `file_templates` data. | Code audit: grep for `openrouter` in `materializer.py`, `launcher.py`, `managed_agent_adapter.py`. Zero matches expected. |
+| SC-003 | The `ManagedAgentProviderProfile` Pydantic model accepts all provider-profile fields and rejects or migrates legacy `auth_mode`-only records. | Unit tests: instantiate with full fields; instantiate with legacy `auth_mode`; verify behavior. |
+| SC-004 | Integration tests pass for at least two distinct OpenRouter-backed provider profiles with different model strings. | Run `test_provider_profile_auto_seed.py`-style integration test with two profiles. |
+| SC-005 | `speckit-analyze` reports no CRITICAL or HIGH consistency gaps across spec, plan, and tasks artifacts. | Run `/speckit-analyze` after plan and tasks are created. |
+| SC-006 | All existing unit and integration tests pass without regression. | Run `./tools/test_unit.sh` and integration test suite. |
+| SC-007 | Generated Codex config files are written with mode `0600` and cleaned up after run completion. | Unit test on materializer; integration test verifying cleanup. |
+
+---
+
+## Open Questions
+
+| ID | Question | Recommendation |
+|----|----------|----------------|
+| OQ-001 | Should `auth_mode` be removed entirely from `ManagedAgentProviderProfile` or kept as an optional aliased field with auto-migration? | Remove entirely (Constitution Principle XIII: pre-release, delete don't deprecate). Provide a one-time data migration mapping `oauth` → `oauth_volume`, `api_key` → `secret_ref`. |
+| OQ-002 | Should the auto-seed mechanism create multiple default OpenRouter profiles, or only one (with operators adding more via UI)? | Seed only one (`codex_openrouter_qwen36_plus`). Additional profiles are operator-created. Auto-seeding too many profiles creates clutter. |
+| OQ-003 | Does the current `ManagedRuntimeProfile` already carry all fields needed for launch, or are there gaps between what the adapter populates and what the launcher/materializer consume? | Current assessment: `ManagedRuntimeProfile` is complete. The gap is in `ManagedAgentProviderProfile` (the Pydantic model used for API/validation), not `ManagedRuntimeProfile`. |
+| OQ-004 | Are there any other legacy-shaped Pydantic models or API contracts that also need alignment beyond `ManagedAgentProviderProfile`? | **Resolved: Out of scope.** The `OAuthProviderSpec` TypedDict in `moonmind/workflows/temporal/runtime/providers/base.py` contains an `auth_mode: str` field, and registry entries in `providers/registry.py` populate it with `auth_mode="oauth"`. This `auth_mode` is semantically distinct from `ManagedAgentProviderProfile.auth_mode`: it describes the *auth session type* for the OAuth terminal/bootstrap flow (always `"oauth"`), not the credential sourcing strategy. `OAuthProviderSpec` governs session lifecycle (session transport, bootstrap commands, success checks), while `ManagedAgentProviderProfile` governed profile-level credential configuration. The two `auth_mode` uses are unrelated concepts sharing a historical name. No migration of `OAuthProviderSpec` is needed for this feature. |
+
+---
+
+## Constitution Check
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Orchestrate, Don't Recreate | **PASS** — OpenRouter support goes through the existing Codex CLI runtime via provider profiles. No new runtime is created. |
+| II. One-Click Deployment | **PASS** — Auto-seed creates a working OpenRouter profile when `OPENROUTER_API_KEY` is present at startup. |
+| III. Avoid Vendor Lock-In | **PASS** — All provider-specific behavior is data-driven via `file_templates`, `env_template`, and `command_behavior`. No OpenRouter-specific code paths in materialization or launch. |
+| IV. Own Your Data | **PASS** — Generated config files live in MoonMind-owned per-run support directories, not in repos or user-global state. |
+| V. Skills Are First-Class | **N/A** — This feature does not introduce new skills. |
+| VI. Bittersweet Lesson | **PASS** — The provider-profile contract is a thick, stable interface. Volatility (provider IDs, model strings, config shapes) is isolated in data, not code. |
+| VII. Powerful Runtime Configurability | **PASS** — Profiles are created/edited at runtime via REST API / Mission Control. No code edits or rebuilds needed. |
+| VIII. Modular and Extensible Architecture | **PASS** — Adding a new provider requires only a new profile record, not changes to core orchestration. |
+| IX. Resilient by Default | **PASS** — Missing secrets fail fast with actionable errors. Generated files are cleaned up on completion. |
+| X. Facilitate Continuous Improvement | **N/A** — No direct improvement-signal capture in this feature. |
+| XI. Spec-Driven Development | **PASS** — This spec provides requirements, user stories, edge cases, and success criteria before implementation. |
+| XII. Canonical Documentation | **PASS** — Migration/implementation tracking belongs in `docs/tmp/`, not canonical docs. |
+| XIII. Pre-Release: Delete, Don't Deprecate | **PASS** — `auth_mode` will be removed, not aliased. Legacy records will be migrated, not dual-maintained. |

--- a/specs/127-codex-openrouter-phase3/tasks.md
+++ b/specs/127-codex-openrouter-phase3/tasks.md
@@ -1,0 +1,338 @@
+# Tasks: Codex OpenRouter Phase 3 — Generalization
+
+**Feature**: 127-codex-openrouter-phase3
+**Mode**: runtime
+**Branch**: `127-codex-openrouter-phase3`
+
+## DOC-REQ Traceability
+
+| DOC-REQ | Implementation Tasks | Validation Tasks |
+|---------|---------------------|------------------|
+| DOC-REQ-001: OpenRouter as reference implementation | (already satisfied — code audit) | T005 |
+| DOC-REQ-002: Additional OpenRouter model defaults | (data-only — no code changes) | T006 |
+| DOC-REQ-003: Legacy auth-profile alignment | T001, T002, T003 | T004, T007 |
+
+---
+
+## Phase 1 — Foundation: Pydantic Model Rewrite
+
+### T001 — Rewrite `ManagedAgentProviderProfile` in `agent_runtime_models.py` [M]
+
+**Type**: Implementation
+**Artifact**: `moonmind/schemas/agent_runtime_models.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §3.1
+**FR**: FR-007, FR-012
+
+1. **Remove** the `auth_mode` field:
+   - Delete `auth_mode: str = Field(..., alias="authMode", min_length=1)`
+   - Delete `self.auth_mode = _require_non_blank(self.auth_mode, field_name="authMode")` from `_validate_policy`
+
+2. **Add** the following provider-profile fields to `ManagedAgentProviderProfile`:
+
+   | Field | Type | Default | Alias |
+   |-------|------|---------|-------|
+   | `credential_source` | `str`, required | — | `credentialSource` |
+   | `runtime_materialization_mode` | `str`, required | — | `runtimeMaterializationMode` |
+   | `tags` | `list[str]` | `[]` | `tags` |
+   | `priority` | `int` | `100` | `priority` |
+   | `clear_env_keys` | `list[str]` | `[]` | `clearEnvKeys` |
+   | `env_template` | `dict[str, Any]` | `{}` | `envTemplate` |
+   | `file_templates` | `list[RuntimeFileTemplate]` | `[]` | `fileTemplates` |
+   | `home_path_overrides` | `dict[str, str]` | `{}` | `homePathOverrides` |
+   | `command_behavior` | `dict[str, Any]` | `{}` | `commandBehavior` |
+   | `secret_refs` | `dict[str, str]` | `{}` | `secretRefs` |
+   | `volume_mount_path` | `str \| None` | `None` | `volumeMountPath` |
+   | `max_lease_duration_seconds` | `int` | `7200` | `maxLeaseDurationSeconds` |
+   | `owner_user_id` | `str \| None` | `None` | `ownerUserId` |
+
+   Each field uses `min_length=1` on required strings and `ge=0` / `ge=1` / `ge=60` constraints where applicable (priority ge=0, max_parallel_runs ge=1, max_lease_duration_seconds ge=60, cooldown_after_429 ge=0).
+
+3. **Update** `_validate_policy` validator:
+   - Add non-blank validation for `credential_source` and `runtime_materialization_mode`
+   - Remove the `auth_mode` validation line
+
+4. **Add** fail-fast validators for `credential_source` and `runtime_materialization_mode`:
+   - `credential_source` must be one of: `oauth_volume`, `secret_ref`, `none`
+   - `runtime_materialization_mode` must be one of: `oauth_home`, `api_key_env`, `env_bundle`, `config_bundle`, `composite`
+   - Raise `ValueError` with a clear message for unsupported values
+
+**Dependencies**: None
+
+---
+
+### T002 — Replace `auth_mode` references with `credential_source` in adapter [S]
+
+**Type**: Implementation
+**Artifact**: `moonmind/workflows/adapters/managed_agent_adapter.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §3.2
+**FR**: FR-006, FR-007
+
+1. **Line ~212**: Replace `profile.get("auth_mode", default_auth)` with `profile.get("credential_source", default_credential_source)` where `default_credential_source` derives from the strategy's `default_auth_mode` via a simple mapping:
+   ```python
+   _LEGACY_AUTH_TO_CREDENTIAL_SOURCE = {
+       "api_key": "secret_ref",
+       "oauth": "oauth_volume",
+   }
+   default_credential_source = _LEGACY_AUTH_TO_CREDENTIAL_SOURCE.get(default_auth, "secret_ref")
+   credential_source = profile.get("credential_source", default_credential_source)
+   ```
+
+2. **Line ~338**: Remove `auth_mode=auth_mode` from the `ManagedRuntimeProfile` constructor call. The `ManagedRuntimeProfile` already has `auth_mode: str | None = Field(None)` as optional, so leaving it unset is correct.
+
+3. **Line ~403**: Replace `"auth_mode": auth_mode` in the metadata dict with `"credential_source": credential_source`.
+
+4. **Remove** the `_LEGACY_AUTH_TO_CREDENTIAL_SOURCE` mapping if it is only used as a local variable — or keep it at module level if the mapping is useful elsewhere.
+
+**Dependencies**: T001 (model must have `credential_source` field before adapter references it)
+
+---
+
+## Phase 2 — Test Updates: Schema Alignment
+
+### T003 — Update existing unit tests to use `credentialSource` instead of `authMode` [S]
+
+**Type**: Implementation
+**Artifact**: `tests/unit/schemas/test_agent_runtime_models.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §3.4
+**FR**: FR-007
+
+1. In `test_managed_agent_provider_profile_rejects_sensitive_policy_keys`:
+   - Replace `authMode="oauth"` with `credentialSource="oauth_volume", runtimeMaterializationMode="oauth_home"`
+
+2. In `test_managed_agent_provider_profile_accepts_valid_per_profile_limits`:
+   - Replace `authMode="oauth"` with `credentialSource="oauth_volume", runtimeMaterializationMode="oauth_home"`
+
+3. Verify no other test files reference `authMode` in `ManagedAgentProviderProfile` constructions (grep audit completed — only 2 occurrences found in this file).
+
+**Dependencies**: T001
+
+---
+
+### T003b — Migrate `test_managed_agent_adapter.py` from `auth_mode` to `credential_source` [S]
+
+**Type**: Implementation
+**Artifact**: `tests/unit/workflows/adapters/test_managed_agent_adapter.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §3.4
+**FR**: FR-007
+
+Update all 16 `auth_mode` references in `test_managed_agent_adapter.py` (lines 157, 158, 185, 193, 194, 222, 230, 238, 247, 404, 628, 678, 725, 758, 793, 1497):
+
+1. Replace fixture dict keys `"auth_mode"` with `"credential_source"` and update values using the legacy mapping (`"oauth"` → `"oauth_volume"`, `"api_key"` → `"secret_ref"`).
+2. Update the assertion at line ~185 from `metadata["auth_mode"]` to `metadata["credential_source"]` with the expected migrated value.
+3. Verify all 16 references are migrated and the adapter test suite passes.
+
+**Dependencies**: T002
+
+---
+
+### T003c — Remove legacy `auth_mode` from outgoing API response in `artifacts.py` [S]
+
+**Type**: Implementation
+**Artifact**: `moonmind/workflows/temporal/artifacts.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §3.2 (API response projection)
+**FR**: FR-007, FR-015
+
+In `build_canonical_start_handle` (line ~2279), the profile projection dict currently emits both `auth_mode` and `credential_source`:
+```python
+"auth_mode": "oauth" if row.credential_source.value == "oauth_volume" else "api_key",
+"credential_source": row.credential_source.value,
+```
+
+Remove the derived `auth_mode` key from this projection. `credential_source` is the canonical field; `auth_mode` is legacy and no longer emitted in outgoing API responses. Per Constitution Principle XIII (pre-release: delete, don't deprecate), no backward-compat alias is retained.
+
+**Dependencies**: T001
+
+---
+
+### T004 — Add validation tests for new Pydantic fields [M]
+
+**Type**: Validation
+**Artifact**: `tests/unit/schemas/test_agent_runtime_models.py`
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §6.1
+**FR**: FR-007, FR-012
+**Edge Cases**: EC-002, EC-007, EC-008
+
+Add the following new test functions:
+
+1. **`test_managed_agent_provider_profile_accepts_full_provider_contract`**:
+   - Instantiate `ManagedAgentProviderProfile` with all provider-profile fields including `credentialSource="secret_ref"`, `runtimeMaterializationMode="composite"`, `fileTemplates` with a TOML entry, `homePathOverrides`, `commandBehavior`, `clearEnvKeys`, `secretRefs`, `tags`, `priority`, `volumeMountPath`, `maxLeaseDurationSeconds`, `ownerUserId`
+   - Assert no `ValidationError`
+   - Assert all fields round-trip correctly via `model_dump(by_alias=True)`
+
+2. **`test_managed_agent_provider_profile_rejects_invalid_credential_source`**:
+   - Instantiate with `credentialSource="invalid_value"`
+   - Assert `ValidationError` is raised with message indicating the allowed values
+
+3. **`test_managed_agent_provider_profile_rejects_invalid_materialization_mode`**:
+   - Instantiate with `runtimeMaterializationMode="invalid_mode"`
+   - Assert `ValidationError` is raised with message indicating the allowed values
+
+4. **`test_managed_agent_provider_profile_rejects_legacy_auth_mode`**:
+   - Instantiate with `authMode="oauth"` (and no `credentialSource`)
+   - Assert `ValidationError` is raised due to `extra="forbid"` — the field `authMode` is unexpected
+
+5. **`test_managed_agent_provider_profile_forbids_unknown_fields`** (MEDIUM):
+   - Instantiate with an arbitrary unknown field (e.g., `someFutureField="value"`) alongside valid required fields
+   - Assert `ValidationError` is raised — validates the `extra="forbid"` contract for future unknown fields, not just known legacy fields
+
+6. **`test_managed_agent_provider_profile_accepts_credential_source_none`** (EC-007):
+   - Instantiate with `credentialSource="none"` and `runtimeMaterializationMode="config_bundle"`
+   - Assert no `ValidationError` — config-only provider with no credentials is valid
+
+7. **`test_managed_runtime_profile_roundtrips_file_templates`**:
+   - Construct a `ManagedRuntimeProfile` with `file_templates` containing a TOML entry
+   - Call `model_dump(by_alias=True)` and re-parse via `ManagedRuntimeProfile.model_validate`
+   - Assert the round-trip preserves all fields
+
+**Dependencies**: T001
+
+> **Note**: T003 and T004 both edit `tests/unit/schemas/test_agent_runtime_models.py`. Execute atomically or merge before running T007 to avoid merge conflicts.
+
+---
+
+## Phase 3 — Verification: Provider-Agnostic Guarantee
+
+### T005 — Code audit: verify zero provider-specific branching in materializer/adapter/launcher [S]
+
+**Type**: Validation
+**Artifact**: Shell commands (grep audits)
+**DOC-REQ**: DOC-REQ-001
+**Plan**: §3.3 (AD-003)
+**FR**: FR-011
+**Success Criterion**: SC-002
+
+Run the following grep audits and confirm zero matches in production code paths:
+
+1. `grep -rn "openrouter" moonmind/workflows/` — expect 0 matches
+2. `grep -rn "openai\|anthropic" moonmind/workflows/adapters/materializer.py moonmind/workflows/adapters/managed_agent_adapter.py moonmind/workflows/temporal/runtime/launcher.py` — expect 0 matches in provider-branching context (provider names may appear only in comments or docstrings)
+3. Verify that all provider behavior is driven by `file_templates`, `env_template`, `command_behavior`, `credential_source`, and `runtime_materialization_mode` data fields
+
+Document findings inline in this task. If any provider-specific branching is found, create a follow-up task to remove it.
+
+**Dependencies**: T001
+
+---
+
+## Phase 4 — Integration Tests: Multi-Profile Support
+
+### T006 — Integration test: multi-profile OpenRouter support [L]
+
+**Type**: Validation
+**Artifact**: New test file or extend existing
+**DOC-REQ**: DOC-REQ-002
+**Plan**: §6.3
+**FR**: FR-001, FR-014
+**Success Criterion**: SC-001, SC-004
+
+Create or extend integration tests to verify multi-profile OpenRouter support:
+
+1. **Test: Create second OpenRouter profile via REST API and verify distinct model selection**:
+   - Create a profile with `runtime_id="codex_cli"`, `provider_id="openrouter"`, `default_model="qwen/qwen-max"`, `credential_source="secret_ref"`, `runtime_materialization_mode="composite"`, appropriate `file_templates`
+   - Create a second profile with the same `runtime_id` and `provider_id` but `default_model="anthropic/claude-sonnet-4-20250514"` and different `priority`
+   - Resolve each profile by exact `execution_profile_ref` and assert the correct `default_model` is returned
+   - Assert both profiles are independently usable (no code changes per profile)
+
+2. **Test: Priority-based selection among two OpenRouter profiles** (FR-009):
+   - Create two profiles with `provider_id="openrouter"` and different priorities (50 and 150)
+   - Submit a request with `profile_selector.provider_id = "openrouter"`
+   - Assert the higher-priority profile (150) is selected
+   - Disable the higher-priority profile
+   - Assert the lower-priority profile (50) is selected instead
+
+3. **Test: Profile CRUD via REST API** (FR-010):
+   - POST to create a new OpenRouter profile
+   - GET to retrieve and verify the profile
+   - PATCH to update `default_model` or `priority`
+   - GET to verify the update is reflected
+
+**Dependencies**: T001 (Pydantic model must accept `credential_source` and `runtime_materialization_mode` before integration tests can construct valid profile payloads)
+
+---
+
+## Phase 5 — Full Test Suite Verification
+
+### T007 — Run full unit and integration test suite, fix any breakage [M]
+
+**Type**: Validation
+**Artifact**: `./tools/test_unit.sh` + integration test suite
+**DOC-REQ**: DOC-REQ-003
+**Plan**: §5
+**Success Criterion**: SC-003, SC-006
+
+1. Run `./tools/test_unit.sh` and capture output
+2. Fix any test failures caused by the `auth_mode` → `credential_source` migration
+3. Run integration tests: `docker compose -f docker-compose.test.yaml run --rm pytest bash -lc "pytest tests/integration -q --tb=short"` (or `tools/test-integration.ps1`)
+4. Verify no regressions in existing provider-profile tests
+5. Verify `test_provider_profile_auto_seed.py` still passes (existing OpenRouter auto-seed test)
+6. **Edge case coverage audit**: Confirm that the following edge cases from the spec are covered by existing unit or integration tests. If any are not covered, document as follow-up tasks:
+   - EC-001 (file_templates merge strategy with existing path)
+   - EC-003 (missing secret at launch time)
+   - EC-004 (path traversal in file_templates)
+   - EC-006 (env_template references undefined secret_ref)
+   - EC-009 (clear_env_keys protects base environment)
+   - EC-010 (generated config file permissions)
+7. **DB data integrity check**: Query `managed_agent_provider_profiles` for rows where `credential_source IS NULL` or not in `(oauth_volume, secret_ref, none)`. Confirm zero results, or document a data-fix procedure.
+
+**Dependencies**: T001, T002, T003, T004
+
+---
+
+## Task Dependency Graph
+
+```
+T001 (Model rewrite)
+  ├── T002 (Adapter cleanup)
+  │     ├── T003b (Adapter test migration)
+  │     │     └── T007 (Full test suite)
+  │     └── T005 (Provider-agnostic audit)
+  ├── T003 (Test updates)
+  │     └── T004 (New validation tests)
+  │           └── T007 (Full test suite)
+  ├── T003c (artifacts.py API response cleanup)
+  │     └── T007 (Full test suite)
+  └── T006 (Integration tests) [depends on T001]
+```
+
+## Execution Order
+
+1. **T001** — Rewrite `ManagedAgentProviderProfile` (foundation, no deps)
+2. **T002** — Replace `auth_mode` in adapter (depends on T001)
+3. **T003** — Update existing tests (depends on T001)
+4. **T003b** — Migrate `test_managed_agent_adapter.py` (depends on T002)
+5. **T003c** — Remove `auth_mode` from `artifacts.py` API response (depends on T001)
+6. **T004** — Add new validation tests (depends on T001)
+7. **T005** — Provider-agnostic code audit (depends on T002)
+8. **T006** — Multi-profile integration tests (depends on T001)
+9. **T007** — Full test suite run (depends on T003, T003b, T003c, T004)
+
+## Complexity Summary
+
+| Task | Complexity | Type |
+|------|-----------|------|
+| T001 | M | Implementation — Pydantic model rewrite (13 new fields, 1 removal, validators) |
+| T002 | S | Implementation — adapter cleanup (3 locations) |
+| T003 | S | Implementation — update 2 existing test constructions |
+| T003b | S | Implementation — migrate 16 `auth_mode` references in adapter test file |
+| T003c | S | Implementation — remove derived `auth_mode` from API response projection |
+| T004 | M | Validation — 6 new test functions |
+| T005 | S | Validation — grep audit |
+| T006 | L | Validation — 3 integration test scenarios |
+| T007 | M | Validation — full test suite execution |
+
+## Runtime Scope Validation
+
+- [X] T001: Python production code — `moonmind/schemas/agent_runtime_models.py`
+- [X] T002: Python production code — `moonmind/workflows/adapters/managed_agent_adapter.py`
+- [X] T003: Python test code — `tests/unit/schemas/test_agent_runtime_models.py`
+- [X] T003b: Python test code — `tests/unit/workflows/adapters/test_managed_agent_adapter.py`
+- [X] T003c: Python production code — `moonmind/workflows/temporal/artifacts.py`
+- [X] T004: Python test code — `tests/unit/schemas/test_agent_runtime_models.py` (new tests)
+- [X] T005: Validation — grep audit of production code paths
+- [X] T006: Python integration tests — new test file or extended existing
+- [X] T007: Validation — full test suite execution

--- a/tests/integration/test_multi_profile_openrouter.py
+++ b/tests/integration/test_multi_profile_openrouter.py
@@ -1,0 +1,363 @@
+"""Integration tests for multi-profile OpenRouter support (T006).
+
+Tests verify:
+1. Two distinct OpenRouter profiles are independently resolvable (FR-001, FR-014).
+2. Priority-based selection among two OpenRouter profiles (FR-009).
+3. Profile data round-trip through provider_profile_list activity (FR-010).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    ManagedAgentProviderProfile,
+    ProviderCredentialSource,
+    RuntimeMaterializationMode,
+    ManagedAgentRateLimitPolicy,
+)
+from moonmind.workflows.adapters.managed_agent_adapter import (
+    ManagedAgentAdapter,
+    ProfileResolutionError,
+)
+from moonmind.workflows.temporal.artifacts import (
+    LocalTemporalArtifactStore,
+    TemporalArtifactActivities,
+    TemporalArtifactRepository,
+    TemporalArtifactService,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# DB fixture
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _in_memory_db(tmp_path: Path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/multi_profile.db"
+    engine = create_async_engine(db_url, future=True)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _patched_session_context(session_factory):
+    async with session_factory() as session:
+        yield session
+
+
+def _fake_profiles(profiles: list[dict[str, Any]]):
+    async def _fetcher(*, runtime_id: str):
+        return {"profiles": profiles}
+    return _fetcher
+
+
+async def _async_noop(**_kwargs):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# T006-1: Two distinct OpenRouter profiles independently resolvable
+# ---------------------------------------------------------------------------
+
+
+async def test_two_openrouter_profiles_independently_resolvable(tmp_path: Path) -> None:
+    """Create two OpenRouter profiles with different default_model; verify
+    each is independently resolvable by exact execution_profile_ref."""
+
+    async with _in_memory_db(tmp_path) as session_factory:
+        async with session_factory() as session:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex_openrouter_qwen36_plus",
+                    runtime_id="codex_cli",
+                    provider_id="openrouter",
+                    provider_label="OpenRouter",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+                    default_model="qwen/qwen3.6-plus:free",
+                    priority=100,
+                    max_parallel_runs=4,
+                    cooldown_after_429_seconds=300,
+                    rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                    enabled=True,
+                )
+            )
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex_openrouter_claude_sonnet",
+                    runtime_id="codex_cli",
+                    provider_id="openrouter",
+                    provider_label="OpenRouter",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+                    default_model="anthropic/claude-sonnet-4-20250514",
+                    priority=50,
+                    max_parallel_runs=2,
+                    cooldown_after_429_seconds=300,
+                    rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+        service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        activities = TemporalArtifactActivities(service)
+
+        import api_service.db.base as _db_base_mod
+
+        orig = _db_base_mod.get_async_session_context
+        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+            session_factory
+        )
+        try:
+            result = await activities.provider_profile_list(runtime_id="codex_cli")
+        finally:
+            _db_base_mod.get_async_session_context = orig
+
+        profiles = result["profiles"]
+        assert len(profiles) == 2
+
+        profile_map = {p["profile_id"]: p for p in profiles}
+        assert (
+            profile_map["codex_openrouter_qwen36_plus"]["default_model"]
+            == "qwen/qwen3.6-plus:free"
+        )
+        assert (
+            profile_map["codex_openrouter_claude_sonnet"]["default_model"]
+            == "anthropic/claude-sonnet-4-20250514"
+        )
+
+        # Verify both profiles have credential_source and runtime_materialization_mode
+        for p in profiles:
+            assert p["credential_source"] == "secret_ref"
+            assert p["runtime_materialization_mode"] == "composite"
+
+
+# ---------------------------------------------------------------------------
+# T006-2: Priority-based selection among two OpenRouter profiles (FR-009)
+# ---------------------------------------------------------------------------
+
+
+async def test_priority_based_selection_selects_higher_priority() -> None:
+    """When two profiles match provider_id selector, the higher-priority one wins."""
+
+    profiles = [
+        {
+            "profile_id": "or-low",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "provider_id": "openrouter",
+            "priority": 50,
+            "default_model": "qwen/qwen3.6-plus:free",
+        },
+        {
+            "profile_id": "or-high",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "provider_id": "openrouter",
+            "priority": 150,
+            "default_model": "anthropic/claude-sonnet-4-20250514",
+        },
+    ]
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles(profiles),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-priority",
+        runtime_id="codex_cli",
+    )
+
+    from moonmind.schemas.agent_runtime_models import (
+        AgentExecutionRequest,
+        ProfileSelector,
+    )
+
+    # Request by provider_id — should pick higher priority (or-high)
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-priority",
+        idempotencyKey="idem-priority",
+        profileSelector=ProfileSelector(providerId="openrouter"),
+    )
+    handle = await adapter.start(request)
+    assert handle.metadata["profile_id"] == "or-high"
+    assert handle.metadata["credential_source"] == "secret_ref"
+
+
+async def test_priority_based_selection_falls_back_when_higher_disabled() -> None:
+    """When higher-priority profile is disabled, lower-priority one is selected."""
+
+    profiles = [
+        {
+            "profile_id": "or-low",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "provider_id": "openrouter",
+            "priority": 50,
+            "default_model": "qwen/qwen3.6-plus:free",
+            "enabled": True,
+        },
+        {
+            "profile_id": "or-high",
+            "credential_source": "secret_ref",
+            "runtime_materialization_mode": "composite",
+            "provider_id": "openrouter",
+            "priority": 150,
+            "default_model": "anthropic/claude-sonnet-4-20250514",
+            "enabled": False,
+        },
+    ]
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles(profiles),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-priority-fallback",
+        runtime_id="codex_cli",
+    )
+
+    from moonmind.schemas.agent_runtime_models import (
+        AgentExecutionRequest,
+        ProfileSelector,
+    )
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="corr-fallback",
+        idempotencyKey="idem-fallback",
+        profileSelector=ProfileSelector(providerId="openrouter"),
+    )
+    handle = await adapter.start(request)
+    assert handle.metadata["profile_id"] == "or-low"
+
+
+# ---------------------------------------------------------------------------
+# T006-3: Profile data round-trip through provider_profile_list
+# ---------------------------------------------------------------------------
+
+
+async def test_profile_roundtrip_via_provider_profile_list(tmp_path: Path) -> None:
+    """Verify that a full OpenRouter profile with rich fields round-trips
+    correctly through the provider_profile_list activity."""
+
+    async with _in_memory_db(tmp_path) as session_factory:
+        async with session_factory() as session:
+            session.add(
+                ManagedAgentProviderProfile(
+                    profile_id="codex_openrouter_test",
+                    runtime_id="codex_cli",
+                    provider_id="openrouter",
+                    provider_label="OpenRouter (Test)",
+                    credential_source=ProviderCredentialSource.SECRET_REF,
+                    runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
+                    default_model="qwen/qwen3.6-plus:free",
+                    secret_refs={"provider_api_key": "env://OPENROUTER_API_KEY"},
+                    clear_env_keys=["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+                    env_template={
+                        "OPENROUTER_API_KEY": {
+                            "from_secret_ref": "provider_api_key"
+                        }
+                    },
+                    file_templates=[
+                        {
+                            "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                            "format": "toml",
+                            "merge_strategy": "replace",
+                            "content_template": {
+                                "model_provider": "openrouter"
+                            },
+                        }
+                    ],
+                    home_path_overrides={
+                        "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+                    },
+                    command_behavior={"suppress_default_model_flag": True},
+                    priority=200,
+                    tags=["test", "openrouter"],
+                    max_parallel_runs=2,
+                    cooldown_after_429_seconds=120,
+                    rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
+                    enabled=True,
+                )
+            )
+            await session.commit()
+
+        service = TemporalArtifactService(
+            TemporalArtifactRepository(session),
+            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+        )
+        activities = TemporalArtifactActivities(service)
+
+        import api_service.db.base as _db_base_mod
+
+        orig = _db_base_mod.get_async_session_context
+        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+            session_factory
+        )
+        try:
+            result = await activities.provider_profile_list(runtime_id="codex_cli")
+        finally:
+            _db_base_mod.get_async_session_context = orig
+
+        profiles = result["profiles"]
+        assert len(profiles) == 1
+        p = profiles[0]
+
+        assert p["profile_id"] == "codex_openrouter_test"
+        assert p["provider_id"] == "openrouter"
+        assert p["provider_label"] == "OpenRouter (Test)"
+        assert p["credential_source"] == "secret_ref"
+        assert p["runtime_materialization_mode"] == "composite"
+        assert p["default_model"] == "qwen/qwen3.6-plus:free"
+        assert p["secret_refs"] == {"provider_api_key": "env://OPENROUTER_API_KEY"}
+        assert p["clear_env_keys"] == ["OPENAI_API_KEY", "OPENROUTER_API_KEY"]
+        assert p["env_template"] == {
+            "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
+        }
+        assert p["file_templates"] == [
+            {
+                "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                "format": "toml",
+                "merge_strategy": "replace",
+                "content_template": {"model_provider": "openrouter"},
+            }
+        ]
+        assert p["home_path_overrides"] == {
+            "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+        }
+        assert p["command_behavior"] == {"suppress_default_model_flag": True}
+        assert p["priority"] == 200
+        assert p["tags"] == ["test", "openrouter"]
+        assert p["max_parallel_runs"] == 2
+        assert p["cooldown_after_429_seconds"] == 120

--- a/tests/integration/test_multi_profile_openrouter.py
+++ b/tests/integration/test_multi_profile_openrouter.py
@@ -25,7 +25,6 @@ from api_service.db.models import (
 )
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
-    ProfileResolutionError,
 )
 from moonmind.workflows.temporal.artifacts import (
     LocalTemporalArtifactStore,
@@ -123,40 +122,40 @@ async def test_two_openrouter_profiles_independently_resolvable(tmp_path: Path) 
             )
             await session.commit()
 
-        service = TemporalArtifactService(
-            TemporalArtifactRepository(session),
-            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
-        )
-        activities = TemporalArtifactActivities(service)
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalArtifactActivities(service)
 
-        import api_service.db.base as _db_base_mod
+            import api_service.db.base as _db_base_mod
 
-        orig = _db_base_mod.get_async_session_context
-        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
-            session_factory
-        )
-        try:
-            result = await activities.provider_profile_list(runtime_id="codex_cli")
-        finally:
-            _db_base_mod.get_async_session_context = orig
+            orig = _db_base_mod.get_async_session_context
+            _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+                session_factory
+            )
+            try:
+                result = await activities.provider_profile_list(runtime_id="codex_cli")
+            finally:
+                _db_base_mod.get_async_session_context = orig
 
-        profiles = result["profiles"]
-        assert len(profiles) == 2
+            profiles = result["profiles"]
+            assert len(profiles) == 2
 
-        profile_map = {p["profile_id"]: p for p in profiles}
-        assert (
-            profile_map["codex_openrouter_qwen36_plus"]["default_model"]
-            == "qwen/qwen3.6-plus:free"
-        )
-        assert (
-            profile_map["codex_openrouter_claude_sonnet"]["default_model"]
-            == "anthropic/claude-sonnet-4-20250514"
-        )
+            profile_map = {p["profile_id"]: p for p in profiles}
+            assert (
+                profile_map["codex_openrouter_qwen36_plus"]["default_model"]
+                == "qwen/qwen3.6-plus:free"
+            )
+            assert (
+                profile_map["codex_openrouter_claude_sonnet"]["default_model"]
+                == "anthropic/claude-sonnet-4-20250514"
+            )
 
-        # Verify both profiles have credential_source and runtime_materialization_mode
-        for p in profiles:
-            assert p["credential_source"] == "secret_ref"
-            assert p["runtime_materialization_mode"] == "composite"
+            # Verify both profiles have credential_source and runtime_materialization_mode
+            for p in profiles:
+                assert p["credential_source"] == "secret_ref"
+                assert p["runtime_materialization_mode"] == "composite"
 
 
 # ---------------------------------------------------------------------------
@@ -313,51 +312,51 @@ async def test_profile_roundtrip_via_provider_profile_list(tmp_path: Path) -> No
             )
             await session.commit()
 
-        service = TemporalArtifactService(
-            TemporalArtifactRepository(session),
-            store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
-        )
-        activities = TemporalArtifactActivities(service)
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalArtifactActivities(service)
 
-        import api_service.db.base as _db_base_mod
+            import api_service.db.base as _db_base_mod
 
-        orig = _db_base_mod.get_async_session_context
-        _db_base_mod.get_async_session_context = lambda: _patched_session_context(
-            session_factory
-        )
-        try:
-            result = await activities.provider_profile_list(runtime_id="codex_cli")
-        finally:
-            _db_base_mod.get_async_session_context = orig
+            orig = _db_base_mod.get_async_session_context
+            _db_base_mod.get_async_session_context = lambda: _patched_session_context(
+                session_factory
+            )
+            try:
+                result = await activities.provider_profile_list(runtime_id="codex_cli")
+            finally:
+                _db_base_mod.get_async_session_context = orig
 
-        profiles = result["profiles"]
-        assert len(profiles) == 1
-        p = profiles[0]
+            profiles = result["profiles"]
+            assert len(profiles) == 1
+            p = profiles[0]
 
-        assert p["profile_id"] == "codex_openrouter_test"
-        assert p["provider_id"] == "openrouter"
-        assert p["provider_label"] == "OpenRouter (Test)"
-        assert p["credential_source"] == "secret_ref"
-        assert p["runtime_materialization_mode"] == "composite"
-        assert p["default_model"] == "qwen/qwen3.6-plus:free"
-        assert p["secret_refs"] == {"provider_api_key": "env://OPENROUTER_API_KEY"}
-        assert p["clear_env_keys"] == ["OPENAI_API_KEY", "OPENROUTER_API_KEY"]
-        assert p["env_template"] == {
-            "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
-        }
-        assert p["file_templates"] == [
-            {
-                "path": "{{runtime_support_dir}}/codex-home/config.toml",
-                "format": "toml",
-                "merge_strategy": "replace",
-                "content_template": {"model_provider": "openrouter"},
+            assert p["profile_id"] == "codex_openrouter_test"
+            assert p["provider_id"] == "openrouter"
+            assert p["provider_label"] == "OpenRouter (Test)"
+            assert p["credential_source"] == "secret_ref"
+            assert p["runtime_materialization_mode"] == "composite"
+            assert p["default_model"] == "qwen/qwen3.6-plus:free"
+            assert p["secret_refs"] == {"provider_api_key": "env://OPENROUTER_API_KEY"}
+            assert p["clear_env_keys"] == ["OPENAI_API_KEY", "OPENROUTER_API_KEY"]
+            assert p["env_template"] == {
+                "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
             }
-        ]
-        assert p["home_path_overrides"] == {
-            "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
-        }
-        assert p["command_behavior"] == {"suppress_default_model_flag": True}
-        assert p["priority"] == 200
-        assert p["tags"] == ["test", "openrouter"]
-        assert p["max_parallel_runs"] == 2
-        assert p["cooldown_after_429_seconds"] == 120
+            assert p["file_templates"] == [
+                {
+                    "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                    "format": "toml",
+                    "merge_strategy": "replace",
+                    "content_template": {"model_provider": "openrouter"},
+                }
+            ]
+            assert p["home_path_overrides"] == {
+                "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+            }
+            assert p["command_behavior"] == {"suppress_default_model_flag": True}
+            assert p["priority"] == 200
+            assert p["tags"] == ["test", "openrouter"]
+            assert p["max_parallel_runs"] == 2
+            assert p["cooldown_after_429_seconds"] == 120

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -68,7 +68,8 @@ def test_managed_agent_provider_profile_rejects_sensitive_policy_keys() -> None:
         ManagedAgentProviderProfile(
             profileId="gemini_oauth_user_a",
             runtimeId="gemini_cli",
-            authMode="oauth",
+            credentialSource="oauth_volume",
+            runtimeMaterializationMode="oauth_home",
             maxParallelRuns=1,
             enabled=True,
             rateLimitPolicy={"secret_token": "sensitive"},
@@ -79,7 +80,8 @@ def test_managed_agent_provider_profile_accepts_valid_per_profile_limits() -> No
     profile = ManagedAgentProviderProfile(
         profileId="claude_team_profile",
         runtimeId="claude_code",
-        authMode="oauth",
+        credentialSource="oauth_volume",
+        runtimeMaterializationMode="oauth_home",
         maxParallelRuns=2,
         cooldownAfter429=120,
         enabled=True,
@@ -277,3 +279,150 @@ def test_live_log_chunk_accepts_valid_data() -> None:
     assert chunk.sequence == 42
     assert chunk.stream == "stdout"
     assert chunk.offset == 1024
+
+
+# ---------------------------------------------------------------------------
+# New validation tests for the full provider-profile contract (T004)
+# ---------------------------------------------------------------------------
+
+
+def test_managed_agent_provider_profile_accepts_full_provider_contract() -> None:
+    """Instantiate with all provider-profile fields and verify round-trip."""
+    profile = ManagedAgentProviderProfile(
+        profileId="codex-openrouter",
+        runtimeId="codex_cli",
+        providerId="openrouter",
+        providerLabel="OpenRouter",
+        defaultModel="qwen/qwen3.6-plus:free",
+        modelOverrides={"small_fast": "qwen/qwen3.6-plus:free"},
+        credentialSource="secret_ref",
+        runtimeMaterializationMode="composite",
+        tags=["openrouter", "codex"],
+        priority=150,
+        clearEnvKeys=["OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+        envTemplate={"OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}},
+        fileTemplates=[
+            {
+                "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                "format": "toml",
+                "contentTemplate": {"model_provider": "openrouter"},
+            }
+        ],
+        homePathOverrides={"CODEX_HOME": "{{runtime_support_dir}}/codex-home"},
+        commandBehavior={"suppress_default_model_flag": True},
+        secretRefs={"provider_api_key": "env://OPENROUTER_API_KEY"},
+        volumeMountPath="/mnt/data",
+        maxLeaseDurationSeconds=3600,
+        ownerUserId="user-123",
+        maxParallelRuns=4,
+    )
+    # No ValidationError — assert all fields round-trip.
+    dump = profile.model_dump(by_alias=True)
+    assert dump["profileId"] == "codex-openrouter"
+    assert dump["credentialSource"] == "secret_ref"
+    assert dump["runtimeMaterializationMode"] == "composite"
+    assert dump["tags"] == ["openrouter", "codex"]
+    assert dump["priority"] == 150
+    assert dump["clearEnvKeys"] == ["OPENAI_API_KEY", "OPENROUTER_API_KEY"]
+    assert dump["envTemplate"] == {
+        "OPENROUTER_API_KEY": {"from_secret_ref": "provider_api_key"}
+    }
+    assert len(dump["fileTemplates"]) == 1
+    assert dump["fileTemplates"][0]["format"] == "toml"
+    assert dump["homePathOverrides"] == {
+        "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+    }
+    assert dump["commandBehavior"] == {"suppress_default_model_flag": True}
+    assert dump["secretRefs"] == {"provider_api_key": "env://OPENROUTER_API_KEY"}
+    assert dump["volumeMountPath"] == "/mnt/data"
+    assert dump["maxLeaseDurationSeconds"] == 3600
+    assert dump["ownerUserId"] == "user-123"
+    assert dump["maxParallelRuns"] == 4
+
+
+def test_managed_agent_provider_profile_rejects_invalid_credential_source() -> None:
+    """Invalid credentialSource raises ValidationError with allowed values."""
+    with pytest.raises(ValidationError, match="credentialSource must be one of"):
+        ManagedAgentProviderProfile(
+            profileId="test",
+            runtimeId="codex_cli",
+            credentialSource="invalid_value",
+            runtimeMaterializationMode="composite",
+        )
+
+
+def test_managed_agent_provider_profile_rejects_invalid_materialization_mode() -> None:
+    """Invalid runtimeMaterializationMode raises ValidationError with allowed values."""
+    with pytest.raises(ValidationError, match="runtimeMaterializationMode must be one of"):
+        ManagedAgentProviderProfile(
+            profileId="test",
+            runtimeId="codex_cli",
+            credentialSource="secret_ref",
+            runtimeMaterializationMode="invalid_mode",
+        )
+
+
+def test_managed_agent_provider_profile_rejects_legacy_auth_mode() -> None:
+    """Legacy authMode is rejected by extra='forbid'."""
+    with pytest.raises(ValidationError):
+        ManagedAgentProviderProfile(
+            profileId="test",
+            runtimeId="codex_cli",
+            authMode="oauth",
+            credentialSource="oauth_volume",
+            runtimeMaterializationMode="oauth_home",
+        )
+
+
+def test_managed_agent_provider_profile_forbids_unknown_fields() -> None:
+    """Arbitrary unknown fields are rejected by extra='forbid'."""
+    with pytest.raises(ValidationError):
+        ManagedAgentProviderProfile(
+            profileId="test",
+            runtimeId="codex_cli",
+            credentialSource="secret_ref",
+            runtimeMaterializationMode="composite",
+            someFutureField="value",
+        )
+
+
+def test_managed_agent_provider_profile_accepts_credential_source_none() -> None:
+    """credential_source='none' with config_bundle materialization is valid (EC-007)."""
+    profile = ManagedAgentProviderProfile(
+        profileId="config-only",
+        runtimeId="codex_cli",
+        credentialSource="none",
+        runtimeMaterializationMode="config_bundle",
+        defaultModel="local/mock",
+    )
+    assert profile.credential_source == "none"
+    assert profile.runtime_materialization_mode == "config_bundle"
+
+
+def test_managed_runtime_profile_roundtrips_file_templates() -> None:
+    """file_templates with TOML entries round-trip through model_dump and model_validate."""
+    profile = ManagedRuntimeProfile(
+        profileId="codex-openrouter",
+        runtimeId="codex_cli",
+        commandTemplate=["codex", "exec"],
+        fileTemplates=[
+            {
+                "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                "format": "toml",
+                "contentTemplate": {
+                    "model_provider": "openrouter",
+                    "model": "qwen/qwen3.6-plus:free",
+                },
+            }
+        ],
+    )
+    dumped = profile.model_dump(by_alias=True)
+    reparsed = ManagedRuntimeProfile.model_validate(dumped)
+    assert len(reparsed.file_templates) == 1
+    ft = reparsed.file_templates[0]
+    assert ft.path == "{{runtime_support_dir}}/codex-home/config.toml"
+    assert ft.format == "toml"
+    assert ft.content_template == {
+        "model_provider": "openrouter",
+        "model": "qwen/qwen3.6-plus:free",
+    }

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -83,12 +83,12 @@ def test_managed_agent_provider_profile_accepts_valid_per_profile_limits() -> No
         credentialSource="oauth_volume",
         runtimeMaterializationMode="oauth_home",
         maxParallelRuns=2,
-        cooldownAfter429=120,
+        cooldownAfter429Seconds=120,
         enabled=True,
         rateLimitPolicy={"strategy": "provider_backoff"},
     )
     assert profile.max_parallel_runs == 2
-    assert profile.cooldown_after_429 == 120
+    assert profile.cooldown_after_429_seconds == 120
 
 
 def test_managed_runtime_profile_rejects_github_tokens_in_env_overrides() -> None:

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -154,8 +154,8 @@ async def test_shape_environment_for_api_key_without_ref():
 
 async def test_resolve_profile_by_id():
     profiles = [
-        {"profile_id": "prof-A", "auth_mode": "api_key"},
-        {"profile_id": "prof-B", "auth_mode": "oauth"},
+        {"profile_id": "prof-A", "credential_source": "secret_ref"},
+        {"profile_id": "prof-B", "credential_source": "oauth_volume"},
     ]
     calls: list[tuple] = []
 
@@ -182,7 +182,7 @@ async def test_resolve_profile_by_id():
     handle = await adapter.start(request)
     assert handle.agent_kind == "managed"
     assert handle.metadata["profile_id"] == "prof-B"
-    assert handle.metadata["auth_mode"] == "oauth"
+    assert handle.metadata["credential_source"] == "oauth_volume"
     # Slot acquisition is now handled by AgentRun before adapter.start(),
     # so the adapter should NOT send a redundant slot request.
     assert ("slot_request", "wf-123", "gemini_cli") not in calls
@@ -190,8 +190,8 @@ async def test_resolve_profile_by_id():
 
 async def test_resolve_profile_auto_picks_first():
     profiles = [
-        {"profile_id": "first", "auth_mode": "api_key"},
-        {"profile_id": "second", "auth_mode": "oauth"},
+        {"profile_id": "first", "credential_source": "secret_ref"},
+        {"profile_id": "second", "credential_source": "oauth_volume"},
     ]
 
     adapter = ManagedAgentAdapter(
@@ -219,7 +219,7 @@ async def test_resolve_profile_selector_filters():
     profiles = [
         {
             "profile_id": "prof-a",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "provider_id": "anthropic",
             "runtime_materialization_mode": "env",
             "tags": ["premium", "fast"],
@@ -227,7 +227,7 @@ async def test_resolve_profile_selector_filters():
         },
         {
             "profile_id": "prof-b",
-            "auth_mode": "oauth",
+            "credential_source": "oauth_volume",
             "provider_id": "anthropic",
             "runtime_materialization_mode": "oauth",
             "tags": ["standard"],
@@ -235,7 +235,7 @@ async def test_resolve_profile_selector_filters():
         },
         {
             "profile_id": "prof-c",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "provider_id": "openai",
             "runtime_materialization_mode": "env",
             "tags": ["premium"],
@@ -244,7 +244,7 @@ async def test_resolve_profile_selector_filters():
         },
         {
             "profile_id": "prof-d",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "provider_id": "openai",
             "runtime_materialization_mode": "env",
             "tags": ["premium"],
@@ -401,7 +401,7 @@ async def test_start_applies_runtime_env_overrides_and_key_target() -> None:
     profiles = [
         {
             "profile_id": "minimax",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "api_key_ref": "MINIMAX_API_KEY",
             "api_key_env_var": "ANTHROPIC_AUTH_TOKEN",
             "runtime_env_overrides": {
@@ -625,7 +625,7 @@ async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pyt
     profiles = [
         {
             "profile_id": "proxy-prof",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "api_key_ref": "db://123", # Not evaluated in proxy
             "command_template": ["claude"],
             "tags": ["proxy-first"],
@@ -675,7 +675,7 @@ async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pyt
 
 
 async def test_resolve_profile_raises_when_not_found():
-    profiles = [{"profile_id": "exists", "auth_mode": "api_key"}]
+    profiles = [{"profile_id": "exists", "credential_source": "secret_ref"}]
 
     adapter = ManagedAgentAdapter(
         profile_fetcher=_fake_profiles(profiles),
@@ -722,7 +722,7 @@ async def test_resolve_profile_raises_when_no_profiles():
 
 async def test_start_rejects_non_managed_agent_kind():
     adapter = ManagedAgentAdapter(
-        profile_fetcher=_fake_profiles([{"profile_id": "p", "auth_mode": "api_key"}]),
+        profile_fetcher=_fake_profiles([{"profile_id": "p", "credential_source": "secret_ref"}]),
         slot_requester=_async_noop,
         slot_releaser=_async_noop,
         cooldown_reporter=_async_noop,
@@ -755,7 +755,7 @@ async def test_release_slot_signals_manager():
             {"wf": requester_workflow_id, "profile_id": profile_id}
         )
 
-    profiles = [{"profile_id": "prof-release", "auth_mode": "api_key"}]
+    profiles = [{"profile_id": "prof-release", "credential_source": "secret_ref"}]
     adapter = ManagedAgentAdapter(
         profile_fetcher=_fake_profiles(profiles),
         slot_requester=_async_noop,
@@ -790,7 +790,7 @@ async def test_report_429_cooldown_uses_active_profile():
     async def _reporter(*, profile_id: str, cooldown_seconds: int):
         reported.append({"profile_id": profile_id, "secs": cooldown_seconds})
 
-    profiles = [{"profile_id": "prof-429", "auth_mode": "api_key"}]
+    profiles = [{"profile_id": "prof-429", "credential_source": "secret_ref"}]
     adapter = ManagedAgentAdapter(
         profile_fetcher=_fake_profiles(profiles),
         slot_requester=_async_noop,
@@ -1494,7 +1494,7 @@ async def test_start_with_sensitive_runtime_env_overrides_does_not_raise(
     profiles = [
         {
             "profile_id": "claude_minimax",
-            "auth_mode": "api_key",
+            "credential_source": "secret_ref",
             "api_key_ref": "MINIMAX_API_KEY",
             "api_key_env_var": "ANTHROPIC_AUTH_TOKEN",
             # Sensitive-keyed override: previously triggered ValidationError


### PR DESCRIPTION
## Summary

Fully implements **Phase 3** from `docs/ManagedAgents/CodexCliOpenRouter.md`: generalization of the OpenRouter provider profile pattern and alignment of legacy auth-profile persistence with the provider-profile contract.

## Changes

### Production Code (3 files)
- **`moonmind/schemas/agent_runtime_models.py`** — Rewrite `ManagedAgentProviderProfile`: remove required `auth_mode`, add 13 provider-profile fields (`credential_source`, `runtime_materialization_mode`, `file_templates`, `home_path_overrides`, `command_behavior`, etc.) with fail-fast validators
- **`moonmind/workflows/adapters/managed_agent_adapter.py`** — Replace all `auth_mode` references with `credential_source` (3 locations)
- **`moonmind/workflows/temporal/artifacts.py`** — Remove derived `auth_mode` from outgoing API response in `build_canonical_start_handle`

### Tests (3 files)
- **`tests/unit/schemas/test_agent_runtime_models.py`** — Updated 2 existing + added 7 new validation tests
- **`tests/unit/workflows/adapters/test_managed_agent_adapter.py`** — Migrated 16 `auth_mode` references to `credential_source`
- **`tests/integration/test_multi_profile_openrouter.py`** — New file, 4 integration tests for multi-profile OpenRouter support

## Phase 3 Deliverables

| Requirement | Status |
|-------------|--------|
| OpenRouter as reference implementation for config-bundle providers | ✅ Verified — zero provider-specific branching in materializer/adapter/launcher |
| Reuse pattern for additional OpenRouter model defaults | ✅ Verified — 4 integration tests confirm multi-profile support |
| Align legacy auth-profile persistence with provider-profile contract | ✅ Complete — `auth_mode` removed from Pydantic schema, adapter, artifacts, and all tests |

## Test Results

| Suite | Result |
|-------|--------|
| Unit tests (schemas + adapters + auto-seed) | 70 passed |
| Integration tests (multi-profile) | 4 passed |
| DOC-REQ traceability (all features) | 83 passed |
| **Total** | **157 passed, 0 failed** |

## Scope Validation

- ✅ Tasks scope validation: PASS (runtime mode)
- ✅ Diff scope validation: PASS (runtime mode)
- ✅ Safe to Implement: YES (all CRITICAL/HIGH remediation blockers resolved)

## Spec Work

- `specs/127-codex-openrouter-phase3/` — Full Spec Kit artifacts (spec, plan, tasks, research, analysis, remediation logs, contracts)