### PR TITLE
[codex] Implement Codex managed session plane phase 4

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import queue
 import shutil
 import signal
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -35,6 +38,8 @@ from moonmind.schemas.managed_session_models import (
 
 _STATE_FILENAME = ".moonmind-codex-session-state.json"
 _READY_LOOP_SECONDS = 3600.0
+_DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = 300.0
+_STDOUT_EOF = object()
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -65,13 +70,19 @@ class CodexAppServerRpcClient:
         client_version: str,
         cwd: str | None = None,
         env: Mapping[str, str] | None = None,
+        notification_timeout_seconds: float | None = None,
     ) -> None:
         self._command = tuple(command)
         self._client_name = client_name
         self._client_version = client_version
         self._cwd = cwd
         self._env = dict(env or {})
+        self._notification_timeout_seconds = notification_timeout_seconds
         self._process: subprocess.Popen[str] | None = None
+        self._stderr_capture: tempfile.SpooledTemporaryFile[str] | None = None
+        self._stdout_reader: threading.Thread | None = None
+        self._stdout_queue: queue.Queue[object] = queue.Queue()
+        self._stdout_reader_error: Exception | None = None
         self._next_id = 1
         self._notifications: list[dict[str, Any]] = []
         self._responses: dict[int, dict[str, Any]] = {}
@@ -80,31 +91,73 @@ class CodexAppServerRpcClient:
     def _ensure_started(self) -> None:
         if self._process is not None:
             return
+        self._stderr_capture = tempfile.SpooledTemporaryFile(
+            max_size=1_000_000,
+            mode="w+",
+            encoding="utf-8",
+        )
         self._process = subprocess.Popen(
             self._command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=self._stderr_capture,
             text=True,
             bufsize=1,
             cwd=self._cwd,
             env={**os.environ, **self._env},
         )
+        self._stdout_reader = threading.Thread(
+            target=self._drain_stdout,
+            name="codex-app-server-stdout",
+            daemon=True,
+        )
+        self._stdout_reader.start()
 
-    def _read_message(self) -> dict[str, Any]:
-        self._ensure_started()
+    def _drain_stdout(self) -> None:
         assert self._process is not None
         assert self._process.stdout is not None
-        line = self._process.stdout.readline()
-        if not line:
-            stderr_text = ""
-            if self._process.stderr is not None:
-                stderr_text = self._process.stderr.read()
+        try:
+            for line in self._process.stdout:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                self._stdout_queue.put(json.loads(stripped))
+        except Exception as exc:
+            self._stdout_reader_error = exc
+        finally:
+            self._stdout_queue.put(_STDOUT_EOF)
+
+    def _stderr_text(self) -> str:
+        if self._stderr_capture is None:
+            return ""
+        self._stderr_capture.flush()
+        self._stderr_capture.seek(0)
+        return self._stderr_capture.read().strip()
+
+    def _read_message(self, *, timeout_seconds: float | None = None) -> dict[str, Any]:
+        self._ensure_started()
+        try:
+            if timeout_seconds is None:
+                message = self._stdout_queue.get()
+            else:
+                message = self._stdout_queue.get(timeout=timeout_seconds)
+        except queue.Empty as exc:
+            raise TimeoutError(
+                "timed out waiting for codex app-server message"
+            ) from exc
+        if message is _STDOUT_EOF:
+            stderr_text = self._stderr_text()
+            if self._stdout_reader_error is not None:
+                raise RuntimeError(
+                    "codex app-server emitted invalid JSON"
+                    + (f": {self._stdout_reader_error}" if str(self._stdout_reader_error) else "")
+                    + (f"; stderr: {stderr_text}" if stderr_text else "")
+                ) from self._stdout_reader_error
             raise RuntimeError(
                 "codex app-server closed unexpectedly"
-                + (f": {stderr_text.strip()}" if stderr_text.strip() else "")
+                + (f": {stderr_text}" if stderr_text else "")
             )
-        return json.loads(line)
+        return message if isinstance(message, dict) else {}
 
     def _write_message(self, message: Mapping[str, Any]) -> None:
         self._ensure_started()
@@ -182,7 +235,16 @@ class CodexAppServerRpcClient:
         method: str,
         *,
         predicate: Callable[[Mapping[str, Any]], bool] | None = None,
+        timeout_seconds: float | None = None,
     ) -> dict[str, Any]:
+        deadline = None
+        effective_timeout = (
+            self._notification_timeout_seconds
+            if timeout_seconds is None
+            else timeout_seconds
+        )
+        if effective_timeout is not None:
+            deadline = time.monotonic() + effective_timeout
         while True:
             for index, notification in enumerate(self._notifications):
                 if notification.get("method") != method:
@@ -191,7 +253,14 @@ class CodexAppServerRpcClient:
                     continue
                 return self._notifications.pop(index)
 
-            message = self._read_message()
+            remaining = None
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"timed out waiting for codex app-server notification {method}"
+                    )
+            message = self._read_message(timeout_seconds=remaining)
             if message.get("method") == method and (
                 predicate is None or predicate(message)
             ):
@@ -212,6 +281,14 @@ class CodexAppServerRpcClient:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=2)
+        if process.stdout is not None:
+            process.stdout.close()
+        if self._stdout_reader is not None:
+            self._stdout_reader.join(timeout=2)
+            self._stdout_reader = None
+        if self._stderr_capture is not None:
+            self._stderr_capture.close()
+            self._stderr_capture = None
 
 
 class CodexManagedSessionRuntime:
@@ -228,6 +305,7 @@ class CodexManagedSessionRuntime:
         control_url: str,
         container_id: str,
         app_server_command: Sequence[str] = ("codex", "app-server"),
+        turn_completion_timeout_seconds: float = _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS,
     ) -> None:
         self._workspace_path = Path(workspace_path)
         self._session_workspace_path = Path(session_workspace_path)
@@ -237,6 +315,7 @@ class CodexManagedSessionRuntime:
         self._control_url = control_url
         self._container_id = container_id
         self._app_server_command = tuple(app_server_command)
+        self._turn_completion_timeout_seconds = turn_completion_timeout_seconds
         self._client: CodexAppServerRpcClient | None = None
 
     @property
@@ -256,7 +335,8 @@ class CodexManagedSessionRuntime:
                 client_name="MoonMind",
                 client_version="phase4",
                 cwd=str(self._workspace_path),
-                env={"HOME": str(self._codex_home_path)},
+                env={"CODEX_HOME": str(self._codex_home_path)},
+                notification_timeout_seconds=self._turn_completion_timeout_seconds,
             )
         return self._client
 
@@ -420,13 +500,20 @@ class CodexManagedSessionRuntime:
         state.last_control_at = time.time()
         self._save_state(state)
 
-        client.wait_for_notification(
-            "turn/completed",
-            predicate=lambda message: (
-                isinstance(message.get("params"), Mapping)
-                and message["params"].get("threadId") == state.vendor_thread_id
-            ),
-        )
+        try:
+            client.wait_for_notification(
+                "turn/completed",
+                predicate=lambda message: (
+                    isinstance(message.get("params"), Mapping)
+                    and message["params"].get("threadId") == state.vendor_thread_id
+                ),
+                timeout_seconds=self._turn_completion_timeout_seconds,
+            )
+        except TimeoutError as exc:
+            raise RuntimeError(
+                "timed out waiting for codex app-server turn/completed notification "
+                f"after {self._turn_completion_timeout_seconds} seconds"
+            ) from exc
         thread_payload = client.request("thread/read", {"threadId": state.vendor_thread_id})
         assistant_text = self._extract_assistant_text(thread_payload)
 
@@ -462,6 +549,26 @@ class CodexManagedSessionRuntime:
         request: InterruptCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
         state = self._validate_locator(request)
+        if state.active_turn_id != request.turn_id:
+            return CodexManagedSessionTurnResponse(
+                sessionState=self._session_state(state),
+                turnId=request.turn_id,
+                status="failed",
+                metadata={
+                    "reason": (
+                        "interrupt_turn requires the active managed-session turn id"
+                    )
+                },
+            )
+        client = self._app_server_client()
+        client.initialize()
+        interrupt_params = {
+            "threadId": state.vendor_thread_id,
+            "turnId": request.turn_id,
+        }
+        if request.reason:
+            interrupt_params["reason"] = request.reason
+        client.request("turn/interrupt", interrupt_params)
         state.active_turn_id = None
         state.last_control_action = "interrupt_turn"
         state.last_control_at = time.time()
@@ -536,12 +643,75 @@ class CodexManagedSessionRuntime:
         )
 
 
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _require_writable_directory(
+    path_value: str,
+    env_name: str,
+    *,
+    create: bool,
+) -> str:
+    path = Path(path_value)
+    if not path.is_absolute():
+        raise RuntimeError(f"{env_name} must be an absolute path: {path}")
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        raise RuntimeError(f"{env_name} must exist: {path}")
+    if not path.is_dir():
+        raise RuntimeError(f"{env_name} must be a directory: {path}")
+    if not os.access(path, os.W_OK):
+        raise RuntimeError(f"{env_name} must be writable: {path}")
+    return str(path)
+
+
+def _validated_runtime_environment() -> dict[str, str]:
+    if shutil.which("codex") is None:
+        raise RuntimeError("codex is required on PATH")
+
+    workspace_path = _require_writable_directory(
+        _require_env("MOONMIND_SESSION_WORKSPACE_PATH"),
+        "MOONMIND_SESSION_WORKSPACE_PATH",
+        create=False,
+    )
+    session_workspace_path = _require_writable_directory(
+        _require_env("MOONMIND_SESSION_WORKSPACE_STATE_PATH"),
+        "MOONMIND_SESSION_WORKSPACE_STATE_PATH",
+        create=True,
+    )
+    artifact_spool_path = _require_writable_directory(
+        _require_env("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"),
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+        create=True,
+    )
+    codex_home_path = _require_writable_directory(
+        _require_env("MOONMIND_SESSION_CODEX_HOME_PATH"),
+        "MOONMIND_SESSION_CODEX_HOME_PATH",
+        create=True,
+    )
+    image_ref = _require_env("MOONMIND_SESSION_IMAGE_REF")
+
+    return {
+        "workspace_path": workspace_path,
+        "session_workspace_path": session_workspace_path,
+        "artifact_spool_path": artifact_spool_path,
+        "codex_home_path": codex_home_path,
+        "image_ref": image_ref,
+    }
+
+
 def _runtime_from_environment() -> CodexManagedSessionRuntime:
-    workspace_path = os.environ["MOONMIND_SESSION_WORKSPACE_PATH"]
-    session_workspace_path = os.environ["MOONMIND_SESSION_WORKSPACE_STATE_PATH"]
-    artifact_spool_path = os.environ["MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"]
-    codex_home_path = os.environ["MOONMIND_SESSION_CODEX_HOME_PATH"]
-    image_ref = os.environ["MOONMIND_SESSION_IMAGE_REF"]
+    env = _validated_runtime_environment()
+    workspace_path = env["workspace_path"]
+    session_workspace_path = env["session_workspace_path"]
+    artifact_spool_path = env["artifact_spool_path"]
+    codex_home_path = env["codex_home_path"]
+    image_ref = env["image_ref"]
     container_id = os.environ.get("MOONMIND_SESSION_CONTAINER_ID", "").strip()
     if not container_id:
         state_path = Path(session_workspace_path) / _STATE_FILENAME
@@ -556,6 +726,12 @@ def _runtime_from_environment() -> CodexManagedSessionRuntime:
     control_url = os.environ.get("MOONMIND_SESSION_CONTROL_URL", "").strip()
     if not control_url:
         control_url = f"docker-exec://{os.environ.get('HOSTNAME', 'codex-session')}"
+    timeout_seconds = float(
+        os.environ.get(
+            "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS",
+            str(_DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS),
+        )
+    )
     return CodexManagedSessionRuntime(
         workspace_path=workspace_path,
         session_workspace_path=session_workspace_path,
@@ -564,6 +740,7 @@ def _runtime_from_environment() -> CodexManagedSessionRuntime:
         image_ref=image_ref,
         control_url=control_url,
         container_id=container_id,
+        turn_completion_timeout_seconds=timeout_seconds,
     )
 
 
@@ -578,11 +755,12 @@ def _emit_json(payload: BaseModel | Mapping[str, Any], *, exit_code: int = 0) ->
 
 
 def _run_ready() -> int:
-    ready = shutil.which("codex") is not None
-    return _emit_json({"ready": ready})
+    _validated_runtime_environment()
+    return _emit_json({"ready": True})
 
 
 def _run_serve() -> int:
+    _validated_runtime_environment()
     stopping = False
 
     def _handle_signal(signum: int, _frame: object) -> None:

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -1,0 +1,667 @@
+"""Container-side transitional Codex managed-session runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionClearRequest,
+    CodexManagedSessionHandle,
+    CodexManagedSessionLocator,
+    CodexManagedSessionState,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+    FetchCodexManagedSessionSummaryRequest,
+    InterruptCodexManagedSessionTurnRequest,
+    LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
+    SendCodexManagedSessionTurnRequest,
+    SteerCodexManagedSessionTurnRequest,
+    TerminateCodexManagedSessionRequest,
+)
+
+
+_STATE_FILENAME = ".moonmind-codex-session-state.json"
+_READY_LOOP_SECONDS = 3600.0
+
+
+class CodexSessionRuntimeState(BaseModel):
+    """Persisted logical-to-vendor session mapping for one container session."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    session_id: str = Field(..., alias="sessionId")
+    session_epoch: int = Field(..., alias="sessionEpoch", ge=1)
+    logical_thread_id: str = Field(..., alias="logicalThreadId")
+    vendor_thread_id: str = Field(..., alias="vendorThreadId")
+    container_id: str = Field(..., alias="containerId")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
+    launched_at: float | None = Field(None, alias="launchedAt")
+    last_control_action: str | None = Field(None, alias="lastControlAction")
+    last_control_at: float | None = Field(None, alias="lastControlAt")
+    last_assistant_text: str | None = Field(None, alias="lastAssistantText")
+
+
+class CodexAppServerRpcClient:
+    """Minimal JSON-RPC stdio client for ``codex app-server``."""
+
+    def __init__(
+        self,
+        *,
+        command: Sequence[str],
+        client_name: str,
+        client_version: str,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self._command = tuple(command)
+        self._client_name = client_name
+        self._client_version = client_version
+        self._cwd = cwd
+        self._env = dict(env or {})
+        self._process: subprocess.Popen[str] | None = None
+        self._next_id = 1
+        self._notifications: list[dict[str, Any]] = []
+        self._responses: dict[int, dict[str, Any]] = {}
+        self._initialize_result: dict[str, Any] | None = None
+
+    def _ensure_started(self) -> None:
+        if self._process is not None:
+            return
+        self._process = subprocess.Popen(
+            self._command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=self._cwd,
+            env={**os.environ, **self._env},
+        )
+
+    def _read_message(self) -> dict[str, Any]:
+        self._ensure_started()
+        assert self._process is not None
+        assert self._process.stdout is not None
+        line = self._process.stdout.readline()
+        if not line:
+            stderr_text = ""
+            if self._process.stderr is not None:
+                stderr_text = self._process.stderr.read()
+            raise RuntimeError(
+                "codex app-server closed unexpectedly"
+                + (f": {stderr_text.strip()}" if stderr_text.strip() else "")
+            )
+        return json.loads(line)
+
+    def _write_message(self, message: Mapping[str, Any]) -> None:
+        self._ensure_started()
+        assert self._process is not None
+        assert self._process.stdin is not None
+        self._process.stdin.write(json.dumps(message) + "\n")
+        self._process.stdin.flush()
+
+    def _stash_message(self, message: Mapping[str, Any]) -> None:
+        if "method" in message:
+            self._notifications.append(dict(message))
+            return
+        raw_id = message.get("id")
+        if isinstance(raw_id, int):
+            self._responses[raw_id] = dict(message)
+
+    def request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if method != "initialize" and self._initialize_result is None:
+            self.initialize()
+
+        message_id = self._next_id
+        self._next_id += 1
+        self._write_message(
+            {
+                "jsonrpc": "2.0",
+                "id": message_id,
+                "method": method,
+                "params": dict(params or {}),
+            }
+        )
+
+        while True:
+            queued = self._responses.pop(message_id, None)
+            if queued is not None:
+                message = queued
+            else:
+                message = self._read_message()
+
+            if "method" in message:
+                self._notifications.append(message)
+                continue
+
+            raw_id = message.get("id")
+            if raw_id != message_id:
+                self._stash_message(message)
+                continue
+
+            if "error" in message:
+                raise RuntimeError(
+                    f"codex app-server request {method} failed: {message['error']}"
+                )
+            result = message.get("result")
+            return result if isinstance(result, dict) else {}
+
+    def initialize(self) -> dict[str, Any]:
+        if self._initialize_result is not None:
+            return self._initialize_result
+        self._initialize_result = self.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": self._client_name,
+                    "version": self._client_version,
+                }
+            },
+        )
+        return self._initialize_result
+
+    def wait_for_notification(
+        self,
+        method: str,
+        *,
+        predicate: Callable[[Mapping[str, Any]], bool] | None = None,
+    ) -> dict[str, Any]:
+        while True:
+            for index, notification in enumerate(self._notifications):
+                if notification.get("method") != method:
+                    continue
+                if predicate is not None and not predicate(notification):
+                    continue
+                return self._notifications.pop(index)
+
+            message = self._read_message()
+            if message.get("method") == method and (
+                predicate is None or predicate(message)
+            ):
+                return message
+            self._stash_message(message)
+
+    def close(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None:
+            return
+        if process.stdin is not None:
+            process.stdin.close()
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+
+
+class CodexManagedSessionRuntime:
+    """Local runtime implementation invoked inside the session container."""
+
+    def __init__(
+        self,
+        *,
+        workspace_path: str,
+        session_workspace_path: str,
+        artifact_spool_path: str,
+        codex_home_path: str,
+        image_ref: str,
+        control_url: str,
+        container_id: str,
+        app_server_command: Sequence[str] = ("codex", "app-server"),
+    ) -> None:
+        self._workspace_path = Path(workspace_path)
+        self._session_workspace_path = Path(session_workspace_path)
+        self._artifact_spool_path = Path(artifact_spool_path)
+        self._codex_home_path = Path(codex_home_path)
+        self._image_ref = image_ref
+        self._control_url = control_url
+        self._container_id = container_id
+        self._app_server_command = tuple(app_server_command)
+        self._client: CodexAppServerRpcClient | None = None
+
+    @property
+    def _state_path(self) -> Path:
+        return self._session_workspace_path / _STATE_FILENAME
+
+    def _ensure_directories(self) -> None:
+        self._workspace_path.mkdir(parents=True, exist_ok=True)
+        self._session_workspace_path.mkdir(parents=True, exist_ok=True)
+        self._artifact_spool_path.mkdir(parents=True, exist_ok=True)
+        self._codex_home_path.mkdir(parents=True, exist_ok=True)
+
+    def _app_server_client(self) -> CodexAppServerRpcClient:
+        if self._client is None:
+            self._client = CodexAppServerRpcClient(
+                command=self._app_server_command,
+                client_name="MoonMind",
+                client_version="phase4",
+                cwd=str(self._workspace_path),
+                env={"HOME": str(self._codex_home_path)},
+            )
+        return self._client
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    def _load_state(self) -> CodexSessionRuntimeState:
+        if not self._state_path.is_file():
+            raise RuntimeError(
+                f"managed session state file is missing: {self._state_path}"
+            )
+        return CodexSessionRuntimeState.model_validate_json(
+            self._state_path.read_text(encoding="utf-8")
+        )
+
+    def _save_state(self, state: CodexSessionRuntimeState) -> None:
+        self._ensure_directories()
+        self._state_path.write_text(
+            state.model_dump_json(by_alias=True, exclude_none=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    def _session_state(self, state: CodexSessionRuntimeState) -> CodexManagedSessionState:
+        return CodexManagedSessionState(
+            sessionId=state.session_id,
+            sessionEpoch=state.session_epoch,
+            containerId=state.container_id,
+            threadId=state.logical_thread_id,
+            activeTurnId=state.active_turn_id,
+        )
+
+    def _handle(
+        self,
+        state: CodexSessionRuntimeState,
+        *,
+        status: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CodexManagedSessionHandle:
+        merged = {
+            "vendorThreadId": state.vendor_thread_id,
+            **dict(metadata or {}),
+        }
+        if state.last_assistant_text:
+            merged.setdefault("lastAssistantText", state.last_assistant_text)
+        return CodexManagedSessionHandle(
+            sessionState=self._session_state(state),
+            status=status,
+            imageRef=self._image_ref,
+            controlUrl=self._control_url,
+            metadata=merged,
+        )
+
+    def _validate_locator(self, request: CodexManagedSessionLocator) -> CodexSessionRuntimeState:
+        state = self._load_state()
+        if state.session_id != request.session_id:
+            raise RuntimeError("sessionId does not match the active managed session")
+        if state.session_epoch != request.session_epoch:
+            raise RuntimeError("sessionEpoch does not match the active managed session")
+        if state.container_id != request.container_id:
+            raise RuntimeError("containerId does not match the active managed session")
+        if state.logical_thread_id != request.thread_id:
+            raise RuntimeError("threadId does not match the active managed session")
+        return state
+
+    @staticmethod
+    def _extract_assistant_text(thread_payload: Mapping[str, Any]) -> str:
+        thread = thread_payload.get("thread")
+        if not isinstance(thread, Mapping):
+            return ""
+        turns = thread.get("turns")
+        if not isinstance(turns, list):
+            return ""
+        for turn in reversed(turns):
+            if not isinstance(turn, Mapping):
+                continue
+            items = turn.get("items")
+            if not isinstance(items, list):
+                continue
+            for item in reversed(items):
+                if not isinstance(item, Mapping):
+                    continue
+                if item.get("type") != "agentMessage":
+                    continue
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+        return ""
+
+    def launch_session(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> CodexManagedSessionHandle:
+        self._ensure_directories()
+        client = self._app_server_client()
+        client.initialize()
+        started = client.request("thread/start", {"cwd": str(self._workspace_path)})
+        thread_payload = started.get("thread")
+        if not isinstance(thread_payload, Mapping):
+            raise RuntimeError("codex app-server thread/start did not return a thread")
+        vendor_thread_id = str(thread_payload.get("id") or "").strip()
+        if not vendor_thread_id:
+            raise RuntimeError("codex app-server thread/start returned a blank thread id")
+
+        state = CodexSessionRuntimeState(
+            sessionId=request.session_id,
+            sessionEpoch=request.session_epoch,
+            logicalThreadId=request.thread_id,
+            vendorThreadId=vendor_thread_id,
+            containerId=self._container_id,
+            activeTurnId=None,
+            launchedAt=time.time(),
+            lastControlAction="start_session",
+            lastControlAt=time.time(),
+        )
+        self._save_state(state)
+        return self._handle(
+            state,
+            status="ready",
+            metadata={
+                "approvalPolicy": started.get("approvalPolicy"),
+                "model": started.get("model"),
+            },
+        )
+
+    def session_status(
+        self,
+        request: CodexManagedSessionLocator,
+    ) -> CodexManagedSessionHandle:
+        state = self._validate_locator(request)
+        status = "busy" if state.active_turn_id else "ready"
+        return self._handle(state, status=status)
+
+    def send_turn(
+        self,
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        state = self._validate_locator(request)
+        client = self._app_server_client()
+        client.initialize()
+
+        started = client.request(
+            "turn/start",
+            {
+                "threadId": state.vendor_thread_id,
+                "instructions": request.instructions,
+                "inputRefs": list(request.input_refs),
+                "metadata": request.metadata,
+            },
+        )
+        turn_payload = started.get("turn")
+        if not isinstance(turn_payload, Mapping):
+            raise RuntimeError("codex app-server turn/start did not return a turn")
+        vendor_turn_id = str(turn_payload.get("id") or "").strip()
+        if not vendor_turn_id:
+            raise RuntimeError("codex app-server turn/start returned a blank turn id")
+
+        state.active_turn_id = vendor_turn_id
+        state.last_control_action = "send_turn"
+        state.last_control_at = time.time()
+        self._save_state(state)
+
+        client.wait_for_notification(
+            "turn/completed",
+            predicate=lambda message: (
+                isinstance(message.get("params"), Mapping)
+                and message["params"].get("threadId") == state.vendor_thread_id
+            ),
+        )
+        thread_payload = client.request("thread/read", {"threadId": state.vendor_thread_id})
+        assistant_text = self._extract_assistant_text(thread_payload)
+
+        state.active_turn_id = None
+        state.last_assistant_text = assistant_text or None
+        self._save_state(state)
+        return CodexManagedSessionTurnResponse(
+            sessionState=self._session_state(state),
+            turnId=vendor_turn_id,
+            status="completed",
+            metadata={"assistantText": assistant_text},
+        )
+
+    def steer_turn(
+        self,
+        request: SteerCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        state = self._validate_locator(request)
+        return CodexManagedSessionTurnResponse(
+            sessionState=self._session_state(state),
+            turnId=request.turn_id,
+            status="failed",
+            metadata={
+                "reason": (
+                    "steer_turn is not supported by the transitional synchronous "
+                    "Codex managed-session runtime"
+                )
+            },
+        )
+
+    def interrupt_turn(
+        self,
+        request: InterruptCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        state = self._validate_locator(request)
+        state.active_turn_id = None
+        state.last_control_action = "interrupt_turn"
+        state.last_control_at = time.time()
+        self._save_state(state)
+        return CodexManagedSessionTurnResponse(
+            sessionState=self._session_state(state),
+            turnId=request.turn_id,
+            status="interrupted",
+            metadata={"reason": request.reason or "interrupt requested"},
+        )
+
+    def clear_session(
+        self,
+        request: CodexManagedSessionClearRequest,
+    ) -> CodexManagedSessionHandle:
+        state = self._validate_locator(request)
+        client = self._app_server_client()
+        client.initialize()
+        started = client.request("thread/start", {"cwd": str(self._workspace_path)})
+        thread_payload = started.get("thread")
+        if not isinstance(thread_payload, Mapping):
+            raise RuntimeError("codex app-server thread/start did not return a thread")
+        vendor_thread_id = str(thread_payload.get("id") or "").strip()
+        if not vendor_thread_id:
+            raise RuntimeError("codex app-server thread/start returned a blank thread id")
+
+        state.session_epoch += 1
+        state.logical_thread_id = request.new_thread_id
+        state.vendor_thread_id = vendor_thread_id
+        state.active_turn_id = None
+        state.last_control_action = "clear_session"
+        state.last_control_at = time.time()
+        self._save_state(state)
+        return self._handle(state, status="ready")
+
+    def terminate_session(
+        self,
+        request: TerminateCodexManagedSessionRequest,
+    ) -> CodexManagedSessionHandle:
+        state = self._validate_locator(request)
+        state.active_turn_id = None
+        state.last_control_action = "terminate_session"
+        state.last_control_at = time.time()
+        self._save_state(state)
+        return self._handle(state, status="terminated")
+
+    def fetch_session_summary(
+        self,
+        request: FetchCodexManagedSessionSummaryRequest,
+    ) -> CodexManagedSessionSummary:
+        state = self._validate_locator(request)
+        return CodexManagedSessionSummary(
+            sessionState=self._session_state(state),
+            latestSummaryRef=None,
+            latestCheckpointRef=None,
+            latestControlEventRef=None,
+            metadata={"lastAssistantText": state.last_assistant_text},
+        )
+
+    def publish_session_artifacts(
+        self,
+        request: PublishCodexManagedSessionArtifactsRequest,
+    ) -> CodexManagedSessionArtifactsPublication:
+        state = self._validate_locator(request)
+        return CodexManagedSessionArtifactsPublication(
+            sessionState=self._session_state(state),
+            publishedArtifactRefs=(),
+            latestSummaryRef=None,
+            latestCheckpointRef=None,
+            latestControlEventRef=None,
+            metadata=dict(request.metadata),
+        )
+
+
+def _runtime_from_environment() -> CodexManagedSessionRuntime:
+    workspace_path = os.environ["MOONMIND_SESSION_WORKSPACE_PATH"]
+    session_workspace_path = os.environ["MOONMIND_SESSION_WORKSPACE_STATE_PATH"]
+    artifact_spool_path = os.environ["MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"]
+    codex_home_path = os.environ["MOONMIND_SESSION_CODEX_HOME_PATH"]
+    image_ref = os.environ["MOONMIND_SESSION_IMAGE_REF"]
+    container_id = os.environ.get("MOONMIND_SESSION_CONTAINER_ID", "").strip()
+    if not container_id:
+        state_path = Path(session_workspace_path) / _STATE_FILENAME
+        if state_path.is_file():
+            state = CodexSessionRuntimeState.model_validate_json(
+                state_path.read_text(encoding="utf-8")
+            )
+            container_id = state.container_id
+    if not container_id:
+        raise RuntimeError("MOONMIND_SESSION_CONTAINER_ID is required")
+
+    control_url = os.environ.get("MOONMIND_SESSION_CONTROL_URL", "").strip()
+    if not control_url:
+        control_url = f"docker-exec://{os.environ.get('HOSTNAME', 'codex-session')}"
+    return CodexManagedSessionRuntime(
+        workspace_path=workspace_path,
+        session_workspace_path=session_workspace_path,
+        artifact_spool_path=artifact_spool_path,
+        codex_home_path=codex_home_path,
+        image_ref=image_ref,
+        control_url=control_url,
+        container_id=container_id,
+    )
+
+
+def _emit_json(payload: BaseModel | Mapping[str, Any], *, exit_code: int = 0) -> int:
+    if isinstance(payload, BaseModel):
+        text = payload.model_dump_json(by_alias=True, exclude_none=True)
+    else:
+        text = json.dumps(payload)
+    sys.stdout.write(text + "\n")
+    sys.stdout.flush()
+    return exit_code
+
+
+def _run_ready() -> int:
+    ready = shutil.which("codex") is not None
+    return _emit_json({"ready": ready})
+
+
+def _run_serve() -> int:
+    stopping = False
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+    while not stopping:
+        time.sleep(_READY_LOOP_SECONDS)
+    return 0
+
+
+def _invoke_action(action: str, payload: Mapping[str, Any]) -> BaseModel:
+    runtime = _runtime_from_environment()
+    try:
+        if action == "launch_session":
+            return runtime.launch_session(
+                LaunchCodexManagedSessionRequest.model_validate(payload)
+            )
+        if action == "session_status":
+            return runtime.session_status(
+                CodexManagedSessionLocator.model_validate(payload)
+            )
+        if action == "send_turn":
+            return runtime.send_turn(
+                SendCodexManagedSessionTurnRequest.model_validate(payload)
+            )
+        if action == "steer_turn":
+            return runtime.steer_turn(
+                SteerCodexManagedSessionTurnRequest.model_validate(payload)
+            )
+        if action == "interrupt_turn":
+            return runtime.interrupt_turn(
+                InterruptCodexManagedSessionTurnRequest.model_validate(payload)
+            )
+        if action == "clear_session":
+            return runtime.clear_session(
+                CodexManagedSessionClearRequest.model_validate(payload)
+            )
+        if action == "terminate_session":
+            return runtime.terminate_session(
+                TerminateCodexManagedSessionRequest.model_validate(payload)
+            )
+        if action == "fetch_session_summary":
+            return runtime.fetch_session_summary(
+                FetchCodexManagedSessionSummaryRequest.model_validate(payload)
+            )
+        if action == "publish_session_artifacts":
+            return runtime.publish_session_artifacts(
+                PublishCodexManagedSessionArtifactsRequest.model_validate(payload)
+            )
+        raise RuntimeError(f"unsupported managed-session action: {action}")
+    finally:
+        runtime.close()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="codex_session_runtime")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("serve")
+    subparsers.add_parser("ready")
+    invoke_parser = subparsers.add_parser("invoke")
+    invoke_parser.add_argument("action")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "serve":
+            return _run_serve()
+        if args.command == "ready":
+            return _run_ready()
+        if args.command == "invoke":
+            raw_payload = sys.stdin.read()
+            payload = json.loads(raw_payload or "{}")
+            return _emit_json(_invoke_action(args.action, payload))
+        raise RuntimeError(f"unsupported command: {args.command}")
+    except Exception as exc:
+        return _emit_json({"error": str(exc), "ready": False}, exit_code=1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1,0 +1,316 @@
+"""Docker-backed controller for transitional Codex managed sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from typing import Any, Awaitable, Callable, Mapping, Sequence
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionClearRequest,
+    CodexManagedSessionHandle,
+    CodexManagedSessionLocator,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+    FetchCodexManagedSessionSummaryRequest,
+    InterruptCodexManagedSessionTurnRequest,
+    LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
+    SendCodexManagedSessionTurnRequest,
+    SteerCodexManagedSessionTurnRequest,
+    TerminateCodexManagedSessionRequest,
+)
+
+
+_RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
+_CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+CommandRunner = Callable[
+    [tuple[str, ...]],
+    Awaitable[tuple[int, str, str]],
+]
+
+
+async def _default_command_runner(
+    command: tuple[str, ...],
+    *,
+    input_text: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdin=asyncio.subprocess.PIPE if input_text is not None else asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, **(env or {})},
+    )
+    stdout, stderr = await process.communicate(
+        input_text.encode("utf-8") if input_text is not None else None
+    )
+    return (
+        process.returncode,
+        stdout.decode("utf-8", errors="replace"),
+        stderr.decode("utf-8", errors="replace"),
+    )
+
+
+class DockerCodexManagedSessionController:
+    """Launch and control managed Codex session containers via Docker CLI."""
+
+    def __init__(
+        self,
+        *,
+        workspace_volume_name: str,
+        codex_volume_name: str,
+        workspace_root: str,
+        docker_binary: str = "docker",
+        docker_host: str | None = None,
+        ready_poll_interval_seconds: float = 1.0,
+        ready_poll_attempts: int = 30,
+        command_runner: Callable[
+            [tuple[str, ...]],
+            Awaitable[tuple[int, str, str]],
+        ] = _default_command_runner,
+    ) -> None:
+        self._workspace_volume_name = workspace_volume_name
+        self._codex_volume_name = codex_volume_name
+        self._workspace_root = workspace_root
+        self._docker_binary = docker_binary
+        self._docker_host = docker_host
+        self._ready_poll_interval_seconds = ready_poll_interval_seconds
+        self._ready_poll_attempts = ready_poll_attempts
+        self._command_runner = command_runner
+
+    def _docker_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        if self._docker_host:
+            env["DOCKER_HOST"] = self._docker_host
+        return env
+
+    def _container_name(self, session_id: str) -> str:
+        sanitized = _CONTAINER_NAME_SANITIZER.sub("-", session_id).strip("-")
+        if not sanitized:
+            sanitized = "managed-session"
+        return f"mm-codex-session-{sanitized}"
+
+    async def _run(
+        self,
+        command: Sequence[str],
+        *,
+        input_text: str | None = None,
+        extra_env: Mapping[str, str] | None = None,
+    ) -> tuple[str, str]:
+        env = self._docker_env()
+        if extra_env:
+            env.update({str(key): str(value) for key, value in extra_env.items()})
+        returncode, stdout, stderr = await self._command_runner(
+            tuple(command),
+            input_text=input_text,
+            env=env,
+        )
+        if returncode != 0:
+            raise RuntimeError(
+                f"{' '.join(command)} failed with exit code {returncode}: {stderr.strip() or stdout.strip()}"
+            )
+        return stdout, stderr
+
+    async def _invoke_json(
+        self,
+        *,
+        container_id: str,
+        action: str,
+        payload: Mapping[str, Any],
+        extra_env: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        command = [
+            self._docker_binary,
+            "exec",
+            "-i",
+        ]
+        if extra_env:
+            for key, value in extra_env.items():
+                command.extend(["-e", f"{key}={value}"])
+        command.extend(
+            [
+                container_id,
+                "python3",
+                "-m",
+                _RUNTIME_MODULE,
+                "invoke",
+                action,
+            ]
+        )
+        stdout, _stderr = await self._run(
+            command,
+            input_text=json.dumps(payload),
+        )
+        return json.loads(stdout.strip() or "{}")
+
+    async def _wait_ready(self, *, container_id: str) -> None:
+        command = (
+            self._docker_binary,
+            "exec",
+            container_id,
+            "python3",
+            "-m",
+            _RUNTIME_MODULE,
+            "ready",
+        )
+        for attempt in range(self._ready_poll_attempts):
+            stdout, _stderr = await self._run(command)
+            payload = json.loads(stdout.strip() or "{}")
+            if payload.get("ready") is True:
+                return
+            if self._ready_poll_interval_seconds > 0:
+                await asyncio.sleep(self._ready_poll_interval_seconds)
+        raise RuntimeError(
+            f"managed session container {container_id} did not become ready"
+        )
+
+    async def launch_session(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> CodexManagedSessionHandle:
+        container_name = self._container_name(request.session_id)
+        run_command = [
+            self._docker_binary,
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "-v",
+            f"{self._workspace_volume_name}:{self._workspace_root}",
+            "-v",
+            f"{self._codex_volume_name}:{request.codex_home_path}",
+            "-e",
+            f"MOONMIND_SESSION_WORKSPACE_PATH={request.workspace_path}",
+            "-e",
+            f"MOONMIND_SESSION_WORKSPACE_STATE_PATH={request.session_workspace_path}",
+            "-e",
+            f"MOONMIND_SESSION_ARTIFACT_SPOOL_PATH={request.artifact_spool_path}",
+            "-e",
+            f"MOONMIND_SESSION_CODEX_HOME_PATH={request.codex_home_path}",
+            "-e",
+            f"MOONMIND_SESSION_IMAGE_REF={request.image_ref}",
+            "-e",
+            f"MOONMIND_SESSION_CONTROL_URL=docker-exec://{container_name}",
+        ]
+        for key, value in sorted(request.environment.items()):
+            run_command.extend(["-e", f"{key}={value}"])
+        run_command.extend(
+            [
+                request.image_ref,
+                "python3",
+                "-m",
+                _RUNTIME_MODULE,
+                "serve",
+            ]
+        )
+        stdout, _stderr = await self._run(run_command)
+        container_id = stdout.strip()
+        if not container_id:
+            raise RuntimeError("docker run returned a blank container id")
+        await self._wait_ready(container_id=container_id)
+        payload = await self._invoke_json(
+            container_id=container_id,
+            action="launch_session",
+            payload=request.model_dump(by_alias=True),
+            extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
+        )
+        return CodexManagedSessionHandle.model_validate(payload)
+
+    async def session_status(
+        self,
+        request: CodexManagedSessionLocator,
+    ) -> CodexManagedSessionHandle:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="session_status",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionHandle.model_validate(payload)
+
+    async def send_turn(
+        self,
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="send_turn",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionTurnResponse.model_validate(payload)
+
+    async def steer_turn(
+        self,
+        request: SteerCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="steer_turn",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionTurnResponse.model_validate(payload)
+
+    async def interrupt_turn(
+        self,
+        request: InterruptCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="interrupt_turn",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionTurnResponse.model_validate(payload)
+
+    async def clear_session(
+        self,
+        request: CodexManagedSessionClearRequest,
+    ) -> CodexManagedSessionHandle:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="clear_session",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionHandle.model_validate(payload)
+
+    async def terminate_session(
+        self,
+        request: TerminateCodexManagedSessionRequest,
+    ) -> CodexManagedSessionHandle:
+        await self._run((self._docker_binary, "rm", "-f", request.container_id))
+        return CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": request.container_id,
+                "threadId": request.thread_id,
+                "activeTurnId": None,
+            },
+            status="terminated",
+        )
+
+    async def fetch_session_summary(
+        self,
+        request: FetchCodexManagedSessionSummaryRequest,
+    ) -> CodexManagedSessionSummary:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="fetch_session_summary",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionSummary.model_validate(payload)
+
+    async def publish_session_artifacts(
+        self,
+        request: PublishCodexManagedSessionArtifactsRequest,
+    ) -> CodexManagedSessionArtifactsPublication:
+        payload = await self._invoke_json(
+            container_id=request.container_id,
+            action="publish_session_artifacts",
+            payload=request.model_dump(by_alias=True),
+        )
+        return CodexManagedSessionArtifactsPublication.model_validate(payload)

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -39,7 +39,8 @@ class CommandRunner(Protocol):
         *,
         input_text: str | None = None,
         env: dict[str, str] | None = None,
-    ) -> tuple[int, str, str]: ...
+    ) -> tuple[int, str, str]:
+        pass
 
 
 async def _default_command_runner(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import posixpath
 import re
-from typing import Any, Awaitable, Callable, Mapping, Sequence
+from pathlib import PurePosixPath
+from typing import Any, Mapping, Protocol, Sequence
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -27,11 +29,17 @@ from moonmind.schemas.managed_session_models import (
 
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
+_RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
 
-CommandRunner = Callable[
-    [tuple[str, ...]],
-    Awaitable[tuple[int, str, str]],
-]
+
+class CommandRunner(Protocol):
+    async def __call__(
+        self,
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]: ...
 
 
 async def _default_command_runner(
@@ -57,6 +65,13 @@ async def _default_command_runner(
     )
 
 
+def _normalize_absolute_posix_path(value: str, *, field_name: str) -> PurePosixPath:
+    normalized = PurePosixPath(posixpath.normpath(value))
+    if not normalized.is_absolute():
+        raise RuntimeError(f"{field_name} must be an absolute path: {value}")
+    return normalized
+
+
 class DockerCodexManagedSessionController:
     """Launch and control managed Codex session containers via Docker CLI."""
 
@@ -70,10 +85,7 @@ class DockerCodexManagedSessionController:
         docker_host: str | None = None,
         ready_poll_interval_seconds: float = 1.0,
         ready_poll_attempts: int = 30,
-        command_runner: Callable[
-            [tuple[str, ...]],
-            Awaitable[tuple[int, str, str]],
-        ] = _default_command_runner,
+        command_runner: CommandRunner = _default_command_runner,
     ) -> None:
         self._workspace_volume_name = workspace_volume_name
         self._codex_volume_name = codex_volume_name
@@ -95,6 +107,56 @@ class DockerCodexManagedSessionController:
         if not sanitized:
             sanitized = "managed-session"
         return f"mm-codex-session-{sanitized}"
+
+    def _validate_workspace_path(self, value: str, *, field_name: str) -> None:
+        workspace_root = _normalize_absolute_posix_path(
+            self._workspace_root,
+            field_name="workspace_root",
+        )
+        candidate = _normalize_absolute_posix_path(value, field_name=field_name)
+        try:
+            candidate.relative_to(workspace_root)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"{field_name} must stay within workspace_root {workspace_root}: {candidate}"
+            ) from exc
+
+    def _validate_launch_request(self, request: LaunchCodexManagedSessionRequest) -> None:
+        self._validate_workspace_path(request.workspace_path, field_name="workspacePath")
+        self._validate_workspace_path(
+            request.session_workspace_path,
+            field_name="sessionWorkspacePath",
+        )
+        self._validate_workspace_path(
+            request.artifact_spool_path,
+            field_name="artifactSpoolPath",
+        )
+        _normalize_absolute_posix_path(
+            request.codex_home_path,
+            field_name="codexHomePath",
+        )
+        reserved_keys = sorted(
+            key
+            for key in request.environment
+            if key.startswith(_RESERVED_SESSION_ENV_PREFIX)
+        )
+        if reserved_keys:
+            raise RuntimeError(
+                "launch_session environment cannot override reserved session keys: "
+                + ", ".join(reserved_keys)
+            )
+
+    async def _remove_container(
+        self,
+        container_identifier: str,
+        *,
+        ignore_failure: bool,
+    ) -> None:
+        try:
+            await self._run((self._docker_binary, "rm", "-f", container_identifier))
+        except RuntimeError:
+            if not ignore_failure:
+                raise
 
     async def _run(
         self,
@@ -159,22 +221,30 @@ class DockerCodexManagedSessionController:
             _RUNTIME_MODULE,
             "ready",
         )
+        last_error: Exception | None = None
         for attempt in range(self._ready_poll_attempts):
-            stdout, _stderr = await self._run(command)
-            payload = json.loads(stdout.strip() or "{}")
-            if payload.get("ready") is True:
-                return
+            try:
+                stdout, _stderr = await self._run(command)
+                payload = json.loads(stdout.strip() or "{}")
+            except (RuntimeError, json.JSONDecodeError) as exc:
+                last_error = exc
+            else:
+                if payload.get("ready") is True:
+                    return
             if self._ready_poll_interval_seconds > 0:
                 await asyncio.sleep(self._ready_poll_interval_seconds)
+        details = f": {last_error}" if last_error is not None else ""
         raise RuntimeError(
-            f"managed session container {container_id} did not become ready"
+            f"managed session container {container_id} did not become ready{details}"
         )
 
     async def launch_session(
         self,
         request: LaunchCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
+        self._validate_launch_request(request)
         container_name = self._container_name(request.session_id)
+        await self._remove_container(container_name, ignore_failure=True)
         run_command = [
             self._docker_binary,
             "run",
@@ -213,13 +283,17 @@ class DockerCodexManagedSessionController:
         container_id = stdout.strip()
         if not container_id:
             raise RuntimeError("docker run returned a blank container id")
-        await self._wait_ready(container_id=container_id)
-        payload = await self._invoke_json(
-            container_id=container_id,
-            action="launch_session",
-            payload=request.model_dump(by_alias=True),
-            extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
-        )
+        try:
+            await self._wait_ready(container_id=container_id)
+            payload = await self._invoke_json(
+                container_id=container_id,
+                action="launch_session",
+                payload=request.model_dump(by_alias=True),
+                extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
+            )
+        except Exception:
+            await self._remove_container(container_id, ignore_failure=True)
+            raise
         return CodexManagedSessionHandle.model_validate(payload)
 
     async def session_status(
@@ -281,7 +355,7 @@ class DockerCodexManagedSessionController:
         self,
         request: TerminateCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
-        await self._run((self._docker_binary, "rm", "-f", request.container_id))
+        await self._remove_container(request.container_id, ignore_failure=True)
         return CodexManagedSessionHandle(
             sessionState={
                 "sessionId": request.session_id,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -82,6 +82,9 @@ from moonmind.workflows.temporal.workflows.oauth_session import (
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
+from moonmind.workflows.temporal.runtime.managed_session_controller import (
+    DockerCodexManagedSessionController,
+)
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 
@@ -499,8 +502,13 @@ def _build_runtime_planner():
     return _runtime_planner
 
 
-def _build_agent_runtime_deps() -> tuple[ManagedRunStore, ManagedRunSupervisor, ManagedRuntimeLauncher]:
-    """Build shared store, supervisor, and launcher for the agent_runtime fleet."""
+def _build_agent_runtime_deps() -> tuple[
+    ManagedRunStore,
+    ManagedRunSupervisor,
+    ManagedRuntimeLauncher,
+    DockerCodexManagedSessionController,
+]:
+    """Build shared runtime dependencies for the ``agent_runtime`` fleet."""
     import os
     from pathlib import Path
 
@@ -533,7 +541,29 @@ def _build_agent_runtime_deps() -> tuple[ManagedRunStore, ManagedRunSupervisor, 
     log_streamer = RuntimeLogStreamer(artifact_storage)
     supervisor = ManagedRunSupervisor(store, log_streamer)
     launcher = ManagedRuntimeLauncher(store, log_streamer=log_streamer)
-    return store, supervisor, launcher
+    workspace_root = os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
+    workspace_volume_name = os.environ.get(
+        "MOONMIND_AGENT_WORKSPACES_VOLUME_NAME",
+        "agent_workspaces",
+    )
+    codex_volume_name = (
+        settings.workflow.codex_volume_name
+        or os.environ.get("CODEX_VOLUME_NAME")
+        or "codex_auth_volume"
+    )
+    docker_host = (
+        os.environ.get("DOCKER_HOST")
+        or os.environ.get("SYSTEM_DOCKER_HOST")
+        or "tcp://docker-proxy:2375"
+    )
+    session_controller = DockerCodexManagedSessionController(
+        workspace_volume_name=workspace_volume_name,
+        codex_volume_name=codex_volume_name,
+        workspace_root=workspace_root,
+        docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
+        docker_host=docker_host,
+    )
+    return store, supervisor, launcher, session_controller
 
 
 async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[object]]:
@@ -560,8 +590,13 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
 
         dispatcher = SkillActivityDispatcher()
 
-        # Build agent_runtime dependencies (store + supervisor + launcher)
-        run_store, run_supervisor, run_launcher = _build_agent_runtime_deps()
+        # Build agent_runtime dependencies (store + supervisor + launcher + session controller)
+        (
+            run_store,
+            run_supervisor,
+            run_launcher,
+            session_controller,
+        ) = _build_agent_runtime_deps()
         reconciled = await run_supervisor.reconcile()
         if reconciled:
             logger.info(
@@ -589,6 +624,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
                 run_store=run_store,
                 run_supervisor=run_supervisor,
                 run_launcher=run_launcher,
+                session_controller=session_controller,
             ),
             proposal_activities=TemporalProposalActivities(
                 artifact_service=artifact_service,

--- a/specs/131-codex-managed-session-plane-phase4/data-model.md
+++ b/specs/131-codex-managed-session-plane-phase4/data-model.md
@@ -1,0 +1,29 @@
+# Data Model: codex-managed-session-plane-phase4
+
+## Transitional Session Runtime State
+
+The container-side bridge persists a small JSON state document in the mounted session workspace.
+
+### Fields
+
+- `sessionId`: MoonMind task-scoped session identity.
+- `sessionEpoch`: current MoonMind epoch for the session.
+- `containerId`: Docker container id for the active session container.
+- `logicalThreadId`: MoonMind-owned logical thread id for the current epoch.
+- `vendorThreadId`: Codex app-server thread id backing the current logical thread.
+- `activeTurnId`: current in-flight turn id when one exists.
+- `launchedAt`: UTC timestamp when the session was initialized.
+- `lastControlAction`: last session action executed through the bridge.
+- `lastControlAt`: UTC timestamp of the last action.
+
+## Invariants
+
+- `sessionId` and `containerId` remain stable across `clear_session`.
+- `sessionEpoch` increments on `clear_session`.
+- `logicalThreadId` changes on `clear_session`.
+- `vendorThreadId` may change on launch and clear/reset, but it is hidden behind the logical mapping.
+- `activeTurnId` is non-null only while a turn is in progress.
+
+## Boundary Rule
+
+This state document is runtime continuity cache only. MoonMind artifacts and bounded workflow metadata remain the durable truth.

--- a/specs/131-codex-managed-session-plane-phase4/plan.md
+++ b/specs/131-codex-managed-session-plane-phase4/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: codex-managed-session-plane-phase4
+
+**Branch**: `131-codex-managed-session-plane-phase4` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/131-codex-managed-session-plane-phase4/spec.md`
+
+## Summary
+
+Implement the Phase 4 transitional launcher for the Codex managed session plane by adding a concrete Docker-backed managed-session controller, a container-side Codex app-server bridge that runs inside the launched session container, and worker bootstrap wiring that injects the controller into the `agent_runtime` activity family. The implementation stays on the container boundary and uses the current MoonMind image as a transitional session image.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing stdlib subprocess/json/http facilities, Temporal runtime activity infrastructure, Docker CLI available in the managed worker image, Codex CLI `app-server`
+**Testing**: focused pytest suites plus repo-required final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal backend runtime and worker bootstrap
+**Constraints**: no worker-local Codex execution for the new path; no new Python dependencies for transport; preserve Phase 3 typed managed-session contracts
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. MoonMind remains the orchestrator while the container owns only runtime-local Codex session state.
+- **II. One-Click Agent Deployment**: PASS. The phase reuses the existing MoonMind image and Docker proxy assumptions instead of adding a new packaging prerequisite.
+- **III. Avoid Vendor Lock-In**: PASS. The slice is Codex-specific, but isolated behind the managed-session controller boundary and image reference.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The implementation preserves the Phase 3 typed activity contracts and adds a small, replaceable session launcher/control layer.
+- **VII. Powerful Runtime Configurability**: PASS. The launched image remains a request/config input, and later switching to a dedicated image is a deployment change.
+- **VIII. Modular and Extensible Architecture**: PASS. The worker depends on a concrete controller boundary, while the container-side bridge encapsulates Codex app-server details.
+- **IX. Resilient by Default**: PASS. Launch readiness, status inspection, and termination failures remain explicit and typed; worker bootstrap tests cover the injected boundary.
+- **XI. Spec-Driven Development**: PASS. This spec/plan/tasks set tracks the Phase 4 launcher slice.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs stay desired-state only; this phase-specific plan lives under `specs/`.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The new path does not add compatibility wrappers around the local managed-runtime launcher; it adds a separate container-first implementation.
+
+## Research
+
+- `codex app-server` supports a line-delimited JSON-RPC stdio transport and can service `initialize`, `thread/start`, `turn/start`, `turn/steer`, `turn/interrupt`, and `thread/read` without extra Python websocket dependencies.
+- The current worker image already includes Docker CLI and Codex CLI, so the transitional session container can reuse the MoonMind image while keeping the session execution loop outside the main worker process.
+- Worker bootstrap currently injects `run_store`, `run_supervisor`, and `run_launcher` only. Phase 4 needs a fourth dependency: the concrete session controller.
+
+## Project Structure
+
+- Add the concrete session controller under `moonmind/workflows/temporal/runtime/` so it lives beside the existing launcher/supervisor infrastructure.
+- Add the container-side session bridge under the same runtime package because it is specific to the managed-runtime activity boundary and transitional session image.
+- Keep worker wiring in `moonmind/workflows/temporal/worker_runtime.py`.
+- Keep tests at the activity/runtime boundary and worker bootstrap boundary.
+
+## Data Model
+
+- The session runtime persists a small session-state document in the mounted session workspace.
+- The state document records:
+  - MoonMind `sessionId`
+  - current `sessionEpoch`
+  - logical MoonMind `threadId`
+  - mapped vendor-native Codex thread id
+  - current active turn id when one exists
+  - timestamps for launch and last control action
+- This state stays inside the container/session workspace and is continuity cache only, not durable truth.
+
+## Implementation Plan
+
+1. Add failing tests for a Docker-backed managed-session controller, the container-side Codex app-server bridge, and worker bootstrap injection.
+2. Implement a container-side session runtime command that:
+   - validates the mount contract on startup,
+   - writes readiness metadata,
+   - translates MoonMind control requests into `codex app-server` stdio requests,
+   - persists logical-to-vendor thread mapping in the session workspace.
+3. Implement a Docker-backed managed-session controller that:
+   - launches the session container from the provided image ref,
+   - polls readiness,
+   - executes control actions in the container boundary,
+   - maps results back into typed Phase 3 managed-session models,
+   - stops/removes the container on termination.
+4. Update worker bootstrap so `_build_agent_runtime_deps()` returns the concrete session controller and `_build_runtime_activities()` injects it into `TemporalAgentRuntimeActivities`.
+5. Run focused tests, then `./tools/test_unit.sh`, then update tasks and analysis artifacts.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+2. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Launch a session through the activity/controller boundary in a Docker-enabled environment and confirm the returned handle contains a distinct container id.
+2. Send a trivial turn and confirm the controller returns a typed response sourced from in-container Codex app-server control.
+3. Clear the session and verify the epoch advances while the container id remains unchanged.
+4. Terminate the session and verify the container is removed.

--- a/specs/131-codex-managed-session-plane-phase4/quickstart.md
+++ b/specs/131-codex-managed-session-plane-phase4/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: codex-managed-session-plane-phase4
+
+## Focused test loop
+
+Run the new launcher/runtime suites while iterating:
+
+```bash
+./tools/test_unit.sh \
+  tests/unit/services/temporal/runtime/test_managed_session_controller.py \
+  tests/unit/services/temporal/runtime/test_codex_session_runtime.py \
+  tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+```
+
+## Final verification
+
+```bash
+./tools/test_unit.sh
+```
+
+## Optional manual smoke check
+
+In a Docker-enabled worker environment:
+
+1. Call `agent_runtime.launch_session` with a `LaunchCodexManagedSessionRequest` that points at the current MoonMind image.
+2. Confirm the returned handle has `status="ready"` and a distinct `containerId`.
+3. Call `agent_runtime.send_turn` with a trivial prompt like `Reply with exactly the word OK`.
+4. Confirm the result is a typed `CodexManagedSessionTurnResponse`.
+5. Call `agent_runtime.clear_session`, then `agent_runtime.terminate_session`.

--- a/specs/131-codex-managed-session-plane-phase4/research.md
+++ b/specs/131-codex-managed-session-plane-phase4/research.md
@@ -1,0 +1,29 @@
+# Research: codex-managed-session-plane-phase4
+
+## Decision 1: Use `codex app-server` stdio transport inside the session container
+
+- **Decision**: The container-side bridge will drive Codex through `codex app-server` over stdio, not `codex exec`.
+- **Rationale**: The canonical managed-session doc freezes Codex App Server as the session protocol. The current CLI already exposes line-delimited JSON-RPC on stdio, which allows a simple bridge without adding websocket dependencies.
+- **Alternatives considered**:
+  - `codex exec --json`: rejected because the canonical desired-state doc explicitly forbids it as the primary session protocol.
+  - direct websocket client from the worker: rejected for Phase 4 because the worker environment does not currently ship websocket client dependencies, and the transport belongs behind the container-side boundary anyway.
+
+## Decision 2: Use a Docker-backed controller that executes control commands in the launched container
+
+- **Decision**: The worker-side controller will launch and inspect the session container with Docker CLI and run control actions inside the container boundary.
+- **Rationale**: This keeps the new path container-first and independent from the worker-local managed-runtime launcher.
+- **Alternatives considered**:
+  - reuse `ManagedRuntimeLauncher`: rejected because that would collapse the new path back into a worker-local subprocess loop.
+  - defer worker wiring until a later phase: rejected because the Phase 4 deliverable is the first real managed-session launcher, not just a standalone helper.
+
+## Decision 3: Keep MoonMind logical thread ids separate from vendor-native Codex thread ids
+
+- **Decision**: Persist a logical-to-vendor thread mapping in the mounted session workspace.
+- **Rationale**: Phase 3 contracts already expose MoonMind-owned `threadId` fields, while Codex app-server generates its own thread ids. A mapping lets MoonMind keep a stable orchestration-facing identity without pretending it controls Codex's native ids.
+- **Alternatives considered**:
+  - expose vendor thread ids directly as MoonMind thread ids: rejected because it leaks runtime-native identity details into MoonMind contracts and makes clear/reset flows harder to reason about.
+
+## Decision 4: Treat the current MoonMind image as transitional-only input
+
+- **Decision**: The launcher will accept the image ref from the typed request and avoid hardcoding `ghcr.io/moonladderstudios/moonmind:latest`.
+- **Rationale**: Phase 4 must prove the session-launch model while leaving the Stage A to Stage B image swap as a packaging change.

--- a/specs/131-codex-managed-session-plane-phase4/spec.md
+++ b/specs/131-codex-managed-session-plane-phase4/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: codex-managed-session-plane-phase4
+
+**Feature Branch**: `131-codex-managed-session-plane-phase4`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Implement Phase 4 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Launch A Transitional Codex Session Container (Priority: P1)
+
+The agent-runtime fleet needs to launch one task-scoped Codex session container through Docker, using the existing MoonMind image as a transitional session image, so the new path is container-first instead of worker-local.
+
+**Why this priority**: This is the architectural guardrail for the rest of the managed-session plane. If launch still falls back to a worker-local Codex process, the new path is incorrect even if later layers are added.
+
+**Independent Test**: Invoke `agent_runtime.launch_session` with a Codex managed-session request and confirm the controller launches a distinct Docker container, records the container identity, and returns a typed managed-session handle without using `ManagedRuntimeLauncher`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a launch request for a managed Codex session, **When** `agent_runtime.launch_session` runs, **Then** MoonMind launches a separate Docker container from the provided image reference and returns a typed session handle with distinct container identity.
+2. **Given** the session launch uses the current MoonMind image, **When** the controller validates the request, **Then** it treats the image as a session-container image rather than as another worker process.
+3. **Given** the worker has no session-controller implementation, **When** the activity is invoked, **Then** it fails fast instead of attempting the worker-local managed-runtime launcher path.
+
+---
+
+### User Story 2 - Control Codex Through The Session Container Boundary (Priority: P1)
+
+The session controller needs to execute Codex session actions inside the launched container, using the Codex app-server protocol from within the container, so MoonMind sends control actions to the container rather than spawning Codex locally in the worker.
+
+**Why this priority**: Phase 4 exists to prove the container boundary and control transport before a dedicated Codex image is built.
+
+**Independent Test**: Launch a session container, send a simple turn through the controller, verify the turn completes through in-container Codex app-server control, then clear and terminate the session.
+
+**Acceptance Scenarios**:
+
+1. **Given** a launched session container, **When** `send_turn` is invoked, **Then** the controller executes the request inside the session container and returns a typed turn response without launching Codex in the worker process.
+2. **Given** a launched session container, **When** `clear_session` is invoked, **Then** the controller preserves the session identity, advances the epoch, rotates the logical thread boundary, and keeps the container alive.
+3. **Given** a launched session container, **When** `terminate_session` is invoked, **Then** the controller stops and removes the session container and returns a terminal typed handle.
+
+---
+
+### User Story 3 - Bootstrap The Real Controller In The Agent Runtime Fleet (Priority: P2)
+
+The Temporal agent-runtime worker needs to construct and inject the concrete managed-session controller so the session activities use the Docker-backed path by default.
+
+**Why this priority**: The launch/controller implementation is not useful if the worker never wires it into `TemporalAgentRuntimeActivities`.
+
+**Independent Test**: Build runtime activities for the `agent_runtime` fleet and assert the concrete session controller is injected alongside the existing run store, supervisor, and launcher dependencies.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agent-runtime worker starts, **When** `_build_agent_runtime_deps()` runs, **Then** it constructs the concrete managed-session controller with Docker command execution support.
+2. **Given** runtime activity handlers are built, **When** `TemporalAgentRuntimeActivities` is instantiated, **Then** the injected `session_controller` is the concrete Docker-backed implementation.
+3. **Given** session activity methods are called through the worker, **When** control flows execute, **Then** no code path routes through `ManagedRuntimeLauncher.launch()`.
+
+### Edge Cases
+
+- Docker is unavailable or the launch command fails before the session container becomes ready.
+- The session container starts but does not satisfy the readiness contract before timeout.
+- The logical MoonMind `threadId` differs from the underlying Codex app-server thread identifier and must remain stable at the MoonMind boundary.
+- A terminate request arrives after the container has already exited or been removed.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST implement a concrete Docker-backed managed-session controller for Codex managed sessions.
+- **FR-002**: `agent_runtime.launch_session` MUST launch a separate Docker container from the `imageRef` provided in the typed request.
+- **FR-003**: The Phase 4 launcher MUST treat the existing MoonMind image as a transitional session image only; the orchestration path MUST remain image-agnostic.
+- **FR-004**: The concrete controller MUST execute session control actions against the launched container boundary and MUST NOT launch Codex locally in the worker.
+- **FR-005**: The container startup contract MUST validate and use the typed workspace mount paths: repo workspace, session workspace, artifact spool path, and Codex home path.
+- **FR-006**: The container MUST expose a readiness contract that the launcher can poll before reporting the session as ready.
+- **FR-007**: The container-side session control implementation MUST use `codex app-server` protocol semantics internally rather than `codex exec` as the primary turn transport.
+- **FR-008**: Session activity control responses MUST preserve the typed managed-session contracts already defined in Phase 3.
+- **FR-009**: `clear_session` MUST preserve `sessionId` and `containerId`, advance `sessionEpoch`, and rotate the MoonMind logical `threadId`.
+- **FR-010**: The agent-runtime worker bootstrap MUST inject the concrete session controller into `TemporalAgentRuntimeActivities`.
+
+### Key Entities
+
+- **Transitional Session Container**: A task-scoped Docker container launched from the current MoonMind image but treated as a dedicated Codex session runtime.
+- **Docker Managed Session Controller**: The worker-side implementation of the managed-session control boundary that launches, inspects, controls, and terminates session containers.
+- **Container Session Runtime**: The in-container entrypoint that validates mounts, manages readiness, and translates MoonMind control actions into Codex app-server requests.
+- **Logical Thread Mapping**: The MoonMind-owned mapping from logical `threadId` values to vendor-native Codex app-server thread identifiers.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A focused test can launch a managed session through the concrete controller and verify a distinct Docker container identity is returned.
+- **SC-002**: A focused test can send a simple turn through the launched container and receive a typed session turn response without using a worker-local Codex subprocess path.
+- **SC-003**: A focused test can clear and terminate the launched session while preserving the typed managed-session state rules.
+- **SC-004**: Worker bootstrap tests prove the agent-runtime fleet injects the concrete managed-session controller by default.

--- a/specs/131-codex-managed-session-plane-phase4/tasks.md
+++ b/specs/131-codex-managed-session-plane-phase4/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Codex Managed Session Plane Phase 4
+
+## T001 — Add TDD coverage for the transitional launcher [P]
+- [X] T001a [P] Add unit tests for the container-side Codex app-server bridge request/response flow and logical thread mapping in `tests/unit/services/temporal/runtime/test_codex_session_runtime.py`.
+- [X] T001b [P] Add unit tests for the Docker-backed managed-session controller launch/status/send-turn/clear/terminate flow in `tests/unit/services/temporal/runtime/test_managed_session_controller.py`.
+- [X] T001c [P] Extend worker bootstrap tests in `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` to assert the concrete session controller is built and injected into `TemporalAgentRuntimeActivities`.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+
+## T002 — Implement the container-side Codex session runtime [P]
+- [X] T002a [P] Add a container-session runtime module under `moonmind/workflows/temporal/runtime/` that validates the mount contract, persists runtime session state, and translates control requests into `codex app-server` stdio calls.
+- [X] T002b [P] Add a stable container startup/control entrypoint that the transitional session container can execute from the existing MoonMind image.
+- [X] T002c [P] Keep MoonMind logical thread ids stable by persisting logical-to-vendor thread mapping in the mounted session workspace.
+
+**Independent Test**: The container-side runtime tests pass without any worker-local Codex execution path.
+
+## T003 — Implement the Docker-backed managed-session controller [P]
+- [X] T003a [P] Add a concrete Docker-backed managed-session controller that launches a separate container from the request image, polls readiness, and executes session control actions against the container boundary.
+- [X] T003b [P] Return typed Phase 3 managed-session models from launch/status/send-turn/clear/terminate operations and fail fast on Docker/control errors.
+- [X] T003c [P] Ensure the controller never routes through `ManagedRuntimeLauncher.launch()`.
+
+**Independent Test**: The controller tests prove launch/status/send-turn/clear/terminate all use the container boundary and preserve the typed contract surface.
+
+## T004 — Wire the controller into the agent-runtime worker [P]
+- [X] T004a [P] Update `moonmind/workflows/temporal/worker_runtime.py` so `_build_agent_runtime_deps()` constructs the concrete session controller.
+- [X] T004b [P] Inject the concrete session controller into `TemporalAgentRuntimeActivities`.
+- [X] T004c [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Worker bootstrap tests and the full unit suite pass with the concrete controller injected.

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionClearRequest,
+    LaunchCodexManagedSessionRequest,
+    SendCodexManagedSessionTurnRequest,
+)
+from moonmind.workflows.temporal.runtime.codex_session_runtime import (
+    CodexAppServerRpcClient,
+    CodexManagedSessionRuntime,
+)
+
+
+def _write_fake_app_server(tmp_path: Path) -> Path:
+    script = tmp_path / "fake_app_server.py"
+    script.write_text(
+        """
+import json
+import sys
+
+for line in sys.stdin:
+    message = json.loads(line)
+    msg_id = message.get("id")
+    method = message.get("method")
+    if method == "initialize":
+        sys.stdout.write(json.dumps({
+            "method": "configWarning",
+            "params": {"summary": "fake-warning", "details": None},
+        }) + "\\n")
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "userAgent": "fake/0.1",
+                "codexHome": "/tmp/fake-codex-home",
+                "platformFamily": "unix",
+                "platformOs": "linux",
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/start":
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": "vendor-thread-1",
+                    "preview": "",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 1,
+                    "status": {"type": "idle"},
+                    "path": "/tmp/vendor-thread-1.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [],
+                },
+                "model": "gpt-5.4",
+                "modelProvider": "openai",
+                "serviceTier": None,
+                "cwd": "/work/repo",
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandbox": {
+                    "type": "workspaceWrite",
+                    "writableRoots": [],
+                    "readOnlyAccess": {"type": "fullAccess"},
+                    "networkAccess": False,
+                    "excludeTmpdirEnvVar": False,
+                    "excludeSlashTmp": False,
+                },
+                "reasoningEffort": "high",
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "turn/start":
+        thread_id = message["params"]["threadId"]
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
+        }) + "\\n")
+        sys.stdout.write(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": thread_id,
+                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/read":
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": "vendor-thread-1",
+                    "preview": "OK",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 2,
+                    "status": {"type": "idle"},
+                    "path": "/tmp/vendor-thread-1.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [
+                        {
+                            "id": "vendor-turn-1",
+                            "status": "completed",
+                            "error": None,
+                            "items": [
+                                {"type": "agentMessage", "id": "msg-1", "text": "OK", "phase": "final_answer", "memoryCitation": None}
+                            ],
+                        }
+                    ],
+                }
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(json.dumps({"id": msg_id, "result": {}}) + "\\n")
+        sys.stdout.flush()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return script
+
+
+def _launch_request(tmp_path: Path) -> LaunchCodexManagedSessionRequest:
+    workspace_path = tmp_path / "repo"
+    session_workspace_path = tmp_path / "session"
+    artifact_spool_path = tmp_path / "artifacts"
+    codex_home_path = tmp_path / "codex-home"
+    workspace_path.mkdir()
+    session_workspace_path.mkdir()
+    artifact_spool_path.mkdir()
+    codex_home_path.mkdir()
+    return LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(session_workspace_path),
+        artifactSpoolPath=str(artifact_spool_path),
+        codexHomePath=str(codex_home_path),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+
+def test_app_server_client_ignores_notifications_until_matching_response(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path)
+    client = CodexAppServerRpcClient(
+        command=("python3", str(script)),
+        client_name="MoonMindTest",
+        client_version="0.1",
+    )
+
+    initialized = client.initialize()
+
+    assert initialized["codexHome"] == "/tmp/fake-codex-home"
+    client.close()
+
+
+def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) -> None:
+    script = _write_fake_app_server(tmp_path)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    handle = runtime.launch_session(request)
+
+    assert handle.status == "ready"
+    assert handle.session_state.thread_id == "logical-thread-1"
+    assert handle.metadata["vendorThreadId"] == "vendor-thread-1"
+    state_payload = json.loads(
+        (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert state_payload["logicalThreadId"] == "logical-thread-1"
+    assert state_payload["vendorThreadId"] == "vendor-thread-1"
+
+
+def test_runtime_send_turn_returns_completed_response_with_assistant_text(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "OK"
+
+
+def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) -> None:
+    script = _write_fake_app_server(tmp_path)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    handle = runtime.clear_session(
+        CodexManagedSessionClearRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            newThreadId="logical-thread-2",
+        )
+    )
+
+    assert handle.status == "ready"
+    assert handle.session_state.session_epoch == 2
+    assert handle.session_state.thread_id == "logical-thread-2"
+    assert handle.metadata["vendorThreadId"] == "vendor-thread-1"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -7,27 +7,53 @@ import pytest
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
+    InterruptCodexManagedSessionTurnRequest,
     LaunchCodexManagedSessionRequest,
     SendCodexManagedSessionTurnRequest,
 )
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexAppServerRpcClient,
     CodexManagedSessionRuntime,
+    _run_ready,
 )
 
 
