### PR TITLE
[codex] Fix managed PR publish for dirty workspaces

### DIFF
--- a/api_service/data/task_step_templates/speckit-orchestrate.yaml
+++ b/api_service/data/task_step_templates/speckit-orchestrate.yaml
@@ -190,8 +190,9 @@ steps:
   - title: Return final report and defer publish actions
     instructions: |-
       If all gates pass (no NO DETERMINATION and no unresolved CRITICAL/HIGH blockers):
-      1. Do NOT create commits, push branches, or open pull requests from runtime execution.
-      2. Return a final report so MoonMind publish stage can handle commit/PR behavior when enabled.
+      1. If publish mode is enabled, commit your completed work once and do not push branches or open pull requests from runtime execution.
+      2. If publish mode is disabled, do not create commits, push branches, or open pull requests from runtime execution.
+      3. Return a final report so MoonMind publish stage can handle push/PR behavior when enabled.
       Return final report including:
       - Feature path and branch
       - Files edited
@@ -200,7 +201,7 @@ steps:
       - Checklist gate outcome
       - Scope validation outcomes (tasks + diff)
       - DOC-REQ coverage status
-      - Publish handoff status (commit/PR handled by wrapper publish stage)
+      - Publish handoff status (push/PR handled by wrapper publish stage)
     skill:
       id: auto
       args: {}

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -127,6 +127,11 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "code: 429",
 )
 _OPERATOR_SUMMARY_TAIL_BYTES = 64 * 1024
+_PUBLISH_GIT_ADD_EXCLUDES: tuple[str, ...] = (
+    ":(exclude)CLAUDE.md",
+    ":(exclude)live_streams.spool",
+    ":(exclude).agents/skills/active",
+)
 
 
 def _managed_runtime_artifact_root() -> Path:
@@ -2890,16 +2895,16 @@ class TemporalAgentRuntimeActivities:
                 else str(support_bin)
             )
         if support_gitconfig.exists():
-            env.setdefault("GIT_CONFIG_GLOBAL", str(support_gitconfig))
+            env["GIT_CONFIG_GLOBAL"] = str(support_gitconfig)
         git_name = str(settings.workflow.git_user_name or "").strip()
         git_email = str(settings.workflow.git_user_email or "").strip()
         if git_name:
-            env.setdefault("GIT_AUTHOR_NAME", git_name)
-            env.setdefault("GIT_COMMITTER_NAME", git_name)
+            env["GIT_AUTHOR_NAME"] = git_name
+            env["GIT_COMMITTER_NAME"] = git_name
         if git_email:
-            env.setdefault("GIT_AUTHOR_EMAIL", git_email)
-            env.setdefault("GIT_COMMITTER_EMAIL", git_email)
-        env.setdefault("GIT_TERMINAL_PROMPT", "0")
+            env["GIT_AUTHOR_EMAIL"] = git_email
+            env["GIT_COMMITTER_EMAIL"] = git_email
+        env["GIT_TERMINAL_PROMPT"] = "0"
         return env
 
     async def _commit_workspace_changes_if_needed(
@@ -2911,19 +2916,17 @@ class TemporalAgentRuntimeActivities:
         env: Mapping[str, str] | None = None,
     ) -> dict[str, Any]:
         """Create one deterministic commit when the workspace is dirty."""
-        import asyncio as _asyncio
-
         command_env = dict(env) if env is not None else self._workspace_command_env(workspace)
 
-        status_proc = await _asyncio.create_subprocess_exec(
+        status_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
                 workspace, "status", "--porcelain", "--untracked-files=all",
             ),
-            stdout=_asyncio.subprocess.PIPE,
-            stderr=_asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             env=command_env,
         )
