### PR TITLE
[codex] Fix pr-resolver managed completion classification

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2386,6 +2386,22 @@ class TemporalAgentRuntimeActivities:
         async def _unused_slot_signal(**_kwargs: Any) -> None:
             return None
 
+        raw_pr_resolver_expected = (
+            request.get("pr_resolver_expected")
+            or request.get("prResolverExpected")
+            if isinstance(request, Mapping)
+            else False
+        )
+        if isinstance(raw_pr_resolver_expected, str):
+            pr_resolver_expected = raw_pr_resolver_expected.strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+        else:
+            pr_resolver_expected = bool(raw_pr_resolver_expected)
+
         adapter = ManagedAgentAdapter(
             profile_fetcher=_unused_profile_fetcher,
             slot_requester=_unused_slot_signal,
@@ -2395,7 +2411,9 @@ class TemporalAgentRuntimeActivities:
             run_store=self._run_store,
         )
         try:
-            result = await adapter.fetch_result(run_id)
+            result = await adapter.fetch_result(
+                run_id, pr_resolver_expected=pr_resolver_expected
+            )
             record = self._run_store.load(run_id)
             if record is not None:
                 result = self._maybe_enrich_gemini_failure_result(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -24,6 +24,7 @@ from moonmind.schemas.manifest_ingest_models import CompiledManifestPlanModel
 from moonmind.schemas.temporal_activity_models import (
     PlanGenerateInput,
 )
+from moonmind.workflows.tasks.routing import _coerce_bool
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.adapters.managed_agent_adapter import ManagedAgentAdapter
 from moonmind.utils.logging import SecretRedactor
@@ -2386,21 +2387,16 @@ class TemporalAgentRuntimeActivities:
         async def _unused_slot_signal(**_kwargs: Any) -> None:
             return None
 
-        raw_pr_resolver_expected = (
-            request.get("pr_resolver_expected")
-            or request.get("prResolverExpected")
-            if isinstance(request, Mapping)
-            else False
-        )
-        if isinstance(raw_pr_resolver_expected, str):
-            pr_resolver_expected = raw_pr_resolver_expected.strip().lower() in {
-                "1",
-                "true",
-                "yes",
-                "on",
-            }
+        if isinstance(request, Mapping):
+            raw_pr_resolver_expected = (
+                request.get("pr_resolver_expected")
+                or request.get("prResolverExpected")
+            )
         else:
-            pr_resolver_expected = bool(raw_pr_resolver_expected)
+            raw_pr_resolver_expected = None
+        pr_resolver_expected = _coerce_bool(
+            raw_pr_resolver_expected, default=False
+        )
 
         adapter = ManagedAgentAdapter(
             profile_fetcher=_unused_profile_fetcher,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -314,6 +314,8 @@ def _build_runtime_planner():
         if isinstance(repository, str) and repository.strip():
             node_inputs["repository"] = repository.strip()
             node_inputs["repo"] = repository.strip()
+        if selected_skill_name:
+            node_inputs["selectedSkill"] = selected_skill_name
 
         for git_key in ("startingBranch", "targetBranch", "branch"):
             git_val = (

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 from temporalio import workflow, activity
@@ -102,6 +103,22 @@ DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
 _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
+
+
+def _request_selected_skill(request: AgentExecutionRequest) -> str | None:
+    """Return the selected agent skill recorded in request metadata, if present."""
+
+    parameters = request.parameters if isinstance(request.parameters, dict) else {}
+    metadata = parameters.get("metadata")
+    metadata_map = metadata if isinstance(metadata, Mapping) else {}
+    moonmind = metadata_map.get("moonmind")
+    moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+    selected_skill = str(
+        moonmind_map.get("selectedSkill")
+        or metadata_map.get("selectedSkill")
+        or ""
+    ).strip()
+    return selected_skill or None
 
 def _legacy_manager_workflow_id(runtime_id: str) -> str:
     return f"auth-profile-manager:{runtime_id}"
@@ -1137,6 +1154,8 @@ class MoonMindAgentRun:
                                 activity_input["publish_mode"] = publish_mode
                             if target_branch:
                                 activity_input["target_branch"] = target_branch
+                            if _request_selected_skill(request) == "pr-resolver":
+                                activity_input["pr_resolver_expected"] = True
 
                             result_payload = await self._execute_routed_activity(
                                 "agent_runtime.fetch_result",
@@ -1151,7 +1170,12 @@ class MoonMindAgentRun:
                             )
                         else:
                             # Managed agent legacy path.
-                            self.final_result = await adapter.fetch_result(self.run_id)
+                            self.final_result = await adapter.fetch_result(
+                                self.run_id,
+                                pr_resolver_expected=(
+                                    _request_selected_skill(request) == "pr-resolver"
+                                ),
+                            )
 
                 if (
                     request.agent_kind == "external"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1446,6 +1446,21 @@ class MoonMindRunWorkflow:
             parameters["metadata"] = self._json_mapping(
                 raw_metadata, path=f"node[{node_id}].metadata"
             )
+        selected_skill = str(node_inputs.get("selectedSkill") or "").strip()
+        if selected_skill:
+            metadata_payload = (
+                parameters.get("metadata")
+                if isinstance(parameters.get("metadata"), dict)
+                else {}
+            )
+            moonmind_payload = (
+                metadata_payload.get("moonmind")
+                if isinstance(metadata_payload.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload.setdefault("selectedSkill", selected_skill)
+            metadata_payload["moonmind"] = moonmind_payload
+            parameters["metadata"] = metadata_payload
         bundle_payload: dict[str, Any] = {}
         for bundle_key in (
             "bundleId",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1458,7 +1458,7 @@ class MoonMindRunWorkflow:
                 if isinstance(metadata_payload.get("moonmind"), dict)
                 else {}
             )
-            moonmind_payload.setdefault("selectedSkill", selected_skill)
+            moonmind_payload["selectedSkill"] = selected_skill
             metadata_payload["moonmind"] = moonmind_payload
             parameters["metadata"] = metadata_payload
         bundle_payload: dict[str, Any] = {}

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -243,6 +243,36 @@ async def test_fetch_result_failed_returns_typed_model(tmp_path: Path) -> None:
     assert result.failure_class == "execution_error"
 
 
+async def test_fetch_result_forwards_pr_resolver_expected_flag(tmp_path: Path) -> None:
+    """T5.3 — pr-resolver expectation reaches the managed adapter."""
+    from unittest.mock import patch
+
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="fr-pr", status="completed")
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+        autospec=True,
+    ) as mock_adapter_cls:
+        adapter = mock_adapter_cls.return_value
+        adapter.fetch_result = AsyncMock(
+            return_value=AgentRunResult(
+                summary="blocked",
+                failure_class="user_error",
+            )
+        )
+
+        result = await activities.agent_runtime_fetch_result(
+            {"run_id": "fr-pr", "pr_resolver_expected": True}
+        )
+
+        adapter.fetch_result.assert_awaited_once_with(
+            "fr-pr", pr_resolver_expected=True
+        )
+        assert result.failure_class == "user_error"
+
+
 async def test_fetch_result_no_record_returns_empty_typed_model(tmp_path: Path) -> None:
     """T5.4 — no record in store returns empty AgentRunResult (not None, not dict)."""
     store = _make_store(tmp_path)
@@ -377,13 +407,20 @@ async def test_agent_runtime_fetch_result_temporal_boundary(tmp_path: Path) -> N
 
                 result = await env.client.execute_workflow(
                     AgentRuntimeFetchResultBoundaryTest.run,
-                    {"run_id": "boundary-1", "agent_id": "claude"},
+                    {
+                        "run_id": "boundary-1",
+                        "agent_id": "claude",
+                        "pr_resolver_expected": True,
+                    },
                     id="boundary-test-fetch",
                     task_queue="boundary-test-queue-fetch",
                 )
 
                 assert isinstance(result, AgentRunResult)
                 assert result.summary == "ok"
+                instance.fetch_result.assert_awaited_once_with(
+                    "boundary-1", pr_resolver_expected=True
+                )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -273,8 +273,33 @@ async def test_fetch_result_forwards_pr_resolver_expected_flag(tmp_path: Path) -
         assert result.failure_class == "user_error"
 
 
+async def test_fetch_result_string_request_defaults_pr_resolver_expected_false(
+    tmp_path: Path,
+) -> None:
+    """T5.4 — string request path must not call mapping-only accessors."""
+    from unittest.mock import patch
+
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="fr-string", status="completed")
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+        autospec=True,
+    ) as mock_adapter_cls:
+        adapter = mock_adapter_cls.return_value
+        adapter.fetch_result = AsyncMock(return_value=AgentRunResult(summary="ok"))
+
+        result = await activities.agent_runtime_fetch_result("fr-string")
+
+        adapter.fetch_result.assert_awaited_once_with(
+            "fr-string", pr_resolver_expected=False
+        )
+        assert result.summary == "ok"
+
+
 async def test_fetch_result_no_record_returns_empty_typed_model(tmp_path: Path) -> None:
-    """T5.4 — no record in store returns empty AgentRunResult (not None, not dict)."""
+    """T5.5 — no record in store returns empty AgentRunResult (not None, not dict)."""
     store = _make_store(tmp_path)
 
     activities = TemporalAgentRuntimeActivities(run_store=store)
@@ -284,7 +309,7 @@ async def test_fetch_result_no_record_returns_empty_typed_model(tmp_path: Path) 
 
 
 async def test_fetch_result_missing_run_id_raises_error(tmp_path: Path) -> None:
-    """T5.5 — missing run_id raises TemporalActivityRuntimeError."""
+    """T5.6 — missing run_id raises TemporalActivityRuntimeError."""
     store = _make_store(tmp_path)
     activities = TemporalAgentRuntimeActivities(run_store=store)
 

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -130,6 +130,7 @@ def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
     )
     assert '"pr": "123"' in node_inputs["instructions"]
     assert node_inputs["repo"] == "MoonLadderStudios/MoonMind"
+    assert node_inputs["selectedSkill"] == "pr-resolver"
 
 
 def test_runtime_planner_pr_resolver_injects_branch_selector_into_instruction():

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -244,3 +244,34 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         metadata = request.parameters.get("metadata") or {}
         moonmind = metadata.get("moonmind") or {}
         self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")
+
+    def test_build_agent_execution_request_overrides_stale_selected_skill(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex",
+                    "selectedSkill": "pr-resolver",
+                    "runtime": {
+                        "metadata": {
+                            "moonmind": {"selectedSkill": "auto"},
+                        }
+                    },
+                },
+                node_id="node-selected-skill-override",
+                tool_name="codex",
+            )
+
+        metadata = request.parameters.get("metadata") or {}
+        moonmind = metadata.get("moonmind") or {}
+        self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -218,3 +218,29 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
 
         self.assertEqual(request.agent_id, "codex")
         self.assertEqual(request.execution_profile_ref, "codex-provider-profile")
+
+    def test_build_agent_execution_request_carries_selected_skill_in_metadata(self) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.info",
+            return_value=MockInfo(),
+        ):
+            request = wf._build_agent_execution_request(
+                node_inputs={
+                    "targetRuntime": "codex",
+                    "selectedSkill": "pr-resolver",
+                },
+                node_id="node-selected-skill",
+                tool_name="codex",
+            )
+
+        metadata = request.parameters.get("metadata") or {}
+        moonmind = metadata.get("moonmind") or {}
+        self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")


### PR DESCRIPTION
## Summary
This fixes a managed-runtime result propagation gap that could mark a `pr-resolver` run as completed even when the resolver had actually stopped in a blocked state.

The change now carries the selected skill through the runtime planner and `AgentExecutionRequest` metadata, then forwards that signal into the managed `agent_runtime.fetch_result` activity so `pr-resolver` artifacts are interpreted before the workflow result is finalized.

## Why
A managed Codex run could exit cleanly while `pr-resolver` had already written a terminal blocked result like `attempts_exhausted`. Because the fetch-result activity was not told the run was a `pr-resolver` run, it ignored the resolver artifact and returned plain success based on process exit.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- `./tools/test_unit.sh`