-def _write_fake_app_server(tmp_path: Path) -> Path:
+def _write_fake_app_server(
+    tmp_path: Path,
+    *,
+    emit_completion: bool = True,
+    interrupt_record_path: Path | None = None,
+    codex_home_record_path: Path | None = None,
+) -> Path:
     script = tmp_path / "fake_app_server.py"
-    script.write_text(
-        """
+    completion_block = """
+        sys.stdout.write(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": thread_id,
+                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
+            },
+        }) + "\\n")
+""".rstrip()
+    if not emit_completion:
+        completion_block = ""
+    script_template = """
 import json
+import os
 import sys
+
+INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
+CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
 
 for line in sys.stdin:
     message = json.loads(line)
     msg_id = message.get("id")
     method = message.get("method")
     if method == "initialize":
+        if CODEX_HOME_RECORD_PATH:
+            with open(CODEX_HOME_RECORD_PATH, "w", encoding="utf-8") as handle:
+                handle.write(sys.argv[0] + "\\n")
+                handle.write(os.environ.get("CODEX_HOME", ""))
         sys.stdout.write(json.dumps({
             "method": "configWarning",
             "params": {"summary": "fake-warning", "details": None},
@@ -88,12 +114,15 @@ for line in sys.stdin:
             "id": msg_id,
             "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
         }) + "\\n")
