### PR TITLE
Implement Codex managed session adapter

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -172,7 +172,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             session_state=session_handle.session_state,
             runtime_epoch=session_handle.session_state.session_epoch,
         )
-        instructions = self._instructions_for_request(request)
+        instructions = await self._instructions_for_request(
+            binding=binding,
+            request=request,
+        )
         turn_response = await self._coerce_turn_response(
             self._send_turn(
                 SendCodexManagedSessionTurnRequest(
@@ -507,7 +510,19 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         )
         return handle
 
-    def _instructions_for_request(self, request: AgentExecutionRequest) -> str:
+    async def _instructions_for_request(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        request: AgentExecutionRequest,
+    ) -> str:
+        workspace_path = Path(self._workspace_path_for_request(binding=binding, request=request))
+        if str(request.instruction_ref or "").strip():
+            from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+                CodexCliStrategy,
+            )
+
+            await CodexCliStrategy().prepare_workspace(workspace_path, request)
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
             return instruction_ref

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -1,0 +1,756 @@
+"""Workflow-side adapter for managed Codex task-scoped sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunState,
+    AgentRunStatus,
+    ManagedRunRecord,
+)
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionBinding,
+    CodexManagedSessionClearRequest,
+    CodexManagedSessionHandle,
+    CodexManagedSessionLocator,
+    CodexManagedSessionSnapshot,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+    FetchCodexManagedSessionSummaryRequest,
+    InterruptCodexManagedSessionTurnRequest,
+    LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
+    SendCodexManagedSessionTurnRequest,
+    TerminateCodexManagedSessionRequest,
+    canonical_codex_managed_runtime_id,
+)
+from moonmind.workflows.adapters.managed_agent_adapter import (
+    ManagedAgentAdapter,
+    build_managed_profile_launch_context,
+)
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+SessionSnapshotLoader = Callable[
+    [str], Awaitable[CodexManagedSessionSnapshot | Mapping[str, Any]]
+]
+SessionHandleSignaler = Callable[[dict[str, Any]], Awaitable[None]]
+SessionControlSignaler = Callable[[dict[str, Any]], Awaitable[None]]
+LaunchSessionFunc = Callable[
+    [LaunchCodexManagedSessionRequest], Awaitable[CodexManagedSessionHandle | Mapping[str, Any]]
+]
+SessionStatusFunc = Callable[
+    [CodexManagedSessionLocator], Awaitable[CodexManagedSessionHandle | Mapping[str, Any]]
+]
+SendTurnFunc = Callable[
+    [SendCodexManagedSessionTurnRequest],
+    Awaitable[CodexManagedSessionTurnResponse | Mapping[str, Any]],
+]
+InterruptTurnFunc = Callable[
+    [InterruptCodexManagedSessionTurnRequest],
+    Awaitable[CodexManagedSessionTurnResponse | Mapping[str, Any]],
+]
+ClearSessionFunc = Callable[
+    [CodexManagedSessionClearRequest],
+    Awaitable[CodexManagedSessionHandle | Mapping[str, Any]],
+]
+TerminateSessionFunc = Callable[
+    [TerminateCodexManagedSessionRequest],
+    Awaitable[CodexManagedSessionHandle | Mapping[str, Any]],
+]
+FetchSummaryFunc = Callable[
+    [FetchCodexManagedSessionSummaryRequest],
+    Awaitable[CodexManagedSessionSummary | Mapping[str, Any]],
+]
+PublishArtifactsFunc = Callable[
+    [PublishCodexManagedSessionArtifactsRequest],
+    Awaitable[CodexManagedSessionArtifactsPublication | Mapping[str, Any]],
+]
+
+
+class CodexSessionExecutionState(BaseModel):
+    """Persisted step-scoped execution state for one session-backed managed run."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    run_id: str = Field(..., alias="runId")
+    workflow_id: str = Field(..., alias="workflowId")
+    agent_id: str = Field(..., alias="agentId")
+    runtime_id: str = Field(..., alias="runtimeId")
+    status: AgentRunState = Field(..., alias="status")
+    started_at: datetime = Field(..., alias="startedAt")
+    finished_at: datetime | None = Field(None, alias="finishedAt")
+    locator: CodexManagedSessionLocator = Field(..., alias="locator")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
+    profile_id: str | None = Field(None, alias="profileId")
+    result: AgentRunResult = Field(..., alias="result")
+
+
+class CodexSessionAdapter(ManagedAgentAdapter):
+    """Managed-session-backed ``AgentAdapter`` for Codex."""
+
+    def __init__(
+        self,
+        *,
+        load_session_snapshot: SessionSnapshotLoader,
+        launch_session: LaunchSessionFunc,
+        session_status: SessionStatusFunc,
+        send_turn: SendTurnFunc,
+        interrupt_turn: InterruptTurnFunc,
+        clear_remote_session: ClearSessionFunc,
+        terminate_remote_session: TerminateSessionFunc,
+        fetch_remote_summary: FetchSummaryFunc,
+        publish_remote_artifacts: PublishArtifactsFunc,
+        attach_runtime_handles: SessionHandleSignaler,
+        apply_session_control_action: SessionControlSignaler,
+        workspace_root: str,
+        session_image_ref: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._load_session_snapshot = load_session_snapshot
+        self._launch_session = launch_session
+        self._session_status = session_status
+        self._send_turn = send_turn
+        self._interrupt_turn = interrupt_turn
+        self._clear_remote_session = clear_remote_session
+        self._terminate_remote_session = terminate_remote_session
+        self._fetch_remote_summary = fetch_remote_summary
+        self._publish_remote_artifacts = publish_remote_artifacts
+        self._attach_runtime_handles = attach_runtime_handles
+        self._apply_session_control_action = apply_session_control_action
+        self._workspace_root = Path(workspace_root).resolve()
+        self._session_image_ref = str(session_image_ref).strip()
+        if self._run_store is None:
+            raise ValueError("CodexSessionAdapter requires run_store")
+
+    async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+        binding = self._require_binding(request)
+        runtime_id = self._runtime_id or canonical_codex_managed_runtime_id(request.agent_id)
+        if runtime_id is None:
+            raise ValueError("CodexSessionAdapter only supports managed Codex runtimes")
+        profile = await self._resolve_profile(
+            execution_profile_ref=request.execution_profile_ref,
+            runtime_id=runtime_id,
+            profile_selector=(
+                request.profile_selector.model_dump(by_alias=True, exclude_none=True)
+                if request.profile_selector
+                else None
+            ),
+        )
+        default_credential_source = "oauth_volume"
+        launch_context = build_managed_profile_launch_context(
+            profile=profile,
+            runtime_for_profile=runtime_id,
+            workflow_id=self._workflow_id,
+            default_credential_source=default_credential_source,
+        )
+        self._active_profile_id = launch_context.profile_id or None
+
+        run_id = str(uuid4())
+        started_at = datetime.now(tz=UTC)
+        session_handle = await self._ensure_remote_session(
+            binding=binding,
+            request=request,
+            environment=launch_context.delta_env_overrides,
+        )
+        locator = self._locator_from_state(
+            session_state=session_handle.session_state,
+            runtime_epoch=session_handle.session_state.session_epoch,
+        )
+        instructions = self._instructions_for_request(request)
+        turn_response = await self._coerce_turn_response(
+            self._send_turn(
+                SendCodexManagedSessionTurnRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    instructions=instructions,
+                    inputRefs=tuple(request.input_refs),
+                    metadata={
+                        "correlationId": request.correlation_id,
+                        "idempotencyKey": request.idempotency_key,
+                    },
+                )
+            )
+        )
+        await self._signal_control_action(
+            action="send_turn",
+            reason=None,
+            container_id=turn_response.session_state.container_id,
+            thread_id=turn_response.session_state.thread_id,
+            active_turn_id=turn_response.turn_id,
+        )
+
+        current_locator = self._locator_from_state(
+            session_state=turn_response.session_state,
+            runtime_epoch=turn_response.session_state.session_epoch,
+        )
+        summary = await self.fetch_session_summary(binding=binding, locator=current_locator)
+        publication = await self._coerce_publication(
+            self._publish_remote_artifacts(
+                PublishCodexManagedSessionArtifactsRequest(
+                    sessionId=current_locator.session_id,
+                    sessionEpoch=current_locator.session_epoch,
+                    containerId=current_locator.container_id,
+                    threadId=current_locator.thread_id,
+                    taskRunId=binding.task_run_id,
+                    metadata={"runId": run_id, "workflowId": self._workflow_id},
+                )
+            )
+        )
+
+        assistant_text = str(
+            turn_response.metadata.get("assistantText")
+            or summary.metadata.get("lastAssistantText")
+            or ""
+        ).strip() or "Codex managed-session turn completed."
+        output_refs = self._merge_output_refs(
+            turn_response.output_refs,
+            publication.published_artifact_refs,
+        )
+        result = AgentRunResult(
+            outputRefs=output_refs,
+            summary=assistant_text,
+            metadata={
+                "sessionSummary": summary.model_dump(mode="json", by_alias=True),
+                "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
+                "turnId": turn_response.turn_id,
+            },
+        )
+        finished_at = datetime.now(tz=UTC)
+        self._save_run_state(
+            run_id=run_id,
+            agent_id=request.agent_id,
+            locator=current_locator.model_dump(mode="json", by_alias=True),
+            active_turn_id=None,
+            result=result.model_dump(mode="json", by_alias=True),
+            status="completed",
+            started_at=started_at,
+            finished_at=finished_at,
+            profile_id=launch_context.profile_id or None,
+        )
+        self._run_store.save(
+            ManagedRunRecord(
+                runId=run_id,
+                workflowId=self._workflow_id,
+                agentId=request.agent_id,
+                runtimeId=runtime_id,
+                status="completed",
+                startedAt=started_at,
+                finishedAt=finished_at,
+                workspacePath=self._workspace_path_for_request(
+                    binding=binding,
+                    request=request,
+                ),
+                errorMessage=assistant_text,
+            )
+        )
+        return AgentRunHandle(
+            runId=run_id,
+            agentKind="managed",
+            agentId=request.agent_id,
+            status="completed",
+            startedAt=started_at,
+            metadata={
+                "profile_id": launch_context.profile_id,
+                "credential_source": launch_context.credential_source,
+                "env_keys_count": len(launch_context.shaped_env),
+                "sessionId": current_locator.session_id,
+                "sessionEpoch": current_locator.session_epoch,
+                "containerId": current_locator.container_id,
+            },
+        )
+
+    async def status(self, run_id: str) -> AgentRunStatus:
+        state = self._load_run_state(run_id)
+        if state is not None:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId=state.agent_id,
+                status=state.status,
+                metadata={
+                    "runtimeId": state.runtime_id,
+                    "sessionId": state.locator.session_id,
+                    "containerId": state.locator.container_id,
+                },
+            )
+        record = self._run_store.load(run_id)
+        if record is not None:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId=record.agent_id,
+                status=record.status,
+                metadata={"runtimeId": record.runtime_id},
+            )
+        return AgentRunStatus(
+            runId=run_id,
+            agentKind="managed",
+            agentId="codex",
+            status="running",
+        )
+
+    async def fetch_result(
+        self,
+        run_id: str,
+        *,
+        pr_resolver_expected: bool = False,
+    ) -> AgentRunResult:
+        del pr_resolver_expected
+        state = self._load_run_state(run_id)
+        if state is not None:
+            return state.result
+        return AgentRunResult(
+            summary="Codex managed-session result not found.",
+            failureClass="execution_error",
+        )
+
+    async def cancel(self, run_id: str) -> AgentRunStatus:
+        state = self._load_run_state(run_id)
+        if state is None:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="canceled",
+            )
+        if state.active_turn_id:
+            response = await self._coerce_turn_response(
+                self._interrupt_turn(
+                    InterruptCodexManagedSessionTurnRequest(
+                        sessionId=state.locator.session_id,
+                        sessionEpoch=state.locator.session_epoch,
+                        containerId=state.locator.container_id,
+                        threadId=state.locator.thread_id,
+                        turnId=state.active_turn_id,
+                        reason="step canceled",
+                    )
+                )
+            )
+            await self._signal_control_action(
+                action="interrupt_turn",
+                reason="step canceled",
+                container_id=response.session_state.container_id,
+                thread_id=response.session_state.thread_id,
+                active_turn_id=response.turn_id,
+            )
+
+        canceled_result = AgentRunResult(
+            summary="Canceled Codex managed-session turn.",
+            failureClass="user_error",
+            metadata=state.result.metadata,
+        )
+        finished_at = datetime.now(tz=UTC)
+        self._save_run_state(
+            run_id=state.run_id,
+            agent_id=state.agent_id,
+            locator=state.locator.model_dump(mode="json", by_alias=True),
+            active_turn_id=None,
+            result=canceled_result.model_dump(mode="json", by_alias=True),
+            status="canceled",
+            started_at=state.started_at,
+            finished_at=finished_at,
+            profile_id=state.profile_id,
+        )
+        record = self._run_store.load(run_id)
+        if record is None:
+            self._run_store.save(
+                ManagedRunRecord(
+                    runId=run_id,
+                    workflowId=self._workflow_id,
+                    agentId=state.agent_id,
+                    runtimeId=state.runtime_id,
+                    status="canceled",
+                    startedAt=state.started_at,
+                    finishedAt=finished_at,
+                    errorMessage=canceled_result.summary,
+                    failureClass=canceled_result.failure_class,
+                )
+            )
+        else:
+            self._run_store.update_status(
+                run_id,
+                "canceled",
+                finished_at=finished_at,
+                error_message=canceled_result.summary,
+                failure_class=canceled_result.failure_class,
+            )
+        return AgentRunStatus(
+            runId=run_id,
+            agentKind="managed",
+            agentId=state.agent_id,
+            status="canceled",
+            metadata={"runtimeId": state.runtime_id},
+        )
+
+    async def clear_session(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        new_thread_id: str,
+        reason: str | None = None,
+    ) -> CodexManagedSessionHandle:
+        locator = await self._current_locator(binding)
+        handle = await self._coerce_handle(
+            self._clear_remote_session(
+                CodexManagedSessionClearRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    newThreadId=new_thread_id,
+                    reason=reason,
+                )
+            )
+        )
+        await self._attach_runtime_handles(
+            {
+                "containerId": handle.session_state.container_id,
+                "threadId": handle.session_state.thread_id,
+            }
+        )
+        await self._signal_control_action(
+            action="clear_session",
+            reason=reason,
+            container_id=handle.session_state.container_id,
+            thread_id=handle.session_state.thread_id,
+        )
+        return handle
+
+    async def interrupt_turn(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        turn_id: str,
+        reason: str | None = None,
+    ) -> CodexManagedSessionTurnResponse:
+        locator = await self._current_locator(binding)
+        response = await self._coerce_turn_response(
+            self._interrupt_turn(
+                InterruptCodexManagedSessionTurnRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    turnId=turn_id,
+                    reason=reason,
+                )
+            )
+        )
+        await self._signal_control_action(
+            action="interrupt_turn",
+            reason=reason,
+            container_id=response.session_state.container_id,
+            thread_id=response.session_state.thread_id,
+            active_turn_id=response.turn_id,
+        )
+        return response
+
+    async def fetch_session_summary(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        locator: CodexManagedSessionLocator | None = None,
+    ) -> CodexManagedSessionSummary:
+        active_locator = locator or await self._current_locator(binding)
+        return await self._coerce_summary(
+            self._fetch_remote_summary(
+                FetchCodexManagedSessionSummaryRequest(
+                    sessionId=active_locator.session_id,
+                    sessionEpoch=active_locator.session_epoch,
+                    containerId=active_locator.container_id,
+                    threadId=active_locator.thread_id,
+                )
+            )
+        )
+
+    async def terminate_session(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        reason: str | None = None,
+    ) -> CodexManagedSessionHandle:
+        locator = await self._current_locator(binding)
+        handle = await self._coerce_handle(
+            self._terminate_remote_session(
+                TerminateCodexManagedSessionRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    reason=reason,
+                )
+            )
+        )
+        await self._apply_session_control_action(
+            {
+                "action": "terminate_session",
+                "reason": reason,
+            }
+        )
+        return handle
+
+    def _instructions_for_request(self, request: AgentExecutionRequest) -> str:
+        instruction_ref = str(request.instruction_ref or "").strip()
+        if instruction_ref:
+            return instruction_ref
+        parameters = request.parameters if isinstance(request.parameters, dict) else {}
+        instructions = str(parameters.get("instructions") or "").strip()
+        if instructions:
+            return instructions
+        raise ValueError("CodexSessionAdapter requires instructionRef or parameters.instructions")
+
+    def _require_binding(self, request: AgentExecutionRequest) -> CodexManagedSessionBinding:
+        binding = request.managed_session
+        if binding is None:
+            raise ValueError("CodexSessionAdapter requires request.managed_session")
+        return binding
+
+    async def _ensure_remote_session(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        request: AgentExecutionRequest,
+        environment: dict[str, str],
+    ) -> CodexManagedSessionHandle:
+        snapshot = await self._load_snapshot(binding.workflow_id)
+        if snapshot.container_id and snapshot.thread_id:
+            return await self._coerce_handle(
+                self._session_status(
+                    CodexManagedSessionLocator(
+                        sessionId=binding.session_id,
+                        sessionEpoch=snapshot.binding.session_epoch,
+                        containerId=snapshot.container_id,
+                        threadId=snapshot.thread_id,
+                    )
+                )
+            )
+
+        launch_request = LaunchCodexManagedSessionRequest(
+            taskRunId=binding.task_run_id,
+            workflowId=self._workflow_id,
+            sessionId=binding.session_id,
+            sessionEpoch=binding.session_epoch,
+            threadId=self._default_thread_id(binding),
+            workspacePath=self._workspace_path_for_request(binding=binding, request=request),
+            sessionWorkspacePath=str(self._session_root(binding) / "session"),
+            artifactSpoolPath=str(self._session_root(binding) / "artifacts"),
+            codexHomePath=str(self._session_root(binding) / ".moonmind" / "codex-home"),
+            imageRef=self._session_image_ref,
+            environment=environment,
+        )
+        handle = await self._coerce_handle(self._launch_session(launch_request))
+        await self._attach_runtime_handles(
+            {
+                "containerId": handle.session_state.container_id,
+                "threadId": handle.session_state.thread_id,
+            }
+        )
+        return handle
+
+    async def _current_locator(
+        self, binding: CodexManagedSessionBinding
+    ) -> CodexManagedSessionLocator:
+        snapshot = await self._load_snapshot(binding.workflow_id)
+        if not snapshot.container_id or not snapshot.thread_id:
+            raise ValueError("Task-scoped managed session has no runtime handles yet")
+        return CodexManagedSessionLocator(
+            sessionId=binding.session_id,
+            sessionEpoch=snapshot.binding.session_epoch,
+            containerId=snapshot.container_id,
+            threadId=snapshot.thread_id,
+        )
+
+    async def _signal_control_action(
+        self,
+        *,
+        action: str,
+        reason: str | None,
+        container_id: str | None,
+        thread_id: str | None,
+        active_turn_id: str | None = None,
+    ) -> None:
+        payload: dict[str, Any] = {"action": action}
+        if reason is not None:
+            payload["reason"] = reason
+        if container_id is not None:
+            payload["containerId"] = container_id
+        if thread_id is not None:
+            payload["threadId"] = thread_id
+        if active_turn_id is not None:
+            payload["activeTurnId"] = active_turn_id
+        await self._apply_session_control_action(payload)
+
+    def _workspace_path_for_request(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        request: AgentExecutionRequest,
+    ) -> str:
+        workspace_spec = request.workspace_spec if isinstance(request.workspace_spec, dict) else {}
+        for key in (
+            "workspacePath",
+            "workspace_path",
+            "path",
+            "repoPath",
+            "repo_path",
+        ):
+            raw_value = workspace_spec.get(key)
+            if isinstance(raw_value, str) and raw_value.strip():
+                return raw_value.strip()
+        return str(self._session_root(binding) / "repo")
+
+    def _session_root(self, binding: CodexManagedSessionBinding) -> Path:
+        return self._workspace_root / binding.task_run_id
+
+    def _default_thread_id(self, binding: CodexManagedSessionBinding) -> str:
+        return f"thread:{binding.session_id}:{binding.session_epoch}"
+
+    def _state_path(self, run_id: str) -> Path:
+        suffix_id = f"{run_id}.codex-session"
+        return self._run_store._resolve_path(suffix_id)  # type: ignore[attr-defined]
+
+    def _load_run_state(self, run_id: str) -> CodexSessionExecutionState | None:
+        path = self._state_path(run_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return CodexSessionExecutionState.model_validate(payload)
+
+    def _persist_state(self, state: CodexSessionExecutionState) -> None:
+        path = self._state_path(state.run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state.model_dump(mode="json", by_alias=True), handle)
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _save_run_state(
+        self,
+        *,
+        run_id: str,
+        agent_id: str,
+        locator: Mapping[str, Any],
+        active_turn_id: str | None,
+        result: Mapping[str, Any],
+        status: AgentRunState,
+        started_at: datetime,
+        finished_at: datetime | None = None,
+        profile_id: str | None = None,
+    ) -> None:
+        self._persist_state(
+            CodexSessionExecutionState(
+                runId=run_id,
+                workflowId=self._workflow_id,
+                agentId=agent_id,
+                runtimeId=self._runtime_id or "codex_cli",
+                status=status,
+                startedAt=started_at,
+                finishedAt=finished_at,
+                locator=locator,
+                activeTurnId=active_turn_id,
+                profileId=profile_id,
+                result=result,
+            )
+        )
+
+    def _merge_output_refs(self, *groups: Any) -> list[str]:
+        seen: list[str] = []
+        for group in groups:
+            for raw_ref in group or ():
+                ref = str(raw_ref).strip()
+                if ref and ref not in seen:
+                    seen.append(ref)
+        return seen
+
+    def _locator_from_state(
+        self,
+        *,
+        session_state: Any,
+        runtime_epoch: int,
+    ) -> CodexManagedSessionLocator:
+        return CodexManagedSessionLocator(
+            sessionId=session_state.session_id,
+            sessionEpoch=runtime_epoch,
+            containerId=session_state.container_id,
+            threadId=session_state.thread_id,
+        )
+
+    async def _load_snapshot(self, workflow_id: str) -> CodexManagedSessionSnapshot:
+        payload = await self._load_session_snapshot(workflow_id)
+        return (
+            payload
+            if isinstance(payload, CodexManagedSessionSnapshot)
+            else CodexManagedSessionSnapshot.model_validate(payload)
+        )
+
+    async def _coerce_handle(
+        self,
+        awaited: Awaitable[CodexManagedSessionHandle | Mapping[str, Any]],
+    ) -> CodexManagedSessionHandle:
+        payload = await awaited
+        return (
+            payload
+            if isinstance(payload, CodexManagedSessionHandle)
+            else CodexManagedSessionHandle.model_validate(payload)
+        )
+
+    async def _coerce_turn_response(
+        self,
+        awaited: Awaitable[CodexManagedSessionTurnResponse | Mapping[str, Any]],
+    ) -> CodexManagedSessionTurnResponse:
+        payload = await awaited
+        return (
+            payload
+            if isinstance(payload, CodexManagedSessionTurnResponse)
+            else CodexManagedSessionTurnResponse.model_validate(payload)
+        )
+
+    async def _coerce_summary(
+        self,
+        awaited: Awaitable[CodexManagedSessionSummary | Mapping[str, Any]],
+    ) -> CodexManagedSessionSummary:
+        payload = await awaited
+        return (
+            payload
+            if isinstance(payload, CodexManagedSessionSummary)
+            else CodexManagedSessionSummary.model_validate(payload)
+        )
+
+    async def _coerce_publication(
+        self,
+        awaited: Awaitable[CodexManagedSessionArtifactsPublication | Mapping[str, Any]],
+    ) -> CodexManagedSessionArtifactsPublication:
+        payload = await awaited
+        return (
+            payload
+            if isinstance(payload, CodexManagedSessionArtifactsPublication)
+            else CodexManagedSessionArtifactsPublication.model_validate(payload)
+        )
+
+
+__all__ = ["CodexSessionAdapter", "CodexSessionExecutionState"]

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import json
-import os
-import tempfile
 from collections.abc import Awaitable, Callable, Mapping
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,7 +15,6 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunResult,
     AgentRunState,
     AgentRunStatus,
-    ManagedRunRecord,
 )
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -40,9 +35,12 @@ from moonmind.schemas.managed_session_models import (
 )
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
+    ManagedProfileLaunchContext,
+    _current_time,
+    _generate_run_id,
     build_managed_profile_launch_context,
