### PR TITLE
[codex] Fix managed Codex blocker classification

### DIFF
--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -22,8 +22,8 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
 _CODEX_BLOCKER_MARKERS: tuple[str, ...] = (
     "blocked on the workspace tooling constraint",
     "apply_patch executable or tool is not available",
-    "actual `apply_patch` tool is available",
-    "actual 'apply_patch' tool is available",
+    "no actual `apply_patch` tool is available",
+    "no actual 'apply_patch' tool is available",
     "strict compliance with the repo rule, i should stop here",
 )
 
@@ -93,8 +93,8 @@ def _extract_matching_lines(
             if not stripped:
                 continue
             lower = stripped.lower()
-            if any(marker in lower for marker in markers) and stripped not in seen:
-                seen.add(stripped)
+            if any(marker in lower for marker in markers) and lower not in seen:
+                seen.add(lower)
                 matches.append(stripped)
     return matches
 
@@ -115,10 +115,10 @@ class CodexCliOutputParser(PlainTextOutputParser):
                 error_messages.append(line)
         return ParsedOutput(
             raw_text=base.raw_text,
-            events=[],
+            events=base.events,
             error_messages=error_messages,
-            rate_limited=False,
-            has_structured_output=False,
+            rate_limited=base.rate_limited,
+            has_structured_output=base.has_structured_output,
         )
 
 

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -19,6 +19,13 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "ratelimitexceeded",
     "retrying with backoff",
 )
+_CODEX_BLOCKER_MARKERS: tuple[str, ...] = (
+    "blocked on the workspace tooling constraint",
+    "apply_patch executable or tool is not available",
+    "actual `apply_patch` tool is available",
+    "actual 'apply_patch' tool is available",
+    "strict compliance with the repo rule, i should stop here",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,6 +79,47 @@ class PlainTextOutputParser(RuntimeOutputParser):
 
     def parse_stream_chunk(self, chunk: str) -> list[dict]:
         return []
+
+
+def _extract_matching_lines(
+    markers: tuple[str, ...],
+    *texts: str,
+) -> list[str]:
+    matches: list[str] = []
+    seen: set[str] = set()
+    for text in texts:
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            lower = stripped.lower()
+            if any(marker in lower for marker in markers) and stripped not in seen:
+                seen.add(stripped)
+                matches.append(stripped)
+    return matches
+
+
+class CodexCliOutputParser(PlainTextOutputParser):
+    """Plain-text parser with Codex-specific managed-runtime blocker detection."""
+
+    @staticmethod
+    def extract_blocker_lines(*texts: str) -> list[str]:
+        return _extract_matching_lines(_CODEX_BLOCKER_MARKERS, *texts)
+
+    def parse(self, stdout: str, stderr: str) -> ParsedOutput:
+        base = super().parse(stdout, stderr)
+        blocker_lines = self.extract_blocker_lines(stdout, stderr)
+        error_messages = list(base.error_messages)
+        for line in blocker_lines:
+            if line not in error_messages:
+                error_messages.append(line)
+        return ParsedOutput(
+            raw_text=base.raw_text,
+            events=[],
+            error_messages=error_messages,
+            rate_limited=False,
+            has_structured_output=False,
+        )
 
 
 class GeminiCliOutputParser(PlainTextOutputParser):

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -36,6 +36,7 @@ _CODEX_MANAGED_RUNTIME_NOTE = (
     "- Prefer targeted reads like `rg` and `sed -n` over dumping whole files "
     "with `cat`, especially for large frontend files.\n"
 )
+_CODEX_MANAGED_RUNTIME_NOTE_HEADER = "Managed Codex CLI note:\n"
 
 
 class CodexCliStrategy(ManagedRuntimeStrategy):
@@ -159,8 +160,8 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             request=request,
             workspace_path=workspace_path,
         )
