### PR TITLE
Standardize around GITHUB_TOKEN and remove all references to GH_TOKEN:

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -213,7 +213,7 @@ async def _sync_env_managed_secrets() -> int:
             return None
         return None
 
-    github_token_slugs = ("GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT")
+    github_token_slugs = ("GITHUB_TOKEN", "GITHUB_PAT")
 
     def _env_value(name: str) -> str | None:
         value = os.environ.get(name)

--- a/frontend/src/entrypoints/dashboard-alerts.tsx
+++ b/frontend/src/entrypoints/dashboard-alerts.tsx
@@ -26,7 +26,7 @@ const PROVIDER_KEY_SLUGS = [
   'MINIMAX_API_KEY',
 ] as const;
 
-const GITHUB_TOKEN_SLUGS = ['GITHUB_PAT', 'GITHUB_TOKEN', 'GH_TOKEN'] as const;
+const GITHUB_TOKEN_SLUGS = ['GITHUB_PAT', 'GITHUB_TOKEN'] as const;
 
 function hasActiveSlug(items: SecretMetadata[], slugs: readonly string[]): boolean {
   return items.some((s) => slugs.includes(s.slug) && s.status === 'active');
@@ -94,8 +94,7 @@ export function DashboardAlerts() {
          )}
          {!hasGithub && (
            <li>
-             A GitHub token in Settings is missing (use slug <code>GITHUB_TOKEN</code>, <code>GH_TOKEN</code>, or{' '}
-             <code>GITHUB_PAT</code> — runtime and docs use <code>GITHUB_TOKEN</code> most often).
+             A GitHub token in Settings is missing (use slug <code>GITHUB_TOKEN</code> or <code>GITHUB_PAT</code>).
            </li>
          )}
       </ul>

--- a/moonmind/agents/codex_worker/cli.py
+++ b/moonmind/agents/codex_worker/cli.py
@@ -434,17 +434,17 @@ def run_preflight(env: Mapping[str, str] | None = None) -> None:
         ],
         input_text=github_token,
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN",),
+        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
     )
     _run_checked_command(
         [gh_path, "auth", "setup-git"],
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN",),
+        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
     )
     _run_checked_command(
         [gh_path, "auth", "status", "--hostname", "github.com"],
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN",),
+        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
     )
 
 

--- a/moonmind/agents/codex_worker/cli.py
+++ b/moonmind/agents/codex_worker/cli.py
@@ -434,17 +434,17 @@ def run_preflight(env: Mapping[str, str] | None = None) -> None:
         ],
         input_text=github_token,
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
+        unset_env_keys=("GITHUB_TOKEN",),
     )
     _run_checked_command(
         [gh_path, "auth", "setup-git"],
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
+        unset_env_keys=("GITHUB_TOKEN",),
     )
     _run_checked_command(
         [gh_path, "auth", "status", "--hostname", "github.com"],
         redaction_values=redaction_values,
-        unset_env_keys=("GITHUB_TOKEN", "GH_TOKEN"),
+        unset_env_keys=("GITHUB_TOKEN",),
     )
 
 

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -10580,7 +10580,6 @@ class CodexWorker:
 
         if token:
             command_env["GITHUB_TOKEN"] = token
-            command_env["GH_TOKEN"] = token
             command_env["GIT_TERMINAL_PROMPT"] = "0"
             configured = True
 

