### PR TITLE
[codex] Prefer latest pr-resolver attempt artifact

### DIFF
--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -61,6 +61,7 @@ _PR_RESOLVER_RESULT_PATHS: tuple[Path, ...] = (
     Path("var/pr_resolver/result.json"),
     Path("artifacts/pr_resolver_result.json"),
 )
+_PR_RESOLVER_ATTEMPTS_DIR = Path("var/pr_resolver/attempts")
 _PR_RESOLVER_FAILURE_STATUSES: frozenset[str] = frozenset(
     {"failed", "blocked", "attempts_exhausted"}
 )
@@ -69,22 +70,79 @@ _PR_RESOLVER_BLOCKED_STATUSES: frozenset[str] = frozenset(
 )
 
 
+def _load_json_dict(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _parse_payload_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _payload_sort_timestamp(path: Path, payload: dict[str, Any]) -> datetime:
+    for key in ("timestamp", "finished_at", "finishedAt", "updated_at", "updatedAt"):
+        parsed = _parse_payload_timestamp(payload.get(key))
+        if parsed is not None:
+            return parsed
+    for key in ("started_at", "startedAt"):
+        parsed = _parse_payload_timestamp(payload.get(key))
+        if parsed is not None:
+            return parsed
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return datetime.min.replace(tzinfo=UTC)
+
+
 def _load_pr_resolver_result(workspace_path: str | None) -> dict[str, Any] | None:
-    """Load a pr-resolver result payload from known workspace locations."""
+    """Load the most recent pr-resolver payload from result/attempt artifacts."""
 
     workspace = str(workspace_path or "").strip()
     if not workspace:
         return None
 
+    workspace_root = Path(workspace)
+    candidates: list[tuple[datetime, Path, dict[str, Any]]] = []
+
     for rel_path in _PR_RESOLVER_RESULT_PATHS:
-        result_path = Path(workspace) / rel_path
-        try:
-            payload = json.loads(result_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if isinstance(payload, dict):
-            return payload
-    return None
+        result_path = workspace_root / rel_path
+        payload = _load_json_dict(result_path)
+        if payload is not None:
+            candidates.append(
+                (_payload_sort_timestamp(result_path, payload), result_path, payload)
+            )
+
+    attempts_dir = workspace_root / _PR_RESOLVER_ATTEMPTS_DIR
+    try:
+        attempt_paths = sorted(attempts_dir.glob("*.json"))
+    except OSError:
+        attempt_paths = []
+    for attempt_path in attempt_paths:
+        payload = _load_json_dict(attempt_path)
+        if payload is not None:
+            candidates.append(
+                (_payload_sort_timestamp(attempt_path, payload), attempt_path, payload)
+            )
+
+    if not candidates:
+        return None
+
+    candidates.sort(key=lambda item: (item[0], str(item[1])))
+    return candidates[-1][2]
 
 # Type aliases for async signal callables injected by the caller/workflow.
 ProfileFetcherFunc = Callable[..., Awaitable[dict[str, Any]]]

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -1339,6 +1339,136 @@ async def test_fetch_result_upgrades_generic_failed_exit_with_pr_result(
     assert "run_fix_comments_skill" in result.summary
 
 
+async def test_fetch_result_prefers_newer_pr_resolver_attempt_over_stale_result(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    attempts_dir = result_dir / "attempts"
+    attempts_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "attempts_exhausted",\n'
+            '  "final_reason": "merge_conflicts",\n'
+            '  "next_step": "run_fix_merge_conflicts_skill",\n'
+            '  "finished_at": "2026-04-05T16:57:44+00:00"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    (attempts_dir / "finalize_attempt_3.json").write_text(
+        (
+            "{\n"
+            '  "status": "blocked",\n'
+            '  "final_reason": "ci_running",\n'
+            '  "next_step": "retry_finalize_after_backoff",\n'
+            '  "timestamp": "2026-04-05T17:01:30+00:00"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-latest-attempt",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-latest-attempt",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-latest-attempt", pr_resolver_expected=True
+    )
+    assert result.failure_class == "user_error"
+    assert result.summary is not None
+    assert "pr-resolver reported status 'blocked'" in result.summary
+    assert "ci_running" in result.summary
+    assert "merge_conflicts" not in result.summary
+
+
+async def test_fetch_result_ignores_stale_failure_when_newer_attempt_is_merged(
+    tmp_path: Path,
+):
+    from datetime import UTC, datetime
+
+    from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+    from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+    workspace_path = tmp_path / "workspace"
+    result_dir = workspace_path / "var" / "pr_resolver"
+    attempts_dir = result_dir / "attempts"
+    attempts_dir.mkdir(parents=True)
+    (result_dir / "result.json").write_text(
+        (
+            "{\n"
+            '  "status": "attempts_exhausted",\n'
+            '  "final_reason": "merge_conflicts",\n'
+            '  "next_step": "run_fix_merge_conflicts_skill",\n'
+            '  "finished_at": "2026-04-05T16:57:44+00:00"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+    (attempts_dir / "finalize_attempt_4.json").write_text(
+        (
+            "{\n"
+            '  "status": "merged",\n'
+            '  "final_reason": "ci_complete",\n'
+            '  "next_step": "done",\n'
+            '  "timestamp": "2026-04-05T17:05:00+00:00"\n'
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    store = ManagedRunStore(tmp_path / "run_store")
+    store.save(
+        ManagedRunRecord(
+            run_id="run-result-pr-merged-attempt",
+            agent_id="gemini_cli",
+            runtime_id="gemini_cli",
+            status="completed",
+            started_at=datetime.now(tz=UTC),
+            workspace_path=str(workspace_path),
+        )
+    )
+
+    adapter = ManagedAgentAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-result-pr-merged-attempt",
+        run_store=store,
+    )
+
+    result = await adapter.fetch_result(
+        "run-result-pr-merged-attempt", pr_resolver_expected=True
+    )
+    assert result.failure_class is None
+    assert result.summary is not None
+    assert "pr-resolver" not in result.summary
+
+
 async def test_fetch_result_ignores_merged_pr_resolver_artifact(tmp_path: Path):
     from datetime import UTC, datetime
 


### PR DESCRIPTION
## Summary
Fix managed `pr-resolver` result classification to prefer the newest persisted resolver artifact instead of blindly trusting a stale `var/pr_resolver/result.json`.

## What Changed
- scan both canonical `pr-resolver` result locations and `var/pr_resolver/attempts/*.json`
- parse artifact timestamps and select the newest payload as authoritative
- keep existing failure classification behavior, but base it on the latest resolver state
- add adapter regressions for stale `merge_conflicts` being superseded by newer `ci_running` and `merged` attempt artifacts

## Root Cause
A managed run can persist an older `var/pr_resolver/result.json` and then continue producing newer finalize-attempt artifacts. The adapter previously loaded the first result file it found and converted that stale state into a workflow-level `user_error`, even when later attempt artifacts showed the resolver had already advanced beyond the earlier failure.

## Impact
Runs like `mm:7127c91b-b716-48ed-9ee0-471abc6673b4` will no longer fail based on a stale `merge_conflicts` snapshot when newer resolver attempts show the current state is `ci_running` or `merged`.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_managed_agent_adapter.py`