+    default_credential_source_for_runtime,
 )
-from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
 
 SessionSnapshotLoader = Callable[
@@ -135,8 +133,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._apply_session_control_action = apply_session_control_action
         self._workspace_root = Path(workspace_root).resolve()
         self._session_image_ref = str(session_image_ref).strip()
-        if self._run_store is None:
-            raise ValueError("CodexSessionAdapter requires run_store")
+        self._run_states: dict[str, CodexSessionExecutionState] = {}
 
     async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
         binding = self._require_binding(request)
@@ -152,17 +149,30 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 else None
             ),
         )
-        default_credential_source = "oauth_volume"
-        launch_context = build_managed_profile_launch_context(
-            profile=profile,
-            runtime_for_profile=runtime_id,
-            workflow_id=self._workflow_id,
-            default_credential_source=default_credential_source,
-        )
+        default_credential_source = default_credential_source_for_runtime(runtime_id)
+        if self._launch_context_builder is not None:
+            built_context = await self._launch_context_builder(
+                profile=profile,
+                runtime_for_profile=runtime_id,
+                workflow_id=self._workflow_id,
+                default_credential_source=default_credential_source,
+            )
+            launch_context = (
+                built_context
+                if isinstance(built_context, ManagedProfileLaunchContext)
+                else ManagedProfileLaunchContext(**built_context)
+            )
+        else:
+            launch_context = build_managed_profile_launch_context(
+                profile=profile,
+                runtime_for_profile=runtime_id,
+                workflow_id=self._workflow_id,
+                default_credential_source=default_credential_source,
+            )
         self._active_profile_id = launch_context.profile_id or None
 