+__COMPLETION_BLOCK__
+        sys.stdout.flush()
+    elif method == "turn/interrupt":
+        if INTERRUPT_RECORD_PATH:
+            with open(INTERRUPT_RECORD_PATH, "w", encoding="utf-8") as handle:
+                json.dump(message["params"], handle)
         sys.stdout.write(json.dumps({
-            "method": "turn/completed",
-            "params": {
-                "threadId": thread_id,
-                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
-            },
+            "id": msg_id,
+            "result": {"status": "interrupted"},
         }) + "\\n")
         sys.stdout.flush()
     elif method == "thread/read":
@@ -133,8 +162,17 @@ for line in sys.stdin:
     else:
         sys.stdout.write(json.dumps({"id": msg_id, "result": {}}) + "\\n")
         sys.stdout.flush()
-""".strip()
-        + "\n",
+""".strip() + "\n"
+    script.write_text(
+        script_template.replace(
+            "__INTERRUPT_RECORD_PATH__",
+            repr(str(interrupt_record_path) if interrupt_record_path is not None else ""),
+        )
+        .replace(
+            "__CODEX_HOME_RECORD_PATH__",
+            repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
+        )
+        .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )
     return script
@@ -267,3 +305,126 @@ def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) 
     assert handle.session_state.session_epoch == 2
     assert handle.session_state.thread_id == "logical-thread-2"
     assert handle.metadata["vendorThreadId"] == "vendor-thread-1"
