### PR TITLE
[codex] Increase pr-resolver CI wait budget

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -14,10 +14,10 @@ You are the master orchestrator for finishing Pull Requests. Use bounded retries
 - inputs.branch (optional)
 - inputs.mergeMethod (merge|squash|rebase)
 - inputs.maxIterations (default 3, full remediation cap per cycle)
-- inputs.finalizeMaxRetries (default 2)
-- inputs.finalizeBackoffSeconds (default 15)
-- inputs.finalizeMaxSleepSeconds (default 60)
-- inputs.finalizeMaxElapsedSeconds (default 900)
+- inputs.finalizeMaxRetries (default 6)
+- inputs.finalizeBackoffSeconds (default 30)
+- inputs.finalizeMaxSleepSeconds (default 120)
+- inputs.finalizeMaxElapsedSeconds (default 1800)
 
 ## Primary Command (use first)
 Run the orchestration entrypoint. **You MUST provide the `--pr` argument** (using either the PR number or the branch name) to ensure the script targets the correct PR, even if you are on a different branch or detached HEAD:

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -461,25 +461,25 @@ def main() -> None:
     parser.add_argument(
         "--finalize-max-retries",
         type=int,
-        default=2,
+        default=6,
         help="Number of finalize retries after the initial attempt.",
     )
     parser.add_argument(
         "--base-sleep-seconds",
         type=int,
-        default=15,
+        default=30,
         help="Base sleep for finalize-only retries (exponential backoff).",
     )
     parser.add_argument(
         "--max-sleep-seconds",
         type=int,
-        default=60,
+        default=120,
         help="Max sleep for finalize-only retries.",
     )
     parser.add_argument(
         "--max-elapsed-seconds",
         type=int,
-        default=900,
+        default=1800,
         help="Hard wall-clock cap for orchestration execution.",
     )
     parser.add_argument(

--- a/docs/ManagedAgents/SkillGithubPrResolver.md
+++ b/docs/ManagedAgents/SkillGithubPrResolver.md
@@ -70,7 +70,7 @@ This matches the standard `AgentTaskWorkflow` capability derivation pattern.
 | `branch`              | string|null |     null | Explicit head branch to resolve; if set and `pr` unset, resolve associated PR.                                       |
 | `mergeMethod`         | enum        | `squash` | `merge`|`squash`|`rebase`                                                                                            |
 | `maxIterations`             | int         |        3 | Guardrail to avoid loops (re-evaluate after each fix).                                                                            |
-| `finalizeMaxRetries`        | int         |        6 | Number of finalize-only retries after the initial attempt when the PR is waiting on transient conditions such as running CI.      |
+| `finalizeMaxRetries`        | int         |        6 | Total retries allowed for the orchestration process, including both finalize-only waits and full remediation cycles.              |
 | `finalizeBackoffSeconds`    | int         |       30 | Base sleep for finalize-only retries. The orchestrator uses exponential backoff and caps each sleep at `finalizeMaxSleepSeconds`. |
 | `finalizeMaxSleepSeconds`   | int         |      120 | Max sleep between finalize-only retries.                                                                                            |
 | `finalizeMaxElapsedSeconds` | int         |     1800 | Hard wall-clock cap for one orchestration run.                                                                                      |
@@ -219,7 +219,10 @@ You are the Master orchestrator for finishing Pull Requests. You diagnose the PR
 - inputs.branch (optional)
 - inputs.mergeMethod (merge|squash|rebase)
 - inputs.maxIterations (default 3)
-- inputs.failFastIfCiRunning (default true)
+- inputs.finalizeMaxRetries (default 6)
+- inputs.finalizeBackoffSeconds (default 30)
+- inputs.finalizeMaxSleepSeconds (default 120)
+- inputs.finalizeMaxElapsedSeconds (default 1800)
 
 ## Workflow
 1. Run `bin/pr_resolve_snapshot.py` to generate `artifacts/pr_resolver_snapshot.json`.
@@ -229,7 +232,7 @@ You are the Master orchestrator for finishing Pull Requests. You diagnose the PR
    - **CI Failures:** If `ci.hasFailures` is true, you MUST read `.agents/skills/fix-ci/SKILL.md` (or similar available skill) and follow its procedure to fix the tests/build.
    - **Review Comments:** If `reviewDecision` indicates changes requested, read `.agents/skills/fix-comments/SKILL.md` and follow its procedure.
    - **Merge:** If all green, `mergeable` is clean, `mergeStateStatus` is `CLEAN`, and NO CI is running, execute `gh pr merge --<mergeMethod>`.
-   - **Blocked:** If CI is running but no failures while `mergeable` is clean and `mergeStateStatus` is exactly `CLEAN`, exit and state the PR is blocked waiting for CI.
+   - **Finalize-only retry:** If CI is running but no failures while `mergeable` is clean and `mergeStateStatus` is exactly `CLEAN`, retry finalize after bounded exponential backoff until the transient retry budget is exhausted.
 4. After applying ANY fix (conflict, CI, or review), you MUST loop back to Step 1 and re-run the snapshot. Stop after `maxIterations`.
 5. Write `artifacts/pr_resolver_result.json` summarizing the actions taken and the final merge outcome.
 

--- a/docs/ManagedAgents/SkillGithubPrResolver.md
+++ b/docs/ManagedAgents/SkillGithubPrResolver.md
@@ -2,7 +2,7 @@
 
 Status: Active
 Owners: MoonMind Engineering
-Last Updated: 2026-03-24
+Last Updated: 2026-04-04
 
 ## 1. Purpose
 
@@ -69,8 +69,11 @@ This matches the standard `AgentTaskWorkflow` capability derivation pattern.
 | `pr`                  | string|null |     null | PR selector: number, URL, or branch (passed to `gh pr view`).                                                        |
 | `branch`              | string|null |     null | Explicit head branch to resolve; if set and `pr` unset, resolve associated PR.                                       |
 | `mergeMethod`         | enum        | `squash` | `merge`|`squash`|`rebase`                                                                                            |
-| `maxIterations`       | int         |        3 | Guardrail to avoid loops (re-evaluate after each fix).                                                               |
-| `failFastIfCiRunning` | bool        |     true | If any CI is in-progress/pending, do not merge and do not attempt CI fixes unless CI is failing (see decision logic) |
+| `maxIterations`             | int         |        3 | Guardrail to avoid loops (re-evaluate after each fix).                                                                            |
+| `finalizeMaxRetries`        | int         |        6 | Number of finalize-only retries after the initial attempt when the PR is waiting on transient conditions such as running CI.      |
+| `finalizeBackoffSeconds`    | int         |       30 | Base sleep for finalize-only retries. The orchestrator uses exponential backoff and caps each sleep at `finalizeMaxSleepSeconds`. |
+| `finalizeMaxSleepSeconds`   | int         |      120 | Max sleep between finalize-only retries.                                                                                            |
+| `finalizeMaxElapsedSeconds` | int         |     1800 | Hard wall-clock cap for one orchestration run.                                                                                      |
 
 ### 4.2 Outputs
 
@@ -113,7 +116,8 @@ The resolver always re-evaluates from the top after each applied fix (bounded by
 3. **CI failures:** If `ci.hasFailures == true` → Delegate to `fix-ci` skill (or fallback to manual diagnosis if skill missing).
 4. **Review comments:** If `reviewDecision` requests changes or comments are actionable → Delegate to `fix-comments` skill.
 5. **Merge:** If `mergeable` is clean, `mergeStateStatus` is `CLEAN`, no CI running, and reviews satisfied → Execute `gh pr merge`.
-6. **Blocked:** If CI is running without failures while `mergeable` is clean (not in conflict) and `mergeStateStatus` is `CLEAN` → Exit with `blocked_by_ci_running`.
+6. **Finalize-only retry:** If CI is running without failures while `mergeable` is clean (not in conflict) and `mergeStateStatus` is `CLEAN` → stay in the finalize loop and retry after exponential backoff.
+7. **Blocked:** If the transient finalize-only retry budget is exhausted or a non-retryable blocker is detected → exit with the corresponding blocked or `attempts_exhausted` result.
 
 ---
 
@@ -190,6 +194,7 @@ Include in result:
 * Working tree must be clean at start.
 * Loop guard: `maxIterations` stops repeated "fix → re-evaluate" loops.
 * Merge guard: do not merge if any CI is running.
+* Transient finalize blockers such as `ci_running` use bounded exponential backoff rather than failing immediately.
 
 ---
 

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -740,6 +740,65 @@ def test_orchestrate_ci_failures_after_transient_ci_states_escalates_fix_ci(
     assert sleeps == [15, 30]
 
 
+def test_orchestrate_main_uses_extended_finalize_wait_defaults(
+    pr_resolve_orchestrate_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    main = pr_resolve_orchestrate_module["main"]
+    globals_dict = main.__globals__
+    captured: dict[str, Any] = {}
+
+    def _fake_run_orchestration(**kwargs: Any) -> tuple[dict[str, Any], int]:
+        captured.update(kwargs)
+        return (
+            {
+                "status": "merged",
+                "decision": "merged",
+                "merge_outcome": "merged",
+                "final_reason": "ci_complete",
+                "next_step": "done",
+                "history": [],
+                "escalations": 0,
+                "max_attempts": 7,
+                "finalize_max_retries": kwargs["finalize_max_retries"],
+                "fix_max_iterations": kwargs["fix_max_iterations"],
+                "started_at": "2026-04-04T00:00:00Z",
+                "finished_at": "2026-04-04T00:00:01Z",
+                "tool": "pr_resolve_orchestrate",
+                "schema_version": "v1",
+            },
+            0,
+        )
+
+    monkeypatch.setitem(globals_dict, "run_orchestration", _fake_run_orchestration)
+
+    result_path = tmp_path / "result.json"
+    snapshot_path = tmp_path / "snapshot.json"
+    attempts_dir = tmp_path / "attempts"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_orchestrate.py",
+            "--result-path",
+            str(result_path),
+            "--snapshot-path",
+            str(snapshot_path),
+            "--attempt-artifacts-dir",
+            str(attempts_dir),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert int(raised.value.code) == 0
+    assert captured["finalize_max_retries"] == 6
+    assert captured["base_sleep_seconds"] == 30
+    assert captured["max_sleep_seconds"] == 120
+    assert captured["max_elapsed_seconds"] == 1800
+
+
 def test_contract_snapshot_refresh_failed_is_finalize_only_retry(
     pr_resolve_contract_module: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## Summary
Increase the default `pr-resolver` finalize wait budget so transient `ci_running` states do not exhaust retries before GitHub checks have time to finish.

## What Changed
- raised the default finalize retry count from 2 to 6
- raised the base finalize backoff from 15s to 30s
- raised the max finalize sleep from 60s to 120s
- raised the orchestration wall-clock cap from 900s to 1800s
- updated the skill and managed-agent docs to match the new defaults
- added a unit test that locks the extended defaults into the orchestrator entrypoint

## Why
`pr-resolver` was frequently returning `attempts_exhausted` while CI was still running. The retry path was already correct, but the default wait budget was too short for normal multi-minute GitHub Actions runs.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`