### PR TITLE
[codex] Fix managed runtime default profile selection

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1397,15 +1397,17 @@ class MoonMindRunWorkflow:
             )
 
         agent_kind = self._agent_kind_for_id(agent_id)
-        execution_profile_ref = str(
+        raw_execution_profile_ref = (
             node_inputs.get("executionProfileRef")
             or runtime_block.get("executionProfileRef")
             or node_inputs.get("profileId")
             or runtime_block.get("profileId")
             or node_inputs.get("providerProfile")
             or runtime_block.get("providerProfile")
-            or f"default:{agent_id}"
         )
+        execution_profile_ref = None
+        if raw_execution_profile_ref is not None:
+            execution_profile_ref = str(raw_execution_profile_ref).strip() or None
         wf_info = workflow.info()
         correlation_id = wf_info.workflow_id
         idempotency_key = f"{wf_info.workflow_id}:{node_id}:{wf_info.run_id}"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1399,10 +1399,10 @@ class MoonMindRunWorkflow:
         agent_kind = self._agent_kind_for_id(agent_id)
         raw_execution_profile_ref = (
             node_inputs.get("executionProfileRef")
-            or runtime_block.get("executionProfileRef")
             or node_inputs.get("profileId")
-            or runtime_block.get("profileId")
             or node_inputs.get("providerProfile")
+            or runtime_block.get("executionProfileRef")
+            or runtime_block.get("profileId")
             or runtime_block.get("providerProfile")
         )
         execution_profile_ref = None

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -244,3 +244,31 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.agent_id, "codex")
         self.assertIsNone(request.execution_profile_ref)
+
+    def test_build_agent_execution_request_prefers_top_level_profile_fields_over_runtime_defaults(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "profileId": "legacy-top-level-profile",
+                    "runtime": {
+                        "mode": "codex",
+                        "executionProfileRef": "runtime-default-profile",
+                    },
+                },
+                node_id="node-profile-priority",
+                tool_name="pr-resolver",
+            )
+
+        self.assertEqual(request.agent_id, "codex")
+        self.assertEqual(request.execution_profile_ref, "legacy-top-level-profile")

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -218,3 +218,29 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.execution_profile_ref, "codex-provider-profile")
+
+    def test_build_agent_execution_request_leaves_profile_unset_when_not_explicit(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "runtime": {
+                        "mode": "codex",
+                    },
+                },
+                node_id="node-default-profile",
+                tool_name="speckit-orchestrate",
+            )
+
+        self.assertEqual(request.agent_id, "codex")
+        self.assertIsNone(request.execution_profile_ref)


### PR DESCRIPTION
## Summary
Fix managed runtime request building so `MoonMind.Run` no longer synthesizes legacy provider-profile ids like `default:codex_cli` when a plan node does not explicitly pin a profile.

## Root Cause
Workflow `mm:1bdc9acf-ef6d-483b-b265-cc6f0e27a4f0` failed because the child `MoonMind.AgentRun` received `execution_profile_ref="default:codex_cli"`, but the live provider-profile table only contains real Codex profile ids such as `codex_default` and `codex_openrouter_qwen36_plus`.

The stale fallback came from `MoonMind.Run._build_agent_execution_request()`, which defaulted missing profile selection to `default:{agent_id}` instead of leaving profile choice to the provider-profile manager.

## Changes
- stop synthesizing `default:{agent_id}` in the managed-runtime execution request builder
- only forward `execution_profile_ref` when the task explicitly selected a provider profile
- add a regression test covering implicit profile selection so unpinned Codex runs leave `execution_profile_ref` unset

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py`
- `./tools/test_unit.sh`