-        run_id = str(uuid4())
-        started_at = datetime.now(tz=UTC)
+        run_id = _generate_run_id()
+        started_at = _current_time()
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -197,7 +207,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             reason=None,
             container_id=turn_response.session_state.container_id,
             thread_id=turn_response.session_state.thread_id,
-            active_turn_id=turn_response.turn_id,
         )
 
         current_locator = self._locator_from_state(
@@ -236,7 +245,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 "turnId": turn_response.turn_id,
             },
         )
-        finished_at = datetime.now(tz=UTC)
+        finished_at = _current_time()
         self._save_run_state(
             run_id=run_id,
             agent_id=request.agent_id,
@@ -248,22 +257,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             finished_at=finished_at,
             profile_id=launch_context.profile_id or None,
         )
-        self._run_store.save(
-            ManagedRunRecord(
-                runId=run_id,
-                workflowId=self._workflow_id,
-                agentId=request.agent_id,
-                runtimeId=runtime_id,
-                status="completed",
-                startedAt=started_at,
-                finishedAt=finished_at,
-                workspacePath=self._workspace_path_for_request(
-                    binding=binding,
-                    request=request,
-                ),
-                errorMessage=assistant_text,
-            )
-        )
         return AgentRunHandle(
             runId=run_id,
             agentKind="managed",
@@ -273,7 +266,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             metadata={
                 "profile_id": launch_context.profile_id,
                 "credential_source": launch_context.credential_source,
-                "env_keys_count": len(launch_context.shaped_env),
+                "env_keys_count": launch_context.env_keys_count,
                 "sessionId": current_locator.session_id,
                 "sessionEpoch": current_locator.session_epoch,
                 "containerId": current_locator.container_id,
@@ -293,15 +286,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     "sessionId": state.locator.session_id,
                     "containerId": state.locator.container_id,
                 },
-            )
-        record = self._run_store.load(run_id)
-        if record is not None:
-            return AgentRunStatus(
-                runId=run_id,
-                agentKind="managed",
-                agentId=record.agent_id,
-                status=record.status,
-                metadata={"runtimeId": record.runtime_id},
             )
         return AgentRunStatus(
             runId=run_id,
@@ -360,7 +344,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             failureClass="user_error",
             metadata=state.result.metadata,
         )
-        finished_at = datetime.now(tz=UTC)
+        finished_at = _current_time()
         self._save_run_state(
             run_id=state.run_id,
             agent_id=state.agent_id,
@@ -372,29 +356,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             finished_at=finished_at,
             profile_id=state.profile_id,
         )
-        record = self._run_store.load(run_id)
-        if record is None:
-            self._run_store.save(
-                ManagedRunRecord(
-                    runId=run_id,
-                    workflowId=self._workflow_id,
-                    agentId=state.agent_id,
-                    runtimeId=state.runtime_id,
-                    status="canceled",
-                    startedAt=state.started_at,
-                    finishedAt=finished_at,
-                    errorMessage=canceled_result.summary,
-                    failureClass=canceled_result.failure_class,
-                )
-            )
-        else:
-            self._run_store.update_status(
-                run_id,
-                "canceled",
-                finished_at=finished_at,
-                error_message=canceled_result.summary,
-                failure_class=canceled_result.failure_class,
-            )
         return AgentRunStatus(
             runId=run_id,
             agentKind="managed",
@@ -558,12 +519,13 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 )
             )
 
