### PR TITLE
[codex] Implement phase 6 session supervision

### DIFF
--- a/moonmind/schemas/__init__.py
+++ b/moonmind/schemas/__init__.py
@@ -25,6 +25,7 @@ from .managed_session_models import (
     CodexManagedSessionHandle,
     CodexManagedSessionLocator,
     CodexManagedSessionPlaneContract,
+    CodexManagedSessionRecord,
     CodexManagedSessionSnapshot,
     CodexManagedSessionState,
     CodexManagedSessionSummary,
@@ -37,6 +38,7 @@ from .managed_session_models import (
     SendCodexManagedSessionTurnRequest,
     SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
+    ManagedSessionRecordStatus,
     canonical_codex_managed_runtime_id,
 )
 from .manifest_models import (
@@ -171,6 +173,7 @@ __all__ = [
     "CodexManagedSessionHandle",
     "CodexManagedSessionLocator",
     "CodexManagedSessionPlaneContract",
+    "CodexManagedSessionRecord",
     "CodexManagedSessionSnapshot",
     "CodexManagedSessionState",
     "CodexManagedSessionSummary",
@@ -183,5 +186,6 @@ __all__ = [
     "SendCodexManagedSessionTurnRequest",
     "SteerCodexManagedSessionTurnRequest",
     "TerminateCodexManagedSessionRequest",
+    "ManagedSessionRecordStatus",
     "canonical_codex_managed_runtime_id",
 ]

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -38,6 +39,15 @@ ManagedSessionTurnStatus = Literal[
     "running",
     "completed",
     "interrupted",
+    "failed",
+]
+ManagedSessionRecordStatus = Literal[
+    "launching",
+    "ready",
+    "busy",
+    "terminating",
+    "terminated",
+    "degraded",
     "failed",
 ]
 
@@ -289,6 +299,120 @@ class CodexManagedSessionArtifactsPublication(_CodexManagedSessionRemoteContract
         None, alias="latestControlEventRef"
     )
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+
+
+class CodexManagedSessionRecord(BaseModel):
+    """Durable session-level supervision record for one managed session."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    session_id: NonBlankStr = Field(..., alias="sessionId")
+    session_epoch: int = Field(..., alias="sessionEpoch", ge=1)
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    container_id: NonBlankStr = Field(..., alias="containerId")
+    thread_id: NonBlankStr = Field(..., alias="threadId")
+    runtime_id: NonBlankStr = Field(..., alias="runtimeId")
+    image_ref: NonBlankStr = Field(..., alias="imageRef")
+    control_url: NonBlankStr = Field(..., alias="controlUrl")
+    status: ManagedSessionRecordStatus = Field(..., alias="status")
+    workspace_path: NonBlankStr = Field(..., alias="workspacePath")
+    session_workspace_path: NonBlankStr = Field(..., alias="sessionWorkspacePath")
+    artifact_spool_path: NonBlankStr = Field(..., alias="artifactSpoolPath")
+    stdout_artifact_ref: str | None = Field(None, alias="stdoutArtifactRef")
+    stderr_artifact_ref: str | None = Field(None, alias="stderrArtifactRef")
+    diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
+    latest_summary_ref: str | None = Field(None, alias="latestSummaryRef")
+    latest_checkpoint_ref: str | None = Field(None, alias="latestCheckpointRef")
+    latest_control_event_ref: str | None = Field(None, alias="latestControlEventRef")
+    last_log_offset: int | None = Field(None, alias="lastLogOffset", ge=0)
+    last_log_at: datetime | None = Field(None, alias="lastLogAt")
+    error_message: str | None = Field(None, alias="errorMessage")
+    started_at: datetime = Field(..., alias="startedAt")
+    updated_at: datetime | None = Field(None, alias="updatedAt")
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "CodexManagedSessionRecord":
+        self.session_id = require_non_blank(self.session_id, field_name="sessionId")
+        self.task_run_id = require_non_blank(self.task_run_id, field_name="taskRunId")
+        self.container_id = require_non_blank(self.container_id, field_name="containerId")
+        self.thread_id = require_non_blank(self.thread_id, field_name="threadId")
+        runtime_id = canonical_codex_managed_runtime_id(self.runtime_id)
+        if runtime_id is None:
+            raise ValueError("runtimeId must identify a managed Codex runtime")
+        self.runtime_id = runtime_id
+        self.image_ref = require_non_blank(self.image_ref, field_name="imageRef")
+        self.control_url = require_non_blank(self.control_url, field_name="controlUrl")
+        self.workspace_path = require_non_blank(self.workspace_path, field_name="workspacePath")
+        self.session_workspace_path = require_non_blank(
+            self.session_workspace_path,
+            field_name="sessionWorkspacePath",
+        )
+        self.artifact_spool_path = require_non_blank(
+            self.artifact_spool_path,
+            field_name="artifactSpoolPath",
+        )
+        if self.stdout_artifact_ref is not None:
+            self.stdout_artifact_ref = require_non_blank(
+                self.stdout_artifact_ref,
+                field_name="stdoutArtifactRef",
+            )
+        if self.stderr_artifact_ref is not None:
+            self.stderr_artifact_ref = require_non_blank(
+                self.stderr_artifact_ref,
+                field_name="stderrArtifactRef",
+            )
+        if self.diagnostics_ref is not None:
+            self.diagnostics_ref = require_non_blank(
+                self.diagnostics_ref,
+                field_name="diagnosticsRef",
+            )
+        if self.latest_summary_ref is not None:
+            self.latest_summary_ref = require_non_blank(
+                self.latest_summary_ref,
+                field_name="latestSummaryRef",
+            )
+        if self.latest_checkpoint_ref is not None:
+            self.latest_checkpoint_ref = require_non_blank(
+                self.latest_checkpoint_ref,
+                field_name="latestCheckpointRef",
+            )
+        if self.latest_control_event_ref is not None:
+            self.latest_control_event_ref = require_non_blank(
+                self.latest_control_event_ref,
+                field_name="latestControlEventRef",
+            )
+        if self.error_message is not None:
+            self.error_message = require_non_blank(
+                self.error_message,
+                field_name="errorMessage",
+            )
+        if self.started_at.tzinfo is None:
+            self.started_at = self.started_at.replace(tzinfo=UTC)
+        if self.last_log_at is not None and self.last_log_at.tzinfo is None:
+            self.last_log_at = self.last_log_at.replace(tzinfo=UTC)
+        if self.updated_at is not None and self.updated_at.tzinfo is None:
+            self.updated_at = self.updated_at.replace(tzinfo=UTC)
+        return self
+
+    def session_state(self) -> CodexManagedSessionState:
+        return CodexManagedSessionState(
+            sessionId=self.session_id,
+            sessionEpoch=self.session_epoch,
+            containerId=self.container_id,
+            threadId=self.thread_id,
+            activeTurnId=None,
+        )
+
+    def published_artifact_refs(self) -> tuple[str, ...]:
+        return tuple(
+            ref
+            for ref in (
+                self.stdout_artifact_ref,
+                self.stderr_artifact_ref,
+                self.diagnostics_ref,
+            )
+            if ref
+        )
 class CodexManagedSessionBinding(BaseModel):
     """Bounded task-scoped session binding passed across workflow boundaries."""
 
@@ -418,6 +542,7 @@ __all__ = [
     "CodexManagedSessionHandle",
     "CodexManagedSessionLocator",
     "CodexManagedSessionPlaneContract",
+    "CodexManagedSessionRecord",
     "CodexManagedSessionSnapshot",
     "CodexManagedSessionState",
     "CodexManagedSessionSummary",
@@ -432,6 +557,7 @@ __all__ = [
     "ManagedSessionControlMode",
     "ManagedSessionHandleStatus",
     "ManagedSessionProtocol",
+    "ManagedSessionRecordStatus",
     "ManagedSessionTurnStatus",
     "PublishCodexManagedSessionArtifactsRequest",
     "SendCodexManagedSessionTurnRequest",

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -328,6 +328,14 @@ class CodexManagedSessionRuntime:
         self._artifact_spool_path.mkdir(parents=True, exist_ok=True)
         self._codex_home_path.mkdir(parents=True, exist_ok=True)
 
+    def _append_spool(self, stream_name: str, text: str) -> None:
+        if stream_name not in {"stdout", "stderr"}:
+            raise ValueError(f"unsupported stream for session spool: {stream_name}")
+        self._ensure_directories()
+        target = self._artifact_spool_path / f"{stream_name}.log"
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(text)
+
     def _app_server_client(self) -> CodexAppServerRpcClient:
         if self._client is None:
             self._client = CodexAppServerRpcClient(
@@ -454,6 +462,10 @@ class CodexManagedSessionRuntime:
             lastControlAt=time.time(),
         )
         self._save_state(state)
+        self._append_spool(
+            "stdout",
+            f"session started: {request.session_id} thread={request.thread_id}\n",
+        )
         return self._handle(
             state,
             status="ready",
@@ -499,6 +511,7 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "send_turn"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._append_spool("stdout", f"turn started: {vendor_turn_id}\n")
 
         try:
             client.wait_for_notification(
@@ -520,6 +533,8 @@ class CodexManagedSessionRuntime:
         state.active_turn_id = None
         state.last_assistant_text = assistant_text or None
         self._save_state(state)
+        if assistant_text:
+            self._append_spool("stdout", f"assistant: {assistant_text}\n")
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),
             turnId=vendor_turn_id,
@@ -532,6 +547,7 @@ class CodexManagedSessionRuntime:
         request: SteerCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
         state = self._validate_locator(request)
+        self._append_spool("stderr", f"steer not supported for turn {request.turn_id}\n")
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),
             turnId=request.turn_id,
@@ -573,6 +589,7 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "interrupt_turn"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._append_spool("stderr", f"interrupt requested: {request.turn_id}\n")
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),
             turnId=request.turn_id,
@@ -602,6 +619,10 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "clear_session"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._append_spool(
+            "stdout",
+            f"session cleared: epoch={state.session_epoch} thread={state.logical_thread_id}\n",
+        )
         return self._handle(state, status="ready")
 
     def terminate_session(
@@ -613,6 +634,7 @@ class CodexManagedSessionRuntime:
         state.last_control_action = "terminate_session"
         state.last_control_at = time.time()
         self._save_state(state)
+        self._append_spool("stdout", f"session terminated: {request.session_id}\n")
         return self._handle(state, status="terminated")
 
     def fetch_session_summary(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -7,6 +7,7 @@ import json
 import os
 import posixpath
 import re
+from datetime import UTC, datetime
 from pathlib import PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
 
@@ -15,6 +16,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
     CodexManagedSessionHandle,
     CodexManagedSessionLocator,
+    CodexManagedSessionRecord,
     CodexManagedSessionSummary,
     CodexManagedSessionTurnResponse,
     FetchCodexManagedSessionSummaryRequest,
@@ -25,6 +27,9 @@ from moonmind.schemas.managed_session_models import (
     SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
+
+from .managed_session_store import ManagedSessionStore
+from .managed_session_supervisor import ManagedSessionSupervisor
 
 
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
@@ -82,6 +87,8 @@ class DockerCodexManagedSessionController:
         workspace_volume_name: str,
         codex_volume_name: str,
         workspace_root: str,
+        session_store: ManagedSessionStore | None = None,
+        session_supervisor: ManagedSessionSupervisor | Any | None = None,
         docker_binary: str = "docker",
         docker_host: str | None = None,
         ready_poll_interval_seconds: float = 1.0,
@@ -91,6 +98,8 @@ class DockerCodexManagedSessionController:
         self._workspace_volume_name = workspace_volume_name
         self._codex_volume_name = codex_volume_name
         self._workspace_root = workspace_root
+        self._session_store = session_store
+        self._session_supervisor = session_supervisor
         self._docker_binary = docker_binary
         self._docker_host = docker_host
         self._ready_poll_interval_seconds = ready_poll_interval_seconds
@@ -146,6 +155,63 @@ class DockerCodexManagedSessionController:
                 "launch_session environment cannot override reserved session keys: "
                 + ", ".join(reserved_keys)
             )
+
+    @staticmethod
+    def _record_status_from_handle_status(status: str) -> str:
+        normalized = str(status or "").strip().lower()
+        if normalized in {"launching", "ready", "busy", "terminating", "terminated", "failed"}:
+            return normalized
+        if normalized in {"clearing", "interrupted"}:
+            return "ready"
+        return "ready"
+
+    def _record_from_launch(
+        self,
+        *,
+        request: LaunchCodexManagedSessionRequest,
+        handle: CodexManagedSessionHandle,
+    ) -> CodexManagedSessionRecord:
+        now = datetime.now(tz=UTC)
+        return CodexManagedSessionRecord(
+            sessionId=request.session_id,
+            sessionEpoch=handle.session_state.session_epoch,
+            taskRunId=request.task_run_id,
+            containerId=handle.session_state.container_id,
+            threadId=handle.session_state.thread_id,
+            runtimeId="codex_cli",
+            imageRef=handle.image_ref or request.image_ref,
+            controlUrl=handle.control_url or f"docker-exec://{handle.session_state.container_id}",
+            status=self._record_status_from_handle_status(handle.status),
+            workspacePath=request.workspace_path,
+            sessionWorkspacePath=request.session_workspace_path,
+            artifactSpoolPath=request.artifact_spool_path,
+            startedAt=now,
+            updatedAt=now,
+        )
+
+    @staticmethod
+    def _matches_locator(
+        record: CodexManagedSessionRecord,
+        locator: CodexManagedSessionLocator,
+    ) -> None:
+        if record.session_epoch != locator.session_epoch:
+            raise RuntimeError("sessionEpoch does not match the durable managed session record")
+        if record.container_id != locator.container_id:
+            raise RuntimeError("containerId does not match the durable managed session record")
+        if record.thread_id != locator.thread_id:
+            raise RuntimeError("threadId does not match the durable managed session record")
+
+    def _require_record(
+        self,
+        locator: CodexManagedSessionLocator,
+    ) -> CodexManagedSessionRecord | None:
+        if self._session_store is None:
+            return None
+        record = self._session_store.load(locator.session_id)
+        if record is None:
+            raise RuntimeError(f"managed session record not found: {locator.session_id}")
+        self._matches_locator(record, locator)
+        return record
 
     async def _remove_container(
         self,
@@ -223,7 +289,7 @@ class DockerCodexManagedSessionController:
             "ready",
         )
         last_error: Exception | None = None
-        for attempt in range(self._ready_poll_attempts):
+        for _attempt in range(self._ready_poll_attempts):
             try:
                 stdout, _stderr = await self._run(command)
                 payload = json.loads(stdout.strip() or "{}")
@@ -238,6 +304,39 @@ class DockerCodexManagedSessionController:
         raise RuntimeError(
             f"managed session container {container_id} did not become ready{details}"
         )
+
+    def _persist_handle_transition(
+        self,
+        *,
+        locator: CodexManagedSessionLocator,
+        status: str,
+    ) -> None:
+        if self._session_store is None:
+            return
+        self._session_store.update(
+            locator.session_id,
+            session_epoch=locator.session_epoch,
+            container_id=locator.container_id,
+            thread_id=locator.thread_id,
+            status=self._record_status_from_handle_status(status),
+            updated_at=datetime.now(tz=UTC),
+            error_message=None,
+        )
+
+    async def _container_exists(self, container_id: str) -> bool:
+        try:
+            await self._run(
+                (
+                    self._docker_binary,
+                    "inspect",
+                    "-f",
+                    "{{.Id}}",
+                    container_id,
+                )
+            )
+        except RuntimeError:
+            return False
+        return True
 
     async def launch_session(
         self,
@@ -295,7 +394,13 @@ class DockerCodexManagedSessionController:
         except Exception:
             await self._remove_container(container_id, ignore_failure=True)
             raise
-        return CodexManagedSessionHandle.model_validate(payload)
+        handle = CodexManagedSessionHandle.model_validate(payload)
+        if self._session_store is not None:
+            record = self._record_from_launch(request=request, handle=handle)
+            self._session_store.save(record)
+            if self._session_supervisor is not None:
+                await self._session_supervisor.start(record)
+        return handle
 
     async def session_status(
         self,
@@ -306,7 +411,9 @@ class DockerCodexManagedSessionController:
             action="session_status",
             payload=request.model_dump(by_alias=True),
         )
-        return CodexManagedSessionHandle.model_validate(payload)
+        handle = CodexManagedSessionHandle.model_validate(payload)
+        self._persist_handle_transition(locator=request, status=handle.status)
+        return handle
 
     async def send_turn(
         self,
@@ -317,7 +424,17 @@ class DockerCodexManagedSessionController:
             action="send_turn",
             payload=request.model_dump(by_alias=True),
         )
-        return CodexManagedSessionTurnResponse.model_validate(payload)
+        response = CodexManagedSessionTurnResponse.model_validate(payload)
+        if self._session_store is not None:
+            self._session_store.update(
+                request.session_id,
+                session_epoch=response.session_state.session_epoch,
+                thread_id=response.session_state.thread_id,
+                status="ready" if response.status == "completed" else "busy",
+                updated_at=datetime.now(tz=UTC),
+                error_message=None,
+            )
+        return response
 
     async def steer_turn(
         self,
@@ -339,7 +456,15 @@ class DockerCodexManagedSessionController:
             action="interrupt_turn",
             payload=request.model_dump(by_alias=True),
         )
-        return CodexManagedSessionTurnResponse.model_validate(payload)
+        response = CodexManagedSessionTurnResponse.model_validate(payload)
+        if self._session_store is not None:
+            self._session_store.update(
+                request.session_id,
+                status="ready",
+                updated_at=datetime.now(tz=UTC),
+                error_message=None,
+            )
+        return response
 
     async def clear_session(
         self,
@@ -350,14 +475,24 @@ class DockerCodexManagedSessionController:
             action="clear_session",
             payload=request.model_dump(by_alias=True),
         )
-        return CodexManagedSessionHandle.model_validate(payload)
+        handle = CodexManagedSessionHandle.model_validate(payload)
+        if self._session_store is not None:
+            self._session_store.update(
+                request.session_id,
+                session_epoch=handle.session_state.session_epoch,
+                thread_id=handle.session_state.thread_id,
+                status=self._record_status_from_handle_status(handle.status),
+                updated_at=datetime.now(tz=UTC),
+                error_message=None,
+            )
+        return handle
 
     async def terminate_session(
         self,
         request: TerminateCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
         await self._remove_container(request.container_id, ignore_failure=True)
-        return CodexManagedSessionHandle(
+        handle = CodexManagedSessionHandle(
             sessionState={
                 "sessionId": request.session_id,
                 "sessionEpoch": request.session_epoch,
@@ -367,25 +502,97 @@ class DockerCodexManagedSessionController:
             },
             status="terminated",
         )
+        if self._session_store is not None:
+            if self._session_supervisor is not None:
+                await self._session_supervisor.finalize(
+                    request.session_id,
+                    status="terminated",
+                )
+            else:
+                self._session_store.update(
+                    request.session_id,
+                    status="terminated",
+                    updated_at=datetime.now(tz=UTC),
+                )
+        return handle
 
     async def fetch_session_summary(
         self,
         request: FetchCodexManagedSessionSummaryRequest,
     ) -> CodexManagedSessionSummary:
-        payload = await self._invoke_json(
-            container_id=request.container_id,
-            action="fetch_session_summary",
-            payload=request.model_dump(by_alias=True),
+        record = self._require_record(request)
+        if record is None:
+            payload = await self._invoke_json(
+                container_id=request.container_id,
+                action="fetch_session_summary",
+                payload=request.model_dump(by_alias=True),
+            )
+            return CodexManagedSessionSummary.model_validate(payload)
+        return CodexManagedSessionSummary(
+            sessionState=record.session_state(),
+            latestSummaryRef=record.latest_summary_ref,
+            latestCheckpointRef=record.latest_checkpoint_ref,
+            latestControlEventRef=record.latest_control_event_ref,
+            metadata={
+                "status": record.status,
+                "stdoutArtifactRef": record.stdout_artifact_ref,
+                "stderrArtifactRef": record.stderr_artifact_ref,
+                "diagnosticsRef": record.diagnostics_ref,
+                "errorMessage": record.error_message,
+            },
         )
-        return CodexManagedSessionSummary.model_validate(payload)
 
     async def publish_session_artifacts(
         self,
         request: PublishCodexManagedSessionArtifactsRequest,
     ) -> CodexManagedSessionArtifactsPublication:
-        payload = await self._invoke_json(
-            container_id=request.container_id,
-            action="publish_session_artifacts",
-            payload=request.model_dump(by_alias=True),
+        record = self._require_record(request)
+        if record is None:
+            payload = await self._invoke_json(
+                container_id=request.container_id,
+                action="publish_session_artifacts",
+                payload=request.model_dump(by_alias=True),
+            )
+            return CodexManagedSessionArtifactsPublication.model_validate(payload)
+        if (
+            self._session_supervisor is not None
+            and not record.published_artifact_refs()
+        ):
+            record = await self._session_supervisor.finalize(
+                request.session_id,
+                status=record.status,
+                error_message=record.error_message,
+            )
+        return CodexManagedSessionArtifactsPublication(
+            sessionState=record.session_state(),
+            publishedArtifactRefs=record.published_artifact_refs(),
+            latestSummaryRef=record.latest_summary_ref,
+            latestCheckpointRef=record.latest_checkpoint_ref,
+            latestControlEventRef=record.latest_control_event_ref,
+            metadata={
+                **dict(request.metadata),
+                "status": record.status,
+                "stdoutArtifactRef": record.stdout_artifact_ref,
+                "stderrArtifactRef": record.stderr_artifact_ref,
+                "diagnosticsRef": record.diagnostics_ref,
+            },
         )
-        return CodexManagedSessionArtifactsPublication.model_validate(payload)
+
+    async def reconcile(self) -> list[CodexManagedSessionRecord]:
+        if self._session_store is None:
+            return []
+        reconciled: list[CodexManagedSessionRecord] = []
+        for record in self._session_store.list_active():
+            if await self._container_exists(record.container_id):
+                if self._session_supervisor is not None:
+                    await self._session_supervisor.start(record)
+                reconciled.append(record)
+                continue
+            updated = self._session_store.update(
+                record.session_id,
+                status="degraded",
+                error_message="managed session container is missing during reconcile",
+                updated_at=datetime.now(tz=UTC),
+            )
+            reconciled.append(updated)
+        return reconciled

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -22,6 +22,7 @@ from moonmind.schemas.managed_session_models import (
     FetchCodexManagedSessionSummaryRequest,
     InterruptCodexManagedSessionTurnRequest,
     LaunchCodexManagedSessionRequest,
+    ManagedSessionRecordStatus,
     PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
     SteerCodexManagedSessionTurnRequest,
@@ -157,13 +158,45 @@ class DockerCodexManagedSessionController:
             )
 
     @staticmethod
-    def _record_status_from_handle_status(status: str) -> str:
+    def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:
         normalized = str(status or "").strip().lower()
         if normalized in {"launching", "ready", "busy", "terminating", "terminated", "failed"}:
             return normalized
         if normalized in {"clearing", "interrupted"}:
             return "ready"
         return "ready"
+
+    @staticmethod
+    def _record_status_from_turn_status(status: str) -> ManagedSessionRecordStatus:
+        normalized = str(status or "").strip().lower()
+        if normalized in {"accepted", "running"}:
+            return "busy"
+        if normalized in {"completed", "interrupted"}:
+            return "ready"
+        if normalized == "failed":
+            return "failed"
+        return "busy"
+
+    @staticmethod
+    def _turn_error_message(response: CodexManagedSessionTurnResponse) -> str | None:
+        if response.status != "failed":
+            return None
+        for key in ("errorMessage", "reason", "error"):
+            value = response.metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _locator_from_session_state(
+        session_state,
+    ) -> CodexManagedSessionLocator:
+        return CodexManagedSessionLocator(
+            sessionId=session_state.session_id,
+            sessionEpoch=session_state.session_epoch,
+            containerId=session_state.container_id,
+            threadId=session_state.thread_id,
+        )
 
     def _record_from_launch(
         self,
@@ -305,7 +338,7 @@ class DockerCodexManagedSessionController:
             f"managed session container {container_id} did not become ready{details}"
         )
 
-    def _persist_handle_transition(
+    async def _persist_handle_transition(
         self,
         *,
         locator: CodexManagedSessionLocator,
@@ -313,7 +346,9 @@ class DockerCodexManagedSessionController:
     ) -> None:
         if self._session_store is None:
             return
-        self._session_store.update(
+        if self._session_store.load(locator.session_id) is None:
+            return
+        await self._session_store.update(
             locator.session_id,
             session_epoch=locator.session_epoch,
             container_id=locator.container_id,
@@ -324,19 +359,25 @@ class DockerCodexManagedSessionController:
         )
 
     async def _container_exists(self, container_id: str) -> bool:
-        try:
-            await self._run(
-                (
-                    self._docker_binary,
-                    "inspect",
-                    "-f",
-                    "{{.Id}}",
-                    container_id,
-                )
-            )
-        except RuntimeError:
+        returncode, stdout, stderr = await self._command_runner(
+            (
+                self._docker_binary,
+                "inspect",
+                "-f",
+                "{{.Id}}",
+                container_id,
+            ),
+            env=self._docker_env(),
+        )
+        if returncode == 0:
+            return True
+        error_output = f"{stdout}\n{stderr}".lower()
+        if "no such object" in error_output or "no such container" in error_output:
             return False
-        return True
+        details = stderr.strip() or stdout.strip() or f"exit code {returncode}"
+        raise RuntimeError(
+            f"failed to inspect managed session container {container_id}: {details}"
+        )
 
     async def launch_session(
         self,
@@ -412,7 +453,10 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         handle = CodexManagedSessionHandle.model_validate(payload)
-        self._persist_handle_transition(locator=request, status=handle.status)
+        await self._persist_handle_transition(
+            locator=self._locator_from_session_state(handle.session_state),
+            status=handle.status,
+        )
         return handle
 
     async def send_turn(
@@ -425,14 +469,18 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
-        if self._session_store is not None:
-            self._session_store.update(
+        if (
+            self._session_store is not None
+            and self._session_store.load(request.session_id) is not None
+        ):
+            await self._session_store.update(
                 request.session_id,
                 session_epoch=response.session_state.session_epoch,
+                container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
-                status="ready" if response.status == "completed" else "busy",
+                status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
-                error_message=None,
+                error_message=self._turn_error_message(response),
             )
         return response
 
@@ -457,12 +505,18 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
-        if self._session_store is not None:
-            self._session_store.update(
+        if (
+            self._session_store is not None
+            and self._session_store.load(request.session_id) is not None
+        ):
+            await self._session_store.update(
                 request.session_id,
-                status="ready",
+                session_epoch=response.session_state.session_epoch,
+                container_id=response.session_state.container_id,
+                thread_id=response.session_state.thread_id,
+                status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
-                error_message=None,
+                error_message=self._turn_error_message(response),
             )
         return response
 
@@ -476,15 +530,10 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         handle = CodexManagedSessionHandle.model_validate(payload)
-        if self._session_store is not None:
-            self._session_store.update(
-                request.session_id,
-                session_epoch=handle.session_state.session_epoch,
-                thread_id=handle.session_state.thread_id,
-                status=self._record_status_from_handle_status(handle.status),
-                updated_at=datetime.now(tz=UTC),
-                error_message=None,
-            )
+        await self._persist_handle_transition(
+            locator=self._locator_from_session_state(handle.session_state),
+            status=handle.status,
+        )
         return handle
 
     async def terminate_session(
@@ -508,8 +557,8 @@ class DockerCodexManagedSessionController:
                     request.session_id,
                     status="terminated",
                 )
-            else:
-                self._session_store.update(
+            elif self._session_store.load(request.session_id) is not None:
+                await self._session_store.update(
                     request.session_id,
                     status="terminated",
                     updated_at=datetime.now(tz=UTC),
@@ -558,11 +607,7 @@ class DockerCodexManagedSessionController:
             self._session_supervisor is not None
             and not record.published_artifact_refs()
         ):
-            record = await self._session_supervisor.finalize(
-                request.session_id,
-                status=record.status,
-                error_message=record.error_message,
-            )
+            record = await self._session_supervisor.publish_snapshot(request.session_id)
         return CodexManagedSessionArtifactsPublication(
             sessionState=record.session_state(),
             publishedArtifactRefs=record.published_artifact_refs(),
@@ -588,7 +633,7 @@ class DockerCodexManagedSessionController:
                     await self._session_supervisor.start(record)
                 reconciled.append(record)
                 continue
-            updated = self._session_store.update(
+            updated = await self._session_store.update(
                 record.session_id,
                 status="degraded",
                 error_message="managed session container is missing during reconcile",

--- a/moonmind/workflows/temporal/runtime/managed_session_store.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_store.py
@@ -1,0 +1,85 @@
+"""JSON file-backed durable store for managed session supervision records."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+
+
+TERMINAL_MANAGED_SESSION_STATUSES = frozenset({"terminated", "degraded", "failed"})
+
+
+class ManagedSessionStore:
+    """Persist ``CodexManagedSessionRecord`` objects under a store root."""
+
+    def __init__(self, store_root: str | Path) -> None:
+        self.store_root = Path(store_root)
+
+    def _resolve_path(self, session_id: str) -> Path:
+        relative = Path(session_id)
+        if not relative.parts:
+            raise ValueError("session_id must not be empty")
+        if relative.is_absolute() or any(part == ".." for part in relative.parts):
+            raise ValueError(
+                "session_id must be a relative path without traversal components"
+            )
+        resolved = (self.store_root / f"{session_id}.json").resolve()
+        root_resolved = self.store_root.resolve()
+        if not resolved.is_relative_to(root_resolved):
+            raise ValueError("session_id resolves outside store root")
+        return resolved
+
+    def save(self, record: CodexManagedSessionRecord) -> Path:
+        path = self._resolve_path(record.session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = record.model_dump(mode="json", by_alias=True)
+        fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle)
+            os.replace(tmp_path, str(path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return path
+
+    def load(self, session_id: str) -> CodexManagedSessionRecord | None:
+        path = self._resolve_path(session_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return CodexManagedSessionRecord(**data)
+
+    def update(self, session_id: str, **kwargs: Any) -> CodexManagedSessionRecord:
+        record = self.load(session_id)
+        if record is None:
+            raise ValueError(f"managed session record not found: {session_id}")
+        for key, value in kwargs.items():
+            if not hasattr(record, key):
+                raise AttributeError(
+                    f"CodexManagedSessionRecord has no attribute '{key}'"
+                )
+            setattr(record, key, value)
+        self.save(record)
+        return record
+
+    def list_active(self) -> list[CodexManagedSessionRecord]:
+        self.store_root.mkdir(parents=True, exist_ok=True)
+        records: list[CodexManagedSessionRecord] = []
+        for path in self.store_root.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                record = CodexManagedSessionRecord(**data)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if record.status not in TERMINAL_MANAGED_SESSION_STATUSES:
+                records.append(record)
+        return records

--- a/moonmind/workflows/temporal/runtime/managed_session_store.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -19,6 +20,14 @@ class ManagedSessionStore:
 
     def __init__(self, store_root: str | Path) -> None:
         self.store_root = Path(store_root)
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _get_lock(self, session_id: str) -> asyncio.Lock:
+        lock = self._locks.get(session_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[session_id] = lock
+        return lock
 
     def _resolve_path(self, session_id: str) -> Path:
         relative = Path(session_id)
@@ -47,6 +56,7 @@ class ManagedSessionStore:
             try:
                 os.unlink(tmp_path)
             except OSError:
+                # The temp file is best-effort cleanup only; the original error wins.
                 pass
             raise
         return path
@@ -58,18 +68,28 @@ class ManagedSessionStore:
         data = json.loads(path.read_text(encoding="utf-8"))
         return CodexManagedSessionRecord(**data)
 
-    def update(self, session_id: str, **kwargs: Any) -> CodexManagedSessionRecord:
-        record = self.load(session_id)
-        if record is None:
-            raise ValueError(f"managed session record not found: {session_id}")
-        for key, value in kwargs.items():
-            if not hasattr(record, key):
-                raise AttributeError(
-                    f"CodexManagedSessionRecord has no attribute '{key}'"
-                )
-            setattr(record, key, value)
-        self.save(record)
-        return record
+    async def update(
+        self,
+        session_id: str,
+        **kwargs: Any,
+    ) -> CodexManagedSessionRecord:
+        async with self._get_lock(session_id):
+            record = self.load(session_id)
+            if record is None:
+                raise ValueError(f"managed session record not found: {session_id}")
+            for key in kwargs:
+                if key not in CodexManagedSessionRecord.model_fields:
+                    raise AttributeError(
+                        f"CodexManagedSessionRecord has no attribute '{key}'"
+                    )
+            updated = CodexManagedSessionRecord.model_validate(
+                {
+                    **record.model_dump(mode="python"),
+                    **kwargs,
+                }
+            )
+            self.save(updated)
+            return updated
 
     def list_active(self) -> list[CodexManagedSessionRecord]:
         self.store_root.mkdir(parents=True, exist_ok=True)

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Protocol
 
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 
 from .log_streamer import RuntimeLogStreamer
 from .managed_session_store import ManagedSessionStore
+
+
+class ArtifactStorageWriter(Protocol):
+    def write_artifact(
+        self,
+        *,
+        job_id: str,
+        artifact_name: str,
+        data: bytes,
+    ) -> tuple[Path, str]:
+        pass
 
 
 class ManagedSessionSupervisor:
@@ -20,10 +32,12 @@ class ManagedSessionSupervisor:
         *,
         store: ManagedSessionStore,
         log_streamer: RuntimeLogStreamer,
+        artifact_storage: ArtifactStorageWriter,
         poll_interval_seconds: float = 1.0,
     ) -> None:
         self._store = store
         self._log_streamer = log_streamer
+        self._artifact_storage = artifact_storage
         self._poll_interval_seconds = poll_interval_seconds
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._stop_events: dict[str, asyncio.Event] = {}
@@ -55,7 +69,7 @@ class ManagedSessionSupervisor:
                 return
             combined_offset = self._combined_offset(record)
             if combined_offset != (record.last_log_offset or 0):
-                self._store.update(
+                await self._store.update(
                     session_id,
                     last_log_offset=combined_offset,
                     last_log_at=datetime.now(tz=UTC),
@@ -78,6 +92,67 @@ class ManagedSessionSupervisor:
             self._watch(record.session_id)
         )
 
+    @staticmethod
+    def _read_spool_bytes(record: CodexManagedSessionRecord) -> tuple[bytes, bytes]:
+        stdout_bytes = b""
+        stderr_bytes = b""
+        stdout_path = ManagedSessionSupervisor._stdout_path(record)
+        stderr_path = ManagedSessionSupervisor._stderr_path(record)
+        if stdout_path.exists():
+            stdout_bytes = stdout_path.read_bytes()
+        if stderr_path.exists():
+            stderr_bytes = stderr_path.read_bytes()
+        return stdout_bytes, stderr_bytes
+
+    async def _publish_record(
+        self,
+        record: CodexManagedSessionRecord,
+        *,
+        status: str,
+        error_message: str | None,
+    ) -> CodexManagedSessionRecord:
+        stdout_bytes, stderr_bytes = self._read_spool_bytes(record)
+        _, stdout_ref = self._artifact_storage.write_artifact(
+            job_id=record.session_id,
+            artifact_name="stdout.log",
+            data=stdout_bytes,
+        )
+        _, stderr_ref = self._artifact_storage.write_artifact(
+            job_id=record.session_id,
+            artifact_name="stderr.log",
+            data=stderr_bytes,
+        )
+        diagnostics_ref = self._log_streamer.collect_diagnostics(
+            run_id=record.session_id,
+            exit_code=None,
+            duration_seconds=0.0,
+            log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
+            annotations=[],
+            events=[],
+        )
+        now = datetime.now(tz=UTC)
+        return await self._store.update(
+            record.session_id,
+            status=status,
+            stdout_artifact_ref=stdout_ref,
+            stderr_artifact_ref=stderr_ref,
+            diagnostics_ref=diagnostics_ref,
+            last_log_offset=len(stdout_bytes) + len(stderr_bytes),
+            last_log_at=now,
+            updated_at=now,
+            error_message=error_message,
+        )
+
+    async def publish_snapshot(self, session_id: str) -> CodexManagedSessionRecord:
+        record = self._store.load(session_id)
+        if record is None:
+            raise ValueError(f"managed session record not found: {session_id}")
+        return await self._publish_record(
+            record,
+            status=record.status,
+            error_message=record.error_message,
+        )
+
     async def finalize(
         self,
         session_id: str,
@@ -95,43 +170,8 @@ class ManagedSessionSupervisor:
         record = self._store.load(session_id)
         if record is None:
             raise ValueError(f"managed session record not found: {session_id}")
-
-        stdout_bytes = b""
-        stderr_bytes = b""
-        stdout_path = self._stdout_path(record)
-        stderr_path = self._stderr_path(record)
-        if stdout_path.exists():
-            stdout_bytes = stdout_path.read_bytes()
-        if stderr_path.exists():
-            stderr_bytes = stderr_path.read_bytes()
-
-        _, stdout_ref = self._log_streamer._storage.write_artifact(
-            job_id=session_id,
-            artifact_name="stdout.log",
-            data=stdout_bytes,
-        )
-        _, stderr_ref = self._log_streamer._storage.write_artifact(
-            job_id=session_id,
-            artifact_name="stderr.log",
-            data=stderr_bytes,
-        )
-        diagnostics_ref = self._log_streamer.collect_diagnostics(
-            run_id=session_id,
-            exit_code=None,
-            duration_seconds=0.0,
-            log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
-            annotations=[],
-            events=[],
-        )
-        now = datetime.now(tz=UTC)
-        return self._store.update(
-            session_id,
+        return await self._publish_record(
+            record,
             status=status,
-            stdout_artifact_ref=stdout_ref,
-            stderr_artifact_ref=stderr_ref,
-            diagnostics_ref=diagnostics_ref,
-            last_log_offset=len(stdout_bytes) + len(stderr_bytes),
-            last_log_at=now,
-            updated_at=now,
             error_message=error_message,
         )

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -1,0 +1,137 @@
+"""Session-level supervision for durable Codex managed session records."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+
+from .log_streamer import RuntimeLogStreamer
+from .managed_session_store import ManagedSessionStore
+
+
+class ManagedSessionSupervisor:
+    """Track session spool progress and publish durable observability artifacts."""
+
+    def __init__(
+        self,
+        *,
+        store: ManagedSessionStore,
+        log_streamer: RuntimeLogStreamer,
+        poll_interval_seconds: float = 1.0,
+    ) -> None:
+        self._store = store
+        self._log_streamer = log_streamer
+        self._poll_interval_seconds = poll_interval_seconds
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._stop_events: dict[str, asyncio.Event] = {}
+
+    @staticmethod
+    def _stdout_path(record: CodexManagedSessionRecord) -> Path:
+        return Path(record.artifact_spool_path) / "stdout.log"
+
+    @staticmethod
+    def _stderr_path(record: CodexManagedSessionRecord) -> Path:
+        return Path(record.artifact_spool_path) / "stderr.log"
+
+    @staticmethod
+    def _combined_offset(record: CodexManagedSessionRecord) -> int:
+        total = 0
+        for path in (
+            ManagedSessionSupervisor._stdout_path(record),
+            ManagedSessionSupervisor._stderr_path(record),
+        ):
+            if path.exists():
+                total += path.stat().st_size
+        return total
+
+    async def _watch(self, session_id: str) -> None:
+        stop_event = self._stop_events[session_id]
+        while not stop_event.is_set():
+            record = self._store.load(session_id)
+            if record is None:
+                return
+            combined_offset = self._combined_offset(record)
+            if combined_offset != (record.last_log_offset or 0):
+                self._store.update(
+                    session_id,
+                    last_log_offset=combined_offset,
+                    last_log_at=datetime.now(tz=UTC),
+                )
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(),
+                    timeout=self._poll_interval_seconds,
+                )
+            except TimeoutError:
+                continue
+
+    async def start(self, record: CodexManagedSessionRecord) -> None:
+        existing = self._tasks.get(record.session_id)
+        if existing is not None and not existing.done():
+            return
+        stop_event = asyncio.Event()
+        self._stop_events[record.session_id] = stop_event
+        self._tasks[record.session_id] = asyncio.create_task(
+            self._watch(record.session_id)
+        )
+
+    async def finalize(
+        self,
+        session_id: str,
+        *,
+        status: str,
+        error_message: str | None = None,
+    ) -> CodexManagedSessionRecord:
+        stop_event = self._stop_events.pop(session_id, None)
+        if stop_event is not None:
+            stop_event.set()
+        task = self._tasks.pop(session_id, None)
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+
+        record = self._store.load(session_id)
+        if record is None:
+            raise ValueError(f"managed session record not found: {session_id}")
+
+        stdout_bytes = b""
+        stderr_bytes = b""
+        stdout_path = self._stdout_path(record)
+        stderr_path = self._stderr_path(record)
+        if stdout_path.exists():
+            stdout_bytes = stdout_path.read_bytes()
+        if stderr_path.exists():
+            stderr_bytes = stderr_path.read_bytes()
+
+        _, stdout_ref = self._log_streamer._storage.write_artifact(
+            job_id=session_id,
+            artifact_name="stdout.log",
+            data=stdout_bytes,
+        )
+        _, stderr_ref = self._log_streamer._storage.write_artifact(
+            job_id=session_id,
+            artifact_name="stderr.log",
+            data=stderr_bytes,
+        )
+        diagnostics_ref = self._log_streamer.collect_diagnostics(
+            run_id=session_id,
+            exit_code=None,
+            duration_seconds=0.0,
+            log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
+            annotations=[],
+            events=[],
+        )
+        now = datetime.now(tz=UTC)
+        return self._store.update(
+            session_id,
+            status=status,
+            stdout_artifact_ref=stdout_ref,
+            stderr_artifact_ref=stderr_ref,
+            diagnostics_ref=diagnostics_ref,
+            last_log_offset=len(stdout_bytes) + len(stderr_bytes),
+            last_log_at=now,
+            updated_at=now,
+            error_message=error_message,
+        )

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -85,6 +85,12 @@ from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
 )
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
+    ManagedSessionSupervisor,
+)
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.workflows.temporal.runtime.supervisor import ManagedRunSupervisor
 
@@ -541,6 +547,17 @@ def _build_agent_runtime_deps() -> tuple[
     log_streamer = RuntimeLogStreamer(artifact_storage)
     supervisor = ManagedRunSupervisor(store, log_streamer)
     launcher = ManagedRuntimeLauncher(store, log_streamer=log_streamer)
+    session_store = ManagedSessionStore(
+        os.path.join(
+            os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
+            "managed_sessions",
+        )
+    )
+    session_log_streamer = RuntimeLogStreamer(artifact_storage)
+    session_supervisor = ManagedSessionSupervisor(
+        store=session_store,
+        log_streamer=session_log_streamer,
+    )
     workspace_root = os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
     workspace_volume_name = os.environ.get(
         "MOONMIND_AGENT_WORKSPACES_VOLUME_NAME",
@@ -560,6 +577,8 @@ def _build_agent_runtime_deps() -> tuple[
         workspace_volume_name=workspace_volume_name,
         codex_volume_name=codex_volume_name,
         workspace_root=workspace_root,
+        session_store=session_store,
+        session_supervisor=session_supervisor,
         docker_binary=os.environ.get("MOONMIND_DOCKER_BINARY", "docker"),
         docker_host=docker_host,
     )
@@ -602,6 +621,12 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
             logger.info(
                 "Reconciled %d stale managed run records during startup",
                 len(reconciled),
+            )
+        session_reconciled = await session_controller.reconcile()
+        if session_reconciled:
+            logger.info(
+                "Reconciled %d managed session records during startup",
+                len(session_reconciled),
             )
 
         bindings = build_worker_activity_bindings(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -557,6 +557,7 @@ def _build_agent_runtime_deps() -> tuple[
     session_supervisor = ManagedSessionSupervisor(
         store=session_store,
         log_streamer=session_log_streamer,
+        artifact_storage=artifact_storage,
     )
     workspace_root = os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs")
     workspace_volume_name = os.environ.get(

--- a/specs/132-codex-managed-session-plane-phase6/data-model.md
+++ b/specs/132-codex-managed-session-plane-phase6/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: Codex Managed Session Plane Phase 6
+
+## Entity: CodexManagedSessionRecord
+
+- Purpose: durable session-level supervision state for one task-scoped Codex managed session.
+- Fields:
+  - `session_id`
+  - `session_epoch`
+  - `task_run_id`
+  - `container_id`
+  - `thread_id`
+  - `runtime_id`
+  - `image_ref`
+  - `control_url`
+  - `status`
+  - `workspace_path`
+  - `session_workspace_path`
+  - `artifact_spool_path`
+  - `stdout_artifact_ref`
+  - `stderr_artifact_ref`
+  - `diagnostics_ref`
+  - `last_log_offset`
+  - `last_log_at`
+  - `error_message`
+
+## Entity: CodexManagedSessionStatus
+
+- Allowed values:
+  - `launching`
+  - `ready`
+  - `busy`
+  - `terminating`
+  - `terminated`
+  - `degraded`
+  - `failed`
+
+## Relationships
+
+- One `CodexManagedSessionRecord` belongs to one `task_run_id`.
+- One `CodexManagedSessionRecord` owns zero or more artifact refs over time, with the latest refs persisted directly on the record.
+- One `CodexManagedSessionRecord` is supervised by at most one active `CodexManagedSessionSupervisor` instance per worker process.

--- a/specs/132-codex-managed-session-plane-phase6/plan.md
+++ b/specs/132-codex-managed-session-plane-phase6/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: codex-managed-session-plane-phase6
+
+**Branch**: `132-codex-managed-session-plane-phase6` | **Date**: 2026-04-06 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/132-codex-managed-session-plane-phase6/spec.md`
+
+## Summary
+
+Extend the Codex managed-session plane from a launch/controller slice into a durable supervised session slice. This phase adds a session record model and store, a session-level supervisor that watches session spool files and publishes artifact refs, controller wiring that persists and serves those records, and worker startup reconciliation that reattaches or degrades active sessions after restart.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing stdlib asyncio/pathlib/json facilities, current managed runtime `RuntimeLogStreamer`, Temporal runtime worker bootstrap, Docker-backed managed-session controller from Phase 4
+**Testing**: focused pytest suites plus final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal backend runtime and worker bootstrap
+**Constraints**: preserve existing managed-session activity contracts; keep logs/diagnostics artifact-first; do not route through `ManagedRuntimeLauncher`; use per-session durable metadata for reconciliation
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Temporal and worker services remain the orchestrator; the container still does not own lifecycle truth.
+- **II. One-Click Agent Deployment**: PASS. The phase reuses the existing Docker/session image assumptions and adds no new deployment prerequisite.
+- **III. Avoid Vendor Lock-In**: PASS. The slice is Codex-specific, but constrained behind session store/supervisor/controller boundaries.
+- **IV. Own Your Data**: PASS. Durable session records plus artifact refs become the authoritative presentation and recovery surface.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The phase adds explicit session record models and worker-boundary tests instead of implicit controller state.
+- **VII. Powerful Runtime Configurability**: PASS. Store roots, artifact roots, and Docker details remain configurable through existing worker settings/env.
+- **VIII. Modular and Extensible Architecture**: PASS. Session supervision is isolated beside the existing managed-run store/supervisor rather than merged into workflow code.
+- **IX. Resilient by Default**: PASS. Worker startup reconciliation and degraded-state handling are first-class acceptance criteria.
+- **XI. Spec-Driven Development**: PASS. This feature slice defines the Phase 6 implementation before code changes land.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Phase sequencing stays under `specs/`; canonical docs need only targeted alignment if behavior wording changes.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The phase introduces one clear session supervision path and avoids compatibility wrappers around the older run-level store.
+
+## Research
+
+- The existing `RuntimeLogStreamer` already provides durable stdout/stderr artifact creation, diagnostics bundle generation, and bounded annotation support; Phase 6 should reuse that artifact path instead of inventing a parallel format.
+- Phase 4 already mounts a task-scoped artifact spool path into the session container, which provides a restart-safe host-visible boundary for session observability without depending on a live container shell.
+- Worker startup already performs managed-run reconciliation through `ManagedRunSupervisor.reconcile()`, so session reconciliation should follow the same bootstrap pattern and remain outside workflow code.
+
+## Project Structure
+
+- Extend `moonmind/schemas/managed_session_models.py` with a durable session record model and status values.
+- Add a session record store under `moonmind/workflows/temporal/runtime/`.
+- Add a session supervisor under `moonmind/workflows/temporal/runtime/` that reuses `RuntimeLogStreamer`.
+- Update `moonmind/workflows/temporal/runtime/codex_session_runtime.py` to emit append-only session spool files for stdout/stderr-oriented supervision.
+- Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` to persist records, delegate supervision, and source summary/publication responses from durable records.
+- Update `moonmind/workflows/temporal/worker_runtime.py` to construct the new session store/supervisor and run reconciliation during startup.
+
+## Data Model
+
+- **CodexManagedSessionRecord**
+  - Required: `session_id`, `session_epoch`, `task_run_id`, `container_id`, `thread_id`, `runtime_id`, `image_ref`, `status`
+  - Durability metadata: `stdout_artifact_ref`, `stderr_artifact_ref`, `diagnostics_ref`, `last_log_at`, `last_log_offset`, `error_message`
+  - Recovery inputs: `artifact_spool_path`, `workspace_path`, `session_workspace_path`, `control_url`
+- **CodexManagedSessionStatus**
+  - Planned values: `launching`, `ready`, `busy`, `terminating`, `terminated`, `degraded`, `failed`
+
+## Implementation Plan
+
+1. Add failing tests for the durable session record/store, session-level artifact publication, controller summary/reconcile behavior, and worker startup reconciliation.
+2. Implement the durable session record schema and JSON-backed session store.
+3. Implement a session supervisor that tails restart-safe session spool files, updates log offsets, publishes stdout/stderr/diagnostics artifacts, and finalizes durable session metadata.
+4. Update the container-side runtime to append session lifecycle and turn output to stdout/stderr spool files under the mounted artifact path.
+5. Wire the controller to persist launch/control transitions, start/stop supervision, answer summary/publication requests from the durable record, and reconcile active sessions on worker startup.
+6. Run focused tests, update task status, run scope validation, then run `./tools/test_unit.sh`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+2. `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Launch a managed session and verify a durable session record appears under the configured session store root.
+2. Exercise at least one session turn, then confirm stdout/stderr/diagnostics artifact refs are available via session summary/publication calls.
+3. Restart the worker process, run startup reconciliation, and confirm the session either resumes supervision or is marked degraded with an explicit error.

--- a/specs/132-codex-managed-session-plane-phase6/quickstart.md
+++ b/specs/132-codex-managed-session-plane-phase6/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: Codex Managed Session Plane Phase 6
+
+## Focused Verification
+
+1. Run the focused session suites:
+
+```bash
+./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+```
+
+2. Run the Spec Kit scope gates for this feature:
+
+```bash
+SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+3. Run the repo unit suite:
+
+```bash
+./tools/test_unit.sh
+```

--- a/specs/132-codex-managed-session-plane-phase6/research.md
+++ b/specs/132-codex-managed-session-plane-phase6/research.md
@@ -1,0 +1,23 @@
+# Research: Codex Managed Session Plane Phase 6
+
+## Decisions
+
+### 1. Reuse `RuntimeLogStreamer`
+
+- Reuse the existing managed-run `RuntimeLogStreamer` for stdout/stderr artifact creation and diagnostics bundle generation.
+- Rationale: it already matches MoonMind's artifact-first observability model and keeps session logs aligned with run logs.
+
+### 2. Supervise Host-Visible Spool Files
+
+- Supervise append-only stdout/stderr spool files under the mounted session artifact path instead of depending on a live interactive session.
+- Rationale: the spool path is restart-safe, container-visible, and compatible with later session continuity projections.
+
+### 3. Durable Session Record As The Summary Source
+
+- `fetch_session_summary` and `publish_session_artifacts` should read from the durable session record first, using the container only for control-plane actions.
+- Rationale: this keeps continuity artifact-first and avoids making the session container the system of record.
+
+### 4. Reconcile In Worker Startup
+
+- Reconciliation belongs in worker bootstrap beside managed-run reconciliation, not in workflow code.
+- Rationale: the worker owns the concrete controller/supervisor lifecycle and can recover active records after restart without changing workflow determinism.

--- a/specs/132-codex-managed-session-plane-phase6/spec.md
+++ b/specs/132-codex-managed-session-plane-phase6/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: codex-managed-session-plane-phase6
+
+**Feature Branch**: `132-codex-managed-session-plane-phase6`
+**Created**: 2026-04-06
+**Status**: Draft
+**Input**: User description: "Implement Phase 6 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Persist Supervised Session State (Priority: P1)
+
+The agent-runtime fleet needs a durable session-level record for each task-scoped Codex session so container identity, runtime metadata, and artifact refs survive beyond a single activity invocation.
+
+**Why this priority**: Phase 6 exists to move from a one-shot launch/controller path to a session-level supervision model that can survive worker restarts and drive continuity views later.
+
+**Independent Test**: Launch a managed session through the controller and verify MoonMind persists a durable session record containing session identity, task run id, container id, runtime id, image ref, and initial status.
+
+**Acceptance Scenarios**:
+
+1. **Given** `agent_runtime.launch_session` launches a Codex session container, **When** the launch completes, **Then** MoonMind persists a durable session record keyed by `session_id` with the launched `container_id`, `task_run_id`, `runtime_id`, and `image_ref`.
+2. **Given** a later control action returns an updated typed handle, **When** MoonMind records the transition, **Then** the durable session record reflects the latest `session_epoch`, `thread_id`, status, and error metadata without losing prior artifact refs.
+3. **Given** a session summary is requested after launch, **When** no artifacts have been published yet, **Then** MoonMind still returns the durable session state and explicit `None` refs rather than fabricating continuity data from container-local state.
+
+---
+
+### User Story 2 - Supervise Session Logs And Diagnostics (Priority: P1)
+
+MoonMind needs a session-level supervisor that watches the managed session workspace, publishes stdout/stderr/diagnostics artifacts, and tracks log offsets independently from per-run process supervision.
+
+**Why this priority**: Logs and diagnostics must stay artifact-first even when the Codex session container persists across steps, and this phase is where the long-lived session path gains the same operational guarantees as managed runs.
+
+**Independent Test**: Start supervision for a persisted session record with append-only stdout/stderr spool files, append output, finalize supervision, and verify stdout/stderr/diagnostics artifact refs plus `last_log_at` and `last_log_offset` are persisted.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active managed session record and writable spool files, **When** the supervisor observes appended output, **Then** it updates `last_log_at` and `last_log_offset` as bounded durable metadata.
+2. **Given** supervision is finalized for a session, **When** artifact publication completes, **Then** the session record stores `stdout_artifact_ref`, `stderr_artifact_ref`, and `diagnostics_ref`.
+3. **Given** `agent_runtime.fetch_session_summary` or `agent_runtime.publish_session_artifacts` is called, **When** MoonMind serves the request, **Then** the response is sourced from the durable supervised session record and artifact refs rather than a container-private cache.
+
+---
+
+### User Story 3 - Reconcile Active Sessions After Worker Restart (Priority: P2)
+
+The agent-runtime worker needs to reconcile active supervised sessions on startup so an existing container can be reattached to supervision, or the session can degrade gracefully if the container is gone.
+
+**Why this priority**: The core Phase 6 exit criterion is restart safety for the session architecture.
+
+**Independent Test**: Persist an active session record, simulate worker startup reconciliation with one existing container and one missing container, and verify MoonMind reattaches supervision for the existing container while marking the missing one degraded.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active durable session record whose container still exists, **When** worker startup reconciliation runs, **Then** the session supervisor reattaches to the session and continues tracking output.
+2. **Given** an active durable session record whose container no longer exists, **When** reconciliation runs, **Then** MoonMind marks the session record as degraded or terminal with an explicit error summary instead of silently discarding it.
+3. **Given** the worker bootstrap builds the `agent_runtime` fleet, **When** startup completes, **Then** both managed-run reconciliation and managed-session reconciliation have executed before activity handlers begin servicing requests.
+
+### Edge Cases
+
+- Session spool files do not exist yet at launch time but appear after the first control action.
+- A session is terminated before any stdout or stderr bytes are written.
+- Reconciliation finds a persisted active session record with malformed offsets or missing metadata.
+- Artifact publication runs after the container is already gone and must use only persisted spool content plus durable metadata.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST persist a durable session-level supervision record for each task-scoped Codex managed session.
+- **FR-002**: The durable session record MUST include at least `session_id`, `session_epoch`, `task_run_id`, `container_id`, `image_ref`, `runtime_id`, `status`, `stdout_artifact_ref`, `stderr_artifact_ref`, `diagnostics_ref`, `last_log_at`, and `last_log_offset`.
+- **FR-003**: MoonMind MUST supervise managed-session stdout/stderr output independently from the existing per-run process supervisor.
+- **FR-004**: Session supervision MUST publish stdout, stderr, and diagnostics as artifacts and persist their refs in the durable session record.
+- **FR-005**: `agent_runtime.fetch_session_summary` and `agent_runtime.publish_session_artifacts` MUST return continuity refs sourced from the durable session record.
+- **FR-006**: Worker startup MUST reconcile active durable session records by reattaching supervision when the container still exists.
+- **FR-007**: Worker startup MUST degrade gracefully when a persisted active session container is missing or cannot be reattached.
+- **FR-008**: The Phase 6 implementation MUST preserve the existing typed managed-session activity contracts and MUST NOT route the new session path through `ManagedRuntimeLauncher`.
+
+### Key Entities
+
+- **Codex Managed Session Record**: The durable session-level supervision record keyed by `session_id`.
+- **Codex Managed Session Supervisor**: The background session observer that tracks spool progress, publishes artifacts, and records diagnostics.
+- **Session Spool Files**: The append-only stdout/stderr files under the managed session artifact spool path that provide restart-safe session observability input.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Launch-time tests verify a durable session record is written with the required Phase 6 metadata.
+- **SC-002**: Supervision tests verify stdout/stderr/diagnostics artifacts and log offsets are persisted from session spool files.
+- **SC-003**: Summary/publication tests verify session continuity responses come from durable record state.
+- **SC-004**: Worker startup tests verify session reconciliation reattaches or degrades gracefully on restart.

--- a/specs/132-codex-managed-session-plane-phase6/speckit_analyze_report.md
+++ b/specs/132-codex-managed-session-plane-phase6/speckit_analyze_report.md
@@ -1,0 +1,46 @@
+# Specification Analysis Report
+
+**Feature**: 132-codex-managed-session-plane-phase6
+**Date**: 2026-04-06
+**Artifacts analyzed**: spec.md, plan.md, tasks.md, constitution.md
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|---|---|---|---|---|---|
+| C1 | Coverage | LOW | tasks.md T003 | Session summary/publication behavior is covered in controller tests rather than a dedicated standalone suite | Keep controller coverage as the primary boundary test unless publication logic grows into a separate service |
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|---|---|---|---|
+| FR-001 (durable session record) | ✅ | T001a, T002a, T002c, T003c | |
+| FR-002 (required Phase 6 fields) | ✅ | T001a, T002a | |
+| FR-003 (session-level supervision) | ✅ | T001b, T003a, T003b | |
+| FR-004 (stdout/stderr/diagnostics artifacts) | ✅ | T001b, T003a, T003c | |
+| FR-005 (summary/publication from durable records) | ✅ | T001c, T003c | |
+| FR-006 (reattach on startup) | ✅ | T001c, T001d, T003c, T004a | |
+| FR-007 (degrade gracefully when missing) | ✅ | T001c, T004a | |
+| FR-008 (preserve typed contracts / no launcher path) | ✅ | T001c, T003c, T004a | |
+
+## Constitution Alignment Issues
+
+None. The plan keeps orchestration in Temporal/worker services, preserves artifact-first durability, and adds replay-safe startup reconciliation.
+
+## Unmapped Tasks
+
+None. All tasks map to at least one functional requirement or verification gate.
+
+## Metrics
+
+- Total Requirements: 8
+- Total Tasks: 14
+- Coverage %: 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- No CRITICAL or HIGH issues were found.
+- Proceed to implementation with TDD, starting from the durable session record/store and session supervisor boundaries.

--- a/specs/132-codex-managed-session-plane-phase6/tasks.md
+++ b/specs/132-codex-managed-session-plane-phase6/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Codex Managed Session Plane Phase 6
+
+## T001 — Add TDD coverage for durable session supervision [P]
+- [X] T001a [P] Add unit tests in `tests/unit/services/temporal/runtime/test_managed_session_store.py` for durable session-record save/load/update behavior and required Phase 6 fields.
+- [X] T001b [P] Add unit tests in `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py` for spool-file supervision, artifact publication, diagnostics generation, and log offset tracking.
+- [X] T001c [P] Extend `tests/unit/services/temporal/runtime/test_managed_session_controller.py` to assert launch/control persistence, summary/publication sourcing from durable records, and reconciliation behavior.
+- [X] T001d [P] Extend `tests/unit/workflows/temporal/test_temporal_worker_runtime.py` to assert worker startup runs managed-session reconciliation.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
+
+## T002 — Implement the durable session record layer [P]
+- [X] T002a [P] Extend `moonmind/schemas/managed_session_models.py` with the Phase 6 durable session record and status models.
+- [X] T002b [P] Export the new managed-session schema symbols from `moonmind/schemas/__init__.py`.
+- [X] T002c [P] Add `moonmind/workflows/temporal/runtime/managed_session_store.py` for JSON-backed durable session persistence.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_store.py`
+
+## T003 — Implement session-level supervision and controller persistence [P]
+- [X] T003a [P] Add `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to watch session spool files, publish stdout/stderr/diagnostics artifacts, and update `last_log_at` / `last_log_offset`.
+- [X] T003b [P] Update `moonmind/workflows/temporal/runtime/codex_session_runtime.py` so session lifecycle and turn activity append restart-safe stdout/stderr spool content under the mounted artifact path.
+- [X] T003c [P] Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` to persist durable session records, start/stop supervision, serve summaries/publications from stored refs, and reconcile active sessions.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+
+## T004 — Wire startup reconciliation and verify [P]
+- [X] T004a [P] Update `moonmind/workflows/temporal/worker_runtime.py` so worker startup builds the session store/supervisor and runs managed-session reconciliation before serving activity traffic.
+- [X] T004b [P] Run `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T004c [P] Run `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+- [X] T004d [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Scope validation passes and `./tools/test_unit.sh` passes.

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2,17 +2,24 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
+    CodexManagedSessionRecord,
+    FetchCodexManagedSessionSummaryRequest,
     LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
+)
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
 )
 
 
@@ -21,6 +28,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "agent_jobs"
+    session_store = ManagedSessionStore(tmp_path / "session-store")
+    session_supervisor = AsyncMock()
     request = LaunchCodexManagedSessionRequest(
         taskRunId="task-1",
         sessionId="sess-1",
@@ -66,6 +75,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
         workspace_root=str(workspace_root),
+        session_store=session_store,
+        session_supervisor=session_supervisor,
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
     )
@@ -81,6 +92,12 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert request.image_ref in run_command
     assert "python3" in run_command
     assert "moonmind.workflows.temporal.runtime.codex_session_runtime" in run_command
+    stored = session_store.load("sess-1")
+    assert stored is not None
+    assert stored.task_run_id == "task-1"
+    assert stored.container_id == "ctr-1"
+    assert stored.runtime_id == "codex_cli"
+    session_supervisor.start.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -190,6 +207,142 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
     assert cleared.session_state.session_epoch == 2
     assert terminated.status == "terminated"
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
+
+
+@pytest.mark.asyncio
+async def test_controller_summary_and_publication_read_from_durable_record(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-2",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/work/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/work/agent_jobs/task-1/session",
+            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            stdoutArtifactRef="sess-1/stdout.log",
+            stderrArtifactRef="sess-1/stderr.log",
+            diagnosticsRef="sess-1/diagnostics.json",
+            latestSummaryRef="sess-1/session.summary.json",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=AsyncMock(),
+        command_runner=AsyncMock(),
+    )
+
+    summary = await controller.fetch_session_summary(
+        FetchCodexManagedSessionSummaryRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="thread-2",
+        )
+    )
+    publication = await controller.publish_session_artifacts(
+        PublishCodexManagedSessionArtifactsRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="thread-2",
+            taskRunId="task-1",
+        )
+    )
+
+    assert summary.latest_summary_ref == "sess-1/session.summary.json"
+    assert summary.metadata["stdoutArtifactRef"] == "sess-1/stdout.log"
+    assert publication.published_artifact_refs == (
+        "sess-1/stdout.log",
+        "sess-1/stderr.log",
+        "sess-1/diagnostics.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_controller_reconcile_reattaches_or_degrades_active_sessions(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-ok",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-ok",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-missing",
+            sessionEpoch=1,
+            taskRunId="task-2",
+            containerId="ctr-missing",
+            threadId="thread-2",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://missing",
+            status="busy",
+            workspacePath="/work/repo2",
+            sessionWorkspacePath="/work/session2",
+            artifactSpoolPath="/work/artifacts2",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = AsyncMock()
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "inspect", "-f"):
+            container_id = command[-1]
+            if container_id == "ctr-ok":
+                return 0, "true\n", ""
+            return 1, "", "No such container"
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    reconciled = await controller.reconcile()
+
+    assert sorted(record.session_id for record in reconciled) == ["sess-missing", "sess-ok"]
+    session_supervisor.start.assert_awaited_once()
+    assert store.load("sess-ok").status == "ready"
+    degraded = store.load("sess-missing")
+    assert degraded is not None
+    assert degraded.status == "degraded"
+    assert degraded.error_message == "managed session container is missing during reconcile"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -8,8 +8,10 @@ import pytest
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
+    CodexManagedSessionLocator,
     CodexManagedSessionRecord,
     FetchCodexManagedSessionSummaryRequest,
+    InterruptCodexManagedSessionTurnRequest,
     LaunchCodexManagedSessionRequest,
     PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
@@ -272,6 +274,76 @@ async def test_controller_summary_and_publication_read_from_durable_record(
 
 
 @pytest.mark.asyncio
+async def test_controller_publication_uses_snapshot_without_stopping_supervision(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-2",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/work/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/work/agent_jobs/task-1/session",
+            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = AsyncMock()
+    published_record = CodexManagedSessionRecord(
+        sessionId="sess-1",
+        sessionEpoch=2,
+        taskRunId="task-1",
+        containerId="ctr-1",
+        threadId="thread-2",
+        runtimeId="codex_cli",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl="docker-exec://mm-codex-session-sess-1",
+        status="ready",
+        workspacePath="/work/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/work/agent_jobs/task-1/session",
+        artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+        stdoutArtifactRef="sess-1/stdout.log",
+        stderrArtifactRef="sess-1/stderr.log",
+        diagnosticsRef="sess-1/diagnostics.json",
+        startedAt="2026-04-06T12:00:00Z",
+    )
+    session_supervisor.publish_snapshot.return_value = published_record
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=AsyncMock(),
+    )
+
+    publication = await controller.publish_session_artifacts(
+        PublishCodexManagedSessionArtifactsRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="thread-2",
+            taskRunId="task-1",
+        )
+    )
+
+    session_supervisor.publish_snapshot.assert_awaited_once_with("sess-1")
+    session_supervisor.finalize.assert_not_called()
+    assert publication.published_artifact_refs == (
+        "sess-1/stdout.log",
+        "sess-1/stderr.log",
+        "sess-1/diagnostics.json",
+    )
+
+
+@pytest.mark.asyncio
 async def test_controller_reconcile_reattaches_or_degrades_active_sessions(
     tmp_path: Path,
 ) -> None:
@@ -343,6 +415,304 @@ async def test_controller_reconcile_reattaches_or_degrades_active_sessions(
     assert degraded is not None
     assert degraded.status == "degraded"
     assert degraded.error_message == "managed session container is missing during reconcile"
+
+
+@pytest.mark.asyncio
+async def test_controller_reconcile_surfaces_transient_inspect_failures(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-ok",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-ok",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "inspect", "-f"):
+            return 1, "", "docker daemon unavailable"
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=AsyncMock(),
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(RuntimeError, match="failed to inspect managed session container ctr-ok"):
+        await controller.reconcile()
+
+
+@pytest.mark.asyncio
+async def test_controller_session_status_persists_returned_session_identity(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if "session_status" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 2,
+                    "containerId": "ctr-2",
+                    "threadId": "thread-2",
+                },
+                "status": "ready",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    await controller.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+        )
+    )
+
+    updated = store.load("sess-1")
+    assert updated is not None
+    assert updated.session_epoch == 2
+    assert updated.container_id == "ctr-2"
+    assert updated.thread_id == "thread-2"
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_skips_missing_durable_record(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 2,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-2",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "completed",
+                "metadata": {"assistantText": "OK"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert store.load("sess-1") is None
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_persists_failed_turn_status(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="busy",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "failed",
+                "metadata": {"reason": "turn execution failed"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    updated = store.load("sess-1")
+    assert response.status == "failed"
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.error_message == "turn execution failed"
+
+
+@pytest.mark.asyncio
+async def test_controller_interrupt_turn_preserves_failed_runtime_result(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ok",
+            status="busy",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if "interrupt_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "failed",
+                "metadata": {"reason": "turn-id mismatch"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.interrupt_turn(
+        InterruptCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            turnId="vendor-turn-1",
+        )
+    )
+
+    updated = store.load("sess-1")
+    assert response.status == "failed"
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.error_message == "turn-id mismatch"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_store.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_store.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 from moonmind.workflows.temporal.runtime.managed_session_store import (
     ManagedSessionStore,
@@ -39,12 +41,13 @@ def test_store_round_trips_phase6_session_record(tmp_path) -> None:
     assert loaded.container_id == "ctr-1"
 
 
-def test_store_update_status_persists_artifact_refs_and_offsets(tmp_path) -> None:
+@pytest.mark.asyncio
+async def test_store_update_status_persists_artifact_refs_and_offsets(tmp_path) -> None:
     store = ManagedSessionStore(tmp_path)
     record = _record()
     store.save(record)
 
-    updated = store.update(
+    updated = await store.update(
         "sess-1",
         status="terminated",
         stdout_artifact_ref="sess-1/stdout.log",
@@ -61,3 +64,19 @@ def test_store_update_status_persists_artifact_refs_and_offsets(tmp_path) -> Non
     assert updated.last_log_offset == 17
     assert updated.last_log_at == datetime(2026, 4, 6, 12, 5, tzinfo=UTC)
 
+
+@pytest.mark.asyncio
+async def test_store_update_revalidates_and_normalizes_mutations(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    store.save(_record())
+
+    updated = await store.update(
+        "sess-1",
+        runtime_id="codex",
+        error_message="  temporary failure  ",
+        updated_at=datetime(2026, 4, 6, 12, 6),
+    )
+
+    assert updated.runtime_id == "codex_cli"
+    assert updated.error_message == "temporary failure"
+    assert updated.updated_at == datetime(2026, 4, 6, 12, 6, tzinfo=UTC)

--- a/tests/unit/services/temporal/runtime/test_managed_session_store.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_store.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+
+
+def _record() -> CodexManagedSessionRecord:
+    return CodexManagedSessionRecord(
+        sessionId="sess-1",
+        sessionEpoch=1,
+        taskRunId="task-1",
+        containerId="ctr-1",
+        threadId="thread-1",
+        runtimeId="codex_cli",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl="docker-exec://mm-codex-session-sess-1",
+        status="ready",
+        workspacePath="/work/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/work/agent_jobs/task-1/session",
+        artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+        startedAt=datetime(2026, 4, 6, 12, 0, tzinfo=UTC),
+    )
+
+
+def test_store_round_trips_phase6_session_record(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    record = _record()
+
+    path = store.save(record)
+    loaded = store.load(record.session_id)
+
+    assert path.name == "sess-1.json"
+    assert loaded == record
+    assert loaded.task_run_id == "task-1"
+    assert loaded.container_id == "ctr-1"
+
+
+def test_store_update_status_persists_artifact_refs_and_offsets(tmp_path) -> None:
+    store = ManagedSessionStore(tmp_path)
+    record = _record()
+    store.save(record)
+
+    updated = store.update(
+        "sess-1",
+        status="terminated",
+        stdout_artifact_ref="sess-1/stdout.log",
+        stderr_artifact_ref="sess-1/stderr.log",
+        diagnostics_ref="sess-1/diagnostics.json",
+        last_log_offset=17,
+        last_log_at=datetime(2026, 4, 6, 12, 5, tzinfo=UTC),
+    )
+
+    assert updated.status == "terminated"
+    assert updated.stdout_artifact_ref == "sess-1/stdout.log"
+    assert updated.stderr_artifact_ref == "sess-1/stderr.log"
+    assert updated.diagnostics_ref == "sess-1/diagnostics.json"
+    assert updated.last_log_offset == 17
+    assert updated.last_log_at == datetime(2026, 4, 6, 12, 5, tzinfo=UTC)
+

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -64,6 +64,7 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
     supervisor = ManagedSessionSupervisor(
         store=store,
         log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
         poll_interval_seconds=0.01,
     )
     record = _record(tmp_path)
@@ -74,9 +75,13 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
     (spool / "stdout.log").write_text("session started\nassistant: OK\n", encoding="utf-8")
     (spool / "stderr.log").write_text("warning: none\n", encoding="utf-8")
     await asyncio.sleep(0.05)
+    watched = store.load("sess-1")
 
     finalized = await supervisor.finalize("sess-1", status="terminated")
 
+    assert watched is not None
+    assert watched.last_log_offset == len("session started\nassistant: OK\nwarning: none\n")
+    assert watched.last_log_at is not None
     assert finalized.status == "terminated"
     assert finalized.stdout_artifact_ref == "sess-1/stdout.log"
     assert finalized.stderr_artifact_ref == "sess-1/stderr.log"
@@ -86,3 +91,33 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
     assert artifact_storage.resolve_storage_path("sess-1/stdout.log").read_text(encoding="utf-8") == "session started\nassistant: OK\n"
     assert artifact_storage.resolve_storage_path("sess-1/stderr.log").read_text(encoding="utf-8") == "warning: none\n"
 
+
+@pytest.mark.asyncio
+async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    spool = Path(record.artifact_spool_path)
+
+    await supervisor.start(record)
+    (spool / "stdout.log").write_text("first\n", encoding="utf-8")
+    await asyncio.sleep(0.05)
+
+    snapshot = await supervisor.publish_snapshot("sess-1")
+    assert snapshot.stdout_artifact_ref == "sess-1/stdout.log"
+
+    (spool / "stdout.log").write_text("first\nsecond\n", encoding="utf-8")
+    await asyncio.sleep(0.05)
+    watched = store.load("sess-1")
+
+    assert watched is not None
+    assert watched.last_log_offset == len("first\nsecond\n")
+
+    await supervisor.finalize("sess-1", status="terminated")

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
+    ManagedSessionSupervisor,
+)
+
+
+class _LocalArtifactStorage:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def write_artifact(
+        self, *, job_id: str, artifact_name: str, data: bytes
+    ) -> tuple[Path, str]:
+        target_dir = self._root / job_id
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / artifact_name
+        target.write_bytes(data)
+        return target, f"{job_id}/{artifact_name}"
+
+    def resolve_storage_path(self, ref: str) -> Path:
+        return self._root / ref
+
+
+def _record(tmp_path: Path) -> CodexManagedSessionRecord:
+    workspace = tmp_path / "repo"
+    session_workspace = tmp_path / "session"
+    spool = tmp_path / "artifacts"
+    workspace.mkdir()
+    session_workspace.mkdir()
+    spool.mkdir()
+    return CodexManagedSessionRecord(
+        sessionId="sess-1",
+        sessionEpoch=1,
+        taskRunId="task-1",
+        containerId="ctr-1",
+        threadId="thread-1",
+        runtimeId="codex_cli",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        controlUrl="docker-exec://mm-codex-session-sess-1",
+        status="ready",
+        workspacePath=str(workspace),
+        sessionWorkspacePath=str(session_workspace),
+        artifactSpoolPath=str(spool),
+        startedAt=datetime(2026, 4, 6, 12, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    spool = Path(record.artifact_spool_path)
+
+    await supervisor.start(record)
+    (spool / "stdout.log").write_text("session started\nassistant: OK\n", encoding="utf-8")
+    (spool / "stderr.log").write_text("warning: none\n", encoding="utf-8")
+    await asyncio.sleep(0.05)
+
+    finalized = await supervisor.finalize("sess-1", status="terminated")
+
+    assert finalized.status == "terminated"
+    assert finalized.stdout_artifact_ref == "sess-1/stdout.log"
+    assert finalized.stderr_artifact_ref == "sess-1/stderr.log"
+    assert finalized.diagnostics_ref == "sess-1/diagnostics.json"
+    assert finalized.last_log_offset == len("session started\nassistant: OK\nwarning: none\n")
+    assert finalized.last_log_at is not None
+    assert artifact_storage.resolve_storage_path("sess-1/stdout.log").read_text(encoding="utf-8") == "session started\nassistant: OK\n"
+    assert artifact_storage.resolve_storage_path("sess-1/stderr.log").read_text(encoding="utf-8") == "warning: none\n"
+

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -678,6 +678,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     run_supervisor.reconcile = AsyncMock(return_value=[])
     run_launcher = MagicMock()
     session_controller = MagicMock()
+    session_controller.reconcile = AsyncMock(return_value=[])
     mock_build_deps.return_value = (
         run_store,
         run_supervisor,
@@ -727,6 +728,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
         session_controller=session_controller,
     )
     run_supervisor.reconcile.assert_awaited_once()
+    session_controller.reconcile.assert_awaited_once()
     mock_dispatcher_cls.assert_called_once_with()
     mock_skill_activities_cls.assert_called_once_with(
         dispatcher=mock_dispatcher_cls.return_value,


### PR DESCRIPTION
## Summary
- add Phase 6 Spec Kit artifacts for the Codex managed session plane session-supervision slice
- add durable managed-session record/store/supervisor support and wire startup reconciliation into the agent-runtime worker
- persist session spool output, source session summary/publication data from durable records, and add targeted coverage for store/supervisor/controller/worker startup behavior

## Why
Phase 4 proved the container-first control path, but the session plane still lacked durable session-level supervision. This change moves the architecture from one-shot controller state to artifact-first durable session records with restart-safe reconciliation.

## Impact
Managed Codex sessions now keep durable session metadata plus stdout/stderr/diagnostics refs outside the container lifecycle, and worker startup can reattach or degrade gracefully instead of losing active session state.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_store.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=132-codex-managed-session-plane-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`