-        instruction = str(getattr(request, "instruction_ref", "") or "").strip()
-        if instruction and _CODEX_MANAGED_RUNTIME_NOTE.strip() not in instruction:
+        instruction = request.instruction_ref or ""
+        if instruction and _CODEX_MANAGED_RUNTIME_NOTE_HEADER not in instruction:
             request.instruction_ref = instruction + _CODEX_MANAGED_RUNTIME_NOTE
 
     def classify_result(

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -8,7 +8,12 @@ from pathlib import Path
 from typing import Any
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.runtime.output_parser import (
+    CodexCliOutputParser,
+    ParsedOutput,
+)
 from moonmind.workflows.temporal.runtime.strategies.base import (
+    ManagedRuntimeExitResult,
     ManagedRuntimeStrategy,
 )
 
@@ -21,6 +26,16 @@ _CODEX_ENV_PASSTHROUGH_KEYS: frozenset[str] = frozenset({
 })
 _CODEX_PROGRESS_TIMEOUT_SECONDS = 300
 _CODEX_PROGRESS_MTIME_PADDING_SECONDS = 5.0
+_CODEX_MANAGED_RUNTIME_NOTE = (
+    "\n\nManaged Codex CLI note:\n"
+    "- This managed runtime does not expose Codex API developer tools such as "
+    "`apply_patch` or `read_file`.\n"
+    "- If repo instructions mention `apply_patch`, follow the intent using the "
+    "shell and editor commands available in this CLI environment instead of "
+    "stopping.\n"
+    "- Prefer targeted reads like `rg` and `sed -n` over dumping whole files "
+    "with `cat`, especially for large frontend files.\n"
+)
 
 
 class CodexCliStrategy(ManagedRuntimeStrategy):
@@ -144,6 +159,34 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             request=request,
             workspace_path=workspace_path,
         )
+        instruction = str(getattr(request, "instruction_ref", "") or "").strip()
+        if instruction and _CODEX_MANAGED_RUNTIME_NOTE.strip() not in instruction:
+            request.instruction_ref = instruction + _CODEX_MANAGED_RUNTIME_NOTE
+
+    def classify_result(
+        self,
+        *,
+        exit_code: int | None,
+        stdout: str,
+        stderr: str,
+        parsed_output: ParsedOutput | None = None,
+    ) -> ManagedRuntimeExitResult:
+        parsed = parsed_output or self.create_output_parser().parse(stdout, stderr)
+        blocker_lines = CodexCliOutputParser.extract_blocker_lines(stdout, stderr)
+        if exit_code == 0 and blocker_lines:
+            return ManagedRuntimeExitResult(
+                status="failed",
+                failure_class="execution_error",
+            )
+        return super().classify_result(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            parsed_output=parsed,
+        )
+
+    def create_output_parser(self) -> CodexCliOutputParser:
+        return CodexCliOutputParser()
 
     def probe_progress_at(
         self,

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -456,3 +456,33 @@ class TestCodexCliPrepareWorkspace:
             request=request,
             workspace_path=tmp_path,
         )
+
+    @pytest.mark.asyncio
+    @patch("moonmind.rag.context_injection.ContextInjectionService")
+    async def test_prepare_workspace_appends_managed_runtime_note(
+        self,
+        mock_service_class,
+        tmp_path,
+    ) -> None:
+        mock_service = mock_service_class.return_value
+        mock_service.inject_context = AsyncMock()
+
+        request = _make_request(instruction_ref="Do work")
+        await CodexCliStrategy().prepare_workspace(
+            workspace_path=tmp_path,
+            request=request,
+        )
+
+        assert "Managed Codex CLI note:" in request.instruction_ref
+        assert "`apply_patch` or `read_file`" in request.instruction_ref
+        assert "`rg` and `sed -n`" in request.instruction_ref
+
+    def test_classify_result_fails_for_managed_runtime_tooling_blocker(self) -> None:
+        result = CodexCliStrategy().classify_result(
+            exit_code=0,
+            stdout="Blocked on the workspace tooling constraint.\n",
+            stderr="",
+        )
+
+        assert result.status == "failed"
+        assert result.failure_class == "execution_error"

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -477,6 +477,25 @@ class TestCodexCliPrepareWorkspace:
         assert "`apply_patch` or `read_file`" in request.instruction_ref
         assert "`rg` and `sed -n`" in request.instruction_ref
 