--- a/moonmind/auth/env_shaping.py
+++ b/moonmind/auth/env_shaping.py
@@ -19,7 +19,6 @@ OAUTH_CLEARED_VARS: frozenset[str] = frozenset(
         "OPENAI_API_KEY",
         "CODEX_API_KEY",
         "GITHUB_TOKEN",
-        "GH_TOKEN",
     }
 )
 _BASE_ENV_FILTER_FRAGMENTS: tuple[str, ...] = (

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -54,7 +54,7 @@ _SENSITIVE_KEY_FRAGMENTS: tuple[str, ...] = (
     "private_key",
 )
 _ALLOWED_SECRET_PASSTHROUGH_ENV_KEYS: frozenset[str] = frozenset(
-    {"GH_TOKEN", "GITHUB_TOKEN"}
+    {"GITHUB_TOKEN"}
 )
 # Non-secret metadata keys allowed in envOverrides (values are refs / env names, not raw secrets).
 _ALLOWED_MANAGED_LAUNCH_METADATA_KEYS: frozenset[str] = frozenset(

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -57,8 +57,8 @@ class GitHubService:
     """Thin wrapper around the GitHub REST API for pull-request operations.
 
     This service is stateless and safe to share across activity invocations.
-    Authentication is resolved from an explicit token, ``GITHUB_TOKEN`` /
-    ``GH_TOKEN`` env vars, or the configured secret reference.
+    Authentication is resolved from an explicit token, ``GITHUB_TOKEN`` env var,
+    or the configured secret reference.
     """
 
     def __init__(self, *, timeout: float = 30.0) -> None:
@@ -69,7 +69,7 @@ class GitHubService:
     @staticmethod
     def _missing_auth_summary(action: str) -> str:
         return (
-            "GitHub auth is not configured; set GITHUB_TOKEN or GH_TOKEN, "
+            "GitHub auth is not configured; set GITHUB_TOKEN, "
             f"or configure GITHUB_TOKEN_SECRET_REF / WORKFLOW_GITHUB_TOKEN_SECRET_REF to {action}."
         )
 
@@ -77,7 +77,7 @@ class GitHubService:
     def _secret_ref_resolution_summary() -> str:
         return (
             "GitHub token secret reference could not be resolved. "
-            "Ensure GITHUB_TOKEN or GH_TOKEN is set, or configure "
+            "Ensure GITHUB_TOKEN is set, or configure "
             "GITHUB_TOKEN_SECRET_REF / WORKFLOW_GITHUB_TOKEN_SECRET_REF; see logs for details."
         )
 
@@ -100,7 +100,6 @@ class GitHubService:
         token = str(
             explicit_token
             or os.environ.get("GITHUB_TOKEN", "")
-            or os.environ.get("GH_TOKEN", "")
         ).strip()
         if token:
             return token, None

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -69,7 +69,7 @@ class GitHubService:
     @staticmethod
     def _missing_auth_summary(action: str) -> str:
         return (
-            "GitHub auth is not configured; set GITHUB_TOKEN, "
+            "GitHub auth is not configured; set GITHUB_TOKEN "
             f"or configure GITHUB_TOKEN_SECRET_REF / WORKFLOW_GITHUB_TOKEN_SECRET_REF to {action}."
         )
 
@@ -97,10 +97,7 @@ class GitHubService:
         explicit_token: str | None = None,
     ) -> tuple[str, str | None]:
         """Resolve a GitHub token from explicit input, env, or secret ref."""
-        token = str(
-            explicit_token
-            or os.environ.get("GITHUB_TOKEN", "")
-        ).strip()
+        token = (explicit_token or os.environ.get("GITHUB_TOKEN", "")).strip()
         if token:
             return token, None
 

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 # GitHub CLI authentication is required for workflows like pr-resolver.
 # Only the *key names* are propagated through workflow/activity payloads; the
 # values are injected at launch time by the agent-runtime activity worker.
-_SECRET_ENV_PASSTHROUGH_KEYS: tuple[str, ...] = ("GH_TOKEN", "GITHUB_TOKEN")
+_SECRET_ENV_PASSTHROUGH_KEYS: tuple[str, ...] = ("GITHUB_TOKEN",)
 
 _PR_RESOLVER_RESULT_PATHS: tuple[Path, ...] = (
     Path("var/pr_resolver/result.json"),

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -201,6 +201,7 @@ def run_gh_wrapper(*, socket_path: str, real_gh_path: str) -> int:
     """Exec the real gh binary with a token fetched from the local broker."""
     token = request_github_token(socket_path)
     env = dict(os.environ)
+    env.pop("GH_TOKEN", None)
     env["GITHUB_TOKEN"] = token
     os.execvpe(real_gh_path, [real_gh_path, *sys.argv[1:]], env)
     return 0

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -201,7 +201,6 @@ def run_gh_wrapper(*, socket_path: str, real_gh_path: str) -> int:
     """Exec the real gh binary with a token fetched from the local broker."""
     token = request_github_token(socket_path)
     env = dict(os.environ)
-    env["GH_TOKEN"] = token
     env["GITHUB_TOKEN"] = token
     os.execvpe(real_gh_path, [real_gh_path, *sys.argv[1:]], env)
     return 0

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -397,7 +397,7 @@ class ManagedRuntimeLauncher:
 
     @staticmethod
     async def _resolve_github_token_for_launch(env: dict[str, str]) -> str | None:
-        token = str(env.get("GITHUB_TOKEN") or "").strip()
+        token = env.get("GITHUB_TOKEN", "").strip()
         if token:
             return token
 

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -397,7 +397,7 @@ class ManagedRuntimeLauncher:
 
     @staticmethod
     async def _resolve_github_token_for_launch(env: dict[str, str]) -> str | None:
-        token = str(env.get("GITHUB_TOKEN") or env.get("GH_TOKEN") or "").strip()
+        token = str(env.get("GITHUB_TOKEN") or "").strip()
         if token:
             return token
 
@@ -438,8 +438,8 @@ class ManagedRuntimeLauncher:
         """Return whether a managed runtime needs token env in addition to broker helpers.
 
         Codex CLI shell-tool execution can bypass the workspace-local ``gh`` wrapper
-        during nested ``bash -lc`` command execution, so direct ``GH_TOKEN`` /
-        ``GITHUB_TOKEN`` env remains necessary for reliable GitHub CLI auth.
+        during nested ``bash -lc`` command execution, so direct ``GITHUB_TOKEN``
+        env remains necessary for reliable GitHub CLI auth.
         """
 
         return str(runtime_id or "").strip() == "codex_cli"
@@ -850,11 +850,9 @@ class ManagedRuntimeLauncher:
                 deferred_cleanup_paths.append(github_socket_path)
                 if self._runtime_requires_direct_github_env(profile.runtime_id):
                     env_overrides["GITHUB_TOKEN"] = github_token
-                    env_overrides["GH_TOKEN"] = github_token
                     env_overrides.setdefault("GIT_TERMINAL_PROMPT", "0")
                 else:
                     env_overrides.pop("GITHUB_TOKEN", None)
-                    env_overrides.pop("GH_TOKEN", None)
 
             if resolved_workspace_path is not None:
                 deferred_cleanup_paths.extend(

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -20,7 +20,6 @@ from moonmind.auth.resolvers import (
 # produced a token (matches api_service startup seeding and dashboard hints).
 _MANAGED_GITHUB_TOKEN_SLUGS: tuple[str, ...] = (
     "GITHUB_TOKEN",
-    "GH_TOKEN",
     "GITHUB_PAT",
 )
 

--- a/tests/integration/test_startup_secret_env_seeding.py
+++ b/tests/integration/test_startup_secret_env_seeding.py
@@ -25,7 +25,7 @@ def _isolate_secret_env_sources(monkeypatch, tmp_path) -> None:
     empty_dotenv = tmp_path / ".env.empty"
     empty_dotenv.write_text("", encoding="utf-8")
     monkeypatch.setattr("moonmind.config.paths.ENV_FILE", empty_dotenv)
-    for key in ("GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT", "ATLASSIAN_API_KEY"):
+    for key in ("GITHUB_TOKEN", "GITHUB_PAT", "ATLASSIAN_API_KEY"):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -104,6 +104,7 @@ async def test_startup_syncs_managed_secrets_from_dotenv_file(
     monkeypatch, disabled_env_keys, tmp_path
 ):
     await _seed_db(tmp_path)
+    _isolate_secret_env_sources(monkeypatch, tmp_path)
 
     dotenv_path = tmp_path / ".env"
     dotenv_path.write_text(
@@ -141,7 +142,7 @@ async def test_startup_syncs_managed_secrets_from_dotenv_file(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("slug", ["GH_TOKEN", "GITHUB_PAT"])
+@pytest.mark.parametrize("slug", ["GITHUB_PAT"])
 async def test_startup_syncs_github_alias_and_refreshes_canonical_slug(
     monkeypatch, disabled_env_keys, tmp_path, slug
 ):
@@ -189,52 +190,13 @@ async def test_startup_syncs_github_alias_and_refreshes_canonical_slug(
 
 
 @pytest.mark.asyncio
-async def test_startup_syncs_all_present_github_aliases(
-    monkeypatch, disabled_env_keys, tmp_path
-):
-    await _seed_db(tmp_path)
-    _isolate_secret_env_sources(monkeypatch, tmp_path)
-
-    monkeypatch.setenv("GH_TOKEN", "ghp-gh-token")
-    monkeypatch.setenv("GITHUB_PAT", "ghp-pat-token")
-
-    with (
-        patch("api_service.main._initialize_embedding_model"),
-        patch("api_service.main._initialize_vector_store"),
-        patch("api_service.main._initialize_contexts"),
-        patch("api_service.main._load_or_create_vector_index"),
-        patch("api_service.main._initialize_oidc_provider"),
-    ):
-        await startup_event()
-
-    async with db_base.async_session_maker() as session:
-        canonical_secret = (
-            await session.execute(
-                select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_TOKEN")
-            )
-        ).scalar_one()
-        gh_token_secret = (
-            await session.execute(select(ManagedSecret).where(ManagedSecret.slug == "GH_TOKEN"))
-        ).scalar_one()
-        github_pat_secret = (
-            await session.execute(
-                select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_PAT")
-            )
-        ).scalar_one()
-
-    assert canonical_secret.ciphertext == "ghp-gh-token"
-    assert gh_token_secret.ciphertext == "ghp-gh-token"
-    assert github_pat_secret.ciphertext == "ghp-pat-token"
-
-
-@pytest.mark.asyncio
 async def test_startup_ignores_whitespace_only_env_tokens(
     monkeypatch, disabled_env_keys, tmp_path
 ):
     await _seed_db(tmp_path)
     _isolate_secret_env_sources(monkeypatch, tmp_path)
 
-    monkeypatch.setenv("GH_TOKEN", "   ")
+    monkeypatch.setenv("GITHUB_PAT", "   ")
     monkeypatch.setenv("ATLASSIAN_API_KEY", "\t")
 
     with (
@@ -252,9 +214,6 @@ async def test_startup_ignores_whitespace_only_env_tokens(
                 select(ManagedSecret).where(ManagedSecret.slug == "GITHUB_TOKEN")
             )
         ).scalar_one_or_none()
-        alias_secret = (
-            await session.execute(select(ManagedSecret).where(ManagedSecret.slug == "GH_TOKEN"))
-        ).scalar_one_or_none()
         atlassian_secret = (
             await session.execute(
                 select(ManagedSecret).where(
@@ -264,5 +223,4 @@ async def test_startup_ignores_whitespace_only_env_tokens(
         ).scalar_one_or_none()
 
     assert github_secret is None
-    assert alias_secret is None
     assert atlassian_secret is None

--- a/tests/unit/agents/codex_worker/test_cli.py
+++ b/tests/unit/agents/codex_worker/test_cli.py
@@ -125,26 +125,22 @@ def test_run_preflight_with_github_token_runs_gh_auth_commands(monkeypatch) -> N
     assert calls[2][2] is not None
     assert calls[2][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[2][2]
-    assert "GH_TOKEN" not in calls[2][2]
     assert calls[3][0] == ["/usr/bin/gh", "auth", "setup-git"]
     assert calls[3][1] is None
     assert calls[3][2] is not None
     assert calls[3][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[3][2]
-    assert "GH_TOKEN" not in calls[3][2]
     assert calls[4][0] == ["/usr/bin/gh", "auth", "status", "--hostname", "github.com"]
     assert calls[4][1] is None
     assert calls[4][2] is not None
     assert calls[4][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[4][2]
-    assert "GH_TOKEN" not in calls[4][2]
 
     for idx in (2, 3, 4):
         env = calls[idx][2]
         assert env is not None
         assert "PATH" in env
         assert "GITHUB_TOKEN" not in env
-        assert "GH_TOKEN" not in env
 
 
 def test_run_preflight_without_github_token_skips_gh_auth(monkeypatch) -> None:

--- a/tests/unit/agents/codex_worker/test_cli.py
+++ b/tests/unit/agents/codex_worker/test_cli.py
@@ -91,6 +91,7 @@ def test_run_preflight_with_github_token_runs_gh_auth_commands(monkeypatch) -> N
 
     calls: list[tuple[list[str], str | None, dict[str, str] | None]] = []
     monkeypatch.setenv("MOONMIND_TEST_ENV", "preserved")
+    monkeypatch.setenv("GH_TOKEN", "ambient-gh-token")
 
     def fake_verify(name: str) -> str:
         return f"/usr/bin/{name}"
@@ -125,22 +126,26 @@ def test_run_preflight_with_github_token_runs_gh_auth_commands(monkeypatch) -> N
     assert calls[2][2] is not None
     assert calls[2][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[2][2]
+    assert "GH_TOKEN" not in calls[2][2]
     assert calls[3][0] == ["/usr/bin/gh", "auth", "setup-git"]
     assert calls[3][1] is None
     assert calls[3][2] is not None
     assert calls[3][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[3][2]
+    assert "GH_TOKEN" not in calls[3][2]
     assert calls[4][0] == ["/usr/bin/gh", "auth", "status", "--hostname", "github.com"]
     assert calls[4][1] is None
     assert calls[4][2] is not None
     assert calls[4][2].get("MOONMIND_TEST_ENV") == "preserved"
     assert "GITHUB_TOKEN" not in calls[4][2]
+    assert "GH_TOKEN" not in calls[4][2]
 
     for idx in (2, 3, 4):
         env = calls[idx][2]
         assert env is not None
         assert "PATH" in env
         assert "GITHUB_TOKEN" not in env
+        assert "GH_TOKEN" not in env
 
 
 def test_run_preflight_without_github_token_skips_gh_auth(monkeypatch) -> None:

--- a/tests/unit/agents/codex_worker/test_worker.py
+++ b/tests/unit/agents/codex_worker/test_worker.py
@@ -8772,7 +8772,6 @@ async def test_build_command_env_uses_minimal_inherited_environment(
     assert command_env["HOME"] == "/tmp/home"
     assert command_env["LANG"] == "C.UTF-8"
     assert command_env["GITHUB_TOKEN"] == "ghp-example"
-    assert command_env["GH_TOKEN"] == "ghp-example"
     assert command_env["GIT_AUTHOR_NAME"] == "Nate Sticco"
     assert command_env["GIT_AUTHOR_EMAIL"] == "nsticco@gmail.com"
     assert "SECRET_TOKEN" not in command_env

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -99,7 +99,7 @@ def test_managed_runtime_profile_rejects_github_tokens_in_env_overrides() -> Non
             profileId="gemini_provider_profile",
             runtimeId="gemini_cli",
             commandTemplate=["gemini"],
-            envOverrides={"GH_TOKEN": "ghp-1", "GITHUB_TOKEN": "ghp-2"},
+            envOverrides={"GITHUB_TOKEN": "ghp-2"},
         )
 
 
@@ -134,9 +134,9 @@ def test_managed_runtime_profile_allows_secret_passthrough_key_names() -> None:
         profileId="gemini_provider_profile",
         runtimeId="gemini_cli",
         commandTemplate=["gemini"],
-        passthroughEnvKeys=["gh_token", "GITHUB_TOKEN", "GH_TOKEN"],
+        passthroughEnvKeys=["github_token", "GITHUB_TOKEN"],
     )
-    assert profile.passthrough_env_keys == ["GH_TOKEN", "GITHUB_TOKEN"]
+    assert profile.passthrough_env_keys == ["GITHUB_TOKEN"]
 
 
 def test_managed_runtime_profile_coerces_legacy_file_templates_mapping() -> None:

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -10,6 +10,7 @@ import pytest
 from moonmind.workflows.temporal.runtime.github_auth_broker import (
     GitHubAuthBrokerManager,
     request_github_token,
+    run_gh_wrapper,
 )
 
 
@@ -36,3 +37,41 @@ async def test_github_auth_broker_serves_token_and_cleans_socket():
     await manager.stop("run-1")
 
     assert not Path(socket_path).exists()
+
+
+def test_run_gh_wrapper_clears_ambient_gh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "ambient-gh-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "stale-github-token")
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.request_github_token",
+        lambda _socket_path: "broker-issued-token",
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.sys.argv",
+        ["gh-wrapper", "auth", "status"],
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execvpe(path: str, args: list[str], env: dict[str, str]) -> None:
+        captured["path"] = path
+        captured["args"] = args
+        captured["env"] = env
+        raise SystemExit(0)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.os.execvpe",
+        _fake_execvpe,
+    )
+
+    with pytest.raises(SystemExit):
+        run_gh_wrapper(socket_path="/tmp/github-auth.sock", real_gh_path="/usr/bin/gh")
+
+    assert captured["path"] == "/usr/bin/gh"
+    assert captured["args"] == ["/usr/bin/gh", "auth", "status"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GITHUB_TOKEN"] == "broker-issued-token"
+    assert "GH_TOKEN" not in env

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -188,8 +188,7 @@ async def test_launch_keeps_workflow_id_none_as_null(tmp_path):
 
 @pytest.mark.asyncio
 async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch):
-    monkeypatch.setenv("GH_TOKEN", "ghp-runtime")
-    monkeypatch.setenv("GITHUB_TOKEN", "ghp-legacy")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-runtime")
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
 
     store = ManagedRunStore(tmp_path)
@@ -206,7 +205,7 @@ async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch)
     profile = _make_profile(
         command_template=["echo", "hello"],
         env_overrides={"MM_SAFE": "1"},
-        passthrough_env_keys=["GH_TOKEN", "GITHUB_TOKEN"],
+        passthrough_env_keys=["GITHUB_TOKEN"],
     )
     request = _make_request()
 
@@ -240,8 +239,7 @@ async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch)
     await process.wait()
 
     assert captured_env["MM_SAFE"] == "1"
-    assert captured_env["GH_TOKEN"] == "ghp-runtime"
-    assert captured_env["GITHUB_TOKEN"] == "ghp-legacy"
+    assert captured_env["GITHUB_TOKEN"] == "ghp-runtime"
 
 
 @pytest.mark.asyncio
@@ -737,6 +735,9 @@ async def test_launch_prepares_workspace_from_repository_spec(tmp_path, monkeypa
 async def test_launch_emits_workspace_preparation_applied_annotation(
     tmp_path, monkeypatch
 ):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
     class _RecorderLogStreamer:
         def __init__(self) -> None:
             self.emissions: list[dict[str, object]] = []
@@ -797,6 +798,9 @@ async def test_launch_emits_workspace_preparation_applied_annotation(
 async def test_launch_emits_workspace_preparation_skipped_annotation_for_existing_file(
     tmp_path, monkeypatch
 ):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
     class _RecorderLogStreamer:
         def __init__(self) -> None:
             self.emissions: list[dict[str, object]] = []
@@ -993,6 +997,7 @@ async def test_launch_env_overrides_layer_on_top_of_os_environ(tmp_path, monkeyp
     monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
     monkeypatch.setenv("HOME", "/home/testuser")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test-drop-me")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
     store = ManagedRunStore(tmp_path)
     launcher = ManagedRuntimeLauncher(store)
@@ -1057,6 +1062,7 @@ async def test_launch_filters_ambient_jira_credentials_from_child_env(
 ):
     monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
     monkeypatch.setenv("HOME", "/home/testuser")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("ATLASSIAN_API_KEY", "atl-secret-token")
     monkeypatch.setenv("ATLASSIAN_API_KEY_SECRET_REF", "atlassian-api-key")
     monkeypatch.setenv("ATLASSIAN_EMAIL", "bot@example.com")
@@ -1227,7 +1233,6 @@ async def test_launch_resolves_github_token_from_secret_ref_setting(
         "db://github-pat",
     )
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
         _fake_create_subprocess_exec,
@@ -1249,7 +1254,6 @@ async def test_launch_resolves_github_token_from_secret_ref_setting(
     run_root = store.store_root.parent / "workspaces" / "run-github-secret-ref-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
     assert "GITHUB_TOKEN" not in captured_env
-    assert "GH_TOKEN" not in captured_env
     assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     gitconfig = Path(captured_env["GIT_CONFIG_GLOBAL"])
     assert gitconfig.exists()
@@ -1307,7 +1311,6 @@ async def test_launch_resolves_github_token_from_managed_secrets_store_without_p
 
     monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
         _fake_create_subprocess_exec,
@@ -1329,7 +1332,6 @@ async def test_launch_resolves_github_token_from_managed_secrets_store_without_p
     run_root = store.store_root.parent / "workspaces" / "run-github-managed-store-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
     assert "GITHUB_TOKEN" not in captured_env
-    assert "GH_TOKEN" not in captured_env
     assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     assert (run_root / ".moonmind" / "bin" / "gh").exists()
 
@@ -1384,7 +1386,6 @@ async def test_launch_keeps_direct_github_env_for_codex_cli_managed_runs(
 
     monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
         _fake_create_subprocess_exec,
@@ -1406,7 +1407,6 @@ async def test_launch_keeps_direct_github_env_for_codex_cli_managed_runs(
     run_root = store.store_root.parent / "workspaces" / "run-github-managed-store-codex-1"
     assert captured_env["GIT_TERMINAL_PROMPT"] == "0"
     assert captured_env["GITHUB_TOKEN"] == "resolved-from-managed-secrets-table"
-    assert captured_env["GH_TOKEN"] == "resolved-from-managed-secrets-table"
     assert captured_env["PATH"].startswith(str(run_root / ".moonmind" / "bin"))
     assert (run_root / ".moonmind" / "bin" / "gh").exists()
 
@@ -1422,7 +1422,6 @@ async def test_resolve_github_token_for_launch_propagates_cancellation_from_secr
 
     monkeypatch.setattr(app_settings.github, "github_token_secret_ref", "db://github-pat")
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
         _fake_resolve,
@@ -1443,7 +1442,6 @@ async def test_resolve_github_token_for_launch_propagates_cancellation_from_stor
 
     monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
         _fake_store_token,

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -60,7 +60,6 @@ async def test_create_pr_success(monkeypatch):
 async def test_create_pr_missing_token(monkeypatch):
     """Missing GITHUB_TOKEN should return created=False gracefully."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     svc = GitHubService()
     result = await svc.create_pull_request(
@@ -73,36 +72,9 @@ async def test_create_pr_missing_token(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_pr_uses_gh_token_fallback(monkeypatch):
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setenv("GH_TOKEN", "ghp_fallback_token")
-
-    mock_client = AsyncMock()
-    mock_client.post = AsyncMock(
-        return_value=_mock_response(201, {"html_url": "https://github.com/o/r/pull/44"})
-    )
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
-    with patch(
-        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
-        return_value=mock_client,
-    ):
-        svc = GitHubService()
-        result = await svc.create_pull_request(
-            repo="o/r", head="feature", base="main", title="T", body="B",
-        )
-
-    assert result.created is True
-    _, kwargs = mock_client.post.call_args
-    assert kwargs["headers"]["Authorization"] == "Bearer ghp_fallback_token"
-
-
-@pytest.mark.asyncio
 async def test_create_pr_uses_secret_ref_when_env_missing(monkeypatch):
     """Secret-ref fallback should be used when raw env token is absent."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(
@@ -208,7 +180,6 @@ async def test_merge_pr_invalid_url():
 async def test_merge_pr_missing_token(monkeypatch):
     """Missing GITHUB_TOKEN should return merged=False."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
 
     svc = GitHubService()
     result = await svc.merge_pull_request(

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -120,12 +120,10 @@ async def test_shape_environment_for_oauth_without_mount_path():
 async def test_shape_environment_for_oauth_clears_github_cli_tokens():
     base = {
         "HOME": "/home/user",
-        "GH_TOKEN": "ghp-token",
         "GITHUB_TOKEN": "github-token",
         "OPENAI_API_KEY": "secret",
     }
     shaped = shape_environment_for_oauth(base, volume_mount_path=None)
-    assert "GH_TOKEN" not in shaped
     assert "GITHUB_TOKEN" not in shaped
     assert "OPENAI_API_KEY" not in shaped
 
@@ -346,8 +344,7 @@ async def test_start_uses_passthrough_keys_for_github_tokens(
             captured_payload.update(payload)
         return {"status": "launching"}
 
-    monkeypatch.setenv("GH_TOKEN", "ghp-direct")
-    monkeypatch.setenv("GITHUB_TOKEN", "ghp-legacy")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-direct")
     monkeypatch.setenv("OPENAI_API_KEY", "should-not-leak")
 
     adapter = ManagedAgentAdapter(
@@ -391,8 +388,7 @@ async def test_start_uses_passthrough_keys_for_github_tokens(
         if isinstance(profile_payload.get("passthroughEnvKeys"), list)
         else []
     )
-    assert set(passthrough_env_keys) == {"GH_TOKEN", "GITHUB_TOKEN"}
-    assert "GH_TOKEN" not in env_overrides
+    assert passthrough_env_keys == ["GITHUB_TOKEN"]
     assert "GITHUB_TOKEN" not in env_overrides
     assert "OPENAI_API_KEY" not in env_overrides
 

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -94,19 +94,6 @@ async def test_resolve_managed_github_token_from_store_first_slug(
     assert session.seen_slugs == ["GITHUB_TOKEN"]
 
 
-async def test_resolve_managed_github_token_from_store_falls_back_slug(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    session = _FakeLookupSession(values={"GH_TOKEN": "ghp-fallback-slug"})
-    session_maker = _FakeSessionMaker(session)
-    monkeypatch.setattr("api_service.db.base.async_session_maker", session_maker)
-
-    out = await resolve_managed_github_token_from_store()
-    assert out == "ghp-fallback-slug"
-    assert session_maker.calls == 1
-    assert session.seen_slugs == ["GITHUB_TOKEN", "GH_TOKEN"]
-
-
 async def test_resolve_managed_github_token_from_store_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -116,7 +103,7 @@ async def test_resolve_managed_github_token_from_store_empty(
 
     assert await resolve_managed_github_token_from_store() is None
     assert session_maker.calls == 1
-    assert session.seen_slugs == ["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_PAT"]
+    assert session.seen_slugs == ["GITHUB_TOKEN", "GITHUB_PAT"]
 
 
 async def test_resolve_managed_github_token_from_store_stops_after_lookup_failure(

--- a/tools/get_pr_comments.py
+++ b/tools/get_pr_comments.py
@@ -54,9 +54,9 @@ def resolve_token(cli_token: str | None) -> str | None:
     if cli_token:
         return cli_token
 
-    for env_name in ("GITHUB_TOKEN",):
-        if os.environ.get(env_name):
-            return os.environ[env_name]
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        return token
 
     try:
         token = (
@@ -272,7 +272,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--token",
-        help="GitHub token. Falls back to GITHUB_TOKEN, then `gh auth token`.",
+        help="GitHub token. Falls back to GITHUB_TOKEN then `gh auth token`.",
     )
     parser.add_argument(
         "--include-empty-reviews",

--- a/tools/get_pr_comments.py
+++ b/tools/get_pr_comments.py
@@ -54,7 +54,7 @@ def resolve_token(cli_token: str | None) -> str | None:
     if cli_token:
         return cli_token
 
-    for env_name in ("GITHUB_TOKEN", "GH_TOKEN"):
+    for env_name in ("GITHUB_TOKEN",):
         if os.environ.get(env_name):
             return os.environ[env_name]
 
@@ -272,7 +272,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--token",
-        help="GitHub token. Falls back to GITHUB_TOKEN, GH_TOKEN, then `gh auth token`.",
+        help="GitHub token. Falls back to GITHUB_TOKEN, then `gh auth token`.",
     )
     parser.add_argument(
         "--include-empty-reviews",

--- a/tools/get_pr_comments.py
+++ b/tools/get_pr_comments.py
@@ -87,6 +87,7 @@ def api_get_json(url: str, token: str | None) -> Any:
         try:
             error_body = exc.read().decode("utf-8", "replace")
         except Exception:
+            # Leave the response body empty when decoding the error payload fails.
             pass
         raise RuntimeError(
             f"GitHub API request failed ({exc.code} {exc.reason}) for {url}\n{error_body}"


### PR DESCRIPTION
Standardize around GITHUB_TOKEN and remove all references to GH_TOKEN:

In MoonMind today, `GITHUB_TOKEN` is already the de facto canonical name in the docs and in the codex worker preflight path. For example, the managed-agents Git doc specifies `GITHUB_TOKEN` as the fast-path token, and the codex worker preflight only reads `GITHUB_TOKEN` before doing `gh auth login` and `gh auth setup-git`  

But `GH_TOKEN` is still real compatibility code, not just a docs alias. The repo still falls back to `GH_TOKEN` in several places:

* GitHub REST service token resolution checks `GITHUB_TOKEN` and then `GH_TOKEN` 
* Managed runtime launch resolution checks `GITHUB_TOKEN` or `GH_TOKEN` 
* Managed secret lookup falls back through `GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_PAT` 
* Startup secret sync imports all three slugs and re-aligns the canonical `GITHUB_TOKEN` record when needed 
* Managed-agent passthrough and schema allowlists explicitly include both names  
* The UI still tells users any of those slugs are acceptable, though it notes `GITHUB_TOKEN` is used most often 

So the right answer is:

You can standardize on `GITHUB_TOKEN`, and that is the cleaner direction. But removing `GH_TOKEN` is a small migration, not just a secret deletion.

What I would do:

1. Operationally standardize now on `GITHUB_TOKEN`.
   Set only `GITHUB_TOKEN` in your `.env`, compose, deployment env, and managed secret settings going forward.

2. Keep `GH_TOKEN` compatibility in code for one transition period.
   That avoids breaking any old environments, profiles, or tests that still rely on it.

3. Then remove `GH_TOKEN` support from code and tests in one cleanup pass.

The cleanup pass would need to touch at least these areas:

`moonmind/workflows/adapters/github_service.py`
Remove `GH_TOKEN` fallback and update error text that currently says “set GITHUB_TOKEN or GH_TOKEN” 

`moonmind/workflows/temporal/runtime/launcher.py`
Remove `GH_TOKEN` fallback in `_resolve_github_token_for_launch()`. Also revisit the codex path that currently injects both `GITHUB_TOKEN` and `GH_TOKEN` for reliability during direct runtime launch 

`moonmind/workflows/temporal/runtime/managed_api_key_resolve.py`
Change `_MANAGED_GITHUB_TOKEN_SLUGS` so it no longer probes `GH_TOKEN` in the managed secrets store 

`api_service/main.py`
Stop syncing `GH_TOKEN` from env/.env into managed secrets on startup 

`moonmind/workflows/adapters/managed_agent_adapter.py`
Change secret passthrough keys from `("GH_TOKEN", "GITHUB_TOKEN")` to just `("GITHUB_TOKEN",)` 

`moonmind/schemas/agent_runtime_models.py`
Change the allowed passthrough secret env keys from both names to just `GITHUB_TOKEN` 

`frontend/src/entrypoints/dashboard-alerts.tsx`
Remove `GH_TOKEN` from the accepted-slug hints in the UI 

Tests
You would also need to update tests that currently assert fallback or dual-name support, especially:

* managed GitHub token resolution fallback tests  
* launcher passthrough tests that expect both vars 
* adapter passthrough tests that expect both vars 
* schema tests that allow both passthrough names 

My recommendation:

Standardize on `GITHUB_TOKEN` immediately, but do not remove `GH_TOKEN` from the codebase until you make the cleanup changes above. Right now, deleting the `GH_TOKEN` secret value alone is probably fine if nothing in your environment still depends on it. Deleting support for `GH_TOKEN` in the repo is a separate, explicit refactor.