### PR TITLE
[codex] Implement Phase 8 managed-session artifact discipline

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -76,6 +76,8 @@ def _is_safe_reason_transition(previous: str, current: str) -> bool:
         return True
     if prev in FULL_REMEDIATION_REASONS and curr in FINALIZE_ONLY_RETRY_REASONS:
         return True
+    if prev in FINALIZE_ONLY_RETRY_REASONS and curr in FULL_REMEDIATION_REASONS:
+        return True
     if prev in FINALIZE_ONLY_RETRY_REASONS and curr in FINALIZE_ONLY_RETRY_REASONS:
         return True
     if curr == "merge_not_ready" and prev in FINALIZE_ONLY_RETRY_REASONS:
@@ -241,45 +243,21 @@ def run_orchestration(
             and normalize_text(reason) != normalize_text(blocked_reason_previous)
             and not _is_safe_reason_transition(blocked_reason_previous, reason)
         ):
-            if normalize_text(reason) == "ci_failures":
-                retry_action = classify_retry_action(
-                    reason,
-                    merge_not_ready_grace_remaining=grace_remaining,
-                )
-                if retry_action == "full_remediation":
-                    blocked_reason_previous = reason
-                else:
-                    result = _build_result(
-                        status="blocked",
-                        decision="reason changed across retries; manual review required",
-                        merge_outcome="blocked",
-                        final_reason=reason,
-                        next_step="manual_review",
-                        max_attempts=max_attempts,
-                        finalize_max_retries=finalize_max_retries,
-                        fix_max_iterations=fix_max_iterations,
-                        history=history,
-                        escalations=escalations,
-                        started_at=started_at,
-                        finished_at=now_utc_iso(),
-                    )
-                    return result, EXIT_CODE_BLOCKED
-            else:
-                result = _build_result(
-                    status="blocked",
-                    decision="reason changed across retries; manual review required",
-                    merge_outcome="blocked",
-                    final_reason=reason,
-                    next_step="manual_review",
-                    max_attempts=max_attempts,
-                    finalize_max_retries=finalize_max_retries,
-                    fix_max_iterations=fix_max_iterations,
-                    history=history,
-                    escalations=escalations,
-                    started_at=started_at,
-                    finished_at=now_utc_iso(),
-                )
-                return result, EXIT_CODE_BLOCKED
+            result = _build_result(
+                status="blocked",
+                decision="reason changed across retries; manual review required",
+                merge_outcome="blocked",
+                final_reason=reason,
+                next_step="manual_review",
+                max_attempts=max_attempts,
+                finalize_max_retries=finalize_max_retries,
+                fix_max_iterations=fix_max_iterations,
+                history=history,
+                escalations=escalations,
+                started_at=started_at,
+                finished_at=now_utc_iso(),
+            )
+            return result, EXIT_CODE_BLOCKED
         if reason:
             blocked_reason_previous = reason
 

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -281,6 +281,9 @@ class CodexManagedSessionSummary(_CodexManagedSessionRemoteContract):
     latest_control_event_ref: NonBlankStr | None = Field(
         None, alias="latestControlEventRef"
     )
+    latest_reset_boundary_ref: NonBlankStr | None = Field(
+        None, alias="latestResetBoundaryRef"
+    )
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
 
 
@@ -297,6 +300,9 @@ class CodexManagedSessionArtifactsPublication(_CodexManagedSessionRemoteContract
     )
     latest_control_event_ref: NonBlankStr | None = Field(
         None, alias="latestControlEventRef"
+    )
+    latest_reset_boundary_ref: NonBlankStr | None = Field(
+        None, alias="latestResetBoundaryRef"
     )
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
 
@@ -324,6 +330,7 @@ class CodexManagedSessionRecord(BaseModel):
     latest_summary_ref: str | None = Field(None, alias="latestSummaryRef")
     latest_checkpoint_ref: str | None = Field(None, alias="latestCheckpointRef")
     latest_control_event_ref: str | None = Field(None, alias="latestControlEventRef")
+    latest_reset_boundary_ref: str | None = Field(None, alias="latestResetBoundaryRef")
     last_log_offset: int | None = Field(None, alias="lastLogOffset", ge=0)
     last_log_at: datetime | None = Field(None, alias="lastLogAt")
     error_message: str | None = Field(None, alias="errorMessage")
@@ -381,6 +388,11 @@ class CodexManagedSessionRecord(BaseModel):
                 self.latest_control_event_ref,
                 field_name="latestControlEventRef",
             )
+        if self.latest_reset_boundary_ref is not None:
+            self.latest_reset_boundary_ref = require_non_blank(
+                self.latest_reset_boundary_ref,
+                field_name="latestResetBoundaryRef",
+            )
         if self.error_message is not None:
             self.error_message = require_non_blank(
                 self.error_message,
@@ -404,15 +416,19 @@ class CodexManagedSessionRecord(BaseModel):
         )
 
     def published_artifact_refs(self) -> tuple[str, ...]:
-        return tuple(
-            ref
-            for ref in (
-                self.stdout_artifact_ref,
-                self.stderr_artifact_ref,
-                self.diagnostics_ref,
-            )
-            if ref
-        )
+        refs: list[str] = []
+        for ref in (
+            self.stdout_artifact_ref,
+            self.stderr_artifact_ref,
+            self.diagnostics_ref,
+            self.latest_summary_ref,
+            self.latest_checkpoint_ref,
+            self.latest_control_event_ref,
+            self.latest_reset_boundary_ref,
+        ):
+            if ref and ref not in refs:
+                refs.append(ref)
+        return tuple(refs)
 class CodexManagedSessionBinding(BaseModel):
     """Bounded task-scoped session binding passed across workflow boundaries."""
 

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -429,6 +429,8 @@ class CodexManagedSessionRecord(BaseModel):
             if ref and ref not in refs:
                 refs.append(ref)
         return tuple(refs)
+
+
 class CodexManagedSessionBinding(BaseModel):
     """Bounded task-scoped session binding passed across workflow boundaries."""
 

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -173,6 +173,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
 
         run_id = _generate_run_id()
         started_at = _current_time()
+        original_instruction_ref = str(request.instruction_ref or "").strip() or None
+        original_skillset_ref = str(request.resolved_skillset_ref or "").strip() or None
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -240,6 +242,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             outputRefs=output_refs,
             summary=assistant_text,
             metadata={
+                "instructionRef": original_instruction_ref,
+                "resolvedSkillsetRef": original_skillset_ref,
                 "sessionSummary": summary.model_dump(mode="json", by_alias=True),
                 "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
                 "turnId": turn_response.turn_id,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2450,10 +2450,11 @@ class TemporalAgentRuntimeActivities:
     ) -> AgentRunResult | None:
         """Publish agent-run outputs back to artifact storage.
 
-        Writes a summary JSON artifact containing the run result metadata
-        (output refs, summary, failure class) via the artifact service.
+        Best-effort publication writes ``output.summary`` and
+        ``output.agent_result`` JSON artifacts plus managed-session
+        ``input.*`` reference artifacts when those refs are present.
         Returns the result enriched with a ``diagnostics_ref`` pointing to
-        the persisted summary artifact.
+        the persisted ``output.agent_result`` artifact.
         """
         if result is None:
             return result
@@ -2518,19 +2519,6 @@ class TemporalAgentRuntimeActivities:
 
         instruction_ref = str(metadata.get("instructionRef") or "").strip()
         resolved_skillset_ref = str(metadata.get("resolvedSkillsetRef") or "").strip()
-        published_refs: dict[str, str] = {}
-        if instruction_ref:
-            published_refs["inputInstructionsRef"] = await _write_reference_artifact(
-                link_type="input.instructions",
-                artifact_ref_value=instruction_ref,
-                field_name="instructionRef",
-            )
-        if resolved_skillset_ref:
-            published_refs["inputSkillSnapshotRef"] = await _write_reference_artifact(
-                link_type="input.skill_snapshot",
-                artifact_ref_value=resolved_skillset_ref,
-                field_name="resolvedSkillsetRef",
-            )
 
         # Build summary payload for the artifact
         summary_payload: dict[str, Any] = {
@@ -2542,6 +2530,19 @@ class TemporalAgentRuntimeActivities:
         }
 
         try:
