### PR TITLE
[codex] Freeze Codex managed session plane phase 1 contract

### DIFF
--- a/docs/ManagedAgents/CodexManagedSessionPlane.md
+++ b/docs/ManagedAgents/CodexManagedSessionPlane.md
@@ -1,0 +1,156 @@
+# Codex Managed Session Plane
+
+Status: Desired state
+Owners: MoonMind Platform
+Last updated: 2026-04-06
+Related:
+- [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
+- [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
+- [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
+- [`docs/Tasks/AgentSkillSystem.md`](../Tasks/AgentSkillSystem.md)
+
+## 1. Purpose
+
+This document defines the desired-state architecture contract for the **Codex managed session plane**.
+
+It freezes the smallest supported session-plane shape before broader implementation work:
+
+- Codex only
+- Docker only
+- one task-scoped session container per task
+- no cross-task session reuse
+- artifact-first logs and continuity
+- no Kubernetes orchestration
+- no Claude/Gemini managed session plane
+- no generic runtime marketplace
+
+This document defines the target contract only. Rollout sequencing and implementation backlog belong in specs or `docs/tmp/`.
+
+## 2. Layering
+
+The Codex managed session plane is split into two layers.
+
+### 2.1 Agent Orchestration Layer
+
+MoonMind owns:
+
+- Temporal workflows
+- activities
+- runtime adapters
+- policy evaluation
+- artifact publication
+- observability hooks
+- recovery and cancellation semantics
+
+Temporal remains the control plane and system of record.
+
+### 2.2 Managed Session Plane
+
+The managed session plane is the task-scoped Codex runtime environment:
+
+- one Docker container per task
+- Codex App Server running inside that container
+- one active Codex thread per session epoch
+- continuity reused across steps within the same task only
+
+The session plane is a continuity and performance cache. It is not durable truth.
+
+## 3. Protocol
+
+For the Codex MVP, the session protocol is **Codex App Server**, not PTY scraping and not `codex exec` as the primary session surface.
+
+MoonMind maps the managed session plane to Codex App Server concepts:
+
+- thread lifecycle
+- turn lifecycle
+- steering and interruption
+- optional approvals and command execution later
+
+`codex exec --json` remains a bring-up and smoke-test harness, not the primary long-lived session protocol.
+
+## 4. Session Identity
+
+The canonical bounded session identity is:
+
+- `session_id`
+- `session_epoch`
+- `container_id`
+- `thread_id`
+- `active_turn_id`
+
+Rules:
+
+1. `session_id` identifies the MoonMind task-scoped managed session.
+2. `session_epoch` identifies one logical continuity interval within that session.
+3. `container_id` identifies the active Docker container for the task-scoped session.
+4. `thread_id` identifies the active Codex App Server thread for the current epoch.
+5. `active_turn_id` identifies the in-flight Codex turn when one exists.
+
+## 5. Control Actions
+
+The canonical Phase 1 control actions are:
+
+- `start_session`
+- `resume_session`
+- `send_turn`
+- `steer_turn`
+- `interrupt_turn`
+- `clear_session`
+- `cancel_session`
+- `terminate_session`
+
+These actions are the stable MoonMind-side vocabulary for the Codex managed session plane. Runtime-specific transport details stay behind the adapter boundary.
+
+## 6. Clear / Reset Semantics
+
+`clear_session` is not a terminal slash-command emulation.
+
+The canonical semantics are:
+
+1. write a `session.control_event` artifact
+2. write a `session.reset_boundary` artifact
+3. increment `session_epoch`
+4. start a new Codex thread inside the same container
+5. clear `active_turn_id`
+
+Rules:
+
+- clear/reset preserves `session_id`
+- clear/reset preserves `container_id`
+- clear/reset requires a new `thread_id`
+- UI and API consumers must present the new epoch boundary explicitly
+
+## 7. Durable State Rule
+
+Container state is performance and continuity state only.
+
+Recovery, audit, and operator presentation must come from:
+
+- artifacts
+- bounded workflow metadata
+
+They must not depend on:
+
+- in-memory container state
+- container-local thread databases
+- terminal scrollback
+- runtime home directories as durable truth
+
+Artifact-backed logs and diagnostics remain authoritative even when live streaming exists.
+
+## 8. Artifact Expectations
+
+Every managed Codex step must remain execution-centric even when a container is reused across steps.
+
+At minimum, each step must produce durable evidence through the existing artifact system, including step outputs and runtime diagnostics. Session continuity should be represented with summary, checkpoint, and control-boundary artifacts rather than inferred from container state.
+
+## 9. Non-goals for This Contract Slice
+
+This contract does not define:
+
+- Kubernetes launch semantics
+- cross-task session reuse
+- session UIs beyond continuity-aware artifact presentation
+- generalized multi-runtime certification
+- Claude/Gemini session-plane behavior
+- PTY attach or interactive terminal embedding

--- a/docs/Temporal/ArtifactPresentationContract.md
+++ b/docs/Temporal/ArtifactPresentationContract.md
@@ -26,6 +26,8 @@ This document is intentionally downstream of the broader Temporal architecture. 
   - Owns execution identity, list/detail query semantics, and task compatibility rules.
 - `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
   - Owns canonical runtime contracts (`AgentRunHandle`, `AgentRunStatus`, `AgentRunResult`) and execution-model boundaries.
+- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+  - Owns the desired-state contract for Codex task-scoped session identity, control actions, and clear/reset semantics.
 - `docs/ManagedAgents/LiveLogs.md`
   - Owns live-log and observability APIs, artifact-backed tails, live streaming, and diagnostics presentation for managed runs.
 - `docs/UI/MissionControlArchitecture.md`

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -9,6 +9,7 @@ Related:
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/ManagedAgents/LiveLogs.md`](../ManagedAgents/LiveLogs.md) — canonical design for artifact-first log capture, live observability streaming, and the MoonMind-native log viewer UI
+- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](../ManagedAgents/CodexManagedSessionPlane.md) — desired-state contract for the Codex task-scoped managed session plane
 
 ---
 

--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -16,6 +16,11 @@ from .agent_skill_models import (
     SkillSelector,
     SkillSelectorEntry,
 )
+from .managed_session_models import (
+    CODEX_MANAGED_SESSION_CONTROL_ACTIONS,
+    CodexManagedSessionPlaneContract,
+    CodexManagedSessionState,
+)
 from .manifest_models import (
     AuthItem,
     Defaults,
@@ -140,4 +145,7 @@ __all__ = [
     "RuntimeMaterializationMode",
     "SkillSelector",
     "SkillSelectorEntry",
+    "CODEX_MANAGED_SESSION_CONTROL_ACTIONS",
+    "CodexManagedSessionPlaneContract",
+    "CodexManagedSessionState",
 ]

--- a/moonmind/schemas/_validation.py
+++ b/moonmind/schemas/_validation.py
@@ -1,0 +1,18 @@
+"""Shared schema validation helpers."""
+
+from __future__ import annotations
+
+from typing import Annotated, TypeAlias
+
+from pydantic import StringConstraints
+
+NonBlankStr: TypeAlias = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1)
+]
+
+
+def require_non_blank(value: str, *, field_name: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, NoReturn, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from moonmind.schemas._validation import require_non_blank
+
 AgentKind = Literal["external", "managed"]
 ExternalExecutionStyle = Literal["polling", "streaming_gateway"]
 AgentRunState = Literal[
@@ -117,14 +119,6 @@ def _contains_sensitive_key(
         )
     return False
 
-
-def _require_non_blank(value: str, *, field_name: str) -> str:
-    normalized = str(value).strip()
-    if not normalized:
-        raise ValueError(f"{field_name} must not be blank")
-    return normalized
-
-
 class ProfileSelector(BaseModel):
     """Dynamic routing criteria for ProviderProfileManager."""
 
@@ -170,32 +164,33 @@ class AgentExecutionRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_contract(self) -> "AgentExecutionRequest":
-        self.agent_id = _require_non_blank(self.agent_id, field_name="agentId")
+        self.agent_id = require_non_blank(self.agent_id, field_name="agentId")
         if self.execution_profile_ref is not None:
             if self.execution_profile_ref.strip().lower() == "auto":
                 self.execution_profile_ref = None
             else:
-                self.execution_profile_ref = _require_non_blank(
+                self.execution_profile_ref = require_non_blank(
                     self.execution_profile_ref, field_name="executionProfileRef"
                 )
-        self.correlation_id = _require_non_blank(
+        self.correlation_id = require_non_blank(
             self.correlation_id, field_name="correlationId"
         )
-        self.idempotency_key = _require_non_blank(
+        self.idempotency_key = require_non_blank(
             self.idempotency_key, field_name="idempotencyKey"
         )
         instruction_ref = self.instruction_ref
         if instruction_ref is not None:
-            self.instruction_ref = _require_non_blank(
+            self.instruction_ref = require_non_blank(
                 instruction_ref, field_name="instructionRef"
             )
         resolved_skillset_ref = self.resolved_skillset_ref
         if resolved_skillset_ref is not None:
-            self.resolved_skillset_ref = _require_non_blank(
+            self.resolved_skillset_ref = require_non_blank(
                 resolved_skillset_ref, field_name="resolvedSkillsetRef"
             )
         self.input_refs = [
-            _require_non_blank(item, field_name="inputRefs[]") for item in self.input_refs
+            require_non_blank(item, field_name="inputRefs[]")
+            for item in self.input_refs
         ]
 
         if _contains_sensitive_key(self.parameters):
@@ -220,8 +215,8 @@ class AgentRunHandle(BaseModel):
 
     @model_validator(mode="after")
     def _normalize(self) -> "AgentRunHandle":
-        self.run_id = _require_non_blank(self.run_id, field_name="runId")
-        self.agent_id = _require_non_blank(self.agent_id, field_name="agentId")
+        self.run_id = require_non_blank(self.run_id, field_name="runId")
+        self.agent_id = require_non_blank(self.agent_id, field_name="agentId")
         if self.started_at.tzinfo is None:
             self.started_at = self.started_at.replace(tzinfo=UTC)
         return self
@@ -248,8 +243,8 @@ class AgentRunStatus(BaseModel):
 
     @model_validator(mode="after")
     def _normalize(self) -> "AgentRunStatus":
-        self.run_id = _require_non_blank(self.run_id, field_name="runId")
-        self.agent_id = _require_non_blank(self.agent_id, field_name="agentId")
+        self.run_id = require_non_blank(self.run_id, field_name="runId")
+        self.agent_id = require_non_blank(self.agent_id, field_name="agentId")
         if self.observed_at.tzinfo is None:
             self.observed_at = self.observed_at.replace(tzinfo=UTC)
         return self
@@ -272,11 +267,12 @@ class AgentRunResult(BaseModel):
     @model_validator(mode="after")
     def _validate_payload(self) -> "AgentRunResult":
         self.output_refs = [
-            _require_non_blank(item, field_name="outputRefs[]") for item in self.output_refs
+            require_non_blank(item, field_name="outputRefs[]")
+            for item in self.output_refs
         ]
         diagnostics_ref = self.diagnostics_ref
         if diagnostics_ref is not None:
-            self.diagnostics_ref = _require_non_blank(
+            self.diagnostics_ref = require_non_blank(
                 diagnostics_ref, field_name="diagnosticsRef"
             )
         summary = self.summary
@@ -357,20 +353,20 @@ class ManagedAgentProviderProfile(BaseModel):
 
     @model_validator(mode="after")
     def _validate_policy(self) -> "ManagedAgentProviderProfile":
-        self.profile_id = _require_non_blank(self.profile_id, field_name="profileId")
-        self.runtime_id = _require_non_blank(self.runtime_id, field_name="runtimeId")
-        self.credential_source = _require_non_blank(
+        self.profile_id = require_non_blank(self.profile_id, field_name="profileId")
+        self.runtime_id = require_non_blank(self.runtime_id, field_name="runtimeId")
+        self.credential_source = require_non_blank(
             self.credential_source, field_name="credentialSource"
         )
-        self.runtime_materialization_mode = _require_non_blank(
+        self.runtime_materialization_mode = require_non_blank(
             self.runtime_materialization_mode, field_name="runtimeMaterializationMode"
         )
         volume_ref = self.volume_ref
         if volume_ref is not None:
-            self.volume_ref = _require_non_blank(volume_ref, field_name="volumeRef")
+            self.volume_ref = require_non_blank(volume_ref, field_name="volumeRef")
         account_label = self.account_label
         if account_label is not None:
-            self.account_label = _require_non_blank(
+            self.account_label = require_non_blank(
                 account_label, field_name="accountLabel"
             )
         if _contains_sensitive_key(self.rate_limit_policy):
@@ -409,7 +405,7 @@ class RuntimeFileTemplate(BaseModel):
 
     @model_validator(mode="after")
     def _validate_template(self) -> "RuntimeFileTemplate":
-        self.path = _require_non_blank(self.path, field_name="path")
+        self.path = require_non_blank(self.path, field_name="path")
         normalized_format = str(self.format or "text").strip().lower()
         if normalized_format not in {"text", "toml", "json"}:
             raise ValueError(
@@ -487,7 +483,7 @@ class ManagedRuntimeProfile(BaseModel):
 
     @model_validator(mode="after")
     def _validate_profile(self) -> "ManagedRuntimeProfile":
-        self.runtime_id = _require_non_blank(
+        self.runtime_id = require_non_blank(
             self.runtime_id, field_name="runtimeId"
         )
         if _contains_sensitive_key(
@@ -499,7 +495,7 @@ class ManagedRuntimeProfile(BaseModel):
         normalized_passthrough: list[str] = []
         seen: set[str] = set()
         for key in self.passthrough_env_keys:
-            normalized_key = _require_non_blank(
+            normalized_key = require_non_blank(
                 str(key), field_name="passthroughEnvKeys[]"
             ).upper()
             if normalized_key not in _ALLOWED_SECRET_PASSTHROUGH_ENV_KEYS:
@@ -548,13 +544,13 @@ class ManagedRunRecord(BaseModel):
 
     @model_validator(mode="after")
     def _normalize(self) -> "ManagedRunRecord":
-        self.run_id = _require_non_blank(self.run_id, field_name="runId")
+        self.run_id = require_non_blank(self.run_id, field_name="runId")
         if self.workflow_id is not None:
-            self.workflow_id = _require_non_blank(
+            self.workflow_id = require_non_blank(
                 self.workflow_id, field_name="workflowId"
             )
-        self.agent_id = _require_non_blank(self.agent_id, field_name="agentId")
-        self.runtime_id = _require_non_blank(
+        self.agent_id = require_non_blank(self.agent_id, field_name="agentId")
+        self.runtime_id = require_non_blank(
             self.runtime_id, field_name="runtimeId"
         )
         if self.started_at.tzinfo is None:

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -1,0 +1,105 @@
+"""Canonical contracts for managed session-plane state."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+ManagedSessionControlAction = Literal[
+    "start_session",
+    "resume_session",
+    "send_turn",
+    "steer_turn",
+    "interrupt_turn",
+    "clear_session",
+    "cancel_session",
+    "terminate_session",
+]
+
+CODEX_MANAGED_SESSION_CONTROL_ACTIONS: tuple[ManagedSessionControlAction, ...] = (
+    "start_session",
+    "resume_session",
+    "send_turn",
+    "steer_turn",
+    "interrupt_turn",
+    "clear_session",
+    "cancel_session",
+    "terminate_session",
+)
+
+
+def _require_non_blank(value: str, *, field_name: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be blank")
+    return normalized
+
+
+class CodexManagedSessionPlaneContract(BaseModel):
+    """Frozen Phase 1 MVP contract for the Codex managed session plane."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    runtime_family: Literal["codex"] = "codex"
+    protocol: Literal["codex_app_server"] = "codex_app_server"
+    container_backend: Literal["docker"] = "docker"
+    session_scope: Literal["task"] = "task"
+    session_container_policy: Literal["one_container_per_task"] = (
+        "one_container_per_task"
+    )
+    cross_task_reuse: bool = False
+    log_authority: Literal["artifact_first"] = "artifact_first"
+    continuity_authority: Literal["artifact_first"] = "artifact_first"
+    durable_state_rule: Literal[
+        "artifacts_and_bounded_workflow_metadata_are_authoritative"
+    ] = "artifacts_and_bounded_workflow_metadata_are_authoritative"
+    clear_behavior: Literal["new_thread_same_container_new_epoch"] = (
+        "new_thread_same_container_new_epoch"
+    )
+    control_actions: tuple[ManagedSessionControlAction, ...] = (
+        CODEX_MANAGED_SESSION_CONTROL_ACTIONS
+    )
+
+
+class CodexManagedSessionState(BaseModel):
+    """Identity and continuity state for one task-scoped Codex session."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    session_id: str = Field(..., alias="sessionId", min_length=1)
+    session_epoch: int = Field(..., alias="sessionEpoch", ge=1)
+    container_id: str = Field(..., alias="containerId", min_length=1)
+    thread_id: str = Field(..., alias="threadId", min_length=1)
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "CodexManagedSessionState":
+        self.session_id = _require_non_blank(self.session_id, field_name="sessionId")
+        self.container_id = _require_non_blank(
+            self.container_id, field_name="containerId"
+        )
+        self.thread_id = _require_non_blank(self.thread_id, field_name="threadId")
+        active_turn_id = self.active_turn_id
+        if active_turn_id is not None:
+            self.active_turn_id = _require_non_blank(
+                active_turn_id, field_name="activeTurnId"
+            )
+        return self
+
+    def clear_session(self, *, new_thread_id: str) -> "CodexManagedSessionState":
+        """Advance to a new session epoch inside the existing container."""
+
+        normalized_thread_id = _require_non_blank(
+            new_thread_id, field_name="threadId"
+        )
+        if normalized_thread_id == self.thread_id:
+            raise ValueError("clear_session must create a new threadId")
+        return self.model_copy(
+            update={
+                "session_epoch": self.session_epoch + 1,
+                "thread_id": normalized_thread_id,
+                "active_turn_id": None,
+            }
+        )

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from moonmind.schemas._validation import NonBlankStr, require_non_blank
+
 
 ManagedSessionControlAction = Literal[
     "start_session",
@@ -28,15 +30,6 @@ CODEX_MANAGED_SESSION_CONTROL_ACTIONS: tuple[ManagedSessionControlAction, ...] =
     "cancel_session",
     "terminate_session",
 )
-
-
-def _require_non_blank(value: str, *, field_name: str) -> str:
-    normalized = str(value).strip()
-    if not normalized:
-        raise ValueError(f"{field_name} must not be blank")
-    return normalized
-
-
 class CodexManagedSessionPlaneContract(BaseModel):
     """Frozen Phase 1 MVP contract for the Codex managed session plane."""
 
@@ -49,7 +42,7 @@ class CodexManagedSessionPlaneContract(BaseModel):
     session_container_policy: Literal["one_container_per_task"] = (
         "one_container_per_task"
     )
-    cross_task_reuse: bool = False
+    cross_task_reuse: Literal[False] = False
     log_authority: Literal["artifact_first"] = "artifact_first"
     continuity_authority: Literal["artifact_first"] = "artifact_first"
     durable_state_rule: Literal[
@@ -62,36 +55,30 @@ class CodexManagedSessionPlaneContract(BaseModel):
         CODEX_MANAGED_SESSION_CONTROL_ACTIONS
     )
 
+    @model_validator(mode="after")
+    def _freeze_phase1_values(self) -> "CodexManagedSessionPlaneContract":
+        if self.control_actions != CODEX_MANAGED_SESSION_CONTROL_ACTIONS:
+            raise ValueError(
+                "control_actions must match the canonical Phase 1 action set"
+            )
+        return self
+
 
 class CodexManagedSessionState(BaseModel):
     """Identity and continuity state for one task-scoped Codex session."""
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-    session_id: str = Field(..., alias="sessionId", min_length=1)
+    session_id: NonBlankStr = Field(..., alias="sessionId")
     session_epoch: int = Field(..., alias="sessionEpoch", ge=1)
-    container_id: str = Field(..., alias="containerId", min_length=1)
-    thread_id: str = Field(..., alias="threadId", min_length=1)
-    active_turn_id: str | None = Field(None, alias="activeTurnId")
-
-    @model_validator(mode="after")
-    def _normalize(self) -> "CodexManagedSessionState":
-        self.session_id = _require_non_blank(self.session_id, field_name="sessionId")
-        self.container_id = _require_non_blank(
-            self.container_id, field_name="containerId"
-        )
-        self.thread_id = _require_non_blank(self.thread_id, field_name="threadId")
-        active_turn_id = self.active_turn_id
-        if active_turn_id is not None:
-            self.active_turn_id = _require_non_blank(
-                active_turn_id, field_name="activeTurnId"
-            )
-        return self
+    container_id: NonBlankStr = Field(..., alias="containerId")
+    thread_id: NonBlankStr = Field(..., alias="threadId")
+    active_turn_id: NonBlankStr | None = Field(None, alias="activeTurnId")
 
     def clear_session(self, *, new_thread_id: str) -> "CodexManagedSessionState":
         """Advance to a new session epoch inside the existing container."""
 
-        normalized_thread_id = _require_non_blank(
+        normalized_thread_id = require_non_blank(
             new_thread_id, field_name="threadId"
         )
         if normalized_thread_id == self.thread_id:

--- a/specs/129-codex-managed-session-plane-phase1/plan.md
+++ b/specs/129-codex-managed-session-plane-phase1/plan.md
@@ -1,0 +1,56 @@
+# Plan: Codex Managed Session Plane Phase 1
+
+## Summary
+
+Freeze the Codex managed session-plane MVP contract before implementing session workflows. This phase adds one canonical desired-state doc plus executable schema/state models that encode the fixed Phase 1 scope and the required clear/reset epoch transition.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Orchestrate, Don't Recreate | PASS | Uses Codex App Server as the intended session protocol and keeps MoonMind at the orchestration boundary. |
+| II. One-Click Agent Deployment | PASS | Contract stays Docker-first and does not add new deployment prerequisites. |
+| III. Avoid Vendor Lock-In | PASS | Phase 1 is intentionally Codex-specific, but the contract is isolated to a bounded schema/doc slice rather than entangled core orchestration logic. |
+| IV. Own Your Data | PASS | Durable-state rule makes artifacts and workflow metadata authoritative. |
+| V. Skills Are First-Class and Easy to Add | PASS | Session contract references existing skill-materialization boundaries and does not mutate skill storage rules. |
+| VI. Thin Scaffolding, Thick Contracts | PASS | This phase is contract-first with unit-test coverage. |
+| VII. Powerful Runtime Configurability | PASS | No new hardcoded runtime execution behavior is introduced beyond the explicit Phase 1 contract. |
+| VIII. Modular and Extensible Architecture | PASS | Adds a dedicated managed-session schema module and desired-state doc instead of overloading existing runtime payloads. |
+| IX. Resilient by Default | PASS | Clear/reset semantics become explicit and durable-state rules stay artifact-first. |
+| X. Facilitate Continuous Improvement | PASS | The contract is explicit enough to measure and evolve in later phases. |
+| XI. Spec-Driven Development | PASS | This spec/plan/tasks set defines the Phase 1 slice before broader implementation. |
+| XII. Canonical Documentation Separates Desired State from Migration Backlog | PASS | Desired-state session-plane contract lives in `docs/`; phase sequencing stays in this spec. |
+
+## Change Map
+
+| Artifact | Change | Rationale |
+|---|---|---|
+| `moonmind/schemas/managed_session_models.py` | Add Codex session-plane contract and state models. | FR-001 through FR-007, NF-001 |
+| `moonmind/schemas/__init__.py` | Export the new session-plane schema symbols. | Keep schema imports consistent for downstream code. |
+| `tests/unit/schemas/test_managed_session_models.py` | Add TDD coverage for fixed MVP defaults and clear/reset semantics. | NF-002 |
+| `docs/ManagedAgents/CodexManagedSessionPlane.md` | Add desired-state canonical doc for the Codex managed session plane. | FR-008 |
+| `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` | Add related-doc link to the new canonical session-plane contract. | Keep orchestration docs connected. |
+| `docs/Temporal/ArtifactPresentationContract.md` | Add related-doc link to the new canonical session-plane contract. | Keep artifact continuity docs connected. |
+| `specs/129-codex-managed-session-plane-phase1/*` | Add phase spec artifacts. | Principle XI |
+
+## Execution Order
+
+1. Write unit tests for the frozen Phase 1 defaults and clear/reset behavior.
+2. Implement the new schema/state models.
+3. Add the canonical desired-state document and cross-links.
+4. Add the spec/plan/tasks artifacts for this phase.
+5. Run targeted schema tests, then the repo unit-test runner.
+
+## Risks
+
+- **Over-modeling risk**: Adding session workflow or API contracts now would spill into later phases. Mitigation: keep this phase limited to the frozen contract and state transition semantics.
+- **Doc drift risk**: A doc-only change could diverge from code. Mitigation: executable schema models and unit tests are the authoritative contract for this phase.
+- **Premature generalization**: Introducing multi-runtime or Kubernetes abstractions now would violate the requested cut line. Mitigation: keep the models explicitly Codex-only and Docker-only.
+
+## Testing Strategy
+
+- Targeted schema tests:
+  - `tests/unit/schemas/test_managed_session_models.py`
+  - `tests/unit/schemas/test_agent_runtime_models.py`
+- Final verification:
+  - `./tools/test_unit.sh`

--- a/specs/129-codex-managed-session-plane-phase1/spec.md
+++ b/specs/129-codex-managed-session-plane-phase1/spec.md
@@ -1,0 +1,39 @@
+# Spec: Codex Managed Session Plane Phase 1
+
+## Problem
+
+MoonMind has canonical contracts for managed agent execution and artifact presentation, but it does not yet have a frozen desired-state contract for a **task-scoped Codex managed session plane**. Without that contract, later implementation work risks drifting across docs, workflow payloads, and runtime boundaries.
+
+Phase 1 must lock the smallest viable session-plane contract before new workflows, activities, or API projections are built.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST define a canonical Phase 1 managed session-plane contract for **Codex only**.
+- **FR-002**: The Phase 1 contract MUST constrain the managed session plane to **Docker only**.
+- **FR-003**: The Phase 1 contract MUST define **one task-scoped session container per task** and MUST explicitly disallow cross-task session reuse.
+- **FR-004**: The Phase 1 contract MUST define the bounded session identity fields: `session_id`, `session_epoch`, `container_id`, `thread_id`, and `active_turn_id`.
+- **FR-005**: The Phase 1 contract MUST define the canonical control actions: `start_session`, `resume_session`, `send_turn`, `steer_turn`, `interrupt_turn`, `clear_session`, `cancel_session`, and `terminate_session`.
+- **FR-006**: The Phase 1 contract MUST define `clear_session` as an epoch boundary that preserves `session_id` and `container_id`, increments `session_epoch`, requires a new `thread_id`, and clears `active_turn_id`.
+- **FR-007**: The Phase 1 contract MUST define the durable-state rule that artifacts plus bounded workflow metadata are authoritative, while container state is continuity/performance state only.
+- **FR-008**: Canonical docs MUST describe the Codex managed session plane as a desired-state contract without embedding phased migration narrative in the canonical document.
+
+### Non-Functional Requirements
+
+- **NF-001**: The contract MUST be encoded in executable schema/state models, not only prose.
+- **NF-002**: The clear/reset epoch semantics MUST be covered by unit tests.
+- **NF-003**: Existing schema tests for agent runtime contracts MUST continue to pass unchanged.
+- **NF-004**: The implementation MUST avoid introducing Kubernetes, cross-task reuse, or multi-runtime abstractions in this phase.
+
+### Acceptance Criteria
+
+1. **Given** the Phase 1 session-plane contract is instantiated, **When** it is inspected, **Then** it exposes Codex-only, Docker-only, task-scoped defaults with artifact-first continuity and no cross-task reuse.
+2. **Given** a managed session state with `session_epoch=1`, `thread_id="thread-1"`, and `active_turn_id="turn-1"`, **When** `clear_session` is applied with `new_thread_id="thread-2"`, **Then** the returned state preserves `session_id` and `container_id`, increments `session_epoch` to `2`, sets `thread_id` to `"thread-2"`, and clears `active_turn_id`.
+3. **Given** `clear_session` is attempted with a blank or unchanged `new_thread_id`, **When** validation runs, **Then** the operation fails fast.
+4. **Given** canonical docs are reviewed, **When** operators look for the Codex managed session-plane definition, **Then** the desired-state contract is documented under `docs/` and phase sequencing remains in `specs/` rather than the canonical doc.
+
+## Scope
+
+- **In scope**: schema/state contract models for the Codex managed session plane, unit tests for those models, canonical desired-state documentation, and a new spec/plan/tasks set for the phase.
+- **Out of scope**: `MoonMind.AgentSession`, activity implementations, session launch/resume APIs, session projection endpoints, operator UI controls, Kubernetes, non-Codex runtimes, and runtime marketplace abstractions.

--- a/specs/129-codex-managed-session-plane-phase1/tasks.md
+++ b/specs/129-codex-managed-session-plane-phase1/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Codex Managed Session Plane Phase 1
+
+## T001 — Add TDD coverage for the frozen contract [P]
+- [X] T001a [P] Add a unit test asserting the Phase 1 contract defaults are Codex-only, Docker-only, task-scoped, artifact-first, and disallow cross-task reuse.
+- [X] T001b [P] Add a unit test asserting the canonical control-action list.
+- [X] T001c [P] Add a unit test asserting `clear_session` preserves `session_id` and `container_id`, increments `session_epoch`, rotates `thread_id`, and clears `active_turn_id`.
+- [X] T001d [P] Add validation tests for blank/same-thread clear requests and invalid `session_epoch`.
+
+**Independent Test**: `./.venv/bin/pytest -q tests/unit/schemas/test_managed_session_models.py` fails before implementation and passes after.
+
+## T002 — Implement the executable session-plane contract [P]
+- [X] T002a [P] Add `moonmind/schemas/managed_session_models.py` with the frozen Phase 1 Codex session-plane contract model.
+- [X] T002b [P] Add the task-scoped session state model with `clear_session()` epoch transition semantics.
+- [X] T002c [P] Export the new schema symbols from `moonmind/schemas/__init__.py`.
+
+**Independent Test**: `./.venv/bin/pytest -q tests/unit/schemas/test_managed_session_models.py tests/unit/schemas/test_agent_runtime_models.py`
+
+## T003 — Freeze the desired-state documentation [P]
+- [X] T003a [P] Add `docs/ManagedAgents/CodexManagedSessionPlane.md` as the canonical desired-state contract.
+- [X] T003b [P] Cross-link the new contract from `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- [X] T003c [P] Cross-link the new contract from `docs/Temporal/ArtifactPresentationContract.md`.
+- [X] T003d [P] Add spec artifacts under `specs/129-codex-managed-session-plane-phase1/`.
+
+**Independent Test**: Scope review confirms the canonical doc contains desired state only and phase sequencing remains in spec artifacts.
+
+## T004 — Verify with the repo test runner [P]
+- [X] T004a [P] Run `./tools/test_unit.sh`
+
+**Independent Test**: `./tools/test_unit.sh` passes.

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -46,6 +46,18 @@ def test_codex_managed_session_plane_contract_exposes_canonical_control_actions(
     )
 
 
+def test_codex_managed_session_plane_contract_rejects_non_canonical_overrides() -> None:
+    with pytest.raises(ValidationError, match="Input should be False"):
+        CodexManagedSessionPlaneContract(cross_task_reuse=True)
+
+    with pytest.raises(
+        ValidationError, match="control_actions must match the canonical"
+    ):
+        CodexManagedSessionPlaneContract(
+            control_actions=("start_session", "send_turn")
+        )
+
+
 def test_codex_managed_session_state_clear_session_bumps_epoch_and_rotates_thread() -> None:
     state = CodexManagedSessionState(
         sessionId="sess-123",
@@ -64,6 +76,21 @@ def test_codex_managed_session_state_clear_session_bumps_epoch_and_rotates_threa
     assert cleared.active_turn_id is None
 
 
+def test_codex_managed_session_state_normalizes_identifier_whitespace() -> None:
+    state = CodexManagedSessionState(
+        sessionId="  sess-123  ",
+        sessionEpoch=1,
+        containerId="  ctr-123  ",
+        threadId="  thread-1  ",
+        activeTurnId="  turn-1  ",
+    )
+
+    assert state.session_id == "sess-123"
+    assert state.container_id == "ctr-123"
+    assert state.thread_id == "thread-1"
+    assert state.active_turn_id == "turn-1"
+
+
 def test_codex_managed_session_state_clear_session_requires_a_new_non_blank_thread() -> None:
     state = CodexManagedSessionState(
         sessionId="sess-123",
@@ -77,6 +104,30 @@ def test_codex_managed_session_state_clear_session_requires_a_new_non_blank_thre
 
     with pytest.raises(ValueError, match="threadId must not be blank"):
         state.clear_session(new_thread_id="   ")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("sessionId", "   "),
+        ("containerId", "   "),
+        ("threadId", "   "),
+        ("activeTurnId", "   "),
+    ],
+)
+def test_codex_managed_session_state_rejects_blank_identifiers(
+    field_name: str, field_value: str
+) -> None:
+    kwargs = {
+        "sessionId": "sess-123",
+        "sessionEpoch": 1,
+        "containerId": "ctr-123",
+        "threadId": "thread-1",
+        field_name: field_value,
+    }
+
+    with pytest.raises(ValidationError):
+        CodexManagedSessionState(**kwargs)
 
 
 def test_codex_managed_session_state_requires_epoch_at_least_one() -> None:

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -1,0 +1,89 @@
+"""Unit tests for the managed session-plane contract models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.managed_session_models import (
+    CODEX_MANAGED_SESSION_CONTROL_ACTIONS,
+    CodexManagedSessionPlaneContract,
+    CodexManagedSessionState,
+)
+
+
+def test_codex_managed_session_plane_contract_freezes_phase1_mvp_scope() -> None:
+    contract = CodexManagedSessionPlaneContract()
+
+    assert contract.runtime_family == "codex"
+    assert contract.protocol == "codex_app_server"
+    assert contract.container_backend == "docker"
+    assert contract.session_scope == "task"
+    assert contract.session_container_policy == "one_container_per_task"
+    assert contract.cross_task_reuse is False
+    assert contract.log_authority == "artifact_first"
+    assert contract.continuity_authority == "artifact_first"
+    assert (
+        contract.durable_state_rule
+        == "artifacts_and_bounded_workflow_metadata_are_authoritative"
+    )
+    assert contract.clear_behavior == "new_thread_same_container_new_epoch"
+
+
+def test_codex_managed_session_plane_contract_exposes_canonical_control_actions() -> None:
+    contract = CodexManagedSessionPlaneContract()
+
+    assert contract.control_actions == CODEX_MANAGED_SESSION_CONTROL_ACTIONS
+    assert contract.control_actions == (
+        "start_session",
+        "resume_session",
+        "send_turn",
+        "steer_turn",
+        "interrupt_turn",
+        "clear_session",
+        "cancel_session",
+        "terminate_session",
+    )
+
+
+def test_codex_managed_session_state_clear_session_bumps_epoch_and_rotates_thread() -> None:
+    state = CodexManagedSessionState(
+        sessionId="sess-123",
+        sessionEpoch=1,
+        containerId="ctr-123",
+        threadId="thread-1",
+        activeTurnId="turn-1",
+    )
+
+    cleared = state.clear_session(new_thread_id="thread-2")
+
+    assert cleared.session_id == "sess-123"
+    assert cleared.container_id == "ctr-123"
+    assert cleared.thread_id == "thread-2"
+    assert cleared.session_epoch == 2
+    assert cleared.active_turn_id is None
+
+
+def test_codex_managed_session_state_clear_session_requires_a_new_non_blank_thread() -> None:
+    state = CodexManagedSessionState(
+        sessionId="sess-123",
+        sessionEpoch=1,
+        containerId="ctr-123",
+        threadId="thread-1",
+    )
+
+    with pytest.raises(ValueError, match="new threadId"):
+        state.clear_session(new_thread_id="thread-1")
+
+    with pytest.raises(ValueError, match="threadId must not be blank"):
+        state.clear_session(new_thread_id="   ")
+
+
+def test_codex_managed_session_state_requires_epoch_at_least_one() -> None:
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        CodexManagedSessionState(
+            sessionId="sess-123",
+            sessionEpoch=0,
+            containerId="ctr-123",
+            threadId="thread-1",
+        )

--- a/tests/unit/test_integration_test_taxonomy.py
+++ b/tests/unit/test_integration_test_taxonomy.py
@@ -124,3 +124,25 @@ def test_shell_and_powershell_runner_commands_select_new_taxonomy() -> None:
     assert 'provider_verification and jules' in provider_runner
     assert 'pytest tests/provider/jules' in provider_runner
     assert 'integration_ci' in powershell_runner
+
+
+def test_docker_compose_test_runners_provision_the_shared_network() -> None:
+    shell_runner = (REPO_ROOT / "tools" / "test_integration.sh").read_text(
+        encoding="utf-8"
+    )
+    provider_runner = (REPO_ROOT / "tools" / "test_jules_provider.sh").read_text(
+        encoding="utf-8"
+    )
+    powershell_runner = (REPO_ROOT / "tools" / "test-integration.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'NETWORK_NAME="local-network"' in shell_runner
+    assert 'docker network inspect "$NETWORK_NAME"' in shell_runner
+    assert 'docker network create "$NETWORK_NAME"' in shell_runner
+    assert 'NETWORK_NAME="local-network"' in provider_runner
+    assert 'docker network inspect "$NETWORK_NAME"' in provider_runner
+    assert 'docker network create "$NETWORK_NAME"' in provider_runner
+    assert '$networkName = "local-network"' in powershell_runner
+    assert 'docker network inspect $networkName' in powershell_runner
+    assert 'docker network create $networkName' in powershell_runner

--- a/tools/test-integration.ps1
+++ b/tools/test-integration.ps1
@@ -12,9 +12,16 @@ Write-Host ""
 
 # Run integration tests
 $test_file = $args[0]
+$networkName = "local-network"
 
 if (!(Test-Path ".env")) {
     Copy-Item ".env-template" ".env"
+}
+
+docker network inspect $networkName *> $null
+if ($LASTEXITCODE -ne 0) {
+    docker network create $networkName | Out-Null
+    Write-Host "Created Docker network: $networkName" -ForegroundColor Cyan
 }
 
 if ($test_file) {

--- a/tools/test_integration.sh
+++ b/tools/test_integration.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yaml"
+NETWORK_NAME="local-network"
 
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   COMPOSE_CMD=(docker compose)
@@ -22,6 +23,11 @@ if [[ ! -f "$REPO_ROOT/.env" ]]; then
     echo "Error: missing $REPO_ROOT/.env and $REPO_ROOT/.env-template." >&2
     exit 1
   fi
+fi
+
+if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  docker network create "$NETWORK_NAME" >/dev/null
+  echo "Created Docker network: $NETWORK_NAME"
 fi
 
 "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" build pytest

--- a/tools/test_jules_provider.sh
+++ b/tools/test_jules_provider.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/docker-compose.test.yaml"
+NETWORK_NAME="local-network"
 
 if [[ -z "${JULES_API_KEY:-}" ]]; then
   echo "Error: JULES_API_KEY must be set to run live Jules provider verification." >&2
@@ -27,6 +28,11 @@ if [[ ! -f "$REPO_ROOT/.env" ]]; then
     echo "Error: missing $REPO_ROOT/.env and $REPO_ROOT/.env-template." >&2
     exit 1
   fi
+fi
+
+if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
+  docker network create "$NETWORK_NAME" >/dev/null
+  echo "Created Docker network: $NETWORK_NAME"
 fi
 
 "${COMPOSE_CMD[@]}" -f "$COMPOSE_FILE" --project-directory "$REPO_ROOT" build pytest


### PR DESCRIPTION
## Summary
Freeze Phase 1 of the Codex managed session plane as a small contract slice instead of jumping ahead to session workflow implementation.

## What changed
- add canonical managed-session schema models for the Codex Phase 1 MVP contract
- encode clear/reset as a new epoch in the same container with a new thread and cleared active turn
- add unit tests for the fixed MVP defaults and clear/reset transition semantics
- add a canonical desired-state doc for the Codex managed session plane
- add spec, plan, and tasks artifacts for Phase 1 and cross-link the new doc from existing Temporal docs

## Why
MoonMind already has canonical managed-runtime and artifact-presentation contracts, but it did not yet have a frozen desired-state contract for a task-scoped Codex managed session plane. This change locks that boundary before later workflow, activity, and API implementation work.

## Validation
- `./.venv/bin/pytest -q tests/unit/schemas/test_managed_session_models.py tests/unit/schemas/test_agent_runtime_models.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`