### PR TITLE
Add Phase 9 task-run artifact session projection API

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -9,10 +9,27 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
 from fastapi.responses import FileResponse, StreamingResponse
 
+from api_service.api.routers.temporal_artifacts import (
+    _get_temporal_artifact_service,
+    _serialize_metadata,
+)
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
+from moonmind.schemas.temporal_artifact_models import (
+    ArtifactMetadataModel,
+    ArtifactRefModel,
+    ArtifactSessionGroupModel,
+    ArtifactSessionProjectionModel,
+)
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
+from moonmind.workflows.temporal.artifacts import (
+    TemporalArtifactAuthorizationError,
+    TemporalArtifactNotFoundError,
+    TemporalArtifactService,
+    TemporalArtifactStateError,
+)
 from moonmind.utils.metrics import get_metrics_emitter
 from moonmind.schemas.agent_runtime_models import is_terminal_agent_run_state
 from moonmind.observability.transport import SpoolLogReader
@@ -30,6 +47,14 @@ def _get_agent_runtime_store_root() -> str:
         os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
         "managed_runs",
     )
+
+
+def _get_managed_session_store_root() -> str:
+    return os.path.join(
+        os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
+        "managed_sessions",
+    )
+
 
 def _get_agent_runtime_artifacts_root() -> str:
     return str(managed_runtime_artifact_root())
@@ -92,6 +117,139 @@ async def _require_observability_access(record: object, user: User) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have permission to access observability for this run.",
         )
+
+
+async def _require_task_run_access(task_run_id: str, user: User) -> None:
+    if getattr(user, "is_superuser", False):
+        return
+
+    owner_type, owner_id = await _load_execution_owner_binding(task_run_id)
+    if owner_type != "user" or owner_id != str(user.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to access observability for this run.",
+        )
+
+
+def _session_projection_not_found() -> None:
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={
+            "code": "session_projection_not_found",
+            "message": "Managed session projection was not found for the requested task run.",
+        },
+    )
+
+
+async def _resolve_projection_artifact(
+    *,
+    artifact_id: str | None,
+    service: TemporalArtifactService,
+) -> ArtifactMetadataModel | None:
+    normalized = str(artifact_id or "").strip()
+    if not normalized:
+        return None
+    try:
+        artifact, links, pinned, read_policy = await service.get_metadata(
+            artifact_id=normalized,
+            principal="service:task_runs",
+        )
+    except (
+        TemporalArtifactAuthorizationError,
+        TemporalArtifactNotFoundError,
+        TemporalArtifactStateError,
+    ):
+        return None
+    return _serialize_metadata(
+        artifact=artifact,
+        links=links,
+        pinned=pinned,
+        read_policy=read_policy,
+    )
+
+
+async def _build_task_run_artifact_session_projection(
+    *,
+    task_run_id: str,
+    session_id: str,
+    service: TemporalArtifactService,
+) -> ArtifactSessionProjectionModel | None:
+    store = ManagedSessionStore(_get_managed_session_store_root())
+    record = await asyncio.to_thread(store.load, session_id)
+    if record is None or record.task_run_id != task_run_id:
+        return None
+
+    cache: dict[str, ArtifactMetadataModel | None] = {}
+
+    async def _cached_metadata(artifact_id: str | None) -> ArtifactMetadataModel | None:
+        normalized = str(artifact_id or "").strip()
+        if not normalized:
+            return None
+        if normalized not in cache:
+            cache[normalized] = await _resolve_projection_artifact(
+                artifact_id=normalized,
+                service=service,
+            )
+        return cache[normalized]
+
+    groups: list[ArtifactSessionGroupModel] = []
+    for group_key, title, refs in (
+        (
+            "runtime",
+            "Runtime",
+            (
+                record.stdout_artifact_ref,
+                record.stderr_artifact_ref,
+                record.diagnostics_ref,
+            ),
+        ),
+        (
+            "continuity",
+            "Continuity",
+            (
+                record.latest_summary_ref,
+                record.latest_checkpoint_ref,
+            ),
+        ),
+        (
+            "control",
+            "Control",
+            (
+                record.latest_control_event_ref,
+                record.latest_reset_boundary_ref,
+            ),
+        ),
+    ):
+        artifacts: list[ArtifactMetadataModel] = []
+        for ref in refs:
+            metadata = await _cached_metadata(ref)
+            if metadata is not None:
+                artifacts.append(metadata)
+        if artifacts:
+            groups.append(
+                ArtifactSessionGroupModel(
+                    group_key=group_key,
+                    title=title,
+                    artifacts=artifacts,
+                )
+            )
+
+    async def _artifact_ref(artifact_id: str | None) -> ArtifactRefModel | None:
+        metadata = await _cached_metadata(artifact_id)
+        if metadata is None:
+            return None
+        return ArtifactRefModel(**metadata.artifact_ref.model_dump())
+
+    return ArtifactSessionProjectionModel(
+        task_run_id=record.task_run_id,
+        session_id=record.session_id,
+        session_epoch=record.session_epoch,
+        grouped_artifacts=groups,
+        latest_summary_ref=await _artifact_ref(record.latest_summary_ref),
+        latest_checkpoint_ref=await _artifact_ref(record.latest_checkpoint_ref),
+        latest_control_event_ref=await _artifact_ref(record.latest_control_event_ref),
+        latest_reset_boundary_ref=await _artifact_ref(record.latest_reset_boundary_ref),
+    )
 
 
 def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]]:
