### PR TITLE
[codex] Fix Run workflow PR publish outcome handling

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -104,6 +104,7 @@ RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
+RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
 )
@@ -171,6 +172,8 @@ class MoonMindRunWorkflow:
         self._summary: str = "Execution initialized."
         self._correlation_id: Optional[str] = None
         self._pull_request_url: Optional[str] = None
+        self._publish_status: Optional[str] = None
+        self._publish_reason: Optional[str] = None
         self._declared_dependencies: list[str] = []
         self._dependency_wait_occurred: bool = False
         self._dependency_wait_duration_ms: int | None = None
@@ -606,34 +609,41 @@ class MoonMindRunWorkflow:
 
         self._set_state(STATE_FINALIZING, summary="Finalizing execution.")
 
+        output_status = "success"
+        output_message = "Workflow completed successfully"
+        finalizing_status = "success"
+        finalizing_error: str | None = None
+        publish_failure = False
+
+        if workflow.patched(RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH):
+            output_status, output_message, publish_failure = (
+                self._determine_publish_completion(parameters=parameters)
+            )
+            if publish_failure:
+                finalizing_status = "failed"
+                finalizing_error = output_message
+            elif output_status == "no_changes":
+                finalizing_error = self._publish_reason or output_message
+
         await self._run_finalizing_stage(
-            parameters=parameters, status="success", error=None
+            parameters=parameters, status=finalizing_status, error=finalizing_error
         )
 
-        self._close_status = CLOSE_STATUS_COMPLETED
-        self._set_state(STATE_COMPLETED, summary="Workflow completed successfully.")
+        if publish_failure:
+            self._close_status = CLOSE_STATUS_FAILED
+            self._set_state(STATE_FAILED, summary=output_message)
+            raise exceptions.ApplicationError(
+                output_message,
+                non_retryable=True,
+            )
 
-        publish_mode = self._publish_mode(parameters)
-        # When publish mode is "pr" but no PR was created (tracked via
-        # _pull_request_url from execution stage), the workflow did not
-        # achieve its business objective. Guard with workflow.patched for
-        # replay safety on in-flight executions.
-        if workflow.patched("run-workflow-pr-status-v1"):
-            if publish_mode == "pr" and self._pull_request_url is None:
-                output: RunWorkflowOutput = {
-                    "status": "no_pr_created",
-                    "message": "Workflow completed but no PR was created",
-                }
-            else:
-                output = {
-                    "status": "success",
-                    "message": "Workflow completed successfully",
-                }
-        else:
-            output = {
-                "status": "success",
-                "message": "Workflow completed successfully",
-            }
+        self._close_status = CLOSE_STATUS_COMPLETED
+        self._set_state(STATE_COMPLETED, summary=output_message)
+
+        output: RunWorkflowOutput = {
+            "status": output_status,
+            "message": output_message,
+        }
         if self._proposals_generated > 0 or self._proposals_submitted > 0:
             output["proposals_generated"] = self._proposals_generated
             output["proposals_submitted"] = self._proposals_submitted
@@ -1002,6 +1012,10 @@ class MoonMindRunWorkflow:
             if result_status is None or result_status != "COMPLETED":
                 continue
 
+            self._record_publish_result(
+                parameters=parameters,
+                execution_result=execution_result,
+            )
             if require_pull_request_url and pull_request_url is None:
                 pull_request_url = self._extract_pull_request_url(execution_result)
 
@@ -1179,6 +1193,13 @@ class MoonMindRunWorkflow:
                         ) from e
         # Persist the PR URL so the workflow output can determine if a PR was created.
         self._pull_request_url = pull_request_url
+        publish_mode = self._publish_mode(parameters)
+        if publish_mode == "pr" and pull_request_url:
+            self._publish_status = "published"
+            self._publish_reason = "published pull request"
+        elif publish_mode == "branch" and self._publish_status is None:
+            self._publish_status = "published"
+            self._publish_reason = "published branch"
         self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 
@@ -1373,6 +1394,78 @@ class MoonMindRunWorkflow:
             if match is not None:
                 return match.group(0)
         return None