+
+
+def test_runtime_send_turn_times_out_without_completion_notification(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path, emit_completion=False)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    with pytest.raises(RuntimeError, match="timed out waiting for codex app-server"):
+        runtime.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
+
+    state_payload = json.loads(
+        (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert state_payload["activeTurnId"] == "vendor-turn-1"
+
+
+def test_runtime_interrupt_turn_uses_app_server_transport(tmp_path: Path) -> None:
+    interrupt_record_path = tmp_path / "interrupt.json"
+    script = _write_fake_app_server(
+        tmp_path,
+        interrupt_record_path=interrupt_record_path,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    state_path = Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+    state_payload["activeTurnId"] = "vendor-turn-1"
+    state_path.write_text(json.dumps(state_payload) + "\n", encoding="utf-8")
+
+    response = runtime.interrupt_turn(
+        InterruptCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            turnId="vendor-turn-1",
+            reason="operator requested interrupt",
+        )
+    )
+
+    assert response.status == "interrupted"
+    assert json.loads(interrupt_record_path.read_text(encoding="utf-8")) == {
+        "threadId": "vendor-thread-1",
+        "turnId": "vendor-turn-1",
+        "reason": "operator requested interrupt",
+    }
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated_state.get("activeTurnId") is None
+
+
+def test_runtime_launch_session_exports_codex_home(tmp_path: Path) -> None:
+    codex_home_record_path = tmp_path / "codex-home.txt"
+    script = _write_fake_app_server(
+        tmp_path,
+        codex_home_record_path=codex_home_record_path,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    runtime.launch_session(request)
+
+    assert codex_home_record_path.read_text(encoding="utf-8").splitlines()[-1] == str(
+        Path(request.codex_home_path)
+    )
+
+
+def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    workspace_path = tmp_path / "repo"
+    workspace_path.mkdir()
+    monkeypatch.setenv("MOONMIND_SESSION_WORKSPACE_PATH", str(workspace_path))
+    monkeypatch.setenv("MOONMIND_SESSION_WORKSPACE_STATE_PATH", str(tmp_path / "session"))
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("MOONMIND_SESSION_CODEX_HOME_PATH", str(tmp_path / "codex-home"))
+    monkeypatch.delenv("MOONMIND_SESSION_IMAGE_REF", raising=False)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.codex_session_runtime.shutil.which",
+        lambda _name: "/usr/bin/codex",
+    )
+
+    with pytest.raises(RuntimeError, match="MOONMIND_SESSION_IMAGE_REF is required"):
+        _run_ready()

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -40,6 +40,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
         if command[:2] == ("docker", "run"):
             return 0, "ctr-1\n", ""
         if "ready" in command:
@@ -63,7 +65,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     controller = DockerCodexManagedSessionController(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
-        workspace_root="/tmp/agent_jobs",
+        workspace_root=str(workspace_root),
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
     )
@@ -73,7 +75,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert handle.status == "ready"
     assert handle.session_state.container_id == "ctr-1"
     assert handle.metadata["vendorThreadId"] == "vendor-thread-1"
-    run_command = commands[0]
+    assert commands[0] == ("docker", "rm", "-f", "mm-codex-session-sess-1")
+    run_command = commands[1]
     assert "--name" in run_command
     assert request.image_ref in run_command
     assert "python3" in run_command
@@ -156,7 +159,7 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
             }
             return 0, json.dumps(payload), ""
         if command[:3] == ("docker", "rm", "-f"):
-            return 0, "ctr-1\n", ""
+            return 1, "", "No such container"
         raise AssertionError(f"unexpected command: {command}")
 
     controller = DockerCodexManagedSessionController(
@@ -187,3 +190,142 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
     assert cleared.session_state.session_epoch == 2
     assert terminated.status == "terminated"
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_retries_ready_probe_errors(tmp_path: Path) -> None:
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath="/tmp/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    ready_attempts = 0
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        nonlocal ready_attempts
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            ready_attempts += 1
+            if ready_attempts == 1:
+                return 1, "", "container not ready"
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+                "metadata": {"vendorThreadId": "vendor-thread-1"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+        ready_poll_attempts=2,
+    )
+
+    handle = await controller.launch_session(request)
+
+    assert handle.status == "ready"
+    assert ready_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_cleans_up_container_when_handshake_fails() -> None:
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath="/tmp/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 0, "", ""
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            return 1, "", "launch failed"
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        await controller.launch_session(request)
+
+    assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_rejects_reserved_session_environment() -> None:
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath="/tmp/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"MOONMIND_SESSION_WORKSPACE_PATH": "/tmp/override"},
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(RuntimeError, match="reserved session keys"):
+        await controller.launch_session(request)

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionClearRequest,
+    LaunchCodexManagedSessionRequest,
+    SendCodexManagedSessionTurnRequest,
+    TerminateCodexManagedSessionRequest,
+)
+from moonmind.workflows.temporal.runtime.managed_session_controller import (
+    DockerCodexManagedSessionController,
+)
+
+
+@pytest.mark.asyncio
+async def test_controller_launches_container_and_returns_typed_handle(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                },
+                "status": "ready",
+                "imageRef": "ghcr.io/moonladderstudios/moonmind:latest",
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+                "metadata": {"vendorThreadId": "vendor-thread-1"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    handle = await controller.launch_session(request)
+
+    assert handle.status == "ready"
+    assert handle.session_state.container_id == "ctr-1"
+    assert handle.metadata["vendorThreadId"] == "vendor-thread-1"
+    run_command = commands[0]
+    assert "--name" in run_command
+    assert request.image_ref in run_command
+    assert "python3" in run_command
+    assert "moonmind.workflows.temporal.runtime.codex_session_runtime" in run_command
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_executes_inside_container(tmp_path: Path) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "completed",
+                "metadata": {"assistantText": "OK"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.metadata["assistantText"] == "OK"
+    exec_command = commands[0]
+    assert exec_command[:3] == ("docker", "exec", "-i")
+    assert "send_turn" in exec_command
+
+
+@pytest.mark.asyncio
+async def test_controller_clear_and_terminate_preserve_container_boundary() -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if "clear_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 2,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-2",
+                },
+                "status": "ready",
+                "imageRef": "ghcr.io/moonladderstudios/moonmind:latest",
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        if command[:3] == ("docker", "rm", "-f"):
+            return 0, "ctr-1\n", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    cleared = await controller.clear_session(
+        CodexManagedSessionClearRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            newThreadId="logical-thread-2",
+        )
+    )
+    terminated = await controller.terminate_session(
+        TerminateCodexManagedSessionRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="logical-thread-2",
+        )
+    )
+
+    assert cleared.session_state.session_epoch == 2
+    assert terminated.status == "terminated"
+    assert commands[-1] == ("docker", "rm", "-f", "ctr-1")

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -204,7 +204,7 @@ def test_build_agent_runtime_deps_uses_artifacts_env_without_double_nesting(
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
     monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
 
-    store, supervisor, _launcher = _build_agent_runtime_deps()
+    store, supervisor, _launcher, _session_controller = _build_agent_runtime_deps()
 
     assert store.store_root == tmp_path / "managed_runs"
     assert supervisor._log_streamer._storage._root == artifacts_root
@@ -677,7 +677,13 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     run_supervisor = MagicMock()
     run_supervisor.reconcile = AsyncMock(return_value=[])
     run_launcher = MagicMock()
-    mock_build_deps.return_value = (run_store, run_supervisor, run_launcher)
+    session_controller = MagicMock()
+    mock_build_deps.return_value = (
+        run_store,
+        run_supervisor,
+        run_launcher,
+        session_controller,
+    )
     @asynccontextmanager
     async def _fake_session_context():
         yield "session"
@@ -718,6 +724,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
         run_store=ANY,
         run_supervisor=ANY,
         run_launcher=ANY,
+        session_controller=session_controller,
     )
     run_supervisor.reconcile.assert_awaited_once()
     mock_dispatcher_cls.assert_called_once_with()