@@ -314,6 +472,31 @@ async def get_observability_summary(
     base["supportsLiveStreaming"] = supports_live
     base["liveStreamStatus"] = live_stream_status
     return {"summary": base}
+
+
+@router.get(
+    "/{task_run_id}/artifact-sessions/{session_id}",
+    response_model=ArtifactSessionProjectionModel,
+    responses={
+        403: {"description": "You do not have permission to access this task run"},
+        404: {"description": "Session projection not found for this task run"},
+    },
+)
+async def get_task_run_artifact_session(
+    task_run_id: str,
+    session_id: str,
+    _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+) -> ArtifactSessionProjectionModel:
+    await _require_task_run_access(task_run_id, _user)
+    projection = await _build_task_run_artifact_session_projection(
+        task_run_id=task_run_id,
+        session_id=session_id,
+        service=artifact_service,
+    )
+    if projection is None:
+        _session_projection_not_found()
+    return projection
 
 
 @router.get(

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -127,7 +127,7 @@ async def _require_task_run_access(task_run_id: str, user: User) -> None:
     if owner_type != "user" or owner_id != str(user.id):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have permission to access observability for this run.",
+            detail="You do not have permission to access this task run or its session projection.",
         )
 
 
@@ -175,7 +175,10 @@ async def _build_task_run_artifact_session_projection(
     service: TemporalArtifactService,
 ) -> ArtifactSessionProjectionModel | None:
     store = ManagedSessionStore(_get_managed_session_store_root())
-    record = await asyncio.to_thread(store.load, session_id)
+    try:
+        record = await asyncio.to_thread(store.load, session_id)
+    except ValueError:
+        return None
     if record is None or record.task_run_id != task_run_id:
         return None
 
@@ -238,7 +241,7 @@ async def _build_task_run_artifact_session_projection(
         metadata = await _cached_metadata(artifact_id)
         if metadata is None:
             return None
-        return ArtifactRefModel(**metadata.artifact_ref.model_dump())
+        return metadata.artifact_ref
 
     return ArtifactSessionProjectionModel(
         task_run_id=record.task_run_id,

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -196,6 +196,31 @@ class ArtifactListResponse(BaseModel):
     artifacts: list[ArtifactMetadataModel] = Field(default_factory=list)
 
 
+class ArtifactSessionGroupModel(BaseModel):
+    """Server-defined grouping of task-scoped session artifacts."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    group_key: str
+    title: str
+    artifacts: list[ArtifactMetadataModel] = Field(default_factory=list)
+
+
+class ArtifactSessionProjectionModel(BaseModel):
+    """Minimal task-scoped session continuity projection."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    task_run_id: str
+    session_id: str
+    session_epoch: int
+    grouped_artifacts: list[ArtifactSessionGroupModel] = Field(default_factory=list)
+    latest_summary_ref: Optional[ArtifactRefModel] = None
+    latest_checkpoint_ref: Optional[ArtifactRefModel] = None
+    latest_control_event_ref: Optional[ArtifactRefModel] = None
+    latest_reset_boundary_ref: Optional[ArtifactRefModel] = None
+
+
 class PresignDownloadResponse(BaseModel):
     """Presigned-download response payload."""
 

--- a/specs/135-codex-managed-session-plane-phase9/checklists/requirements.md
+++ b/specs/135-codex-managed-session-plane-phase9/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Codex Managed Session Plane Phase 9
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent is explicit: this phase requires backend/API code plus validation tests, not docs-only changes.

--- a/specs/135-codex-managed-session-plane-phase9/contracts/task-run-artifact-session-projection.md
+++ b/specs/135-codex-managed-session-plane-phase9/contracts/task-run-artifact-session-projection.md
@@ -1,0 +1,94 @@
+# Task-Run Artifact Session Projection Contract
+
+## Endpoint
+
+`GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}`
+
+## Success Response
+
+`200 OK`
+
+```json
+{
+  "task_run_id": "wf-task-1",
+  "session_id": "sess:wf-task-1:codex_cli",
+  "session_epoch": 2,
+  "grouped_artifacts": [
+    {
+      "group_key": "runtime",
+      "title": "Runtime",
+      "artifacts": ["ArtifactMetadataModel", "..."]
+    },
+    {
+      "group_key": "continuity",
+      "title": "Continuity",
+      "artifacts": ["ArtifactMetadataModel", "..."]
+    },
+    {
+      "group_key": "control",
+      "title": "Control",
+      "artifacts": ["ArtifactMetadataModel", "..."]
+    }
+  ],
+  "latest_summary_ref": {
+    "artifact_ref_v": 1,
+    "artifact_id": "art_summary",
+    "sha256": null,
+    "size_bytes": 512,
+    "content_type": "application/json",
+    "encryption": "none"
+  },
+  "latest_checkpoint_ref": {
+    "artifact_ref_v": 1,
+    "artifact_id": "art_checkpoint",
+    "sha256": null,
+    "size_bytes": 640,
+    "content_type": "application/json",
+    "encryption": "none"
+  },
+  "latest_control_event_ref": {
+    "artifact_ref_v": 1,
+    "artifact_id": "art_control",
+    "sha256": null,
+    "size_bytes": 256,
+    "content_type": "application/json",
+    "encryption": "none"
+  },
+  "latest_reset_boundary_ref": {
+    "artifact_ref_v": 1,
+    "artifact_id": "art_reset",
+    "sha256": null,
+    "size_bytes": 256,
+    "content_type": "application/json",
+    "encryption": "none"
+  }
+}
+```
+
+## Error Responses
+
+### Missing or mismatched session
+
+`404 Not Found`
+
+```json
+{
+  "detail": {
+    "code": "session_projection_not_found",
+    "message": "Managed session projection was not found for the requested task run."
+  }
+}
+```
+
+### Forbidden
+
+`403 Forbidden`
+
+The route follows the existing task-run ownership rules and must not leak session metadata to non-owners.
+
+## Contract Rules
+
+- The response is a server-side read model over persisted artifacts and the durable managed-session record.
+- The response must not require a live session container, live session-controller query, or container-local history.
+- Missing artifact refs may be omitted from both the latest-ref fields and the grouped-artifact lists.
+- Every returned artifact must still carry its normal execution `links[]`.

--- a/specs/135-codex-managed-session-plane-phase9/data-model.md
+++ b/specs/135-codex-managed-session-plane-phase9/data-model.md
@@ -1,0 +1,67 @@
+# Data Model: Codex Managed Session Plane Phase 9
+
+## ArtifactSessionProjectionModel
+
+Server-side read model returned by `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `task_run_id` | string | Root task-run identity supplied in the route and verified against the durable session record |
+| `session_id` | string | Task-scoped managed-session identity |
+| `session_epoch` | integer | Latest durable continuity epoch for the managed session |
+| `grouped_artifacts` | list[`ArtifactSessionGroupModel`] | Server-defined artifact groups for continuity panel rendering |
+| `latest_summary_ref` | `ArtifactRefModel \| null` | Latest durable `session.summary` artifact ref when resolvable |
+| `latest_checkpoint_ref` | `ArtifactRefModel \| null` | Latest durable `session.step_checkpoint` artifact ref when resolvable |
+| `latest_control_event_ref` | `ArtifactRefModel \| null` | Latest durable `session.control_event` artifact ref when resolvable |
+| `latest_reset_boundary_ref` | `ArtifactRefModel \| null` | Optional latest durable `session.reset_boundary` artifact ref |
+
+## ArtifactSessionGroupModel
+
+Stable group emitted by the projection API.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `group_key` | string | Machine-stable grouping key such as `runtime` or `continuity` |
+| `title` | string | Human-readable group label |
+| `artifacts` | list[`ArtifactMetadataModel`] | Artifact metadata entries already filtered and ordered by the server |
+
+## Projection Source Inputs
+
+### Durable managed-session record
+
+`CodexManagedSessionRecord` supplies:
+
+- `task_run_id`
+- `session_id`
+- `session_epoch`
+- `stdout_artifact_ref`
+- `stderr_artifact_ref`
+- `diagnostics_ref`
+- `latest_summary_ref`
+- `latest_checkpoint_ref`
+- `latest_control_event_ref`
+- `latest_reset_boundary_ref`
+
+### Artifact metadata
+
+Each stored ref is resolved into:
+
+- `ArtifactMetadataModel`
+- execution `links[]`
+- safe preview/default-read fields
+- artifact-ref payload used by the latest-ref fields
+
+## Grouping Rules
+
+- `runtime` group:
+  - stdout
+  - stderr
+  - diagnostics
+- `continuity` group:
+  - session summary
+  - step checkpoint
+- `control` group:
+  - control event
+  - reset boundary
+
+Groups omit missing or unreadable artifacts rather than returning placeholders.

--- a/specs/135-codex-managed-session-plane-phase9/plan.md
+++ b/specs/135-codex-managed-session-plane-phase9/plan.md
@@ -1,0 +1,142 @@
+# Implementation Plan: codex-managed-session-plane-phase9
+
+**Branch**: `135-codex-managed-session-plane-phase9` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/135-codex-managed-session-plane-phase9/spec.md`
+
+## Summary
+
+Implement the minimal Phase 9 session continuity projection API for task-scoped Codex managed sessions. This slice adds a task-run API endpoint that reads the durable managed-session record, resolves the persisted artifact refs into artifact metadata, and returns a grouped server-side read model that Mission Control can consume without inferring continuity from live container state.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: FastAPI task-run router, SQLAlchemy-backed `TemporalArtifactService`, JSON-backed `ManagedSessionStore`, existing artifact metadata schemas
+**Storage**: Temporal artifact metadata tables plus file-backed managed-session records under `MOONMIND_AGENT_RUNTIME_STORE`
+**Testing**: focused pytest router coverage plus final verification via `./tools/test_unit.sh`
+**Target Platform**: Linux server containers in the existing MoonMind Docker deployment
+**Project Type**: Backend API and projection read-model slice
+**Performance Goals**: One request should build the projection from durable refs only, with no live session-controller or container dependency
+**Constraints**: preserve task-run ownership semantics; reuse persisted artifact metadata rather than container-local state; keep the endpoint small enough that later UI work can iterate without changing orchestration contracts
+**Scale/Scope**: one task-scoped session projection per request, using the latest durable session epoch only for the MVP
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The endpoint reads durable orchestration outputs and does not move control or execution into the API layer.
+- **II. One-Click Agent Deployment**: PASS. No new operator dependency or deployment step is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The projection is an artifact/read-model API over generic artifact metadata and session refs, not a Codex-specific execution shortcut.
+- **IV. Own Your Data**: PASS. Session continuity becomes easier to inspect after container teardown because the API reads persisted artifacts and session metadata.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The work adds a typed response contract and API tests rather than UI-side grouping heuristics.
+- **VII. Powerful Runtime Configurability**: PASS. Existing runtime-store and artifact-store env configuration remains authoritative.
+- **VIII. Modular and Extensible Architecture**: PASS. The change stays inside API/router and schema boundaries and does not alter workflow orchestration.
+- **IX. Resilient by Default**: PASS. The endpoint is explicitly durable-state-first and does not fail merely because the session container is gone.
+- **XI. Spec-Driven Development**: PASS. Phase 9 is implemented from fresh spec/plan/tasks artifacts.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Migration sequencing stays in the spec artifacts; canonical docs already define the desired projection behavior.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The feature extends the live task-run API directly with no compatibility shim layer.
+
+## Research
+
+### Decision: Build the MVP projection from the durable managed-session record plus artifact metadata lookups
+
+- **Rationale**: Phase 8 already persists the latest continuity refs and runtime artifact refs on `CodexManagedSessionRecord`, which is enough to serve a first useful projection without querying live session infrastructure.
+- **Alternatives considered**:
+  - Query live session-controller/container state: rejected because it violates the artifact-first continuity rule.
+  - Add a new persisted projection table: rejected because Phase 9 only needs a minimal read model and the current durable refs already exist.
+
+### Decision: Reuse task-run ownership checks before reading artifacts through a service principal
+
+- **Rationale**: The task-run router already owns operator-facing access control. Once access is granted, the API can resolve artifact metadata through a service principal without exposing raw artifact permissions complexity to the client.
+- **Alternatives considered**:
+  - Require end-user artifact ownership for each resolved artifact: rejected because managed-session artifacts are often system-produced and the route already enforces task-level access.
+
+### Decision: Limit the MVP to the latest durable epoch and grouped latest refs
+
+- **Rationale**: The Phase 9 plan only requires a minimal continuity projection. Returning the latest epoch plus grouped latest artifacts satisfies the exit criteria and keeps the implementation small.
+- **Alternatives considered**:
+  - Full historical timeline across all epochs and step executions: rejected as premature for the Phase 9 MVP.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/135-codex-managed-session-plane-phase9/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-run-artifact-session-projection.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── task_runs.py
+
+moonmind/
+└── schemas/
+    └── temporal_artifact_models.py
+
+tests/
+└── unit/
+    └── api/
+        └── routers/
+            └── test_task_runs.py
+```
+
+**Structure Decision**: Keep the MVP inside the existing task-run API surface. Add typed response models under `moonmind/schemas/temporal_artifact_models.py`, implement the projection assembly in `api_service/api/routers/task_runs.py`, and verify behavior in `tests/unit/api/routers/test_task_runs.py`.
+
+## Data Model
+
+- **ArtifactSessionProjectionModel**
+  - `task_run_id`
+  - `session_id`
+  - `session_epoch`
+  - `grouped_artifacts`
+  - `latest_summary_ref`
+  - `latest_checkpoint_ref`
+  - `latest_control_event_ref`
+  - optional `latest_reset_boundary_ref`
+- **ArtifactSessionGroupModel**
+  - `group_key`
+  - `title`
+  - `artifacts[]`
+- **Projection Source Inputs**
+  - durable `CodexManagedSessionRecord`
+  - artifact metadata for `stdout_artifact_ref`, `stderr_artifact_ref`, `diagnostics_ref`
+  - artifact metadata for `latest_summary_ref`, `latest_checkpoint_ref`, `latest_control_event_ref`, `latest_reset_boundary_ref`
+
+## Contracts
+
+- Add `specs/135-codex-managed-session-plane-phase9/contracts/task-run-artifact-session-projection.md` capturing the endpoint path, status/error rules, and response shape for the MVP read model.
+
+## Implementation Plan
+
+1. Add failing router tests for successful projection reads, grouped artifact output, durable-only behavior without a live container, owner checks, and missing-session errors.
+2. Extend `moonmind/schemas/temporal_artifact_models.py` with typed response models for artifact session groups and the projection envelope.
+3. Extend `api_service/api/routers/task_runs.py` with:
+   - managed-session store root helpers,
+   - task-run ownership validation for projection reads,
+   - projection assembly from the durable session record and artifact metadata lookups,
+   - stable `404` error mapping for missing or mismatched task/session pairs.
+4. Keep grouping server-defined and minimal by returning runtime and continuity/control buckets plus the latest ref fields needed by later UI work.
+5. Run focused router tests, run runtime scope validation, rerun the full unit suite, and mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
+2. `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Request `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}` for a persisted Codex managed session and confirm the response can drive a continuity panel without any live session dependency.
+2. Confirm the response groups runtime artifacts separately from continuity/control artifacts and reports the current session epoch.
+3. Confirm a non-owner receives `403` and a missing or mismatched session/task pair receives `404` with `session_projection_not_found`.

--- a/specs/135-codex-managed-session-plane-phase9/quickstart.md
+++ b/specs/135-codex-managed-session-plane-phase9/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Codex Managed Session Plane Phase 9
+
+## Focused Verification
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py
+SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+## Full Verification
+
+```bash
+./tools/test_unit.sh
+```
+
+## Example API Call
+
+```bash
+curl -s \
+  "http://localhost:5000/api/task-runs/<task_run_id>/artifact-sessions/<session_id>"
+```
+
+Expected result:
+
+- returns the latest durable `session_epoch`
+- includes grouped runtime and continuity/control artifacts
+- includes the latest summary/checkpoint/control refs needed for a continuity panel
+- works even when the live managed-session container no longer exists

--- a/specs/135-codex-managed-session-plane-phase9/research.md
+++ b/specs/135-codex-managed-session-plane-phase9/research.md
@@ -1,0 +1,23 @@
+# Research: Codex Managed Session Plane Phase 9
+
+## Decision 1: Use the durable managed-session record as the projection seed
+
+- **Decision**: Build the Phase 9 projection from `CodexManagedSessionRecord` plus artifact metadata lookups for the refs already persisted in Phase 8.
+- **Rationale**: The durable session record already stores the latest runtime and continuity refs, which is sufficient for a minimal continuity read model.
+- **Alternatives considered**:
+  - Live session-controller queries: rejected because Phase 9 must stay artifact-first and durable-state-first.
+  - A new projection persistence layer: rejected because the MVP can be computed cheaply at request time.
+
+## Decision 2: Reuse task-run authorization, then read artifacts as a service principal
+
+- **Decision**: Authorize access at the task-run API boundary and use a service principal for artifact metadata resolution inside the projection builder.
+- **Rationale**: Managed-session artifacts are system-produced; task-run ownership is the operator-facing authorization boundary that already fits Mission Control.
+- **Alternatives considered**:
+  - Enforce artifact-by-artifact end-user ownership: rejected because it would hide system-generated artifacts that belong to the user-visible task.
+
+## Decision 3: Return grouped latest artifacts, not a full historical timeline
+
+- **Decision**: The Phase 9 response returns the latest durable epoch and grouped latest artifacts for runtime and continuity/control categories.
+- **Rationale**: The user asked for a minimal projection API; later phases can extend this to broader timeline/history queries if needed.
+- **Alternatives considered**:
+  - Cross-epoch timeline reconstruction: rejected because it adds query complexity before the first continuity UI exists.

--- a/specs/135-codex-managed-session-plane-phase9/spec.md
+++ b/specs/135-codex-managed-session-plane-phase9/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: codex-managed-session-plane-phase9
+
+**Feature Branch**: `135-codex-managed-session-plane-phase9`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Implement Phase 9 of the Codex Managed Session Plane MVP plan using test-driven development. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read a durable session continuity projection (Priority: P1)
+
+Operators need one server-side session read model for a task-scoped Codex session so Mission Control can render continuity from persisted artifacts and bounded session metadata instead of from live container state.
+
+**Why this priority**: Phase 9 exists to make session continuity a first-class API surface before UI work begins.
+
+**Independent Test**: Call `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}` for a managed session with persisted continuity artifacts and verify the response includes the current session identity, latest continuity refs, and grouped artifact metadata without contacting a live session container.
+
+**Acceptance Scenarios**:
+
+1. **Given** a durable Codex managed-session record exists for `task_run_id` and `session_id`, **When** the session projection endpoint is requested, **Then** the response includes `task_run_id`, `session_id`, the latest `session_epoch`, grouped artifact metadata, and the latest continuity refs required to build the session view.
+2. **Given** the managed session container is already gone, **When** the session projection endpoint is requested, **Then** MoonMind still returns the projection from durable artifact metadata and the managed-session record without querying live container state.
+3. **Given** the latest summary, checkpoint, or control-event refs are missing individually, **When** the projection endpoint is requested, **Then** MoonMind omits only the missing ref fields while still returning the remaining grouped artifacts and continuity metadata.
+
+---
+
+### User Story 2 - Group continuity artifacts server-side (Priority: P1)
+
+Operators need the backend to group continuity artifacts into a stable read model so the UI does not have to infer grouping or "latest" semantics client-side.
+
+**Why this priority**: Server-defined grouping is the core Phase 9 outcome and the prerequisite for a simple continuity panel in Phase 11.
+
+**Independent Test**: Seed artifact metadata for session summary, step checkpoint, control-event, reset-boundary, stdout, stderr, and diagnostics artifacts, then verify the endpoint returns those artifacts in stable server-defined groups with matching latest refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session record stores `runtime.stdout`, `runtime.stderr`, `runtime.diagnostics`, `session.summary`, `session.step_checkpoint`, `session.control_event`, and `session.reset_boundary` refs, **When** the projection endpoint is requested, **Then** MoonMind returns those artifacts grouped by continuity purpose instead of as one flat unordered list.
+2. **Given** the latest summary/checkpoint/control refs point at concrete persisted artifacts, **When** the grouped projection is built, **Then** the matching artifact metadata appears in the corresponding groups and the latest refs resolve to those same artifacts.
+3. **Given** a clear/reset has advanced the durable `session_epoch`, **When** the grouped projection is built, **Then** the response reports the new epoch and includes the control/reset artifacts needed to render the boundary explicitly.
+
+---
+
+### User Story 3 - Enforce projection ownership and missing-session behavior (Priority: P2)
+
+Operators need the new projection endpoint to follow the same task-run access rules and clear error semantics as the rest of the task-run API surface.
+
+**Why this priority**: The endpoint becomes part of Mission Control and cannot bypass existing ownership or missing-resource rules.
+
+**Independent Test**: Request the endpoint as the task owner, as a non-owner, and for a missing session, then verify success, `403`, and structured `404` behavior respectively.
+
+**Acceptance Scenarios**:
+
+1. **Given** the requesting user owns the task run, **When** the session projection endpoint is requested, **Then** MoonMind returns `200` with the session projection.
+2. **Given** the requesting user does not own the task run and is not a superuser, **When** the session projection endpoint is requested, **Then** MoonMind returns `403` without leaking session metadata.
+3. **Given** no durable session record matches the requested `task_run_id` and `session_id`, **When** the session projection endpoint is requested, **Then** MoonMind returns `404` with a stable `session_projection_not_found` error code.
+
+### Edge Cases
+
+- The durable managed-session record exists, but only runtime log artifacts are present and no continuity artifacts have been published yet.
+- The durable record contains continuity refs whose artifacts were soft-deleted or are otherwise unreadable; the projection must not claim those artifacts are available.
+- The requested `session_id` exists for a different `task_run_id`; MoonMind must not cross-wire projections across tasks.
+- The latest control event exists without a paired reset-boundary artifact, or vice versa.
+- Artifact metadata exists for one session epoch while the durable record has already advanced to a later epoch.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST expose `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}` as the minimal server-side session continuity projection endpoint for task-scoped Codex managed sessions.
+- **FR-002**: The session projection response MUST include `task_run_id`, `session_id`, and the latest durable `session_epoch` from the managed-session record.
+- **FR-003**: The session projection response MUST include grouped artifact metadata for the latest continuity and runtime artifact refs persisted on the managed-session record.
+- **FR-004**: The session projection response MUST include `latest_summary_ref`, `latest_checkpoint_ref`, and `latest_control_event_ref` when those refs exist durably.
+- **FR-005**: The session projection response MUST preserve reset visibility by surfacing the latest reset-boundary artifact in the grouped artifact output when that artifact exists durably.
+- **FR-006**: The projection implementation MUST resolve artifact metadata from persisted artifacts and bounded session metadata, and MUST NOT require a live container or live session-controller query to build the response.
+- **FR-007**: The endpoint MUST enforce the same task-run ownership rules as the existing task-run observability APIs.
+- **FR-008**: When no durable managed-session record matches the requested `task_run_id` and `session_id`, the endpoint MUST return `404` with a stable `session_projection_not_found` error code.
+- **FR-009**: The Phase 9 implementation MUST remain container-first by adding only a read-model API over persisted artifacts and durable session state; it MUST NOT move Codex execution back into the main worker process.
+
+### Key Entities
+
+- **Artifact Session Projection**: Server-side read model for one task-scoped managed session, containing identity, latest continuity refs, and grouped artifact metadata.
+- **Artifact Session Group**: Named server-defined grouping of session artifacts, such as runtime logs/diagnostics or continuity/control artifacts, returned as part of the projection.
+- **Managed Session Projection Source**: The combination of the durable managed-session record and persisted artifact metadata used to build the projection without live container access.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Tests verify `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}` returns a valid session projection with grouped artifacts and the latest continuity refs for a persisted managed session.
+- **SC-002**: Tests verify the projection still succeeds when the live session container is absent because the response is built from durable state only.
+- **SC-003**: Tests verify the endpoint rejects cross-owner access and returns `session_projection_not_found` for missing or mismatched session/task pairs.
+- **SC-004**: Scope validation confirms the Phase 9 diff includes production runtime/API code changes and test coverage for the new projection endpoint.

--- a/specs/135-codex-managed-session-plane-phase9/tasks.md
+++ b/specs/135-codex-managed-session-plane-phase9/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: Codex Managed Session Plane Phase 9
+
+**Input**: Design documents from `/specs/135-codex-managed-session-plane-phase9/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/task-run-artifact-session-projection.md
+
+**Tests**: TDD is required for this phase. Add or update failing tests before implementation.
+
+**Organization**: Tasks are grouped by user story to keep the minimal projection API independently testable.
+
+## Phase 1: Setup
+
+**Purpose**: Lock the MVP projection contract and add the first failing tests.
+
+- [X] T001 [P] Record the API contract in `specs/135-codex-managed-session-plane-phase9/contracts/task-run-artifact-session-projection.md`
+- [X] T002 [P] Add failing projection endpoint tests in `tests/unit/api/routers/test_task_runs.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add the typed response models and reusable projection helpers before story-specific route behavior.
+
+- [X] T003 [P] Add session projection response models in `moonmind/schemas/temporal_artifact_models.py`
+- [X] T004 [P] Add managed-session store and projection helper utilities in `api_service/api/routers/task_runs.py`
+
+**Checkpoint**: Typed models and projection helpers exist; user-story route work can proceed.
+
+---
+
+## Phase 3: User Story 1 - Read a durable session continuity projection (Priority: P1) 🎯 MVP
+
+**Goal**: Return one task-scoped session projection from durable session state and artifact metadata only.
+
+**Independent Test**: Call the endpoint in `tests/unit/api/routers/test_task_runs.py` and verify it returns the latest task/session identity, latest epoch, and continuity refs without any live session dependency.
+
+### Tests for User Story 1
+
+- [X] T005 [P] [US1] Add success-path projection assertions in `tests/unit/api/routers/test_task_runs.py`
+- [X] T006 [P] [US1] Add durable-only/no-live-container assertions in `tests/unit/api/routers/test_task_runs.py`
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Implement `GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}` in `api_service/api/routers/task_runs.py`
+- [X] T008 [US1] Build the projection from `ManagedSessionStore` and artifact metadata lookups in `api_service/api/routers/task_runs.py`
+
+---
+
+## Phase 4: User Story 2 - Group continuity artifacts server-side (Priority: P1)
+
+**Goal**: Return stable server-defined runtime and continuity/control groups plus latest refs so the UI does not infer continuity locally.
+
+**Independent Test**: Verify the endpoint groups runtime, continuity, and control artifacts correctly and resolves the latest summary/checkpoint/control refs from the same persisted artifacts.
+
+### Tests for User Story 2
+
+- [X] T009 [P] [US2] Add grouped-artifact assertions in `tests/unit/api/routers/test_task_runs.py`
+- [X] T010 [P] [US2] Add reset-boundary and latest-ref assertions in `tests/unit/api/routers/test_task_runs.py`
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Return grouped runtime and continuity/control artifacts in `api_service/api/routers/task_runs.py`
+- [X] T012 [US2] Surface `latest_summary_ref`, `latest_checkpoint_ref`, `latest_control_event_ref`, and reset-boundary visibility in `api_service/api/routers/task_runs.py`
+
+---
+
+## Phase 5: User Story 3 - Enforce projection ownership and missing-session behavior (Priority: P2)
+
+**Goal**: Keep the new endpoint aligned with existing task-run access control and stable missing-resource semantics.
+
+**Independent Test**: Verify owner success, non-owner `403`, and missing-session `404` responses.
+
+### Tests for User Story 3
+
+- [X] T013 [P] [US3] Add owner/non-owner access tests in `tests/unit/api/routers/test_task_runs.py`
+- [X] T014 [P] [US3] Add missing or mismatched session-task error tests in `tests/unit/api/routers/test_task_runs.py`
+
+### Implementation for User Story 3
+
+- [X] T015 [US3] Enforce task-run ownership checks for session projections in `api_service/api/routers/task_runs.py`
+- [X] T016 [US3] Return stable `session_projection_not_found` errors for missing or mismatched task/session pairs in `api_service/api/routers/task_runs.py`
+
+---
+
+## Phase 6: Polish & Validation
+
+**Purpose**: Run focused verification, scope validation, and the full unit suite.
+
+- [X] T017 [P] Run `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
+- [X] T018 [P] Run `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T019 [P] Run `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+- [X] T020 [P] Run `./tools/test_unit.sh`
+
+## Dependencies & Execution Order
+
+- Phase 1 must complete before implementation starts.
+- Phase 2 depends on Phase 1 and blocks all user stories.
+- User Stories 1 and 2 share the same endpoint and should proceed sequentially after Phase 2.
+- User Story 3 depends on the endpoint existing but can add access/error handling after the success path is in place.
+- Phase 6 depends on all implementation tasks being complete.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing tests for the projection endpoint.
+2. Add response models and helper utilities.
+3. Implement the success-path projection from durable state only.
+4. Add grouped-artifact behavior and latest refs.
+5. Add access control and missing-session handling.
+6. Run focused tests, scope gates, and the full unit suite.
+
+### Parallel Opportunities
+
+- `T001` and `T002` can run in parallel.
+- `T003` and `T004` can run in parallel.
+- Story-phase tests marked `[P]` can be added together before the corresponding implementation tasks.
+- Validation commands in Phase 6 can be run independently once code and tests are complete.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -14,9 +14,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api_service.api.routers.task_runs import router
+from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
 from api_service.auth_providers import get_current_user
 from api_service.api.routers.worker_auth import _require_worker_auth, _WorkerRequestAuth
+from api_service.db import models as db_models
 from api_service.db.models import User
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 
 
 @pytest.fixture
@@ -39,13 +42,14 @@ def test_worker_auth() -> _WorkerRequestAuth:
 def client(test_user: User, test_worker_auth: _WorkerRequestAuth) -> Iterator[tuple[TestClient, AsyncMock]]:
     app = FastAPI()
     app.include_router(router, prefix="/api")
-    db_mock = AsyncMock()
+    artifact_service = AsyncMock()
 
     app.dependency_overrides[get_current_user()] = lambda: test_user
     app.dependency_overrides[_require_worker_auth] = lambda: test_worker_auth
+    app.dependency_overrides[_get_temporal_artifact_service] = lambda: artifact_service
 
     with TestClient(app) as test_client:
-        yield test_client, db_mock
+        yield test_client, artifact_service
 
     app.dependency_overrides.clear()
 
@@ -708,3 +712,259 @@ def test_get_task_run_diagnostics_uses_supported_artifact_root_layouts(
 # ---------------------------------------------------------------------------
 
 # Tests removed due to an AnyIO test transport deadlock with fake streaming generators
+
+
+def _build_session_record() -> CodexManagedSessionRecord:
+    now = datetime.now(UTC)
+    return CodexManagedSessionRecord(
+        sessionId="sess:wf-task-1:codex_cli",
+        sessionEpoch=2,
+        taskRunId="wf-task-1",
+        containerId="container-123",
+        threadId="thread-2",
+        runtimeId="codex_cli",
+        imageRef="moonmind:latest",
+        controlUrl="docker-exec://container-123",
+        status="ready",
+        workspacePath="/work/agent_jobs/wf-task-1/repo",
+        sessionWorkspacePath="/work/agent_jobs/wf-task-1/session",
+        artifactSpoolPath="/work/agent_jobs/wf-task-1/artifacts",
+        stdoutArtifactRef="art_stdout",
+        stderrArtifactRef="art_stderr",
+        diagnosticsRef="art_diag",
+        latestSummaryRef="art_summary",
+        latestCheckpointRef="art_checkpoint",
+        latestControlEventRef="art_control",
+        latestResetBoundaryRef="art_reset",
+        startedAt=now,
+        updatedAt=now,
+    )
+
+
+def _build_artifact(artifact_id: str, link_type: str, *, label: str) -> tuple[SimpleNamespace, list[SimpleNamespace], bool, SimpleNamespace]:
+    now = datetime.now(UTC)
+    artifact = SimpleNamespace(
+        artifact_id=artifact_id,
+        created_at=now,
+        created_by_principal="system:agent_runtime",
+        content_type="application/json",
+        size_bytes=128,
+        sha256=None,
+        storage_backend=db_models.TemporalArtifactStorageBackend.LOCAL_FS,
+        storage_key=f"moonmind/artifacts/2026/04/07/{artifact_id}",
+        encryption=db_models.TemporalArtifactEncryption.NONE,
+        status=db_models.TemporalArtifactStatus.COMPLETE,
+        retention_class=db_models.TemporalArtifactRetentionClass.STANDARD,
+        expires_at=None,
+        redaction_level=db_models.TemporalArtifactRedactionLevel.NONE,
+        metadata_json={"label": label},
+    )
+    links = [
+        SimpleNamespace(
+            namespace="moonmind",
+            workflow_id="wf-step-1",
+            run_id="run-step-1",
+            link_type=link_type,
+            label=label,
+            created_at=now,
+            created_by_activity_type="activity:agent_runtime.publish_artifacts",
+            created_by_worker="worker-1",
+        )
+    ]
+    read_policy = SimpleNamespace(
+        raw_access_allowed=True,
+        preview_artifact_ref=None,
+        default_read_ref=SimpleNamespace(
+            artifact_ref_v=1,
+            artifact_id=artifact_id,
+            sha256=None,
+            size_bytes=128,
+            content_type="application/json",
+            encryption="none",
+        ),
+    )
+    return artifact, links, False, read_policy
+
+
+def test_get_task_run_artifact_session_projection_returns_grouped_projection(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record()
+
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_stderr": _build_artifact("art_stderr", "runtime.stderr", label="stderr"),
+        "art_diag": _build_artifact("art_diag", "runtime.diagnostics", label="diagnostics"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+        "art_checkpoint": _build_artifact("art_checkpoint", "session.step_checkpoint", label="checkpoint"),
+        "art_control": _build_artifact("art_control", "session.control_event", label="control"),
+        "art_reset": _build_artifact("art_reset", "session.reset_boundary", label="reset"),
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == "service:task_runs"
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=record):
+        response = test_client.get(
+            "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["task_run_id"] == "wf-task-1"
+    assert body["session_id"] == "sess:wf-task-1:codex_cli"
+    assert body["session_epoch"] == 2
+    assert body["latest_summary_ref"]["artifact_id"] == "art_summary"
+    assert body["latest_checkpoint_ref"]["artifact_id"] == "art_checkpoint"
+    assert body["latest_control_event_ref"]["artifact_id"] == "art_control"
+    assert body["latest_reset_boundary_ref"]["artifact_id"] == "art_reset"
+    assert [group["group_key"] for group in body["grouped_artifacts"]] == [
+        "runtime",
+        "continuity",
+        "control",
+    ]
+    assert [artifact["artifact_id"] for artifact in body["grouped_artifacts"][0]["artifacts"]] == [
+        "art_stdout",
+        "art_stderr",
+        "art_diag",
+    ]
+    assert [artifact["artifact_id"] for artifact in body["grouped_artifacts"][2]["artifacts"]] == [
+        "art_control",
+        "art_reset",
+    ]
+
+
+def test_get_task_run_artifact_session_projection_reads_durable_state_only(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record().model_copy(update={"status": "degraded"})
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_stderr": _build_artifact("art_stderr", "runtime.stderr", label="stderr"),
+        "art_diag": _build_artifact("art_diag", "runtime.diagnostics", label="diagnostics"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+        "art_checkpoint": _build_artifact("art_checkpoint", "session.step_checkpoint", label="checkpoint"),
+        "art_control": _build_artifact("art_control", "session.control_event", label="control"),
+        "art_reset": _build_artifact("art_reset", "session.reset_boundary", label="reset"),
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == "service:task_runs"
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=record):
+        response = test_client.get(
+            "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+        )
+
+    assert response.status_code == 200
+    assert response.json()["session_epoch"] == 2
+
+
+def test_get_task_run_artifact_session_projection_returns_404_when_missing(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _artifact_service = client
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=None):
+        response = test_client.get(
+            "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "session_projection_not_found"
+
+
+def test_get_task_run_artifact_session_projection_returns_404_for_task_mismatch(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _artifact_service = client
+    record = _build_session_record().model_copy(update={"task_run_id": "wf-task-2"})
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=record):
+        response = test_client.get(
+            "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "session_projection_not_found"
+
+
+def test_get_task_run_artifact_session_projection_allows_owner_access() -> None:
+    owner_id = uuid4()
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    artifact_service = AsyncMock()
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=owner_id,
+        email="owner@example.com",
+        is_superuser=False,
+    )
+    app.dependency_overrides[_get_temporal_artifact_service] = lambda: artifact_service
+
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_stderr": _build_artifact("art_stderr", "runtime.stderr", label="stderr"),
+        "art_diag": _build_artifact("art_diag", "runtime.diagnostics", label="diagnostics"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+        "art_checkpoint": _build_artifact("art_checkpoint", "session.step_checkpoint", label="checkpoint"),
+        "art_control": _build_artifact("art_control", "session.control_event", label="control"),
+        "art_reset": _build_artifact("art_reset", "session.reset_boundary", label="reset"),
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == "service:task_runs"
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(owner_id))),
+            ):
+                response = test_client.get(
+                    "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+                )
+
+    assert response.status_code == 200
+
+
+def test_get_task_run_artifact_session_projection_forbids_cross_owner_access() -> None:
+    owner_id = uuid4()
+    other_id = uuid4()
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    artifact_service = AsyncMock()
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=other_id,
+        email="other@example.com",
+        is_superuser=False,
+    )
+    app.dependency_overrides[_get_temporal_artifact_service] = lambda: artifact_service
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedSessionStore.load",
+            return_value=_build_session_record(),
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(owner_id))),
+            ):
+                response = test_client.get(
+                    "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli"
+                )
+
+    assert response.status_code == 403

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -882,6 +882,21 @@ def test_get_task_run_artifact_session_projection_returns_404_when_missing(
     assert response.json()["detail"]["code"] == "session_projection_not_found"
 
 
+def test_get_task_run_artifact_session_projection_returns_404_for_invalid_session_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _artifact_service = client
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedSessionStore.load",
+        side_effect=ValueError("session_id resolves outside store root"),
+    ):
+        response = test_client.get("/api/task-runs/wf-task-1/artifact-sessions/%2E%2E")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "session_projection_not_found"
+
+
 def test_get_task_run_artifact_session_projection_returns_404_for_task_mismatch(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -968,3 +983,7 @@ def test_get_task_run_artifact_session_projection_forbids_cross_owner_access() -
                 )
 
     assert response.status_code == 403
+    assert (
+        response.json()["detail"]
+        == "You do not have permission to access this task run or its session projection."
+    )

--- a/tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_dependency_signals.py
@@ -191,27 +191,18 @@ async def test_run_workflow_duplicate_signal_is_idempotent(
     """Sending the same DependencyResolved signal twice must not corrupt state
     or cause duplicate processing."""
 
-    signal_count = 0
+    memo_updates: list[dict] = []
 
     async def fake_reconcile(self, dependency_ids):
         pass  # Leave unresolved
-
-    original_record = MoonMindRunWorkflow._record_dependency_outcome
-
-    def spy_record(self, **kwargs):
-        nonlocal signal_count
-        signal_count += 1
-        return original_record(self, **kwargs)
 
     monkeypatch.setattr(
         workflow, "patched",
         lambda patch_id: patch_id == DEPENDENCY_GATE_PATCH,
     )
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
     monkeypatch.setattr(
         MoonMindRunWorkflow, "_reconcile_dependencies", fake_reconcile
-    )
-    monkeypatch.setattr(
-        MoonMindRunWorkflow, "_record_dependency_outcome", spy_record
     )
 
     async with await WorkflowEnvironment.start_time_skipping() as env:
@@ -237,12 +228,21 @@ async def test_run_workflow_duplicate_signal_is_idempotent(
             result = await handle.result()
 
     assert result["status"] == "success"
-    # The signal handler calls _record_dependency_outcome for each signal.
-    # The initial reconcile leaves deps unresolved (no record call), but
-    # each of the 3 signals triggers one call. The workflow's finish path
-    # may also record once more. Accept 3-4 calls — the key invariant is
-    # that the workflow completed successfully (no state corruption).
-    assert 3 <= signal_count <= 4
+    final_dependency_memo = next(
+        memo for memo in reversed(memo_updates) if "dependencies" in memo
+    )
+    assert final_dependency_memo["dependencies"]["resolution"] == "satisfied"
+    assert final_dependency_memo["dependencies"]["failedDependencyId"] is None
+    assert final_dependency_memo["dependencies"]["outcomes"] == [
+        {
+            "workflowId": "dep-dup-1",
+            "terminalState": "completed",
+            "closeStatus": "completed",
+            "resolvedAt": "2026-04-05T00:00:00+00:00",
+            "failureCategory": None,
+            "message": None,
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add the minimal task-run artifact session projection endpoint for Codex managed sessions
- return grouped runtime/continuity/control artifacts plus latest continuity refs from durable managed-session state
- add Phase 9 spec, plan, contract, and task artifacts and cover the endpoint with router tests

## Remediation
- no CRITICAL or HIGH spec remediation blockers were found after the spec/plan/tasks analysis pass

## Verification
- `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
- `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=135-codex-managed-session-plane-phase9 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`