### PR TITLE
[codex] add Codex AgentSession workflow for Phase 2

### DIFF
--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -18,8 +18,13 @@ from .agent_skill_models import (
 )
 from .managed_session_models import (
     CODEX_MANAGED_SESSION_CONTROL_ACTIONS,
+    CodexManagedSessionBinding,
+    CodexManagedSessionControlRequest,
     CodexManagedSessionPlaneContract,
+    CodexManagedSessionSnapshot,
     CodexManagedSessionState,
+    CodexManagedSessionWorkflowInput,
+    canonical_codex_managed_runtime_id,
 )
 from .manifest_models import (
     AuthItem,
@@ -146,6 +151,11 @@ __all__ = [
     "SkillSelector",
     "SkillSelectorEntry",
     "CODEX_MANAGED_SESSION_CONTROL_ACTIONS",
+    "CodexManagedSessionBinding",
+    "CodexManagedSessionControlRequest",
     "CodexManagedSessionPlaneContract",
+    "CodexManagedSessionSnapshot",
     "CodexManagedSessionState",
+    "CodexManagedSessionWorkflowInput",
+    "canonical_codex_managed_runtime_id",
 ]

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -8,6 +8,10 @@ from typing import Any, Literal, NoReturn, get_args
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from moonmind.schemas._validation import require_non_blank
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionBinding,
+    canonical_codex_managed_runtime_id,
+)
 
 AgentKind = Literal["external", "managed"]
 ExternalExecutionStyle = Literal["polling", "streaming_gateway"]
@@ -144,6 +148,9 @@ class AgentExecutionRequest(BaseModel):
     idempotency_key: str = Field(..., alias="idempotencyKey", min_length=1)
     instruction_ref: str | None = Field(None, alias="instructionRef")
     resolved_skillset_ref: str | None = Field(None, alias="resolvedSkillsetRef")
+    managed_session: CodexManagedSessionBinding | None = Field(
+        None, alias="managedSession"
+    )
     input_refs: list[str] = Field(default_factory=list, alias="inputRefs")
     expected_output_schema: dict[str, Any] = Field(
         default_factory=dict, alias="expectedOutputSchema"
@@ -188,6 +195,16 @@ class AgentExecutionRequest(BaseModel):
             self.resolved_skillset_ref = require_non_blank(
                 resolved_skillset_ref, field_name="resolvedSkillsetRef"
             )
+        if self.managed_session is not None:
+            canonical_runtime_id = canonical_codex_managed_runtime_id(self.agent_id)
+            if self.agent_kind != "managed" or canonical_runtime_id is None:
+                raise ValueError(
+                    "managedSession is only supported for managed Codex runtimes"
+                )
+            if self.managed_session.runtime_id != canonical_runtime_id:
+                raise ValueError(
+                    "managedSession.runtimeId must match the managed Codex runtime"
+                )
         self.input_refs = [
             require_non_blank(item, field_name="inputRefs[]")
             for item in self.input_refs

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -30,6 +30,25 @@ CODEX_MANAGED_SESSION_CONTROL_ACTIONS: tuple[ManagedSessionControlAction, ...] =
     "cancel_session",
     "terminate_session",
 )
+
+CodexManagedSessionWorkflowStatus = Literal[
+    "initializing",
+    "active",
+    "clearing",
+    "terminating",
+    "terminated",
+]
+
+
+def canonical_codex_managed_runtime_id(runtime_id: str) -> str | None:
+    """Return the canonical managed-session runtime ID for Codex."""
+
+    normalized = str(runtime_id or "").strip().lower().replace("-", "_")
+    if normalized in {"codex", "codex_cli"}:
+        return "codex_cli"
+    return None
+
+
 class CodexManagedSessionPlaneContract(BaseModel):
     """Frozen Phase 1 MVP contract for the Codex managed session plane."""
 
@@ -90,3 +109,125 @@ class CodexManagedSessionState(BaseModel):
                 "active_turn_id": None,
             }
         )