+            published_refs: dict[str, str] = {}
+            if instruction_ref:
+                published_refs["inputInstructionsRef"] = await _write_reference_artifact(
+                    link_type="input.instructions",
+                    artifact_ref_value=instruction_ref,
+                    field_name="instructionRef",
+                )
+            if resolved_skillset_ref:
+                published_refs["inputSkillSnapshotRef"] = await _write_reference_artifact(
+                    link_type="input.skill_snapshot",
+                    artifact_ref_value=resolved_skillset_ref,
+                    field_name="resolvedSkillsetRef",
+                )
             summary_ref = await _write_json_artifact(
                 self._artifact_service,
                 principal="system:agent_runtime",
@@ -2590,17 +2591,23 @@ class TemporalAgentRuntimeActivities:
                 return enriched
             if hasattr(result, "diagnostics_ref"):
                 result.diagnostics_ref = agent_result_ref.artifact_id
-            result.metadata.update(
-                {
-                    **published_refs,
-                    "outputSummaryRef": summary_ref.artifact_id,
-                    "outputAgentResultRef": agent_result_ref.artifact_id,
-                }
-            )
+            if hasattr(result, "metadata"):
+                metadata_obj = getattr(result, "metadata", None)
+                enriched_metadata = (
+                    dict(metadata_obj) if isinstance(metadata_obj, Mapping) else {}
+                )
+                enriched_metadata.update(
+                    {
+                        **published_refs,
+                        "outputSummaryRef": summary_ref.artifact_id,
+                        "outputAgentResultRef": agent_result_ref.artifact_id,
+                    }
+                )
+                result.metadata = enriched_metadata
             return result
         except Exception as exc:
             logger.warning(
-                "agent_runtime.publish_artifacts failed to write summary artifact",
+                "agent_runtime.publish_artifacts failed to publish managed-session artifacts",
                 exc_info=True,
             )
             return result

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2472,6 +2472,66 @@ class TemporalAgentRuntimeActivities:
         else:
             result_dict = {"raw": str(result)}
 
+        from temporalio import activity
+
+        try:
+            info = activity.info()
+        except RuntimeError:
+            info = None
+
+        def _execution_ref(link_type: str) -> ExecutionRef | None:
+            if info is None:
+                return None
+            return ExecutionRef(
+                namespace=info.namespace,
+                workflow_id=info.workflow_id,
+                run_id=info.workflow_run_id,
+                link_type=link_type,
+            )
+
+        metadata = (
+            result_dict.get("metadata")
+            if isinstance(result_dict.get("metadata"), Mapping)
+            else {}
+        )
+
+        async def _write_reference_artifact(
+            *,
+            link_type: str,
+            artifact_ref_value: str,
+            field_name: str,
+        ) -> str:
+            ref = await _write_json_artifact(
+                self._artifact_service,
+                principal="system:agent_runtime",
+                payload={
+                    field_name: artifact_ref_value,
+                },
+                execution_ref=_execution_ref(link_type),
+                metadata_json={
+                    "name": link_type.replace(".", "_") + ".json",
+                    "producer": "activity:agent_runtime.publish_artifacts",
+                    "labels": ["agent_runtime", link_type],
+                },
+            )
+            return ref.artifact_id
+
+        instruction_ref = str(metadata.get("instructionRef") or "").strip()
+        resolved_skillset_ref = str(metadata.get("resolvedSkillsetRef") or "").strip()
+        published_refs: dict[str, str] = {}
+        if instruction_ref:
+            published_refs["inputInstructionsRef"] = await _write_reference_artifact(
+                link_type="input.instructions",
+                artifact_ref_value=instruction_ref,
+                field_name="instructionRef",
+            )
+        if resolved_skillset_ref:
+            published_refs["inputSkillSnapshotRef"] = await _write_reference_artifact(
+                link_type="input.skill_snapshot",
+                artifact_ref_value=resolved_skillset_ref,
+                field_name="resolvedSkillsetRef",
+            )
+
         # Build summary payload for the artifact
         summary_payload: dict[str, Any] = {
             "summary": result_dict.get("summary") or result_dict.get("raw", ""),
@@ -2486,25 +2546,57 @@ class TemporalAgentRuntimeActivities:
                 self._artifact_service,
                 principal="system:agent_runtime",
                 payload=summary_payload,
+                execution_ref=_execution_ref("output.summary"),
+                metadata_json={
+                    "name": "agent_run_summary.json",
+                    "producer": "activity:agent_runtime.publish_artifacts",
+                    "labels": ["agent_runtime", "output.summary"],
+                },
+            )
+            agent_result_ref = await _write_json_artifact(
+                self._artifact_service,
+                principal="system:agent_runtime",
+                payload=result_dict,
+                execution_ref=_execution_ref("output.agent_result"),
                 metadata_json={
                     "name": "agent_run_result.json",
                     "producer": "activity:agent_runtime.publish_artifacts",
-                    "labels": ["agent_runtime", "result"],
+                    "labels": ["agent_runtime", "output.agent_result"],
                 },
             )
             # Enrich result with the diagnostics ref
             if isinstance(result, Mapping):
                 enriched = dict(result)
                 if "diagnosticsRef" in enriched:
-                    enriched["diagnosticsRef"] = summary_ref.artifact_id
+                    enriched["diagnosticsRef"] = agent_result_ref.artifact_id
                 else:
-                    enriched["diagnostics_ref"] = summary_ref.artifact_id
+                    enriched["diagnostics_ref"] = agent_result_ref.artifact_id
+                enriched_metadata = (
+                    dict(enriched.get("metadata") or {})
+                    if isinstance(enriched.get("metadata"), Mapping)
+                    else {}
+                )
+                enriched_metadata.update(
+                    {
+                        **published_refs,
+                        "outputSummaryRef": summary_ref.artifact_id,
+                        "outputAgentResultRef": agent_result_ref.artifact_id,
+                    }
+                )
+                enriched["metadata"] = enriched_metadata
                 # Remove snake_case if alias is present to avoid Pydantic validation errors
                 if "diagnosticsRef" in enriched and "diagnostics_ref" in enriched:
                     del enriched["diagnostics_ref"]
                 return enriched
             if hasattr(result, "diagnostics_ref"):
-                result.diagnostics_ref = summary_ref.artifact_id
+                result.diagnostics_ref = agent_result_ref.artifact_id
+            result.metadata.update(
+                {
+                    **published_refs,
+                    "outputSummaryRef": summary_ref.artifact_id,
+                    "outputAgentResultRef": agent_result_ref.artifact_id,
+                }
+            )
             return result
         except Exception as exc:
             logger.warning(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -524,6 +524,11 @@ class DockerCodexManagedSessionController:
         self,
         request: CodexManagedSessionClearRequest,
     ) -> CodexManagedSessionHandle:
+        previous_record = (
+            self._session_store.load(request.session_id)
+            if self._session_store is not None
+            else None
+        )
         payload = await self._invoke_json(
             container_id=request.container_id,
             action="clear_session",
@@ -534,6 +539,31 @@ class DockerCodexManagedSessionController:
             locator=self._locator_from_session_state(handle.session_state),
             status=handle.status,
         )
+        if self._session_supervisor is not None and previous_record is not None:
+            await self._session_supervisor.publish_reset_artifacts(
+                request.session_id,
+                control_event={
+                    "action": "clear_session",
+                    "sessionId": request.session_id,
+                    "containerId": request.container_id,
+                    "oldSessionEpoch": request.session_epoch,
+                    "newSessionEpoch": handle.session_state.session_epoch,
+                    "oldThreadId": request.thread_id,
+                    "newThreadId": handle.session_state.thread_id,
+                    "reason": request.reason,
+                    "clearedAt": datetime.now(tz=UTC).isoformat(),
+                },
+                reset_boundary={
+                    "sessionId": request.session_id,
+                    "containerId": request.container_id,
+                    "oldSessionEpoch": previous_record.session_epoch,
+                    "newSessionEpoch": handle.session_state.session_epoch,
+                    "oldThreadId": previous_record.thread_id,
+                    "newThreadId": handle.session_state.thread_id,
+                    "reason": request.reason,
+                    "clearedAt": datetime.now(tz=UTC).isoformat(),
+                },
+            )
         return handle
 
     async def terminate_session(
@@ -582,6 +612,7 @@ class DockerCodexManagedSessionController:
             latestSummaryRef=record.latest_summary_ref,
             latestCheckpointRef=record.latest_checkpoint_ref,
             latestControlEventRef=record.latest_control_event_ref,
+            latestResetBoundaryRef=record.latest_reset_boundary_ref,
             metadata={
                 "status": record.status,
                 "stdoutArtifactRef": record.stdout_artifact_ref,
@@ -614,6 +645,7 @@ class DockerCodexManagedSessionController:
             latestSummaryRef=record.latest_summary_ref,
             latestCheckpointRef=record.latest_checkpoint_ref,
             latestControlEventRef=record.latest_control_event_ref,
+            latestResetBoundaryRef=record.latest_reset_boundary_ref,
             metadata={
                 **dict(request.metadata),
                 "status": record.status,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -529,6 +529,8 @@ class DockerCodexManagedSessionController:
             if self._session_store is not None
             else None
         )
+        if previous_record is not None:
+            self._matches_locator(previous_record, request)
         payload = await self._invoke_json(
             container_id=request.container_id,
             action="clear_session",
@@ -540,18 +542,19 @@ class DockerCodexManagedSessionController:
             status=handle.status,
         )
         if self._session_supervisor is not None and previous_record is not None:
+            cleared_at = datetime.now(tz=UTC).isoformat()
             await self._session_supervisor.publish_reset_artifacts(
                 request.session_id,
                 control_event={
                     "action": "clear_session",
                     "sessionId": request.session_id,
                     "containerId": request.container_id,
-                    "oldSessionEpoch": request.session_epoch,
+                    "oldSessionEpoch": previous_record.session_epoch,
                     "newSessionEpoch": handle.session_state.session_epoch,
-                    "oldThreadId": request.thread_id,
+                    "oldThreadId": previous_record.thread_id,
                     "newThreadId": handle.session_state.thread_id,
                     "reason": request.reason,
-                    "clearedAt": datetime.now(tz=UTC).isoformat(),
+                    "clearedAt": cleared_at,
                 },
                 reset_boundary={
                     "sessionId": request.session_id,
@@ -561,7 +564,7 @@ class DockerCodexManagedSessionController:
                     "oldThreadId": previous_record.thread_id,
                     "newThreadId": handle.session_state.thread_id,
                     "reason": request.reason,
-                    "clearedAt": datetime.now(tz=UTC).isoformat(),
+                    "clearedAt": cleared_at,
                 },
             )
         return handle

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
@@ -104,6 +105,20 @@ class ManagedSessionSupervisor:
             stderr_bytes = stderr_path.read_bytes()
         return stdout_bytes, stderr_bytes
 
+    def _write_json_artifact(
+        self,
+        *,
+        job_id: str,
+        artifact_name: str,
+        payload: dict[str, object],
+    ) -> str:
+        _path, ref = self._artifact_storage.write_artifact(
+            job_id=job_id,
+            artifact_name=artifact_name,
+            data=(json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8"),
+        )
+        return ref
+
     async def _publish_record(
         self,
         record: CodexManagedSessionRecord,
@@ -130,6 +145,37 @@ class ManagedSessionSupervisor:
             annotations=[],
             events=[],
         )
+        summary_ref = self._write_json_artifact(
+            job_id=record.session_id,
+            artifact_name="session.summary.json",
+            payload={
+                "sessionId": record.session_id,
+                "sessionEpoch": record.session_epoch,
+                "containerId": record.container_id,
+                "threadId": record.thread_id,
+                "status": status,
+                "stdoutArtifactRef": stdout_ref,
+                "stderrArtifactRef": stderr_ref,
+                "diagnosticsRef": diagnostics_ref,
+                "errorMessage": error_message,
+            },
+        )
+        checkpoint_ref = self._write_json_artifact(
+            job_id=record.session_id,
+            artifact_name="session.step_checkpoint.json",
+            payload={
+                "sessionState": record.session_state().model_dump(
+                    mode="json", by_alias=True, exclude_none=True
+                ),
+                "status": status,
+                "runtimeArtifacts": {
+                    "stdout": stdout_ref,
+                    "stderr": stderr_ref,
+                    "diagnostics": diagnostics_ref,
+                },
+                "recordUpdatedAt": datetime.now(tz=UTC).isoformat(),
+            },
+        )
         now = datetime.now(tz=UTC)
         return await self._store.update(
             record.session_id,
@@ -137,6 +183,8 @@ class ManagedSessionSupervisor:
             stdout_artifact_ref=stdout_ref,
             stderr_artifact_ref=stderr_ref,
             diagnostics_ref=diagnostics_ref,
+            latest_summary_ref=summary_ref,
+            latest_checkpoint_ref=checkpoint_ref,
             last_log_offset=len(stdout_bytes) + len(stderr_bytes),
             last_log_at=now,
             updated_at=now,
@@ -174,4 +222,31 @@ class ManagedSessionSupervisor:
             record,
             status=status,
             error_message=error_message,
+        )
+
+    async def publish_reset_artifacts(
+        self,
+        session_id: str,
+        *,
+        control_event: dict[str, object],
+        reset_boundary: dict[str, object],
+    ) -> CodexManagedSessionRecord:
+        record = self._store.load(session_id)
+        if record is None:
+            raise ValueError(f"managed session record not found: {session_id}")
+        control_ref = self._write_json_artifact(
+            job_id=session_id,
+            artifact_name="session.control_event.json",
+            payload=control_event,
+        )
+        reset_ref = self._write_json_artifact(
+            job_id=session_id,
+            artifact_name="session.reset_boundary.json",
+            payload=reset_boundary,
+        )
+        return await self._store.update(
+            session_id,
+            latest_control_event_ref=control_ref,
+            latest_reset_boundary_ref=reset_ref,
+            updated_at=datetime.now(tz=UTC),
         )

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -325,6 +325,10 @@ class MoonMindAgentRun:
             mode="json",
             by_alias=True,
         )
+        if request.instruction_ref:
+            metadata.setdefault("instructionRef", request.instruction_ref)
+        if request.resolved_skillset_ref:
+            metadata.setdefault("resolvedSkillsetRef", request.resolved_skillset_ref)
         return result.model_copy(update={"metadata": metadata})
 
     @staticmethod

--- a/specs/133-codex-managed-session-plane-phase8/data-model.md
+++ b/specs/133-codex-managed-session-plane-phase8/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: Codex Managed Session Plane Phase 8
+
+## Entity: CodexManagedSessionRecord
+
+- Purpose: durable session-level artifact and continuity state for one task-scoped Codex managed session.
+- Fields:
+  - existing Phase 6 fields, including runtime observability refs
+  - `latest_summary_ref`
+  - `latest_checkpoint_ref`
+  - `latest_control_event_ref`
+  - `latest_reset_boundary_ref`
+
+## Entity: Managed Session Step Publication
+
+- Purpose: the step-scoped artifact-backed result envelope for one managed Codex session step.
+- Fields:
+  - `instruction_ref`
+  - `resolved_skillset_ref` when present
+  - `output.summary` artifact ref
+  - `output.agent_result` artifact ref
+  - runtime stdout/stderr/diagnostics refs
+  - continuity refs returned from session publication
+
+## Entity: Reset Boundary Artifact
+
+- Purpose: durable epoch-boundary record emitted when `clear_session` succeeds.
+- Fields:
+  - `session_id`
+  - `container_id`
+  - `old_session_epoch`
+  - `new_session_epoch`
+  - `old_thread_id`
+  - `new_thread_id`
+  - `reason`
+  - `cleared_at`
+
+## Relationships
+
+- One `CodexManagedSessionRecord` belongs to one `task_run_id`.
+- One managed session can emit many step publications over time, but only the latest continuity refs live directly on the durable session record.
+- One reset emits exactly one `session.control_event` artifact and one `session.reset_boundary` artifact for the new epoch boundary.

--- a/specs/133-codex-managed-session-plane-phase8/plan.md
+++ b/specs/133-codex-managed-session-plane-phase8/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: codex-managed-session-plane-phase8
+
+**Branch**: `133-codex-managed-session-plane-phase8` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/133-codex-managed-session-plane-phase8/spec.md`
+
+## Summary
+
+Implement Phase 8 artifact discipline for the Codex managed session plane. This slice adds durable session summary/checkpoint/control/reset artifact refs to the managed-session record, publishes reset-boundary artifacts during clear operations, and upgrades managed-session step result publication so step inputs and outputs have durable artifact evidence beyond the session container.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing stdlib asyncio/json/pathlib support, `TemporalArtifactService`, `RuntimeLogStreamer`, JSON-backed managed-session store/controller, current Codex session adapter and `MoonMind.AgentRun` workflow
+**Testing**: focused pytest suites plus final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal backend runtime, artifact publication, and managed-session supervision
+**Constraints**: preserve current typed managed-session contracts; keep session control remote-container-first; keep workflow payloads compact; store latest continuity refs durably instead of depending on container state
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Temporal/worker services still own lifecycle and artifact publication; the session container remains a controlled runtime rather than the source of truth.
+- **II. One-Click Agent Deployment**: PASS. No new operator prerequisite or deployment surface is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The artifact discipline sits behind managed-session controller/activity boundaries rather than Codex-specific workflow logic.
+- **IV. Own Your Data**: PASS. Step/session understanding moves further toward durable artifacts and bounded metadata.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The work adds explicit durable refs and artifact publication tests instead of relying on implicit container history.
+- **VII. Powerful Runtime Configurability**: PASS. Existing workspace/artifact roots and session image settings remain the only runtime knobs.
+- **VIII. Modular and Extensible Architecture**: PASS. Controller/supervisor/activity boundaries stay explicit and future dedicated-image work remains a packaging change.
+- **IX. Resilient by Default**: PASS. Later reads come from durable record state, so restart safety improves instead of regressing.
+- **XI. Spec-Driven Development**: PASS. The Phase 8 slice is specified before code edits land.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Phase sequencing remains in `specs/`; canonical docs already describe the desired artifact-first behavior.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The phase extends the live managed-session path directly and avoids compatibility side channels.
+
+## Research
+
+- The durable managed-session record already stores the latest continuity refs, so Phase 8 should extend that record instead of introducing a second continuity cache.
+- `ManagedSessionSupervisor` already owns spool-file publication into restart-safe artifact storage; it is the right place to emit session summary/checkpoint artifacts beside stdout/stderr/diagnostics.
+- `TemporalAgentRuntimeActivities.agent_runtime_publish_artifacts` already has access to `TemporalArtifactService` and Temporal activity info, so it can publish step-scoped `input.*` and `output.*` artifacts without pushing artifact semantics into workflow code.
+- `clear_session` already performs the remote reset through the session controller and the `MoonMind.AgentSession` workflow signal; Phase 8 should piggyback durable control/reset artifact writes onto that existing control boundary.
+
+## Project Structure
+
+- Extend `moonmind/schemas/managed_session_models.py` with the additional latest reset-boundary ref and publication helpers.
+- Update `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to publish `session.summary`, `session.step_checkpoint`, `session.control_event`, and `session.reset_boundary`.
+- Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` to store the new refs on clear/session publication and surface them through summary/publication responses.
+- Update `moonmind/workflows/adapters/codex_session_adapter.py` and `moonmind/workflows/temporal/workflows/agent_run.py` to preserve the input/session metadata needed by step artifact publication.
+- Update `moonmind/workflows/temporal/activity_runtime.py` so `agent_runtime.publish_artifacts` writes managed-session `input.*` and `output.*` artifacts through the Temporal artifact service.
+
+## Data Model
+
+- **CodexManagedSessionRecord**
+  - Existing durable fields remain.
+  - Add `latest_reset_boundary_ref`.
+  - Treat `latest_summary_ref`, `latest_checkpoint_ref`, `latest_control_event_ref`, and `latest_reset_boundary_ref` as the authoritative latest continuity refs.
+- **Managed Session Publication Metadata**
+  - Step result metadata should carry `instructionRef`, `resolvedSkillsetRef`, and the latest session artifact refs needed by `agent_runtime.publish_artifacts`.
+- **Reset Artifact Payload**
+  - Include `session_id`, old/new epoch, old/new thread id, reason, timestamp, and container id.
+
+## Implementation Plan
+
+1. Add failing tests for session artifact publication, clear/reset artifact persistence, and managed-session step artifact publication.
+2. Extend the managed-session schemas and durable record helpers to represent the new continuity refs.
+3. Update the managed-session supervisor to publish `session.summary` and `session.step_checkpoint` during snapshot/finalize and to publish `session.control_event` / `session.reset_boundary` during clear.
+4. Update the managed-session controller to persist those refs, return them from summary/publication calls, and keep clear-session epoch updates durable.
+5. Update the adapter/workflow/activity publish path so managed Codex session results produce `input.instructions`, optional `input.skill_snapshot`, `output.summary`, and `output.agent_result` artifacts.
+6. Run focused tests, run scope validation, rerun the full unit suite, and mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/test_agent_runtime_activities.py`
+2. `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Launch a managed Codex session, complete one step, and confirm stdout/stderr/diagnostics plus session summary/checkpoint refs remain available after the session container exits.
+2. Clear the managed session and confirm a visible control-event/reset-boundary pair exists for the new epoch.
+3. Inspect the published step result and confirm it includes durable `input.*` and `output.*` artifact evidence rather than relying only on container-local continuity.

--- a/specs/133-codex-managed-session-plane-phase8/quickstart.md
+++ b/specs/133-codex-managed-session-plane-phase8/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: Codex Managed Session Plane Phase 8
+
+## Focused Verification
+
+1. Run the focused Phase 8 suites:
+
+```bash
+./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/test_agent_runtime_activities.py
+```
+
+2. Run the Spec Kit scope gates for this feature:
+
+```bash
+SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+3. Run the repo unit suite:
+
+```bash
+./tools/test_unit.sh
+```

--- a/specs/133-codex-managed-session-plane-phase8/research.md
+++ b/specs/133-codex-managed-session-plane-phase8/research.md
@@ -1,0 +1,23 @@
+# Research: Codex Managed Session Plane Phase 8
+
+## Decisions
+
+### 1. Publish continuity artifacts from the session supervisor
+
+- Reuse `ManagedSessionSupervisor` for `session.summary` and `session.step_checkpoint`.
+- Rationale: it already owns durable spool-backed publication and is the closest boundary to session observability state.
+
+### 2. Publish reset artifacts from the session controller clear boundary
+
+- Persist `session.control_event` and `session.reset_boundary` during `clear_session`.
+- Rationale: reset is a control-plane action and should be durably recorded at the same boundary that applies the remote clear.
+
+### 3. Use the Temporal artifact activity for step-scoped `input.*` / `output.*`
+
+- Extend `agent_runtime.publish_artifacts` to publish managed-session `input.instructions`, optional `input.skill_snapshot`, `output.summary`, and `output.agent_result`.
+- Rationale: the activity already has Temporal execution context and the artifact service, so step-scoped publication stays outside workflow code.
+
+### 4. Keep the durable session record as the latest continuity source
+
+- Store the latest summary/checkpoint/control/reset refs directly on `CodexManagedSessionRecord`.
+- Rationale: later session summary/projection reads should not need a live container or ephemeral controller cache.

--- a/specs/133-codex-managed-session-plane-phase8/spec.md
+++ b/specs/133-codex-managed-session-plane-phase8/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: codex-managed-session-plane-phase8
+
+**Feature Branch**: `133-codex-managed-session-plane-phase8`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Implement Phase 8 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Persist step-scoped managed-session artifacts (Priority: P1)
+
+Operators need each Codex-managed step to leave behind a durable, step-scoped artifact record so the step can be understood after the session container is gone.
+
+**Why this priority**: Phase 8 exists to make artifact-backed presentation authoritative rather than depending on container continuity.
+
+**Independent Test**: Execute one Codex managed-session step and verify the persisted result and session publication include step-scoped output, runtime, and continuity artifact refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed Codex step completes through the session adapter, **When** MoonMind publishes the step result, **Then** it persists `output.summary` and `output.agent_result` artifacts and preserves runtime/session artifact refs in the published result.
+2. **Given** a managed Codex session publishes session artifacts for a completed step, **When** publication completes, **Then** the durable session record stores `session.summary` and `session.step_checkpoint` refs alongside stdout, stderr, and diagnostics refs.
+3. **Given** the step request includes an instruction ref and an optional resolved skill snapshot ref, **When** artifact publication runs, **Then** MoonMind persists step-scoped `input.instructions` and `input.skill_snapshot` reference artifacts when those inputs are present.
+
+---
+
+### User Story 2 - Make reset boundaries durable and visible (Priority: P1)
+
+Operators need clear/reset actions to leave behind explicit durable artifacts so a session epoch change is visible without inspecting runtime-private state.
+
+**Why this priority**: Phase 8 depends on reset artifacts being first-class so later projections and UI surfaces can expose epoch boundaries.
+
+**Independent Test**: Clear a persisted managed session and verify the durable session record advances epoch and stores control/reset-boundary refs that survive after the container stops.
+
+**Acceptance Scenarios**:
+
+1. **Given** `agent_runtime.clear_session` succeeds for a durable managed session record, **When** MoonMind updates the record, **Then** it persists a `session.control_event` artifact describing the reset request and outcome.
+2. **Given** a clear/reset creates a new epoch, **When** MoonMind finalizes the reset bookkeeping, **Then** it persists a `session.reset_boundary` artifact describing the old epoch, new epoch, and new logical thread id.
+3. **Given** a later session summary or publication is requested, **When** MoonMind serves that response, **Then** the latest control/reset refs are returned from durable record state instead of being inferred from container-local history.
+
+---
+
+### User Story 3 - Preserve continuity and result metadata across worker boundaries (Priority: P2)
+
+The managed-session path needs a compact durable record of the latest continuity refs so later projections and workflow results can rebuild the session story without replaying the container.
+
+**Why this priority**: Phase 8 is the artifact discipline slice that feeds later continuity projections and session UI work.
+
+**Independent Test**: Publish session artifacts, restart the worker-facing controller in a test seam, and verify continuity refs are still served from the durable record without requiring a live container query.
+
+**Acceptance Scenarios**:
+
+1. **Given** a durable session record already contains session summary/checkpoint/control/reset refs, **When** `fetch_session_summary` is called, **Then** MoonMind returns those refs from the durable record.
+2. **Given** `publish_session_artifacts` is called after prior publication, **When** no new container interaction is needed, **Then** MoonMind returns the durable artifact refs without clearing prior continuity metadata.
+3. **Given** `agent_runtime.publish_artifacts` runs for a managed Codex session result, **When** it publishes the final step envelope, **Then** the returned result metadata includes the durable refs needed to rebuild the step from artifacts.
+
+### Edge Cases
+
+- A managed step produces no primary output refs but still needs `output.summary`, `output.agent_result`, runtime logs, diagnostics, and continuity artifacts.
+- A reset happens before any prior session summary/checkpoint artifacts were published.
+- `resolvedSkillsetRef` is absent; MoonMind must skip `input.skill_snapshot` without fabricating a placeholder artifact.
+- Session stdout or stderr spool files are empty when summary/checkpoint publication runs.
+- Repeated publication for the same session should update latest refs without losing previously published runtime refs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every Codex-managed session step MUST persist a durable `output.summary` artifact.
+- **FR-002**: Every Codex-managed session step MUST persist a durable `output.agent_result` artifact containing the structured run-result envelope.
+- **FR-003**: When an instruction ref is present, the managed-session publish path MUST persist a step-scoped `input.instructions` reference artifact for the step.
+- **FR-004**: When a resolved skill snapshot ref is present, the managed-session publish path MUST persist a step-scoped `input.skill_snapshot` reference artifact for the step.
+- **FR-005**: Managed-session publication MUST persist or surface durable refs for `runtime.stdout`, `runtime.stderr`, and `runtime.diagnostics`.
+- **FR-006**: Managed-session publication MUST persist `session.summary` and `session.step_checkpoint` artifacts and store their latest refs on the durable session record.
+- **FR-007**: `agent_runtime.clear_session` MUST persist `session.control_event` and `session.reset_boundary` artifacts and store their latest refs on the durable session record.
+- **FR-008**: `fetch_session_summary` and `publish_session_artifacts` MUST source continuity refs from the durable session record, including the latest control/reset refs, rather than from container-local caches.
+- **FR-009**: The Phase 8 implementation MUST preserve the container-first session-control model and MUST NOT move the Codex execution loop back into the main worker process.
+
+### Key Entities
+
+- **Codex Managed Session Record**: Durable session-level record holding the latest runtime and continuity artifact refs for one task-scoped Codex session.
+- **Managed Session Step Publication**: The artifact-backed envelope for one Codex-managed step, including input reference artifacts, result artifacts, runtime artifacts, and continuity refs.
+- **Reset Boundary Artifact**: Durable artifact describing a session clear/reset epoch transition.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests verify `output.summary` and `output.agent_result` artifacts are created for managed Codex session results.
+- **SC-002**: Tests verify session publication persists `session.summary` and `session.step_checkpoint` refs in the durable session record.
+- **SC-003**: Tests verify clear/reset persists `session.control_event` and `session.reset_boundary` refs and advances durable epoch state.
+- **SC-004**: Tests verify later summary/publication calls return continuity refs from durable record state without requiring container-local state.

--- a/specs/133-codex-managed-session-plane-phase8/speckit_analyze_report.md
+++ b/specs/133-codex-managed-session-plane-phase8/speckit_analyze_report.md
@@ -1,0 +1,48 @@
+# Specification Analysis Report
+
+**Feature**: 133-codex-managed-session-plane-phase8
+**Date**: 2026-04-07
+**Artifacts analyzed**: spec.md, plan.md, tasks.md, constitution.md
+
+## Findings
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|---|---|---|---|---|---|
+| C1 | Coverage | LOW | plan.md:Data Model, spec.md:FR-007/FR-008 | Reset-boundary durability introduces a new latest-ref that must be surfaced consistently through summary and publication responses | Implement the new reset-boundary ref end-to-end in the record model, controller responses, and tests so the feature does not stop at storage only |
+
+## Coverage Summary
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|---|---|---|---|
+| FR-001 (`output.summary`) | Yes | T001d, T004b | |
+| FR-002 (`output.agent_result`) | Yes | T001d, T004b | |
+| FR-003 (`input.instructions`) | Yes | T001d, T004a, T004b | |
+| FR-004 (`input.skill_snapshot`) | Yes | T001d, T004a, T004b | Optional-path coverage included |
+| FR-005 (`runtime.*`) | Yes | T001a, T001c, T002b, T004c | |
+| FR-006 (`session.summary` + `session.step_checkpoint`) | Yes | T001a, T002b, T002c | |
+| FR-007 (`session.control_event` + `session.reset_boundary`) | Yes | T001b, T003a, T003b | |
+| FR-008 (durable continuity reads) | Yes | T001b, T002c, T003b | |
+| FR-009 (container-first path preserved) | Yes | T002c, T004a, T004b | Kept at controller/activity boundaries |
+
+## Constitution Alignment Issues
+
+None. The artifacts keep durable truth outside the container, the worker remains the orchestrator, and the work stays behind explicit runtime/controller/activity contracts.
+
+## Unmapped Tasks
+
+None. Every task maps to at least one functional requirement or validation gate.
+
+## Metrics
+
+- Total Requirements: 9
+- Total Tasks: 14
+- Coverage %: 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- No CRITICAL or HIGH issues were found.
+- Proceed to implementation with TDD.
+- Ensure the reset-boundary ref is surfaced end-to-end, not only stored on the durable session record.

--- a/specs/133-codex-managed-session-plane-phase8/tasks.md
+++ b/specs/133-codex-managed-session-plane-phase8/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: Codex Managed Session Plane Phase 8
+
+## T001 — Add TDD coverage for artifact-discipline boundaries [P]
+- [X] T001a [P] Extend `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py` to cover `session.summary` / `session.step_checkpoint` publication and latest continuity refs.
+- [X] T001b [P] Extend `tests/unit/services/temporal/runtime/test_managed_session_controller.py` to cover `session.control_event` / `session.reset_boundary` persistence during `clear_session` and durable continuity reads.
+- [X] T001c [P] Extend `tests/unit/workflows/adapters/test_codex_session_adapter.py` to assert managed-session step results preserve the published continuity refs needed for artifact-first step reconstruction.
+- [X] T001d [P] Extend `tests/unit/services/temporal/test_agent_runtime_activities.py` to assert managed-session `agent_runtime.publish_artifacts` publishes `input.instructions`, optional `input.skill_snapshot`, `output.summary`, and `output.agent_result`.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/test_agent_runtime_activities.py`
+
+## T002 — Persist the new continuity artifact refs [P]
+- [X] T002a [P] Extend `moonmind/schemas/managed_session_models.py` with the latest reset-boundary ref and helper coverage for the expanded publication set.
+- [X] T002b [P] Update `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to publish `session.summary` and `session.step_checkpoint` artifacts beside stdout/stderr/diagnostics.
+- [X] T002c [P] Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` to persist and return summary/checkpoint/control/reset refs from durable record state.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+
+## T003 — Make reset boundaries durable [P]
+- [X] T003a [P] Update `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` and/or `moonmind/workflows/temporal/runtime/managed_session_controller.py` so `clear_session` emits `session.control_event` and `session.reset_boundary`.
+- [X] T003b [P] Ensure the durable session record keeps the latest reset-boundary metadata without losing existing runtime or continuity refs.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+
+## T004 — Publish step-scoped managed-session input/output artifacts [P]
+- [X] T004a [P] Update `moonmind/workflows/adapters/codex_session_adapter.py` and `moonmind/workflows/temporal/workflows/agent_run.py` to preserve the instruction/skill/session metadata required for step-scoped artifact publication.
+- [X] T004b [P] Update `moonmind/workflows/temporal/activity_runtime.py` so managed Codex session results publish `input.instructions`, optional `input.skill_snapshot`, `output.summary`, and `output.agent_result`.
+- [X] T004c [P] Keep runtime stdout/stderr/diagnostics and session continuity refs visible in the returned result metadata/output refs after publication.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/test_agent_runtime_activities.py`
+
+## T005 — Verify scope and finalize [P]
+- [X] T005a [P] Run `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T005b [P] Run `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+- [X] T005c [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Scope validation passes and `./tools/test_unit.sh` passes.

--- a/specs/134-pr-resolver-retry-policy/plan.md
+++ b/specs/134-pr-resolver-retry-policy/plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: pr-resolver-retry-policy
+
+**Branch**: `codex/phase-8-managed-session-artifacts` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/134-pr-resolver-retry-policy/spec.md`
+
+## Summary
+
+Align the `pr-resolver` orchestration retry-state machine with its documented behavior by allowing transitions from transient finalize-only retry states into actionable merge-conflict remediation. Add regression coverage so future retry-policy changes do not silently reintroduce the manual-review stop.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: `pr_resolve_orchestrate.py`, `pr_resolve_contract.py`, `tests/unit/test_pr_resolver_tools.py`
+**Testing**: focused pytest coverage for pr-resolver tooling
+**Project Type**: agent skill orchestration script and unit tests
+**Constraints**: preserve bounded retry/manual-review safeguards for unknown reason transitions; keep remediation routing delegated through existing specialized skills
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The change only corrects which existing specialized skill path the orchestrator chooses.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The fix keeps remediation routed through the declared `fix-merge-conflicts` skill instead of ad hoc behavior.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The retry-policy contract is made explicit with a regression test instead of hidden in ad hoc state transitions.
+- **IX. Resilient by Default**: PASS. Actionable merge-conflict blockers no longer stop unnecessarily after transient CI waits.
+- **XI. Spec-Driven Development**: PASS. This change is tracked with spec/plan/tasks before implementation.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The live transition logic is corrected directly without compatibility shims.
+
+## Research
+
+- `docs/ManagedAgents/SkillGithubPrResolver.md` already defines merge conflicts as higher priority than CI waiting and says `DIRTY` should delegate to `fix-merge-conflicts` before any wait path.
+- The current orchestration code only special-cases transitions into `ci_failures`, causing `ci_running -> merge_conflicts` to fall into the generic manual-review stop.
+- Existing unit tests already cover `ci_running` waits and `ci_failures` escalation, so the new regression fits naturally into `tests/unit/test_pr_resolver_tools.py`.
+
+## Implementation Plan
+
+1. Add a regression test for `ci_running -> merge_conflicts -> merged`.
+2. Update the orchestration transition guard so actionable remediation reasons reached after finalize-only retry states continue into full remediation.
+3. Run focused pr-resolver unit tests to verify the new escalation and existing retry behavior.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`
+
+### Manual Validation
+
+1. Re-run `pr-resolve_orchestrate.py` against a PR that transitions from running checks to `DIRTY` mergeability and confirm the result directs `run_fix_merge_conflicts_skill` instead of `manual_review`.

--- a/specs/134-pr-resolver-retry-policy/spec.md
+++ b/specs/134-pr-resolver-retry-policy/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: pr-resolver-retry-policy
+
+**Feature Branch**: `codex/phase-8-managed-session-artifacts`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Fix the pr-resolver skill so it automatically proceeds to fix merge conflicts when finalize retries move from ci_running into merge_conflicts."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Escalate merge conflicts after transient CI waits (Priority: P1)
+
+Operators need `pr-resolver` to keep following its documented priority order when GitHub only surfaces merge conflicts after CI finishes.
+
+**Why this priority**: The current behavior stops at manual review even though the skill contract and design docs describe merge conflicts as an actionable remediation path.
+
+**Independent Test**: Simulate finalize attempts returning `ci_running` before `merge_conflicts` and verify orchestration escalates to full remediation with `run_fix_merge_conflicts_skill` instead of returning `manual_review`.
+
+**Acceptance Scenarios**:
+
+1. **Given** finalize retries previously returned `ci_running`, **When** a later finalize attempt returns `merge_conflicts`, **Then** orchestration treats the new reason as actionable full remediation and invokes the conflict-fix path.
+2. **Given** merge-conflict remediation runs after transient CI states, **When** a later finalize attempt returns `merged`, **Then** orchestration exits successfully without reporting a reason-transition manual review blocker.
+3. **Given** a blocker reason changes from a finalize-only retry state to an unknown or unsupported reason, **When** orchestration evaluates the transition, **Then** it still returns `manual_review` rather than silently expanding remediation scope.
+
+### Edge Cases
+
+- A PR is `ci_running` for several retries before GitHub recomputes mergeability as `DIRTY`.
+- A finalize-only retry reason changes to another actionable remediation reason after one or more waits.
+- Unknown blocker transitions must remain fail-fast and require manual review.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `pr-resolver` MUST treat `merge_conflicts` as actionable remediation even when the previous blocked reason was a finalize-only retry state such as `ci_running`.
+- **FR-002**: The orchestration transition guard MUST preserve explicit manual-review behavior for unknown or unsupported reason changes.
+- **FR-003**: The retry-policy behavior MUST be covered by a regression test at the pr-resolver orchestration boundary.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A focused pr-resolver unit test fails before the fix and passes after the fix for the `ci_running -> merge_conflicts -> merged` sequence.
+- **SC-002**: Existing finalize-only retry behavior for pure `ci_running` waits remains unchanged.

--- a/specs/134-pr-resolver-retry-policy/tasks.md
+++ b/specs/134-pr-resolver-retry-policy/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: pr-resolver-retry-policy
+
+## T001 — Add regression coverage for actionable transition handling [P]
+- [X] T001a [P] Extend `tests/unit/test_pr_resolver_tools.py` to cover `ci_running -> merge_conflicts -> merged` and assert conflict remediation is invoked instead of `manual_review`.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`
+
+## T002 — Fix pr-resolver transition policy [P]
+- [X] T002a [P] Update `.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py` so actionable remediation reasons reached after finalize-only retry states still escalate through the specialized skill path.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`
+
+## T003 — Verify and finalize [P]
+- [X] T003a [P] Run `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`.
+- [X] T003b [P] Mark completed tasks in this file.
+
+**Independent Test**: Focused pr-resolver tests pass.

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -246,8 +246,64 @@ async def test_controller_clear_and_terminate_preserve_container_boundary(
     assert stored.latest_control_event_ref == "sess-1/session.control_event.json"
     assert stored.latest_reset_boundary_ref == "sess-1/session.reset_boundary.json"
     session_supervisor.publish_reset_artifacts.assert_awaited_once()
+    publish_kwargs = session_supervisor.publish_reset_artifacts.await_args.kwargs
+    assert publish_kwargs["control_event"]["oldSessionEpoch"] == 1
+    assert publish_kwargs["control_event"]["oldThreadId"] == "logical-thread-1"
+    assert (
+        publish_kwargs["control_event"]["clearedAt"]
+        == publish_kwargs["reset_boundary"]["clearedAt"]
+    )
     assert terminated.status == "terminated"
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
+
+
+@pytest.mark.asyncio
+async def test_controller_clear_session_rejects_stale_locator_before_runtime_call(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=2,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-2",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/tmp/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+            artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    command_runner = AsyncMock()
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=AsyncMock(),
+        command_runner=command_runner,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="sessionEpoch does not match the durable managed session record",
+    ):
+        await controller.clear_session(
+            CodexManagedSessionClearRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                newThreadId="logical-thread-3",
+            )
+        )
+
+    command_runner.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -154,8 +154,38 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_controller_clear_and_terminate_preserve_container_boundary() -> None:
+async def test_controller_clear_and_terminate_preserve_container_boundary(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            controlUrl="docker-exec://mm-codex-session-sess-1",
+            status="ready",
+            workspacePath="/tmp/agent_jobs/task-1/repo",
+            sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+            artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
     commands: list[tuple[str, ...]] = []
+    session_supervisor = AsyncMock()
+
+    async def _publish_reset_artifacts(session_id: str, **_: object):
+        return await store.update(
+            session_id,
+            latest_control_event_ref="sess-1/session.control_event.json",
+            latest_reset_boundary_ref="sess-1/session.reset_boundary.json",
+        )
+
+    session_supervisor.publish_reset_artifacts.side_effect = _publish_reset_artifacts
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -185,6 +215,8 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
         workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
         command_runner=_fake_runner,
     )
 
@@ -207,6 +239,13 @@ async def test_controller_clear_and_terminate_preserve_container_boundary() -> N
     )
 
     assert cleared.session_state.session_epoch == 2
+    stored = store.load("sess-1")
+    assert stored is not None
+    assert stored.session_epoch == 2
+    assert stored.thread_id == "logical-thread-2"
+    assert stored.latest_control_event_ref == "sess-1/session.control_event.json"
+    assert stored.latest_reset_boundary_ref == "sess-1/session.reset_boundary.json"
+    session_supervisor.publish_reset_artifacts.assert_awaited_once()
     assert terminated.status == "terminated"
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
 
@@ -234,6 +273,9 @@ async def test_controller_summary_and_publication_read_from_durable_record(
             stderrArtifactRef="sess-1/stderr.log",
             diagnosticsRef="sess-1/diagnostics.json",
             latestSummaryRef="sess-1/session.summary.json",
+            latestCheckpointRef="sess-1/session.step_checkpoint.json",
+            latestControlEventRef="sess-1/session.control_event.json",
+            latestResetBoundaryRef="sess-1/session.reset_boundary.json",
             startedAt="2026-04-06T12:00:00Z",
         )
     )
@@ -265,11 +307,18 @@ async def test_controller_summary_and_publication_read_from_durable_record(
     )
 
     assert summary.latest_summary_ref == "sess-1/session.summary.json"
+    assert summary.latest_checkpoint_ref == "sess-1/session.step_checkpoint.json"
+    assert summary.latest_control_event_ref == "sess-1/session.control_event.json"
+    assert summary.latest_reset_boundary_ref == "sess-1/session.reset_boundary.json"
     assert summary.metadata["stdoutArtifactRef"] == "sess-1/stdout.log"
     assert publication.published_artifact_refs == (
         "sess-1/stdout.log",
         "sess-1/stderr.log",
         "sess-1/diagnostics.json",
+        "sess-1/session.summary.json",
+        "sess-1/session.step_checkpoint.json",
+        "sess-1/session.control_event.json",
+        "sess-1/session.reset_boundary.json",
     )
 
 
@@ -312,6 +361,8 @@ async def test_controller_publication_uses_snapshot_without_stopping_supervision
         stdoutArtifactRef="sess-1/stdout.log",
         stderrArtifactRef="sess-1/stderr.log",
         diagnosticsRef="sess-1/diagnostics.json",
+        latestSummaryRef="sess-1/session.summary.json",
+        latestCheckpointRef="sess-1/session.step_checkpoint.json",
         startedAt="2026-04-06T12:00:00Z",
     )
     session_supervisor.publish_snapshot.return_value = published_record
@@ -340,6 +391,8 @@ async def test_controller_publication_uses_snapshot_without_stopping_supervision
         "sess-1/stdout.log",
         "sess-1/stderr.log",
         "sess-1/diagnostics.json",
+        "sess-1/session.summary.json",
+        "sess-1/session.step_checkpoint.json",
     )
 
 

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -86,10 +86,14 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
     assert finalized.stdout_artifact_ref == "sess-1/stdout.log"
     assert finalized.stderr_artifact_ref == "sess-1/stderr.log"
     assert finalized.diagnostics_ref == "sess-1/diagnostics.json"
