### PR TITLE
[codex] Slim runtime Dockerfile footprint

### DIFF
--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -252,9 +252,6 @@ COPY --from=tooling-builder /usr/local/lib/node_modules/@anthropic-ai/claude-cod
 RUN apt-get update && \
     apt-get install -y \
         bubblewrap \
-        build-essential \
-        pkg-config \
-        libcairo2-dev \
         libffi-dev \
         ripgrep \
         tesseract-ocr \
@@ -303,7 +300,7 @@ RUN runuser -u app -- env -u NODE_OPTIONS -u npm_config_node_options \
 RUN install -d -o root -g app -m 0750 /etc/codex
 COPY --chown=root:app --chmod=0640 api_service/config.template.toml /etc/codex/config.toml
 
-RUN pip install watchfiles
+RUN pip install --no-cache-dir watchfiles
 
 # Copy pyproject.toml and README.md first for better Docker layer caching
 COPY pyproject.toml /app/pyproject.toml
@@ -314,15 +311,15 @@ RUN mkdir -p /app/moonmind /app/api_service
 RUN touch /app/moonmind/__init__.py /app/api_service/__init__.py
 
 # Install dependencies first (this layer will be cached as long as pyproject.toml doesn't change)
-RUN pip install -e .
-RUN pip install readmeai~=0.6.3 --no-deps && \
+RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir readmeai~=0.6.3 --no-deps && \
     # Keep test runners available in all worker images (codex/gemini/claude).
-    pip install pytest pytest-xdist
+    pip install --no-cache-dir pytest pytest-xdist
 
 # Install test extras when requested so compose-driven test runs have pytest and
 # related dependencies baked into the image, avoiding runtime network installs.
 RUN if [ "${INSTALL_TEST_DEPS}" = "true" ]; then \
-        pip install -e .[tests]; \
+        pip install --no-cache-dir -e .[tests]; \
     fi
 
 # Copy source code AFTER installing dependencies

--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -250,7 +250,7 @@ COPY --from=tooling-builder /usr/local/lib/node_modules/@anthropic-ai/claude-cod
 # Install system packages required by the Python service along with the
 # Node.js runtime libraries that the bundled CLIs rely on.
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
         bubblewrap \
         libffi-dev \
         ripgrep \
@@ -258,7 +258,6 @@ RUN apt-get update && \
         tesseract-ocr-eng \
         git \
         gh \
-        ripgrep \
         curl \
         ca-certificates \
         openssh-client \
@@ -312,8 +311,8 @@ RUN touch /app/moonmind/__init__.py /app/api_service/__init__.py
 
 # Install dependencies first (this layer will be cached as long as pyproject.toml doesn't change)
 RUN pip install --no-cache-dir -e .
+# Keep test runners available in all worker images (codex/gemini/claude).
 RUN pip install --no-cache-dir readmeai~=0.6.3 --no-deps && \
-    # Keep test runners available in all worker images (codex/gemini/claude).
     pip install --no-cache-dir pytest pytest-xdist
 
 # Install test extras when requested so compose-driven test runs have pytest and


### PR DESCRIPTION
## Summary
- remove `build-essential`, `pkg-config`, and `libcairo2-dev` from the final runtime apt install
- switch runtime `pip install` steps to `--no-cache-dir` to avoid carrying pip cache in the image
- keep the builder/tooling stages unchanged so CLI installation behavior stays intact

## Why
The runtime image was carrying several build-only packages and a large pip cache that are not needed in the final container. This trims the image without changing the current single-image deployment shape.

## Impact
- reduces final runtime image footprint
- preserves the current shared-image model for API and workers
- keeps OCR and other runtime tooling in place for now

## Validation
- `docker build -f api_service/Dockerfile --build-arg INSTALL_CODEX_CLI=false --build-arg INSTALL_GEMINI_CLI=false --build-arg INSTALL_CLAUDE_CLI=false -t moonmind-build-check .`
- resulting validation image size: `1252419953` bytes