+    @pytest.mark.asyncio
+    @patch("moonmind.rag.context_injection.ContextInjectionService")
+    async def test_prepare_workspace_preserves_instruction_whitespace(
+        self,
+        mock_service_class,
+        tmp_path,
+    ) -> None:
+        mock_service = mock_service_class.return_value
+        mock_service.inject_context = AsyncMock()
+
+        request = _make_request(instruction_ref="  Do work  ")
+        await CodexCliStrategy().prepare_workspace(
+            workspace_path=tmp_path,
+            request=request,
+        )
+
+        assert request.instruction_ref.startswith("  Do work  ")
+        assert "Managed Codex CLI note:" in request.instruction_ref
+
     def test_classify_result_fails_for_managed_runtime_tooling_blocker(self) -> None:
         result = CodexCliStrategy().classify_result(
             exit_code=0,

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
 
 from moonmind.workflows.temporal.runtime.output_parser import (
     CodexCliOutputParser,
     GeminiCliOutputParser,
+    ParsedOutput,
     PlainTextOutputParser,
 )
 
@@ -102,7 +104,7 @@ class TestDefaultOutputParser:
         s = ClaudeCodeStrategy()
         assert isinstance(s.create_output_parser(), PlainTextOutputParser)
 
-    def test_codex_returns_plain_text(self) -> None:
+    def test_codex_returns_codex_cli_output_parser(self) -> None:
         s = CodexCliStrategy()
         assert isinstance(s.create_output_parser(), CodexCliOutputParser)
 
@@ -116,6 +118,14 @@ class TestCodexCliOutputParser:
         )
         assert result.error_messages == ["Blocked on the workspace tooling constraint."]
 
+    def test_parse_deduplicates_blocker_lines_case_insensitively(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "Blocked on the workspace tooling constraint.\n",
+            "blocked on the workspace tooling constraint.\n",
+        )
+        assert result.error_messages == ["Blocked on the workspace tooling constraint."]
+
     def test_parse_ignores_non_blocker_stdout(self) -> None:
         parser = CodexCliOutputParser()
         result = parser.parse(
@@ -123,6 +133,27 @@ class TestCodexCliOutputParser:
             "",
         )
         assert result.error_messages == []
+
+    def test_parse_ignores_positive_apply_patch_availability_message(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "The actual `apply_patch` tool is available in this environment.\n",
+            "",
+        )
+        assert result.error_messages == []
+
+    def test_parse_preserves_base_parser_fields(self) -> None:
+        parser = CodexCliOutputParser()
+        base = ParsedOutput(
+            raw_text="stdoutstderr",
+            events=[{"type": "event"}],
+            error_messages=["Error: base"],
+            rate_limited=True,
+            has_structured_output=True,
+        )
+        with patch.object(PlainTextOutputParser, "parse", return_value=base):
+            result = parser.parse("stdout", "stderr")
+        assert result == base
 
 
 class TestGeminiCliOutputParser:

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 
 from moonmind.workflows.temporal.runtime.output_parser import (
+    CodexCliOutputParser,
     GeminiCliOutputParser,
     PlainTextOutputParser,
 )
@@ -103,7 +104,25 @@ class TestDefaultOutputParser:
 
     def test_codex_returns_plain_text(self) -> None:
         s = CodexCliStrategy()
-        assert isinstance(s.create_output_parser(), PlainTextOutputParser)
+        assert isinstance(s.create_output_parser(), CodexCliOutputParser)
+
+
+class TestCodexCliOutputParser:
+    def test_parse_detects_managed_runtime_blocker_message(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "Blocked on the workspace tooling constraint.\n",
+            "",
+        )
+        assert result.error_messages == ["Blocked on the workspace tooling constraint."]
+
+    def test_parse_ignores_non_blocker_stdout(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "Let me search more broadly for provider profiles in the backend API.\n",
+            "",
+        )
+        assert result.error_messages == []
 
 
 class TestGeminiCliOutputParser:


### PR DESCRIPTION
## Summary
This fixes a managed Codex runtime failure mode that showed up in an OpenRouter/Qwen workflow run.

## What changed
- add Codex-specific output parsing for explicit managed-runtime blocker messages
- classify those blocker/no-op exits as `execution_error` instead of `completed`
- inject a runtime-accurate note into managed Codex instructions so the agent knows `apply_patch`/`read_file` are not available in this environment and should use shell-based equivalents
- add unit coverage for the parser, instruction note, and classification behavior

## Root cause
The failing workflow used the OpenRouter `qwen/qwen3.6-plus:free` profile. The managed Codex child run exited with code `0`, but the raw logs showed that the model treated missing Codex API developer tools like `apply_patch` as a hard blocker and produced no code changes. MoonMind then treated the run as completed until publish failed with `publishMode 'pr' requested but no local changes were produced`.

## Impact
Managed Codex runs that explicitly report this blocker now fail with the real execution error instead of surfacing later as an ambiguous publish-time no-op.

## Validation
- `./tools/test_unit.sh`