+    assert finalized.latest_summary_ref == "sess-1/session.summary.json"
+    assert finalized.latest_checkpoint_ref == "sess-1/session.step_checkpoint.json"
     assert finalized.last_log_offset == len("session started\nassistant: OK\nwarning: none\n")
     assert finalized.last_log_at is not None
     assert artifact_storage.resolve_storage_path("sess-1/stdout.log").read_text(encoding="utf-8") == "session started\nassistant: OK\n"
     assert artifact_storage.resolve_storage_path("sess-1/stderr.log").read_text(encoding="utf-8") == "warning: none\n"
+    assert artifact_storage.resolve_storage_path("sess-1/session.summary.json").exists()
+    assert artifact_storage.resolve_storage_path("sess-1/session.step_checkpoint.json").exists()
 
 
 @pytest.mark.asyncio
@@ -112,6 +116,8 @@ async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None
 
     snapshot = await supervisor.publish_snapshot("sess-1")
     assert snapshot.stdout_artifact_ref == "sess-1/stdout.log"
+    assert snapshot.latest_summary_ref == "sess-1/session.summary.json"
+    assert snapshot.latest_checkpoint_ref == "sess-1/session.step_checkpoint.json"
 
     (spool / "stdout.log").write_text("first\nsecond\n", encoding="utf-8")
     await asyncio.sleep(0.05)
