### PR TITLE
Implement Phase 7 durable Codex session reset artifacts

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -524,29 +524,30 @@ class DockerCodexManagedSessionController:
         self,
         request: CodexManagedSessionClearRequest,
     ) -> CodexManagedSessionHandle:
-        previous_record = (
-            self._session_store.load(request.session_id)
-            if self._session_store is not None
-            else None
-        )
+        session_store = self._session_store
+        previous_record = None
+        if session_store is not None:
+            previous_record = session_store.load(request.session_id)
+            if previous_record is not None:
+                self._matches_locator(previous_record, request)
         payload = await self._invoke_json(
             container_id=request.container_id,
             action="clear_session",
             payload=request.model_dump(by_alias=True),
         )
         handle = CodexManagedSessionHandle.model_validate(payload)
-        if previous_record is not None and self._session_store is not None:
-            updated_record = previous_record.model_copy(
-                update={
-                    "session_epoch": handle.session_state.session_epoch,
-                    "container_id": handle.session_state.container_id,
-                    "thread_id": handle.session_state.thread_id,
-                    "image_ref": handle.image_ref or previous_record.image_ref,
-                    "control_url": handle.control_url or previous_record.control_url,
-                    "status": self._record_status_from_handle_status(handle.status),
-                    "updated_at": datetime.now(tz=UTC),
-                    "error_message": None,
-                }
+        if previous_record is not None:
+            assert session_store is not None
+            updated_record = await session_store.update(
+                request.session_id,
+                session_epoch=handle.session_state.session_epoch,
+                container_id=handle.session_state.container_id,
+                thread_id=handle.session_state.thread_id,
+                image_ref=handle.image_ref or previous_record.image_ref,
+                control_url=handle.control_url or previous_record.control_url,
+                status=self._record_status_from_handle_status(handle.status),
+                updated_at=datetime.now(tz=UTC),
+                error_message=None,
             )
             if self._session_supervisor is not None:
                 await self._session_supervisor.publish_reset_artifacts(
@@ -555,8 +556,6 @@ class DockerCodexManagedSessionController:
                     action="clear_session",
                     reason=request.reason,
                 )
-            else:
-                self._session_store.save(updated_record)
         else:
             await self._persist_handle_transition(
                 locator=self._locator_from_session_state(handle.session_state),

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -524,16 +524,44 @@ class DockerCodexManagedSessionController:
         self,
         request: CodexManagedSessionClearRequest,
     ) -> CodexManagedSessionHandle:
+        previous_record = (
+            self._session_store.load(request.session_id)
+            if self._session_store is not None
+            else None
+        )
         payload = await self._invoke_json(
             container_id=request.container_id,
             action="clear_session",
             payload=request.model_dump(by_alias=True),
         )
         handle = CodexManagedSessionHandle.model_validate(payload)
-        await self._persist_handle_transition(
-            locator=self._locator_from_session_state(handle.session_state),
-            status=handle.status,
-        )
+        if previous_record is not None and self._session_store is not None:
+            updated_record = previous_record.model_copy(
+                update={
+                    "session_epoch": handle.session_state.session_epoch,
+                    "container_id": handle.session_state.container_id,
+                    "thread_id": handle.session_state.thread_id,
+                    "image_ref": handle.image_ref or previous_record.image_ref,
+                    "control_url": handle.control_url or previous_record.control_url,
+                    "status": self._record_status_from_handle_status(handle.status),
+                    "updated_at": datetime.now(tz=UTC),
+                    "error_message": None,
+                }
+            )
+            if self._session_supervisor is not None:
+                await self._session_supervisor.publish_reset_artifacts(
+                    previous_record=previous_record,
+                    record=updated_record,
+                    action="clear_session",
+                    reason=request.reason,
+                )
+            else:
+                self._session_store.save(updated_record)
+        else:
+            await self._persist_handle_transition(
+                locator=self._locator_from_session_state(handle.session_state),
+                status=handle.status,
+            )
         return handle
 
     async def terminate_session(

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
@@ -152,6 +153,76 @@ class ManagedSessionSupervisor:
             status=record.status,
             error_message=record.error_message,
         )
+
+    async def publish_reset_artifacts(
+        self,
+        *,
+        previous_record: CodexManagedSessionRecord,
+        record: CodexManagedSessionRecord,
+        action: str,
+        reason: str | None,
+    ) -> CodexManagedSessionRecord:
+        if record.session_id != previous_record.session_id:
+            raise ValueError("reset artifact publication requires one session_id")
+
+        epoch = record.session_epoch
+        recorded_at = datetime.now(tz=UTC)
+        control_ref = self._artifact_storage.write_artifact(
+            job_id=record.session_id,
+            artifact_name=f"session.control_event.epoch-{epoch}.json",
+            data=(
+                json.dumps(
+                    {
+                        "linkType": "session.control_event",
+                        "action": action,
+                        "sessionId": record.session_id,
+                        "taskRunId": record.task_run_id,
+                        "containerId": record.container_id,
+                        "previousSessionEpoch": previous_record.session_epoch,
+                        "newSessionEpoch": record.session_epoch,
+                        "previousThreadId": previous_record.thread_id,
+                        "newThreadId": record.thread_id,
+                        "reason": reason,
+                        "recordedAt": recorded_at.isoformat(),
+                    },
+                    sort_keys=True,
+                    indent=2,
+                )
+                + "\n"
+            ).encode("utf-8"),
+        )[1]
+        boundary_ref = self._artifact_storage.write_artifact(
+            job_id=record.session_id,
+            artifact_name=f"session.reset_boundary.epoch-{epoch}.json",
+            data=(
+                json.dumps(
+                    {
+                        "linkType": "session.reset_boundary",
+                        "boundaryKind": action,
+                        "sessionId": record.session_id,
+                        "taskRunId": record.task_run_id,
+                        "containerId": record.container_id,
+                        "sessionEpoch": record.session_epoch,
+                        "threadId": record.thread_id,
+                        "previousSessionEpoch": previous_record.session_epoch,
+                        "previousThreadId": previous_record.thread_id,
+                        "recordedAt": recorded_at.isoformat(),
+                    },
+                    sort_keys=True,
+                    indent=2,
+                )
+                + "\n"
+            ).encode("utf-8"),
+        )[1]
+        updated = record.model_copy(
+            update={
+                "latest_control_event_ref": control_ref,
+                "latest_checkpoint_ref": boundary_ref,
+                "updated_at": recorded_at,
+            }
+        )
+        self._store.save(updated)
+        return updated
 
     async def finalize(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -214,15 +214,12 @@ class ManagedSessionSupervisor:
                 + "\n"
             ).encode("utf-8"),
         )[1]
