### PR TITLE
[codex] Improve no-change publish summaries

### DIFF
--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -124,6 +124,86 @@ describe('Task Detail Entrypoint', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/executions/test-123?source=temporal');
   });
 
+  it('renders structured run summary details from the summary artifact', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Explained task',
+      summary: "publishMode 'pr' requested but no local changes were produced",
+      status: 'failed',
+      state: 'failed',
+      rawState: 'failed',
+      temporalStatus: 'failed',
+      closeStatus: 'FAILED',
+      summaryArtifactRef: 'art-summary-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      startedAt: '2026-03-28T00:00:01Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      closedAt: '2026-03-28T00:00:03Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts/art-summary-1/download')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              finishOutcome: {
+                code: 'FAILED',
+                stage: 'finalizing',
+                reason: "publishMode 'pr' requested, but no publishable diff was produced.",
+              },
+              publish: {
+                mode: 'pr',
+                status: 'failed',
+                reason:
+                  "publishMode 'pr' requested, but no publishable diff was produced. branch 'feature/no-op' has no commits ahead of origin/main.",
+              },
+              operatorSummary:
+                'The requested behavior already existed in the repo.\nFiles edited in this run: none.',
+              publishContext: {
+                branch: 'feature/no-op',
+                baseRef: 'origin/main',
+                commitCount: 0,
+              },
+              lastStep: {
+                summary: 'Files edited in this run: none',
+              },
+            }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Explained task')).toBeTruthy();
+      expect(screen.getByText(/The requested behavior already existed in the repo\./)).toBeTruthy();
+      expect(screen.getByText('Run Summary')).toBeTruthy();
+      expect(screen.getByText('feature/no-op')).toBeTruthy();
+      expect(screen.getByText('origin/main')).toBeTruthy();
+      expect(screen.getAllByText(/no publishable diff was produced/).length).toBeGreaterThan(0);
+    });
+  });
+
   it('renders artifact rows from snake_case temporal artifact payloads', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -49,6 +49,8 @@ const ExecutionDetailSchema = z
     resolvedSkillsetRef: z.string().nullable().optional(),
     taskSkills: z.array(z.string()).nullable().optional(),
     publishMode: z.string().nullable().optional(),
+    summaryArtifactRef: z.string().nullable().optional(),
+    summary_artifact_ref: z.string().nullable().optional(),
     scheduledFor: z.string().nullable().optional(),
     createdAt: z.string(),
     startedAt: z.string().nullable().optional(),
@@ -138,6 +140,46 @@ const ArtifactListSchema = z.object({
     )
     .default([]),
 });