@@ -121,3 +127,38 @@ async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None
     assert watched.last_log_offset == len("first\nsecond\n")
 
     await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
+async def test_session_supervisor_publishes_control_and_reset_boundary_artifacts(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+
+    updated = await supervisor.publish_reset_artifacts(
+        "sess-1",
+        control_event={
+            "action": "clear_session",
+            "oldSessionEpoch": 1,
+            "newSessionEpoch": 2,
+        },
+        reset_boundary={
+            "oldSessionEpoch": 1,
+            "newSessionEpoch": 2,
+            "newThreadId": "thread-2",
+        },
+    )
+
+    assert updated.latest_control_event_ref == "sess-1/session.control_event.json"
+    assert updated.latest_reset_boundary_ref == "sess-1/session.reset_boundary.json"
+    assert artifact_storage.resolve_storage_path("sess-1/session.control_event.json").exists()
+    assert artifact_storage.resolve_storage_path("sess-1/session.reset_boundary.json").exists()

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -8,6 +8,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 
 from moonmind.schemas.agent_runtime_models import AgentRunResult
+from moonmind.workflows.temporal.artifacts import ExecutionRef
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalAgentRuntimeActivities,
 )
@@ -51,19 +52,34 @@ async def test_publish_artifacts_writes_summary_artifact():
         failure_class=None,
     )
 
