### PR TITLE
[codex] Harden Codex OpenRouter managed runs

### DIFF
--- a/moonmind/rag/context_injection.py
+++ b/moonmind/rag/context_injection.py
@@ -6,18 +6,60 @@ import asyncio
 import hashlib
 import logging
 import os
+import re
+import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
 
-from moonmind.rag.context_pack import ContextPack
+from moonmind.rag.context_pack import ContextItem, ContextPack, build_context_pack
 from moonmind.rag.service import ContextRetrievalService
 from moonmind.rag.settings import RagRuntimeSettings
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.utils.env_bool import env_to_bool
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_FALLBACK_STOPWORDS: frozenset[str] = frozenset({
+    "about",
+    "above",
+    "after",
+    "agent",
+    "allow",
+    "automatic",
+    "change",
+    "changes",
+    "commit",
+    "complete",
+    "create",
+    "handled",
+    "requested",
+    "should",
+    "show",
+    "showing",
+    "their",
+    "using",
+    "work",
+})
+_LOCAL_FALLBACK_GLOBS: tuple[str, ...] = (
+    "*.md",
+    "*.py",
+    "*.ts",
+    "*.tsx",
+    "*.js",
+    "*.jsx",
+    "*.svelte",
+)
+_LOCAL_FALLBACK_SEARCH_ROOTS: tuple[str, ...] = (
+    "specs",
+    "docs",
+    "frontend",
+    "moonmind",
+    "api_service",
+    "tests",
+)
+_LOCAL_FALLBACK_MAX_ITEMS = 8
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,12 +104,25 @@ class ContextInjectionService:
                 retrieval_skip_reason = None
         except Exception as exc:
             logger.info("[rag] retrieval skipped: %s", exc)
-            return PromptContextResolution(instruction=instruction_ref)
+            fallback_pack = self._build_local_fallback_pack(
+                instruction=instruction_ref,
+                workspace_path=workspace_path,
+            )
+            if fallback_pack is None:
+                return PromptContextResolution(instruction=instruction_ref)
+            pack = fallback_pack
+            retrieval_skip_reason = "local_fallback_after_retrieval_error"
 
         if pack is None:
             if retrieval_skip_reason:
                 logger.info("[rag] retrieval skipped: %s", retrieval_skip_reason)
-            return PromptContextResolution(instruction=instruction_ref)
+            fallback_pack = self._build_local_fallback_pack(
+                instruction=instruction_ref,
+                workspace_path=workspace_path,
+            )
+            if fallback_pack is None:
+                return PromptContextResolution(instruction=instruction_ref)
+            pack = fallback_pack
 
         artifact_path = self._persist_context_pack(
             request=request,
@@ -227,3 +282,99 @@ class ContextInjectionService:
             self._env.get("MOONMIND_RAG_AUTO_CONTEXT", "true"),
             default=True,
         )
+
+    def _build_local_fallback_pack(
+        self,
+        *,
+        instruction: str,
+        workspace_path: Path,
+    ) -> ContextPack | None:
+        query_terms = self._extract_query_terms(instruction)
+        if not query_terms:
+            return None
+
+        search_roots = [
+            str(workspace_path / root)
+            for root in _LOCAL_FALLBACK_SEARCH_ROOTS
+            if (workspace_path / root).exists()
+        ]
+        if not search_roots:
+            return None
+
+        pattern = "|".join(re.escape(term) for term in query_terms)
+        command = ["rg", "-n", "-i", "-m", "1"]
+        for glob in _LOCAL_FALLBACK_GLOBS:
+            command.extend(["-g", glob])
+        command.extend([pattern, *search_roots])
+
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=workspace_path,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except OSError:
+            return None
+
+        if completed.returncode not in {0, 1}:
+            return None
+
+        items: list[ContextItem] = []
+        for raw_line in completed.stdout.splitlines():
+            if len(items) >= _LOCAL_FALLBACK_MAX_ITEMS:
+                break
+            source, line_number, snippet = self._parse_rg_match_line(raw_line)
+            if source is None or line_number is None or snippet is None:
+                continue
+            items.append(
+                ContextItem(
+                    score=1.0,
+                    source=source,
+                    text=f"line {line_number}: {snippet}",
+                    trust_class="canonical",
+                    payload={"line": line_number, "mode": "local_fallback"},
+                )
+            )
+
+        if not items:
+            return None
+
+        return build_context_pack(
+            items=items,
+            filters={"mode": "local_fallback"},
+            budgets={},
+            usage={"matches": len(items)},
+            transport="local_fallback",
+            telemetry_id="local-fallback",
+            max_chars=2400,
+        )
+
+    @staticmethod
+    def _extract_query_terms(instruction: str) -> list[str]:
+        terms: list[str] = []
+        seen: set[str] = set()
+        for raw in re.findall(r"[A-Za-z0-9_/-]+", instruction.lower()):
+            term = raw.strip("-_/")
+            if len(term) < 4 or term in _LOCAL_FALLBACK_STOPWORDS:
+                continue
+            if term in seen:
+                continue
+            seen.add(term)
+            terms.append(term)
+            if len(terms) >= 6:
+                break
+        return terms
+
+    @staticmethod
+    def _parse_rg_match_line(raw_line: str) -> tuple[str | None, int | None, str | None]:
+        parts = raw_line.split(":", 2)
+        if len(parts) != 3:
+            return None, None, None
+        source, line_number_raw, snippet = parts
+        try:
+            line_number = int(line_number_raw)
+        except ValueError:
+            return None, None, None
+        return source, line_number, snippet.strip()

