### PR TITLE
[codex] Detect stalled managed runtime progress

### DIFF
--- a/moonmind/workflows/temporal/runtime/strategies/base.py
+++ b/moonmind/workflows/temporal/runtime/strategies/base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -186,6 +187,25 @@ class ManagedRuntimeStrategy(ABC):
     def terminate_on_live_rate_limit(self) -> bool:
         """Whether supervisor should stop the process on streamed rate-limit events."""
         return False
+
+    def progress_stall_timeout_seconds(self, *, timeout_seconds: int) -> int | None:
+        """Return the max allowed idle-progress window before the runtime is stalled.
+
+        ``None`` disables supervisor-owned stall termination for the runtime.
+        """
+
+        return None
+
+    def probe_progress_at(
+        self,
+        *,
+        workspace_path: str | None,
+        run_id: str,
+        started_at: datetime,
+    ) -> datetime | None:
+        """Return the latest runtime-specific progress timestamp, if observable."""
+
+        return None
 
     def should_retry_exit(self, failure_class: str | None) -> bool:
         """Determine if a failure class should trigger a self-heal retry.

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,8 @@ _CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
     "CODEX_CONFIG_HOME",
     "CODEX_CONFIG_PATH",
 })
+_CODEX_PROGRESS_TIMEOUT_SECONDS = 300
+_CODEX_PROGRESS_MTIME_PADDING_SECONDS = 5.0
 
 
 class CodexCliStrategy(ManagedRuntimeStrategy):
@@ -40,6 +43,14 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
     @property
     def default_command_template(self) -> list[str]:
         return ["codex", "exec"]
+
+    def progress_stall_timeout_seconds(self, *, timeout_seconds: int) -> int | None:
+        """Cap how long a Codex run may stop advancing its session state."""
+
+        normalized_timeout = int(timeout_seconds) if timeout_seconds > 0 else 0
+        if normalized_timeout <= 0:
+            return _CODEX_PROGRESS_TIMEOUT_SECONDS
+        return min(normalized_timeout, _CODEX_PROGRESS_TIMEOUT_SECONDS)
 
     def build_command(
         self,
@@ -132,3 +143,50 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             request=request,
             workspace_path=workspace_path,
         )
+
+    def probe_progress_at(
+        self,
+        *,
+        workspace_path: str | None,
+        run_id: str,
+        started_at: datetime,
+    ) -> datetime | None:
+        """Use Codex session artifacts as the managed-run progress signal."""
+
+        codex_home = self._resolve_codex_home(workspace_path)
+        if codex_home is None:
+            return None
+
+        threshold_ts = started_at.timestamp() - _CODEX_PROGRESS_MTIME_PADDING_SECONDS
+        latest_ts: float | None = None
+        for pattern in ("sessions/**/*.jsonl", "state_*.sqlite", "logs_*.sqlite"):
+            for candidate in codex_home.glob(pattern):
+                try:
+                    stat = candidate.stat()
+                except OSError:
+                    continue
+                if stat.st_mtime < threshold_ts:
+                    continue
+                if latest_ts is None or stat.st_mtime > latest_ts:
+                    latest_ts = stat.st_mtime
+
+        if latest_ts is None:
+            return None
+        return datetime.fromtimestamp(latest_ts, tz=UTC)
+
+    @staticmethod
+    def _resolve_codex_home(workspace_path: str | None) -> Path | None:
+        normalized = str(workspace_path or "").strip()
+        if not normalized:
+            return None
+
+        resolved_workspace = Path(normalized).resolve()
+        run_root = (
+            resolved_workspace.parent
+            if resolved_workspace.name == "repo"
+            else resolved_workspace
+        )
+        codex_home = run_root / ".moonmind" / "codex-home"
+        if not codex_home.exists():
+            return None
+        return codex_home

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -159,20 +160,65 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
 
         threshold_ts = started_at.timestamp() - _CODEX_PROGRESS_MTIME_PADDING_SECONDS
         latest_ts: float | None = None
-        for pattern in ("sessions/**/*.jsonl", "state_*.sqlite", "logs_*.sqlite"):
-            for candidate in codex_home.glob(pattern):
-                try:
-                    stat = candidate.stat()
-                except OSError:
-                    continue
-                if stat.st_mtime < threshold_ts:
-                    continue
-                if latest_ts is None or stat.st_mtime > latest_ts:
-                    latest_ts = stat.st_mtime
+        for candidate in self._iter_progress_candidates(
+            codex_home=codex_home,
+            started_at=started_at,
+        ):
+            try:
+                stat = candidate.stat()
+            except OSError:
+                continue
+            if stat.st_mtime < threshold_ts:
+                continue
+            if latest_ts is None or stat.st_mtime > latest_ts:
+                latest_ts = stat.st_mtime
 
         if latest_ts is None:
             return None
         return datetime.fromtimestamp(latest_ts, tz=UTC)
+
+    @staticmethod
+    def _iter_progress_candidates(
+        *,
+        codex_home: Path,
+        started_at: datetime,
+    ) -> Iterator[Path]:
+        yield from codex_home.glob("state_*.sqlite")
+        yield from codex_home.glob("logs_*.sqlite")
+
+        sessions_root = codex_home / "sessions"
+        if not sessions_root.is_dir():
+            return
+
+        for session_day_dir in CodexCliStrategy._iter_session_day_dirs(
+            sessions_root=sessions_root,
+            started_at=started_at,
+        ):
+            if not session_day_dir.is_dir():
+                continue
+            yield from session_day_dir.rglob("*.jsonl")
+
+    @staticmethod
+    def _iter_session_day_dirs(
+        *,
+        sessions_root: Path,
+        started_at: datetime,
+    ) -> Iterator[Path]:
+        normalized_started_at = (
+            started_at
+            if started_at.tzinfo is not None
+            else started_at.replace(tzinfo=UTC)
+        )
+        utc_now = datetime.now(tz=UTC)
+        # Codex stores sessions under day-partitioned paths; scanning only the
+        # current/recent partitions avoids re-walking the entire session tree.
+        candidate_days = {
+            normalized_started_at.astimezone(UTC).date(),
+            utc_now.date(),
+            (utc_now - timedelta(days=1)).date(),
+        }
+        for day in sorted(candidate_days):
+            yield sessions_root / f"{day.year:04d}" / f"{day.month:02d}" / f"{day.day:02d}"
 
     @staticmethod
     def _resolve_codex_home(workspace_path: str | None) -> Path | None:
@@ -181,12 +227,8 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             return None
 
         resolved_workspace = Path(normalized).resolve()
-        run_root = (
-            resolved_workspace.parent
-            if resolved_workspace.name == "repo"
-            else resolved_workspace
-        )
+        run_root = resolved_workspace.parent
         codex_home = run_root / ".moonmind" / "codex-home"
-        if not codex_home.exists():
+        if not codex_home.is_dir():
             return None
         return codex_home

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -87,8 +87,11 @@ class ManagedRunSupervisor:
             strategy = get_strategy(runtime_id) if runtime_id else None
             parser = strategy.create_output_parser() if strategy else None
             live_rate_limit_detected = asyncio.Event()
+            stalled_progress_detected = asyncio.Event()
             timed_out_by_supervisor = False
             live_rate_limit_requested = False
+            stalled_no_progress = False
+            stalled_progress_reason: str | None = None
             last_output_seen_at = start_time
             last_no_output_annotation_at = start_time
             first_stdout_seen = False
@@ -96,6 +99,12 @@ class ManagedRunSupervisor:
             stderr_buffer = ""
             warning_counts: dict[str, int] = {}
             warning_dedup_announced: set[str] = set()
+            progress_probe_warning_logged = False
+            progress_timeout_seconds = (
+                strategy.progress_stall_timeout_seconds(timeout_seconds=timeout_seconds)
+                if strategy is not None
+                else None
+            )
 
             def _record_annotation(
                 annotation_type: str,
@@ -208,8 +217,69 @@ class ManagedRunSupervisor:
                         live_rate_limit_requested = True
                         break
 
+            def _latest_progress_at() -> datetime:
+                nonlocal progress_probe_warning_logged
+                latest = last_output_seen_at
+                if (
+                    strategy is None
+                    or progress_timeout_seconds is None
+                    or record is None
+                    or not record.workspace_path
+                ):
+                    return latest
+                try:
+                    progress_at = strategy.probe_progress_at(
+                        workspace_path=record.workspace_path,
+                        run_id=run_id,
+                        started_at=start_time,
+                    )
+                except Exception:
+                    if not progress_probe_warning_logged:
+                        logger.warning(
+                            "Progress probe failed for managed run %s",
+                            run_id,
+                            exc_info=True,
+                        )
+                        progress_probe_warning_logged = True
+                    return latest
+                if progress_at is None:
+                    return latest
+                if progress_at.tzinfo is None:
+                    progress_at = progress_at.replace(tzinfo=UTC)
+                return max(latest, progress_at)
+
             def _emit_no_output_annotation(now: datetime) -> None:
-                nonlocal last_no_output_annotation_at
+                nonlocal last_no_output_annotation_at, stalled_no_progress, stalled_progress_reason
+                latest_progress_at = _latest_progress_at()
+                idle_progress_seconds = max(
+                    0.0,
+                    (now - latest_progress_at).total_seconds(),
+                )
+                if (
+                    progress_timeout_seconds is not None
+                    and not stalled_progress_detected.is_set()
+                    and idle_progress_seconds >= progress_timeout_seconds
+                ):
+                    stalled_no_progress = True
+                    stalled_progress_reason = (
+                        "Managed runtime made no observable progress for "
+                        f"{int(idle_progress_seconds)}s."
+                    )
+                    _record_annotation(
+                        annotation_type="termination_requested_stalled_progress",
+                        text=(
+                            "Supervisor: process termination requested after "
+                            f"{int(idle_progress_seconds)}s without observable progress."
+                        ),
+                        reason="stalled_no_progress",
+                        metadata={
+                            "progress_timeout_seconds": progress_timeout_seconds,
+                            "idle_progress_seconds": int(idle_progress_seconds),
+                            "last_progress_at": latest_progress_at.isoformat(),
+                        },
+                    )
+                    stalled_progress_detected.set()
+                    return
                 if (
                     now - last_output_seen_at
                 ).total_seconds() < NO_OUTPUT_ANNOTATION_INTERVAL_SECONDS:
@@ -256,9 +326,17 @@ class ManagedRunSupervisor:
             terminate_on_rate_limit_task = None
             if strategy is not None and strategy.terminate_on_live_rate_limit():
                 terminate_on_rate_limit_task = asyncio.create_task(
-                    self._terminate_on_live_rate_limit(
+                    self._terminate_on_signal(
                         process=process,
                         trigger=live_rate_limit_detected,
+                    )
+                )
+            terminate_on_stall_task = None
+            if progress_timeout_seconds is not None:
+                terminate_on_stall_task = asyncio.create_task(
+                    self._terminate_on_signal(
+                        process=process,
+                        trigger=stalled_progress_detected,
                     )
                 )
             (
@@ -269,6 +347,10 @@ class ManagedRunSupervisor:
                 terminate_on_rate_limit_task.cancel()
                 with suppress(asyncio.CancelledError):
                     _ = await terminate_on_rate_limit_task
+            if terminate_on_stall_task is not None:
+                terminate_on_stall_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    _ = await terminate_on_stall_task
 
             if timed_out:
                 exit_code = None
@@ -301,22 +383,41 @@ class ManagedRunSupervisor:
                     ),
                     reason="rate_limit",
                 )
+            if stalled_no_progress:
+                _record_annotation(
+                    annotation_type="run_classified_stalled_progress",
+                    text=(
+                        "Supervisor: managed runtime stalled without progress; "
+                        "classifying as failed."
+                    ),
+                    reason="stalled_no_progress",
+                )
 
             # Classify exit
-            exit_result = self._classify_exit(
-                runtime_id=runtime_id,
-                exit_code=exit_code,
-                timed_out=timed_out,
-                stdout=stdout_content,
-                stderr=stderr_content,
-                parsed_output=parsed_output,
-            )
+            if stalled_no_progress:
+                exit_result = ManagedRuntimeExitResult(
+                    status="failed",
+                    failure_class="system_error",
+                )
+            else:
+                exit_result = self._classify_exit(
+                    runtime_id=runtime_id,
+                    exit_code=exit_code,
+                    timed_out=timed_out,
+                    stdout=stdout_content,
+                    stderr=stderr_content,
+                    parsed_output=parsed_output,
+                )
             status = exit_result.status
             failure_class = exit_result.failure_class
 
             error_message = None
             if status == "failed":
-                if runtime_id == "gemini_cli" and exit_result.provider_error_code == "429":
+                if stalled_no_progress:
+                    error_message = stalled_progress_reason or (
+                        "Managed runtime stalled without observable progress"
+                    )
+                elif runtime_id == "gemini_cli" and exit_result.provider_error_code == "429":
                     error_message = "Gemini API rate limit exceeded"
                 else:
                     error_message = f"Process exited with code {exit_code}"
@@ -530,7 +631,7 @@ class ManagedRunSupervisor:
         self._cleanup_runtime_files(self._deferred_cleanup_paths.pop(run_id, ()))
 
     @staticmethod
-    async def _terminate_on_live_rate_limit(
+    async def _terminate_on_signal(
         *,
         process: asyncio.subprocess.Process,
         trigger: asyncio.Event,

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -217,7 +217,7 @@ class ManagedRunSupervisor:
                         live_rate_limit_requested = True
                         break
 
-            def _latest_progress_at() -> datetime:
+            async def _latest_progress_at() -> datetime:
                 nonlocal progress_probe_warning_logged
                 latest = last_output_seen_at
                 if (
@@ -227,11 +227,15 @@ class ManagedRunSupervisor:
                     or not record.workspace_path
                 ):
                     return latest
+                progress_started_at = record.started_at or start_time
+                if progress_started_at.tzinfo is None:
+                    progress_started_at = progress_started_at.replace(tzinfo=UTC)
                 try:
-                    progress_at = strategy.probe_progress_at(
+                    progress_at = await asyncio.to_thread(
+                        strategy.probe_progress_at,
                         workspace_path=record.workspace_path,
                         run_id=run_id,
-                        started_at=start_time,
+                        started_at=progress_started_at,
                     )
                 except Exception:
                     if not progress_probe_warning_logged:
@@ -248,9 +252,9 @@ class ManagedRunSupervisor:
                     progress_at = progress_at.replace(tzinfo=UTC)
                 return max(latest, progress_at)
 
-            def _emit_no_output_annotation(now: datetime) -> None:
+            async def _emit_no_output_annotation(now: datetime) -> None:
                 nonlocal last_no_output_annotation_at, stalled_no_progress, stalled_progress_reason
-                latest_progress_at = _latest_progress_at()
+                latest_progress_at = await _latest_progress_at()
                 idle_progress_seconds = max(
                     0.0,
                     (now - latest_progress_at).total_seconds(),
@@ -344,13 +348,24 @@ class ManagedRunSupervisor:
                 (log_refs, stdout_content, stderr_content, parsed_output, events),
             ) = await asyncio.gather(heartbeat_task, stream_task)
             if terminate_on_rate_limit_task is not None:
-                terminate_on_rate_limit_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    _ = await terminate_on_rate_limit_task
+                if live_rate_limit_detected.is_set():
+                    with suppress(asyncio.CancelledError):
+                        _ = await terminate_on_rate_limit_task
+                else:
+                    terminate_on_rate_limit_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        _ = await terminate_on_rate_limit_task
+            stalled_progress_termination_performed = False
             if terminate_on_stall_task is not None:
-                terminate_on_stall_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    _ = await terminate_on_stall_task
+                if stalled_progress_detected.is_set():
+                    with suppress(asyncio.CancelledError):
+                        stalled_progress_termination_performed = bool(
+                            await terminate_on_stall_task
+                        )
+                else:
+                    terminate_on_stall_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        _ = await terminate_on_stall_task
 
             if timed_out:
                 exit_code = None
@@ -383,7 +398,7 @@ class ManagedRunSupervisor:
                     ),
                     reason="rate_limit",
                 )
-            if stalled_no_progress:
+            if stalled_no_progress and stalled_progress_termination_performed:
                 _record_annotation(
                     annotation_type="run_classified_stalled_progress",
                     text=(
@@ -392,9 +407,19 @@ class ManagedRunSupervisor:
                     ),
                     reason="stalled_no_progress",
                 )
+            elif stalled_no_progress:
+                _record_annotation(
+                    annotation_type="run_completed_before_stalled_progress_termination",
+                    text=(
+                        "Supervisor: stalled-progress threshold was reached, but the "
+                        "process exited before termination completed; using normal "
+                        "exit classification."
+                    ),
+                    reason="stalled_no_progress",
+                )
 
             # Classify exit
-            if stalled_no_progress:
+            if stalled_no_progress and stalled_progress_termination_performed:
                 exit_result = ManagedRuntimeExitResult(
                     status="failed",
                     failure_class="system_error",
@@ -413,7 +438,7 @@ class ManagedRunSupervisor:
 
             error_message = None
             if status == "failed":
-                if stalled_no_progress:
+                if stalled_no_progress and stalled_progress_termination_performed:
                     error_message = stalled_progress_reason or (
                         "Managed runtime stalled without observable progress"
                     )
@@ -503,7 +528,7 @@ class ManagedRunSupervisor:
         self,
         run_id: str,
         process: asyncio.subprocess.Process,
-        no_output_callback: Callable[[datetime], None] | None = None,
+        no_output_callback: Callable[[datetime], Awaitable[None]] | None = None,
     ) -> int:
         """Send heartbeats while waiting for the process to complete."""
         while True:
@@ -514,7 +539,7 @@ class ManagedRunSupervisor:
                 return exit_code
             except asyncio.TimeoutError:
                 if no_output_callback is not None:
-                    no_output_callback(datetime.now(tz=UTC))
+                    await no_output_callback(datetime.now(tz=UTC))
                 try:
                     activity.heartbeat({"run_id": run_id})
                 except Exception as e:
@@ -531,7 +556,7 @@ class ManagedRunSupervisor:
         run_id: str,
         process: asyncio.subprocess.Process,
         timeout_seconds: int,
-        no_output_callback: Callable[[datetime], None] | None = None,
+        no_output_callback: Callable[[datetime], Awaitable[None]] | None = None,
     ) -> tuple[int | None, bool]:
         """Wrap _heartbeat_and_wait with a total timeout.
 