+        active_binding = snapshot.binding
         launch_request = LaunchCodexManagedSessionRequest(
-            taskRunId=binding.task_run_id,
+            taskRunId=active_binding.task_run_id,
             workflowId=self._workflow_id,
-            sessionId=binding.session_id,
-            sessionEpoch=binding.session_epoch,
-            threadId=self._default_thread_id(binding),
+            sessionId=active_binding.session_id,
+            sessionEpoch=active_binding.session_epoch,
+            threadId=self._default_thread_id(active_binding),
             workspacePath=self._workspace_path_for_request(binding=binding, request=request),
             sessionWorkspacePath=str(self._session_root(binding) / "session"),
             artifactSpoolPath=str(self._session_root(binding) / "artifacts"),
@@ -638,31 +600,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
     def _default_thread_id(self, binding: CodexManagedSessionBinding) -> str:
         return f"thread:{binding.session_id}:{binding.session_epoch}"
 
-    def _state_path(self, run_id: str) -> Path:
-        suffix_id = f"{run_id}.codex-session"
-        return self._run_store._resolve_path(suffix_id)  # type: ignore[attr-defined]
-
     def _load_run_state(self, run_id: str) -> CodexSessionExecutionState | None:
-        path = self._state_path(run_id)
-        if not path.exists():
-            return None
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        return CodexSessionExecutionState.model_validate(payload)
-
-    def _persist_state(self, state: CodexSessionExecutionState) -> None:
-        path = self._state_path(state.run_id)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                json.dump(state.model_dump(mode="json", by_alias=True), handle)
-            os.replace(tmp_path, path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+        return self._run_states.get(run_id)
 
     def _save_run_state(
         self,
@@ -677,20 +616,18 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         finished_at: datetime | None = None,
         profile_id: str | None = None,
     ) -> None:
-        self._persist_state(
-            CodexSessionExecutionState(
-                runId=run_id,
-                workflowId=self._workflow_id,
-                agentId=agent_id,
-                runtimeId=self._runtime_id or "codex_cli",
-                status=status,
-                startedAt=started_at,
-                finishedAt=finished_at,
-                locator=locator,
-                activeTurnId=active_turn_id,
-                profileId=profile_id,
-                result=result,
-            )
+        self._run_states[run_id] = CodexSessionExecutionState(
+            runId=run_id,
+            workflowId=self._workflow_id,
+            agentId=agent_id,
+            runtimeId=self._runtime_id or "codex_cli",
+            status=status,
+            startedAt=started_at,
+            finishedAt=finished_at,
+            locator=locator,
+            activeTurnId=active_turn_id,
+            profileId=profile_id,
+            result=result,
         )
 
     def _merge_output_refs(self, *groups: Any) -> list[str]:

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -35,6 +34,8 @@ from typing import Any
 from uuid import uuid4
 
 from moonmind.schemas.agent_runtime_models import (
+    _ALLOWED_MANAGED_LAUNCH_METADATA_KEYS,
+    _contains_sensitive_key,
     AgentExecutionRequest,
     AgentRunHandle,
     AgentRunResult,
@@ -44,10 +45,7 @@ from moonmind.schemas.agent_runtime_models import (
     TERMINAL_AGENT_RUN_STATES,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
-from moonmind.auth.env_shaping import (
-    OAUTH_CLEARED_VARS,
-    _should_filter_base_env_var,
-)
+from moonmind.auth.env_shaping import OAUTH_CLEARED_VARS
 from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 
 logger = logging.getLogger(__name__)
@@ -78,8 +76,18 @@ class ManagedProfileLaunchContext:
     profile_id: str
     credential_source: str
     delta_env_overrides: dict[str, str]
-    shaped_env: dict[str, str]
     passthrough_env_keys: list[str]
+    env_keys_count: int
+
+
+def default_credential_source_for_runtime(runtime_id: str) -> str:
+    """Return the deterministic default credential source for one runtime."""
+
+    from moonmind.workflows.temporal.runtime.strategies import get_strategy
+
+    strategy = get_strategy(runtime_id)
+    default_auth = strategy.default_auth_mode if strategy is not None else "api_key"
+    return "oauth_volume" if default_auth == "oauth" else "secret_ref"
 
 
 def build_managed_profile_launch_context(
@@ -89,61 +97,21 @@ def build_managed_profile_launch_context(
     workflow_id: str,
     default_credential_source: str,
 ) -> ManagedProfileLaunchContext:
-    """Build the shared launch-time environment context for one profile."""
+    """Build deterministic launch metadata safe to compute in workflow code."""
 
-    del runtime_for_profile  # Reserved for future profile-strategy shaping.
-    credential_source: str = profile.get(
-        "credential_source", default_credential_source
-    )
-
-    base_env = {
-        k: v for k, v in os.environ.items()
-        if not _should_filter_base_env_var(k)
-    }
-    tags = profile.get("tags") or []
-    is_proxy_first = "proxy-first" in tags
-
+    del runtime_for_profile, workflow_id  # Reserved for activity-side shaping.
+    credential_source = str(
+        profile.get("credential_source") or default_credential_source
+    ).strip() or default_credential_source
     delta_env_overrides: dict[str, str] = {}
-
-    if is_proxy_first:
-        import time
-        from cryptography.fernet import Fernet
-        from api_service.core.encryption import get_encryption_key
-
-        provider = str(profile.get("provider_id") or "anthropic").strip().lower()
-        payload_bytes = json.dumps(
-            {
-                "provider": provider,
-                "workflow_id": workflow_id,
-                "secret_refs": profile.get("secret_refs", {}),
-                "exp": time.time() + 3600,
-            }
-        ).encode("utf-8")
-
-        fernet = Fernet(get_encryption_key().encode("utf-8"))
-        proxy_token = "mm-proxy-token:" + fernet.encrypt(payload_bytes).decode("utf-8")
-        api_url = os.environ.get(
-            "MOONMIND_PROXY_URL",
-            "http://moonmind-api:8000/api/v1/proxy",
-        )
-
-        delta_env_overrides["MOONMIND_PROXY_TOKEN"] = proxy_token
-
-        if provider in {"anthropic", "minimax"}:
-            delta_env_overrides["ANTHROPIC_BASE_URL"] = f"{api_url}/{provider}"
-            delta_env_overrides["ANTHROPIC_API_KEY"] = proxy_token
-            delta_env_overrides["ANTHROPIC_AUTH_TOKEN"] = proxy_token
-        elif provider == "openai":
-            delta_env_overrides["OPENAI_BASE_URL"] = f"{api_url}/openai/v1"
-            delta_env_overrides["OPENAI_API_KEY"] = proxy_token
 
     volume_mount_path = profile.get("volume_mount_path")
     if volume_mount_path:
-        delta_env_overrides["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
+        delta_env_overrides["MANAGED_AUTH_VOLUME_PATH"] = str(volume_mount_path)
 
     account_label = profile.get("account_label")
     if account_label:
-        delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = account_label
+        delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = str(account_label)
 
     runtime_env_overrides = profile.get("runtime_env_overrides") or {}
     if isinstance(runtime_env_overrides, dict):
@@ -151,26 +119,48 @@ def build_managed_profile_launch_context(
             ks = str(key).strip()
             if not ks:
                 continue
-            is_safe_proxy_var = is_proxy_first and (
-                ks == "MOONMIND_PROXY_TOKEN" or ks.endswith("_BASE_URL")
-            )
-            if not _should_filter_base_env_var(ks) or is_safe_proxy_var:
-                delta_env_overrides[ks] = str(value) if value is not None else ""
+            if _contains_sensitive_key(
+                {ks: value},
+                allowed_sensitive_keys=_ALLOWED_MANAGED_LAUNCH_METADATA_KEYS,
+            ):
+                continue
+            delta_env_overrides[ks] = str(value) if value is not None else ""
 
-    shaped_env = base_env.copy()
-    shaped_env.update(delta_env_overrides)
-    passthrough_env_keys = [
-        key
-        for key in _SECRET_ENV_PASSTHROUGH_KEYS
-        if str(os.environ.get(key, "")).strip()
-    ]
+    passthrough_env_keys = list(_SECRET_ENV_PASSTHROUGH_KEYS)
     return ManagedProfileLaunchContext(
         profile_id=str(profile.get("profile_id") or "").strip(),
         credential_source=credential_source,
         delta_env_overrides=delta_env_overrides,
-        shaped_env=shaped_env,
         passthrough_env_keys=passthrough_env_keys,
+        env_keys_count=len(delta_env_overrides) + len(passthrough_env_keys),
     )
+
+
+def _in_workflow_context() -> bool:
+    try:
+        from temporalio import workflow
+    except ImportError:
+        return False
+    try:
+        return workflow.in_workflow()
+    except RuntimeError:
+        return False
+
+
+def _generate_run_id() -> str:
+    if _in_workflow_context():
+        from temporalio import workflow
+
+        return str(workflow.uuid4())
+    return str(uuid4())
+
+
+def _current_time() -> datetime:
+    if _in_workflow_context():
+        from temporalio import workflow
+
+        return workflow.now()
+    return datetime.now(tz=UTC)
 
 
 def _load_json_dict(path: Path) -> dict[str, Any] | None:
@@ -253,6 +243,7 @@ SlotRequestFunc = Callable[..., Awaitable[Any]]
 SlotReleaseFunc = Callable[..., Awaitable[Any]]
 CooldownReportFunc = Callable[..., Awaitable[Any]]
 RunLauncherFunc = Callable[..., Awaitable[Any]]
+LaunchContextBuilderFunc = Callable[..., Awaitable[ManagedProfileLaunchContext | dict[str, Any]]]
 
 
 
@@ -329,6 +320,7 @@ class ManagedAgentAdapter:
         runtime_id: str | None = None,
         run_store: ManagedRunStore | None = None,
         run_launcher: RunLauncherFunc | None = None,
+        launch_context_builder: LaunchContextBuilderFunc | None = None,
     ) -> None:
         self._fetch_profiles = profile_fetcher
         self._request_slot = slot_requester
@@ -338,6 +330,7 @@ class ManagedAgentAdapter:
         self._runtime_id = runtime_id
         self._run_store = run_store
         self._run_launcher = run_launcher
+        self._launch_context_builder = launch_context_builder
         self._active_profile_id: str | None = None
 
     # ------------------------------------------------------------------
@@ -364,39 +357,38 @@ class ManagedAgentAdapter:
         from moonmind.workflows.temporal.runtime.strategies import get_strategy
 
         _strategy = get_strategy(runtime_for_profile)
-
-        default_auth = (
-            _strategy.default_auth_mode
-            if _strategy is not None
-            else "api_key"
+        default_credential_source = default_credential_source_for_runtime(
+            runtime_for_profile
         )
-        # Map legacy strategy auth_mode values to credential_source equivalents.
-        default_credential_source = (
-            "oauth_volume" if default_auth == "oauth" else "secret_ref"
-        )
-        launch_context = build_managed_profile_launch_context(
-            profile=profile,
-            runtime_for_profile=runtime_for_profile,
-            workflow_id=self._workflow_id,
-            default_credential_source=default_credential_source,
-        )
+        if self._launch_context_builder is not None:
+            built_context = await self._launch_context_builder(
+                profile=profile,
+                runtime_for_profile=runtime_for_profile,
+                workflow_id=self._workflow_id,
+                default_credential_source=default_credential_source,
+            )
+            launch_context = (
+                built_context
+                if isinstance(built_context, ManagedProfileLaunchContext)
+                else ManagedProfileLaunchContext(**built_context)
+            )
+        else:
+            launch_context = build_managed_profile_launch_context(
+                profile=profile,
+                runtime_for_profile=runtime_for_profile,
+                workflow_id=self._workflow_id,
+                default_credential_source=default_credential_source,
+            )
         credential_source = launch_context.credential_source
         delta_env_overrides = launch_context.delta_env_overrides
-        shaped_env = launch_context.shaped_env
         passthrough_env_keys = launch_context.passthrough_env_keys
 
         # Persist only the profile_id reference — never raw credentials
         # (DOC-REQ-008 / constitution security rule).
         self._active_profile_id = launch_context.profile_id
         
-        try:
-            from temporalio import workflow
-            if workflow.in_workflow():
-                run_id = str(workflow.uuid4())
-            else:
-                run_id = str(uuid4())
-        except ImportError:
-            run_id = str(uuid4())
+        run_id = _generate_run_id()
+        started_at = _current_time()
 
         # NOTE: Slot acquisition is handled by AgentRun before adapter.start()
         # is called.  Do NOT request a slot here — a duplicate request_slot
@@ -463,7 +455,7 @@ class ManagedAgentAdapter:
                 agent_id=request.agent_id,
                 runtime_id=self._runtime_id or request.agent_id,
                 status="launching",
-                started_at=datetime.now(tz=UTC),
+                started_at=started_at,
             )
             self._run_store.save(record)
             status = "launching"
@@ -481,11 +473,11 @@ class ManagedAgentAdapter:
                 agentKind="managed",
                 agentId=request.agent_id,
                 status=status,
-                startedAt=datetime.now(tz=UTC),
+                startedAt=started_at,
                 metadata={
                 "profile_id": launch_context.profile_id,
                 "credential_source": credential_source,
-                "env_keys_count": len(shaped_env),
+                "env_keys_count": launch_context.env_keys_count,
             },
         )
 

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -45,7 +45,6 @@ from moonmind.schemas.agent_runtime_models import (
     TERMINAL_AGENT_RUN_STATES,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
-from moonmind.auth.env_shaping import OAUTH_CLEARED_VARS
 from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 
 logger = logging.getLogger(__name__)

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -68,6 +69,108 @@ _PR_RESOLVER_FAILURE_STATUSES: frozenset[str] = frozenset(
 _PR_RESOLVER_BLOCKED_STATUSES: frozenset[str] = frozenset(
     {"blocked", "attempts_exhausted"}
 )
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedProfileLaunchContext:
+    """Resolved managed-profile launch context shared across adapters."""
+
+    profile_id: str
+    credential_source: str
+    delta_env_overrides: dict[str, str]
+    shaped_env: dict[str, str]
+    passthrough_env_keys: list[str]
+
+
+def build_managed_profile_launch_context(
+    *,
+    profile: dict[str, Any],
+    runtime_for_profile: str,
+    workflow_id: str,
+    default_credential_source: str,
+) -> ManagedProfileLaunchContext:
+    """Build the shared launch-time environment context for one profile."""
+
+    del runtime_for_profile  # Reserved for future profile-strategy shaping.
+    credential_source: str = profile.get(
+        "credential_source", default_credential_source
+    )
+
+    base_env = {
+        k: v for k, v in os.environ.items()
+        if not _should_filter_base_env_var(k)
+    }
+    tags = profile.get("tags") or []
+    is_proxy_first = "proxy-first" in tags
+
+    delta_env_overrides: dict[str, str] = {}
+
+    if is_proxy_first:
+        import time
+        from cryptography.fernet import Fernet
+        from api_service.core.encryption import get_encryption_key
+
+        provider = str(profile.get("provider_id") or "anthropic").strip().lower()
+        payload_bytes = json.dumps(
+            {
+                "provider": provider,
+                "workflow_id": workflow_id,
+                "secret_refs": profile.get("secret_refs", {}),
+                "exp": time.time() + 3600,
+            }
+        ).encode("utf-8")
+
+        fernet = Fernet(get_encryption_key().encode("utf-8"))
+        proxy_token = "mm-proxy-token:" + fernet.encrypt(payload_bytes).decode("utf-8")
+        api_url = os.environ.get(
+            "MOONMIND_PROXY_URL",
+            "http://moonmind-api:8000/api/v1/proxy",
+        )
+
+        delta_env_overrides["MOONMIND_PROXY_TOKEN"] = proxy_token
+
+        if provider in {"anthropic", "minimax"}:
+            delta_env_overrides["ANTHROPIC_BASE_URL"] = f"{api_url}/{provider}"
+            delta_env_overrides["ANTHROPIC_API_KEY"] = proxy_token
+            delta_env_overrides["ANTHROPIC_AUTH_TOKEN"] = proxy_token
+        elif provider == "openai":
+            delta_env_overrides["OPENAI_BASE_URL"] = f"{api_url}/openai/v1"
+            delta_env_overrides["OPENAI_API_KEY"] = proxy_token
+
+    volume_mount_path = profile.get("volume_mount_path")
+    if volume_mount_path:
+        delta_env_overrides["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
+
+    account_label = profile.get("account_label")
+    if account_label:
+        delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = account_label
+
+    runtime_env_overrides = profile.get("runtime_env_overrides") or {}
+    if isinstance(runtime_env_overrides, dict):
+        for key, value in runtime_env_overrides.items():
+            ks = str(key).strip()
+            if not ks:
+                continue
+            is_safe_proxy_var = is_proxy_first and (
+                ks == "MOONMIND_PROXY_TOKEN" or ks.endswith("_BASE_URL")
+            )
+            if not _should_filter_base_env_var(ks) or is_safe_proxy_var:
+                delta_env_overrides[ks] = str(value) if value is not None else ""
+
+    shaped_env = base_env.copy()
+    shaped_env.update(delta_env_overrides)
+    passthrough_env_keys = [
+        key
+        for key in _SECRET_ENV_PASSTHROUGH_KEYS
+        if str(os.environ.get(key, "")).strip()
+    ]
+    return ManagedProfileLaunchContext(
+        profile_id=str(profile.get("profile_id") or "").strip(),
+        credential_source=credential_source,
+        delta_env_overrides=delta_env_overrides,
+        shaped_env=shaped_env,
+        passthrough_env_keys=passthrough_env_keys,
+    )
 
 
 def _load_json_dict(path: Path) -> dict[str, Any] | None:
@@ -271,102 +374,20 @@ class ManagedAgentAdapter:
         default_credential_source = (
             "oauth_volume" if default_auth == "oauth" else "secret_ref"
         )
-        credential_source: str = profile.get(
-            "credential_source", default_credential_source
+        launch_context = build_managed_profile_launch_context(
+            profile=profile,
+            runtime_for_profile=runtime_for_profile,
+            workflow_id=self._workflow_id,
+            default_credential_source=default_credential_source,
         )
-
-        # Build a safe delta-only env_overrides dict for ManagedRuntimeProfile.
-        #
-        # The launcher (launcher.py) already starts from os.environ and then
-        # overlays env_overrides on top.  Therefore env_overrides MUST contain
-        # only the profile-specific delta keys — never the full base environment.
-        # Passing the entire shaped_env (which inherits os.environ) would cause
-        # the ManagedRuntimeProfile validator to reject any sensitive-named env
-        # vars that the profile legitimately reads from the ambient environment
-        # (e.g. ANTHROPIC_AUTH_TOKEN, MINIMAX_API_KEY).
-        #
-        # The full shaped_env is still computed below for use in env_keys_count
-        # metadata only.
-        base_env = {
-            k: v for k, v in os.environ.items()
-            if not _should_filter_base_env_var(k)
-        }
-        # Determine if we should use proxy-first token injection instead of 
-        # distributing the raw secret_ref downstream.
-        tags = profile.get("tags") or []
-        is_proxy_first = "proxy-first" in tags
-        
-        # delta_env_overrides: only the safe profile-specific additions.
-        delta_env_overrides: dict[str, str] = {}
-        
-        if is_proxy_first:
-            import time
-            from cryptography.fernet import Fernet
-            from api_service.core.encryption import get_encryption_key
-            
-            provider = str(profile.get("provider_id") or "anthropic").strip().lower()
-            
-            # Mint a synthetic proxy token to authorize internal routes without leaking the true DB secret
-            payload_bytes = json.dumps({
-                "provider": provider,
-                "workflow_id": self._workflow_id,
-                "secret_refs": profile.get("secret_refs", {}),
-                "exp": time.time() + 3600  # 1 hour expiration for proxied tokens
-            }).encode("utf-8")
-            
-            fernet = Fernet(get_encryption_key().encode("utf-8"))
-            proxy_token = "mm-proxy-token:" + fernet.encrypt(payload_bytes).decode("utf-8")
-            
-            api_url = os.environ.get("MOONMIND_PROXY_URL", "http://moonmind-api:8000/api/v1/proxy")
-            
-            # Inject standard proxy variables into the delta block directly for the worker
-            delta_env_overrides["MOONMIND_PROXY_TOKEN"] = proxy_token
-            
-            if provider == "anthropic" or provider == "minimax":
-                delta_env_overrides["ANTHROPIC_BASE_URL"] = f"{api_url}/{provider}"
-                delta_env_overrides["ANTHROPIC_API_KEY"] = proxy_token
-                delta_env_overrides["ANTHROPIC_AUTH_TOKEN"] = proxy_token
-            elif provider == "openai":
-                delta_env_overrides["OPENAI_BASE_URL"] = f"{api_url}/openai/v1"
-                delta_env_overrides["OPENAI_API_KEY"] = proxy_token
-
-        # Phase 4: Removed auth_mode branching and shape_environment_* calls.
-        # Ensure base environment variables from proxy and runtime overrides are preserved.
-        volume_mount_path = profile.get("volume_mount_path")
-        if volume_mount_path:
-            delta_env_overrides["MANAGED_AUTH_VOLUME_PATH"] = volume_mount_path
-
-        account_label = profile.get("account_label")
-        if account_label:
-            delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = account_label
-
-        runtime_env_overrides = profile.get("runtime_env_overrides") or {}
-        if isinstance(runtime_env_overrides, dict):
-            for key, value in runtime_env_overrides.items():
-                ks = str(key).strip()
-                if not ks:
-                    continue
-                # Only propagate non-sensitive runtime_env_overrides keys
-                # into delta_env_overrides so they reach the launcher.
-                is_safe_proxy_var = is_proxy_first and (
-                    ks == "MOONMIND_PROXY_TOKEN" or ks.endswith("_BASE_URL")
-                )
-                if not _should_filter_base_env_var(ks) or is_safe_proxy_var:
-                    delta_env_overrides[ks] = str(value) if value is not None else ""
-
-        # We construct shaped_env purely for the metadata count metric, matching the old behavior
-        # where it included base_env + delta.
-        shaped_env = base_env.copy()
-        shaped_env.update(delta_env_overrides)
-        passthrough_env_keys = [
-            key
-            for key in _SECRET_ENV_PASSTHROUGH_KEYS
-            if str(os.environ.get(key, "")).strip()
-        ]
+        credential_source = launch_context.credential_source
+        delta_env_overrides = launch_context.delta_env_overrides
+        shaped_env = launch_context.shaped_env
+        passthrough_env_keys = launch_context.passthrough_env_keys
 
         # Persist only the profile_id reference — never raw credentials
         # (DOC-REQ-008 / constitution security rule).
-        self._active_profile_id = profile_id
+        self._active_profile_id = launch_context.profile_id
         
         try:
             from temporalio import workflow
@@ -456,13 +477,13 @@ class ManagedAgentAdapter:
             self._workflow_id,
         )
         return AgentRunHandle(
-            runId=run_id,
-            agentKind="managed",
-            agentId=request.agent_id,
-            status=status,
-            startedAt=datetime.now(tz=UTC),
-            metadata={
-                "profile_id": profile_id,
+                runId=run_id,
+                agentKind="managed",
+                agentId=request.agent_id,
+                status=status,
+                startedAt=datetime.now(tz=UTC),
+                metadata={
+                "profile_id": launch_context.profile_id,
                 "credential_source": credential_source,
                 "env_keys_count": len(shaped_env),
             },
@@ -687,10 +708,12 @@ class ManagedAgentAdapter:
 
 __all__ = [
     "ManagedAgentAdapter",
+    "ManagedProfileLaunchContext",
     "ProfileResolutionError",
     "ProfileFetcherFunc",
     "SlotRequestFunc",
     "SlotReleaseFunc",
     "CooldownReportFunc",
+    "build_managed_profile_launch_context",
 
 ]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -735,6 +735,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.build_launch_context",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 180),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.launch",
             family="agent_runtime",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -28,7 +28,12 @@ from moonmind.schemas.temporal_activity_models import (
 )
 from moonmind.workflows.tasks.routing import _coerce_bool
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
-from moonmind.workflows.adapters.managed_agent_adapter import ManagedAgentAdapter
+from moonmind.auth.env_shaping import _should_filter_base_env_var
+from moonmind.workflows.adapters.managed_agent_adapter import (
+    ManagedAgentAdapter,
+    ManagedProfileLaunchContext,
+    build_managed_profile_launch_context,
+)
 from moonmind.utils.logging import SecretRedactor
 from moonmind.workflows.adapters.jules_agent_adapter import JulesAgentAdapter
 from moonmind.workflows.adapters.codex_cloud_agent_adapter import CodexCloudAgentAdapter
@@ -345,6 +350,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     # General-purpose repo operations (provider-agnostic)
     "repo.create_pr": ("integrations", "repo_create_pr"),
     "repo.merge_pr": ("integrations", "repo_merge_pr"),
+    "agent_runtime.build_launch_context": (
+        "agent_runtime",
+        "agent_runtime_build_launch_context",
+    ),
     "agent_runtime.launch": ("agent_runtime", "agent_runtime_launch"),
     "agent_runtime.launch_session": ("agent_runtime", "agent_runtime_launch_session"),
     "integration.codex_cloud.start": ("integrations", "integration_codex_cloud_start"),
@@ -2260,6 +2269,94 @@ class TemporalAgentRuntimeActivities:
                 run_id,
                 exc_info=True,
             )
+
+    async def agent_runtime_build_launch_context(
+        self,
+        payload: Mapping[str, Any],
+        /,
+    ) -> dict[str, Any]:
+        """Build managed launch context on the activity side."""
+
+        profile_raw = payload.get("profile")
+        if not isinstance(profile_raw, Mapping):
+            raise TemporalActivityRuntimeError(
+                "payload.profile is required for agent_runtime.build_launch_context"
+            )
+        runtime_for_profile = str(payload.get("runtime_for_profile") or "").strip()
+        workflow_id = str(payload.get("workflow_id") or "").strip()
+        default_credential_source = str(
+            payload.get("default_credential_source")
+            or payload.get("defaultCredentialSource")
+            or ""
+        ).strip()
+        if not runtime_for_profile or not workflow_id or not default_credential_source:
+            raise TemporalActivityRuntimeError(
+                "payload must include runtime_for_profile, workflow_id, and default_credential_source"
+            )
+
+        profile = dict(profile_raw)
+        context = build_managed_profile_launch_context(
+            profile=profile,
+            runtime_for_profile=runtime_for_profile,
+            workflow_id=workflow_id,
+            default_credential_source=default_credential_source,
+        )
+        delta_env_overrides = dict(context.delta_env_overrides)
+        tags = profile.get("tags") or []
+        if "proxy-first" in tags:
+            from cryptography.fernet import Fernet
+
+            from api_service.core.encryption import get_encryption_key
+
+            provider = str(profile.get("provider_id") or "anthropic").strip().lower()
+            payload_bytes = json.dumps(
+                {
+                    "provider": provider,
+                    "workflow_id": workflow_id,
+                    "secret_refs": profile.get("secret_refs", {}),
+                    "exp": time.time() + 3600,
+                }
+            ).encode("utf-8")
+            fernet = Fernet(get_encryption_key().encode("utf-8"))
+            proxy_token = "mm-proxy-token:" + fernet.encrypt(payload_bytes).decode(
+                "utf-8"
+            )
+            api_url = os.environ.get(
+                "MOONMIND_PROXY_URL",
+                "http://moonmind-api:8000/api/v1/proxy",
+            )
+            delta_env_overrides["MOONMIND_PROXY_TOKEN"] = proxy_token
+            if provider in {"anthropic", "minimax"}:
+                delta_env_overrides["ANTHROPIC_BASE_URL"] = f"{api_url}/{provider}"
+                delta_env_overrides["ANTHROPIC_API_KEY"] = proxy_token
+                delta_env_overrides["ANTHROPIC_AUTH_TOKEN"] = proxy_token
+            elif provider == "openai":
+                delta_env_overrides["OPENAI_BASE_URL"] = f"{api_url}/openai/v1"
+                delta_env_overrides["OPENAI_API_KEY"] = proxy_token
+
+        passthrough_env_keys = [
+            key
+            for key in context.passthrough_env_keys
+            if str(os.environ.get(key, "")).strip()
+        ]
+        combined_env_keys = {
+            key for key in os.environ if not _should_filter_base_env_var(key)
+        }
+        combined_env_keys.update(delta_env_overrides)
+        result = ManagedProfileLaunchContext(
+            profile_id=context.profile_id,
+            credential_source=context.credential_source,
+            delta_env_overrides=delta_env_overrides,
+            passthrough_env_keys=passthrough_env_keys,
+            env_keys_count=len(combined_env_keys),
+        )
+        return {
+            "profile_id": result.profile_id,
+            "credential_source": result.credential_source,
+            "delta_env_overrides": result.delta_env_overrides,
+            "passthrough_env_keys": result.passthrough_env_keys,
+            "env_keys_count": result.env_keys_count,
+        }
 
     async def agent_runtime_launch(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -106,6 +106,14 @@ DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 _SLOT_WAIT_TIMEOUT_SECONDS = 120
 _SLOT_WAIT_MAX_RESETS = 3
 _DEFAULT_MANAGED_429_RETRY_DELAY_SECONDS = 900
+_MANAGED_RUNTIME_STORE_ROOT = os.environ.get(
+    "MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"
+)
+_MANAGED_RUN_STORE_ROOT = os.path.join(_MANAGED_RUNTIME_STORE_ROOT, "managed_runs")
+_DEFAULT_SESSION_IMAGE_REF = os.environ.get(
+    "WORKFLOW_JOB_IMAGE",
+    "ghcr.io/moonladderstudios/moonmind:latest",
+)
 
 
 def _request_selected_skill(request: AgentExecutionRequest) -> str | None:
@@ -885,11 +893,14 @@ class MoonMindAgentRun:
                             cancellation_type=ActivityCancellationType.TRY_CANCEL,
                         )
 
-                    store_root = os.path.join(
-                        os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
-                        "managed_runs",
-                    )
-                    run_store = ManagedRunStore(store_root)
+                    async def _launch_context_builder(**kw):
+                        return await self._execute_routed_activity(
+                            "agent_runtime.build_launch_context",
+                            kw,
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        )
+
+                    run_store = ManagedRunStore(_MANAGED_RUN_STORE_ROOT)
 
                     if uses_codex_session_adapter:
                         if request.managed_session is None:
@@ -988,14 +999,9 @@ class MoonMindAgentRun:
                             publish_remote_artifacts=_publish_session_artifacts,
                             attach_runtime_handles=_attach_runtime_handles,
                             apply_session_control_action=_apply_session_control_action,
-                            workspace_root=os.environ.get(
-                                "MOONMIND_AGENT_RUNTIME_STORE",
-                                "/work/agent_jobs",
-                            ),
-                            session_image_ref=os.environ.get(
-                                "WORKFLOW_JOB_IMAGE",
-                                "ghcr.io/moonladderstudios/moonmind:latest",
-                            ),
+                            workspace_root=_MANAGED_RUNTIME_STORE_ROOT,
+                            session_image_ref=_DEFAULT_SESSION_IMAGE_REF,
+                            launch_context_builder=_launch_context_builder,
                         )
                     else:
                         adapter = ManagedAgentAdapter(
@@ -1007,6 +1013,7 @@ class MoonMindAgentRun:
                             runtime_id=runtime_id,
                             run_store=run_store,
                             run_launcher=_run_launcher,
+                            launch_context_builder=_launch_context_builder,
                         )
 
                     # --- Managed agent: launch via adapter ---
@@ -1021,6 +1028,12 @@ class MoonMindAgentRun:
                     self.run_id = handle.run_id
                     self.run_status = handle.status
                     poll_interval = handle.poll_hint_seconds or 10
+                    if (
+                        uses_codex_session_adapter
+                        and handle.status in _TERMINAL_RUN_STATUSES
+                    ):
+                        self.final_result = await adapter.fetch_result(handle.run_id)
+                        skip_poll_and_fetch = True
 
                 elif request.agent_kind == "external":
                     # Validate adapter availability and resolve execution style.

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -21,6 +21,9 @@ with workflow.unsafe.imports_passed_through():
         ManagedAgentAdapter,
         ProfileResolutionError,
     )
+    from moonmind.workflows.adapters.codex_session_adapter import (
+        CodexSessionAdapter,
+    )
     from moonmind.workflows.adapters.external_adapter_registry import (
         build_default_registry,
     )
@@ -315,6 +318,10 @@ class MoonMindAgentRun:
             by_alias=True,
         )
         return result.model_copy(update={"metadata": metadata})
+
+    @staticmethod
+    def _uses_codex_session_adapter(request: AgentExecutionRequest) -> bool:
+        return request.agent_kind == "managed" and request.managed_session is not None
 
     async def _ensure_manager_and_signal(
         self,
@@ -681,6 +688,7 @@ class MoonMindAgentRun:
         try:
             while True:
                 skip_poll_and_fetch = False
+                uses_codex_session_adapter = self._uses_codex_session_adapter(request)
                 elapsed = (workflow.now() - overall_start).total_seconds()
                 if elapsed >= timeout_seconds:
                     self.run_status = RunStatus.timed_out
@@ -883,16 +891,123 @@ class MoonMindAgentRun:
                     )
                     run_store = ManagedRunStore(store_root)
 
-                    adapter: AgentAdapter = ManagedAgentAdapter(
-                        profile_fetcher=_profile_fetcher,
-                        slot_requester=_slot_requester,
-                        slot_releaser=_slot_releaser,
-                        cooldown_reporter=_cooldown_reporter,
-                        workflow_id=wf_id,
-                        runtime_id=runtime_id,
-                        run_store=run_store,
-                        run_launcher=_run_launcher,
-                    )
+                    if uses_codex_session_adapter:
+                        if request.managed_session is None:
+                            raise ApplicationError(
+                                "managedSession is required for Codex session-backed runs",
+                                type="MissingManagedSession",
+                                non_retryable=True,
+                            )
+                        session_workflow_id = request.managed_session.workflow_id
+                        session_handle = workflow.get_external_workflow_handle(
+                            session_workflow_id
+                        )
+
+                        async def _load_session_snapshot(workflow_id: str) -> dict[str, Any]:
+                            handle = workflow.get_external_workflow_handle(workflow_id)
+                            return await handle.query("get_status")
+
+                        async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+                            await session_handle.signal("attach_runtime_handles", payload)
+
+                        async def _apply_session_control_action(payload: dict[str, Any]) -> None:
+                            await session_handle.signal("control_action", payload)
+
+                        async def _launch_session(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.launch_session",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _session_status(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.session_status",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _send_turn(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.send_turn",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _interrupt_turn(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.interrupt_turn",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _clear_session(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.clear_session",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _terminate_session(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.terminate_session",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _fetch_session_summary(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.fetch_session_summary",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        async def _publish_session_artifacts(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.publish_session_artifacts",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
+                        adapter = CodexSessionAdapter(
+                            profile_fetcher=_profile_fetcher,
+                            slot_requester=_slot_requester,
+                            slot_releaser=_slot_releaser,
+                            cooldown_reporter=_cooldown_reporter,
+                            workflow_id=wf_id,
+                            runtime_id=runtime_id,
+                            run_store=run_store,
+                            load_session_snapshot=_load_session_snapshot,
+                            launch_session=_launch_session,
+                            session_status=_session_status,
+                            send_turn=_send_turn,
+                            interrupt_turn=_interrupt_turn,
+                            clear_remote_session=_clear_session,
+                            terminate_remote_session=_terminate_session,
+                            fetch_remote_summary=_fetch_session_summary,
+                            publish_remote_artifacts=_publish_session_artifacts,
+                            attach_runtime_handles=_attach_runtime_handles,
+                            apply_session_control_action=_apply_session_control_action,
+                            workspace_root=os.environ.get(
+                                "MOONMIND_AGENT_RUNTIME_STORE",
+                                "/work/agent_jobs",
+                            ),
+                            session_image_ref=os.environ.get(
+                                "WORKFLOW_JOB_IMAGE",
+                                "ghcr.io/moonladderstudios/moonmind:latest",
+                            ),
+                        )
+                    else:
+                        adapter = ManagedAgentAdapter(
+                            profile_fetcher=_profile_fetcher,
+                            slot_requester=_slot_requester,
+                            slot_releaser=_slot_releaser,
+                            cooldown_reporter=_cooldown_reporter,
+                            workflow_id=wf_id,
+                            runtime_id=runtime_id,
+                            run_store=run_store,
+                            run_launcher=_run_launcher,
+                        )
 
                     # --- Managed agent: launch via adapter ---
                     try:
@@ -1030,7 +1145,9 @@ class MoonMindAgentRun:
                                     fallback_agent_id=request.agent_id,
                                 )
                             else:
-                                if use_managed_status_activity:
+                                if uses_codex_session_adapter:
+                                    status_obj = await adapter.status(self.run_id)
+                                elif use_managed_status_activity:
                                     status_payload = await self._execute_routed_activity(
                                         "agent_runtime.status",
                                         {
@@ -1155,7 +1272,9 @@ class MoonMindAgentRun:
                         )
                         self.final_result = AgentRunResult(**result_dict) if isinstance(result_dict, dict) else result_dict
                     else:
-                        if use_managed_status_activity:
+                        if uses_codex_session_adapter:
+                            self.final_result = await adapter.fetch_result(self.run_id)
+                        elif use_managed_status_activity:
                             raw_publish_mode = (request.parameters or {}).get("publishMode")
                             publish_mode = str(raw_publish_mode).strip().lower() if isinstance(raw_publish_mode, str) and raw_publish_mode.strip() else "none"
                             params = request.parameters or {}

--- a/specs/132-codex-managed-session-plane-phase5/plan.md
+++ b/specs/132-codex-managed-session-plane-phase5/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: codex-managed-session-plane-phase5
+
+**Branch**: `132-codex-managed-session-plane-phase5` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/132-codex-managed-session-plane-phase5/spec.md`
+
+## Summary
+
+Implement the Phase 5 Codex session adapter slice by adding a workflow-side `CodexSessionAdapter`, persisting canonical step results for session-backed managed Codex turns, and wiring `MoonMind.AgentRun` to choose the adapter whenever a managed Codex request already carries a task-scoped managed-session binding. The new path must stay container-first and reuse the Phase 3 session activity contracts plus the Phase 4 Docker-backed controller without falling back to the worker-local managed-runtime launcher.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing Pydantic models, Temporal workflow/activity primitives, current managed run store, Phase 4 managed-session activity/controller surface
+**Testing**: focused pytest suites plus final verification with `./tools/test_unit.sh`
+**Project Type**: Temporal backend workflow + adapter integration
+**Constraints**: no worker-local Codex execution for the session-backed path; preserve Phase 3 typed session contracts; keep image selection deployment-configurable; keep non-Codex managed runtimes on the existing adapter path
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. MoonMind stays the orchestrator and the adapter only translates workflow intent into the existing remote session control surface.
+- **II. One-Click Agent Deployment**: PASS. The implementation reuses the current managed worker/session-image assumptions and does not introduce new operator prerequisites.
+- **III. Avoid Vendor Lock-In**: PASS. The adapter is Codex-specific, but isolated behind the `AgentAdapter` boundary and deployment-configurable image selection.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The change adds a narrow adapter layer over the already-typed session contracts instead of expanding workflow-side provider logic.
+- **VII. Powerful Runtime Configurability**: PASS. Session image/path defaults remain config-derived and request overrides stay bounded.
+- **VIII. Modular and Extensible Architecture**: PASS. The workflow picks an adapter; the adapter owns session transport details; the controller/runtime remain unchanged.
+- **IX. Resilient by Default**: PASS. Session-backed managed runs persist canonical result state and add workflow-boundary tests so step completion does not depend on adapter-local memory only.
+- **XI. Spec-Driven Development**: PASS. This spec/plan/tasks set tracks the Phase 5 adapter slice explicitly.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Desired-state docs stay canonical; this implementation detail remains in the spec set.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The new path chooses the session adapter directly for session-bound Codex steps instead of adding compatibility shims around the worker-local launcher.
+
+## Research
+
+- The current codebase already provides the Phase 2 task-scoped `MoonMind.AgentSession` workflow, the Phase 3 session activity family, and the Phase 4 Docker-backed managed-session controller/runtime.
+- `MoonMind.Run` already binds managed Codex steps to one task-scoped `CodexManagedSessionBinding`, but `MoonMind.AgentRun` still routes all managed runtimes through `ManagedAgentAdapter`.
+- The session runtime’s `send_turn`, `clear_session`, `interrupt_turn`, `fetch_session_summary`, and `terminate_session` contracts are already typed and container-first; Phase 5 only needs an adapter that consumes them from workflow code.
+- The existing managed run store is the lightest place to persist canonical step status/result data for session-backed managed runs without redesigning the broader managed-runtime result flow.
+
+## Project Structure
+
+- Add `moonmind/workflows/adapters/codex_session_adapter.py` for the new workflow-side adapter.
+- Keep profile resolution/env shaping helpers in `moonmind/workflows/adapters/managed_agent_adapter.py` reusable rather than duplicating session-specific provider-profile logic.
+- Update `moonmind/workflows/temporal/workflows/agent_run.py` to select the session adapter for managed Codex requests with `managedSession`.
+- Add focused adapter tests under `tests/unit/workflows/adapters/`.
+- Add workflow-boundary regression tests under `tests/unit/workflows/temporal/workflows/`.
+
+## Data Model
+
+- Persist one session-backed managed step record in the existing managed run store plus a small sidecar payload for the canonical `AgentRunResult` and session locator metadata needed for adapter `status`, `fetch_result`, and `cancel`.
+- The sidecar payload records:
+  - managed `run_id`
+  - session locator (`session_id`, `session_epoch`, `container_id`, `thread_id`)
+  - latest turn id
+  - canonical `AgentRunResult`
+  - optional latest session summary/control refs
+- This state is step-scoped execution metadata, not durable task continuity truth. `MoonMind.AgentSession` and artifacts remain authoritative for session continuity.
+
+## Implementation Plan
+
+1. Add failing tests for `CodexSessionAdapter` start/reuse/clear/cancel/terminate behavior and for `MoonMind.AgentRun` adapter selection.
+2. Extract or reuse the managed provider-profile resolution/env-shaping helpers needed by both `ManagedAgentAdapter` and `CodexSessionAdapter`.
+3. Implement `CodexSessionAdapter` so it:
+   - resolves the managed provider profile,
+   - queries/signals `MoonMind.AgentSession`,
+   - launches or reuses the task-scoped session container,
+   - sends step instructions through `agent_runtime.send_turn`,
+   - persists canonical run/result state for later `status` and `fetch_result`,
+   - exposes explicit clear/interrupt/summary/terminate methods.
+4. Update `MoonMind.AgentRun` to instantiate `CodexSessionAdapter` for managed Codex requests with `managedSession` and to keep the existing adapter path for all other managed runtimes.
+5. Run focused tests, run full unit verification, update `tasks.md`, and validate implementation scope.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
+2. `./tools/test_unit.sh`
+3. `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+4. `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+### Manual Validation
+
+1. Submit a managed Codex task with at least two steps and confirm the second step reuses the existing task-scoped session binding.
+2. Verify `MoonMind.AgentSession` query state reflects launched container/thread handles after the first step.
+3. Clear/reset the session through the adapter boundary and verify the session epoch/thread boundary changes while the session container identity stays stable.

--- a/specs/132-codex-managed-session-plane-phase5/spec.md
+++ b/specs/132-codex-managed-session-plane-phase5/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: codex-managed-session-plane-phase5
+
+**Feature Branch**: `132-codex-managed-session-plane-phase5`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Implement Phase 5 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run A Managed Codex Step Through The Session Adapter (Priority: P1)
+
+The agent-run workflow needs a dedicated Codex session adapter so one managed Codex step can create or attach to the task-scoped session container, send the step instructions through the remote session control surface, and collect a typed result without falling back to the worker-local managed-runtime launcher path.
+
+**Why this priority**: Phase 5 is only complete when a real managed Codex step executes through the managed-session plane. Without this slice, Phases 2 through 4 remain disconnected infrastructure.
+
+**Independent Test**: Execute the adapter with a managed Codex request that includes a task-scoped managed-session binding and verify it launches or reuses the session, sends one turn through the session controller, persists a managed run result, and returns a canonical `AgentRunHandle`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed Codex request with no launched container yet, **When** `CodexSessionAdapter.start()` runs, **Then** it launches the task-scoped session container, signals the session workflow with the runtime handles, sends the step instructions through `send_turn`, and returns a canonical managed run handle.
+2. **Given** a managed Codex request whose task-scoped session already has container and thread handles, **When** `CodexSessionAdapter.start()` runs, **Then** it reuses the existing session via the remote session control surface instead of launching a new session container.
+3. **Given** a managed Codex request bound to a task-scoped session, **When** the adapter executes the step, **Then** no code path routes through `ManagedRuntimeLauncher.launch()` or a worker-local Codex subprocess loop.
+
+---
+
+### User Story 2 - Keep Session Control First-Class At The Adapter Boundary (Priority: P1)
+
+The Codex session adapter needs explicit clear/reset, interrupt/cancel, summary, and termination methods so workflow-level code can keep talking in session-control actions while the execution loop remains inside the session container.
+
+**Why this priority**: The adapter is the stable boundary MoonMind intends to keep after the session image changes. It must expose the session vocabulary directly instead of burying it in workflow glue.
+
+**Independent Test**: Invoke the adapter’s clear, interrupt, summary, and terminate methods against a mocked task-scoped session and confirm each one delegates to the session control surface, updates the task-scoped session workflow state, and preserves the typed managed-session contracts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a launched task-scoped session, **When** `CodexSessionAdapter.clear_session()` is invoked, **Then** it issues `clear_session` against the remote session container, advances the logical thread boundary, and signals the `MoonMind.AgentSession` workflow with the new epoch/thread handles.
+2. **Given** an in-flight turn in a launched task-scoped session, **When** `CodexSessionAdapter.cancel()` or `interrupt_turn()` is invoked, **Then** it delegates to the remote session control surface and records a canonical canceled/interrupted run outcome.
+3. **Given** a launched task-scoped session, **When** `CodexSessionAdapter.fetch_session_summary()` or `terminate_session()` is invoked, **Then** it delegates through the remote session control surface and updates the `MoonMind.AgentSession` workflow state instead of reading local worker process state.
+
+---
+
+### User Story 3 - Route Managed Codex Steps Through The Adapter In `MoonMind.AgentRun` (Priority: P2)
+
+The managed-runtime branch of `MoonMind.AgentRun` needs to choose the Codex session adapter whenever a managed Codex step has a task-scoped session binding, so the workflow uses the session plane transparently while keeping the existing managed-runtime workflow shape.
+
+**Why this priority**: The adapter is not useful unless the real workflow path uses it by default for task-scoped managed Codex steps.
+
+**Independent Test**: Run `MoonMind.AgentRun` with a managed Codex request containing `managedSession` and verify it instantiates `CodexSessionAdapter`, not `ManagedAgentAdapter`, and publishes a canonical `AgentRunResult` from the adapter-backed execution path.
+
+**Acceptance Scenarios**:
+
+1. **Given** `MoonMind.AgentRun` receives a managed Codex request with `managedSession`, **When** it starts the step, **Then** it instantiates `CodexSessionAdapter` and does not instantiate `ManagedAgentAdapter`.
+2. **Given** `MoonMind.AgentRun` uses `CodexSessionAdapter`, **When** the step completes, **Then** the workflow still publishes a canonical `AgentRunResult` and preserves managed-session metadata on the result.
+3. **Given** `MoonMind.AgentRun` receives a managed non-session runtime request, **When** it starts the step, **Then** it continues using the existing `ManagedAgentAdapter` path unchanged.
+
+### Edge Cases
+
+- The task-scoped session workflow exists but has no runtime handles yet.
+- The session workflow has handles, but `session_status` reports the container is no longer usable.
+- The adapter is asked to clear or terminate a session before any container was launched.
+- Session summary or artifact publication returns empty refs; the adapter must degrade honestly and keep the canonical result valid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST implement a `CodexSessionAdapter` that satisfies the `AgentAdapter` lifecycle for managed Codex steps bound to a task-scoped managed session.
+- **FR-002**: `CodexSessionAdapter.start()` MUST create or attach to a task-scoped remote Codex session container through the session control surface and MUST NOT invoke a worker-local managed-runtime launcher/process loop.
+- **FR-003**: `CodexSessionAdapter` MUST resolve the managed provider profile and shape launch-time environment overrides for the session container using the same provider-profile inputs used by managed runtimes.
+- **FR-004**: `CodexSessionAdapter` MUST synchronize launched container/thread/turn handles back into `MoonMind.AgentSession` through workflow signals or queries rather than storing them only in adapter-local memory.
+- **FR-005**: `CodexSessionAdapter` MUST provide explicit adapter methods for send/start, interrupt/cancel, clear/reset, session-summary retrieval, and termination against the remote session control surface.
+- **FR-006**: `CodexSessionAdapter` MUST persist canonical managed run status/result data so `MoonMind.AgentRun` can read step completion through the adapter boundary without reconstructing provider-native payloads in workflow code.
+- **FR-007**: `MoonMind.AgentRun` MUST instantiate `CodexSessionAdapter` for managed Codex requests that include `managedSession`, and MUST keep the existing `ManagedAgentAdapter` path for managed requests without a task-scoped session binding.
+- **FR-008**: The Phase 5 implementation MUST preserve the Phase 3 typed session activity contracts and the Phase 4 Docker-backed session controller as the only control path.
+- **FR-009**: The adapter MUST keep the image reference and launch path deployment-configurable so later switching from the current MoonMind image to a dedicated Codex image remains a packaging change rather than an orchestration redesign.
+
+### Key Entities
+
+- **Codex Session Adapter**: The workflow-side adapter that maps the `AgentAdapter` lifecycle and explicit session-control methods onto the managed-session activity surface.
+- **Session Execution Record**: The persisted canonical run/result state for one managed Codex step executed through the task-scoped session plane.
+- **Task-Scoped Session Snapshot**: The `MoonMind.AgentSession` workflow-owned view of the current container, thread, active turn, and epoch state used by the adapter to create or attach to the session.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Focused adapter tests prove a managed Codex step launches or reuses a task-scoped session container and executes one turn through the remote session control surface.
+- **SC-002**: Focused adapter tests prove clear/reset, interrupt/cancel, summary, and terminate calls all delegate through the remote session control surface and update the task-scoped session workflow state.
+- **SC-003**: Workflow-boundary tests prove `MoonMind.AgentRun` uses `CodexSessionAdapter` for managed Codex requests with `managedSession` and continues to use `ManagedAgentAdapter` otherwise.
+- **SC-004**: The final diff passes runtime scope validation with production runtime file changes and validation test changes.

--- a/specs/132-codex-managed-session-plane-phase5/tasks.md
+++ b/specs/132-codex-managed-session-plane-phase5/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Codex Managed Session Plane Phase 5
+
+## T001 — Add TDD coverage for the session adapter [P]
+- [X] T001a [P] Add unit tests for `CodexSessionAdapter` launch-or-reuse behavior, canonical result persistence, and session workflow synchronization in `tests/unit/workflows/adapters/test_codex_session_adapter.py`.
+- [X] T001b [P] Add unit tests for `CodexSessionAdapter.clear_session()`, `cancel()`, `fetch_session_summary()`, and `terminate_session()` in `tests/unit/workflows/adapters/test_codex_session_adapter.py`.
+- [X] T001c [P] Add workflow-boundary tests for `MoonMind.AgentRun` adapter selection and managed-session result publication in `tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
+
+## T002 — Implement the workflow-side Codex session adapter [P]
+- [X] T002a [P] Add `moonmind/workflows/adapters/codex_session_adapter.py` implementing the session-backed managed Codex `AgentAdapter` lifecycle plus explicit session control methods.
+- [X] T002b [P] Reuse or extract managed provider-profile resolution/environment-shaping helpers in `moonmind/workflows/adapters/managed_agent_adapter.py` so the session adapter gets the same profile inputs without duplicating the worker-local launcher path.
+- [X] T002c [P] Persist canonical step status/result and session locator metadata for session-backed managed runs in `moonmind/workflows/adapters/codex_session_adapter.py` and related helpers.
+
+**Independent Test**: The adapter tests pass while the implementation delegates only through the remote session control surface.
+
+## T003 — Route managed Codex session steps through the adapter [P]
+- [X] T003a [P] Update `moonmind/workflows/temporal/workflows/agent_run.py` so managed Codex requests with `managedSession` instantiate `CodexSessionAdapter`.
+- [X] T003b [P] Keep managed non-session runtimes on `ManagedAgentAdapter` in `moonmind/workflows/temporal/workflows/agent_run.py`.
+- [X] T003c [P] Preserve canonical `AgentRunResult` publication and managed-session metadata enrichment in `moonmind/workflows/temporal/workflows/agent_run.py`.
+
+**Independent Test**: The workflow-boundary tests prove `MoonMind.AgentRun` uses the new adapter only for session-bound managed Codex requests.
+
+## T004 — Validate the Phase 5 slice [P]
+- [X] T004a [P] Run `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`.
+- [X] T004b [P] Run `./tools/test_unit.sh`.
+- [X] T004c [P] Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime` and `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+
+**Independent Test**: Focused tests, full unit verification, and both runtime scope validation checks pass.

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -274,7 +274,8 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert launch_request.artifact_spool_path.endswith(f"{binding.task_run_id}/artifacts")
     assert launch_request.codex_home_path.endswith(f"{binding.task_run_id}/.moonmind/codex-home")
     assert launch_request.image_ref == "ghcr.io/moonladderstudios/moonmind:latest"
-    assert send_turn_calls[0].instructions == "artifact:instructions"
+    assert send_turn_calls[0].instructions.startswith("artifact:instructions")
+    assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
     assert send_turn_calls[0].input_refs == ("artifact:input-1",)
 
     assert handle.status == "completed"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionBinding,
+    CodexManagedSessionHandle,
+    CodexManagedSessionSnapshot,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+)
+from moonmind.workflows.adapters.codex_session_adapter import CodexSessionAdapter
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _fake_profiles(profiles: list[dict[str, Any]]):
+    async def _fetcher(*, runtime_id: str):
+        return {"profiles": profiles}
+
+    return _fetcher
+
+
+async def _async_noop(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+def _binding() -> CodexManagedSessionBinding:
+    return CodexManagedSessionBinding(
+        workflowId="wf-task-1:session:codex_cli",
+        taskRunId="wf-task-1",
+        sessionId="sess:wf-task-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+
+def _snapshot(
+    *,
+    binding: CodexManagedSessionBinding,
+    container_id: str | None = None,
+    thread_id: str | None = None,
+    active_turn_id: str | None = None,
+    session_epoch: int | None = None,
+) -> CodexManagedSessionSnapshot:
+    effective_binding = (
+        binding.model_copy(update={"session_epoch": session_epoch})
+        if session_epoch is not None
+        else binding
+    )
+    return CodexManagedSessionSnapshot(
+        binding=effective_binding,
+        status="active",
+        containerId=container_id,
+        threadId=thread_id,
+        activeTurnId=active_turn_id,
+        terminationRequested=False,
+    )
+
+
+def _request(
+    binding: CodexManagedSessionBinding,
+    *,
+    workspace_path: str | None = None,
+) -> AgentExecutionRequest:
+    workspace_spec = {}
+    if workspace_path is not None:
+        workspace_spec["workspacePath"] = workspace_path
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId="corr-1",
+        idempotencyKey="idem-1",
+        instructionRef="artifact:instructions",
+        managedSession=binding,
+        inputRefs=["artifact:input-1"],
+        workspaceSpec=workspace_spec,
+        parameters={"publishMode": "none"},
+    )
+
+
+def _session_handle(
+    *,
+    session_id: str,
+    session_epoch: int,
+    container_id: str,
+    thread_id: str,
+    status: str = "ready",
+) -> CodexManagedSessionHandle:
+    return CodexManagedSessionHandle(
+        sessionState={
+            "sessionId": session_id,
+            "sessionEpoch": session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        status=status,
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl=f"docker-exec://{container_id}",
+    )
+
+
+def _turn_response(
+    *,
+    session_id: str,
+    session_epoch: int,
+    container_id: str,
+    thread_id: str,
+    turn_id: str = "turn-1",
+    status: str = "completed",
+    assistant_text: str = "Implemented through the session container.",
+) -> CodexManagedSessionTurnResponse:
+    return CodexManagedSessionTurnResponse(
+        sessionState={
+            "sessionId": session_id,
+            "sessionEpoch": session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        turnId=turn_id,
+        status=status,
+        outputRefs=("artifact:turn-output",),
+        metadata={"assistantText": assistant_text},
+    )
+
+
+def _summary(
+    *,
+    session_id: str,
+    session_epoch: int,
+    container_id: str,
+    thread_id: str,
+) -> CodexManagedSessionSummary:
+    return CodexManagedSessionSummary(
+        sessionState={
+            "sessionId": session_id,
+            "sessionEpoch": session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        latestSummaryRef="artifact:session-summary",
+        latestCheckpointRef="artifact:session-checkpoint",
+        latestControlEventRef=None,
+        metadata={"lastAssistantText": "Implemented through the session container."},
+    )
+
+
+def _publication(
+    *,
+    session_id: str,
+    session_epoch: int,
+    container_id: str,
+    thread_id: str,
+) -> CodexManagedSessionArtifactsPublication:
+    return CodexManagedSessionArtifactsPublication(
+        sessionState={
+            "sessionId": session_id,
+            "sessionEpoch": session_epoch,
+            "containerId": container_id,
+            "threadId": thread_id,
+            "activeTurnId": None,
+        },
+        publishedArtifactRefs=("artifact:session-summary", "artifact:session-checkpoint"),
+        latestSummaryRef="artifact:session-summary",
+        latestCheckpointRef="artifact:session-checkpoint",
+        latestControlEventRef=None,
+    )
+
+
+async def test_start_launches_missing_task_scoped_session_and_persists_result(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    launch_calls: list[Any] = []
+    attach_calls: list[dict[str, Any]] = []
+    control_calls: list[dict[str, Any]] = []
+    send_turn_calls: list[Any] = []
+
+    async def _load_snapshot(workflow_id: str) -> CodexManagedSessionSnapshot:
+        assert workflow_id == binding.workflow_id
+        return _snapshot(binding=binding)
+
+    async def _launch_session(request: Any) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        raise AssertionError("session_status should not be used before launch")
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _publish_artifacts(_request: Any) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+        attach_calls.append(payload)
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_attach_runtime_handles,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+    status = await adapter.status(handle.run_id)
+    result = await adapter.fetch_result(handle.run_id)
+
+    assert len(launch_calls) == 1
+    launch_request = launch_calls[0]
+    assert launch_request.session_id == binding.session_id
+    assert launch_request.workspace_path == str(workspace_path)
+    assert launch_request.session_workspace_path.endswith(f"{binding.task_run_id}/session")
+    assert launch_request.artifact_spool_path.endswith(f"{binding.task_run_id}/artifacts")
+    assert launch_request.codex_home_path.endswith(f"{binding.task_run_id}/.moonmind/codex-home")
+    assert launch_request.image_ref == "ghcr.io/moonladderstudios/moonmind:latest"
+    assert send_turn_calls[0].instructions == "artifact:instructions"
+    assert send_turn_calls[0].input_refs == ("artifact:input-1",)
+
+    assert handle.status == "completed"
+    assert handle.metadata["sessionId"] == binding.session_id
+    assert handle.metadata["containerId"] == "container-1"
+    assert status.status == "completed"
+    assert result.summary == "Implemented through the session container."
+    assert result.output_refs == [
+        "artifact:turn-output",
+        "artifact:session-summary",
+        "artifact:session-checkpoint",
+    ]
+    assert result.metadata["sessionSummary"]["latestSummaryRef"] == "artifact:session-summary"
+    assert result.metadata["sessionArtifacts"]["latestCheckpointRef"] == "artifact:session-checkpoint"
+
+    assert attach_calls == [{"containerId": "container-1", "threadId": "thread-1"}]
+    assert control_calls[-1]["action"] == "send_turn"
+    assert control_calls[-1]["containerId"] == "container-1"
+    assert control_calls[-1]["threadId"] == "thread-1"
+
+
+async def test_start_reuses_existing_task_scoped_session_without_launching(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    session_status_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-existing",
+            thread_id="thread-existing",
+        )
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        raise AssertionError("launch_session should not be called for a ready session")
+
+    async def _session_status(request: Any) -> CodexManagedSessionHandle:
+        session_status_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-existing",
+            thread_id="thread-existing",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-existing",
+            thread_id="thread-existing",
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-existing",
+            thread_id="thread-existing",
+        )
+
+    async def _publish_artifacts(_request: Any) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-existing",
+            thread_id="thread-existing",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding))
+
+    assert handle.metadata["containerId"] == "container-existing"
+    assert len(session_status_calls) == 1
+    assert session_status_calls[0].container_id == "container-existing"
+    assert session_status_calls[0].thread_id == "thread-existing"
+
+
+async def test_clear_session_rotates_epoch_and_signals_session_workflow(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    attach_calls: list[dict[str, Any]] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _clear_remote_session(request: Any) -> CodexManagedSessionHandle:
+        assert request.new_thread_id == "thread-2"
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=2,
+            container_id="container-1",
+            thread_id="thread-2",
+        )
+
+    async def _attach_runtime_handles(payload: dict[str, Any]) -> None:
+        attach_calls.append(payload)
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_clear_remote_session,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_attach_runtime_handles,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.clear_session(binding=binding, new_thread_id="thread-2", reason="reset")
+
+    assert handle.session_state.session_epoch == 2
+    assert handle.session_state.thread_id == "thread-2"
+    assert attach_calls == [{"containerId": "container-1", "threadId": "thread-2"}]
+    assert control_calls == [
+        {
+            "action": "clear_session",
+            "reason": "reset",
+            "containerId": "container-1",
+            "threadId": "thread-2",
+        }
+    ]
+
+
+async def test_cancel_interrupts_active_turn_and_marks_run_canceled(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    interrupt_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+            active_turn_id="turn-active",
+        )
+
+    async def _interrupt_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        interrupt_calls.append(request)
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            turn_id="turn-active",
+            status="interrupted",
+            assistant_text="Interrupted.",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        send_turn=_async_noop,
+        interrupt_turn=_interrupt_turn,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    run_id = "run-cancel-1"
+    adapter._save_run_state(
+        run_id=run_id,
+        agent_id="codex",
+        locator={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id="turn-active",
+        result={
+            "summary": "Still running",
+            "metadata": {},
+        },
+        status="running",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    status = await adapter.cancel(run_id)
+    result = await adapter.fetch_result(run_id)
+
+    assert interrupt_calls[0].turn_id == "turn-active"
+    assert status.status == "canceled"
+    assert result.failure_class == "user_error"
+    assert result.summary == "Canceled Codex managed-session turn."
+
+
+async def test_terminate_session_uses_remote_session_control_surface(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    terminate_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(
+            binding=binding,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _terminate_remote_session(request: Any) -> CodexManagedSessionHandle:
+        terminate_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            status="terminated",
+        )
+
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_async_noop,
+        session_status=_async_noop,
+        send_turn=_async_noop,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_terminate_remote_session,
+        fetch_remote_summary=_async_noop,
+        publish_remote_artifacts=_async_noop,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_apply_control_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.terminate_session(binding=binding, reason="task-complete")
+
+    assert terminate_calls[0].container_id == "container-1"
+    assert handle.status == "terminated"
+    assert control_calls == [{"action": "terminate_session", "reason": "task-complete"}]

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -43,6 +43,7 @@ from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactRepository,
     TemporalArtifactService,
 )
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -637,6 +638,11 @@ async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pyt
             captured_payload.update(payload)
         return {"status": "launching"}
 
+    activity_runtime = TemporalAgentRuntimeActivities()
+
+    async def _launch_context_builder(**kwargs: Any):
+        return await activity_runtime.agent_runtime_build_launch_context(kwargs)
+
     adapter = ManagedAgentAdapter(
         profile_fetcher=_fake_profiles(profiles),
         slot_requester=_async_noop,
@@ -645,6 +651,7 @@ async def test_start_applies_proxy_mode_when_tagged_proxy_first(monkeypatch: pyt
         workflow_id="wf-proxy",
         runtime_id="claude_code",
         run_launcher=_run_launcher,
+        launch_context_builder=_launch_context_builder,
     )
 
     from moonmind.schemas.agent_runtime_models import AgentExecutionRequest

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1283,6 +1283,7 @@ async def test_build_activity_bindings_resolves_agent_runtime_fleet(
             assert bindings
             assert {binding.fleet for binding in bindings} == {AGENT_RUNTIME_FLEET}
             bound_types = {binding.activity_type for binding in bindings}
+            assert "agent_runtime.build_launch_context" in bound_types
             assert "agent_runtime.launch_session" in bound_types
             assert "agent_runtime.publish_artifacts" in bound_types
             assert "agent_runtime.session_status" in bound_types

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -690,6 +691,17 @@ class AgentRuntimeFetchResultBoundaryTest:
             start_to_close_timeout=timedelta(minutes=1),
         )
 
+
+@workflow.defn(name="AgentRuntimeBuildLaunchContextBoundaryTest")
+class AgentRuntimeBuildLaunchContextBoundaryTest:
+    @workflow.run
+    async def run(self, input_dict: dict) -> dict[str, Any]:
+        return await workflow.execute_activity(
+            "agent_runtime.build_launch_context",
+            input_dict,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+
 @workflow.defn(name="AgentRuntimeCancelBoundaryTest")
 class AgentRuntimeCancelBoundaryTest:
     @workflow.run
@@ -743,6 +755,52 @@ async def test_agent_runtime_status_temporal_boundary(tmp_path: Path) -> None:
 
             assert isinstance(result, AgentRunStatus)
             assert result.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_build_launch_context_temporal_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs_test_token")
+    monkeypatch.setenv("MOONMIND_ALLOW_LOCAL_ENCRYPTION_KEY_GENERATION", "1")
+    activities_impl = TemporalAgentRuntimeActivities()
+    from temporalio import activity
+
+    @activity.defn(name="agent_runtime.build_launch_context")
+    async def _agent_runtime_build_launch_context_wrapper(
+        request: dict,
+    ) -> dict[str, Any]:
+        return await activities_impl.agent_runtime_build_launch_context(request)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="boundary-test-queue-build-launch-context",
+            workflows=[AgentRuntimeBuildLaunchContextBoundaryTest],
+            activities=[_agent_runtime_build_launch_context_wrapper],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                AgentRuntimeBuildLaunchContextBoundaryTest.run,
+                {
+                    "profile": {
+                        "profile_id": "proxy-prof",
+                        "credential_source": "secret_ref",
+                        "tags": ["proxy-first"],
+                        "provider_id": "anthropic",
+                        "secret_refs": {"anthropic_api_key": "db://123"},
+                    },
+                    "runtime_for_profile": "claude_code",
+                    "workflow_id": "wf-boundary",
+                    "default_credential_source": "secret_ref",
+                },
+                id="boundary-test-build-launch-context",
+                task_queue="boundary-test-queue-build-launch-context",
+            )
+
+            assert result["profile_id"] == "proxy-prof"
+            assert "MOONMIND_PROXY_TOKEN" in result["delta_env_overrides"]
+            assert "GITHUB_TOKEN" in result["passthrough_env_keys"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+pytestmark = [pytest.mark.asyncio]
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-agent-run-1",
+            "run_id": "run-1",
+            "search_attributes": {},
+            "parent": None,
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {"info": lambda *a, **k: None, "warning": lambda *a, **k: None},
+    )
+    monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+
+
+def _managed_session_request() -> AgentExecutionRequest:
+    return AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="codex-default",
+        correlationId="corr-managed-1",
+        idempotencyKey="idem-managed-1",
+        instructionRef="artifact:instructions",
+        managedSession={
+            "workflowId": "wf-task-1:session:codex_cli",
+            "taskRunId": "wf-task-1",
+            "sessionId": "sess:wf-task-1:codex_cli",
+            "sessionEpoch": 1,
+            "runtimeId": "codex_cli",
+            "executionProfileRef": "codex-default",
+        },
+        parameters={"publishMode": "none"},
+    )
+
+
+async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+    session_adapter_requests: list[AgentExecutionRequest] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("ManagedAgentAdapter should not be used for managedSession requests")
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            session_adapter_requests.append(request)
+            return AgentRunHandle(
+                runId="managed-session-run-1",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+                metadata={"sessionId": request.managed_session.session_id},
+            )
+
+        async def status(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="completed",
+            )
+
+        async def fetch_result(self, run_id: str) -> AgentRunResult:
+            return AgentRunResult(
+                summary="Session-backed Codex step completed.",
+                metadata={"resultSource": "codex-session-adapter"},
+            )
+
+        async def cancel(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="canceled",
+            )
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        raise asyncio.TimeoutError()
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+        async def query(self, query_name: str) -> dict[str, Any]:
+            return {
+                "binding": {
+                    "workflowId": "wf-task-1:session:codex_cli",
+                    "taskRunId": "wf-task-1",
+                    "sessionId": "sess:wf-task-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": None,
+                "threadId": None,
+                "activeTurnId": None,
+                "terminationRequested": False,
+            }
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_managed_session_request())
+
+    assert session_adapter_requests[0].managed_session is not None
+    assert run.run_id == "managed-session-run-1"
+    assert result.summary == "Session-backed Codex step completed."
+    assert result.metadata["resultSource"] == "codex-session-adapter"
+    assert result.metadata["managedSession"]["sessionId"] == "sess:wf-task-1:codex_cli"
+    assert [name for name, _payload in routed_calls] == ["agent_runtime.publish_artifacts"]
+
+
+async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+    managed_requests: list[AgentExecutionRequest] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            managed_requests.append(request)
+            return AgentRunHandle(
+                runId="managed-run-1",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="running",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("CodexSessionAdapter should not be used without managedSession")
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        run.completion_event.set()
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Managed adapter path", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(
+        AgentExecutionRequest(
+            agentKind="managed",
+            agentId="codex_cli",
+            executionProfileRef="codex-default",
+            correlationId="corr-managed-plain-1",
+            idempotencyKey="idem-managed-plain-1",
+            parameters={"publishMode": "none"},
+        )
+    )
+
+    assert len(managed_requests) == 1
+    assert managed_requests[0].managed_session is None
+    assert result.summary == "Managed adapter path"
+    assert [name for name, _payload in routed_calls] == [
+        "agent_runtime.fetch_result",
+        "agent_runtime.publish_artifacts",
+    ]

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunHandle
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
+)
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -269,16 +274,31 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
 
     class _FakeManagedAgentAdapter:
         def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError("ManagedAgentAdapter should not be used for managedSession requests")
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
             pass
 
         async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
             return AgentRunHandle(
-                runId="managed-run-1",
+                runId="managed-session-run-2",
                 agentKind="managed",
                 agentId=request.agent_id,
-                status="running",
+                status="completed",
                 startedAt=agent_run_module.workflow.now(),
             )
+
+        async def status(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex_cli",
+                status="completed",
+            )
+
+        async def fetch_result(self, run_id: str) -> AgentRunResult:
+            return AgentRunResult(summary="Managed success", metadata={})
 
     async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
         run.completion_event.set()
@@ -286,6 +306,27 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
     class _FakeManagerHandle:
         async def signal(self, signal_name: str, payload: Any) -> None:
             return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+        async def query(self, query_name: str) -> dict[str, Any]:
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": None,
+                "threadId": None,
+                "activeTurnId": None,
+                "terminationRequested": False,
+            }
 
     async def fake_ensure_manager_and_signal(
         manager_id: str,
@@ -311,8 +352,6 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         payload: Any,
         **_kwargs: Any,
     ) -> Any:
-        if activity_name == "agent_runtime.fetch_result":
-            return {"summary": "Managed success", "metadata": {}}
         if activity_name == "agent_runtime.publish_artifacts":
             return payload
         raise AssertionError(f"Unexpected routed activity: {activity_name}")
@@ -321,6 +360,11 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         agent_run_module,
         "ManagedAgentAdapter",
         _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "CodexSessionAdapter",
+        _FakeCodexSessionAdapter,
     )
     monkeypatch.setattr(
         run,
@@ -333,6 +377,11 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         fake_sync_manager_profiles,
     )
     monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
     monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
 
     result = await run.run(


### PR DESCRIPTION
## Summary
- add the Phase 5 spec/plan/tasks set for the Codex managed session plane
- introduce `CodexSessionAdapter` to drive managed Codex steps through the remote session control surface
- wire `MoonMind.AgentRun` to use the session adapter for managed Codex requests with `managedSession` and add workflow-boundary coverage

## Remediation
- extracted the managed profile/env shaping logic so the new adapter reuses the existing provider-profile launch inputs
- updated the existing managed-session metadata regression test to match the new adapter-first path

## Verification
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
- `./tools/test_unit.sh`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`