### PR TITLE
[codex] Fix no-op PR publish task handling

### DIFF
--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -9964,12 +9964,21 @@ class CodexWorker:
             "WORKSPACE:\n"
             "- Repo is already checked out on the working branch.\n"
             f"{workspace_publish_line}\n"
-            "- Skills are available via .agents/skills and .gemini/skills links.\n"
-            "- Selected skills are always materialized under ../skills_active/<skill-id>/.\n"
             "- Write logs to stdout/stderr; MoonMind captures them.\n\n"
             f"RUNTIME ADAPTER: {runtime_mode}"
         )
-        if step.effective_skill_id != "auto":
+        if step.effective_skill_id == "auto":
+            instruction += (
+                "\n\nSKILL USAGE:\n"
+                "- No explicit skill is selected for this step.\n"
+                "- Work directly from the task objective and repository code.\n"
+                "- Do not activate repo skill bundles unless a task/step explicitly selects one."
+            )
+        else:
+            instruction += (
+                "\n- Skills are available via .agents/skills and .gemini/skills links.\n"
+                "- Selected skills are always materialized under ../skills_active/<skill-id>/."
+            )
             instruction += (
                 "\n\nSKILL USAGE:\n"
                 "Use the selected skill's files under .agents/skills/{skill}/ as the procedure for this step. "

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -9965,10 +9965,10 @@ class CodexWorker:
             "- Repo is already checked out on the working branch.\n"
             f"{workspace_publish_line}\n"
             "- Write logs to stdout/stderr; MoonMind captures them.\n\n"
-            f"RUNTIME ADAPTER: {runtime_mode}"
         )
         if step.effective_skill_id == "auto":
             instruction += (
+                f"\nRUNTIME ADAPTER: {runtime_mode}"
                 "\n\nSKILL USAGE:\n"
                 "- No explicit skill is selected for this step.\n"
                 "- Work directly from the task objective and repository code.\n"
@@ -9976,10 +9976,11 @@ class CodexWorker:
             )
         else:
             instruction += (
-                "\n- Skills are available via .agents/skills and .gemini/skills links.\n"
+                "- Skills are available via .agents/skills and .gemini/skills links.\n"
                 "- Selected skills are always materialized under ../skills_active/<skill-id>/."
             )
             instruction += (
+                f"\n\nRUNTIME ADAPTER: {runtime_mode}"
                 "\n\nSKILL USAGE:\n"
                 "Use the selected skill's files under .agents/skills/{skill}/ as the procedure for this step. "
                 "If that path is missing, use ../skills_active/{skill}/."

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1502,6 +1502,16 @@ class MoonMindRunWorkflow:
             return ("success", "Workflow completed successfully", False)
 
         if self._publish_status == "skipped":
+            if publish_mode == "pr":
+                self._publish_status = "failed"
+                self._publish_reason = (
+                    "publishMode 'pr' requested but no local changes were produced"
+                )
+                return (
+                    "failed",
+                    self._publish_reason,
+                    True,
+                )
             return ("no_changes", "Workflow completed with no local changes", False)
 
         if self._publish_status == "failed":

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -479,7 +479,7 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     ["failed"]
                 )
 
-    async def test_moonmind_run_workflow_pr_publish_without_changes_returns_no_changes(
+    async def test_moonmind_run_workflow_pr_publish_without_changes_fails(
         self,
     ) -> None:
         async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -507,24 +507,35 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     workflow_runner=UnsandboxedWorkflowRunner(),
                 ),
             ):