--- a/moonmind/rag/context_injection.py
+++ b/moonmind/rag/context_injection.py
@@ -59,7 +59,14 @@ _LOCAL_FALLBACK_SEARCH_ROOTS: tuple[str, ...] = (
     "api_service",
     "tests",
 )
+_LOCAL_FALLBACK_ALLOWED_SKIP_REASONS: frozenset[str] = frozenset({
+    "collection_unavailable",
+    "qdrant_unavailable",
+    "retrieval_unavailable",
+    "retrieval_gateway_unavailable",
+})
 _LOCAL_FALLBACK_MAX_ITEMS = 8
+_LOCAL_FALLBACK_TERMINATE_TIMEOUT_SECONDS = 1.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +123,8 @@ class ContextInjectionService:
         if pack is None:
             if retrieval_skip_reason:
                 logger.info("[rag] retrieval skipped: %s", retrieval_skip_reason)
+            if not self._should_use_local_fallback(retrieval_skip_reason):
+                return PromptContextResolution(instruction=instruction_ref)
             fallback_pack = self._build_local_fallback_pack(
                 instruction=instruction_ref,
                 workspace_path=workspace_path,
@@ -142,8 +151,7 @@ class ContextInjectionService:
             context_text=pack.context_text,
             instruction=instruction_ref,
         )
-        
-        # Mutate the request
+
         request.instruction_ref = new_instruction
 
         return PromptContextResolution(
@@ -199,11 +207,11 @@ class ContextInjectionService:
         artifacts_dir = workspace_path / "artifacts"
         context_dir = artifacts_dir / "context"
         context_dir.mkdir(parents=True, exist_ok=True)
-        
+
         job_id = request.correlation_id
         repo = request.parameters.get("repository", "")
         instruction = request.instruction_ref or ""
-        
+
         digest_input = f"{job_id}:{repo}:{instruction}".encode(
             "utf-8", errors="replace"
         )
@@ -283,6 +291,12 @@ class ContextInjectionService:
             default=True,
         )
 
+    @staticmethod
+    def _should_use_local_fallback(retrieval_skip_reason: str | None) -> bool:
+        if retrieval_skip_reason is None:
+            return True
+        return retrieval_skip_reason in _LOCAL_FALLBACK_ALLOWED_SKIP_REASONS
+
     def _build_local_fallback_pack(
         self,
         *,
@@ -294,9 +308,7 @@ class ContextInjectionService:
             return None
 
         search_roots = [
-            str(workspace_path / root)
-            for root in _LOCAL_FALLBACK_SEARCH_ROOTS
-            if (workspace_path / root).exists()
+            root for root in _LOCAL_FALLBACK_SEARCH_ROOTS if (workspace_path / root).exists()
         ]
         if not search_roots:
             return None
@@ -307,36 +319,56 @@ class ContextInjectionService:
             command.extend(["-g", glob])
         command.extend([pattern, *search_roots])
 
+        items: list[ContextItem] = []
+        terminated_early = False
+        returncode: int | None = None
+
         try:
-            completed = subprocess.run(
+            with subprocess.Popen(
                 command,
                 cwd=workspace_path,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                check=False,
-            )
+            ) as process:
+                assert process.stdout is not None
+                for raw_line in process.stdout:
+                    source, line_number, snippet = self._parse_rg_match_line(
+                        raw_line.rstrip("\n"),
+                        workspace_path=workspace_path,
+                    )
+                    if source is None or line_number is None or snippet is None:
+                        continue
+                    items.append(
+                        ContextItem(
+                            score=1.0,
+                            source=source,
+                            text=f"line {line_number}: {snippet}",
+                            trust_class="canonical",
+                            payload={"line": line_number, "mode": "local_fallback"},
+                        )
+                    )
+                    if len(items) >= _LOCAL_FALLBACK_MAX_ITEMS:
+                        terminated_early = True
+                        process.terminate()
+                        break
+
+                if terminated_early:
+                    with suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=_LOCAL_FALLBACK_TERMINATE_TIMEOUT_SECONDS)
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+                else:
+                    process.wait()
+                returncode = process.returncode
+                if process.stderr is not None:
+                    process.stderr.read()
         except OSError:
             return None
 
-        if completed.returncode not in {0, 1}:
+        if not terminated_early and returncode not in {0, 1}:
             return None
-
-        items: list[ContextItem] = []
-        for raw_line in completed.stdout.splitlines():
-            if len(items) >= _LOCAL_FALLBACK_MAX_ITEMS:
-                break
-            source, line_number, snippet = self._parse_rg_match_line(raw_line)
-            if source is None or line_number is None or snippet is None:
-                continue
-            items.append(
-                ContextItem(
-                    score=1.0,
-                    source=source,
-                    text=f"line {line_number}: {snippet}",
-                    trust_class="canonical",
-                    payload={"line": line_number, "mode": "local_fallback"},
-                )
-            )
 
         if not items:
             return None
@@ -367,14 +399,39 @@ class ContextInjectionService:
                 break
         return terms
 
-    @staticmethod
-    def _parse_rg_match_line(raw_line: str) -> tuple[str | None, int | None, str | None]:
+    @classmethod
+    def _parse_rg_match_line(
+        cls,
+        raw_line: str,
+        *,
+        workspace_path: Path,
+    ) -> tuple[str | None, int | None, str | None]:
         parts = raw_line.split(":", 2)
         if len(parts) != 3:
             return None, None, None
-        source, line_number_raw, snippet = parts
+        source_raw, line_number_raw, snippet = parts
         try:
             line_number = int(line_number_raw)
         except ValueError:
             return None, None, None