### PR DESCRIPTION
## Summary

Implements Phase 4 of the Codex managed session plane MVP using the transitional launcher model.

This change adds a container-first Codex managed-session path that launches a separate Docker container from the existing MoonMind image, keeps the Codex execution loop inside that container, and controls it through a remote session contract rather than a worker-local subprocess path.

## What Changed

- added a container-side Codex session runtime that talks to `codex app-server` over stdio JSON-RPC
- persisted logical MoonMind thread identity to vendor Codex thread identity in the mounted session workspace
- added a Docker-backed managed-session controller that launches the session container, polls readiness, and executes control actions through `docker exec`
- wired the concrete session controller into `TemporalAgentRuntimeActivities` from the Temporal worker bootstrap
- added TDD coverage for the container runtime, Docker controller, and worker dependency injection seam
- added the Phase 4 spec-kit artifacts and marked the implementation tasks complete

## Why

Phase 4 exists to prove the managed-session control model before introducing a dedicated Codex image.

The root issue was that the new managed-session path needed to be explicitly container-first even while reusing the existing MoonMind image. MoonMind now launches and controls a separate session container, which keeps the orchestration semantics aligned with the later dedicated-image target.

## Impact

- managed Codex session control now has a concrete Docker-backed launcher path
- the worker no longer needs to own the Codex execution loop for the new managed-session path
- the image swap from the current MoonMind image to a future dedicated Codex session image stays an implementation/deployment concern instead of an orchestration redesign

## Validation

- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `./tools/test_unit.sh`