-        updated = record.model_copy(
-            update={
-                "latest_control_event_ref": control_ref,
-                "latest_checkpoint_ref": boundary_ref,
-                "updated_at": recorded_at,
-            }
+        return await self._store.update(
+            record.session_id,
+            latest_control_event_ref=control_ref,
+            latest_checkpoint_ref=boundary_ref,
+            updated_at=recorded_at,
         )
-        self._store.save(updated)
-        return updated
 
     async def finalize(
         self,

--- a/specs/133-codex-managed-session-plane-phase7/data-model.md
+++ b/specs/133-codex-managed-session-plane-phase7/data-model.md
@@ -1,0 +1,36 @@
+# Data Model: Codex Managed Session Plane Phase 7
+
+## Codex Managed Session Record
+
+- Continues to use the Phase 6 durable record.
+- `latest_control_event_ref` stores the newest `session.control_event` artifact ref.
+- `latest_checkpoint_ref` stores the newest `session.reset_boundary` artifact ref.
+
+## Session Control Event Artifact
+
+- Suggested filename: `session.control_event.epoch-<N>.json`
+- Required payload fields:
+  - `linkType`
+  - `action`
+  - `sessionId`
+  - `taskRunId`
+  - `containerId`
+  - `previousSessionEpoch`
+  - `newSessionEpoch`
+  - `previousThreadId`
+  - `newThreadId`
+  - `reason`
+
+## Session Reset Boundary Artifact
+
+- Suggested filename: `session.reset_boundary.epoch-<N>.json`
+- Required payload fields:
+  - `linkType`
+  - `boundaryKind`
+  - `sessionId`
+  - `taskRunId`
+  - `containerId`
+  - `sessionEpoch`
+  - `threadId`
+  - `previousSessionEpoch`
+  - `previousThreadId`

--- a/specs/133-codex-managed-session-plane-phase7/plan.md
+++ b/specs/133-codex-managed-session-plane-phase7/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: codex-managed-session-plane-phase7
+
+**Branch**: `133-codex-managed-session-plane-phase7` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/133-codex-managed-session-plane-phase7/spec.md`
+
+## Summary
+
+Build the durable reset slice of the Codex managed-session plane. This phase teaches the managed-session controller/supervisor to materialize `clear_session` as durable `session.control_event` and `session.reset_boundary` artifacts, persist the latest refs on the managed session record, and return those refs through the existing summary/publication contracts without changing workflow or activity payload shapes.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing managed-session controller/store/supervisor modules, current JSON-backed runtime artifact storage, Temporal activity/workflow bindings for `agent_runtime.clear_session`
+**Testing**: focused pytest suites plus final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal backend runtime/session supervision
+**Constraints**: preserve existing managed-session activity/workflow contracts; keep the path container-first; keep reset evidence durable and artifact-first; avoid compatibility shims
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Temporal plus the managed-session controller remain the orchestrator; the remote container still only executes Codex session actions.
+- **II. One-Click Agent Deployment**: PASS. The phase reuses the current worker/session deployment shape and adds no new operator prerequisite.
+- **III. Avoid Vendor Lock-In**: PASS. The reset publication logic stays behind controller/supervisor boundaries and does not leak image-specific behavior into workflows.
+- **IV. Own Your Data**: PASS. Reset visibility moves into durable artifacts and bounded session metadata instead of container-private state.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The phase extends the explicit session record and summary/publication contracts rather than inventing ad hoc reset bookkeeping.
+- **VII. Powerful Runtime Configurability**: PASS. Artifact roots and workspace roots remain controlled by existing environment/config surfaces.
+- **VIII. Modular and Extensible Architecture**: PASS. Reset artifact publication lives in the session supervisor/controller boundary and does not couple workflow code to artifact storage details.
+- **IX. Resilient by Default**: PASS. Reset evidence survives container loss and worker restart because it is persisted in artifacts plus durable session record state.
+- **XI. Spec-Driven Development**: PASS. The Phase 7 scope is defined in spec/plan/tasks before code changes.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs already define the desired reset semantics; implementation sequencing remains under `specs/`.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The phase extends the one active session supervision path rather than layering fallback reset mechanisms on top.
+
+## Research
+
+- `docs/ManagedAgents/CodexManagedSessionPlane.md` already fixes clear/reset semantics as two artifacts plus an epoch bump, so the implementation only needs to align the Phase 6 durable session layer to that desired-state contract.
+- `CodexManagedSessionRecord` already has `latest_checkpoint_ref` and `latest_control_event_ref`, which means Phase 7 can land without changing activity/workflow schemas.
+- `ManagedSessionSupervisor` already owns durable log/diagnostics publication using the session artifact storage root, making it the correct place to add reset artifact writing instead of embedding file IO in workflow code.
+- The current controller updates epoch/thread/status on `clear_session` but does not publish continuity artifacts, so the minimum viable change is controller-triggered supervisor publication after the remote clear succeeds.
+
+## Project Structure
+
+- Extend `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` with reset artifact publication helpers and durable record updates.
+- Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` so `clear_session` persists the new epoch/thread state and invokes durable reset artifact publication.
+- Adjust `moonmind/schemas/managed_session_models.py` if needed for helper behavior such as published artifact ref enumeration.
+- Add or update tests under `tests/unit/services/temporal/runtime/`, `tests/unit/workflows/temporal/`, and `tests/unit/workflows/adapters/` for clear/reset durability and boundary behavior.
+
+## Data Model
+
+- **CodexManagedSessionRecord**
+  - Existing fields retained: `session_id`, `session_epoch`, `thread_id`, `latest_control_event_ref`, `latest_checkpoint_ref`, `updated_at`
+  - New Phase 7 behavior: `latest_control_event_ref` points to the newest `session.control_event` artifact and `latest_checkpoint_ref` points to the newest `session.reset_boundary` artifact.
+- **Session Control Event Payload**
+  - `linkType`: `session.control_event`
+  - `action`: `clear_session`
+  - `sessionId`, `taskRunId`, `containerId`
+  - `previousSessionEpoch`, `newSessionEpoch`
+  - `previousThreadId`, `newThreadId`
+  - `reason`
+- **Session Reset Boundary Payload**
+  - `linkType`: `session.reset_boundary`
+  - `sessionId`, `taskRunId`, `containerId`
+  - `sessionEpoch`
+  - `threadId`
+  - `previousSessionEpoch`, `previousThreadId`
+  - `boundaryKind`: `clear_session`
+
+## Implementation Plan
+
+1. Add failing tests for clear/reset durability in the managed-session supervisor and controller plus boundary assertions for summary/publication behavior after reset.
+2. Implement a reset publication helper in the session supervisor that writes epoch-specific JSON artifacts for `session.control_event` and `session.reset_boundary` and updates the durable session record refs.
+3. Update the controller clear/reset path to capture the previous record state, persist the returned epoch/thread transition, invoke reset publication, and preserve the container-first remote control flow.
+4. Update any session-record helper behavior needed so publication responses include the latest reset refs consistently.
+5. Run focused tests, update task status, run scope validation, then run `./tools/test_unit.sh`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_session.py`
+2. `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Launch a managed session, clear it once, and verify the session artifact root contains one `session.control_event` artifact and one `session.reset_boundary` artifact for the new epoch.
+2. Clear the same session again and verify the second epoch writes distinct artifact names while the durable session record points to the latest refs.
+3. Fetch session summary/publication after restart and confirm the latest reset refs are returned without querying container-private continuity state.

--- a/specs/133-codex-managed-session-plane-phase7/quickstart.md
+++ b/specs/133-codex-managed-session-plane-phase7/quickstart.md
@@ -1,0 +1,6 @@
+# Quickstart: Codex Managed Session Plane Phase 7
+
+1. Launch a managed Codex session through the existing Phase 4/5/6 path.
+2. Call `agent_runtime.clear_session` with a new `threadId`.
+3. Call `agent_runtime.fetch_session_summary` and verify `latestControlEventRef` and `latestCheckpointRef` are populated.
+4. Inspect the managed session artifact root and verify the epoch-specific `session.control_event` and `session.reset_boundary` artifacts exist.

--- a/specs/133-codex-managed-session-plane-phase7/research.md
+++ b/specs/133-codex-managed-session-plane-phase7/research.md
@@ -1,0 +1,5 @@
+# Research: Codex Managed Session Plane Phase 7
+
+- The desired-state reset contract already exists in [`docs/ManagedAgents/CodexManagedSessionPlane.md`](../../docs/ManagedAgents/CodexManagedSessionPlane.md): `clear_session` must write `session.control_event`, write `session.reset_boundary`, then increment `session_epoch`.
+- Phase 6 already introduced the durable `CodexManagedSessionRecord` fields needed for this slice: `latest_control_event_ref` and `latest_checkpoint_ref`.
+- The current implementation gap is limited to the service boundary: the remote runtime clears the session and appends spool text, but the controller/supervisor never materialize durable reset artifacts.

--- a/specs/133-codex-managed-session-plane-phase7/spec.md
+++ b/specs/133-codex-managed-session-plane-phase7/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: codex-managed-session-plane-phase7
+
+**Feature Branch**: `133-codex-managed-session-plane-phase7`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Implement Phase 7 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Publish Durable Reset Artifacts On Clear (Priority: P1)
+
+When an operator or workflow clears a managed Codex session, MoonMind must materialize the reset as durable artifacts instead of treating it as an in-container implementation detail.
+
+**Why this priority**: Phase 7 exists to make reset/clear explicit and durable. Without artifact publication, the epoch boundary is invisible after the container is gone.
+
+**Independent Test**: Clear a durable managed session through the controller and verify MoonMind writes one `session.control_event` artifact and one `session.reset_boundary` artifact, updates the durable session record with their refs, and advances the epoch.
+
+**Acceptance Scenarios**:
+
+1. **Given** a persisted managed session record and a successful remote `clear_session` response, **When** the controller records the reset, **Then** the durable session record stores the new `session_epoch`, `thread_id`, `latest_control_event_ref`, and `latest_checkpoint_ref`.
+2. **Given** a clear/reset action is applied, **When** the reset artifacts are published, **Then** MoonMind writes a durable `session.control_event` artifact describing the control action and a durable `session.reset_boundary` artifact describing the new epoch boundary.
+3. **Given** a second clear/reset is applied later, **When** MoonMind publishes the next artifacts, **Then** it writes new artifact paths for the new epoch instead of overwriting the previous epoch's reset evidence.
+
+---
+
+### User Story 2 - Reuse Reset Refs Through Session Summary APIs (Priority: P1)
+
+The existing managed-session summary/publication surfaces must expose the latest reset artifacts from durable record state so UI and API callers can build continuity views without reading container-private state.
+
+**Why this priority**: The reset only becomes operator-visible if the same continuity surfaces used elsewhere return the refs.
+
+**Independent Test**: After a clear/reset, fetch session summary and publish session artifacts and verify both responses return the persisted control-event and reset-boundary refs from the durable session record.
+
+**Acceptance Scenarios**:
+
+1. **Given** a durable session record containing latest reset refs, **When** `agent_runtime.fetch_session_summary` is called, **Then** the response returns `latestControlEventRef` and `latestCheckpointRef` from the durable record.
+2. **Given** a durable session record containing latest reset refs, **When** `agent_runtime.publish_session_artifacts` is called, **Then** the response includes those refs and does not ask the container to synthesize continuity history.
+3. **Given** the reset artifacts were written by a prior clear/reset, **When** summary/publication is requested after a worker restart, **Then** the refs are still served from the durable session record.
+
+---
+
+### User Story 3 - Preserve Container-First Reset Semantics (Priority: P2)
+
+The new reset behavior must remain layered on top of the remote session container control path rather than reintroducing worker-local Codex ownership.
+
+**Why this priority**: Phase 7 must strengthen durability without violating the earlier session-container architecture.
+
+**Independent Test**: Invoke `agent_runtime.clear_session` and verify MoonMind still sends the remote clear action first, then records the resulting epoch boundary durably without routing through `ManagedRuntimeLauncher` or a local Codex subprocess path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed session clear request, **When** the controller handles it, **Then** it still issues the control action against the remote session container and only uses the worker to publish durable artifacts and update metadata.
+2. **Given** the `MoonMind.AgentSession` workflow receives the clear/reset control action, **When** it updates its snapshot, **Then** the workflow still preserves `session_id`, increments `session_epoch`, rotates `thread_id`, and clears `active_turn_id`.
+
+### Edge Cases
+
+- A clear/reset is requested for a session that has never published any prior continuity artifacts.
+- A clear/reset reason is omitted and MoonMind must still publish a valid control artifact.
+- A session is cleared multiple times in one task and each epoch boundary must remain distinguishable by artifact name and metadata.
+- The controller publishes reset artifacts after the remote container reports success but before any later step runs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `agent_runtime.clear_session` MUST remain a remote session-container control action and MUST NOT execute Codex locally in the worker process.
+- **FR-002**: A successful managed-session clear/reset MUST write one durable `session.control_event` artifact describing the clear action.
+- **FR-003**: A successful managed-session clear/reset MUST write one durable `session.reset_boundary` artifact describing the new continuity interval.
+- **FR-004**: The durable managed session record MUST persist the latest clear/reset artifact refs using `latest_control_event_ref` and `latest_checkpoint_ref`.
+- **FR-005**: The durable managed session record MUST persist the new `session_epoch`, `thread_id`, and `updated_at` produced by `clear_session`.
+- **FR-006**: Reset artifacts MUST be written with epoch-specific names or metadata so successive resets do not overwrite prior reset evidence.
+- **FR-007**: `agent_runtime.fetch_session_summary` and `agent_runtime.publish_session_artifacts` MUST return reset-boundary refs from durable session state after a clear/reset.
+- **FR-008**: The Phase 7 implementation MUST preserve the existing `MoonMind.AgentSession` and `mm.activity.agent_runtime` request/response shapes.
+
+### Key Entities
+
+- **Session Control Event Artifact**: Durable JSON artifact describing one explicit control action such as `clear_session`, including session identity, reason, and epoch transition metadata.
+- **Session Reset Boundary Artifact**: Durable JSON artifact describing the new logical continuity interval after a reset, including previous and new epoch/thread values.
+- **Durable Managed Session Record**: The Phase 6 JSON-backed session record that now carries the latest reset-boundary refs in addition to runtime observability refs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Controller/service tests verify `clear_session` writes reset artifacts and updates durable refs plus epoch metadata.
+- **SC-002**: Supervisor/store tests verify repeated clears preserve distinct reset artifact refs instead of overwriting prior epoch evidence.
+- **SC-003**: Summary/publication tests verify reset refs are served from the durable session record after clear/reset.
+- **SC-004**: Focused activity/workflow boundary tests confirm the existing clear/reset request/response contracts still hold while the epoch boundary remains explicit.

--- a/specs/133-codex-managed-session-plane-phase7/tasks.md
+++ b/specs/133-codex-managed-session-plane-phase7/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: Codex Managed Session Plane Phase 7
+
+## T001 — Add TDD coverage for durable reset publication [P]
+- [X] T001a [P] Extend `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py` with unit tests for publishing `session.control_event` and `session.reset_boundary` artifacts with distinct epoch-specific refs.
+- [X] T001b [P] Extend `tests/unit/services/temporal/runtime/test_managed_session_controller.py` to assert `clear_session` persists the new epoch/thread plus latest reset refs and that summary/publication surfaces return those durable refs.
+- [X] T001c [P] Extend `tests/unit/workflows/temporal/test_agent_runtime_activities.py` or `tests/unit/workflows/temporal/workflows/test_agent_session.py` with boundary assertions confirming the existing clear/reset contract still holds while the epoch boundary stays explicit.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_session.py`
+
+## T002 — Implement durable reset artifact publication [P]
+- [X] T002a [P] Update `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to publish `session.control_event` and `session.reset_boundary` artifacts and persist their refs on the durable session record.
+- [X] T002b [P] Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` so `clear_session` records the previous and new epoch/thread boundary, invokes reset artifact publication, and preserves the remote-container control flow.
+- [X] T002c [P] Update `moonmind/schemas/managed_session_models.py` if needed so managed-session publication helpers expose the latest continuity refs consistently.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+
+## T003 — Verify scope and full unit suite [P]
+- [X] T003a [P] Run `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T003b [P] Run `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+- [X] T003c [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Scope validation passes and `./tools/test_unit.sh` passes.

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -23,6 +24,27 @@ from moonmind.workflows.temporal.runtime.managed_session_controller import (
 from moonmind.workflows.temporal.runtime.managed_session_store import (
     ManagedSessionStore,
 )
+from moonmind.workflows.temporal.runtime.managed_session_supervisor import (
+    ManagedSessionSupervisor,
+)
+from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
+
+
+class _LocalArtifactStorage:
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def write_artifact(
+        self, *, job_id: str, artifact_name: str, data: bytes
+    ) -> tuple[Path, str]:
+        target_dir = self._root / job_id
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / artifact_name
+        target.write_bytes(data)
+        return target, f"{job_id}/{artifact_name}"
+
+    def resolve_storage_path(self, ref: str) -> Path:
+        return self._root / ref
 
 
 @pytest.mark.asyncio
@@ -212,6 +234,116 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
 
 
 @pytest.mark.asyncio
+async def test_controller_clear_session_publishes_durable_reset_artifacts(
+    tmp_path: Path,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+    store = ManagedSessionStore(tmp_path / "session-store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/work/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/work/agent_jobs/task-1/session",
+            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            startedAt=datetime(2026, 4, 7, 8, 0, tzinfo=UTC),
+        )
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if "clear_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 2,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-2",
+                },
+                "status": "ready",
+                "imageRef": "ghcr.io/moonladderstudios/moonmind:latest",
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=supervisor,
+        command_runner=_fake_runner,
+    )
+
+    cleared = await controller.clear_session(
+        CodexManagedSessionClearRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            newThreadId="logical-thread-2",
+            reason="reset stale context",
+        )
+    )
+    stored = store.load("sess-1")
+    assert stored is not None
+
+    assert cleared.session_state.session_epoch == 2
+    assert stored.thread_id == "logical-thread-2"
+    assert stored.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert stored.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+    control_payload = json.loads(
+        artifact_storage.resolve_storage_path(
+            stored.latest_control_event_ref
+        ).read_text(encoding="utf-8")
+    )
+    assert control_payload["reason"] == "reset stale context"
+
+    summary = await controller.fetch_session_summary(
+        FetchCodexManagedSessionSummaryRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="logical-thread-2",
+        )
+    )
+    publication = await controller.publish_session_artifacts(
+        PublishCodexManagedSessionArtifactsRequest(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="logical-thread-2",
+            taskRunId="task-1",
+        )
+    )
+
+    assert summary.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert summary.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+    assert publication.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert publication.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+
+
+@pytest.mark.asyncio
 async def test_controller_summary_and_publication_read_from_durable_record(
     tmp_path: Path,
 ) -> None:
@@ -234,6 +366,8 @@ async def test_controller_summary_and_publication_read_from_durable_record(
             stderrArtifactRef="sess-1/stderr.log",
             diagnosticsRef="sess-1/diagnostics.json",
             latestSummaryRef="sess-1/session.summary.json",
+            latestCheckpointRef="sess-1/session.reset_boundary.epoch-2.json",
+            latestControlEventRef="sess-1/session.control_event.epoch-2.json",
             startedAt="2026-04-06T12:00:00Z",
         )
     )
@@ -265,12 +399,16 @@ async def test_controller_summary_and_publication_read_from_durable_record(
     )
 
     assert summary.latest_summary_ref == "sess-1/session.summary.json"
+    assert summary.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+    assert summary.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert summary.metadata["stdoutArtifactRef"] == "sess-1/stdout.log"
     assert publication.published_artifact_refs == (
         "sess-1/stdout.log",
         "sess-1/stderr.log",
         "sess-1/diagnostics.json",
     )
+    assert publication.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+    assert publication.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -344,6 +344,55 @@ async def test_controller_clear_session_publishes_durable_reset_artifacts(
 
 
 @pytest.mark.asyncio
+async def test_controller_clear_session_rejects_stale_durable_locator(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-2",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/work/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/work/agent_jobs/task-1/session",
+            artifactSpoolPath="/work/agent_jobs/task-1/artifacts",
+            startedAt=datetime(2026, 4, 7, 8, 0, tzinfo=UTC),
+        )
+    )
+    runner = AsyncMock()
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=AsyncMock(),
+        command_runner=runner,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="sessionEpoch does not match the durable managed session record",
+    ):
+        await controller.clear_session(
+            CodexManagedSessionClearRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                newThreadId="logical-thread-2",
+            )
+        )
+
+    runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_controller_summary_and_publication_read_from_durable_record(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -204,3 +204,44 @@ async def test_publish_reset_artifacts_writes_epoch_specific_control_and_boundar
     assert artifact_storage.resolve_storage_path(
         "sess-1/session.reset_boundary.epoch-2.json"
     ).exists()
+
+
+@pytest.mark.asyncio
+async def test_publish_reset_artifacts_preserves_newer_store_fields(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    previous = _record(tmp_path)
+    store.save(previous)
+    await store.update(
+        "sess-1",
+        session_epoch=2,
+        thread_id="thread-2",
+        last_log_offset=77,
+        last_log_at=datetime(2026, 4, 7, 8, 1, tzinfo=UTC),
+    )
+    stale_current = previous.model_copy(
+        update={
+            "session_epoch": 2,
+            "thread_id": "thread-2",
+            "last_log_offset": None,
+            "last_log_at": None,
+        }
+    )
+
+    published = await supervisor.publish_reset_artifacts(
+        previous_record=previous,
+        record=stale_current,
+        action="clear_session",
+        reason=None,
+    )
+
+    assert published.last_log_offset == 77
+    assert published.last_log_at == datetime(2026, 4, 7, 8, 1, tzinfo=UTC)
+    assert published.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert published.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -121,3 +122,85 @@ async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None
     assert watched.last_log_offset == len("first\nsecond\n")
 
     await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
+async def test_publish_reset_artifacts_writes_epoch_specific_control_and_boundary_refs(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    previous = _record(tmp_path)
+    store.save(previous)
+    current = previous.model_copy(
+        update={
+            "session_epoch": 2,
+            "thread_id": "thread-2",
+            "updated_at": datetime(2026, 4, 7, 8, 0, tzinfo=UTC),
+        }
+    )
+
+    published = await supervisor.publish_reset_artifacts(
+        previous_record=previous,
+        record=current,
+        action="clear_session",
+        reason="reset stale context",
+    )
+
+    assert published.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert published.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-2.json"
+
+    control_payload = json.loads(
+        artifact_storage.resolve_storage_path(
+            "sess-1/session.control_event.epoch-2.json"
+        ).read_text(encoding="utf-8")
+    )
+    boundary_payload = json.loads(
+        artifact_storage.resolve_storage_path(
+            "sess-1/session.reset_boundary.epoch-2.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert control_payload["linkType"] == "session.control_event"
+    assert control_payload["action"] == "clear_session"
+    assert control_payload["previousSessionEpoch"] == 1
+    assert control_payload["newSessionEpoch"] == 2
+    assert control_payload["previousThreadId"] == "thread-1"
+    assert control_payload["newThreadId"] == "thread-2"
+    assert control_payload["reason"] == "reset stale context"
+
+    assert boundary_payload["linkType"] == "session.reset_boundary"
+    assert boundary_payload["boundaryKind"] == "clear_session"
+    assert boundary_payload["previousSessionEpoch"] == 1
+    assert boundary_payload["sessionEpoch"] == 2
+    assert boundary_payload["previousThreadId"] == "thread-1"
+    assert boundary_payload["threadId"] == "thread-2"
+
+    next_record = published.model_copy(
+        update={
+            "session_epoch": 3,
+            "thread_id": "thread-3",
+            "updated_at": datetime(2026, 4, 7, 8, 5, tzinfo=UTC),
+        }
+    )
+    republished = await supervisor.publish_reset_artifacts(
+        previous_record=published,
+        record=next_record,
+        action="clear_session",
+        reason=None,
+    )
+
+    assert republished.latest_control_event_ref == "sess-1/session.control_event.epoch-3.json"
+    assert republished.latest_checkpoint_ref == "sess-1/session.reset_boundary.epoch-3.json"
+    assert artifact_storage.resolve_storage_path(
+        "sess-1/session.control_event.epoch-2.json"
+    ).exists()
+    assert artifact_storage.resolve_storage_path(
+        "sess-1/session.reset_boundary.epoch-2.json"
+    ).exists()

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -507,6 +507,7 @@ async def test_fetch_session_summary_delegates_to_remote_session_controller() ->
             },
             latestSummaryRef="art-summary",
             latestCheckpointRef="art-checkpoint",
+            latestControlEventRef="art-control",
         )
     )
     activities = TemporalAgentRuntimeActivities(session_controller=controller)
@@ -522,6 +523,8 @@ async def test_fetch_session_summary_delegates_to_remote_session_controller() ->
 
     assert isinstance(result, CodexManagedSessionSummary)
     assert result.latest_summary_ref == "art-summary"
+    assert result.latest_checkpoint_ref == "art-checkpoint"
+    assert result.latest_control_event_ref == "art-control"
 
 
 async def test_publish_session_artifacts_delegates_to_remote_session_controller() -> None:
@@ -536,6 +539,8 @@ async def test_publish_session_artifacts_delegates_to_remote_session_controller(
             },
             publishedArtifactRefs=("art-summary", "art-checkpoint"),
             latestSummaryRef="art-summary",
+            latestCheckpointRef="art-checkpoint",
+            latestControlEventRef="art-control",
         )
     )
     activities = TemporalAgentRuntimeActivities(session_controller=controller)
@@ -551,6 +556,8 @@ async def test_publish_session_artifacts_delegates_to_remote_session_controller(
 
     assert isinstance(result, CodexManagedSessionArtifactsPublication)
     assert result.published_artifact_refs == ("art-summary", "art-checkpoint")
+    assert result.latest_checkpoint_ref == "art-checkpoint"
+    assert result.latest_control_event_ref == "art-control"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- implement Phase 7 of the Codex managed session plane MVP
- publish durable `session.control_event` and `session.reset_boundary` artifacts on managed `clear_session`
- persist the latest reset refs on the managed session record and surface them through session summary/publication responses

## Testing
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_session.py`
- `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=133-codex-managed-session-plane-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`