-                result = await env.client.execute_workflow(
-                    MoonMindRunWorkflow.run,
-                    {
-                        "workflowType": "MoonMind.Run",
-                        "initialParameters": {
-                            "repo": "moonladder/moonmind",
-                            "publishMode": "pr",
+                with self.assertRaises(client.WorkflowFailureError) as exc_info:
+                    await env.client.execute_workflow(
+                        MoonMindRunWorkflow.run,
+                        {
+                            "workflowType": "MoonMind.Run",
+                            "initialParameters": {
+                                "repo": "moonladder/moonmind",
+                                "publishMode": "pr",
+                            },
                         },
-                    },
-                    id="test-workflow-pr-no-changes",
-                    task_queue="test-task-queue",
-                    search_attributes=_trusted_search_attributes(),
+                        id="test-workflow-pr-no-changes",
+                        task_queue="test-task-queue",
+                        search_attributes=_trusted_search_attributes(),
+                    )
+
+                self.assertIsInstance(
+                    exc_info.exception.cause, exceptions.ApplicationError
+                )
+                self.assertEqual(
+                    exc_info.exception.cause.message,
+                    "publishMode 'pr' requested but no local changes were produced",
                 )
 
-            self.assertEqual(result["status"], "no_changes")
-            self.assertEqual(
-                result["message"], "Workflow completed with no local changes"
-            )
+                handle = env.client.get_workflow_handle("test-workflow-pr-no-changes")
+                desc = await handle.describe()
+                self.assertEqual(
+                    desc.search_attributes.get("mm_state"),
+                    ["failed"],
+                )
 
     async def test_proposals_stage_enabled(self) -> None:
         """When proposeTasks is true, proposal activities are invoked."""

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -4424,6 +4424,60 @@ async def test_compose_step_instruction_allows_pr_resolver_self_publish_when_pub
     )
 
 
+async def test_compose_step_instruction_keeps_skill_workspace_lines_under_workspace_section(
+    tmp_path: Path,
+) -> None:
+    """Non-auto steps should keep skill-location guidance within WORKSPACE."""
+
+    config = CodexWorkerConfig(
+        moonmind_url="http://localhost:5000",
+        worker_id="worker-1",
+        worker_token=None,
+        poll_interval_ms=1500,
+        lease_seconds=120,
+        workdir=tmp_path,
+    )
+    queue = FakeQueueClient()
+    handler = FakeHandler(
+        WorkerExecutionResult(succeeded=True, summary="unused", error_message=None)
+    )
+    worker = CodexWorker(config=config, queue_client=queue, codex_exec_handler=handler)  # type: ignore[arg-type]
+
+    instruction = worker._compose_step_instruction_for_runtime(
+        canonical_payload={
+            "task": {
+                "instructions": "Apply the selected workflow.",
+            }
+        },
+        runtime_mode="codex",
+        step=ResolvedTaskStep(
+            step_index=0,
+            step_id="step-1",
+            title="Execute",
+            instructions="Follow the selected skill.",
+            effective_skill_id="pr-resolver",
+            effective_skill_args={},
+            has_step_instructions=True,
+        ),
+        total_steps=1,
+    )
+
+    workspace_index = instruction.index("WORKSPACE:\n")
+    runtime_index = instruction.index("\n\nRUNTIME ADAPTER: codex")
+    skills_index = instruction.index(
+        "- Skills are available via .agents/skills and .gemini/skills links."
+    )
+    selected_index = instruction.index(
+        "- Selected skills are always materialized under ../skills_active/<skill-id>/."
+    )
+
+    assert workspace_index < skills_index < selected_index < runtime_index
+    assert (
+        "SKILL USAGE:\nUse the selected skill's files under .agents/skills/pr-resolver/ as the procedure for this step."
+        in instruction
+    )
+
+
 async def test_run_once_task_steps_fail_fast_on_first_failed_step(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -4320,6 +4320,9 @@ async def test_compose_step_instruction_dedupes_objective_text(
         in instruction
     )
     assert instruction.count("Implement direct worker to Qdrant retrieval path.") == 1
+    assert "No explicit skill is selected for this step." in instruction
+    assert "Do not activate repo skill bundles unless a task/step explicitly selects one." in instruction
+    assert "- Skills are available via .agents/skills and .gemini/skills links." not in instruction
 
 
 async def test_compose_step_instruction_keeps_distinct_step_text(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -541,7 +541,7 @@ async def test_run_integration_stage_multi_step_bundles_into_single_start(
     assert mock_run_workflow._external_status == "completed"
 
 
-def test_determine_publish_completion_returns_no_changes_for_no_commit_pr_publish(
+def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
     mock_run_workflow._publish_status = "skipped"
@@ -551,9 +551,12 @@ def test_determine_publish_completion_returns_no_changes_for_no_commit_pr_publis
         parameters={"publishMode": "pr"}
     )
 
-    assert status == "no_changes"
-    assert message == "Workflow completed with no local changes"
-    assert publish_failure is False
+    assert status == "failed"
+    assert (
+        message
+        == "publishMode 'pr' requested but no local changes were produced"
+    )
+    assert publish_failure is True
 
 
 def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(


### PR DESCRIPTION
## Summary
- fail `publishMode="pr"` runs when the agent finishes without producing any local changes instead of reporting them as completed
- update workflow boundary coverage so the no-commit PR publish path is asserted as a failed outcome
- stop `auto` Codex task steps from advertising repo skill bundles so they do not self-select proposal-only skills like `fix-proposal`

## Root cause
The investigated workflow completed without a PR because the agent never created edits or commits. In the managed workspace, Codex discovered the repo `fix-proposal` skill during an `auto` step, and that skill explicitly forbids modifying source files or committing. The workflow then treated the resulting `no_commits` publish outcome as a successful `no_changes` completion.

## Impact
PR-publish tasks that produce no local changes now fail explicitly, and `auto` task steps are less likely to route themselves into repo-local skills that are only intended for specialized post-run flows.

## Validation
- `./tools/test_unit.sh`
- `.venv/bin/pytest tests/integration/workflows/temporal/workflows/test_run.py -q -k pr_publish_without_changes_fails`
- `.venv/bin/pytest tests/unit/workflows/temporal/workflows/test_run_integration.py -q -k no_commit_pr_publish`
- `.venv/bin/pytest tests/unit/agents/codex_worker/test_worker.py -q -k 'compose_step_instruction_deduplicates_repeated_objective_text or compose_step_instruction_keeps_distinct_step_text'`
