### PR TITLE
Implement Codex managed session plane Phase 10 observability reuse

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -15,6 +15,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunResult,
     AgentRunState,
     AgentRunStatus,
+    ManagedRunRecord,
 )
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -253,6 +254,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._save_run_state(
             run_id=run_id,
             agent_id=request.agent_id,
+            binding=binding,
             locator=current_locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
             result=result.model_dump(mode="json", by_alias=True),
@@ -352,6 +354,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._save_run_state(
             run_id=state.run_id,
             agent_id=state.agent_id,
+            binding=None,
             locator=state.locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
             result=canceled_result.model_dump(mode="json", by_alias=True),
@@ -612,6 +615,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         *,
         run_id: str,
         agent_id: str,
+        binding: CodexManagedSessionBinding | None = None,
         locator: Mapping[str, Any],
         active_turn_id: str | None,
         result: Mapping[str, Any],
@@ -633,6 +637,109 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             profileId=profile_id,
             result=result,
         )
+        self._persist_managed_run_record(
+            run_id=run_id,
+            agent_id=agent_id,
+            binding=binding,
+            result=result,
+            status=status,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+    def _persist_managed_run_record(
+        self,
+        *,
+        run_id: str,
+        agent_id: str,
+        binding: CodexManagedSessionBinding | None,
+        result: Mapping[str, Any],
+        status: AgentRunState,
+        started_at: datetime,
+        finished_at: datetime | None,
+    ) -> None:
+        if self._run_store is None:
+            return
+
+        existing = self._run_store.load(run_id)
+        session_artifacts = result.get("metadata", {}).get("sessionArtifacts")
+        session_artifact_metadata = (
+            session_artifacts.get("metadata", {})
+            if isinstance(session_artifacts, Mapping)
+            else {}
+        )
+        published_artifact_refs = (
+            tuple(session_artifacts.get("publishedArtifactRefs", ()))
+            if isinstance(session_artifacts, Mapping)
+            else ()
+        )
+
+        def _artifact_ref(value: Any, *, fallback: str | None = None) -> str | None:
+            normalized = str(value or "").strip()
+            return normalized or fallback
+
+        def _infer_runtime_artifact_ref(
+            kind: str,
+            *,
+            fallback: str | None = None,
+        ) -> str | None:
+            normalized_kind = kind.strip().lower()
+            for raw_ref in published_artifact_refs:
+                ref = str(raw_ref or "").strip()
+                lowered = ref.lower()
+                if not ref:
+                    continue
+                if normalized_kind == "stdout" and "stdout" in lowered:
+                    return ref
+                if normalized_kind == "stderr" and "stderr" in lowered:
+                    return ref
+                if normalized_kind == "diagnostics" and "diagnostics" in lowered:
+                    return ref
+            return fallback
+
+        runtime_id = self._runtime_id or "codex_cli"
+        summary = str(result.get("summary") or "").strip() or None
+        workspace_path = (
+            str(self._session_root(binding))
+            if binding is not None
+            else (existing.workspace_path if existing is not None else None)
+        )
+        record = ManagedRunRecord(
+            runId=run_id,
+            workflowId=self._workflow_id,
+            agentId=agent_id,
+            runtimeId=runtime_id,
+            status=status,
+            startedAt=started_at,
+            finishedAt=finished_at,
+            workspacePath=workspace_path,
+            stdoutArtifactRef=_artifact_ref(
+                session_artifact_metadata.get("stdoutArtifactRef"),
+                fallback=_infer_runtime_artifact_ref(
+                    "stdout",
+                    fallback=existing.stdout_artifact_ref if existing is not None else None,
+                ),
+            ),
+            stderrArtifactRef=_artifact_ref(
+                session_artifact_metadata.get("stderrArtifactRef"),
+                fallback=_infer_runtime_artifact_ref(
+                    "stderr",
+                    fallback=existing.stderr_artifact_ref if existing is not None else None,
+                ),
+            ),
+            diagnosticsRef=_artifact_ref(
+                session_artifact_metadata.get("diagnosticsRef"),
+                fallback=_infer_runtime_artifact_ref(
+                    "diagnostics",
+                    fallback=existing.diagnostics_ref if existing is not None else None,
+                ),
+            ),
+            errorMessage=summary if status != "completed" else None,
+            failureClass=result.get("failureClass"),
+            providerErrorCode=_artifact_ref(result.get("providerErrorCode")),
+            liveStreamCapable=False,
+        )
+        self._run_store.save(record)
 
     def _merge_output_refs(self, *groups: Any) -> list[str]:
         seen: list[str] = []

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -93,6 +93,7 @@ class CodexSessionExecutionState(BaseModel):
     status: AgentRunState = Field(..., alias="status")
     started_at: datetime = Field(..., alias="startedAt")
     finished_at: datetime | None = Field(None, alias="finishedAt")
+    managed_run_id: str | None = Field(None, alias="managedRunId")
     locator: CodexManagedSessionLocator = Field(..., alias="locator")
     active_turn_id: str | None = Field(None, alias="activeTurnId")
     profile_id: str | None = Field(None, alias="profileId")
@@ -254,6 +255,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._save_run_state(
             run_id=run_id,
             agent_id=request.agent_id,
+            managed_run_id=binding.task_run_id,
             binding=binding,
             locator=current_locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
@@ -354,6 +356,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._save_run_state(
             run_id=state.run_id,
             agent_id=state.agent_id,
+            managed_run_id=state.managed_run_id,
             binding=None,
             locator=state.locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
@@ -615,6 +618,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         *,
         run_id: str,
         agent_id: str,
+        managed_run_id: str | None = None,
         binding: CodexManagedSessionBinding | None = None,
         locator: Mapping[str, Any],
         active_turn_id: str | None,
@@ -632,6 +636,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             status=status,
             startedAt=started_at,
             finishedAt=finished_at,
+            managedRunId=managed_run_id,
             locator=locator,
             activeTurnId=active_turn_id,
             profileId=profile_id,
@@ -640,6 +645,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._persist_managed_run_record(
             run_id=run_id,
             agent_id=agent_id,
+            managed_run_id=managed_run_id,
             binding=binding,
             result=result,
             status=status,
@@ -652,6 +658,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         *,
         run_id: str,
         agent_id: str,
+        managed_run_id: str | None,
         binding: CodexManagedSessionBinding | None,
         result: Mapping[str, Any],
         status: AgentRunState,
@@ -661,7 +668,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         if self._run_store is None:
             return
 
-        existing = self._run_store.load(run_id)
+        record_key = str(managed_run_id or "").strip() or run_id
+        existing = self._run_store.load(record_key)
         session_artifacts = result.get("metadata", {}).get("sessionArtifacts")
         session_artifact_metadata = (
             session_artifacts.get("metadata", {})
@@ -705,7 +713,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             else (existing.workspace_path if existing is not None else None)
         )
         record = ManagedRunRecord(
-            runId=run_id,
+            runId=record_key,
             workflowId=self._workflow_id,
             agentId=agent_id,
             runtimeId=runtime_id,

--- a/specs/135-codex-managed-session-plane-phase10/contracts/observability-summary-session-backed.md
+++ b/specs/135-codex-managed-session-plane-phase10/contracts/observability-summary-session-backed.md
@@ -1,0 +1,15 @@
+# Contract: Session-Backed Observability Summary Reuse
+
+Phase 10 does not add a new observability endpoint.
+
+## Existing route reused
+
+- `GET /api/task-runs/{taskRunId}/observability-summary`
+
+## Session-backed run expectations
+
+- The route reads a normal `ManagedRunRecord` stored under the step `taskRunId`.
+- The record may originate from a session-backed Codex step rather than a launcher-supervised one-shot process.
+- `stdoutArtifactRef`, `stderrArtifactRef`, and `diagnosticsRef` remain the authoritative observability artifacts.
+- `supportsLiveStreaming` stays `false` for this path until a later live-follow slice exists.
+- No session-only router, PTY, or terminal-attach contract is introduced in this phase.

--- a/specs/135-codex-managed-session-plane-phase10/data-model.md
+++ b/specs/135-codex-managed-session-plane-phase10/data-model.md
@@ -1,0 +1,39 @@
+# Data Model: Codex Managed Session Plane Phase 10
+
+## Session-Backed ManagedRunRecord
+
+Phase 10 reuses the existing `ManagedRunRecord` entity rather than introducing a new observability record type.
+
+### Fields used by this slice
+
+- `runId`: the step-scoped managed run identifier used by `/api/task-runs/{taskRunId}/...`
+- `workflowId`: producing `MoonMind.AgentRun` workflow id for authorization and observability ownership
+- `agentId`: managed agent identifier
+- `runtimeId`: canonical runtime id (`codex_cli`)
+- `status`: final managed-run status for the step
+- `startedAt`
+- `finishedAt`
+- `workspacePath`: task-scoped workspace root used for artifact-backed fallbacks
+- `stdoutArtifactRef`
+- `stderrArtifactRef`
+- `diagnosticsRef`
+- `errorMessage`
+- `failureClass`
+- `liveStreamCapable`: `false` for this phase
+
+## Source Mapping
+
+The managed-session publication payload already contains the durable runtime refs needed for Phase 10.
+
+### Mapping
+
+- `sessionArtifacts.metadata.stdoutArtifactRef` -> `ManagedRunRecord.stdoutArtifactRef`
+- `sessionArtifacts.metadata.stderrArtifactRef` -> `ManagedRunRecord.stderrArtifactRef`
+- `sessionArtifacts.metadata.diagnosticsRef` -> `ManagedRunRecord.diagnosticsRef`
+- step result terminal status -> `ManagedRunRecord.status`
+
+## Non-Goals
+
+- No new session-only observability entity
+- No live-stream transport metadata for session-backed runs yet
+- No terminal attach or shell session projection in the managed-run record

--- a/specs/135-codex-managed-session-plane-phase10/plan.md
+++ b/specs/135-codex-managed-session-plane-phase10/plan.md
@@ -1,0 +1,83 @@
+# Implementation Plan: codex-managed-session-plane-phase10
+
+**Branch**: `135-codex-managed-session-plane-phase10` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/135-codex-managed-session-plane-phase10/spec.md`
+
+## Summary
+
+Implement Phase 10 by making Codex managed-session steps reuse the existing managed-run observability model. The session adapter will persist a normal `ManagedRunRecord` for each session-backed step run using durable stdout/stderr/diagnostics refs already produced by the managed-session publication path, allowing the current `/api/task-runs/{taskRunId}/...` APIs to remain artifact-first without inventing a parallel session observability surface.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: existing `ManagedRunRecord` / `ManagedRunStore`, `CodexSessionAdapter`, task-runs observability router, managed-session publication metadata
+**Testing**: focused pytest suites plus final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal backend runtime adapter and observability API reuse
+**Constraints**: keep observability artifact-first; reuse the existing task-runs API; do not add live-terminal semantics; do not require live session-container access to inspect completed runs
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. This reuses the established observability plane instead of adding a Codex-specific side channel.
+- **II. One-Click Agent Deployment**: PASS. No new deployment dependency or operator setup is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The shape is the generic managed-run observability record, not a Codex-only API.
+- **IV. Own Your Data**: PASS. Observability comes from durable artifacts and persisted records rather than session liveness.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The implementation extends the current record contract instead of introducing terminal scraping or UI-only heuristics.
+- **VII. Powerful Runtime Configurability**: PASS. No new runtime knobs are needed.
+- **VIII. Modular and Extensible Architecture**: PASS. The change stays inside adapter and observability boundaries and remains reusable for later managed-session runtimes.
+- **IX. Resilient by Default**: PASS. Operators can inspect completed runs after the session container is gone.
+- **XI. Spec-Driven Development**: PASS. Phase 10 artifacts are defined before code changes.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. The desired-state observability behavior already lives in canonical docs; this plan only covers the implementation slice.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The work reuses the current path directly and adds no compatibility alias.
+
+## Research
+
+- The task-runs observability router already serves artifact-backed managed-run records and does not need a new session-specific endpoint.
+- Managed-session publication already yields durable stdout/stderr/diagnostics refs, so the missing Phase 10 behavior is wiring those refs into a persisted `ManagedRunRecord`.
+- `CodexSessionAdapter` currently keeps step execution state in memory, which is enough for result delivery inside one workflow turn but not enough for the API-side observability record expected by Mission Control.
+- Live streaming is already optional in the observability model, so Phase 10 can intentionally set `liveStreamCapable=false` for session-backed runs until a later live-follow slice exists.
+
+## Project Structure
+
+- Update `moonmind/workflows/adapters/codex_session_adapter.py` to persist session-backed `ManagedRunRecord` entries.
+- Reuse `moonmind/schemas/agent_runtime_models.py` / `ManagedRunStore` without adding a new observability schema.
+- Extend `tests/unit/workflows/adapters/test_codex_session_adapter.py` to verify record persistence.
+- Extend `tests/unit/api/routers/test_task_runs.py` to verify the existing observability summary contract works for a session-backed record.
+
+## Data Model
+
+- **Session-Backed ManagedRunRecord**
+  - `run_id`: step `taskRunId`
+  - `workflow_id`: producing `MoonMind.AgentRun` workflow id
+  - `agent_id`: managed agent id (Codex)
+  - `runtime_id`: `codex_cli`
+  - `status`: terminal managed-run status
+  - `workspace_path`: task-scoped workspace root used for artifact-backed fallbacks
+  - `stdout_artifact_ref`, `stderr_artifact_ref`, `diagnostics_ref`: copied from durable session publication metadata
+  - `live_stream_capable`: `false` for this phase
+
+## Contracts
+
+- Existing API surface reused: [contracts/observability-summary-session-backed.md](./contracts/observability-summary-session-backed.md)
+
+## Implementation Plan
+
+1. Add failing tests proving session-backed runs do not currently persist a managed-run observability record and that the existing observability summary contract should work once such a record exists.
+2. Update `CodexSessionAdapter` to persist a `ManagedRunRecord` whenever it finalizes a session-backed step result.
+3. Copy durable stdout/stderr/diagnostics refs from session publication metadata into the managed-run record and mark live streaming unavailable for this path.
+4. Verify the task-runs observability summary route serves the persisted session-backed record without router changes or live-session dependencies.
+5. Run focused tests, run Spec Kit scope validation, rerun the full unit suite, and mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py`
+2. `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Execute a Codex managed-session step and confirm Mission Control can load `/api/task-runs/{taskRunId}/observability-summary`.
+2. Confirm stdout, stderr, and diagnostics remain readable after the session container exits.
+3. Confirm the observability summary does not advertise live streaming or terminal attach for the managed-session path.

--- a/specs/135-codex-managed-session-plane-phase10/quickstart.md
+++ b/specs/135-codex-managed-session-plane-phase10/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Codex Managed Session Plane Phase 10
+
+1. Run the focused Phase 10 verification:
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py
+```
+
+2. Validate Spec Kit scope:
+
+```bash
+SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+3. Run the full unit suite before finalizing:
+
+```bash
+./tools/test_unit.sh
+```
+
+4. Manual smoke check:
+
+```text
+Execute one Codex managed-session step, note its taskRunId, and load /api/task-runs/{taskRunId}/observability-summary.
+Confirm stdout/stderr/diagnostics refs are present and live streaming is not advertised.
+```

--- a/specs/135-codex-managed-session-plane-phase10/research.md
+++ b/specs/135-codex-managed-session-plane-phase10/research.md
@@ -1,0 +1,6 @@
+# Research: Codex Managed Session Plane Phase 10
+
+- Reuse the existing `/api/task-runs/{taskRunId}/...` observability plane instead of adding a session-specific route. This keeps Mission Control on the same artifact-first fetch sequence already documented in `docs/ManagedAgents/LiveLogs.md`.
+- The managed-session controller and supervisor already persist stdout, stderr, diagnostics, summary, checkpoint, and reset refs durably. Phase 10 should consume those durable refs rather than query the session container again.
+- `CodexSessionAdapter` is currently the gap because it finishes a session-backed step without persisting a `ManagedRunRecord`, so API-side observability cannot discover the run through `ManagedRunStore`.
+- A session-backed `ManagedRunRecord` can legitimately set `liveStreamCapable=false` in this phase because the MVP requirement is artifact-first observability, with optional live following explicitly deferred.

--- a/specs/135-codex-managed-session-plane-phase10/spec.md
+++ b/specs/135-codex-managed-session-plane-phase10/spec.md
@@ -1,0 +1,82 @@
+# Feature Specification: codex-managed-session-plane-phase10
+
+**Feature Branch**: `135-codex-managed-session-plane-phase10`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Implement Phase 10 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reuse managed-run observability for session-backed Codex steps (Priority: P1)
+
+Operators need Codex managed-session steps to appear through the existing managed-run observability APIs so they can inspect stdout, stderr, and diagnostics without a new session-only log path.
+
+**Why this priority**: Phase 10 is explicitly about keeping the existing artifact-first observability model even though the runtime now lives in a separate session container.
+
+**Independent Test**: Complete one managed Codex session-backed step and verify MoonMind persists a normal managed-run observability record keyed by the step task run ID.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Codex managed-session step completes and publishes session artifacts, **When** the adapter finalizes the step result, **Then** MoonMind persists a `ManagedRunRecord` for that step run ID with stdout, stderr, and diagnostics artifact refs copied from durable session publication metadata.
+2. **Given** the session-backed step wrote a managed-run observability record, **When** `/api/task-runs/{taskRunId}/observability-summary` is requested, **Then** the response comes from the existing observability router and includes the persisted artifact refs and terminal status.
+
+---
+
+### User Story 2 - Keep the observability path artifact-first after the session container is gone (Priority: P1)
+
+Operators need managed-session runs to remain inspectable after the live session container no longer exists.
+
+**Why this priority**: Phase 10 forbids terminal-first or session-liveness-dependent observability for the managed-session path.
+
+**Independent Test**: Persist a session-backed managed-run record with stdout/stderr/diagnostics refs and verify the task-runs observability surface still treats the artifacts as authoritative without consulting live session state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session-backed managed run already has durable stdout, stderr, and diagnostics refs, **When** the observability summary is loaded later, **Then** MoonMind serves those refs from the persisted managed-run record instead of querying the session container.
+2. **Given** a session-backed managed run has no live-follow implementation yet, **When** observability summary is loaded, **Then** the response reports artifact-backed observability only and does not claim live streaming support.
+
+---
+
+### User Story 3 - Avoid introducing terminal-first semantics for the managed-session path (Priority: P2)
+
+Operators should keep using the current MoonMind-native logs and diagnostics surfaces rather than a new embedded shell or session attach path.
+
+**Why this priority**: Phase 10 is specifically the observability reuse slice, not a terminal-attach or live-session UI slice.
+
+**Independent Test**: Inspect the persisted observability summary for a session-backed run and verify it disables live streaming while preserving artifact refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed session-backed managed run, **When** its observability summary is returned, **Then** `supportsLiveStreaming` is `false` and `liveStreamStatus` is `ended`.
+2. **Given** a non-terminal session-backed managed run record is surfaced before live-follow exists, **When** observability summary is returned, **Then** `supportsLiveStreaming` is `false` and `liveStreamStatus` is `unavailable`.
+
+## Edge Cases
+
+- Session publication omits one or more runtime artifact refs; MoonMind must not fabricate missing refs.
+- The session-backed run completes successfully but has no live stream capability yet.
+- The session adapter restarts inside the worker process; the durable managed-run observability record must still survive on disk.
+- A canceled or failed session-backed run must still persist terminal status and any available diagnostics ref.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Codex managed-session steps MUST persist a durable `ManagedRunRecord` keyed by the step `taskRunId` used by `/api/task-runs/{taskRunId}/...`.
+- **FR-002**: The persisted managed-run record MUST include `workflowId`, `agentId`, `runtimeId`, `status`, `startedAt`, optional `finishedAt`, and any available `stdoutArtifactRef`, `stderrArtifactRef`, and `diagnosticsRef`.
+- **FR-003**: The managed-session observability record MUST source runtime artifact refs from durable session publication metadata and MUST NOT depend on a live container query.
+- **FR-004**: The existing `/api/task-runs/{taskRunId}/observability-summary` route MUST serve session-backed managed runs without adding a session-specific observability endpoint.
+- **FR-005**: Until a later live-follow phase is implemented, session-backed managed runs MUST set `liveStreamCapable` to `false`.
+- **FR-006**: Phase 10 MUST preserve artifact-first observability and MUST NOT add terminal attach, PTY embedding, or session-shell semantics for the managed-session path.
+
+### Key Entities
+
+- **Session-Backed Managed Run Record**: The existing managed-run observability record populated for a Codex managed-session step so current task-run APIs can read its artifact refs.
+- **Session Publication Metadata**: The durable session artifact publication payload that exposes stdout, stderr, diagnostics, and continuity refs after a step completes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests verify a completed Codex managed-session step writes a `ManagedRunRecord` with stdout/stderr/diagnostics refs sourced from session publication metadata.
+- **SC-002**: Tests verify the existing task-runs observability summary route serves that record without session-specific router branching.
+- **SC-003**: Tests verify session-backed observability summaries keep live streaming disabled while preserving artifact-first logs and diagnostics.

--- a/specs/135-codex-managed-session-plane-phase10/speckit_analyze_report.md
+++ b/specs/135-codex-managed-session-plane-phase10/speckit_analyze_report.md
@@ -1,0 +1,35 @@
+# Speckit Analyze Report: codex-managed-session-plane-phase10
+
+## spec.md
+
+### LOW
+
+- **Artifact**: `spec.md`
+- **Location**: Edge Cases
+- **Problem**: The edge cases mention canceled and failed runs together without restating that partial artifacts are allowed to remain missing.
+- **Remediation**: Keep implementation conservative and only persist artifact refs that actually exist.
+- **Rationale**: This is already implied by FR-002 and should be handled in code rather than by broadening the spec further.
+
+## plan.md
+
+No actionable remediations.
+
+## tasks.md
+
+No actionable remediations.
+
+## docs
+
+No actionable remediations.
+
+## Safe to Implement
+
+YES
+
+## Blocking Remediations
+
+None.
+
+## Determination Rationale
+
+The Phase 10 artifacts are internally consistent, include production runtime code plus validation work, and keep the implementation scoped to reusing the existing artifact-first observability model.

--- a/specs/135-codex-managed-session-plane-phase10/tasks.md
+++ b/specs/135-codex-managed-session-plane-phase10/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Codex Managed Session Plane Phase 10
+
+## T001 — Add TDD coverage for session-backed observability reuse [P]
+- [X] T001a [P] Extend `tests/unit/workflows/adapters/test_codex_session_adapter.py` to assert a completed session-backed run persists a `ManagedRunRecord` with stdout/stderr/diagnostics refs and `liveStreamCapable=false`.
+- [X] T001b [P] Extend `tests/unit/api/routers/test_task_runs.py` to assert the existing observability summary route serves a session-backed managed-run record artifact-first and reports live streaming unavailable/ended as appropriate.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py`
+
+## T002 — Persist managed-run observability records for session-backed runs [P]
+- [X] T002a [P] Update `moonmind/workflows/adapters/codex_session_adapter.py` so finalized session-backed step runs write a durable `ManagedRunRecord`.
+- [X] T002b [P] Copy stdout/stderr/diagnostics refs from durable session publication metadata into the managed-run record and preserve workflow/runtime identifiers needed by the existing observability APIs.
+- [X] T002c [P] Keep `liveStreamCapable=false` for this path and avoid adding terminal/session-attach semantics.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py`
+
+## T003 — Verify scope and finalize [P]
+- [X] T003a [P] Run `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T003b [P] Run `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+- [X] T003c [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Scope validation passes and `./tools/test_unit.sh` passes.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -87,6 +87,38 @@ def test_get_observability_summary_returns_200(
     assert body["status"] == "running"
 
 
+def test_get_observability_summary_returns_session_backed_artifact_refs(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {
+        "runId": str(run_id),
+        "status": "completed",
+        "runtimeId": "codex_cli",
+        "stdoutArtifactRef": "sess-1/stdout.log",
+        "stderrArtifactRef": "sess-1/stderr.log",
+        "diagnosticsRef": "sess-1/diagnostics.json",
+        "liveStreamCapable": False,
+    }
+    mock_record.status = "completed"
+    mock_record.live_stream_capable = False
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    body = response.json()["summary"]
+    assert body["runtimeId"] == "codex_cli"
+    assert body["stdoutArtifactRef"] == "sess-1/stdout.log"
+    assert body["stderrArtifactRef"] == "sess-1/stderr.log"
+    assert body["diagnosticsRef"] == "sess-1/diagnostics.json"
+    assert body["supportsLiveStreaming"] is False
+    assert body["liveStreamStatus"] == "ended"
+
+
 def test_get_observability_summary_includes_live_stream_fields_for_active_run(
     client: tuple[TestClient, AsyncMock],
 ) -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -245,6 +245,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     async def _apply_control_action(payload: dict[str, Any]) -> None:
         control_calls.append(payload)
 
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
     adapter = CodexSessionAdapter(
         profile_fetcher=_fake_profiles(
             [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
@@ -254,7 +255,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
         cooldown_reporter=_async_noop,
         workflow_id="wf-agent-run-1",
         runtime_id="codex_cli",
-        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        run_store=run_store,
         load_session_snapshot=_load_snapshot,
         launch_session=_launch_session,
         session_status=_session_status,
@@ -273,6 +274,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
     status = await adapter.status(handle.run_id)
     result = await adapter.fetch_result(handle.run_id)
+    persisted_record = run_store.load(handle.run_id)
 
     assert len(launch_calls) == 1
     launch_request = launch_calls[0]
@@ -289,6 +291,14 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert handle.status == "completed"
     assert handle.metadata["sessionId"] == binding.session_id
     assert handle.metadata["containerId"] == "container-1"
+    assert persisted_record is not None
+    assert persisted_record.workflow_id == "wf-agent-run-1"
+    assert persisted_record.runtime_id == "codex_cli"
+    assert persisted_record.status == "completed"
+    assert persisted_record.stdout_artifact_ref == "artifact:stdout"
+    assert persisted_record.stderr_artifact_ref == "artifact:stderr"
+    assert persisted_record.diagnostics_ref == "artifact:diagnostics"
+    assert persisted_record.live_stream_capable is False
     assert status.status == "completed"
     assert result.summary == "Implemented through the session container."
     assert result.output_refs == [

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -274,7 +274,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     handle = await adapter.start(_request(binding, workspace_path=str(workspace_path)))
     status = await adapter.status(handle.run_id)
     result = await adapter.fetch_result(handle.run_id)
-    persisted_record = run_store.load(handle.run_id)
+    persisted_record = run_store.load(binding.task_run_id)
 
     assert len(launch_calls) == 1
     launch_request = launch_calls[0]
@@ -292,6 +292,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert handle.metadata["sessionId"] == binding.session_id
     assert handle.metadata["containerId"] == "container-1"
     assert persisted_record is not None
+    assert persisted_record.run_id == binding.task_run_id
     assert persisted_record.workflow_id == "wf-agent-run-1"
     assert persisted_record.runtime_id == "codex_cli"
     assert persisted_record.status == "completed"


### PR DESCRIPTION
## Summary
Implement Phase 10 of the Codex Managed Session Plane MVP by reusing the existing managed-run observability model for session-backed Codex steps.

## What Changed
- persist a standard `ManagedRunRecord` for completed session-backed Codex runs
- source `stdout` / `stderr` / `diagnostics` refs from durable session publication metadata with a published-ref fallback
- keep `liveStreamCapable=false` for the session-backed path so observability stays artifact-first without terminal semantics
- add Phase 10 spec artifacts under `specs/135-codex-managed-session-plane-phase10/`
- add unit coverage for the session adapter and the existing `/api/task-runs/{taskRunId}/observability-summary` route

## Why
Phase 10 requires managed-session observability to keep using MoonMind's current artifact-first logs and diagnostics model rather than introducing a session-only or terminal-first observability path.

## Impact
Session-backed Codex steps now appear through the existing task-run observability APIs after completion, even after the session container is gone.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py`
- `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=135-codex-managed-session-plane-phase10 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`