-        status_stdout, status_stderr = await _asyncio.wait_for(
+        status_stdout, status_stderr = await asyncio.wait_for(
             status_proc.communicate(), timeout=15,
         )
         if status_proc.returncode != 0:
@@ -2938,13 +2941,15 @@ class TemporalAgentRuntimeActivities:
         if not status_stdout.decode("utf-8", errors="replace").strip():
             return {}
 
-        add_proc = await _asyncio.create_subprocess_exec(
-            *self._workspace_git_command(workspace, "add", "-A"),
-            stdout=_asyncio.subprocess.PIPE,
-            stderr=_asyncio.subprocess.PIPE,
+        add_proc = await asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace, "add", "-A", "--", ".", *_PUBLISH_GIT_ADD_EXCLUDES,
+            ),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             env=command_env,
         )
-        add_stdout, add_stderr = await _asyncio.wait_for(
+        add_stdout, add_stderr = await asyncio.wait_for(
             add_proc.communicate(), timeout=30,
         )
         if add_proc.returncode != 0:
@@ -2956,15 +2961,15 @@ class TemporalAgentRuntimeActivities:
                 "push_error": f"could not stage workspace changes: {detail}",
             }
 
-        staged_proc = await _asyncio.create_subprocess_exec(
+        staged_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
                 workspace, "diff", "--cached", "--name-only",
             ),
-            stdout=_asyncio.subprocess.PIPE,
-            stderr=_asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             env=command_env,
         )
-        staged_stdout, staged_stderr = await _asyncio.wait_for(
+        staged_stdout, staged_stderr = await asyncio.wait_for(
             staged_proc.communicate(), timeout=15,
         )
         if staged_proc.returncode != 0:
@@ -2984,15 +2989,15 @@ class TemporalAgentRuntimeActivities:
             if isinstance(commit_message, str) and commit_message.strip()
             else f"MoonMind task result for run {run_id}"
         )
-        commit_proc = await _asyncio.create_subprocess_exec(
+        commit_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
                 workspace, "commit", "-m", normalized_message,
             ),
-            stdout=_asyncio.subprocess.PIPE,
-            stderr=_asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             env=command_env,
         )
