### PR TITLE
Fix provider profile validation on parent workflow before child spawn

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -35,6 +35,7 @@ with workflow.unsafe.imports_passed_through():
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
 from moonmind.workflows.skills.skill_registry import parse_skill_registry
 from moonmind.workflows.temporal.activity_catalog import (
+    ARTIFACTS_TASK_QUEUE,
     INTEGRATIONS_TASK_QUEUE,
     WORKFLOW_TASK_QUEUE,
     TemporalActivityRoute,
@@ -104,7 +105,8 @@ RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
-ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"
+RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
+_PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
 )
@@ -758,28 +760,31 @@ class MoonMindRunWorkflow:
         ``_build_agent_execution_request`` can validate plan node profile refs
         against known profiles before spawning child workflows.
         """
-        self._profile_snapshots: dict[str, dict[str, Any]] = {}
-        runtime_ids = ("codex_cli", "claude_code", "gemini_cli")
-        for runtime_id in runtime_ids:
+        snapshots: dict[str, dict[str, Any]] = {}
+        has_data = False
+        profile_list_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("provider_profile.list")
+        for runtime_id in _PROFILE_SYNC_RUNTIME_IDS:
             try:
+                kwargs = self._execute_kwargs_for_route(profile_list_route)
+                kwargs["start_to_close_timeout"] = timedelta(seconds=30)
+                kwargs["retry_policy"] = RetryPolicy(
+                    initial_interval=timedelta(seconds=2),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=30),
+                    maximum_attempts=3,
+                )
                 result = await workflow.execute_activity(
                     "provider_profile.list",
                     {"runtime_id": runtime_id},
-                    task_queue=ACTIVITY_TASK_QUEUE,
-                    start_to_close_timeout=timedelta(seconds=30),
-                    retry_policy=RetryPolicy(
-                        initial_interval=timedelta(seconds=2),
-                        backoff_coefficient=2.0,
-                        maximum_interval=timedelta(seconds=30),
-                        maximum_attempts=3,
-                    ),
+                    **kwargs,
                 )
                 if isinstance(result, dict):
                     for profile in result.get("profiles", []):
                         if isinstance(profile, dict):
                             pid = str(profile.get("profile_id", "")).strip()
                             if pid:
-                                self._profile_snapshots[pid] = profile
+                                snapshots[pid] = profile
+                                has_data = True
             except Exception:
                 self._get_logger().warning(
                     "Failed to fetch provider profiles for runtime_id=%s; "
@@ -787,6 +792,8 @@ class MoonMindRunWorkflow:
                     runtime_id,
                     exc_info=True,
                 )
+        if has_data:
+            self._profile_snapshots = snapshots
 
     async def _run_execution_stage(
         self, *, parameters: dict[str, Any], plan_ref: Optional[str]
@@ -801,7 +808,8 @@ class MoonMindRunWorkflow:
 
         # Fetch provider profile snapshots so that _build_agent_execution_request
         # can validate plan node profile refs against known profiles.
-        await self._fetch_profile_snapshots()
+        if workflow.patched(RUN_FETCH_PROFILE_SNAPSHOTS_PATCH):
+            await self._fetch_profile_snapshots()
 
         artifact_read_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("artifact.read")
         plan_payload = await execute_typed_activity(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -104,6 +104,7 @@ RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
+ACTIVITY_TASK_QUEUE = "mm.activity.artifacts"
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
 )
@@ -750,6 +751,43 @@ class MoonMindRunWorkflow:
             self._update_memo()
         return resolved_plan_ref
 
+    async def _fetch_profile_snapshots(self) -> None:
+        """Best-effort fetch of provider profile snapshots for all managed runtimes.
+
+        Populates ``self._profile_snapshots`` so that
+        ``_build_agent_execution_request`` can validate plan node profile refs
+        against known profiles before spawning child workflows.
+        """
+        self._profile_snapshots: dict[str, dict[str, Any]] = {}
+        runtime_ids = ("codex_cli", "claude_code", "gemini_cli")
+        for runtime_id in runtime_ids:
+            try:
+                result = await workflow.execute_activity(
+                    "provider_profile.list",
+                    {"runtime_id": runtime_id},
+                    task_queue=ACTIVITY_TASK_QUEUE,
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(
+                        initial_interval=timedelta(seconds=2),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(seconds=30),
+                        maximum_attempts=3,
+                    ),
+                )
+                if isinstance(result, dict):
+                    for profile in result.get("profiles", []):
+                        if isinstance(profile, dict):
+                            pid = str(profile.get("profile_id", "")).strip()
+                            if pid:
+                                self._profile_snapshots[pid] = profile
+            except Exception:
+                self._get_logger().warning(
+                    "Failed to fetch provider profiles for runtime_id=%s; "
+                    "profile validation will be skipped for this runtime.",
+                    runtime_id,
+                    exc_info=True,
+                )
+
     async def _run_execution_stage(
         self, *, parameters: dict[str, Any], plan_ref: Optional[str]
     ) -> None:
@@ -760,6 +798,10 @@ class MoonMindRunWorkflow:
                 "Ensure the planning activity returns a non-None 'plan_ref'."
             )
         self._set_state(STATE_EXECUTING, summary="Executing run steps.")
+
+        # Fetch provider profile snapshots so that _build_agent_execution_request
+        # can validate plan node profile refs against known profiles.
+        await self._fetch_profile_snapshots()
 
         artifact_read_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("artifact.read")
         plan_payload = await execute_typed_activity(

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -140,6 +140,8 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         **_kwargs: Any,
     ) -> Any:
         captured.append((activity_type, _normalize_payload(payload)))
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
         if activity_type == "artifact.read":
             if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
                 return json.dumps(
@@ -225,12 +227,14 @@ async def test_run_execution_stage_reads_plan_and_dispatches_steps(
         plan_ref="art_plan_1",
     )
 
-    assert captured[0][0] == "artifact.read"
-    assert captured[0][1]["artifact_ref"] == "art_plan_1"
-    assert captured[1][0] == "artifact.read"
-    assert captured[1][1]["artifact_ref"] == "artifact://registry/1"
-    assert captured[2][0] == "mm.skill.execute"
-    assert captured[2][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    # provider_profile.list calls (3) happen first, then artifact.read for plan,
+    # artifact.read for registry, then mm.skill.execute
+    assert captured[3][0] == "artifact.read"
+    assert captured[3][1]["artifact_ref"] == "art_plan_1"
+    assert captured[4][0] == "artifact.read"
+    assert captured[4][1]["artifact_ref"] == "artifact://registry/1"
+    assert captured[5][0] == "mm.skill.execute"
+    assert captured[5][1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 
 @pytest.mark.asyncio
@@ -324,6 +328,8 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
         **_kwargs: Any,
     ) -> Any:
         captured.append((activity_type, _normalize_payload(payload)))
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
         if activity_type == "artifact.read":
             if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
                 return json.dumps(
@@ -413,8 +419,10 @@ async def test_run_execution_stage_routes_mm_tool_execute_from_registry(
         plan_ref="art_plan_1",
     )
 
-    assert captured[2][0] == "mm.tool.execute"
-    assert captured[2][1]["registry_snapshot_ref"] == "artifact://registry/1"
+    # provider_profile.list calls (3) happen first, then artifact.read for plan,
+    # artifact.read for registry, then mm.tool.execute
+    assert captured[5][0] == "mm.tool.execute"
+    assert captured[5][1]["registry_snapshot_ref"] == "artifact://registry/1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -395,3 +395,106 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         metadata = request.parameters.get("metadata") or {}
         moonmind = metadata.get("moonmind") or {}
         self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")
+
+
+class TestFetchProfileSnapshots(unittest.TestCase):
+    """Verify the _fetch_profile_snapshots method populates profile snapshots."""
+
+    def test_fetch_profile_snapshots_populates_dict(self) -> None:
+        """When provider_profile.list activity returns profiles, they should
+        be stored in _profile_snapshots keyed by profile_id."""
+        import asyncio
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        async def run_test() -> None:
+            async def mock_execute_activity(
+                activity_name: str, *args: object, **kwargs: object
+            ) -> object:
+                if activity_name == "provider_profile.list":
+                    runtime_id = args[0].get("runtime_id") if args else kwargs.get("runtime_id")
+                    if runtime_id == "codex_cli":
+                        return {
+                            "profiles": [
+                                {
+                                    "profile_id": "codex_openrouter_qwen36_plus",
+                                    "runtime_id": "codex_cli",
+                                    "provider_id": "openrouter",
+                                },
+                                {
+                                    "profile_id": "codex_default",
+                                    "runtime_id": "codex_cli",
+                                    "provider_id": "openai",
+                                },
+                            ]
+                        }
+                    elif runtime_id == "claude_code":
+                        return {
+                            "profiles": [
+                                {
+                                    "profile_id": "claude_anthropic_sonnet",
+                                    "runtime_id": "claude_code",
+                                    "provider_id": "anthropic",
+                                },
+                            ]
+                        }
+                    elif runtime_id == "gemini_cli":
+                        return {"profiles": []}
+                return {}
+
+            with patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                side_effect=mock_execute_activity,
+            ):
+                await wf._fetch_profile_snapshots()
+
+            self.assertIn("codex_openrouter_qwen36_plus", wf._profile_snapshots)
+            self.assertIn("codex_default", wf._profile_snapshots)
+            self.assertIn("claude_anthropic_sonnet", wf._profile_snapshots)
+            self.assertNotIn("default:codex_cli", wf._profile_snapshots)
+
+        asyncio.run(run_test())
+
+    def test_fetch_profile_snapshots_tolerates_activity_failure(self) -> None:
+        """When provider_profile.list activity fails, _fetch_profile_snapshots
+        should not raise and should continue with whatever profiles it got."""
+        import asyncio
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        async def run_test() -> None:
+            async def mock_execute_activity(
+                activity_name: str, *args: object, **kwargs: object
+            ) -> object:
+                if activity_name == "provider_profile.list":
+                    runtime_id = args[0].get("runtime_id") if args else kwargs.get("runtime_id")
+                    if runtime_id == "codex_cli":
+                        raise RuntimeError("DB connection failed")
+                    elif runtime_id == "claude_code":
+                        return {
+                            "profiles": [
+                                {
+                                    "profile_id": "claude_anthropic_sonnet",
+                                    "runtime_id": "claude_code",
+                                    "provider_id": "anthropic",
+                                },
+                            ]
+                        }
+                    elif runtime_id == "gemini_cli":
+                        return {"profiles": []}
+                return {}
+
+            with patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                side_effect=mock_execute_activity,
+            ):
+                # Should not raise — best-effort fetch
+                await wf._fetch_profile_snapshots()
+
+            # codex_cli profiles are missing, but claude_code profiles should be there
+            self.assertIn("claude_anthropic_sonnet", wf._profile_snapshots)
+            self.assertNotIn("codex_openrouter_qwen36_plus", wf._profile_snapshots)
+
+        asyncio.run(run_test())

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -404,9 +404,19 @@ class TestFetchProfileSnapshots(unittest.TestCase):
         """When provider_profile.list activity returns profiles, they should
         be stored in _profile_snapshots keyed by profile_id."""
         import asyncio
+        from datetime import timedelta
+        from temporalio.common import RetryPolicy
         from unittest.mock import patch
 
         wf = MoonMindRunWorkflow()
+
+        # Provide a mock _execute_kwargs_for_route that returns valid kwargs
+        wf._execute_kwargs_for_route = lambda route: {
+            "task_queue": "mm.activity.artifacts",
+            "start_to_close_timeout": timedelta(seconds=60),
+            "schedule_to_close_timeout": timedelta(seconds=120),
+            "retry_policy": RetryPolicy(maximum_attempts=1),
+        }
 
         async def run_test() -> None:
             async def mock_execute_activity(
@@ -460,9 +470,18 @@ class TestFetchProfileSnapshots(unittest.TestCase):
         """When provider_profile.list activity fails, _fetch_profile_snapshots
         should not raise and should continue with whatever profiles it got."""
         import asyncio
+        from datetime import timedelta
+        from temporalio.common import RetryPolicy
         from unittest.mock import patch
 
         wf = MoonMindRunWorkflow()
+
+        wf._execute_kwargs_for_route = lambda route: {
+            "task_queue": "mm.activity.artifacts",
+            "start_to_close_timeout": timedelta(seconds=60),
+            "schedule_to_close_timeout": timedelta(seconds=120),
+            "retry_policy": RetryPolicy(maximum_attempts=1),
+        }
 
         async def run_test() -> None:
             async def mock_execute_activity(
@@ -496,5 +515,39 @@ class TestFetchProfileSnapshots(unittest.TestCase):
             # codex_cli profiles are missing, but claude_code profiles should be there
             self.assertIn("claude_anthropic_sonnet", wf._profile_snapshots)
             self.assertNotIn("codex_openrouter_qwen36_plus", wf._profile_snapshots)
+
+        asyncio.run(run_test())
+
+    def test_fetch_profile_snapshots_empty_result_does_not_set_snapshots(self) -> None:
+        """When all activity calls return empty profiles, _profile_snapshots
+        should NOT be set, so validation is skipped (best-effort behavior)."""
+        import asyncio
+        from datetime import timedelta
+        from temporalio.common import RetryPolicy
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        wf._execute_kwargs_for_route = lambda route: {
+            "task_queue": "mm.activity.artifacts",
+            "start_to_close_timeout": timedelta(seconds=60),
+            "schedule_to_close_timeout": timedelta(seconds=120),
+            "retry_policy": RetryPolicy(maximum_attempts=1),
+        }
+
+        async def run_test() -> None:
+            async def mock_execute_activity(
+                activity_name: str, *args: object, **kwargs: object
+            ) -> object:
+                return {"profiles": []}
+
+            with patch(
+                "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+                side_effect=mock_execute_activity,
+            ):
+                await wf._fetch_profile_snapshots()
+
+            # Should NOT be set when no data was fetched
+            self.assertFalse(hasattr(wf, "_profile_snapshots"))
 
         asyncio.run(run_test())


### PR DESCRIPTION
## Problem

The previous fix in b8ddaef3 added profile ref validation in `_build_agent_execution_request`, but the guard condition `profile_snapshots is not None` was always false because `_profile_snapshots` was never populated on the parent workflow (`MoonMind.Run`). It was only set on the child (`AgentRun`) workflow, making the parent-side validation dead code.

This caused AI-hallucinated profile IDs like `default:codex_cli` to pass through to the child workflow, which correctly rejected them as non-retryable failures, immediately failing the run.

**Example failure:**
```
Provider profile 'default:codex_cli' not found for runtime_id='codex_cli'
```

## Root Cause

The validation code in `run.py` line 1417:
```python
profile_snapshots = getattr(self, "_profile_snapshots", None)
if candidate is not None and profile_snapshots is not None:
    # validation only happens here
```

Since `_profile_snapshots` was never set on the parent workflow, `profile_snapshots` was always `None`, so the validation never executed. The invalid profile value passed through unchanged to the child workflow.

## Fix

- Add `_fetch_profile_snapshots()` method to `MoonMind.Run` that calls the `provider_profile.list` activity for all managed runtimes (`codex_cli`, `claude_code`, `gemini_cli`) at the start of the execution stage, before any plan nodes are processed.
- Failures to fetch profiles for a runtime are logged and tolerated (best-effort), so workflows continue even if the provider profile service is temporarily unavailable.
- Add unit tests for the new fetch method covering both success and failure cases.

## Tests

- 21/21 tests pass in `test_run_agent_dispatch.py` (including 2 new tests)
- 35/35 tests pass across related run workflow test files