### PR TITLE
Slim frontend CI to one deterministic path. Right now generate:check, ci:test, and --dashboard-only overlap heavily. I would turn that into one fronte

### DIFF
--- a/.github/workflows/contract-check.yml
+++ b/.github/workflows/contract-check.yml
@@ -1,0 +1,58 @@
+name: Contract Check
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'api_service/**'
+      - 'tools/export_openapi.py'
+      - 'tools/generate_openapi_types.py'
+      - 'frontend/src/generated/openapi.ts'
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'api_service/**'
+      - 'tools/export_openapi.py'
+      - 'tools/generate_openapi_types.py'
+      - 'frontend/src/generated/openapi.ts'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contract-check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 1
+    - name: Set up Python for OpenAPI generation
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcairo2-dev pkg-config
+    - name: Cache pip dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install backend dependencies via uv
+      run: |
+        python -m pip install --upgrade pip uv
+        uv pip install --system -e .
+    - name: Verify generated frontend API types are in sync
+      run: npm run generate:check

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
         set -euo pipefail
         ./tools/test_unit.sh --python-only
 
-  test-frontend:
+  frontend:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -77,36 +77,19 @@ jobs:
         cache: npm
     - name: Install Node dependencies
       run: npm ci
-    - name: Set up Python for OpenAPI generation
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-    - name: Install system dependencies for backend API check
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libcairo2-dev pkg-config
-    - name: Cache pip dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install backend dependencies via uv
-      run: |
-        python -m pip install --upgrade pip uv
-        uv pip install --system -e .[tests]
-    - name: Verify generated frontend API types are in sync
-      run: npm run generate:check
-    - name: Run frontend tests and build
-      run: npm run ci:test
+    - name: Run frontend typecheck
+      run: npm run ui:typecheck
+    - name: Run frontend lint
+      run: npm run ui:lint
+    - name: Run frontend unit tests
+      run: npm run ui:test
+    - name: Build frontend
+      run: npm run ui:build
+    - name: Verify generated artifact
+      run: npm run ui:verify-manifest
     - name: Upload Mission Control dist artifact
       uses: actions/upload-artifact@v7
       with:
         name: mission-control-dist
         path: api_service/static/task_dashboard/dist/
         if-no-files-found: error
-    - name: Run frontend unit tests via canonical shell wrapper
-      run: |
-        set -euo pipefail
-        ./tools/test_unit.sh --dashboard-only


### PR DESCRIPTION
Slim frontend CI to one deterministic path. Right now generate:check, ci:test, and --dashboard-only overlap heavily. I would turn that into one frontend job that runs exactly once through typecheck, lint, unit tests, build, and one generated-artifact verification pass. Then move api:types:check into a separate contract/generation job, or at least only run it when backend/OpenAPI-affecting files changed. Also remove the extra ui:test rerun via tools/test_unit.sh --dashboard-only.