+
+    def _record_publish_result(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+        execution_result: Any,
+    ) -> None:
+        publish_mode = self._publish_mode(parameters)
+        if publish_mode not in {"pr", "branch"}:
+            return
+
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return
+
+        push_status = self._coerce_text(outputs.get("push_status"))
+        if push_status is None:
+            return
+
+        if push_status == "no_commits":
+            self._publish_status = "skipped"
+            self._publish_reason = "publish skipped: no local changes"
+            return
+
+        if push_status == "failed":
+            push_error = self._coerce_text(outputs.get("push_error"), max_chars=200)
+            self._publish_status = "failed"
+            self._publish_reason = push_error or "publish failed"
+            return
+
+        if push_status == "protected_branch":
+            push_branch = self._coerce_text(outputs.get("push_branch"), max_chars=120)
+            self._publish_status = "failed"
+            if push_branch:
+                self._publish_reason = (
+                    f"publish failed: working branch '{push_branch}' is protected"
+                )
+            else:
+                self._publish_reason = "publish failed: working branch is protected"
+            return
+
+        if push_status == "pushed" and publish_mode == "branch":
+            self._publish_status = "published"
+            self._publish_reason = "published branch"
+
+    def _determine_publish_completion(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+    ) -> tuple[str, str, bool]:
+        publish_mode = self._publish_mode(parameters)
+        if publish_mode == "none":
+            return ("success", "Workflow completed successfully", False)
+
+        if self._publish_status == "skipped":
+            return ("no_changes", "Workflow completed with no local changes", False)
+
+        if self._publish_status == "failed":
+            return (
+                "failed",
+                self._publish_reason or "Publish failed",
+                True,
+            )
+
+        if publish_mode == "pr" and self._pull_request_url is None:
+            return (
+                "failed",
+                "publishMode 'pr' requested but no PR was created",
+                True,
+            )
+
+        return ("success", "Workflow completed successfully", False)
 
     def _build_agent_execution_request(
         self,
@@ -2046,28 +2139,63 @@ class MoonMindRunWorkflow:
         try:
             self._get_logger().info("Generating finish summary.")
 
-            # Map Temporal status back to FinishOutcome code
+            publish_mode = self._publish_mode(parameters)
+            publish_status = "skipped" if status != "success" else "published"
+            publish_reason = (
+                "run did not complete successfully"
+                if status in ("failed", "canceled")
+                else (
+                    "publishing disabled"
+                    if publish_mode == "none"
+                    else "published successfully"
+                )
+            )
+
+            # Map Temporal status back to FinishOutcome code.
             code = "FAILED" if status == "failed" else "NO_CHANGES"
             if status == "canceled":
                 code = "CANCELLED"
-            # Try to refine it based on publish if it was successful
-            if status == "success":
-                publish_mode = self._publish_mode(parameters)
-                if publish_mode == "pr":
-                    # Guard with workflow.patched for replay safety.
-                    if workflow.patched("run-workflow-pr-status-v1"):
-                        # Use explicit PR URL tracking from execution stage
-                        code = (
-                            "PUBLISHED_PR"
-                            if self._pull_request_url
-                            else "NO_PR_CREATED"
+
+            if workflow.patched(RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH):
+                if status == "success":
+                    if publish_mode == "none":
+                        code = "PUBLISH_DISABLED"
+                        publish_status = "skipped"
+                        publish_reason = "publishing disabled"
+                    elif self._publish_status == "skipped":
+                        code = "NO_CHANGES"
+                        publish_status = "skipped"
+                        publish_reason = (
+                            self._publish_reason or "publish skipped: no local changes"
                         )
-                    else:
+                    elif publish_mode == "pr":
                         code = "PUBLISHED_PR"
-                elif publish_mode == "branch":
-                    code = "PUBLISHED_BRANCH"
-                elif publish_mode == "none":
-                    code = "PUBLISH_DISABLED"
+                        publish_status = "published"
+                        publish_reason = self._publish_reason or "published pull request"
+                    elif publish_mode == "branch":
+                        code = "PUBLISHED_BRANCH"
+                        publish_status = "published"
+                        publish_reason = self._publish_reason or "published branch"
+                elif self._publish_status == "failed":
+                    publish_status = "failed"
+                    publish_reason = self._publish_reason or error or "publish failed"
+            else:
+                if status == "success":
+                    if publish_mode == "pr":
+                        # Guard with workflow.patched for replay safety.
+                        if workflow.patched("run-workflow-pr-status-v1"):
+                            # Use explicit PR URL tracking from execution stage
+                            code = (
+                                "PUBLISHED_PR"
+                                if self._pull_request_url
+                                else "NO_PR_CREATED"
+                            )
+                        else:
+                            code = "PUBLISHED_PR"
+                    elif publish_mode == "branch":
+                        code = "PUBLISHED_BRANCH"
+                    elif publish_mode == "none":
+                        code = "PUBLISH_DISABLED"
 
             finish_summary = {
                 "schemaVersion": "v1",
@@ -2087,21 +2215,9 @@ class MoonMindRunWorkflow:
                     "reason": error or "completed",
                 },
                 "publish": {
-                    "mode": self._publish_mode(parameters),
-                    "status": "skipped" if status != "success" else "published",
-                    "reason": (
-                        "run did not complete successfully"
-                        if status in ("failed", "canceled")
-                        else (
-                            "publishing disabled"
-                            if self._publish_mode(parameters) == "none"
-                            else (
-                                "published successfully"
-                                if status == "success"
-                                else "no local changes"
-                            )
-                        )
-                    ),
+                    "mode": publish_mode,
+                    "status": publish_status,
+                    "reason": publish_reason,
                 },
                 "proposals": {
                     "requested": self._proposal_generation_requested(parameters),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1197,9 +1197,6 @@ class MoonMindRunWorkflow:
         if publish_mode == "pr" and pull_request_url:
             self._publish_status = "published"
             self._publish_reason = "published pull request"
-        elif publish_mode == "branch" and self._publish_status is None:
-            self._publish_status = "published"
-            self._publish_reason = "published branch"
         self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 
@@ -1424,6 +1421,12 @@ class MoonMindRunWorkflow:
             self._publish_reason = push_error or "publish failed"
             return
 
+        if push_status == "skipped":
+            push_error = self._coerce_text(outputs.get("push_error"), max_chars=200)
+            self._publish_status = "failed"
+            self._publish_reason = push_error or "publish skipped"
+            return
+
         if push_status == "protected_branch":
             push_branch = self._coerce_text(outputs.get("push_branch"), max_chars=120)
             self._publish_status = "failed"
@@ -1458,10 +1461,25 @@ class MoonMindRunWorkflow:
                 True,
             )
 
-        if publish_mode == "pr" and self._pull_request_url is None:
+        if publish_mode == "branch" and self._publish_status is None:
+            self._publish_status = "failed"
+            self._publish_reason = "branch publish outcome unknown"
             return (
                 "failed",
-                "publishMode 'pr' requested but no PR was created",
+                self._publish_reason,
+                True,
+            )
+
+        if (
+            publish_mode == "pr"
+            and self._integration is None
+            and self._pull_request_url is None
+        ):
+            self._publish_status = "failed"
+            self._publish_reason = "publishMode 'pr' requested but no PR was created"
+            return (
+                "failed",
+                self._publish_reason,
                 True,
             )
 
@@ -2016,6 +2034,9 @@ class MoonMindRunWorkflow:
                     merged = self._get_from_result(merge_result, "merged")
                     merge_summary = self._get_from_result(merge_result, "summary") or ""
                     if merged:
+                        self._pull_request_url = pr_url
+                        self._publish_status = "published"
+                        self._publish_reason = "published branch"
                         self._get_logger().info(
                             "Jules branch-publish: PR merged: %s", merge_summary
                         )

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -178,6 +178,18 @@ async def mock_skill_execute_failed(args: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+@activity.defn(name="mm.skill.execute")
+async def mock_skill_execute_no_commits(args: Dict[str, Any]) -> Dict[str, Any]:
+    SKILL_EXECUTE_CALLS.append(args)
+    return {
+        "status": "COMPLETED",
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "feature/no-op",
+        },
+    }
+
+
 @activity.defn(name="sandbox.run_command")
 async def mock_sandbox_command(args: Dict[str, Any]) -> Dict[str, Any]:
     SANDBOX_COMMAND_CALLS.append(args)
@@ -466,6 +478,53 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     desc.search_attributes.get("mm_state"),
                     ["failed"]
                 )
+
+    async def test_moonmind_run_workflow_pr_publish_without_changes_returns_no_changes(
+        self,
+    ) -> None:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _register_test_search_attributes(env)
+            async with (
+                Worker(
+                    env.client,
+                    task_queue=LLM_TASK_QUEUE,
+                    activities=[mock_plan_generate],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=ARTIFACTS_TASK_QUEUE,
+                    activities=[mock_artifact_read],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=SANDBOX_TASK_QUEUE,
+                    activities=[mock_sandbox_command, mock_skill_execute_no_commits],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="test-task-queue",
+                    workflows=[MoonMindRunWorkflow],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+            ):
+                result = await env.client.execute_workflow(
+                    MoonMindRunWorkflow.run,
+                    {
+                        "workflowType": "MoonMind.Run",
+                        "initialParameters": {
+                            "repo": "moonladder/moonmind",
+                            "publishMode": "pr",
+                        },
+                    },
+                    id="test-workflow-pr-no-changes",
+                    task_queue="test-task-queue",
+                    search_attributes=_trusted_search_attributes(),
+                )
+
+            self.assertEqual(result["status"], "no_changes")
+            self.assertEqual(
+                result["message"], "Workflow completed with no local changes"
+            )
 
     async def test_proposals_stage_enabled(self) -> None:
         """When proposeTasks is true, proposal activities are invoked."""

--- a/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -131,6 +131,38 @@ async def mock_artifact_read_agent(args: Dict[str, Any]) -> bytes:
     return json.dumps(payload).encode("utf-8")
 
 
+@activity.defn(name="artifact.read")
+async def mock_artifact_read_jules_missing_pr(args: Dict[str, Any]) -> bytes:
+    ARTIFACT_READ_CALLS.append(args)
+    payload = {
+        "plan_version": "1.0",
+        "metadata": {
+            "title": "Jules missing PR plan",
+            "created_at": "2026-04-04T00:00:00Z",
+            "registry_snapshot": {
+                "digest": "reg:sha256:" + ("c" * 64),
+                "artifact_ref": "artifact://registry/jules-missing-pr",
+            },
+        },
+        "policy": {"failure_mode": "FAIL_FAST"},
+        "nodes": [
+            {
+                "id": "agent-step-1",
+                "tool": {
+                    "type": "agent_runtime",
+                    "name": "jules",
+                },
+                "inputs": {
+                    "targetRuntime": "jules",
+                    "instructions": "Fix the bug",
+                    "repo": "moonladder/moonmind",
+                },
+            }
+        ],
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
 @activity.defn(name="artifact.create")
 async def mock_artifact_create(args: Dict[str, Any]) -> Dict[str, Any]:
     return {"artifact_id": "test-artifact-id", "artifact_ref": f"artifact://{args.get('artifact_id', 'test')}"}
@@ -186,6 +218,21 @@ class MockProviderProfileManager:
                 handle = workflow.get_external_workflow_handle(req["requester_workflow_id"])
                 await handle.signal("slot_assigned", {"profile_id": profile_id})
         return {}
+
+
+@workflow.defn(name="MoonMind.AgentRun")
+class MockNoPrAgentRun:
+    @workflow.run
+    async def run(self, _input_payload: dict) -> dict:
+        return {
+            "summary": "Completed without creating a PR",
+            "metadata": {},
+            "outputRefs": [],
+            "diagnosticsRef": None,
+            "failureClass": None,
+            "providerErrorCode": None,
+            "retryRecommendation": None,
+        }
 
 
 @activity.defn(name="mm.skill.execute")
@@ -319,6 +366,60 @@ class TestAgentRuntimeDispatch(unittest.IsolatedAsyncioTestCase):
                     )
                 self.assertIn(
                     "must be 'skill' or 'agent_runtime'",
+                    exc_info.exception.cause.message,
+                )
+
+    async def test_jules_agent_runtime_pr_publish_without_pr_fails_in_finalization(
+        self,
+    ) -> None:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _register_test_search_attributes(env)
+            async with (
+                Worker(
+                    env.client,
+                    task_queue=LLM_TASK_QUEUE,
+                    activities=[mock_plan_generate_agent],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=ARTIFACTS_TASK_QUEUE,
+                    activities=[
+                        mock_artifact_read_jules_missing_pr,
+                        mock_artifact_create,
+                        mock_artifact_write_complete,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=WORKFLOW_TASK_QUEUE,
+                    workflows=[MockNoPrAgentRun],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+                Worker(
+                    env.client,
+                    task_queue="test-task-queue",
+                    workflows=[MoonMindRunWorkflow],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+            ):
+                with self.assertRaises(client.WorkflowFailureError) as exc_info:
+                    await env.client.execute_workflow(
+                        MoonMindRunWorkflow.run,
+                        {
+                            "workflowType": "MoonMind.Run",
+                            "title": "Jules missing PR failure",
+                            "initialParameters": {
+                                "repo": "moonladder/moonmind",
+                                "publishMode": "pr",
+                            },
+                        },
+                        id="test-jules-agent-runtime-missing-pr",
+                        task_queue="test-task-queue",
+                        search_attributes=_trusted_search_attributes(),
+                    )
+
+                self.assertIn(
+                    "publishMode 'pr' requested but no PR was created",
                     exc_info.exception.cause.message,
                 )
 

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -559,10 +559,38 @@ def test_determine_publish_completion_returns_no_changes_for_no_commit_pr_publis
 def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
+    mock_run_workflow._integration = None
+
     status, message, publish_failure = mock_run_workflow._determine_publish_completion(
         parameters={"publishMode": "pr"}
     )
 
     assert status == "failed"
     assert message == "publishMode 'pr' requested but no PR was created"
+    assert publish_failure is True
+
+
+def test_determine_publish_completion_allows_integration_pr_without_local_pr_url(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._integration = "jules"
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == "success"
+    assert message == "Workflow completed successfully"
+    assert publish_failure is False
+
+
+def test_determine_publish_completion_fails_for_unknown_branch_publish_outcome(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "branch"}
+    )
+
+    assert status == "failed"
+    assert message == "branch publish outcome unknown"
     assert publish_failure is True

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -539,3 +539,30 @@ async def test_run_integration_stage_multi_step_bundles_into_single_start(
     assert all(c[0] != "integration.jules.send_message" for c in captured)
     assert len(status_calls) == 1
     assert mock_run_workflow._external_status == "completed"
+
+
+def test_determine_publish_completion_returns_no_changes_for_no_commit_pr_publish(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._publish_status = "skipped"
+    mock_run_workflow._publish_reason = "publish skipped: no local changes"
+
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == "no_changes"
+    assert message == "Workflow completed with no local changes"
+    assert publish_failure is False
+
+
+def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters={"publishMode": "pr"}
+    )
+
+    assert status == "failed"
+    assert message == "publishMode 'pr' requested but no PR was created"
+    assert publish_failure is True


### PR DESCRIPTION
## Summary
Fix `MoonMind.Run` finalization so PR publish outcomes are classified truthfully when the managed child run completes without producing a pull request.

## What Changed
- record publish outcome details from execution results in `MoonMind.Run`
- map `push_status=no_commits` to a `no_changes` workflow result instead of generic success
- fail `publishMode=pr` runs when no PR was created for reasons other than no local changes
- write finish-summary publish status and reason from the actual publish outcome instead of always reporting `published`
- add workflow boundary tests for the no-change PR path and the missing-PR failure path

## Root Cause
Workflow `mm:97da4471-0a31-4416-95f3-4a7678741c5d` finished its child `MoonMind.AgentRun` with `push_status=no_commits`, but the parent workflow only checked for a pull request URL late in finalization and still treated the run as completed. That produced misleading finish metadata and left the run in a business-success state even though no PR could exist.

## Impact
PR-publish runs now distinguish between:
- no local changes
- publish failure
- successful PR creation

That keeps workflow result status, finish summary, and operator-visible outcome aligned with the actual publish result.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `./tools/test_unit.sh --python-only tests/integration/workflows/temporal/workflows/test_run.py`