-    with patch(
-        "moonmind.workflows.temporal.activity_runtime._write_json_artifact",
-    ) as mock_write:
-        mock_ref = MagicMock()
-        mock_ref.artifact_id = "art-456"
-        mock_write.return_value = mock_ref
+    with (
+        patch("moonmind.workflows.temporal.activity_runtime._write_json_artifact") as mock_write,
+        patch("temporalio.activity.info", return_value=SimpleNamespace(namespace="default", workflow_id="wf-1", workflow_run_id="run-1")),
+    ):
+        summary_ref = MagicMock()
+        summary_ref.artifact_id = "art-summary"
+        result_ref = MagicMock()
+        result_ref.artifact_id = "art-result"
+        mock_write.side_effect = [summary_ref, result_ref]
 
         result = await activities.agent_runtime_publish_artifacts(input_result)
 
     assert isinstance(result, AgentRunResult)
-    assert result.diagnostics_ref == "art-456"
+    assert result.diagnostics_ref == "art-result"
     assert result.summary == "Completed successfully"
-    mock_write.assert_called_once()
+    assert mock_write.await_count == 2
+    assert mock_write.await_args_list[0].kwargs["execution_ref"] == ExecutionRef(
+        namespace="default",
+        workflow_id="wf-1",
+        run_id="run-1",
+        link_type="output.summary",
+    )
+    assert mock_write.await_args_list[1].kwargs["execution_ref"] == ExecutionRef(
+        namespace="default",
+        workflow_id="wf-1",
+        run_id="run-1",
+        link_type="output.agent_result",
+    )
 
 
 @pytest.mark.asyncio