+
+
+class CodexManagedSessionBinding(BaseModel):
+    """Bounded task-scoped session binding passed across workflow boundaries."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    workflow_id: NonBlankStr = Field(..., alias="workflowId")
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    session_id: NonBlankStr = Field(..., alias="sessionId")
+    session_epoch: int = Field(1, alias="sessionEpoch", ge=1)
+    runtime_id: NonBlankStr = Field(..., alias="runtimeId")
+    execution_profile_ref: str | None = Field(None, alias="executionProfileRef")
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "CodexManagedSessionBinding":
+        self.workflow_id = require_non_blank(self.workflow_id, field_name="workflowId")
+        self.task_run_id = require_non_blank(self.task_run_id, field_name="taskRunId")
+        self.session_id = require_non_blank(self.session_id, field_name="sessionId")
+        runtime_id = canonical_codex_managed_runtime_id(self.runtime_id)
+        if runtime_id is None:
+            raise ValueError("runtimeId must identify a managed Codex runtime")
+        self.runtime_id = runtime_id
+        if self.execution_profile_ref is not None:
+            self.execution_profile_ref = require_non_blank(
+                self.execution_profile_ref,
+                field_name="executionProfileRef",
+            )
+        return self
+
+    @classmethod
+    def from_input(
+        cls,
+        *,
+        workflow_id: str,
+        session_input: "CodexManagedSessionWorkflowInput",
+    ) -> "CodexManagedSessionBinding":
+        runtime_id = canonical_codex_managed_runtime_id(session_input.runtime_id)
+        if runtime_id is None:
+            raise ValueError("runtimeId must identify a managed Codex runtime")
+        session_id = session_input.session_id or f"sess:{session_input.task_run_id}:{runtime_id}"
+        return cls(
+            workflowId=workflow_id,
+            taskRunId=session_input.task_run_id,
+            sessionId=session_id,
+            sessionEpoch=session_input.session_epoch,
+            runtimeId=runtime_id,
+            executionProfileRef=session_input.execution_profile_ref,
+        )
+
+
+class CodexManagedSessionWorkflowInput(BaseModel):
+    """Workflow input for one task-scoped Codex managed session."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    runtime_id: NonBlankStr = Field(..., alias="runtimeId")
+    execution_profile_ref: str | None = Field(None, alias="executionProfileRef")
+    session_id: str | None = Field(None, alias="sessionId")
+    session_epoch: int = Field(1, alias="sessionEpoch", ge=1)
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "CodexManagedSessionWorkflowInput":
+        self.task_run_id = require_non_blank(self.task_run_id, field_name="taskRunId")
+        runtime_id = canonical_codex_managed_runtime_id(self.runtime_id)
+        if runtime_id is None:
+            raise ValueError("runtimeId must identify a managed Codex runtime")
+        self.runtime_id = runtime_id
+        if self.execution_profile_ref is not None:
+            self.execution_profile_ref = require_non_blank(
+                self.execution_profile_ref,
+                field_name="executionProfileRef",
+            )
+        if self.session_id is not None:
+            self.session_id = require_non_blank(self.session_id, field_name="sessionId")
+        return self
+
+
+class CodexManagedSessionControlRequest(BaseModel):
+    """Control payload applied to the task-scoped Codex session workflow."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    action: ManagedSessionControlAction = Field(..., alias="action")
+    reason: str | None = Field(None, alias="reason")
+    container_id: str | None = Field(None, alias="containerId")
+    thread_id: str | None = Field(None, alias="threadId")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "CodexManagedSessionControlRequest":
+        if self.reason is not None:
+            self.reason = require_non_blank(self.reason, field_name="reason")
+        if self.container_id is not None:
+            self.container_id = require_non_blank(
+                self.container_id, field_name="containerId"
+            )
+        if self.thread_id is not None:
+            self.thread_id = require_non_blank(self.thread_id, field_name="threadId")
+        if self.active_turn_id is not None:
+            self.active_turn_id = require_non_blank(
+                self.active_turn_id, field_name="activeTurnId"
+            )
+        return self
+
+
+class CodexManagedSessionSnapshot(BaseModel):
+    """Workflow-owned snapshot of one task-scoped Codex session."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    binding: CodexManagedSessionBinding = Field(..., alias="binding")
+    status: CodexManagedSessionWorkflowStatus = Field(..., alias="status")
+    container_id: str | None = Field(None, alias="containerId")
+    thread_id: str | None = Field(None, alias="threadId")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
+    last_control_action: ManagedSessionControlAction | None = Field(
+        None, alias="lastControlAction"
+    )
+    last_control_reason: str | None = Field(None, alias="lastControlReason")
+    termination_requested: bool = Field(False, alias="terminationRequested")

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -146,9 +146,7 @@ class CodexManagedSessionBinding(BaseModel):
         workflow_id: str,
         session_input: "CodexManagedSessionWorkflowInput",
     ) -> "CodexManagedSessionBinding":
-        runtime_id = canonical_codex_managed_runtime_id(session_input.runtime_id)
-        if runtime_id is None:
-            raise ValueError("runtimeId must identify a managed Codex runtime")
+        runtime_id = session_input.runtime_id
         session_id = session_input.session_id or f"sess:{session_input.task_run_id}:{runtime_id}"
         return cls(
             workflowId=workflow_id,

--- a/moonmind/workflows/temporal/worker_entrypoint.py
+++ b/moonmind/workflows/temporal/worker_entrypoint.py
@@ -11,6 +11,16 @@ from moonmind.workflows.temporal.workers import (
     build_worker_activity_bindings,
     describe_configured_worker,
 )
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+from moonmind.workflows.temporal.workflows.agent_session import (
+    MoonMindAgentSessionWorkflow,
+)
+from moonmind.workflows.temporal.workflows.oauth_session import (
+    MoonMindOAuthSessionWorkflow,
+)
+from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    MoonMindProviderProfileManagerWorkflow,
+)
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 
@@ -27,7 +37,15 @@ async def main():
 
     workflows = []
     if topology.fleet == WORKFLOW_FLEET:
-        workflows.append(MoonMindRunWorkflow)
+        workflows.extend(
+            [
+                MoonMindRunWorkflow,
+                MoonMindProviderProfileManagerWorkflow,
+                MoonMindAgentSessionWorkflow,
+                MoonMindAgentRun,
+                MoonMindOAuthSessionWorkflow,
+            ]
+        )
         # Import ManifestIngest workflow if it exists
         try:
             from moonmind.workflows.temporal.workflows.manifest_ingest import (

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -66,6 +66,9 @@ from moonmind.workflows.temporal.workflows.manifest_ingest import (
 from moonmind.workflows.temporal.jules_bundle import JULES_AGENT_IDS
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow as MoonMindRun
 from moonmind.workflows.temporal.worker_healthcheck import start_healthcheck_server
+from moonmind.workflows.temporal.workflows.agent_session import (
+    MoonMindAgentSessionWorkflow as MoonMindAgentSession,
+)
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     resolve_adapter_metadata,
@@ -719,7 +722,14 @@ async def main_async() -> None:
     runtime_resources: AsyncExitStack | None = None
 
     if topology.fleet == WORKFLOW_FLEET:
-        workflows = [MoonMindRun, MoonMindManifestIngest, MoonMindProviderProfileManager, MoonMindAgentRun, MoonMindOAuthSession]
+        workflows = [
+            MoonMindRun,
+            MoonMindManifestIngest,
+            MoonMindProviderProfileManager,
+            MoonMindAgentSession,
+            MoonMindAgentRun,
+            MoonMindOAuthSession,
+        ]
         activities = [
             resolve_adapter_metadata,
             get_activity_route,

--- a/moonmind/workflows/temporal/workers.py
+++ b/moonmind/workflows/temporal/workers.py
@@ -77,6 +77,7 @@ REGISTERED_TEMPORAL_WORKFLOW_TYPES = (
     "MoonMind.Run",
     "MoonMind.ManifestIngest",
     "MoonMind.ProviderProfileManager",
+    "MoonMind.AgentSession",
     "MoonMind.AgentRun",
     "MoonMind.OAuthSession",
 )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -301,6 +301,21 @@ class MoonMindAgentRun:
             f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
         )
 
+    @staticmethod
+    def _merge_managed_session_metadata(
+        *,
+        request: AgentExecutionRequest,
+        result: AgentRunResult | None,
+    ) -> AgentRunResult | None:
+        if result is None or request.managed_session is None:
+            return result
+        metadata = dict(result.metadata or {})
+        metadata["managedSession"] = request.managed_session.model_dump(
+            mode="json",
+            by_alias=True,
+        )
+        return result.model_copy(update={"metadata": metadata})
+
     async def _ensure_manager_and_signal(
         self,
         manager_id: str,
@@ -1329,6 +1344,11 @@ class MoonMindAgentRun:
                 # Not a 429 or external agent
                 if manager_handle and request.execution_profile_ref:
                     await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+
+                self.final_result = self._merge_managed_session_metadata(
+                    request=request,
+                    result=self.final_result,
+                )
 
                 # Post-run artifact publishing via the agent_runtime activity fleet.
                 enriched_result = await self._execute_routed_activity(

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Any
+
+from temporalio import workflow
+
+with workflow.unsafe.imports_passed_through():
+    from moonmind.schemas.managed_session_models import (
+        CodexManagedSessionBinding,
+        CodexManagedSessionControlRequest,
+        CodexManagedSessionPlaneContract,
+        CodexManagedSessionSnapshot,
+        CodexManagedSessionState,
+        CodexManagedSessionWorkflowInput,
+    )
+
+
+AGENT_SESSION_STATUS_INITIALIZING = "initializing"
+AGENT_SESSION_STATUS_ACTIVE = "active"
+AGENT_SESSION_STATUS_CLEARING = "clearing"
+AGENT_SESSION_STATUS_TERMINATING = "terminating"
+AGENT_SESSION_STATUS_TERMINATED = "terminated"
+
+
+@workflow.defn(name="MoonMind.AgentSession")
+class MoonMindAgentSessionWorkflow:
+    def __init__(self) -> None:
+        self._contract = CodexManagedSessionPlaneContract()
+        self._binding: CodexManagedSessionBinding | None = None
+        self._status = AGENT_SESSION_STATUS_INITIALIZING
+        self._container_id: str | None = None
+        self._thread_id: str | None = None
+        self._active_turn_id: str | None = None
+        self._last_control_action: str | None = None
+        self._last_control_reason: str | None = None
+        self._termination_requested = False
+
+    def _initialize_session(self, session_input: CodexManagedSessionWorkflowInput) -> None:
+        self._binding = CodexManagedSessionBinding.from_input(
+            workflow_id=workflow.info().workflow_id,
+            session_input=session_input,
+        )
+        self._status = AGENT_SESSION_STATUS_ACTIVE
+
+    def _require_binding(self) -> CodexManagedSessionBinding:
+        if self._binding is None:
+            raise ValueError("Agent session has not been initialized")
+        return self._binding
+
+    @workflow.run
+    async def run(
+        self, session_input: CodexManagedSessionWorkflowInput
+    ) -> dict[str, Any]:
+        self._initialize_session(session_input)
+        await workflow.wait_condition(lambda: self._termination_requested)
+        self._status = AGENT_SESSION_STATUS_TERMINATED
+        return self.get_status()
+
+    @workflow.signal(name="attach_runtime_handles")
+    def attach_runtime_handles(self, payload: dict[str, Any] | None = None) -> None:
+        payload = payload or {}
+        container_id = payload.get("containerId") or payload.get("container_id")
+        thread_id = payload.get("threadId") or payload.get("thread_id")
+        active_turn_id = payload.get("activeTurnId") or payload.get("active_turn_id")
+        if container_id is not None:
+            self._container_id = str(container_id).strip() or None
+        if thread_id is not None:
+            self._thread_id = str(thread_id).strip() or None
+        if active_turn_id is not None:
+            self._active_turn_id = str(active_turn_id).strip() or None
+
+    @workflow.signal(name="control_action")
+    def apply_control_action(self, payload: dict[str, Any] | None = None) -> None:
+        request = CodexManagedSessionControlRequest.model_validate(payload or {})
+        binding = self._require_binding()
+        self._last_control_action = request.action
+        self._last_control_reason = request.reason
+
+        if request.action == "clear_session":
+            if request.thread_id is None:
+                raise ValueError("clear_session requires threadId")
+            self._status = AGENT_SESSION_STATUS_CLEARING
+            if self._container_id and self._thread_id:
+                cleared = CodexManagedSessionState(
+                    sessionId=binding.session_id,
+                    sessionEpoch=binding.session_epoch,
+                    containerId=self._container_id,
+                    threadId=self._thread_id,
+                    activeTurnId=self._active_turn_id,
+                ).clear_session(new_thread_id=request.thread_id)
+                next_epoch = cleared.session_epoch
+                self._thread_id = cleared.thread_id
+                self._active_turn_id = cleared.active_turn_id
+            else:
+                next_epoch = binding.session_epoch + 1
+                self._thread_id = request.thread_id
+                self._active_turn_id = None
+            if request.container_id is not None:
+                self._container_id = request.container_id
+            self._binding = binding.model_copy(update={"session_epoch": next_epoch})
+            self._status = AGENT_SESSION_STATUS_ACTIVE
+            return
+
+        if request.action in {"cancel_session", "terminate_session"}:
+            self._status = AGENT_SESSION_STATUS_TERMINATING
+            self._termination_requested = True
+            return
+
+        if request.container_id is not None:
+            self._container_id = request.container_id
+        if request.thread_id is not None:
+            self._thread_id = request.thread_id
+        if request.active_turn_id is not None:
+            self._active_turn_id = request.active_turn_id
+
+    @workflow.query
+    def get_status(self) -> dict[str, Any]:
+        snapshot = CodexManagedSessionSnapshot(
+            binding=self._require_binding(),
+            status=self._status,
+            containerId=self._container_id,
+            threadId=self._thread_id,
+            activeTurnId=self._active_turn_id,
+            lastControlAction=self._last_control_action,
+            lastControlReason=self._last_control_reason,
+            terminationRequested=self._termination_requested,
+        )
+        return snapshot.model_dump(mode="json", by_alias=True)

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1585,11 +1585,10 @@ class MoonMindRunWorkflow:
         try:
             if handle is not None and binding is not None:
                 await handle.signal(
-                    "terminate_session",
+                    "control_action",
                     {
+                        "action": "terminate_session",
                         "reason": reason,
-                        "sessionId": binding.session_id,
-                        "sessionEpoch": binding.session_epoch,
                     },
                 )
         finally:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -14,6 +14,11 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
     )
+    from moonmind.schemas.managed_session_models import (
+        CodexManagedSessionBinding,
+        CodexManagedSessionWorkflowInput,
+        canonical_codex_managed_runtime_id,
+    )
     from moonmind.schemas.temporal_activity_models import (
         ArtifactReadInput,
         ArtifactWriteCompleteInput,
@@ -255,6 +260,8 @@ class MoonMindRunWorkflow:
         self._assigned_runtime_id: Optional[str] = None
         self._active_agent_child_workflow_id: Optional[str] = None
         self._active_agent_id: Optional[str] = None
+        self._codex_session_handle: Any | None = None
+        self._codex_session_binding: CodexManagedSessionBinding | None = None
 
     def _retry_policy_for_route(self, route: TemporalActivityRoute) -> RetryPolicy:
         return RetryPolicy(
@@ -1151,6 +1158,7 @@ class MoonMindRunWorkflow:
                             tool_name=tool_name,
                             resolved_skillset_ref=registry_snapshot_ref,
                         )
+                        request = await self._maybe_bind_task_scoped_session(request)
                         child_workflow_id = (
                             f"{workflow.info().workflow_id}:agent:{node_id}"
                         )
@@ -1525,6 +1533,68 @@ class MoonMindRunWorkflow:
             return ""
         normalized = value.strip().lower()
         return normalized if normalized in {"none", "branch", "pr"} else ""
+
+    def _managed_session_runtime_id(
+        self, request: AgentExecutionRequest
+    ) -> str | None:
+        if request.agent_kind != "managed":
+            return None
+        return canonical_codex_managed_runtime_id(request.agent_id)
+
+    def _task_scoped_session_workflow_id(self, runtime_id: str) -> str:
+        return f"{workflow.info().workflow_id}:session:{runtime_id}"
+
+    async def _ensure_task_scoped_codex_session(
+        self, request: AgentExecutionRequest
+    ) -> CodexManagedSessionBinding | None:
+        runtime_id = self._managed_session_runtime_id(request)
+        if runtime_id is None:
+            return None
+        if self._codex_session_binding is not None:
+            return self._codex_session_binding
+
+        session_input = CodexManagedSessionWorkflowInput(
+            taskRunId=workflow.info().workflow_id,
+            runtimeId=runtime_id,
+            executionProfileRef=request.execution_profile_ref,
+        )
+        session_workflow_id = self._task_scoped_session_workflow_id(runtime_id)
+        self._codex_session_handle = await workflow.start_child_workflow(
+            "MoonMind.AgentSession",
+            session_input,
+            id=session_workflow_id,
+            task_queue=WORKFLOW_TASK_QUEUE,
+        )
+        self._codex_session_binding = CodexManagedSessionBinding.from_input(
+            workflow_id=session_workflow_id,
+            session_input=session_input,
+        )
+        return self._codex_session_binding
+
+    async def _maybe_bind_task_scoped_session(
+        self, request: AgentExecutionRequest
+    ) -> AgentExecutionRequest:
+        binding = await self._ensure_task_scoped_codex_session(request)
+        if binding is None:
+            return request
+        return request.model_copy(update={"managed_session": binding})
+
+    async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
+        handle = self._codex_session_handle
+        binding = self._codex_session_binding
+        try:
+            if handle is not None and binding is not None:
+                await handle.signal(
+                    "terminate_session",
+                    {
+                        "reason": reason,
+                        "sessionId": binding.session_id,
+                        "sessionEpoch": binding.session_epoch,
+                    },
+                )
+        finally:
+            self._codex_session_handle = None
+            self._codex_session_binding = None
 
     def _coerce_text(
         self, value: Any, max_chars: int | None = None, *, flatten: bool = True
@@ -2567,6 +2637,12 @@ class MoonMindRunWorkflow:
     async def _run_finalizing_stage(
         self, *, parameters: dict[str, Any], status: str, error: Optional[str] = None
     ) -> None:
+        try:
+            await self._terminate_task_scoped_sessions(reason=status)
+        except Exception as exc:
+            self._get_logger().warning(
+                "Failed to terminate task-scoped agent sessions: %s", exc
+            )
         try:
             self._get_logger().info("Generating finish summary.")
 

--- a/specs/130-codex-managed-session-plane-phase2/plan.md
+++ b/specs/130-codex-managed-session-plane-phase2/plan.md
@@ -1,0 +1,60 @@
+# Plan: Codex Managed Session Plane Phase 2
+
+## Summary
+
+Introduce the durable task-scoped workflow owner for Codex managed sessions. This phase adds the `MoonMind.AgentSession` workflow, the bounded session-binding models it uses, and the `MoonMind.Run` wiring that starts one session workflow per task for managed Codex steps and tears it down during finalization.
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Orchestrate, Don't Recreate | PASS | The session owner is a Temporal workflow boundary, not an in-process Codex loop. |
+| II. One-Click Agent Deployment | PASS | No new deployment prerequisite is introduced in this workflow-only phase. |
+| III. Avoid Vendor Lock-In | PASS | The change is isolated to Codex-specific session models/workflow rather than entangling the general agent path. |
+| IV. Own Your Data | PASS | Session identity becomes workflow-owned metadata instead of ephemeral step-local state. |
+| V. Skills Are First-Class and Easy to Add | PASS | Skill resolution remains an input ref on `MoonMind.AgentRun`; session ownership does not change skill semantics. |
+| VI. Thin Scaffolding, Thick Contracts | PASS | Bounded session models and workflow tests anchor the phase before launcher/activity work exists. |
+| VII. Powerful Runtime Configurability | PASS | Runtime/profile choice continues to flow through existing request parameters. |
+| VIII. Modular and Extensible Architecture | PASS | Adds a dedicated workflow/module boundary for session ownership. |
+| IX. Resilient by Default | PASS | Session continuity becomes replay-safe and task-scoped under Temporal control. |
+| X. Facilitate Continuous Improvement | PASS | The workflow can later expose richer control/summary surfaces without redesigning root task orchestration. |
+| XI. Spec-Driven Development | PASS | This phase is captured in a dedicated spec/plan/tasks slice. |
+| XII. Canonical Documentation Separates Desired State from Migration Backlog | PASS | Detailed implementation sequencing stays in spec artifacts. |
+
+## Change Map
+
+| Artifact | Change | Rationale |
+|---|---|---|
+| `moonmind/schemas/managed_session_models.py` | Add Phase 2 session binding/input/control/status models. | FR-001, FR-002, NF-001 |
+| `moonmind/schemas/agent_runtime_models.py` | Allow managed Codex steps to carry a bounded `managedSession` binding. | FR-004, NF-003 |
+| `moonmind/workflows/temporal/workflows/agent_session.py` | Add the new `MoonMind.AgentSession` workflow. | FR-001, FR-002 |
+| `moonmind/workflows/temporal/workflows/run.py` | Start/reuse/terminate the task-scoped Codex session workflow and bind requests. | FR-003, FR-004, FR-005 |
+| `moonmind/workflows/temporal/workflows/agent_run.py` | Preserve managed-session identity on managed Codex step results. | FR-004 |
+| `moonmind/workflows/temporal/workers.py`, `moonmind/workflows/temporal/worker_runtime.py`, `moonmind/workflows/temporal/worker_entrypoint.py` | Register the new workflow type. | FR-006 |
+| `tests/unit/workflows/temporal/workflows/test_agent_session.py` | Add TDD coverage for the session-owner workflow. | NF-002 |
+| `tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py` | Add TDD coverage for root-workflow session binding and teardown. | NF-002 |
+| `tests/unit/schemas/test_agent_runtime_models.py` | Pin the new request contract behavior. | NF-002 |
+
+## Execution Order
+
+1. Add failing schema/workflow tests for the new binding and session-owner behavior.
+2. Implement the new managed-session models and `MoonMind.AgentSession` workflow.
+3. Wire `MoonMind.Run` to start/reuse/terminate one task-scoped Codex session and pass the binding into `MoonMind.AgentRun`.
+4. Register the workflow and update worker-topology expectations.
+5. Run targeted tests, then `./tools/test_unit.sh`.
+
+## Risks
+
+- **Premature runtime coupling**: This phase must not sneak in launcher/activity behavior from later phases. Mitigation: keep session workflow state-only and bounded.
+- **Execution-path regression**: Non-Codex or external agent steps must keep their current path. Mitigation: gate the session binding strictly to managed Codex requests and add a negative-path unit test.
+- **Workflow registration drift**: Adding the workflow in one runtime bootstrap path but not another would create environment-specific failures. Mitigation: update both worker registration sites and the topology test.
+
+## Testing Strategy
+
+- Targeted tests:
+  - `tests/unit/schemas/test_agent_runtime_models.py`
+  - `tests/unit/workflows/temporal/workflows/test_agent_session.py`
+  - `tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py`
+  - `tests/unit/workflows/temporal/test_temporal_workers.py`
+- Final verification:
+  - `./tools/test_unit.sh`

--- a/specs/130-codex-managed-session-plane-phase2/spec.md
+++ b/specs/130-codex-managed-session-plane-phase2/spec.md
@@ -1,0 +1,34 @@
+# Spec: Codex Managed Session Plane Phase 2
+
+## Problem
+
+Phase 1 froze the Codex managed-session contract, but MoonMind still lacks the task-scoped workflow owner that keeps session continuity independent from any single step execution. Without that workflow, managed Codex session reuse cannot be introduced behind a durable Temporal boundary.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST add a `MoonMind.AgentSession` workflow for task-scoped Codex managed sessions.
+- **FR-002**: `MoonMind.AgentSession` MUST own the stable `session_id` and current `session_epoch` for the task-scoped Codex session.
+- **FR-003**: `MoonMind.Run` MUST ensure that a managed Codex step reuses one task-scoped `MoonMind.AgentSession` instead of creating a per-step session identity.
+- **FR-004**: `MoonMind.Run` MUST pass a bounded session binding into managed Codex `MoonMind.AgentRun` requests.
+- **FR-005**: `MoonMind.Run` MUST terminate the task-scoped session workflow at task end.
+- **FR-006**: Temporal worker registration MUST treat `MoonMind.AgentSession` as a first-class workflow type.
+
+### Non-Functional Requirements
+
+- **NF-001**: The new session-owner contract MUST be encoded in executable schema models, not only workflow-local dicts.
+- **NF-002**: The new workflow and request-boundary wiring MUST be covered by unit tests.
+- **NF-003**: Non-Codex runtimes MUST retain their existing execution path unchanged.
+
+### Acceptance Criteria
+
+1. **Given** a task with multiple managed Codex steps, **When** `MoonMind.Run` prepares their requests, **Then** both steps receive the same task-scoped session binding and only one `MoonMind.AgentSession` child workflow is started.
+2. **Given** a task-scoped session workflow has been initialized, **When** a clear/reset control action is applied, **Then** the workflow preserves `session_id`, increments `session_epoch`, and clears `active_turn_id`.
+3. **Given** a task completes, **When** finalization runs, **Then** the root workflow signals the active `MoonMind.AgentSession` to terminate and clears its local binding/handle cache.
+4. **Given** a managed non-Codex runtime step, **When** `MoonMind.Run` dispatches it, **Then** no `MoonMind.AgentSession` is created.
+
+## Scope
+
+- **In scope**: new session-owner workflow/models, run-workflow session binding/teardown, Temporal worker registration, and unit tests.
+- **Out of scope**: remote session activities, Docker session launch, session adapter implementation, projection API, and UI controls.

--- a/specs/130-codex-managed-session-plane-phase2/tasks.md
+++ b/specs/130-codex-managed-session-plane-phase2/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Codex Managed Session Plane Phase 2
+
+## T001 — Add TDD coverage for the session owner and request binding [P]
+- [ ] T001a [P] Add unit tests for `MoonMind.AgentSession` initialization, clear/reset epoch handling, and termination state.
+- [ ] T001b [P] Add unit tests for `MoonMind.Run` starting exactly one task-scoped Codex session, reusing it across steps, and skipping non-Codex runtimes.
+- [ ] T001c [P] Add schema tests for `AgentExecutionRequest.managedSession`.
+- [ ] T001d [P] Update worker-topology tests for the new registered workflow type.
+
+**Independent Test**: `./.venv/bin/pytest -q tests/unit/schemas/test_agent_runtime_models.py tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/test_temporal_workers.py`
+
+## T002 — Implement the task-scoped session owner workflow [P]
+- [ ] T002a [P] Add Phase 2 managed-session binding/input/control/status models in `moonmind/schemas/managed_session_models.py`.
+- [ ] T002b [P] Add `MoonMind.AgentSession` in `moonmind/workflows/temporal/workflows/agent_session.py`.
+- [ ] T002c [P] Export the new schema symbols from `moonmind/schemas/__init__.py`.
+
+**Independent Test**: `./.venv/bin/pytest -q tests/unit/workflows/temporal/workflows/test_agent_session.py`
+
+## T003 — Wire the root and step workflows to the session owner [P]
+- [ ] T003a [P] Update `MoonMind.Run` to start/reuse/terminate one task-scoped Codex session workflow.
+- [ ] T003b [P] Pass the bounded managed-session binding into managed Codex `MoonMind.AgentRun` requests.
+- [ ] T003c [P] Preserve managed-session identity in managed Codex step results.
+
+**Independent Test**: `./.venv/bin/pytest -q tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py`
+
+## T004 — Register the workflow and verify [P]
+- [ ] T004a [P] Register `MoonMind.AgentSession` in Temporal worker bootstrap paths.
+- [ ] T004b [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: `./tools/test_unit.sh`

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -41,6 +41,46 @@ def test_agent_execution_request_rejects_sensitive_parameter_keys() -> None:
         )
 
 
+def test_agent_execution_request_accepts_codex_managed_session_binding() -> None:
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        managedSession={
+            "workflowId": "wf-run-1:session:codex_cli",
+            "taskRunId": "wf-run-1",
+            "sessionId": "sess:wf-run-1:codex_cli",
+            "sessionEpoch": 1,
+            "runtimeId": "codex_cli",
+        },
+    )
+
+    assert request.managed_session is not None
+    assert request.managed_session.runtime_id == "codex_cli"
+    assert request.managed_session.session_id == "sess:wf-run-1:codex_cli"
+
+
+def test_agent_execution_request_rejects_managed_session_for_non_codex_runtime() -> None:
+    with pytest.raises(
+        ValidationError,
+        match="managedSession is only supported for managed Codex runtimes",
+    ):
+        AgentExecutionRequest(
+            agentKind="managed",
+            agentId="claude_code",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+            managedSession={
+                "workflowId": "wf-run-1:session:codex_cli",
+                "taskRunId": "wf-run-1",
+                "sessionId": "sess:wf-run-1:codex_cli",
+                "sessionEpoch": 1,
+                "runtimeId": "codex_cli",
+            },
+        )
+
+
 def test_agent_run_status_terminal_helpers() -> None:
     status = AgentRunStatus(
         runId="run-1",

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -575,12 +575,16 @@ async def test_main_async_workflow_fleet(mock_worker_cls, mock_connect, mock_des
     mock_worker_cls.assert_called_once()
     kwargs = mock_worker_cls.call_args.kwargs
     assert kwargs["task_queue"] == "mm.workflow"
+    from moonmind.workflows.temporal.workflows.agent_session import (
+        MoonMindAgentSessionWorkflow,
+    )
     from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow
     from moonmind.workflows.temporal.workflows.oauth_session import MoonMindOAuthSessionWorkflow as MoonMindOAuthSession
     assert kwargs["workflows"] == [
         MoonMindRun,
         MoonMindManifestIngest,
         MoonMindProviderProfileManagerWorkflow,
+        MoonMindAgentSessionWorkflow,
         MoonMindAgentRun,
         MoonMindOAuthSession,
     ]

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -93,6 +93,7 @@ def test_registered_workflow_types_include_manifest_ingest():
         "MoonMind.Run",
         "MoonMind.ManifestIngest",
         "MoonMind.ProviderProfileManager",
+        "MoonMind.AgentSession",
         "MoonMind.AgentRun",
         "MoonMind.OAuthSession",
     )

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -258,3 +258,105 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
     )
     assert fetch_payload["publish_mode"] == "pr"
     assert fetch_payload["commit_message"] == "Use producer commit text"
+
+
+async def test_agent_run_managed_preserves_task_scoped_session_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-run-1",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="running",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        run.completion_event.set()
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "default-managed"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Managed success", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        run,
+        "_ensure_manager_and_signal",
+        fake_ensure_manager_and_signal,
+    )
+    monkeypatch.setattr(
+        run,
+        "_sync_manager_profiles",
+        fake_sync_manager_profiles,
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(
+        AgentExecutionRequest(
+            agentKind="managed",
+            agentId="codex_cli",
+            correlationId="corr-managed-2",
+            idempotencyKey="idem-managed-2",
+            executionProfileRef="codex-default",
+            managedSession={
+                "workflowId": "wf-run-1:session:codex_cli",
+                "taskRunId": "wf-run-1",
+                "sessionId": "sess:wf-run-1:codex_cli",
+                "sessionEpoch": 1,
+                "runtimeId": "codex_cli",
+            },
+        )
+    )
+
+    assert result.metadata["managedSession"] == {
+        "workflowId": "wf-run-1:session:codex_cli",
+        "taskRunId": "wf-run-1",
+        "sessionId": "sess:wf-run-1:codex_cli",
+        "sessionEpoch": 1,
+        "runtimeId": "codex_cli",
+        "executionProfileRef": None,
+    }

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionControlRequest,
+    CodexManagedSessionWorkflowInput,
+)
+from moonmind.workflows.temporal.workflows import agent_session as agent_session_module
+from moonmind.workflows.temporal.workflows.agent_session import (
+    AGENT_SESSION_STATUS_ACTIVE,
+    AGENT_SESSION_STATUS_TERMINATING,
+    MoonMindAgentSessionWorkflow,
+)
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-run-1:session:codex_cli",
+            "run_id": "run-session-1",
+            "task_queue": "mm.workflow",
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(agent_session_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_session_module.workflow, "logger", logger)
+
+
+def test_agent_session_initializes_task_scoped_codex_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+            executionProfileRef="codex-default",
+        )
+    )
+
+    status = workflow.get_status()
+
+    assert status["status"] == AGENT_SESSION_STATUS_ACTIVE
+    assert status["binding"]["workflowId"] == "wf-run-1:session:codex_cli"
+    assert status["binding"]["taskRunId"] == "wf-run-1"
+    assert status["binding"]["runtimeId"] == "codex_cli"
+    assert status["binding"]["sessionEpoch"] == 1
+    assert status["binding"]["executionProfileRef"] == "codex-default"
+    assert status["binding"]["sessionId"] == "sess:wf-run-1:codex_cli"
+
+
+def test_agent_session_clear_control_action_bumps_epoch_and_rotates_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+        )
+    )
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+            "activeTurnId": "turn-1",
+        }
+    )
+
+    workflow.apply_control_action(
+        CodexManagedSessionControlRequest(
+            action="clear_session",
+            reason="Reset stale context",
+            threadId="thread-2",
+        ).model_dump(by_alias=True)
+    )
+
+    status = workflow.get_status()
+
+    assert status["status"] == AGENT_SESSION_STATUS_ACTIVE
+    assert status["binding"]["sessionEpoch"] == 2
+    assert status["containerId"] == "container-1"
+    assert status["threadId"] == "thread-2"
+    assert status["activeTurnId"] is None
+    assert status["lastControlAction"] == "clear_session"
+    assert status["lastControlReason"] == "Reset stale context"
+
+
+def test_agent_session_terminate_control_action_marks_termination_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+        )
+    )
+
+    workflow.apply_control_action({"action": "terminate_session", "reason": "done"})
+
+    status = workflow.get_status()
+
+    assert status["status"] == AGENT_SESSION_STATUS_TERMINATING
+    assert status["terminationRequested"] is True
+    assert status["lastControlAction"] == "terminate_session"
+    assert status["lastControlReason"] == "done"

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from moonmind.schemas.managed_session_models import (

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -142,11 +142,10 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     assert signal_calls == [
         (
-            "terminate_session",
+            "control_action",
             {
+                "action": "terminate_session",
                 "reason": "success",
-                "sessionId": "sess:wf-run-1:codex_cli",
-                "sessionEpoch": 1,
             },
         )
     ]

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-run-1",
+            "run_id": "run-1",
+            "task_queue": "mm.workflow",
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_module.workflow, "logger", logger)
+
+
+def _managed_request(agent_id: str = "codex") -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId=agent_id,
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        executionProfileRef="codex-default",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_starts_one_task_scoped_codex_session_and_reuses_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    start_calls: list[tuple[str, Any, str, str]] = []
+
+    class _FakeHandle:
+        async def signal(self, _signal_name: str, _payload: Any = None) -> None:
+            return None
+
+    async def fake_start_child_workflow(
+        workflow_name: str,
+        payload: Any,
+        *,
+        id: str,
+        task_queue: str,
+        **_kwargs: Any,
+    ) -> _FakeHandle:
+        start_calls.append((workflow_name, payload, id, task_queue))
+        return _FakeHandle()
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "start_child_workflow",
+        fake_start_child_workflow,
+    )
+
+    first = await workflow._maybe_bind_task_scoped_session(_managed_request("codex"))
+    second = await workflow._maybe_bind_task_scoped_session(
+        _managed_request("codex_cli")
+    )
+
+    assert len(start_calls) == 1
+    workflow_name, payload, workflow_id, task_queue = start_calls[0]
+    assert workflow_name == "MoonMind.AgentSession"
+    assert workflow_id == "wf-run-1:session:codex_cli"
+    assert task_queue == run_module.WORKFLOW_TASK_QUEUE
+    assert payload.task_run_id == "wf-run-1"
+    assert payload.runtime_id == "codex_cli"
+    assert payload.execution_profile_ref == "codex-default"
+    assert first.managed_session is not None
+    assert second.managed_session is not None
+    assert first.managed_session == second.managed_session
+    assert first.managed_session.session_id == "sess:wf-run-1:codex_cli"
+    assert first.managed_session.session_epoch == 1
+
+
+@pytest.mark.asyncio
+async def test_run_skips_task_scoped_session_for_non_codex_managed_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    started = False
+
+    async def fake_start_child_workflow(*_args: Any, **_kwargs: Any) -> Any:
+        nonlocal started
+        started = True
+        raise AssertionError("start_child_workflow should not be called")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "start_child_workflow",
+        fake_start_child_workflow,
+    )
+
+    request = await workflow._maybe_bind_task_scoped_session(
+        _managed_request("claude_code")
+    )
+
+    assert request.managed_session is None
+    assert started is False
+
+
+@pytest.mark.asyncio
+async def test_run_terminates_active_task_scoped_codex_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert signal_calls == [
+        (
+            "terminate_session",
+            {
+                "reason": "success",
+                "sessionId": "sess:wf-run-1:codex_cli",
+                "sessionEpoch": 1,
+            },
+        )
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None


### PR DESCRIPTION
## Summary
- add the task-scoped `MoonMind.AgentSession` workflow for managed Codex continuity ownership
- extend the managed-session and agent-runtime schemas with bounded session binding contracts
- wire `MoonMind.Run` to start, reuse, and terminate one Codex session per task, and preserve the binding through `MoonMind.AgentRun`
- register the new workflow in Temporal worker bootstrap paths and add Phase 2 spec artifacts

## Why
Phase 1 froze the Codex managed-session contract, but there was still no durable workflow owner for task-scoped session identity. Without that boundary, managed Codex session reuse could not be introduced independently from any single step execution.

## Impact
- managed Codex steps can now share one task-scoped session binding across multiple steps
- the session identity is workflow-owned and explicitly terminated at task end
- non-Codex runtimes stay on their existing execution path

## Root Cause
The managed-session plane had contract models only. The orchestration layer did not yet have a first-class Temporal workflow that owned `session_id`, `session_epoch`, and session lifecycle across step boundaries.

## Validation
- `./.venv/bin/pytest -q tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_temporal_workers.py tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/schemas/test_agent_runtime_models.py`
- `./tools/test_unit.sh`