-        commit_stdout, commit_stderr = await _asyncio.wait_for(
+        commit_stdout, commit_stderr = await asyncio.wait_for(
             commit_proc.communicate(), timeout=60,
         )
         if commit_proc.returncode != 0:
@@ -3052,8 +3057,6 @@ class TemporalAgentRuntimeActivities:
         Uses ``asyncio.create_subprocess_exec`` to avoid blocking the event
         loop.
         """
-        import asyncio as _asyncio
-
         if self._run_store is None:
             return {"push_status": "skipped", "push_error": "no run store"}
 
@@ -3064,15 +3067,15 @@ class TemporalAgentRuntimeActivities:
         workspace = record.workspace_path
         try:
             command_env = self._workspace_command_env(workspace)
-            branch_proc = await _asyncio.create_subprocess_exec(
+            branch_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
                     workspace, "rev-parse", "--abbrev-ref", "HEAD",
                 ),
-                stdout=_asyncio.subprocess.PIPE,
-                stderr=_asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
                 env=command_env,
             )
-            stdout_bytes, stderr_bytes = await _asyncio.wait_for(
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
                 branch_proc.communicate(), timeout=10,
             )
             if branch_proc.returncode != 0:
@@ -3107,15 +3110,15 @@ class TemporalAgentRuntimeActivities:
                 commit_info.setdefault("push_branch", current_branch)
                 return commit_info
 
-            push_proc = await _asyncio.create_subprocess_exec(
+            push_proc = await asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
                     workspace, "push", "-u", "origin", current_branch,
                 ),
-                stdout=_asyncio.subprocess.PIPE,
-                stderr=_asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
                 env=command_env,
             )
-            push_stdout, push_stderr = await _asyncio.wait_for(
+            push_stdout, push_stderr = await asyncio.wait_for(
                 push_proc.communicate(), timeout=120,
             )
             if push_proc.returncode != 0:
@@ -3140,18 +3143,18 @@ class TemporalAgentRuntimeActivities:
             # with HTTP 422 ("No commits between main and <branch>").
             base_ref = f"origin/{target_branch or 'main'}"
             try:
-                count_proc = await _asyncio.create_subprocess_exec(
+                count_proc = await asyncio.create_subprocess_exec(
                     *self._workspace_git_command(
                         workspace,
                         "rev-list",
                         "--count",
                         f"{base_ref}..{current_branch}",
                     ),
-                    stdout=_asyncio.subprocess.PIPE,
-                    stderr=_asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
                     env=command_env,
                 )
-                count_stdout, _ = await _asyncio.wait_for(
+                count_stdout, _ = await asyncio.wait_for(
                     count_proc.communicate(), timeout=10,
                 )
                 if count_proc.returncode != 0:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2505,8 +2505,23 @@ class TemporalAgentRuntimeActivities:
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
             if result.failure_class is None and publish_mode != "none":
+                raw_commit_message = None
+                if isinstance(request, Mapping):
+                    raw_commit_message = (
+                        request.get("commit_message")
+                        or request.get("commitMessage")
+                    )
+                push_kwargs: dict[str, Any] = {
+                    "target_branch": target_branch,
+                }
+                if (
+                    isinstance(raw_commit_message, str)
+                    and raw_commit_message.strip()
+                ):
+                    push_kwargs["commit_message"] = raw_commit_message.strip()
                 push_info = await self._push_workspace_branch(
-                    run_id, target_branch=target_branch
+                    run_id,
+                    **push_kwargs,
                 )
                 meta.update(push_info)
 
@@ -2864,7 +2879,9 @@ class TemporalAgentRuntimeActivities:
     def _workspace_command_env(workspace: str) -> dict[str, str]:
         """Build a subprocess env that exposes workspace-local command shims."""
         env = dict(os.environ)
-        support_bin = Path(workspace).resolve().parent / ".moonmind" / "bin"
+        support_root = Path(workspace).resolve().parent / ".moonmind"
+        support_bin = support_root / "bin"
+        support_gitconfig = support_root / "gitconfig"
         if support_bin.exists():
             existing_path = str(env.get("PATH") or "").strip()
             env["PATH"] = (
@@ -2872,8 +2889,129 @@ class TemporalAgentRuntimeActivities:
                 if existing_path
                 else str(support_bin)
             )
+        if support_gitconfig.exists():
+            env.setdefault("GIT_CONFIG_GLOBAL", str(support_gitconfig))
+        git_name = str(settings.workflow.git_user_name or "").strip()
+        git_email = str(settings.workflow.git_user_email or "").strip()
+        if git_name:
+            env.setdefault("GIT_AUTHOR_NAME", git_name)
+            env.setdefault("GIT_COMMITTER_NAME", git_name)
+        if git_email:
+            env.setdefault("GIT_AUTHOR_EMAIL", git_email)
+            env.setdefault("GIT_COMMITTER_EMAIL", git_email)
         env.setdefault("GIT_TERMINAL_PROMPT", "0")
         return env
+
+    async def _commit_workspace_changes_if_needed(
+        self,
+        workspace: str,
+        *,
+        run_id: str,
+        commit_message: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Create one deterministic commit when the workspace is dirty."""
+        import asyncio as _asyncio
+
+        command_env = dict(env) if env is not None else self._workspace_command_env(workspace)
+
+        status_proc = await _asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace, "status", "--porcelain", "--untracked-files=all",
+            ),
+            stdout=_asyncio.subprocess.PIPE,
+            stderr=_asyncio.subprocess.PIPE,
+            env=command_env,
+        )
+        status_stdout, status_stderr = await _asyncio.wait_for(
+            status_proc.communicate(), timeout=15,
+        )
+        if status_proc.returncode != 0:
+            detail = status_stderr.decode("utf-8", errors="replace").strip() or (
+                status_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            return {
+                "push_status": "failed",
+                "push_error": f"could not inspect workspace changes: {detail}",
+            }
+
+        if not status_stdout.decode("utf-8", errors="replace").strip():
+            return {}
+
+        add_proc = await _asyncio.create_subprocess_exec(
+            *self._workspace_git_command(workspace, "add", "-A"),
+            stdout=_asyncio.subprocess.PIPE,
+            stderr=_asyncio.subprocess.PIPE,
+            env=command_env,
+        )
+        add_stdout, add_stderr = await _asyncio.wait_for(
+            add_proc.communicate(), timeout=30,
+        )
+        if add_proc.returncode != 0:
+            detail = add_stderr.decode("utf-8", errors="replace").strip() or (
+                add_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            return {
+                "push_status": "failed",
+                "push_error": f"could not stage workspace changes: {detail}",
+            }
+
+        staged_proc = await _asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace, "diff", "--cached", "--name-only",
+            ),
+            stdout=_asyncio.subprocess.PIPE,
+            stderr=_asyncio.subprocess.PIPE,
+            env=command_env,
+        )
+        staged_stdout, staged_stderr = await _asyncio.wait_for(
+            staged_proc.communicate(), timeout=15,
+        )
+        if staged_proc.returncode != 0:
+            detail = staged_stderr.decode("utf-8", errors="replace").strip() or (
+                staged_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            return {
+                "push_status": "failed",
+                "push_error": f"could not inspect staged workspace changes: {detail}",
+            }
+
+        if not staged_stdout.decode("utf-8", errors="replace").strip():
+            return {}
+
+        normalized_message = (
+            str(commit_message).strip()
+            if isinstance(commit_message, str) and commit_message.strip()
+            else f"MoonMind task result for run {run_id}"
+        )
+        commit_proc = await _asyncio.create_subprocess_exec(
+            *self._workspace_git_command(
+                workspace, "commit", "-m", normalized_message,
+            ),
+            stdout=_asyncio.subprocess.PIPE,
+            stderr=_asyncio.subprocess.PIPE,
+            env=command_env,
+        )
+        commit_stdout, commit_stderr = await _asyncio.wait_for(
+            commit_proc.communicate(), timeout=60,
+        )
+        if commit_proc.returncode != 0:
+            detail = commit_stderr.decode("utf-8", errors="replace").strip() or (
+                commit_stdout.decode("utf-8", errors="replace").strip() or "(no stderr)"
+            )
+            lowered_detail = detail.lower()
+            if "nothing to commit" in lowered_detail:
+                return {}
+            return {
+                "push_status": "failed",
+                "push_error": f"could not commit workspace changes: {detail}",
+            }
+
+        logger.info(
+            "Created deterministic publish commit for run %s before push.",
+            run_id,
+        )
+        return {"push_commit_message": normalized_message}
 
     @staticmethod
     def _report_matches_record(path: Path, record: ManagedRunRecord) -> bool:
@@ -2903,6 +3041,7 @@ class TemporalAgentRuntimeActivities:
         run_id: str,
         *,
         target_branch: str | None = None,
+        commit_message: str | None = None,
     ) -> dict[str, Any]:
         """Push the workspace branch to origin.
 
@@ -2924,12 +3063,14 @@ class TemporalAgentRuntimeActivities:
 
         workspace = record.workspace_path
         try:
+            command_env = self._workspace_command_env(workspace)
             branch_proc = await _asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
                     workspace, "rev-parse", "--abbrev-ref", "HEAD",
                 ),
                 stdout=_asyncio.subprocess.PIPE,
                 stderr=_asyncio.subprocess.PIPE,
+                env=command_env,
             )
             stdout_bytes, stderr_bytes = await _asyncio.wait_for(
                 branch_proc.communicate(), timeout=10,
@@ -2956,12 +3097,23 @@ class TemporalAgentRuntimeActivities:
                     "push_branch": current_branch or "(unknown)",
                 }
 
+            commit_info = await self._commit_workspace_changes_if_needed(
+                workspace,
+                run_id=run_id,
+                commit_message=commit_message,
+                env=command_env,
+            )
+            if commit_info.get("push_status") == "failed":
+                commit_info.setdefault("push_branch", current_branch)
+                return commit_info
+
             push_proc = await _asyncio.create_subprocess_exec(
                 *self._workspace_git_command(
                     workspace, "push", "-u", "origin", current_branch,
                 ),
                 stdout=_asyncio.subprocess.PIPE,
                 stderr=_asyncio.subprocess.PIPE,
+                env=command_env,
             )
             push_stdout, push_stderr = await _asyncio.wait_for(
                 push_proc.communicate(), timeout=120,
@@ -2997,6 +3149,7 @@ class TemporalAgentRuntimeActivities:
                     ),
                     stdout=_asyncio.subprocess.PIPE,
                     stderr=_asyncio.subprocess.PIPE,
+                    env=command_env,
                 )
                 count_stdout, _ = await _asyncio.wait_for(
                     count_proc.communicate(), timeout=10,
@@ -3045,6 +3198,7 @@ class TemporalAgentRuntimeActivities:
                 "push_branch": current_branch,
                 "push_base_ref": base_ref,
             }
+            result.update(commit_info)
             if commit_count >= 0:
                 result["push_commit_count"] = commit_count
             return result

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -302,6 +302,9 @@ def _build_runtime_planner():
         )
         if isinstance(publish_mode, str) and publish_mode.strip():
             node_inputs["publishMode"] = publish_mode.strip()
+        commit_message = publish_payload.get("commitMessage")
+        if isinstance(commit_message, str) and commit_message.strip():
+            node_inputs["commitMessage"] = commit_message.strip()
 
         repository = (
             task_payload.get("repository")

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -302,7 +302,9 @@ def _build_runtime_planner():
         )
         if isinstance(publish_mode, str) and publish_mode.strip():
             node_inputs["publishMode"] = publish_mode.strip()
-        commit_message = publish_payload.get("commitMessage")
+        commit_message = publish_payload.get(
+            "commitMessage", parameter_payload.get("commitMessage")
+        )
         if isinstance(commit_message, str) and commit_message.strip():
             node_inputs["commitMessage"] = commit_message.strip()
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1152,6 +1152,16 @@ class MoonMindAgentRun:
                             }
                             if publish_mode != "none":
                                 activity_input["publish_mode"] = publish_mode
+                            raw_commit_message = (request.parameters or {}).get(
+                                "commitMessage"
+                            )
+                            if (
+                                isinstance(raw_commit_message, str)
+                                and raw_commit_message.strip()
+                            ):
+                                activity_input["commit_message"] = (
+                                    raw_commit_message.strip()
+                                )
                             if target_branch:
                                 activity_input["target_branch"] = target_branch
                             if _request_selected_skill(request) == "pr-resolver":

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1743,6 +1743,7 @@ class MoonMindRunWorkflow:
             "model",
             "effort",
             "publishMode",
+            "commitMessage",
             "allowed_tools",
             "stepCount",
             "maxAttempts",

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -183,7 +183,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"feature/delete-spec-048\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -302,7 +305,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -332,7 +338,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -366,7 +375,7 @@ class TestPushWorkspaceBranch:
                     return_value=(b" M api_service/main.py\n?? tests/new_test.py\n", b"")
                 )
                 proc.returncode = 0
-            elif call_count == 3:  # git add -A
+            elif call_count == 3:  # git add -A with runtime exclusions
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             elif call_count == 4:  # staged diff check
@@ -395,6 +404,14 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "auto-dirty123"
         assert result["push_commit_count"] == 1
         assert result["push_commit_message"] == "Ship dirty workspace"
+        add_call = recorded_calls[2]
+        assert list(add_call[-5:]) == [
+            "--",
+            ".",
+            ":(exclude)CLAUDE.md",
+            ":(exclude)live_streams.spool",
+            ":(exclude).agents/skills/active",
+        ]
         commit_call = next(call for call in recorded_calls if "commit" in call)
         assert list(commit_call[-3:]) == ["commit", "-m", "Ship dirty workspace"]
 
@@ -435,6 +452,43 @@ class TestPushWorkspaceBranch:
         assert "could not commit workspace changes" in result["push_error"]
         assert "Author identity unknown" in result["push_error"]
 
+    @pytest.mark.asyncio
+    async def test_push_ignores_runtime_scaffolding_only_changes(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-claude123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"?? CLAUDE.md\n", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # git add -A with exclusions
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # staged diff check
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"0\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "no_commits"
+        assert result["push_branch"] == "auto-claude123"
+        assert result["push_commit_count"] == 0
+
     def test_workspace_command_env_includes_support_gitconfig_and_git_identity(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
     ) -> None:
@@ -453,6 +507,34 @@ class TestPushWorkspaceBranch:
         env = TemporalAgentRuntimeActivities._workspace_command_env(str(workspace))
 
         assert env["PATH"].startswith(str(support_bin))
+        assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+        assert env["GIT_AUTHOR_NAME"] == "MoonMind Bot"
+        assert env["GIT_COMMITTER_NAME"] == "MoonMind Bot"
+        assert env["GIT_AUTHOR_EMAIL"] == "moonmind@example.com"
+        assert env["GIT_COMMITTER_EMAIL"] == "moonmind@example.com"
+
+    def test_workspace_command_env_overrides_preexisting_git_identity(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "run-1" / "repo"
+        support_root = workspace.parent / ".moonmind"
+        support_bin = support_root / "bin"
+        support_bin.mkdir(parents=True)
+        gitconfig = support_root / "gitconfig"
+        gitconfig.write_text("[safe]\n", encoding="utf-8")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/tmp/external.gitconfig")
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "External Author")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "External Committer")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "external@example.com")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "external@example.com")
+        monkeypatch.setattr(settings.workflow, "git_user_name", "MoonMind Bot")
+        monkeypatch.setattr(
+            settings.workflow, "git_user_email", "moonmind@example.com"
+        )
+
+        env = TemporalAgentRuntimeActivities._workspace_command_env(str(workspace))
+
         assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
         assert env["GIT_AUTHOR_NAME"] == "MoonMind Bot"
         assert env["GIT_COMMITTER_NAME"] == "MoonMind Bot"
@@ -536,7 +618,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
+from moonmind.config.settings import settings
 from moonmind.schemas.agent_runtime_models import AgentRunResult
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
@@ -202,18 +203,23 @@ class TestPushWorkspaceBranch:
         activities = TemporalAgentRuntimeActivities(run_store=store)
         recorded_calls: list[tuple[object, ...]] = []
         workspace = "/work/agent_jobs/run-1/repo"
+        call_count = 0
 
         async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
             recorded_calls.append(args)
             proc = AsyncMock()
-            command = list(args)
-            if "rev-parse" in command:
+            if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"feature/safe-branch\n", b""))
                 proc.returncode = 0
-            elif "push" in command:
+            elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            else:
+            elif call_count == 3:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"1\n", b""))
                 proc.returncode = 0
             return proc
@@ -222,7 +228,7 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
 
         assert result["push_status"] == "pushed"
-        assert len(recorded_calls) == 3
+        assert len(recorded_calls) == 4
         for call in recorded_calls:
             command = list(call)
             assert command[:5] == [
@@ -245,6 +251,9 @@ class TestPushWorkspaceBranch:
             proc = AsyncMock()
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"feature/delete-spec-048\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b"remote: Permission denied"))
@@ -337,6 +346,120 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "auto-abc123"
 
     @pytest.mark.asyncio
+    async def test_push_commits_dirty_workspace_before_push(self):
+        """Dirty managed workspaces are committed before publish push."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-dirty123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(
+                    return_value=(b" M api_service/main.py\n?? tests/new_test.py\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 3:  # git add -A
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # staged diff check
+                proc.communicate = AsyncMock(
+                    return_value=(b"api_service/main.py\ntests/new_test.py\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 5:  # commit
+                proc.communicate = AsyncMock(return_value=(b"[auto-dirty123 abc123] msg\n", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                commit_message="Ship dirty workspace",
+            )
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "auto-dirty123"
+        assert result["push_commit_count"] == 1
+        assert result["push_commit_message"] == "Ship dirty workspace"
+        commit_call = next(call for call in recorded_calls if "commit" in call)
+        assert list(commit_call[-3:]) == ["commit", "-m", "Ship dirty workspace"]
+
+    @pytest.mark.asyncio
+    async def test_push_dirty_workspace_commit_failure_returns_failed(self):
+        """Commit failures surface as publish failures instead of false no-ops."""
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-dirty123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b" M api_service/main.py\n", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # git add -A
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # staged diff check
+                proc.communicate = AsyncMock(return_value=(b"api_service/main.py\n", b""))
+                proc.returncode = 0
+            else:  # commit
+                proc.communicate = AsyncMock(
+                    return_value=(b"", b"Author identity unknown")
+                )
+                proc.returncode = 128
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "failed"
+        assert "could not commit workspace changes" in result["push_error"]
+        assert "Author identity unknown" in result["push_error"]
+
+    def test_workspace_command_env_includes_support_gitconfig_and_git_identity(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "run-1" / "repo"
+        support_root = workspace.parent / ".moonmind"
+        support_bin = support_root / "bin"
+        support_bin.mkdir(parents=True)
+        gitconfig = support_root / "gitconfig"
+        gitconfig.write_text("[safe]\n", encoding="utf-8")
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setattr(settings.workflow, "git_user_name", "MoonMind Bot")
+        monkeypatch.setattr(
+            settings.workflow, "git_user_email", "moonmind@example.com"
+        )
+
+        env = TemporalAgentRuntimeActivities._workspace_command_env(str(workspace))
+
+        assert env["PATH"].startswith(str(support_bin))
+        assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+        assert env["GIT_AUTHOR_NAME"] == "MoonMind Bot"
+        assert env["GIT_COMMITTER_NAME"] == "MoonMind Bot"
+        assert env["GIT_AUTHOR_EMAIL"] == "moonmind@example.com"
+        assert env["GIT_COMMITTER_EMAIL"] == "moonmind@example.com"
+
+    @pytest.mark.asyncio
     async def test_push_revlist_failure_falls_through(self):
         """When rev-list --count raises, we fall through to 'pushed' (safe default)."""
         store = _make_mock_store()
@@ -350,7 +473,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count — simulate failure
@@ -377,7 +503,10 @@ class TestPushWorkspaceBranch:
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-abc123\n", b""))
                 proc.returncode = 0
-            elif call_count == 2:  # push
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count — non-zero exit with empty stdout
@@ -632,6 +761,47 @@ class TestFetchResultPushIntegration:
 
         assert result.metadata["push_status"] == "failed"
         assert result.metadata["push_error"] == "remote: Permission denied"
+
+    @pytest.mark.asyncio
+    async def test_fetch_result_passes_commit_message_override_to_push(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        with (
+            patch.object(
+                activities,
+                "_push_workspace_branch",
+                new_callable=AsyncMock,
+                return_value={"push_status": "pushed", "push_branch": "my-branch"},
+            ) as mock_push,
+            patch.object(
+                activities, "_detect_pr_url_from_workspace",
+                return_value=None,
+            ),
+            patch(
+                "moonmind.workflows.temporal.activity_runtime.ManagedAgentAdapter",
+            ) as MockAdapter,
+        ):
+            adapter_instance = MockAdapter.return_value
+            adapter_instance.fetch_result = AsyncMock(return_value=AgentRunResult(
+                summary="done",
+                failure_class=None,
+            ))
+
+            await activities.agent_runtime_fetch_result(
+                {
+                    "run_id": "run-1",
+                    "agent_id": "claude",
+                    "publish_mode": "pr",
+                    "commit_message": "Use explicit publish commit",
+                },
+            )
+
+        mock_push.assert_called_once_with(
+            "run-1",
+            target_branch=None,
+            commit_message="Use explicit publish commit",
+        )
 
     @pytest.mark.asyncio
     async def test_fetch_result_defaults_publish_mode_none(self):

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -514,6 +514,25 @@ def test_runtime_planner_publish_pr_propagates_commit_message_override():
     )
 
 
+def test_runtime_planner_publish_pr_falls_back_to_top_level_commit_message():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "runtime": {"mode": "gemini_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={"publishMode": "pr", "commitMessage": "Top-level commit text"},
+        snapshot=snapshot,
+    )
+
+    assert plan["nodes"][-1]["inputs"]["commitMessage"] == "Top-level commit text"
+
+
 def test_enforce_codex_config_skips_non_managed_fleet() -> None:
     with patch("api_service.scripts.ensure_codex_config.ensure_codex_config") as mock_ensure:
         _enforce_codex_config_for_managed_fleet(WORKFLOW_FLEET)

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -489,6 +489,31 @@ def test_runtime_planner_publish_pr_uses_step_title_for_target_branch_prefix():
     assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", target)
 
 
+def test_runtime_planner_publish_pr_propagates_commit_message_override():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "runtime": {"mode": "gemini_cli"},
+                "publish": {
+                    "mode": "pr",
+                    "commitMessage": "Use producer commit text",
+                },
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert (
+        plan["nodes"][-1]["inputs"]["commitMessage"]
+        == "Use producer commit text"
+    )
+
+
 def test_enforce_codex_config_skips_non_managed_fleet() -> None:
     with patch("api_service.scripts.ensure_codex_config.ensure_codex_config") as mock_ensure:
         _enforce_codex_config_for_managed_fleet(WORKFLOW_FLEET)

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunHandle
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -159,3 +159,102 @@ async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(
     assert result.failure_class == "execution_error"
     assert result.provider_error_code == "branch_publish_failed"
     assert result.metadata["publishOutcome"] == "publish_failed"
+
+
+async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-run-1",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="running",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        run.completion_event.set()
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "default-managed"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Managed success", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        run,
+        "_ensure_manager_and_signal",
+        fake_ensure_manager_and_signal,
+    )
+    monkeypatch.setattr(
+        run,
+        "_sync_manager_profiles",
+        fake_sync_manager_profiles,
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(
+        AgentExecutionRequest(
+            agentKind="managed",
+            agentId="codex_cli",
+            correlationId="corr-managed-1",
+            idempotencyKey="idem-managed-1",
+            parameters={
+                "publishMode": "pr",
+                "commitMessage": "Use producer commit text",
+            },
+            workspaceSpec={"startingBranch": "main"},
+        )
+    )
+
+    assert result.summary == "Managed success"
+    fetch_payload = next(
+        payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
+    )
+    assert fetch_payload["publish_mode"] == "pr"
+    assert fetch_payload["commit_message"] == "Use producer commit text"


### PR DESCRIPTION
## Summary
This fixes a managed-runtime publish bug where a workflow could complete with real file edits in the workspace but still fail PR publication as a no-op.

## Root Cause
The wrapper publish path only knew how to push existing commits. In this workflow shape, the final `speckit-orchestrate` step deferred publish actions and left changes uncommitted, so the managed `AgentRun` reported `push_status=no_commits` even though the workspace was dirty.

## What Changed
- Teach managed publish to inspect the workspace, stage dirty changes, and create one deterministic commit before push when publish mode is enabled.
- Reuse workspace `.moonmind` git config and git identity env for post-run git subprocesses.
- Thread explicit `publish.commitMessage` / `commitMessage` overrides through the runtime planner, `MoonMind.AgentRun`, and the managed fetch-result activity.
- Align the `speckit-orchestrate` final handoff instructions so publish-enabled runs commit once but still leave push and PR creation to the wrapper.
- Add regression coverage for dirty-workspace publish, commit-message propagation, and the managed `AgentRun -> fetch_result` boundary.

## Validation
- `./tools/test_unit.sh`