@@ -82,6 +98,42 @@ async def test_publish_artifacts_handles_write_failure_gracefully():
     # Should return the original result even if write fails
     assert isinstance(result, AgentRunResult)
     assert result.summary == "test"
+
+
+@pytest.mark.asyncio
+async def test_publish_artifacts_writes_managed_session_input_reference_artifacts():
+    activities = TemporalAgentRuntimeActivities(artifact_service=MagicMock())
+    input_result = AgentRunResult(
+        summary="Completed successfully",
+        output_refs=["artifact:stdout", "artifact:session-summary"],
+        metadata={
+            "managedSession": {"sessionId": "sess-1", "sessionEpoch": 1},
+            "instructionRef": "artifact:instructions",
+            "resolvedSkillsetRef": "artifact:skill-snapshot",
+        },
+    )
+
+    with (
+        patch("moonmind.workflows.temporal.activity_runtime._write_json_artifact") as mock_write,
+        patch("temporalio.activity.info", return_value=SimpleNamespace(namespace="default", workflow_id="wf-1", workflow_run_id="run-1")),
+    ):
+        refs = []
+        for artifact_id in ("art-input", "art-skill", "art-summary", "art-result"):
+            ref = MagicMock()
+            ref.artifact_id = artifact_id
+            refs.append(ref)
+        mock_write.side_effect = refs
+
+        result = await activities.agent_runtime_publish_artifacts(input_result)
+
+    assert isinstance(result, AgentRunResult)
+    assert result.diagnostics_ref == "art-result"
+    assert [call.kwargs["execution_ref"].link_type for call in mock_write.await_args_list] == [
+        "input.instructions",
+        "input.skill_snapshot",
+        "output.summary",
+        "output.agent_result",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/services/temporal/test_agent_runtime_activities.py
@@ -101,6 +101,26 @@ async def test_publish_artifacts_handles_write_failure_gracefully():
 
 
 @pytest.mark.asyncio
+async def test_publish_artifacts_handles_input_reference_write_failure_gracefully():
+    activities = TemporalAgentRuntimeActivities(artifact_service=MagicMock())
+    input_result = AgentRunResult(
+        summary="Completed successfully",
+        output_refs=[],
+        metadata={"instructionRef": "artifact:instructions"},
+    )
+
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime._write_json_artifact",
+        side_effect=RuntimeError("write failed"),
+    ):
+        result = await activities.agent_runtime_publish_artifacts(input_result)
+
+    assert isinstance(result, AgentRunResult)
+    assert result.summary == "Completed successfully"
+    assert result.metadata == {"instructionRef": "artifact:instructions"}
+
+
+@pytest.mark.asyncio
 async def test_publish_artifacts_writes_managed_session_input_reference_artifacts():
     activities = TemporalAgentRuntimeActivities(artifact_service=MagicMock())
     input_result = AgentRunResult(
@@ -134,6 +154,27 @@ async def test_publish_artifacts_writes_managed_session_input_reference_artifact
         "output.summary",
         "output.agent_result",
     ]
