### PR TITLE
Slim frontend CI to one deterministic path. Right now generate:check, ci:test, and --dashboard-only overlap heavily. I would turn that into one fronte

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,16 +54,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Check and Test Frontend
+      - name: Check frontend and generated contracts
         run: |
           npm ci
-          npm run ui:typecheck
-          npm run ui:lint
-          npm run ui:test
-          npm run ui:clean-dist
-          npm run ui:build
-          npm run ui:verify-manifest
-          npm run api:types:check
+          npm run frontend:ci
+          npm run contracts:check
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -77,15 +77,69 @@ jobs:
         cache: npm
     - name: Install Node dependencies
       run: npm ci
+    - name: Run frontend CI
+      run: npm run frontend:ci
+    - name: Upload Mission Control dist artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: mission-control-dist
+        path: api_service/static/task_dashboard/dist/
+        if-no-files-found: error
+
+  check-generated-contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+    - name: Detect OpenAPI-affecting changes
+      id: detect
+      run: |
+        set -euo pipefail
+
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+        elif [[ -n "${{ github.event.before }}" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
+          base_sha="${{ github.event.before }}"
+          head_sha="${{ github.sha }}"
+        else
+          echo "run_check=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+
+        if printf '%s\n' "$changed_files" | grep -Eq '^(api_service/|moonmind/|tools/(export_openapi\.py|generate_openapi_types\.py)|frontend/src/generated/openapi\.ts|pyproject\.toml|uv\.lock$)'; then
+          echo "run_check=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "run_check=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Set up Node.js
+      if: steps.detect.outputs.run_check == 'true'
+      uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+        cache: npm
+    - name: Install Node dependencies
+      if: steps.detect.outputs.run_check == 'true'
+      run: npm ci
     - name: Set up Python for OpenAPI generation
+      if: steps.detect.outputs.run_check == 'true'
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - name: Install system dependencies for backend API check
+      if: steps.detect.outputs.run_check == 'true'
       run: |
         sudo apt-get update
         sudo apt-get install -y libcairo2-dev pkg-config
     - name: Cache pip dependencies
+      if: steps.detect.outputs.run_check == 'true'
       uses: actions/cache@v5
       with:
         path: ~/.cache/pip
@@ -93,20 +147,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install backend dependencies via uv
+      if: steps.detect.outputs.run_check == 'true'
       run: |
         python -m pip install --upgrade pip uv
         uv pip install --system -e .[tests]
     - name: Verify generated frontend API types are in sync
-      run: npm run generate:check
-    - name: Run frontend tests and build
-      run: npm run ci:test
-    - name: Upload Mission Control dist artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: mission-control-dist
-        path: api_service/static/task_dashboard/dist/
-        if-no-files-found: error
-    - name: Run frontend unit tests via canonical shell wrapper
-      run: |
-        set -euo pipefail
-        ./tools/test_unit.sh --dashboard-only
+      if: steps.detect.outputs.run_check == 'true'
+      run: npm run contracts:check
+    - name: Skip generated contract check
+      if: steps.detect.outputs.run_check != 'true'
+      run: echo "No backend/OpenAPI-affecting files changed; skipping generated contract verification."

--- a/.github/workflows/pytest-unit-tests.yml
+++ b/.github/workflows/pytest-unit-tests.yml
@@ -104,17 +104,17 @@ jobs:
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
+          changed_files="$(git diff --name-only "$base_sha...$head_sha")"
         elif [[ -n "${{ github.event.before }}" && "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
           base_sha="${{ github.event.before }}"
           head_sha="${{ github.sha }}"
+          changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
         else
           echo "run_check=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
 
-        changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
-
-        if printf '%s\n' "$changed_files" | grep -Eq '^(api_service/|moonmind/|tools/(export_openapi\.py|generate_openapi_types\.py)|frontend/src/generated/openapi\.ts|pyproject\.toml|uv\.lock$)'; then
+        if printf '%s\n' "$changed_files" | grep -Eq '^(api_service/|moonmind/|tools/(export_openapi\.py|generate_openapi_types\.py|run_repo_python\.sh)|frontend/src/generated/openapi\.ts|package(-lock)?\.json|pyproject\.toml|uv\.lock)$'; then
           echo "run_check=true" >> "$GITHUB_OUTPUT"
         else
           echo "run_check=false" >> "$GITHUB_OUTPUT"

--- a/docs/Development/PreCommitWorkflow.md
+++ b/docs/Development/PreCommitWorkflow.md
@@ -10,7 +10,7 @@ The current hook set is defined in `.pre-commit-config.yaml` and runs:
 - `isort --profile=black`
 - `ruff --fix`
 
-Frontend build output and generated API types are validated separately. `pre-commit` does not run the asset pipeline because the repository wrappers invoke `pre-commit run --all-files`, and forcing full Vite/OpenAPI regeneration on every wrapper-driven test pass would add unnecessary latency. Use `npm run ui:build:check` to validate a clean Mission Control bundle build, use `npm run generate` to refresh checked-in generated frontend API types, and use `npm run generate:check` to verify those tracked generated files are in sync.
+Frontend build output and generated API types are validated separately. `pre-commit` does not run the asset pipeline because the repository wrappers invoke `pre-commit run --all-files`, and forcing full Vite/OpenAPI regeneration on every wrapper-driven test pass would add unnecessary latency. Use `npm run frontend:ci` for the canonical frontend validation pass, use `npm run generate` to refresh checked-in generated frontend API types, and use `npm run contracts:check` to verify those tracked generated files are in sync.
 
 ## Current Project Behavior
 
@@ -44,7 +44,7 @@ In WSL, `./tools/test_unit.sh` automatically delegates to `./tools/test_unit_doc
 
 ### CI Behavior
 
-The current GitHub unit-test workflow runs frontend validation plus `./tools/test_unit.sh`.
+The current GitHub unit-test workflow runs one dedicated frontend validation job, a separate generated-contract check that only runs when OpenAPI-affecting files change, plus `./tools/test_unit.sh` for backend unit tests.
 
 CI does **not** currently run a dedicated `pre-commit` step, so local `pre-commit` runs are still the main way to catch formatting and auto-fixable lint issues before pushing.
 
@@ -66,7 +66,7 @@ pre-commit install
 
 1. Run `pre-commit run --all-files`
 2. Review and stage any files rewritten by the hooks
-3. If your change touches dashboard styling inputs, run `npm run ui:build:check`; if it touches frontend-consumed API schemas, run `npm run generate:check`
+3. If your change touches the frontend, run `npm run frontend:ci`; if it touches frontend-consumed API schemas, run `npm run contracts:check`
 4. Run `./tools/test_unit.sh` for the canonical unit-test pass
 5. Run targeted integration or end-to-end scripts only when your change needs them
 

--- a/docs/UI/MissionControlArchitecture.md
+++ b/docs/UI/MissionControlArchitecture.md
@@ -114,7 +114,7 @@ The canonical local commands are:
 
 `npm run ui:build:check` rebuilds `api_service/static/task_dashboard/dist/` from source and verifies the manifest. `npm run generate` regenerates `frontend/src/generated/openapi.ts`.
 
-The canonical CI drift gate for tracked generated files is `npm run generate:check`, which verifies `frontend/src/generated/openapi.ts` is synchronized with backend schema sources. OpenAPI generation writes its intermediate schema to a temporary file instead of dirtying a tracked repo-root `openapi.json`.
+The canonical CI drift gate for tracked generated files is `npm run contracts:check`, which verifies `frontend/src/generated/openapi.ts` is synchronized with backend schema sources when OpenAPI-affecting files change. OpenAPI generation writes its intermediate schema to a temporary file instead of dirtying a tracked repo-root `openapi.json`.
 
 Representative workflow:
 

--- a/docs/UI/TypeScriptSystem.md
+++ b/docs/UI/TypeScriptSystem.md
@@ -351,7 +351,7 @@ Recommended scripts:
 
 ### Authoritative builds (correctness)
 
-- **CI** verifies checked-in generated API types with **`npm run generate:check`**, then runs typecheck, lint, frontend tests, and **`npm run ui:build:check`**. The workflow may upload **`mission-control-dist`** as an artifact.
+- **CI** runs **`npm run frontend:ci`** once for the deterministic frontend path (typecheck, lint, unit tests, build, manifest verification). Generated API types are checked separately with **`npm run contracts:check`** only when backend/OpenAPI-affecting files change. The workflow may upload **`mission-control-dist`** as an artifact.
 - **Docker / release:** the **`frontend-builder`** stage in `api_service/Dockerfile` removes any pre-existing `dist/`, runs `npm ci`, `npm run ui:build`, and **`python3 tools/verify_vite_manifest.py`**. The runtime image copies **only** that freshly built tree. **Production correctness does not depend** on whatever `dist/` was last committed to git.
 - **Shared Mission Control CSS:** Tailwind scans **`frontend/src/**/*.{js,jsx,ts,tsx}`** plus the shared React shell templates so the frontend-owned stylesheet imported from `frontend/src/styles/mission-control.css` emits the utilities used by React routes even when **`dist/` does not exist yet**. Do not rely on scanning Vite output alone. See [`docs/UI/MissionControlArchitecture.md`](MissionControlArchitecture.md) §3.2.
 - **Runtime:** misconfiguration or a bad deploy still returns **503** with explicit HTML from the task dashboard router instead of an empty content area.
@@ -467,7 +467,7 @@ Canonical flow:
 
 This reduces backend/frontend drift for core payloads.
 
-`npm run generate:check` is the canonical verification path used by CI to ensure `frontend/src/generated/openapi.ts` stays synchronized with its backend schema source. Mission Control `dist/` output is verified by `npm run ui:build:check` and produced from source in CI and Docker.
+`npm run contracts:check` is the canonical verification path used by CI to ensure `frontend/src/generated/openapi.ts` stays synchronized with its backend schema source when OpenAPI-affecting files change. Mission Control `dist/` output is verified by `npm run frontend:ci` and produced from source in CI and Docker.
 
 ## 10.4 Domain Types vs Generated Types
 

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "ui:build": "vite build --config frontend/vite.config.ts",
     "ui:build:check": "npm run ui:clean-dist && npm run ui:build && npm run ui:verify-manifest",
     "ui:verify-manifest": "bash tools/run_repo_python.sh tools/verify_vite_manifest.py",
-    "generate:check": "npm run api:types:check",
+    "contracts:check": "npm run api:types:check",
     "ui:typecheck": "tsc --noEmit -p frontend/tsconfig.json",
     "ui:lint": "eslint -c frontend/eslint.config.mjs frontend/src",
     "ui:test": "vitest run --config frontend/vite.config.ts",
     "ui:test:watch": "vitest --config frontend/vite.config.ts",
     "api:types": "bash tools/run_repo_python.sh tools/generate_openapi_types.py",
     "api:types:check": "npm run api:types && git diff --exit-code -- frontend/src/generated/openapi.ts",
-    "ci:test": "npm run ui:typecheck && npm run ui:lint && npm run ui:test && npm run ui:build:check"
+    "frontend:ci": "npm run ui:typecheck && npm run ui:lint && npm run ui:test && npm run ui:build:check"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Slim frontend CI to one deterministic path. Right now generate:check, ci:test, and --dashboard-only overlap heavily. I would turn that into one frontend job that runs exactly once through typecheck, lint, unit tests, build, and one generated-artifact verification pass. Then move api:types:check into a separate contract/generation job, or at least only run it when backend/OpenAPI-affecting files changed. Also remove the extra ui:test rerun via tools/test_unit.sh --dashboard-only.