+        source = cls._normalize_local_fallback_source(
+            source_raw.strip(),
+            workspace_path=workspace_path,
+        )
+        if not source:
+            return None, None, None
         return source, line_number, snippet.strip()
+
+    @staticmethod
+    def _normalize_local_fallback_source(
+        source: str,
+        *,
+        workspace_path: Path,
+    ) -> str:
+        if not source:
+            return ""
+        source_path = Path(source)
+        if source_path.is_absolute():
+            with suppress(ValueError):
+                return source_path.relative_to(workspace_path).as_posix()
+        return source_path.as_posix()

--- a/moonmind/rag/qdrant_client.py
+++ b/moonmind/rag/qdrant_client.py
@@ -101,7 +101,7 @@ class RagQdrantClient:
     ) -> SearchResult:
         start = time.perf_counter()
         filter_obj = self._build_filter(filters)
-        canonical = self._client.search(
+        canonical = self._search_points(
             collection_name=self.collection,
             query_vector=query_vector,
             limit=top_k,
@@ -113,7 +113,7 @@ class RagQdrantClient:
         if overlay_policy == "include" and overlay_collection:
             try:
                 overlay_filter = self._build_filter(filters)
-                overlay_points = self._client.search(
+                overlay_points = self._search_points(
                     collection_name=overlay_collection,
                     query_vector=query_vector,
                     limit=top_k,
@@ -126,6 +126,36 @@ class RagQdrantClient:
         merge = self._merge_results(overlay_points, canonical, trust_overrides)
         latency_ms = (time.perf_counter() - start) * 1000
         return SearchResult(items=merge[:top_k], latency_ms=latency_ms)
+
+    def _search_points(
+        self,
+        *,
+        collection_name: str,
+        query_vector: Sequence[float],
+        limit: int,
+        with_payload: bool,
+        with_vectors: bool,
+        query_filter: qmodels.Filter | None,
+    ) -> list[qmodels.ScoredPoint]:
+        if hasattr(self._client, "search"):
+            return self._client.search(
+                collection_name=collection_name,
+                query_vector=query_vector,
+                limit=limit,
+                with_payload=with_payload,
+                with_vectors=with_vectors,
+                query_filter=query_filter,
+            )
+
+        query_response = self._client.query_points(
+            collection_name=collection_name,
+            query=list(query_vector),
+            limit=limit,
+            with_payload=with_payload,
+            with_vectors=with_vectors,
+            query_filter=query_filter,
+        )
+        return list(query_response.points)
 
     def _merge_results(
         self,

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -722,9 +722,6 @@ class ManagedRuntimeLauncher:
         # Update profile with the materialized command template so build_command uses it
         profile.command_template = mat_cmd
 
-        cmd = self.build_command(profile, request, strategy=strategy)
-        self._reset_live_log_spool(resolved_workspace_path)
-
         # Invoke strategy-level workspace preparation hook (e.g. RAG context
         # injection for Codex).
         if resolved_workspace_path is not None and strategy is not None:
@@ -773,6 +770,9 @@ class ManagedRuntimeLauncher:
                     profile.runtime_id,
                     exc_info=True,
                 )
+
+        cmd = self.build_command(profile, request, strategy=strategy)
+        self._reset_live_log_spool(resolved_workspace_path)
 
         # Expose active skills projection if present
         run_root: Path | None = None

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -24,7 +24,12 @@ _CODEX_BLOCKER_MARKERS: tuple[str, ...] = (
     "apply_patch executable or tool is not available",
     "no actual `apply_patch` tool is available",
     "no actual 'apply_patch' tool is available",
+    "i'll start by exploring the codebase",
+    "let me search more broadly",
+    "let me search more specifically",
     "strict compliance with the repo rule, i should stop here",
+    "want me to keep going",
+    "is there something specific you'd like me to work on",
 )
 
 

--- a/moonmind/workflows/temporal/runtime/output_parser.py
+++ b/moonmind/workflows/temporal/runtime/output_parser.py
@@ -19,11 +19,13 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "ratelimitexceeded",
     "retrying with backoff",
 )
-_CODEX_BLOCKER_MARKERS: tuple[str, ...] = (
+_CODEX_HARD_BLOCKER_MARKERS: tuple[str, ...] = (
     "blocked on the workspace tooling constraint",
     "apply_patch executable or tool is not available",
     "no actual `apply_patch` tool is available",
     "no actual 'apply_patch' tool is available",
+)
+_CODEX_TERMINAL_BLOCKER_MARKERS: tuple[str, ...] = (
     "i'll start by exploring the codebase",
     "let me search more broadly",
     "let me search more specifically",
@@ -31,7 +33,6 @@ _CODEX_BLOCKER_MARKERS: tuple[str, ...] = (
     "want me to keep going",
     "is there something specific you'd like me to work on",
 )
-
 
 @dataclass(frozen=True, slots=True)
 class ParsedOutput:
@@ -104,12 +105,32 @@ def _extract_matching_lines(
     return matches
 
 
+def _last_nonempty_line(text: str) -> str | None:
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
+
+
 class CodexCliOutputParser(PlainTextOutputParser):
     """Plain-text parser with Codex-specific managed-runtime blocker detection."""
 
     @staticmethod
     def extract_blocker_lines(*texts: str) -> list[str]:
-        return _extract_matching_lines(_CODEX_BLOCKER_MARKERS, *texts)
+        matches = _extract_matching_lines(_CODEX_HARD_BLOCKER_MARKERS, *texts)
+        seen = {line.lower() for line in matches}
+        for text in texts:
+            line = _last_nonempty_line(text)
+            if not line:
+                continue
+            lower = line.lower()
+            if lower in seen:
+                continue
+            if any(marker in lower for marker in _CODEX_TERMINAL_BLOCKER_MARKERS):
+                seen.add(lower)
+                matches.append(line)
+        return matches
 
     def parse(self, stdout: str, stderr: str) -> ParsedOutput:
         base = super().parse(stdout, stderr)
@@ -229,22 +250,17 @@ class NdjsonOutputParser(RuntimeOutputParser):
             events=events,
             error_messages=error_messages,
             rate_limited=rate_limited,
-            has_structured_output=len(events) > 0,
+            has_structured_output=bool(events),
         )
 
     def parse_stream_chunk(self, chunk: str) -> list[dict]:
-        """Extract JSON events from streamed text chunks.
-        Assumes chunk contains whole lines separated by newlines,
-        or is a single line, as buffering handles line splitting.
-        """
         events: list[dict] = []
         for line in chunk.splitlines():
             stripped = line.strip()
             if not stripped:
                 continue
             try:
-                event = json.loads(stripped)
-                events.append(event)
+                events.append(json.loads(stripped))
             except json.JSONDecodeError:
-                logger.debug("Skipping malformed NDJSON line: %s", stripped)
+                continue
         return events

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -33,6 +33,17 @@ _CODEX_MANAGED_RUNTIME_NOTE = (
     "- If repo instructions mention `apply_patch`, follow the intent using the "
     "shell and editor commands available in this CLI environment instead of "
     "stopping.\n"
+    "- This run is non-interactive. Do not ask whether to continue, do not ask "
+    "follow-up questions, and do not stop after exploration.\n"
+    "- Do not end the run with a progress-only message such as 'I'll inspect "
+    "the codebase' or 'Let me search more specifically'. Keep working until "
+    "you either make the change and verify it, or you hit a concrete blocker.\n"
+    "- Continue autonomously until you either finish the requested work, run "
+    "relevant verification, and make the requested commit, or you hit a "
+    "concrete blocker you cannot resolve locally.\n"
+    "- For repo search, use `rg -n PATTERN <path>` for content search or "
+    "`rg --files <path> | rg NAME` for filename filtering. Do not combine a "
+    "content pattern with `rg --files`.\n"
     "- Prefer targeted reads like `rg` and `sed -n` over dumping whole files "
     "with `cat`, especially for large frontend files.\n"
 )
@@ -96,7 +107,16 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
 
         model = None
         if requested_model:
-            model = self.get_model(profile, request)
+            resolved_requested_model = self.get_model(profile, request)
+            profile_default_model = (
+                str(getattr(profile, "default_model", None) or "").strip() or None
+            )
+            if not (
+                suppress_default_model_flag
+                and profile_default_model
+                and resolved_requested_model == profile_default_model
+            ):
+                model = resolved_requested_model
         elif not suppress_default_model_flag:
             model = self.get_model(profile, request)
         if model:

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -106,19 +106,19 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
         )
 
         model = None
+        resolved_model = self.get_model(profile, request)
         if requested_model:
-            resolved_requested_model = self.get_model(profile, request)
             profile_default_model = (
                 str(getattr(profile, "default_model", None) or "").strip() or None
             )
             if not (
                 suppress_default_model_flag
                 and profile_default_model
-                and resolved_requested_model == profile_default_model
+                and resolved_model == profile_default_model
             ):
-                model = resolved_requested_model
+                model = resolved_model
         elif not suppress_default_model_flag:
-            model = self.get_model(profile, request)
+            model = resolved_model
         if model:
             cmd.extend(["-m", model])
 

--- a/tests/unit/moonmind/rag/test_qdrant_client.py
+++ b/tests/unit/moonmind/rag/test_qdrant_client.py
@@ -92,6 +92,59 @@ def test_search_caps_results_to_top_k_after_overlay_merge():
     assert result.items[1].source == "src/overlay_b.py"
 
 
+def test_search_uses_query_points_when_search_api_is_unavailable():
+    client = _client()
+    calls: list[str] = []
+
+    class QueryResponse:
+        def __init__(self, points):
+            self.points = points
+
+    class FakeQdrant:
+        def query_points(self, *, collection_name, **kwargs):
+            _ = kwargs
+            calls.append(collection_name)
+            if collection_name == "repo-main__overlay__run":
+                return QueryResponse(
+                    [
+                        _point(
+                            score=0.99,
+                            path="src/overlay_a.py",
+                            chunk_hash="ov-a",
+                            text="overlay a",
+                        )
+                    ]
+                )
+            if collection_name == "repo-main":
+                return QueryResponse(
+                    [
+                        _point(
+                            score=0.80,
+                            path="src/canon_a.py",
+                            chunk_hash="ca-a",
+                            text="canon a",
+                        )
+                    ]
+                )
+            raise AssertionError("unexpected collection")
+
+    client._client = FakeQdrant()  # type: ignore[assignment]
+    result = client.search(
+        query_vector=[0.1, 0.2],
+        filters={"repo": "moonmind"},
+        top_k=2,
+        overlay_policy="include",
+        overlay_collection="repo-main__overlay__run",
+        trust_overrides=None,
+    )
+
+    assert calls == ["repo-main", "repo-main__overlay__run"]
+    assert [item.source for item in result.items] == [
+        "src/overlay_a.py",
+        "src/canon_a.py",
+    ]
+
+
 def test_merge_results_skips_expired_overlay_chunks():
     client = _client()
     expired_overlay = _point(

--- a/tests/unit/rag/test_context_injection.py
+++ b/tests/unit/rag/test_context_injection.py
@@ -1,16 +1,50 @@
 """Unit tests for RAG ContextInjectionService."""
 
-import subprocess
-import pytest
+from __future__ import annotations
+
+import io
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from moonmind.rag.context_injection import ContextInjectionService
+from moonmind.rag.context_pack import ContextItem, ContextPack
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
-from moonmind.rag.context_pack import ContextPack, ContextItem
+
+
+class FakePopen:
+    def __init__(self, lines: list[str], *, returncode: int = 0) -> None:
+        self.stdout = io.StringIO("".join(lines))
+        self.stderr = io.StringIO("")
+        self.returncode = returncode
+        self.terminated = False
+        self.killed = False
+        self._wait_calls: list[float | None] = []
+
+    def __enter__(self) -> "FakePopen":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._wait_calls.append(timeout)
+        return self.returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
 
 
 @pytest.fixture
-def mock_request():
+def mock_request() -> AgentExecutionRequest:
     return AgentExecutionRequest(
         agentKind="managed",
         agentId="test-agent",
@@ -23,15 +57,14 @@ def mock_request():
 
 
 @pytest.mark.asyncio
-async def test_inject_context_disabled(mock_request, tmp_path):
-    """Test injection when MOONMIND_RAG_AUTO_CONTEXT is false."""
+async def test_inject_context_disabled(mock_request: AgentExecutionRequest, tmp_path) -> None:
     service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "false"})
-    
+
     result = await service.inject_context(
         request=mock_request,
         workspace_path=tmp_path,
     )
-    
+
     assert result.instruction == "Original instruction"
     assert result.items_count == 0
     assert result.artifact_path is None
@@ -40,84 +73,81 @@ async def test_inject_context_disabled(mock_request, tmp_path):
 
 @pytest.mark.asyncio
 @patch("moonmind.rag.context_injection.ContextInjectionService._retrieve_context_pack")
-async def test_inject_context_enabled_with_items(mock_retrieve, mock_request, tmp_path):
-    """Test successful context injection with retrieved items."""
+async def test_inject_context_enabled_with_items(
+    mock_retrieve,
+    mock_request: AgentExecutionRequest,
+    tmp_path,
+) -> None:
     service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
-    
-    # Mock retrieval returning a pack with 1 item
+
     mock_pack = MagicMock(spec=ContextPack)
     mock_pack.items = [MagicMock(spec=ContextItem)]
     mock_pack.context_text = "Retrieved context snippet"
     mock_pack.transport = "test-transport"
     mock_pack.to_json.return_value = '{"test": "json"}'
-    
     mock_retrieve.return_value = (mock_pack, None)
-    
+
     result = await service.inject_context(
         request=mock_request,
         workspace_path=tmp_path,
     )
-    
+
     assert result.items_count == 1
     assert result.artifact_path is not None
     assert result.artifact_path.exists()
-    
-    expected_instruction_part = "BEGIN_RETRIEVED_CONTEXT\nRetrieved context snippet\nEND_RETRIEVED_CONTEXT"
-    assert expected_instruction_part in result.instruction
+    assert "BEGIN_RETRIEVED_CONTEXT\nRetrieved context snippet\nEND_RETRIEVED_CONTEXT" in result.instruction
     assert "Original instruction" in result.instruction
-    
-    # Verify request was mutated
     assert mock_request.instruction_ref == result.instruction
 
 
 @pytest.mark.asyncio
 @patch("moonmind.rag.context_injection.ContextInjectionService._retrieve_context_pack")
-async def test_inject_context_no_items(mock_retrieve, mock_request, tmp_path):
-    """Test when retrieval succeeds but returns 0 items."""
+async def test_inject_context_no_items(
+    mock_retrieve,
+    mock_request: AgentExecutionRequest,
+    tmp_path,
+) -> None:
     service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
-    
+
     mock_pack = MagicMock(spec=ContextPack)
     mock_pack.items = []
     mock_pack.context_text = ""
     mock_pack.transport = "test-transport"
     mock_pack.to_json.return_value = '{"test": "json"}'
-    
     mock_retrieve.return_value = (mock_pack, None)
-    
+
     result = await service.inject_context(
         request=mock_request,
         workspace_path=tmp_path,
     )
-    
+
     assert result.items_count == 0
     assert result.instruction == "Original instruction"
     assert mock_request.instruction_ref == "Original instruction"
 
 
 @pytest.mark.asyncio
+@patch("moonmind.rag.context_injection.subprocess.Popen")
 @patch("moonmind.rag.context_injection.ContextInjectionService._retrieve_context_pack")
-@patch("moonmind.rag.context_injection.subprocess.run")
 async def test_inject_context_uses_local_fallback_when_retrieval_fails(
-    mock_run,
     mock_retrieve,
-    mock_request,
+    mock_popen,
+    mock_request: AgentExecutionRequest,
     tmp_path,
-):
+) -> None:
     service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
     mock_request.instruction_ref = (
         "Task details should show the provider profile selected for the workflow run"
     )
     (tmp_path / "docs").mkdir()
+    (tmp_path / "frontend").mkdir()
 
     mock_retrieve.side_effect = RuntimeError("qdrant unavailable")
-    mock_run.return_value = subprocess.CompletedProcess(
-        args=["rg"],
-        returncode=0,
-        stdout=(
-            f"{tmp_path / 'docs' / 'TaskDetails.md'}:12:Task details view shows workflow metadata\n"
-            f"{tmp_path / 'frontend' / 'TaskView.tsx'}:8:providerProfile is rendered in the details panel\n"
-        ),
-        stderr="",
+    mock_popen.return_value = FakePopen(
+        [
+            f"{tmp_path / 'docs' / 'TaskDetails.md'}:12:Task details view shows workflow metadata\n",
+            f"frontend/TaskView.tsx:8:providerProfile is rendered in the details panel\n",
+        ]
     )
 
     result = await service.inject_context(
@@ -127,12 +157,66 @@ async def test_inject_context_uses_local_fallback_when_retrieval_fails(
 
     assert result.items_count == 2
     assert "BEGIN_RETRIEVED_CONTEXT" in result.instruction
-    assert "TaskDetails.md" in result.instruction
+    assert "docs/TaskDetails.md" in result.instruction
+    assert str(tmp_path) not in result.instruction
     assert "providerProfile is rendered in the details panel" in result.instruction
     assert mock_request.instruction_ref == result.instruction
 
 
-def test_extract_query_terms_keeps_domain_words():
+@pytest.mark.asyncio
+@patch("moonmind.rag.context_injection.ContextInjectionService._build_local_fallback_pack")
+@patch("moonmind.rag.context_injection.ContextInjectionService._retrieve_context_pack")
+async def test_inject_context_skips_local_fallback_for_explicit_disable_reason(
+    mock_retrieve,
+    mock_build_fallback,
+    mock_request: AgentExecutionRequest,
+    tmp_path,
+) -> None:
+    service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
+    mock_retrieve.return_value = (None, "qdrant_disabled")
+
+    result = await service.inject_context(
+        request=mock_request,
+        workspace_path=tmp_path,
+    )
+
+    mock_build_fallback.assert_not_called()
+    assert result.instruction == "Original instruction"
+    assert result.items_count == 0
+    assert result.artifact_path is None
+
+
+@patch("moonmind.rag.context_injection.subprocess.Popen")
+def test_build_local_fallback_pack_stops_after_max_items(mock_popen, tmp_path) -> None:
+    service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
+    (tmp_path / "docs").mkdir()
+    process = FakePopen(
+        [f"docs/file-{idx}.md:{idx}:match {idx}\n" for idx in range(1, 20)]
+    )
+    mock_popen.return_value = process
+
+    pack = service._build_local_fallback_pack(
+        instruction="provider profile workflow details context",
+        workspace_path=tmp_path,
+    )
+
+    assert pack is not None
+    assert len(pack.items) == 8
+    assert process.terminated
+
+
+def test_parse_rg_match_line_normalizes_absolute_source(tmp_path) -> None:
+    source, line_number, snippet = ContextInjectionService._parse_rg_match_line(
+        f"{tmp_path / 'docs' / 'guide.md'}:14:matched text",
+        workspace_path=tmp_path,
+    )
+
+    assert source == "docs/guide.md"
+    assert line_number == 14
+    assert snippet == "matched text"
+
+
+def test_extract_query_terms_keeps_domain_words() -> None:
     terms = ContextInjectionService._extract_query_terms(
         "Task details should show the provider profile selected for the workflow run"
     )

--- a/tests/unit/rag/test_context_injection.py
+++ b/tests/unit/rag/test_context_injection.py
@@ -1,5 +1,6 @@
 """Unit tests for RAG ContextInjectionService."""
 
+import subprocess
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -91,3 +92,53 @@ async def test_inject_context_no_items(mock_retrieve, mock_request, tmp_path):
     assert result.items_count == 0
     assert result.instruction == "Original instruction"
     assert mock_request.instruction_ref == "Original instruction"
+
+
+@pytest.mark.asyncio
+@patch("moonmind.rag.context_injection.ContextInjectionService._retrieve_context_pack")
+@patch("moonmind.rag.context_injection.subprocess.run")
+async def test_inject_context_uses_local_fallback_when_retrieval_fails(
+    mock_run,
+    mock_retrieve,
+    mock_request,
+    tmp_path,
+):
+    service = ContextInjectionService(env={"MOONMIND_RAG_AUTO_CONTEXT": "true"})
+    mock_request.instruction_ref = (
+        "Task details should show the provider profile selected for the workflow run"
+    )
+    (tmp_path / "docs").mkdir()
+
+    mock_retrieve.side_effect = RuntimeError("qdrant unavailable")
+    mock_run.return_value = subprocess.CompletedProcess(
+        args=["rg"],
+        returncode=0,
+        stdout=(
+            f"{tmp_path / 'docs' / 'TaskDetails.md'}:12:Task details view shows workflow metadata\n"
+            f"{tmp_path / 'frontend' / 'TaskView.tsx'}:8:providerProfile is rendered in the details panel\n"
+        ),
+        stderr="",
+    )
+
+    result = await service.inject_context(
+        request=mock_request,
+        workspace_path=tmp_path,
+    )
+
+    assert result.items_count == 2
+    assert "BEGIN_RETRIEVED_CONTEXT" in result.instruction
+    assert "TaskDetails.md" in result.instruction
+    assert "providerProfile is rendered in the details panel" in result.instruction
+    assert mock_request.instruction_ref == result.instruction
+
+
+def test_extract_query_terms_keeps_domain_words():
+    terms = ContextInjectionService._extract_query_terms(
+        "Task details should show the provider profile selected for the workflow run"
+    )
+
+    assert "task" in terms
+    assert "details" in terms
+    assert "provider" in terms
+    assert "profile" in terms
+    assert "workflow" in terms

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import subprocess
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -316,6 +317,78 @@ async def test_launch_registers_generated_support_dir_for_cleanup(tmp_path, monk
     support_dir = support_dirs[0]
     assert support_dir.exists()
     assert str(support_dir / "codex-home" / "config.toml") in cleanup_path_set
+
+
+@pytest.mark.asyncio
+@patch("moonmind.rag.context_injection.ContextInjectionService")
+async def test_launch_builds_codex_command_after_workspace_preparation(
+    mock_service_class,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+
+    store = ManagedRunStore(tmp_path)
+    launcher = ManagedRuntimeLauncher(store)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    mock_service = mock_service_class.return_value
+    mock_service.inject_context = AsyncMock()
+
+    async def _fake_resolve(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._resolve_github_token_for_launch",
+        _fake_resolve,
+    )
+
+    class _FakeProcess:
+        def __init__(self, pid: int = 889) -> None:
+            self.pid = pid
+            self.returncode = 0
+            self.stdout = asyncio.StreamReader()
+            self.stderr = asyncio.StreamReader()
+
+        async def wait(self) -> int:
+            return 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    captured_args: tuple[object, ...] = ()
+
+    async def _fake_create_subprocess_exec(*args, **_kwargs):
+        nonlocal captured_args
+        captured_args = args
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.launcher.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    profile = _make_profile(
+        runtime_id="codex_cli",
+        command_template=["codex", "exec"],
+        default_model="qwen/qwen3.6-plus:free",
+    )
+    request = _make_request(instruction_ref="Do work")
+
+    _record, process, _cleanup, _deferred_cleanup = await launcher.launch(
+        run_id="run-codex-note",
+        request=request,
+        profile=profile,
+        workspace_path=workspace,
+    )
+    await process.wait()
+
+    assert captured_args[:2] == ("codex", "exec")
+    assert any(
+        isinstance(arg, str) and "Managed Codex CLI note:" in arg
+        for arg in captured_args
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -395,7 +395,7 @@ class TestCodexCliBuildCommand:
         cmd = s.build_command(profile, request)
         assert cmd == ["codex", "exec", "Go"]
 
-    def test_suppress_default_model_flag_keeps_explicit_request_model(self) -> None:
+    def test_suppress_default_model_flag_omits_redundant_explicit_default_model(self) -> None:
         s = CodexCliStrategy()
         profile = _make_profile(
             command_template=["codex", "exec"],
@@ -407,7 +407,21 @@ class TestCodexCliBuildCommand:
             parameters={"model": "qwen/qwen3.6-plus:free"},
         )
         cmd = s.build_command(profile, request)
-        assert cmd == ["codex", "exec", "-m", "qwen/qwen3.6-plus:free", "Go"]
+        assert cmd == ["codex", "exec", "Go"]
+
+    def test_suppress_default_model_flag_keeps_explicit_non_default_model(self) -> None:
+        s = CodexCliStrategy()
+        profile = _make_profile(
+            command_template=["codex", "exec"],
+            default_model="qwen/qwen3.6-plus:free",
+        )
+        profile.command_behavior = {"suppress_default_model_flag": True}
+        request = _make_request(
+            instruction_ref="Go",
+            parameters={"model": "qwen/qwen3-coder-plus:free"},
+        )
+        cmd = s.build_command(profile, request)
+        assert cmd == ["codex", "exec", "-m", "qwen/qwen3-coder-plus:free", "Go"]
 
 
 class TestCodexCliShapeEnvironment:
@@ -475,6 +489,10 @@ class TestCodexCliPrepareWorkspace:
 
         assert "Managed Codex CLI note:" in request.instruction_ref
         assert "`apply_patch` or `read_file`" in request.instruction_ref
+        assert "This run is non-interactive." in request.instruction_ref
+        assert "Do not ask whether to continue" in request.instruction_ref
+        assert "Do not end the run with a progress-only message" in request.instruction_ref
+        assert "Do not combine a content pattern with `rg --files`" in request.instruction_ref
         assert "`rg` and `sed -n`" in request.instruction_ref
 
     @pytest.mark.asyncio
@@ -500,6 +518,19 @@ class TestCodexCliPrepareWorkspace:
         result = CodexCliStrategy().classify_result(
             exit_code=0,
             stdout="Blocked on the workspace tooling constraint.\n",
+            stderr="",
+        )
+
+        assert result.status == "failed"
+        assert result.failure_class == "execution_error"
+
+    def test_classify_result_fails_for_progress_only_exit(self) -> None:
+        result = CodexCliStrategy().classify_result(
+            exit_code=0,
+            stdout=(
+                "Let me search more specifically for frontend components and "
+                "provider-related code.\n"
+            ),
             stderr="",
         )
 

--- a/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
+++ b/tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py
@@ -536,3 +536,17 @@ class TestCodexCliPrepareWorkspace:
 
         assert result.status == "failed"
         assert result.failure_class == "execution_error"
+
+def test_codex_classify_result_ignores_intermediate_progress_only_line() -> None:
+    result = CodexCliStrategy().classify_result(
+        exit_code=0,
+        stdout=(
+            "Let me search more specifically for frontend components and "
+            "provider-related code.\n"
+            "Implemented provider profile details in task history and added unit coverage.\n"
+        ),
+        stderr="",
+    )
+
+    assert result.status == "completed"
+    assert result.failure_class is None

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -118,6 +118,26 @@ class TestCodexCliOutputParser:
         )
         assert result.error_messages == ["Blocked on the workspace tooling constraint."]
 
+    def test_parse_detects_interactive_handoff_message(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "Want me to keep going with that, or is there something specific you'd like me to work on?\n",
+            "",
+        )
+        assert result.error_messages == [
+            "Want me to keep going with that, or is there something specific you'd like me to work on?"
+        ]
+
+    def test_parse_detects_progress_only_exploration_message(self) -> None:
+        parser = CodexCliOutputParser()
+        result = parser.parse(
+            "Let me search more specifically for frontend components and provider-related code.\n",
+            "",
+        )
+        assert result.error_messages == [
+            "Let me search more specifically for frontend components and provider-related code."
+        ]
+
     def test_parse_deduplicates_blocker_lines_case_insensitively(self) -> None:
         parser = CodexCliOutputParser()
         result = parser.parse(
@@ -129,7 +149,7 @@ class TestCodexCliOutputParser:
     def test_parse_ignores_non_blocker_stdout(self) -> None:
         parser = CodexCliOutputParser()
         result = parser.parse(
-            "Let me search more broadly for provider profiles in the backend API.\n",
+            "Implemented provider profile details in task history and added unit coverage.\n",
             "",
         )
         assert result.error_messages == []

--- a/tests/unit/workflows/temporal/runtime/test_output_parser.py
+++ b/tests/unit/workflows/temporal/runtime/test_output_parser.py
@@ -22,11 +22,6 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
 )
 
 
-# ---------------------------------------------------------------------------
-# PlainTextOutputParser
-# ---------------------------------------------------------------------------
-
-
 class TestPlainTextOutputParser:
     def test_parse_stream_chunk_returns_empty(self) -> None:
         parser = PlainTextOutputParser()
@@ -46,7 +41,7 @@ class TestPlainTextOutputParser:
             "some output",
             "Error: something went wrong\nWarning: be careful\nFatal: crash",
         )
-        assert len(result.error_messages) == 2  # Error: and Fatal:
+        assert len(result.error_messages) == 2
         assert any("Error:" in m for m in result.error_messages)
         assert any("Fatal:" in m for m in result.error_messages)
 
@@ -54,12 +49,6 @@ class TestPlainTextOutputParser:
         parser = PlainTextOutputParser()
         result = parser.parse("output", "just some debug info")
         assert result.error_messages == []
-
-
-
-# ---------------------------------------------------------------------------
-# Default strategy exit classification (Gemini, Claude, Codex)
-# ---------------------------------------------------------------------------
 
 
 class TestDefaultStrategyClassifyExit:
@@ -118,7 +107,7 @@ class TestCodexCliOutputParser:
         )
         assert result.error_messages == ["Blocked on the workspace tooling constraint."]
 
-    def test_parse_detects_interactive_handoff_message(self) -> None:
+    def test_parse_detects_terminal_interactive_handoff_message(self) -> None:
         parser = CodexCliOutputParser()
         result = parser.parse(
             "Want me to keep going with that, or is there something specific you'd like me to work on?\n",
@@ -128,15 +117,14 @@ class TestCodexCliOutputParser:
             "Want me to keep going with that, or is there something specific you'd like me to work on?"
         ]
 
-    def test_parse_detects_progress_only_exploration_message(self) -> None:
+    def test_parse_ignores_intermediate_progress_message_when_output_finishes_cleanly(self) -> None:
         parser = CodexCliOutputParser()
         result = parser.parse(
-            "Let me search more specifically for frontend components and provider-related code.\n",
+            "Let me search more specifically for frontend components and provider-related code.\n"
+            "Implemented provider profile details in task history and added unit coverage.\n",
             "",
         )
-        assert result.error_messages == [
-            "Let me search more specifically for frontend components and provider-related code."
-        ]
+        assert result.error_messages == []
 
     def test_parse_deduplicates_blocker_lines_case_insensitively(self) -> None:
         parser = CodexCliOutputParser()


### PR DESCRIPTION
## Summary
- harden managed `codex_cli` OpenRouter runs so exploratory/no-op exits are treated as execution failures instead of clean completions
- fix Codex launcher ordering so workspace preparation can mutate the prompt before the command is built
- restore RAG retrieval compatibility with the installed Qdrant client and add a bounded local repo-search fallback when the `moonmind` vector collection is unavailable

## Root Cause
The original workflow failed because the managed Codex note was appended during workspace preparation, but `ManagedRuntimeLauncher` built the `codex exec` command before that mutation happened. Qwen/OpenRouter runs could then exit after exploration with no repo changes, get classified as completed, and only fail later during publish with `no_commits`. While validating that path, a second issue surfaced: RAG retrieval in the worker was broken because `RagQdrantClient` still called the legacy Qdrant `search()` API, and the local environment currently has no `moonmind` collection populated.

## What Changed
- classify progress-only and interactive-handoff Codex outputs as `execution_error`
- make the managed note more explicit for non-interactive Codex runs and avoid redundant default `-m` for the OpenRouter profile
- build the Codex command after workspace preparation
- switch Qdrant retrieval to `query_points()` when the legacy API is unavailable
- add local context fallback in `ContextInjectionService` when vector retrieval is unavailable
- add regression coverage for the launcher, parser, Codex strategy, Qdrant client, and context injection

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/workflows/temporal/runtime/test_output_parser.py`
- `./tools/test_unit.sh tests/unit/rag/test_context_injection.py tests/unit/moonmind/rag/test_qdrant_client.py tests/unit/services/temporal/runtime/test_launcher.py tests/unit/workflows/temporal/runtime/strategies/test_remaining_strategies.py tests/unit/workflows/temporal/runtime/test_output_parser.py`
- reran the original workflow family after worker restarts and confirmed the runtime now reaches the managed-note path, fails fast on no-op exits, and falls back to local context when Qdrant retrieval is unavailable