+
+const RunSummaryArtifactSchema = z
+  .object({
+    finishOutcome: z
+      .object({
+        code: z.string().optional(),
+        stage: z.string().optional(),
+        reason: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    publish: z
+      .object({
+        mode: z.string().optional(),
+        status: z.string().optional(),
+        reason: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    operatorSummary: z.string().nullable().optional(),
+    nextAction: z.string().nullable().optional(),
+    lastStep: z
+      .object({
+        id: z.string().nullable().optional(),
+        summary: z.string().nullable().optional(),
+        diagnosticsRef: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .optional(),
+    publishContext: z
+      .object({
+        branch: z.string().nullable().optional(),
+        baseRef: z.string().nullable().optional(),
+        commitCount: z.union([z.number(), z.string()]).nullable().optional(),
+        pullRequestUrl: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
 
 function readDashboardConfig(payload: BootPayload): DashboardConfig | undefined {
   const raw = payload.initialData as { dashboardConfig?: DashboardConfig } | undefined;
@@ -267,6 +309,23 @@ async function fetchDiagnostics(apiBase: string, taskRunId: string): Promise<str
     throw buildObservabilityRequestError(resp.status);
   }
   return resp.text();
+}
+
+async function fetchRunSummaryArtifact(
+  apiBase: string,
+  artifactId: string,
+): Promise<z.infer<typeof RunSummaryArtifactSchema> | null> {
+  const resp = await fetch(
+    `${apiBase}/artifacts/${encodeURIComponent(artifactId)}/download`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw new Error(`Run summary: ${resp.statusText}`);
+  }
+  const text = await resp.text();
+  if (!text.trim()) return null;
+  return RunSummaryArtifactSchema.parse(JSON.parse(text));
 }
 
 /** Fetch the observability summary for a task run. */
@@ -972,6 +1031,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const workflowId = execution?.workflowId || execution?.taskId || taskId || '';
   const runId = execution?.temporalRunId || execution?.runId || '';
   const namespace = execution?.namespace || '';
+  const summaryArtifactRef = execution?.summaryArtifactRef || execution?.summary_artifact_ref || '';
   const explicitTaskRunId = execution?.taskRunId || execution?.task_run_id || '';
   const resolvedTaskRunId = explicitTaskRunId;
   const previousTaskRunIdRef = useRef(resolvedTaskRunId);
@@ -1014,9 +1074,19 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     refetchInterval: liveUpdates && namespace && workflowId && runId ? detailPoll : false,
   });
 
+  const runSummaryQuery = useQuery({
+    queryKey: ['task-detail-run-summary', summaryArtifactRef],
+    queryFn: () => fetchRunSummaryArtifact(payload.apiBase, summaryArtifactRef),
+    enabled: Boolean(summaryArtifactRef),
+    refetchInterval: liveUpdates && summaryArtifactRef ? detailPoll : false,
+  });
+  const runSummary = runSummaryQuery.data;
+  const displayedSummary = runSummary?.operatorSummary || execution?.summary || '—';
+
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['task-detail', encodedTaskId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-artifacts', namespace, workflowId, runId] });
+    void queryClient.invalidateQueries({ queryKey: ['task-detail-run-summary', summaryArtifactRef] });
   };
 
   const updateMutation = useMutation({
@@ -1257,8 +1327,57 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
 
           <section>
             <h3>Summary</h3>
-            <p className="whitespace-pre-wrap">{execution.summary || '—'}</p>
+            <p className="whitespace-pre-wrap">{displayedSummary}</p>
+            {runSummary?.finishOutcome?.reason && runSummary.finishOutcome.reason !== displayedSummary ? (
+              <p className="small">Outcome: {runSummary.finishOutcome.reason}</p>
+            ) : null}
           </section>
+
+          {runSummary ? (
+            <section className="stack">
+              <h3>Run Summary</h3>
+              {runSummary.finishOutcome ? (
+                <div className="grid-2">
+                  <Card label="Outcome Code">{runSummary.finishOutcome.code || '—'}</Card>
+                  <Card label="Outcome Stage">{runSummary.finishOutcome.stage || '—'}</Card>
+                </div>
+              ) : null}
+              {runSummary.publish ? (
+                <div className="grid-2">
+                  <Card label="Publish Status">{runSummary.publish.status || '—'}</Card>
+                  <Card label="Publish Mode">{runSummary.publish.mode || '—'}</Card>
+                </div>
+              ) : null}
+              {runSummary.publish?.reason ? (
+                <p className="whitespace-pre-wrap">{runSummary.publish.reason}</p>
+              ) : null}
+              {runSummary.publishContext ? (
+                <div className="grid-2">
+                  {runSummary.publishContext.branch ? (
+                    <Card label="Publish Branch">
+                      <code className="text-xs break-all">{runSummary.publishContext.branch}</code>
+                    </Card>
+                  ) : null}
+                  {runSummary.publishContext.baseRef ? (
+                    <Card label="Base Ref">
+                      <code className="text-xs break-all">{runSummary.publishContext.baseRef}</code>
+                    </Card>
+                  ) : null}
+                  {runSummary.publishContext.commitCount !== undefined &&
+                  runSummary.publishContext.commitCount !== null ? (
+                    <Card label="Commit Count">{String(runSummary.publishContext.commitCount)}</Card>
+                  ) : null}
+                </div>
+              ) : null}
+              {runSummary.lastStep?.summary && runSummary.lastStep.summary !== displayedSummary ? (
+                <div>
+                  <strong>Last Step</strong>
+                  <p className="whitespace-pre-wrap">{runSummary.lastStep.summary}</p>
+                </div>
+              ) : null}
+              {runSummary.nextAction ? <p className="small">{runSummary.nextAction}</p> : null}
+            </section>
+          ) : null}
 
           {execution.waitingReason ? (
             <section>

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Mapping, Sequence, get_type_hints
+from typing import Any, Awaitable, Callable, Iterable, Mapping, Sequence, get_type_hints
 
 from moonmind.config.settings import settings
 from moonmind.jules.status import JulesStatusSnapshot, normalize_jules_status
@@ -126,6 +126,7 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     " 429",
     "code: 429",
 )
+_OPERATOR_SUMMARY_TAIL_BYTES = 64 * 1024
 
 
 def _managed_runtime_artifact_root() -> Path:
@@ -2472,22 +2473,98 @@ class TemporalAgentRuntimeActivities:
         if self._artifact_service is None or not record.stdout_artifact_ref:
             return None
 
+        text = await self._read_stdout_artifact_tail(
+            artifact_id=record.stdout_artifact_ref,
+            run_id=record.run_id,
+            max_bytes=_OPERATOR_SUMMARY_TAIL_BYTES,
+        )
+        if text is None:
+            return None
+
+        extracted = self._extract_operator_summary_from_text(text)
+        return self._sanitize_operator_summary(extracted)
+
+    async def _read_stdout_artifact_tail(
+        self,
+        *,
+        artifact_id: str,
+        run_id: str,
+        max_bytes: int,
+    ) -> str | None:
+        if self._artifact_service is None:
+            return None
+
+        try:
+            _, path = await self._artifact_service.read_path(
+                artifact_id=artifact_id,
+                principal="system:agent_runtime",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to read stdout artifact path for managed run %s",
+                run_id,
+                exc_info=True,
+            )
+        else:
+            try:
+                return self._read_path_tail_text(path, max_bytes=max_bytes)
+            except Exception:
+                logger.debug(
+                    "Failed to read stdout artifact tail from path for managed run %s",
+                    run_id,
+                    exc_info=True,
+                )
+
+        try:
+            _, chunks = await self._artifact_service.read_chunks(
+                artifact_id=artifact_id,
+                principal="system:agent_runtime",
+                chunk_size=max_bytes,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to stream stdout artifact for managed run %s",
+                run_id,
+                exc_info=True,
+            )
+        else:
+            payload = self._tail_bytes_from_chunks(chunks, max_bytes=max_bytes)
+            return payload.decode("utf-8", errors="replace")
+
         try:
             _, payload = await self._artifact_service.read_bytes(
-                artifact_id=record.stdout_artifact_ref,
+                artifact_id=artifact_id,
                 principal="system:agent_runtime",
             )
         except Exception:
             logger.debug(
                 "Failed to read stdout artifact for managed run %s",
-                record.run_id,
+                run_id,
                 exc_info=True,
             )
             return None
 
-        text = payload.decode("utf-8", errors="replace")
-        extracted = self._extract_operator_summary_from_text(text)
-        return self._sanitize_operator_summary(extracted)
+        return payload[-max_bytes:].decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _read_path_tail_text(path: Path, *, max_bytes: int) -> str:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            tail_start = max(handle.tell() - max_bytes, 0)
+            handle.seek(tail_start)
+            payload = handle.read()
+        return payload.decode("utf-8", errors="replace")
+
+    @staticmethod
+    def _tail_bytes_from_chunks(chunks: Iterable[bytes], *, max_bytes: int) -> bytes:
+        tail = bytearray()
+        for chunk in chunks:
+            if not chunk:
+                continue
+            tail.extend(chunk)
+            if len(tail) > max_bytes:
+                del tail[:-max_bytes]
+        return bytes(tail)
 
     @staticmethod
     def _extract_operator_summary_from_text(text: str) -> str | None:
@@ -2890,12 +2967,14 @@ class TemporalAgentRuntimeActivities:
                 run_id,
                 current_branch,
             )
-            return {
+            result: dict[str, Any] = {
                 "push_status": "pushed",
                 "push_branch": current_branch,
                 "push_base_ref": base_ref,
-                "push_commit_count": commit_count,
             }
+            if commit_count >= 0:
+                result["push_commit_count"] = commit_count
+            return result
         except Exception as exc:
             logger.warning(
                 "Post-agent git push failed for run %s",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2420,6 +2420,13 @@ class TemporalAgentRuntimeActivities:
             # Build merged metadata from the typed result, then enrich with
             # push/PR URL info using model_copy to preserve the typed contract.
             meta = dict(result.metadata or {})
+            if record is not None:
+                operator_summary = await self._collect_operator_summary(
+                    record=record,
+                    result=result,
+                )
+                if operator_summary:
+                    meta["operator_summary"] = operator_summary
 
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
@@ -2442,6 +2449,110 @@ class TemporalAgentRuntimeActivities:
             return result
         finally:
             await self._cleanup_managed_run_publish_support_best_effort(run_id)
+
+    async def _collect_operator_summary(
+        self,
+        *,
+        record: ManagedRunRecord,
+        result: AgentRunResult,
+    ) -> str | None:
+        stdout_summary = await self._extract_stdout_operator_summary(record)
+        if stdout_summary:
+            return stdout_summary
+
+        summary = self._sanitize_operator_summary(result.summary)
+        if summary and summary != "Completed with status completed":
+            return summary
+        return None
+
+    async def _extract_stdout_operator_summary(
+        self,
+        record: ManagedRunRecord,
+    ) -> str | None:
+        if self._artifact_service is None or not record.stdout_artifact_ref:
+            return None
+
+        try:
+            _, payload = await self._artifact_service.read_bytes(
+                artifact_id=record.stdout_artifact_ref,
+                principal="system:agent_runtime",
+            )
+        except Exception:
+            logger.debug(
+                "Failed to read stdout artifact for managed run %s",
+                record.run_id,
+                exc_info=True,
+            )
+            return None
+
+        text = payload.decode("utf-8", errors="replace")
+        extracted = self._extract_operator_summary_from_text(text)
+        return self._sanitize_operator_summary(extracted)
+
+    @staticmethod
+    def _extract_operator_summary_from_text(text: str) -> str | None:
+        normalized = str(text or "").replace("\r\n", "\n").strip()
+        if not normalized:
+            return None
+
+        report_start = normalized.rfind("**Final Report**")
+        if report_start >= 0:
+            normalized = normalized[report_start + len("**Final Report**") :].strip()
+        else:
+            report_start = normalized.rfind("Final Report")
+            if report_start >= 0:
+                normalized = normalized[report_start + len("Final Report") :].strip()
+
+        stop_markers = (
+            "\ncodex\n",
+            "\nexec\n",
+            "\ntokens used",
+            "\nCommand:",
+            "\n/bin/bash -lc",
+        )
+        for marker in stop_markers:
+            marker_index = normalized.find(marker)
+            if marker_index >= 0:
+                normalized = normalized[:marker_index].strip()
+
+        filtered_lines: list[str] = []
+        for raw_line in normalized.splitlines():
+            line = raw_line.rstrip()
+            stripped = line.strip()
+            if not stripped:
+                if filtered_lines and filtered_lines[-1] != "":
+                    filtered_lines.append("")
+                continue
+            if stripped in {"**Final Report**", "Final Report", "codex"}:
+                continue
+            if stripped.startswith("exec") or stripped.startswith("/bin/bash -lc"):
+                continue
+            filtered_lines.append(line)
+            if len(filtered_lines) >= 18:
+                break
+
+        while filtered_lines and filtered_lines[0] == "":
+            filtered_lines.pop(0)
+        while filtered_lines and filtered_lines[-1] == "":
+            filtered_lines.pop()
+
+        summary = "\n".join(filtered_lines).strip()
+        return summary or None
+
+    @staticmethod
+    def _sanitize_operator_summary(summary: str | None) -> str | None:
+        if not summary:
+            return None
+
+        from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
+
+        redactor = SecretRedactor.from_environ(placeholder="[REDACTED]")
+        scrubbed = scrub_github_tokens(redactor.scrub(summary)).strip()
+        if not scrubbed:
+            return None
+        if len(scrubbed) <= 1400:
+            return scrubbed
+        return f"{scrubbed[:1397].rstrip()}..."
 
     @staticmethod
     def _is_generic_process_exit_summary(summary: str | None) -> bool:
@@ -2642,11 +2753,12 @@ class TemporalAgentRuntimeActivities:
         run_id: str,
         *,
         target_branch: str | None = None,
-    ) -> dict[str, str]:
+    ) -> dict[str, Any]:
         """Push the workspace branch to origin.
 
         Returns a dict with ``push_status``, ``push_branch``, and optionally
-        ``push_error`` that the caller merges into result metadata.
+        ``push_error``, ``push_base_ref``, and ``push_commit_count`` that the
+        caller merges into result metadata.
 
         Uses ``asyncio.create_subprocess_exec`` to avoid blocking the event
         loop.
@@ -2769,6 +2881,8 @@ class TemporalAgentRuntimeActivities:
                 return {
                     "push_status": "no_commits",
                     "push_branch": current_branch,
+                    "push_base_ref": base_ref,
+                    "push_commit_count": 0,
                 }
 
             logger.info(
@@ -2779,6 +2893,8 @@ class TemporalAgentRuntimeActivities:
             return {
                 "push_status": "pushed",
                 "push_branch": current_branch,
+                "push_base_ref": base_ref,
+                "push_commit_count": commit_count,
             }
         except Exception as exc:
             logger.warning(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -177,6 +177,11 @@ class MoonMindRunWorkflow:
         self._pull_request_url: Optional[str] = None
         self._publish_status: Optional[str] = None
         self._publish_reason: Optional[str] = None
+        self._publish_context: dict[str, Any] = {}
+        self._operator_summary: Optional[str] = None
+        self._last_step_id: Optional[str] = None
+        self._last_step_summary: Optional[str] = None
+        self._last_diagnostics_ref: Optional[str] = None
         self._declared_dependencies: list[str] = []
         self._dependency_wait_occurred: bool = False
         self._dependency_wait_duration_ms: int | None = None
@@ -1062,6 +1067,10 @@ class MoonMindRunWorkflow:
             if result_status is None or result_status != "COMPLETED":
                 continue
 
+            self._record_execution_context(
+                node_id=node_id,
+                execution_result=execution_result,
+            )
             self._record_publish_result(
                 parameters=parameters,
                 execution_result=execution_result,
@@ -1203,6 +1212,8 @@ class MoonMindRunWorkflow:
                     self._get_logger().info(
                         f"Creating PR natively from {head_branch} into {base_branch} for repo {self._repo}"
                     )
+                    self._publish_context["branch"] = head_branch
+                    self._publish_context["baseRef"] = base_branch
                     create_payload = {
                         "repo": self._repo,
                         "head": head_branch,
@@ -1247,6 +1258,7 @@ class MoonMindRunWorkflow:
         if publish_mode == "pr" and pull_request_url:
             self._publish_status = "published"
             self._publish_reason = "published pull request"
+            self._publish_context["pullRequestUrl"] = pull_request_url
         self._summary = f"Executed {len(ordered_nodes)} plan step(s)."
         self._update_memo()
 
@@ -1462,7 +1474,10 @@ class MoonMindRunWorkflow:
 
         if push_status == "no_commits":
             self._publish_status = "skipped"
-            self._publish_reason = "publish skipped: no local changes"
+            self._publish_reason = self._compose_no_change_publish_reason(
+                publish_mode=publish_mode,
+                outputs=outputs,
+            )
             return
 
         if push_status == "failed":
@@ -1492,6 +1507,115 @@ class MoonMindRunWorkflow:
             self._publish_status = "published"
             self._publish_reason = "published branch"
 
+    def _record_execution_context(self, *, node_id: str, execution_result: Any) -> None:
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return
+
+        self._last_step_id = node_id
+        operator_summary = self._coerce_text(
+            outputs.get("operator_summary") or outputs.get("operatorSummary"),
+            max_chars=1600,
+        )
+        if operator_summary:
+            self._operator_summary = operator_summary
+
+        last_step_summary = self._coerce_text(
+            operator_summary
+            or outputs.get("summary")
+            or outputs.get("message"),
+            max_chars=1600,
+        )
+        if last_step_summary:
+            self._last_step_summary = last_step_summary
+
+        diagnostics_ref = self._coerce_text(
+            outputs.get("diagnostics_ref") or outputs.get("diagnosticsRef"),
+            max_chars=200,
+        )
+        if diagnostics_ref:
+            self._last_diagnostics_ref = diagnostics_ref
+
+        publish_branch = self._coerce_text(
+            outputs.get("push_branch") or outputs.get("branch"),
+            max_chars=120,
+        )
+        if publish_branch:
+            self._publish_context["branch"] = publish_branch
+
+        publish_base_ref = self._coerce_text(
+            outputs.get("push_base_ref") or outputs.get("pushBaseRef"),
+            max_chars=120,
+        )
+        if publish_base_ref:
+            self._publish_context["baseRef"] = publish_base_ref
+
+        push_commit_count = outputs.get("push_commit_count")
+        if push_commit_count is None:
+            push_commit_count = outputs.get("pushCommitCount")
+        if isinstance(push_commit_count, bool):
+            push_commit_count = None
+        if isinstance(push_commit_count, (int, float)):
+            self._publish_context["commitCount"] = int(push_commit_count)
+        elif isinstance(push_commit_count, str) and push_commit_count.strip().isdigit():
+            self._publish_context["commitCount"] = int(push_commit_count.strip())
+
+        pull_request_url = self._extract_pull_request_url(execution_result)
+        if pull_request_url:
+            self._publish_context["pullRequestUrl"] = pull_request_url
+
+    def _compose_no_change_publish_reason(
+        self,
+        *,
+        publish_mode: str,
+        outputs: Mapping[str, Any],
+    ) -> str:
+        branch = self._coerce_text(
+            outputs.get("push_branch") or outputs.get("branch"),
+            max_chars=120,
+        )
+        base_ref = self._coerce_text(
+            outputs.get("push_base_ref") or outputs.get("pushBaseRef"),
+            max_chars=120,
+        )
+        operator_summary = self._coerce_text(
+            outputs.get("operator_summary") or outputs.get("operatorSummary"),
+            max_chars=700,
+        )
+        commit_count_value = outputs.get("push_commit_count")
+        if commit_count_value is None:
+            commit_count_value = outputs.get("pushCommitCount")
+        commit_count: int | None = None
+        if isinstance(commit_count_value, bool):
+            commit_count_value = None
+        if isinstance(commit_count_value, (int, float)):
+            commit_count = int(commit_count_value)
+        elif isinstance(commit_count_value, str) and commit_count_value.strip().isdigit():
+            commit_count = int(commit_count_value.strip())
+
+        parts: list[str] = []
+        if publish_mode == "pr":
+            parts.append(
+                "publishMode 'pr' requested, but no publishable diff was produced"
+            )
+        else:
+            parts.append("publish skipped because no local changes were produced")
+
+        if branch and base_ref and commit_count is not None:
+            parts.append(
+                f"branch '{branch}' has {commit_count} commits ahead of {base_ref}"
+            )
+        elif branch and base_ref:
+            parts.append(f"branch '{branch}' has no commits ahead of {base_ref}")
+        elif branch:
+            parts.append(f"branch '{branch}' has no commits to publish")
+
+        if operator_summary:
+            parts.append(f"final agent report: {operator_summary}")
+
+        reason = ". ".join(part.rstrip(".") for part in parts if part)
+        return f"{reason}." if reason else "publish skipped: no local changes"
+
     def _determine_publish_completion(
         self,
         *,
@@ -1504,12 +1628,10 @@ class MoonMindRunWorkflow:
         if self._publish_status == "skipped":
             if publish_mode == "pr":
                 self._publish_status = "failed"
-                self._publish_reason = (
-                    "publishMode 'pr' requested but no local changes were produced"
-                )
                 return (
                     "failed",
-                    self._publish_reason,
+                    self._publish_reason
+                    or "publishMode 'pr' requested but no local changes were produced",
                     True,
                 )
             return ("no_changes", "Workflow completed with no local changes", False)
@@ -2314,6 +2436,16 @@ class MoonMindRunWorkflow:
                     "failedDependencyId": self._failed_dependency_id,
                 },
             }
+            if self._operator_summary:
+                finish_summary["operatorSummary"] = self._operator_summary
+            if self._publish_context:
+                finish_summary["publishContext"] = dict(self._publish_context)
+            if self._last_step_id or self._last_step_summary or self._last_diagnostics_ref:
+                finish_summary["lastStep"] = {
+                    "id": self._last_step_id,
+                    "summary": self._last_step_summary,
+                    "diagnosticsRef": self._last_diagnostics_ref,
+                }
 
             artifact_create_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
                 "artifact.create"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -26,6 +26,7 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.workflows.tasks.routing import _coerce_bool
     from moonmind.config.settings import settings
+    from moonmind.utils.logging import scrub_github_tokens
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
@@ -1476,7 +1477,6 @@ class MoonMindRunWorkflow:
             self._publish_status = "skipped"
             self._publish_reason = self._compose_no_change_publish_reason(
                 publish_mode=publish_mode,
-                outputs=outputs,
             )
             return
 
@@ -1513,28 +1513,28 @@ class MoonMindRunWorkflow:
             return
 
         self._last_step_id = node_id
-        operator_summary = self._coerce_text(
-            outputs.get("operator_summary") or outputs.get("operatorSummary"),
-            max_chars=1600,
+        operator_summary = self._sanitize_operator_summary(
+            self._coerce_text(
+                outputs.get("operator_summary") or outputs.get("operatorSummary"),
+                max_chars=1600,
+            )
         )
         if operator_summary:
             self._operator_summary = operator_summary
 
-        last_step_summary = self._coerce_text(
-            operator_summary
-            or outputs.get("summary")
-            or outputs.get("message"),
-            max_chars=1600,
+        self._last_step_summary = self._sanitize_operator_summary(
+            self._coerce_text(
+                operator_summary
+                or outputs.get("summary")
+                or outputs.get("message"),
+                max_chars=1600,
+            )
         )
-        if last_step_summary:
-            self._last_step_summary = last_step_summary
 
-        diagnostics_ref = self._coerce_text(
+        self._last_diagnostics_ref = self._coerce_text(
             outputs.get("diagnostics_ref") or outputs.get("diagnosticsRef"),
             max_chars=200,
         )
-        if diagnostics_ref:
-            self._last_diagnostics_ref = diagnostics_ref
 
         publish_branch = self._coerce_text(
             outputs.get("push_branch") or outputs.get("branch"),
@@ -1553,42 +1553,47 @@ class MoonMindRunWorkflow:
         push_commit_count = outputs.get("push_commit_count")
         if push_commit_count is None:
             push_commit_count = outputs.get("pushCommitCount")
+        normalized_commit_count: int | None = None
         if isinstance(push_commit_count, bool):
             push_commit_count = None
         if isinstance(push_commit_count, (int, float)):
-            self._publish_context["commitCount"] = int(push_commit_count)
+            normalized_commit_count = int(push_commit_count)
         elif isinstance(push_commit_count, str) and push_commit_count.strip().isdigit():
-            self._publish_context["commitCount"] = int(push_commit_count.strip())
+            normalized_commit_count = int(push_commit_count.strip())
+
+        if normalized_commit_count is not None:
+            if normalized_commit_count >= 0:
+                self._publish_context["commitCount"] = normalized_commit_count
+            else:
+                self._publish_context.pop("commitCount", None)
 
         pull_request_url = self._extract_pull_request_url(execution_result)
         if pull_request_url:
             self._publish_context["pullRequestUrl"] = pull_request_url
 
+    @staticmethod
+    def _sanitize_operator_summary(summary: str | None) -> str | None:
+        if not summary:
+            return None
+        scrubbed = scrub_github_tokens(summary).strip()
+        return scrubbed or None
+
     def _compose_no_change_publish_reason(
         self,
         *,
         publish_mode: str,
-        outputs: Mapping[str, Any],
     ) -> str:
-        branch = self._coerce_text(
-            outputs.get("push_branch") or outputs.get("branch"),
-            max_chars=120,
-        )
-        base_ref = self._coerce_text(
-            outputs.get("push_base_ref") or outputs.get("pushBaseRef"),
-            max_chars=120,
-        )
+        branch = self._coerce_text(self._publish_context.get("branch"), max_chars=120)
+        base_ref = self._coerce_text(self._publish_context.get("baseRef"), max_chars=120)
         operator_summary = self._coerce_text(
-            outputs.get("operator_summary") or outputs.get("operatorSummary"),
+            self._operator_summary,
             max_chars=700,
         )
-        commit_count_value = outputs.get("push_commit_count")
-        if commit_count_value is None:
-            commit_count_value = outputs.get("pushCommitCount")
         commit_count: int | None = None
+        commit_count_value = self._publish_context.get("commitCount")
         if isinstance(commit_count_value, bool):
             commit_count_value = None
-        if isinstance(commit_count_value, (int, float)):
+        if isinstance(commit_count_value, (int, float)) and int(commit_count_value) >= 0:
             commit_count = int(commit_count_value)
         elif isinstance(commit_count_value, str) and commit_count_value.strip().isdigit():
             commit_count = int(commit_count_value.strip())
@@ -1601,7 +1606,7 @@ class MoonMindRunWorkflow:
         else:
             parts.append("publish skipped because no local changes were produced")
 
-        if branch and base_ref and commit_count is not None:
+        if branch and base_ref and commit_count and commit_count > 0:
             parts.append(
                 f"branch '{branch}' has {commit_count} commits ahead of {base_ref}"
             )

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -525,9 +525,13 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                 self.assertIsInstance(
                     exc_info.exception.cause, exceptions.ApplicationError
                 )
-                self.assertEqual(
+                self.assertIn(
+                    "publishMode 'pr' requested, but no publishable diff was produced",
                     exc_info.exception.cause.message,
-                    "publishMode 'pr' requested but no local changes were produced",
+                )
+                self.assertIn(
+                    "feature/no-op",
+                    exc_info.exception.cause.message,
                 )
 
                 handle = env.client.get_workflow_handle("test-workflow-pr-no-changes")

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -361,6 +361,7 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "auto-abc123"
+        assert "push_commit_count" not in result
 
     @pytest.mark.asyncio
     async def test_push_revlist_nonzero_returncode_falls_through(self):
@@ -389,6 +390,7 @@ class TestPushWorkspaceBranch:
         # Should NOT be no_commits; should fall through to pushed
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "auto-abc123"
+        assert "push_commit_count" not in result
 
     @pytest.mark.asyncio
     async def test_push_revlist_uses_target_branch(self):
@@ -469,18 +471,24 @@ class TestFetchResultPushIntegration:
         assert result.metadata["push_branch"] == "my-branch"
 
     @pytest.mark.asyncio
-    async def test_fetch_result_adds_operator_summary_from_stdout_artifact(self):
+    async def test_fetch_result_adds_operator_summary_from_stdout_artifact(self, tmp_path):
         store = _make_mock_store()
         store.load.return_value.stdout_artifact_ref = "art-stdout"
+        stdout_path = tmp_path / "stdout.log"
+        stdout_path.write_text(
+            "noise\n**Final Report**\nThe requested behavior already existed in the repo.\n"
+            "Files edited in this run: none.\n\ncodex\n",
+            encoding="utf-8",
+        )
         artifact_service = MagicMock()
+        artifact_service.read_path = AsyncMock(
+            return_value=(MagicMock(), stdout_path)
+        )
+        artifact_service.read_chunks = AsyncMock(
+            side_effect=AssertionError("stdout tail should come from the local artifact path")
+        )
         artifact_service.read_bytes = AsyncMock(
-            return_value=(
-                MagicMock(),
-                (
-                    b"noise\n**Final Report**\nThe requested behavior already existed in the repo.\n"
-                    b"Files edited in this run: none.\n\ncodex\n"
-                ),
-            )
+            side_effect=AssertionError("stdout tail should not require full artifact reads")
         )
         activities = TemporalAgentRuntimeActivities(
             run_store=store,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -305,6 +305,8 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "no_commits"
         assert result["push_branch"] == "auto-abc123"
+        assert result["push_base_ref"] == "origin/main"
+        assert result["push_commit_count"] == 0
         assert "push_error" not in result
 
     @pytest.mark.asyncio
@@ -465,6 +467,62 @@ class TestFetchResultPushIntegration:
         mock_push.assert_called_once_with("run-1", target_branch=None)
         assert result.metadata["push_status"] == "pushed"
         assert result.metadata["push_branch"] == "my-branch"
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_adds_operator_summary_from_stdout_artifact(self):
+        store = _make_mock_store()
+        store.load.return_value.stdout_artifact_ref = "art-stdout"
+        artifact_service = MagicMock()
+        artifact_service.read_bytes = AsyncMock(
+            return_value=(
+                MagicMock(),
+                (
+                    b"noise\n**Final Report**\nThe requested behavior already existed in the repo.\n"
+                    b"Files edited in this run: none.\n\ncodex\n"
+                ),
+            )
+        )
+        activities = TemporalAgentRuntimeActivities(
+            run_store=store,
+            artifact_service=artifact_service,
+        )
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={
+                    "push_status": "no_commits",
+                    "push_branch": "feature/no-op",
+                    "push_base_ref": "origin/main",
+                    "push_commit_count": 0,
+                },
+            ),
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(
+                return_value=AgentRunResult(
+                    summary="Completed with status completed",
+                    failure_class=None,
+                )
+            )
+
+            result = await activities.agent_runtime_fetch_result(
+                {"run_id": "run-1", "agent_id": "claude", "publish_mode": "pr"},
+            )
+
+        assert result.metadata["operator_summary"].startswith(
+            "The requested behavior already existed in the repo."
+        )
+        assert "Files edited in this run: none." in result.metadata["operator_summary"]
 
     @pytest.mark.asyncio
     async def test_fetch_result_skips_push_when_publish_mode_none(self):

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -544,17 +544,22 @@ async def test_run_integration_stage_multi_step_bundles_into_single_start(
 def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
+    execution_result = {
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "feature/no-op",
+            "push_base_ref": "origin/main",
+            "push_commit_count": 0,
+            "operator_summary": "Files edited in this run: none.",
+        }
+    }
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result=execution_result,
+    )
     mock_run_workflow._record_publish_result(
         parameters={"publishMode": "pr"},
-        execution_result={
-            "outputs": {
-                "push_status": "no_commits",
-                "push_branch": "feature/no-op",
-                "push_base_ref": "origin/main",
-                "push_commit_count": 0,
-                "operator_summary": "Files edited in this run: none.",
-            }
-        },
+        execution_result=execution_result,
     )
 
     status, message, publish_failure = mock_run_workflow._determine_publish_completion(
@@ -565,8 +570,54 @@ def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     assert "no publishable diff was produced" in message
     assert "feature/no-op" in message
     assert "origin/main" in message
+    assert "has no commits ahead of origin/main" in message
+    assert "0 commits ahead" not in message
     assert "Files edited in this run: none." in message
     assert publish_failure is True
+
+
+def test_record_execution_context_resets_last_step_fields_when_current_node_has_no_summary(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "summary": "Completed the substantive step.",
+                "diagnostics_ref": "diag-1",
+            }
+        },
+    )
+
+    mock_run_workflow._record_execution_context(
+        node_id="step-2",
+        execution_result={"outputs": {}},
+    )
+
+    assert mock_run_workflow._last_step_id == "step-2"
+    assert mock_run_workflow._last_step_summary is None
+    assert mock_run_workflow._last_diagnostics_ref is None
+
+
+def test_record_execution_context_scrubs_operator_summary_and_ignores_negative_commit_count(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    mock_run_workflow._record_execution_context(
+        node_id="step-1",
+        execution_result={
+            "outputs": {
+                "operator_summary": "Final report token ghp_abcdefghijklmnopqrstuvwxyz123456",
+                "push_branch": "feature/no-op",
+                "push_base_ref": "origin/main",
+                "push_commit_count": -1,
+            }
+        },
+    )
+
+    assert mock_run_workflow._operator_summary is not None
+    assert "[REDACTED]" in mock_run_workflow._operator_summary
+    assert "ghp_" not in mock_run_workflow._operator_summary
+    assert "commitCount" not in mock_run_workflow._publish_context
 
 
 def test_determine_publish_completion_fails_when_pr_publish_creates_no_pr(

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -544,18 +544,28 @@ async def test_run_integration_stage_multi_step_bundles_into_single_start(
 def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     mock_run_workflow: MoonMindRunWorkflow,
 ) -> None:
-    mock_run_workflow._publish_status = "skipped"
-    mock_run_workflow._publish_reason = "publish skipped: no local changes"
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={
+            "outputs": {
+                "push_status": "no_commits",
+                "push_branch": "feature/no-op",
+                "push_base_ref": "origin/main",
+                "push_commit_count": 0,
+                "operator_summary": "Files edited in this run: none.",
+            }
+        },
+    )
 
     status, message, publish_failure = mock_run_workflow._determine_publish_completion(
         parameters={"publishMode": "pr"}
     )
 
     assert status == "failed"
-    assert (
-        message
-        == "publishMode 'pr' requested but no local changes were produced"
-    )
+    assert "no publishable diff was produced" in message
+    assert "feature/no-op" in message
+    assert "origin/main" in message
+    assert "Files edited in this run: none." in message
     assert publish_failure is True
 
 


### PR DESCRIPTION
## Summary
This updates the Temporal run finish-summary flow so `publishMode=pr` runs that produce no diff explain what actually happened instead of collapsing to a generic "no local changes were produced" message.

## What changed
- capture operator-facing summary, last-step context, diagnostics ref, branch, base ref, and commit count in `MoonMind.Run`
- build richer `push_status == no_commits` publish reasons from that structured context
- persist `operatorSummary`, `publishContext`, and `lastStep` in `reports/run_summary.json`
- enrich managed agent fetch results with an operator summary extracted from stdout and with push base-ref / commit-count metadata
- update task detail UI to read `summaryArtifactRef` and render the structured run summary instead of relying only on `execution.summary`
- add workflow, activity, integration-shape, and frontend coverage for the richer summary path

## Why
The workflow already had enough evidence to explain a no-op publish outcome, but it discarded that context and surfaced only a hard-coded failure string. This change keeps the useful evidence and exposes it in both the finish-summary artifact and the task detail page.

## Impact
Operators should now see explanations such as the target branch/base ref, zero commits ahead, and the final agent report when a PR publish is requested but nothing changed.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/workflows/test_run_integration.py`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx`
- attempted `pytest tests/integration/workflows/temporal/workflows/test_run.py -q`, but the temporary Temporal test server did not complete startup cleanly, so that run is not claimed as passing