@@ -559,7 +584,7 @@ class ManagedRunSupervisor:
             # and can complete, allowing asyncio.gather() to unblock.
             await self._terminate_process(process)
             if no_output_callback is not None:
-                no_output_callback(datetime.now(tz=UTC))
+                await no_output_callback(datetime.now(tz=UTC))
             return None, True
 
     async def cancel(self, run_id: str) -> None:
@@ -635,9 +660,12 @@ class ManagedRunSupervisor:
         *,
         process: asyncio.subprocess.Process,
         trigger: asyncio.Event,
-    ) -> None:
+    ) -> bool:
         await trigger.wait()
+        if process.returncode is not None:
+            return False
         await ManagedRunSupervisor._terminate_process(process)
+        return True
 
     @staticmethod
     def _is_live_rate_limit_event(event: dict[str, Any]) -> bool:

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -10,6 +10,7 @@ from moonmind.schemas.agent_runtime_models import ManagedRunRecord
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
+from moonmind.workflows.temporal.runtime.strategies.base import ManagedRuntimeExitResult
 
 
 class _StubArtifactStorage:
@@ -192,6 +193,132 @@ async def test_supervise_terminates_stalled_runtime_progress(supervisor_env):
 
 
 @pytest.mark.asyncio
+async def test_supervise_uses_record_started_at_for_progress_probe(supervisor_env):
+    store, _, _, supervisor = supervisor_env
+    expected_started_at = datetime(2026, 4, 4, 6, 0, tzinfo=UTC)
+    record = ManagedRunRecord(
+        run_id="run-started-at",
+        agent_id="codex_cli",
+        runtime_id="codex_cli",
+        status="launching",
+        started_at=expected_started_at,
+        workspace_path="/tmp/workspace",
+    )
+    store.save(record)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "60",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    captured_started_at: list[datetime] = []
+    to_thread_calls: list[str] = []
+
+    def _probe_progress_at(**kwargs):
+        captured_started_at.append(kwargs["started_at"])
+        return record.started_at
+
+    async def _fake_to_thread(func, /, *args, **kwargs):
+        to_thread_calls.append(getattr(func, "__name__", "probe_progress_at"))
+        return func(*args, **kwargs)
+
+    stub_strategy = SimpleNamespace(
+        create_output_parser=lambda: None,
+        terminate_on_live_rate_limit=lambda: False,
+        progress_stall_timeout_seconds=lambda *, timeout_seconds: 2,
+        probe_progress_at=_probe_progress_at,
+    )
+
+    with patch("moonmind.workflows.temporal.runtime.supervisor.get_strategy", return_value=stub_strategy):
+        with patch("moonmind.workflows.temporal.runtime.supervisor.asyncio.to_thread", new=_fake_to_thread):
+            with patch("moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL", 1):
+                with patch(
+                    "moonmind.workflows.temporal.runtime.supervisor.NO_OUTPUT_ANNOTATION_INTERVAL_SECONDS",
+                    1,
+                ):
+                    result = await supervisor.supervise(
+                        run_id="run-started-at",
+                        process=process,
+                        timeout_seconds=30,
+                    )
+
+    assert result.status == "failed"
+    assert result.failure_class == "system_error"
+    assert to_thread_calls
+    assert captured_started_at == [expected_started_at, expected_started_at]
+
+
+@pytest.mark.asyncio
+async def test_stalled_progress_does_not_override_clean_exit_without_termination(supervisor_env):
+    store, artifact_storage, _, supervisor = supervisor_env
+    record = ManagedRunRecord(
+        run_id="run-stall-race",
+        agent_id="codex_cli",
+        runtime_id="codex_cli",
+        status="launching",
+        started_at=datetime.now(tz=UTC),
+        workspace_path="/tmp/workspace",
+    )
+    store.save(record)
+
+    process = await asyncio.create_subprocess_exec(
+        "sh", "-c", "sleep 2; exit 0",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stub_strategy = SimpleNamespace(
+        create_output_parser=lambda: None,
+        terminate_on_live_rate_limit=lambda: False,
+        progress_stall_timeout_seconds=lambda *, timeout_seconds: 1,
+        probe_progress_at=lambda **_: record.started_at,
+        classify_result=lambda **_: ManagedRuntimeExitResult(
+            status="completed",
+            failure_class=None,
+        ),
+    )
+
+    async def _no_op_terminate_on_signal(*, process, trigger):
+        await trigger.wait()
+        return False
+
+    with patch("moonmind.workflows.temporal.runtime.supervisor.get_strategy", return_value=stub_strategy):
+        with patch(
+            "moonmind.workflows.temporal.runtime.supervisor.ManagedRunSupervisor._terminate_on_signal",
+            new=staticmethod(_no_op_terminate_on_signal),
+        ):
+            with patch("moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL", 1):
+                with patch(
+                    "moonmind.workflows.temporal.runtime.supervisor.NO_OUTPUT_ANNOTATION_INTERVAL_SECONDS",
+                    1,
+                ):
+                    result = await supervisor.supervise(
+                        run_id="run-stall-race",
+                        process=process,
+                        timeout_seconds=30,
+                    )
+
+    assert result.status == "completed"
+    assert result.failure_class is None
+
+    diagnostics_path = _resolve_diagnostics_path(artifact_storage, result)
+    assert diagnostics_path is not None
+    diagnostics = json.loads(
+        artifact_storage.resolve_storage_path(diagnostics_path).read_text(encoding="utf-8")
+    )
+    annotations = diagnostics.get("annotations", [])
+    assert any(
+        isinstance(annotation, dict)
+        and annotation.get("annotation_type")
+        == "run_completed_before_stalled_progress_termination"
+        for annotation in annotations
+    )
+
+
+@pytest.mark.asyncio
 async def test_exit_code_file_is_authoritative(supervisor_env, tmp_path):
     store, artifact_storage, _, supervisor = supervisor_env
     _make_record(store, "run-exit-file", "launching")
@@ -340,9 +467,9 @@ async def test_supervise_debounces_no_output_interval(supervisor_env):
         base_time = datetime.now(tz=UTC)
         if no_output_callback is None:
             return 0, False
-        no_output_callback(base_time + timedelta(seconds=2.5))
-        no_output_callback(base_time + timedelta(seconds=4.9))
-        no_output_callback(base_time + timedelta(seconds=5.0))
+        await no_output_callback(base_time + timedelta(seconds=2.5))
+        await no_output_callback(base_time + timedelta(seconds=4.9))
+        await no_output_callback(base_time + timedelta(seconds=5.0))
         return 0, False
 
     process = await asyncio.create_subprocess_exec(

--- a/tests/unit/services/temporal/runtime/test_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor.py
@@ -3,6 +3,7 @@ import os
 import json
 import pytest
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from moonmind.schemas.agent_runtime_models import ManagedRunRecord
@@ -132,6 +133,62 @@ async def test_timeout_exit_classification(supervisor_env):
     assert record.status == "timed_out"
     assert record.failure_class == "execution_error"
     assert "timed out" in record.error_message
+
+
+@pytest.mark.asyncio
+async def test_supervise_terminates_stalled_runtime_progress(supervisor_env):
+    store, artifact_storage, _, supervisor = supervisor_env
+    record = ManagedRunRecord(
+        run_id="run-stalled-progress",
+        agent_id="codex_cli",
+        runtime_id="codex_cli",
+        status="launching",
+        started_at=datetime.now(tz=UTC),
+        workspace_path="/tmp/workspace",
+    )
+    store.save(record)
+
+    process = await asyncio.create_subprocess_exec(
+        "sleep", "60",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    stub_strategy = SimpleNamespace(
+        create_output_parser=lambda: None,
+        terminate_on_live_rate_limit=lambda: False,
+        progress_stall_timeout_seconds=lambda *, timeout_seconds: 2,
+        probe_progress_at=lambda **_: record.started_at,
+    )
+
+    with patch("moonmind.workflows.temporal.runtime.supervisor.get_strategy", return_value=stub_strategy):
+        with patch("moonmind.workflows.temporal.runtime.supervisor.HEARTBEAT_INTERVAL", 1):
+            with patch(
+                "moonmind.workflows.temporal.runtime.supervisor.NO_OUTPUT_ANNOTATION_INTERVAL_SECONDS",
+                1,
+            ):
+                result = await supervisor.supervise(
+                    run_id="run-stalled-progress",
+                    process=process,
+                    timeout_seconds=30,
+                )
+
+    assert result.status == "failed"
+    assert result.failure_class == "system_error"
+    assert "no observable progress" in str(result.error_message)
+
+    diagnostics_path = _resolve_diagnostics_path(artifact_storage, result)
+    assert diagnostics_path is not None
+    diagnostics = json.loads(
+        artifact_storage.resolve_storage_path(diagnostics_path).read_text(encoding="utf-8")
+    )
+    annotations = diagnostics.get("annotations", [])
+    assert any(
+        isinstance(annotation, dict)
+        and annotation.get("annotation_type") == "termination_requested_stalled_progress"
+        for annotation in annotations
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/runtime/strategies/test_base.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_base.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from moonmind.workflows.temporal.runtime.strategies.base import (
@@ -63,6 +65,21 @@ class TestConcreteDefaults:
         parser = s.create_output_parser()
         from moonmind.workflows.temporal.runtime.output_parser import PlainTextOutputParser
         assert isinstance(parser, PlainTextOutputParser)
+
+    def test_default_progress_stall_timeout_is_disabled(self) -> None:
+        s = self._MinimalStrategy()
+        assert s.progress_stall_timeout_seconds(timeout_seconds=600) is None
+
+    def test_default_progress_probe_returns_none(self) -> None:
+        s = self._MinimalStrategy()
+        assert (
+            s.probe_progress_at(
+                workspace_path="/tmp/workspace",
+                run_id="run-1",
+                started_at=datetime.now(tz=UTC),
+            )
+            is None
+        )
 
     @pytest.mark.parametrize(
         ("failure_class", "expected"),

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -274,6 +274,48 @@ class TestCodexCliProperties:
 
         assert observed == expected_progress_at
 
+    def test_probe_progress_uses_workspace_parent_for_custom_workspace_name(self, tmp_path) -> None:
+        strategy = CodexCliStrategy()
+        run_root = tmp_path / "run-2"
+        workspace_path = run_root / "project"
+        sessions_dir = (
+            run_root / ".moonmind" / "codex-home" / "sessions" / "2026" / "04" / "04"
+        )
+        workspace_path.mkdir(parents=True)
+        sessions_dir.mkdir(parents=True)
+        rollout_path = sessions_dir / "rollout.jsonl"
+        rollout_path.write_text("{}", encoding="utf-8")
+
+        started_at = datetime(2026, 4, 4, 5, 34, 13, tzinfo=UTC)
+        expected_progress_at = datetime(2026, 4, 4, 5, 34, 59, tzinfo=UTC)
+        ts = expected_progress_at.timestamp()
+        os.utime(rollout_path, (ts, ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-2",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
+
+    def test_probe_progress_ignores_non_directory_codex_home(self, tmp_path) -> None:
+        strategy = CodexCliStrategy()
+        run_root = tmp_path / "run-3"
+        workspace_path = run_root / "repo"
+        codex_home = run_root / ".moonmind" / "codex-home"
+        workspace_path.mkdir(parents=True)
+        codex_home.parent.mkdir(parents=True)
+        codex_home.write_text("not a directory", encoding="utf-8")
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-3",
+            started_at=datetime(2026, 4, 4, 5, 34, 13, tzinfo=UTC),
+        )
+
+        assert observed is None
+
 
 class TestCodexCliBuildCommand:
     def test_basic_prompt(self) -> None:

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -241,6 +243,36 @@ class TestCodexCliProperties:
 
     def test_default_auth_mode(self) -> None:
         assert CodexCliStrategy().default_auth_mode == "api_key"
+
+    def test_progress_stall_timeout_is_bounded(self) -> None:
+        strategy = CodexCliStrategy()
+        assert strategy.progress_stall_timeout_seconds(timeout_seconds=120) == 120
+        assert strategy.progress_stall_timeout_seconds(timeout_seconds=900) == 300
+
+    def test_probe_progress_uses_codex_session_files(self, tmp_path) -> None:
+        strategy = CodexCliStrategy()
+        run_root = tmp_path / "run-1"
+        workspace_path = run_root / "repo"
+        sessions_dir = (
+            run_root / ".moonmind" / "codex-home" / "sessions" / "2026" / "04" / "04"
+        )
+        workspace_path.mkdir(parents=True)
+        sessions_dir.mkdir(parents=True)
+        rollout_path = sessions_dir / "rollout.jsonl"
+        rollout_path.write_text("{}", encoding="utf-8")
+
+        started_at = datetime(2026, 4, 4, 5, 34, 13, tzinfo=UTC)
+        expected_progress_at = datetime(2026, 4, 4, 5, 34, 59, tzinfo=UTC)
+        ts = expected_progress_at.timestamp()
+        os.utime(rollout_path, (ts, ts))
+
+        observed = strategy.probe_progress_at(
+            workspace_path=str(workspace_path),
+            run_id="run-1",
+            started_at=started_at,
+        )
+
+        assert observed == expected_progress_at
 
 
 class TestCodexCliBuildCommand:


### PR DESCRIPTION
## What changed
This updates the managed runtime supervisor to stop treating a live-but-idle process as healthy progress.

- add optional strategy hooks for stall timeout and progress probing
- probe Codex session artifacts under `.moonmind/codex-home` to detect actual runtime progress
- terminate managed runs that exceed the no-progress threshold and classify them as `failed` with `system_error`
- add regression coverage for the supervisor and strategy boundaries

## Why
A managed Codex run hit a prerequisite failure, stopped emitting rollout progress, and then remained alive indefinitely. Temporal kept polling because the subprocess still existed, so the workflow appeared stuck even though the runtime was no longer making forward progress.

## Impact
Stalled managed Codex runs now fail fast with an explicit stalled-progress classification instead of polling forever. That gives operators a terminal outcome they can diagnose and retry.

## Validation
- `./tools/test_unit.sh`