+
+
+@pytest.mark.asyncio
+async def test_publish_artifacts_handles_object_without_metadata_mapping():
+    activities = TemporalAgentRuntimeActivities(artifact_service=MagicMock())
+    input_result = SimpleNamespace(diagnostics_ref=None)
+
+    with patch(
+        "moonmind.workflows.temporal.activity_runtime._write_json_artifact"
+    ) as mock_write:
+        summary_ref = MagicMock()
+        summary_ref.artifact_id = "art-summary"
+        result_ref = MagicMock()
+        result_ref.artifact_id = "art-result"
+        mock_write.side_effect = [summary_ref, result_ref]
+
+        result = await activities.agent_runtime_publish_artifacts(input_result)
+
+    assert result is input_result
+    assert input_result.diagnostics_ref == "art-result"
+    assert not hasattr(input_result, "metadata")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -740,6 +740,59 @@ def test_orchestrate_ci_failures_after_transient_ci_states_escalates_fix_ci(
     assert sleeps == [15, 30]
 
 
+def test_orchestrate_merge_conflicts_after_ci_running_escalates_fix_conflicts(
+    pr_resolve_orchestrate_module: dict[str, Any],
+) -> None:
+    run_orchestration = pr_resolve_orchestrate_module["run_orchestration"]
+
+    finalize_results = iter(
+        [
+            {
+                "status": "blocked",
+                "merge_outcome": "blocked",
+                "reason": "ci_running",
+            },
+            {
+                "status": "blocked",
+                "merge_outcome": "blocked",
+                "reason": "merge_conflicts",
+            },
+            {
+                "status": "merged",
+                "merge_outcome": "merged",
+                "reason": "ci_complete",
+            },
+        ]
+    )
+    full_calls: list[tuple[int, int, str]] = []
+    sleeps: list[int] = []
+
+    result, exit_code = run_orchestration(
+        finalize_runner=lambda _attempt: next(finalize_results),
+        full_runner=lambda attempt, escalation, reason: (
+            full_calls.append((attempt, escalation, reason))
+            or {
+                "status": "needs_remediation",
+                "merge_outcome": "blocked",
+                "reason": reason,
+            }
+        ),
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=3,
+        fix_max_iterations=3,
+        base_sleep_seconds=15,
+        max_sleep_seconds=60,
+        max_elapsed_seconds=900,
+        merge_not_ready_grace_retries=1,
+    )
+
+    assert exit_code == 0
+    assert result["status"] == "merged"
+    assert full_calls == [(2, 1, "merge_conflicts")]
+    assert sleeps == [15]
+
+
 def test_orchestrate_main_uses_extended_finalize_wait_defaults(
     pr_resolve_orchestrate_module: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -154,6 +154,7 @@ def _summary(
         latestSummaryRef="artifact:session-summary",
         latestCheckpointRef="artifact:session-checkpoint",
         latestControlEventRef=None,
+        latestResetBoundaryRef=None,
         metadata={"lastAssistantText": "Implemented through the session container."},
     )
 
@@ -173,10 +174,17 @@ def _publication(
             "threadId": thread_id,
             "activeTurnId": None,
         },
-        publishedArtifactRefs=("artifact:session-summary", "artifact:session-checkpoint"),
+        publishedArtifactRefs=(
+            "artifact:stdout",
+            "artifact:stderr",
+            "artifact:diagnostics",
+            "artifact:session-summary",
+            "artifact:session-checkpoint",
+        ),
         latestSummaryRef="artifact:session-summary",
         latestCheckpointRef="artifact:session-checkpoint",
         latestControlEventRef=None,
+        latestResetBoundaryRef=None,
     )
 
 
@@ -285,9 +293,13 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert result.summary == "Implemented through the session container."
     assert result.output_refs == [
         "artifact:turn-output",
+        "artifact:stdout",
+        "artifact:stderr",
+        "artifact:diagnostics",
         "artifact:session-summary",
         "artifact:session-checkpoint",
     ]
+    assert result.metadata["instructionRef"] == "artifact:instructions"
     assert result.metadata["sessionSummary"]["latestSummaryRef"] == "artifact:session-summary"
     assert result.metadata["sessionArtifacts"]["latestCheckpointRef"] == "artifact:session-checkpoint"
 


### PR DESCRIPTION
## Summary
Implement Phase 8 artifact discipline for the Codex managed session plane.

This change:
- persists latest managed-session continuity refs, including reset-boundary state
- publishes `session.summary`, `session.step_checkpoint`, `session.control_event`, and `session.reset_boundary` artifacts from the durable session path
- upgrades managed-session step publication to emit `input.instructions`, optional `input.skill_snapshot`, `output.summary`, and `output.agent_result`
- adds the full Spec Kit artifact set for feature `133-codex-managed-session-plane-phase8`

## Why
Phase 8 requires the managed-session path to stay artifact-first so operators can understand a task after the session container is gone and so later continuity projections do not depend on live container state.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/test_agent_runtime_activities.py`
- `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=133-codex-managed-session-plane-phase8 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`

## Impact
Managed Codex session steps now leave behind durable step/session artifacts for output, runtime diagnostics, and epoch boundaries, which unblocks later session projection and UI work.