### PR TITLE
[codex] Add Phase 11 session continuity controls

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -3,6 +3,7 @@ import json
 import os
 from collections.abc import Iterator
 from datetime import UTC, datetime
+from functools import lru_cache
 from pathlib import Path
 from uuid import UUID
 
@@ -18,12 +19,15 @@ from api_service.db.models import User
 from moonmind.schemas.temporal_artifact_models import (
     ArtifactMetadataModel,
     ArtifactRefModel,
+    ArtifactSessionControlRequest,
+    ArtifactSessionControlResponse,
     ArtifactSessionGroupModel,
     ArtifactSessionProjectionModel,
 )
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
+from moonmind.workflows.temporal.client import TemporalClientAdapter
 from moonmind.workflows.temporal.artifacts import (
     TemporalArtifactAuthorizationError,
     TemporalArtifactNotFoundError,
@@ -58,6 +62,11 @@ def _get_managed_session_store_root() -> str:
 
 def _get_agent_runtime_artifacts_root() -> str:
     return str(managed_runtime_artifact_root())
+
+
+@lru_cache(maxsize=1)
+def get_temporal_client_adapter() -> TemporalClientAdapter:
+    return TemporalClientAdapter()
 
 
 def _enum_value(value: object) -> object:
@@ -253,6 +262,10 @@ async def _build_task_run_artifact_session_projection(
         latest_control_event_ref=await _artifact_ref(record.latest_control_event_ref),
         latest_reset_boundary_ref=await _artifact_ref(record.latest_reset_boundary_ref),
     )
+
+
+def _task_run_session_workflow_id(*, task_run_id: str, runtime_id: str) -> str:
+    return f"{task_run_id}:session:{runtime_id}"
 
 
 def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]]:
@@ -500,6 +513,69 @@ async def get_task_run_artifact_session(
     if projection is None:
         _session_projection_not_found()
     return projection
+
+
+@router.post(
+    "/{task_run_id}/artifact-sessions/{session_id}/control",
+    response_model=ArtifactSessionControlResponse,
+    responses={
+        403: {"description": "You do not have permission to access this task run"},
+        404: {"description": "Session projection not found for this task run"},
+        409: {"description": "The managed session cannot accept this control action"},
+    },
+)
+async def control_task_run_artifact_session(
+    task_run_id: str,
+    session_id: str,
+    payload: ArtifactSessionControlRequest,
+    _user: User = Depends(get_current_user()),
+    artifact_service: TemporalArtifactService = Depends(_get_temporal_artifact_service),
+) -> ArtifactSessionControlResponse:
+    await _require_task_run_access(task_run_id, _user)
+    store = ManagedSessionStore(_get_managed_session_store_root())
+    try:
+        record = await asyncio.to_thread(store.load, session_id)
+    except ValueError:
+        record = None
+    if record is None or record.task_run_id != task_run_id:
+        _session_projection_not_found()
+    if record.status in {"terminated", "degraded", "failed"}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This managed session is not available for control actions.",
+        )
+
+    client = get_temporal_client_adapter()
+    workflow_id = _task_run_session_workflow_id(
+        task_run_id=task_run_id,
+        runtime_id=record.runtime_id,
+    )
+    if payload.action == "send_follow_up":
+        await client.update_workflow(
+            workflow_id,
+            "SendFollowUp",
+            {
+                "message": payload.message,
+                **({"reason": payload.reason} if payload.reason else {}),
+            },
+        )
+    else:
+        await client.update_workflow(
+            workflow_id,
+            "ClearSession",
+            {
+                **({"reason": payload.reason} if payload.reason else {}),
+            },
+        )
+
+    projection = await _build_task_run_artifact_session_projection(
+        task_run_id=task_run_id,
+        session_id=session_id,
+        service=artifact_service,
+    )
+    if projection is None:
+        _session_projection_not_found()
+    return ArtifactSessionControlResponse(action=payload.action, projection=projection)
 
 
 @router.get(

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -559,13 +559,18 @@ async def control_task_run_artifact_session(
                 **({"reason": payload.reason} if payload.reason else {}),
             },
         )
-    else:
+    elif payload.action == "clear_session":
         await client.update_workflow(
             workflow_id,
             "ClearSession",
             {
                 **({"reason": payload.reason} if payload.reason else {}),
             },
+        )
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported session control action: {payload.action}",
         )
 
     projection = await _build_task_run_artifact_session_projection(

--- a/api_service/templates/react_dashboard.html
+++ b/api_service/templates/react_dashboard.html
@@ -57,7 +57,7 @@
         </div>
         {% if build_id %}
         <div class="masthead-controls">
-          <div class="version-badge" title="Build version">{{ build_id }}</div>
+          <div class="version-badge" title="Build ID">{{ build_id }}</div>
         </div>
         {% endif %}
       </header>

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -773,6 +773,290 @@ describe('Task Detail Entrypoint', () => {
 
     confirmSpy.mockRestore();
   });
+
+  it('renders a Session Continuity panel for Codex managed-session task runs', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex session task',
+      summary: 'Session-backed work',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      targetRuntime: 'codex_cli',
+      taskRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            task_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 2,
+            grouped_artifacts: [
+              {
+                group_key: 'continuity',
+                title: 'Continuity',
+                artifacts: [
+                  { artifact_id: 'art-summary', status: 'complete' },
+                  { artifact_id: 'art-checkpoint', status: 'complete' },
+                ],
+              },
+              {
+                group_key: 'control',
+                title: 'Control',
+                artifacts: [
+                  { artifact_id: 'art-control', status: 'complete' },
+                  { artifact_id: 'art-reset', status: 'complete' },
+                ],
+              },
+            ],
+            latest_summary_ref: { artifact_id: 'art-summary' },
+            latest_checkpoint_ref: { artifact_id: 'art-checkpoint' },
+            latest_control_event_ref: { artifact_id: 'art-control' },
+            latest_reset_boundary_ref: { artifact_id: 'art-reset' },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={codexPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Session Continuity' })).toBeTruthy();
+      expect(screen.getByText(/Epoch 2/)).toBeTruthy();
+      expect(screen.getAllByText('art-summary').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('art-checkpoint').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('art-control').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('art-reset').length).toBeGreaterThan(0);
+      expect(screen.getByText('Live Logs')).toBeTruthy();
+      expect(screen.getByText('Diagnostics')).toBeTruthy();
+    });
+  });
+
+  it('routes Session Continuity follow-up and reset controls through the task-run session control API', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex session task',
+      summary: 'Session-backed work',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      targetRuntime: 'codex_cli',
+      taskRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            action: JSON.parse(String(init?.body || '{}')).action,
+            projection: {
+              task_run_id: 'wf-task-1',
+              session_id: 'sess:wf-task-1:codex_cli',
+              session_epoch: JSON.parse(String(init?.body || '{}')).action === 'clear_session' ? 2 : 1,
+              grouped_artifacts: [],
+              latest_summary_ref: { artifact_id: 'art-summary' },
+              latest_checkpoint_ref: { artifact_id: 'art-checkpoint' },
+              latest_control_event_ref: { artifact_id: 'art-control' },
+              latest_reset_boundary_ref:
+                JSON.parse(String(init?.body || '{}')).action === 'clear_session'
+                  ? { artifact_id: 'art-reset' }
+                  : null,
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            task_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 1,
+            grouped_artifacts: [],
+            latest_summary_ref: { artifact_id: 'art-summary' },
+            latest_checkpoint_ref: { artifact_id: 'art-checkpoint' },
+            latest_control_event_ref: null,
+            latest_reset_boundary_ref: null,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={codexPayload} />);
+
+    fireEvent.change(await screen.findByLabelText('Follow-up message'), {
+      target: { value: 'Continue with the existing session.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send follow-up' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/task-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'send_follow_up',
+            message: 'Continue with the existing session.',
+          }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear / Reset' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/task-runs/wf-task-1/artifact-sessions/sess%3Awf-task-1%3Acodex_cli/control',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'clear_session',
+          }),
+        }),
+      );
+    });
+  });
+
+  it('reuses the existing execution cancel route from the Session Continuity panel', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex session task',
+      summary: 'Session-backed work',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      targetRuntime: 'codex_cli',
+      taskRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/cancel')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...mockExecution,
+            state: 'canceled',
+            rawState: 'canceled',
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            task_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 1,
+            grouped_artifacts: [],
+            latest_summary_ref: null,
+            latest_checkpoint_ref: null,
+            latest_control_event_ref: null,
+            latest_reset_boundary_ref: null,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={codexPayload} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Session' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/executions/test-123/cancel',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'cancel',
+            graceful: true,
+          }),
+        }),
+      );
+    });
+
+    confirmSpy.mockRestore();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
-import { TaskDetailPage } from './task-detail';
+import { getSessionProjectionRefetchInterval, TaskDetailPage } from './task-detail';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
@@ -791,7 +791,7 @@ describe('Task Detail Entrypoint', () => {
       status: 'running',
       state: 'executing',
       rawState: 'executing',
-      targetRuntime: 'codex_cli',
+      targetRuntime: 'codex',
       taskRunId: 'wf-task-1',
       createdAt: '2026-03-28T00:00:00Z',
       updatedAt: '2026-03-28T00:00:02Z',
@@ -867,7 +867,7 @@ describe('Task Detail Entrypoint', () => {
     };
     const mockExecution = {
       taskId: 'test-123',
-      workflowId: 'test-123',
+      workflowId: 'wf-session-123',
       namespace: 'default',
       temporalRunId: '01-run',
       runId: '01-run',
@@ -885,6 +885,7 @@ describe('Task Detail Entrypoint', () => {
         canCancel: true,
       },
     };
+    const executionDetailUrl = '/api/executions/test-123?source=temporal';
 
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -954,6 +955,11 @@ describe('Task Detail Entrypoint', () => {
           }),
         }),
       );
+    });
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.filter(([input]) => String(input) === executionDetailUrl).length,
+      ).toBeGreaterThan(1);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear / Reset' }));
@@ -1040,7 +1046,7 @@ describe('Task Detail Entrypoint', () => {
 
     renderWithClient(<TaskDetailPage payload={codexPayload} />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Session' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Execution' }));
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -1056,6 +1062,13 @@ describe('Task Detail Entrypoint', () => {
     });
 
     confirmSpy.mockRestore();
+  });
+
+  it('keeps polling session continuity until a projection or terminal state exists', () => {
+    expect(getSessionProjectionRefetchInterval(false, false, false)).toBe(5000);
+    expect(getSessionProjectionRefetchInterval(false, true, false)).toBe(false);
+    expect(getSessionProjectionRefetchInterval(false, false, true)).toBe(false);
+    expect(getSessionProjectionRefetchInterval(true, false, false)).toBe(false);
   });
 });
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -172,6 +172,52 @@ const ArtifactSummarySchema = z
   })
   .passthrough();
 
+const ArtifactRefSummarySchema = z
+  .object({
+    artifact_id: z.string(),
+  })
+  .passthrough();
+
+const ArtifactSessionProjectionSchema = z.object({
+  task_run_id: z.string(),
+  session_id: z.string(),
+  session_epoch: z.number(),
+  grouped_artifacts: z
+    .array(
+      z.object({
+        group_key: z.string(),
+        title: z.string(),
+        artifacts: z
+          .array(
+            z
+              .object({
+                artifact_id: z.string().optional(),
+                artifactId: z.string().optional(),
+                status: z.string().optional(),
+              })
+              .passthrough()
+              .transform((artifact) =>
+                ArtifactSummarySchema.parse({
+                  ...artifact,
+                  artifactId: artifact.artifactId ?? artifact.artifact_id,
+                }),
+              ),
+          )
+          .default([]),
+      }),
+    )
+    .default([]),
+  latest_summary_ref: ArtifactRefSummarySchema.nullable().optional(),
+  latest_checkpoint_ref: ArtifactRefSummarySchema.nullable().optional(),
+  latest_control_event_ref: ArtifactRefSummarySchema.nullable().optional(),
+  latest_reset_boundary_ref: ArtifactRefSummarySchema.nullable().optional(),
+});
+
+const ArtifactSessionControlResponseSchema = z.object({
+  action: z.enum(['send_follow_up', 'clear_session']),
+  projection: ArtifactSessionProjectionSchema,
+});
+
 const ArtifactListSchema = z.object({
   artifacts: z
     .array(
@@ -435,6 +481,53 @@ async function fetchRunSummaryArtifact(
   const text = await resp.text();
   if (!text.trim()) return null;
   return RunSummaryArtifactSchema.parse(JSON.parse(text));
+}
+
+function deriveCodexSessionId(
+  taskRunId: string | null | undefined,
+  runtimeId: string | null | undefined,
+): string | null {
+  if (!taskRunId || String(runtimeId || '').trim().toLowerCase() !== 'codex_cli') {
+    return null;
+  }
+  return `sess:${taskRunId}:codex_cli`;
+}
+
+async function fetchArtifactSessionProjection(
+  apiBase: string,
+  taskRunId: string,
+  sessionId: string,
+): Promise<z.infer<typeof ArtifactSessionProjectionSchema> | null> {
+  const resp = await fetch(
+    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw new Error(`Session continuity: ${resp.status}`);
+  }
+  return ArtifactSessionProjectionSchema.parse(await resp.json());
+}
+
+async function controlArtifactSession(
+  apiBase: string,
+  taskRunId: string,
+  sessionId: string,
+  body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string },
+): Promise<z.infer<typeof ArtifactSessionControlResponseSchema>> {
+  const resp = await fetch(
+    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}/control`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`Session control: ${resp.status}`);
+  }
+  return ArtifactSessionControlResponseSchema.parse(await resp.json());
 }
 
 /** Fetch the observability summary for a task run. */
@@ -1066,6 +1159,194 @@ function DiagnosticsPanel({
   );
 }
 
+function SessionContinuityPanel({
+  apiBase,
+  workflowId,
+  taskRunId,
+  targetRuntime,
+  isTerminal,
+  onCancel,
+  cancelBusy,
+}: {
+  apiBase: string;
+  workflowId: string;
+  taskRunId: string;
+  targetRuntime: string | null | undefined;
+  isTerminal: boolean;
+  onCancel: () => void;
+  cancelBusy: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const sessionId = deriveCodexSessionId(taskRunId, targetRuntime);
+  const [followUpMessage, setFollowUpMessage] = useState('');
+  const [panelError, setPanelError] = useState<string | null>(null);
+
+  const projectionQuery = useQuery({
+    queryKey: ['task-run-session-projection', taskRunId, sessionId],
+    queryFn: () => {
+      if (!sessionId) return Promise.resolve(null);
+      return fetchArtifactSessionProjection(apiBase, taskRunId, sessionId);
+    },
+    enabled: Boolean(taskRunId && sessionId),
+    retry: false,
+  });
+
+  const controlMutation = useMutation({
+    mutationFn: async (body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string }) => {
+      if (!sessionId) throw new Error('Managed session is unavailable.');
+      return controlArtifactSession(apiBase, taskRunId, sessionId, body);
+    },
+    onSuccess: (result) => {
+      setPanelError(null);
+      void queryClient.setQueryData(
+        ['task-run-session-projection', taskRunId, sessionId],
+        result.projection,
+      );
+      void queryClient.invalidateQueries({ queryKey: ['task-detail', encodeURIComponent(workflowId)] });
+      if (result.action === 'send_follow_up') {
+        setFollowUpMessage('');
+      }
+    },
+    onError: (error: Error) => setPanelError(error.message),
+  });
+
+  if (!sessionId) {
+    return null;
+  }
+  if (projectionQuery.isLoading) {
+    return (
+      <section className="stack">
+        <h3>Session Continuity</h3>
+        <p className="small">Loading session continuity...</p>
+      </section>
+    );
+  }
+  if (projectionQuery.isError) {
+    return (
+      <section className="stack">
+        <h3>Session Continuity</h3>
+        <div className="notice error">{(projectionQuery.error as Error).message}</div>
+      </section>
+    );
+  }
+  if (!projectionQuery.data) {
+    return null;
+  }
+
+  const projection = projectionQuery.data;
+  const latestBadges = [
+    ['Latest Summary', projection.latest_summary_ref?.artifact_id ?? null],
+    ['Latest Checkpoint', projection.latest_checkpoint_ref?.artifact_id ?? null],
+    ['Latest Control', projection.latest_control_event_ref?.artifact_id ?? null],
+    ['Latest Reset', projection.latest_reset_boundary_ref?.artifact_id ?? null],
+  ].filter(([, artifactId]) => artifactId !== null) as Array<[string, string]>;
+  const busy = controlMutation.isPending || cancelBusy;
+
+  const submitFollowUp = () => {
+    const message = followUpMessage.trim();
+    if (!message) return;
+    setPanelError(null);
+    controlMutation.mutate({
+      action: 'send_follow_up',
+      message,
+    });
+  };
+
+  const clearSession = () => {
+    setPanelError(null);
+    controlMutation.mutate({
+      action: 'clear_session',
+    });
+  };
+
+  return (
+    <section className="stack">
+      <div>
+        <h3>Session Continuity</h3>
+        <p className="small">
+          Session <code>{projection.session_id}</code> — Epoch {projection.session_epoch}
+        </p>
+      </div>
+
+      {panelError ? <div className="notice error">{panelError}</div> : null}
+
+      <div className="grid-2">
+        <Card label="Session ID">
+          <code className="text-xs break-all">{projection.session_id}</code>
+        </Card>
+        <Card label="Current Epoch">{projection.session_epoch}</Card>
+      </div>
+
+      {latestBadges.length > 0 ? (
+        <div className="actions">
+          {latestBadges.map(([label, artifactId]) => (
+            <span key={`${label}-${artifactId}`} className="card">
+              <strong>{label}:</strong> <code className="text-xs">{artifactId}</code>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="stack">
+        {projection.grouped_artifacts.map((group) => (
+          <div key={group.group_key} className="card">
+            <strong>{group.title}</strong>
+            <div className="stack gap-1" style={{ marginTop: '0.5rem' }}>
+              {group.artifacts.length === 0 ? (
+                <span className="small">No artifacts.</span>
+              ) : (
+                group.artifacts.map((artifact) => (
+                  <code key={artifact.artifactId} className="text-xs break-all">
+                    {artifact.artifactId}
+                  </code>
+                ))
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="stack">
+        <label htmlFor="session-follow-up">Follow-up message</label>
+        <textarea
+          id="session-follow-up"
+          value={followUpMessage}
+          onChange={(event) => setFollowUpMessage(event.target.value)}
+          rows={3}
+          placeholder="Send a follow-up turn to the managed Codex session."
+          disabled={busy || isTerminal}
+        />
+        <div className="actions">
+          <button
+            type="button"
+            className="secondary"
+            disabled={busy || isTerminal || !followUpMessage.trim()}
+            onClick={submitFollowUp}
+          >
+            Send follow-up
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            disabled={busy || isTerminal}
+            onClick={clearSession}
+          >
+            Clear / Reset
+          </button>
+          <button
+            type="button"
+            className="queue-action queue-action-danger"
+            disabled={busy || isTerminal}
+            onClick={onCancel}
+          >
+            Cancel Session
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 type MissingTaskRunState = 'waiting_for_launch' | 'binding_missing' | 'launch_failed';
 
 function inferMissingTaskRunState(execution: z.infer<typeof ExecutionDetailSchema>): MissingTaskRunState {
@@ -1352,6 +1633,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
 
   const actions = execution?.actions;
   const busy = updateMutation.isPending || signalMutation.isPending || cancelMutation.isPending;
+  const isTerminalExecution = TERMINAL_STATES.has(execution?.rawState || execution?.state || '');
   const hasTaskActions = Boolean(actions?.canSetTitle || actions?.canRerun);
   const hasInterventionSection = Boolean(
     actions &&
@@ -1660,6 +1942,18 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             />
           ) : null}
 
+          {resolvedTaskRunId ? (
+            <SessionContinuityPanel
+              apiBase={payload.apiBase}
+              workflowId={workflowId}
+              taskRunId={resolvedTaskRunId}
+              targetRuntime={execution.targetRuntime}
+              isTerminal={isTerminalExecution}
+              onCancel={onCancel}
+              cancelBusy={cancelMutation.isPending}
+            />
+          ) : null}
+
           <section className="stack">
             <h3>Timeline</h3>
             <div className="queue-table-wrapper" data-layout="table">
@@ -1774,7 +2068,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   <LiveLogsPanel
                     apiBase={payload.apiBase}
                     taskRunId={resolvedTaskRunId}
-                    isTerminal={TERMINAL_STATES.has(execution.rawState || execution.state || '')}
+                    isTerminal={isTerminalExecution}
                     autoExpand={showTaskRunAttachNotice}
                   />
                   <StaticLogPanel apiBase={payload.apiBase} taskRunId={resolvedTaskRunId} stream="stdout" />

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -21,6 +21,18 @@ type DashboardConfig = {
 };
 
 const GITHUB_PULL_REQUEST_PATH_PATTERN = /^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+$/i;
+const SESSION_PROJECTION_POLL_MS = 5000;
+
+export function getSessionProjectionRefetchInterval(
+  isTerminal: boolean,
+  hasProjection: boolean,
+  hasError: boolean,
+): number | false {
+  if (isTerminal || hasProjection || hasError) {
+    return false;
+  }
+  return SESSION_PROJECTION_POLL_MS;
+}
 
 function normalizeGitHubPullRequestUrl(value: string | null | undefined): string | null {
   if (!value) {
@@ -487,7 +499,8 @@ function deriveCodexSessionId(
   taskRunId: string | null | undefined,
   runtimeId: string | null | undefined,
 ): string | null {
-  if (!taskRunId || String(runtimeId || '').trim().toLowerCase() !== 'codex_cli') {
+  const normalizedRuntime = String(runtimeId || '').trim().toLowerCase();
+  if (!taskRunId || (normalizedRuntime !== 'codex' && normalizedRuntime !== 'codex_cli')) {
     return null;
   }
   return `sess:${taskRunId}:codex_cli`;
@@ -1161,19 +1174,19 @@ function DiagnosticsPanel({
 
 function SessionContinuityPanel({
   apiBase,
-  workflowId,
   taskRunId,
   targetRuntime,
   isTerminal,
   onCancel,
+  invalidateTaskDetail,
   cancelBusy,
 }: {
   apiBase: string;
-  workflowId: string;
   taskRunId: string;
   targetRuntime: string | null | undefined;
   isTerminal: boolean;
   onCancel: () => void;
+  invalidateTaskDetail: () => void;
   cancelBusy: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -1188,6 +1201,13 @@ function SessionContinuityPanel({
       return fetchArtifactSessionProjection(apiBase, taskRunId, sessionId);
     },
     enabled: Boolean(taskRunId && sessionId),
+    refetchInterval: (query) => {
+      return getSessionProjectionRefetchInterval(
+        isTerminal,
+        Boolean(query.state.data),
+        Boolean(query.state.error),
+      );
+    },
     retry: false,
   });
 
@@ -1202,7 +1222,7 @@ function SessionContinuityPanel({
         ['task-run-session-projection', taskRunId, sessionId],
         result.projection,
       );
-      void queryClient.invalidateQueries({ queryKey: ['task-detail', encodeURIComponent(workflowId)] });
+      invalidateTaskDetail();
       if (result.action === 'send_follow_up') {
         setFollowUpMessage('');
       }
@@ -1230,7 +1250,15 @@ function SessionContinuityPanel({
     );
   }
   if (!projectionQuery.data) {
-    return null;
+    if (isTerminal) {
+      return null;
+    }
+    return (
+      <section className="stack">
+        <h3>Session Continuity</h3>
+        <p className="small">Waiting for session continuity artifacts...</p>
+      </section>
+    );
   }
 
   const projection = projectionQuery.data;
@@ -1339,7 +1367,7 @@ function SessionContinuityPanel({
             disabled={busy || isTerminal}
             onClick={onCancel}
           >
-            Cancel Session
+            Cancel Execution
           </button>
         </div>
       </div>
@@ -1945,11 +1973,11 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
           {resolvedTaskRunId ? (
             <SessionContinuityPanel
               apiBase={payload.apiBase}
-              workflowId={workflowId}
               taskRunId={resolvedTaskRunId}
               targetRuntime={execution.targetRuntime}
               isTerminal={isTerminalExecution}
               onCancel={onCancel}
+              invalidateTaskDetail={invalidate}
               cancelBusy={cancelMutation.isPending}
             />
           ) : null}

--- a/moonmind/schemas/temporal_artifact_models.py
+++ b/moonmind/schemas/temporal_artifact_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -16,6 +16,7 @@ from moonmind.core.artifacts import (
     TemporalArtifactRedactionLevel,
     TemporalArtifactUploadMode,
 )
+from moonmind.schemas._validation import require_non_blank
 
 
 class ArtifactRefModel(BaseModel):
@@ -219,6 +220,33 @@ class ArtifactSessionProjectionModel(BaseModel):
     latest_checkpoint_ref: Optional[ArtifactRefModel] = None
     latest_control_event_ref: Optional[ArtifactRefModel] = None
     latest_reset_boundary_ref: Optional[ArtifactRefModel] = None
+
+
+class ArtifactSessionControlRequest(BaseModel):
+    """Operator control request for one task-scoped artifact session."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: Literal["send_follow_up", "clear_session"]
+    message: str | None = None
+    reason: str | None = None
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.message is not None:
+            self.message = require_non_blank(self.message, field_name="message")
+        if self.reason is not None:
+            self.reason = require_non_blank(self.reason, field_name="reason")
+        if self.action == "send_follow_up" and self.message is None:
+            raise ValueError("message is required when action=send_follow_up")
+
+
+class ArtifactSessionControlResponse(BaseModel):
+    """Control response envelope with the refreshed session projection."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: Literal["send_follow_up", "clear_session"]
+    projection: ArtifactSessionProjectionModel
 
 
 class PresignDownloadResponse(BaseModel):

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any
 
 from temporalio import workflow
+from temporalio.common import RetryPolicy
 
 with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.managed_session_models import (
@@ -12,6 +14,16 @@ with workflow.unsafe.imports_passed_through():
         CodexManagedSessionSnapshot,
         CodexManagedSessionState,
         CodexManagedSessionWorkflowInput,
+        FetchCodexManagedSessionSummaryRequest,
+        PublishCodexManagedSessionArtifactsRequest,
+        SendCodexManagedSessionTurnRequest,
+        CodexManagedSessionClearRequest,
+        CodexManagedSessionLocator,
+    )
+    from moonmind.schemas._validation import require_non_blank
+    from moonmind.workflows.temporal.activity_catalog import (
+        TemporalActivityRoute,
+        build_default_activity_catalog,
     )
 
 
@@ -20,6 +32,7 @@ AGENT_SESSION_STATUS_ACTIVE = "active"
 AGENT_SESSION_STATUS_CLEARING = "clearing"
 AGENT_SESSION_STATUS_TERMINATING = "terminating"
 AGENT_SESSION_STATUS_TERMINATED = "terminated"
+DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 
 
 @workflow.defn(name="MoonMind.AgentSession")
@@ -35,6 +48,46 @@ class MoonMindAgentSessionWorkflow:
         self._last_control_reason: str | None = None
         self._termination_requested = False
 
+    @staticmethod
+    def _retry_policy_for_route(route: TemporalActivityRoute) -> RetryPolicy:
+        return RetryPolicy(
+            initial_interval=timedelta(seconds=5),
+            backoff_coefficient=2.0,
+            maximum_interval=timedelta(seconds=route.retries.max_interval_seconds),
+            maximum_attempts=route.retries.max_attempts,
+            non_retryable_error_types=list(route.retries.non_retryable_error_codes),
+        )
+
+    @classmethod
+    def _execute_kwargs_for_route(cls, route: TemporalActivityRoute) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "task_queue": route.task_queue,
+            "start_to_close_timeout": timedelta(
+                seconds=route.timeouts.start_to_close_seconds
+            ),
+            "schedule_to_close_timeout": timedelta(
+                seconds=route.timeouts.schedule_to_close_seconds
+            ),
+            "retry_policy": cls._retry_policy_for_route(route),
+        }
+        if route.timeouts.heartbeat_timeout_seconds is not None:
+            kwargs["heartbeat_timeout"] = timedelta(
+                seconds=route.timeouts.heartbeat_timeout_seconds
+            )
+        return kwargs
+
+    async def _execute_routed_activity(
+        self,
+        activity_name: str,
+        payload: dict[str, Any],
+    ) -> object:
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(activity_name)
+        return await workflow.execute_activity(
+            activity_name,
+            payload,
+            **self._execute_kwargs_for_route(route),
+        )
+
     def _initialize_session(self, session_input: CodexManagedSessionWorkflowInput) -> None:
         self._binding = CodexManagedSessionBinding.from_input(
             workflow_id=workflow.info().workflow_id,
@@ -46,6 +99,56 @@ class MoonMindAgentSessionWorkflow:
         if self._binding is None:
             raise ValueError("Agent session has not been initialized")
         return self._binding
+
+    def _require_locator(self) -> CodexManagedSessionLocator:
+        binding = self._require_binding()
+        if not self._container_id or not self._thread_id:
+            raise ValueError("Managed session runtime handles are not attached yet")
+        return CodexManagedSessionLocator(
+            sessionId=binding.session_id,
+            sessionEpoch=binding.session_epoch,
+            containerId=self._container_id,
+            threadId=self._thread_id,
+        )
+
+    async def _refresh_continuity_projection(
+        self,
+        *,
+        locator: CodexManagedSessionLocator,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        summary = await self._execute_routed_activity(
+            "agent_runtime.fetch_session_summary",
+            FetchCodexManagedSessionSummaryRequest(
+                sessionId=locator.session_id,
+                sessionEpoch=locator.session_epoch,
+                containerId=locator.container_id,
+                threadId=locator.thread_id,
+            ).model_dump(by_alias=True),
+        )
+        publication = await self._execute_routed_activity(
+            "agent_runtime.publish_session_artifacts",
+            PublishCodexManagedSessionArtifactsRequest(
+                sessionId=locator.session_id,
+                sessionEpoch=locator.session_epoch,
+                containerId=locator.container_id,
+                threadId=locator.thread_id,
+                taskRunId=locator.session_id.split("sess:", 1)[-1].rsplit(":", 1)[0],
+                metadata=metadata or {},
+            ).model_dump(by_alias=True),
+        )
+        summary_payload = dict(summary if isinstance(summary, dict) else {})
+        publication_payload = dict(publication if isinstance(publication, dict) else {})
+        return {
+            "latestSummaryRef": publication_payload.get("latestSummaryRef")
+            or summary_payload.get("latestSummaryRef"),
+            "latestCheckpointRef": publication_payload.get("latestCheckpointRef")
+            or summary_payload.get("latestCheckpointRef"),
+            "latestControlEventRef": publication_payload.get("latestControlEventRef")
+            or summary_payload.get("latestControlEventRef"),
+            "latestResetBoundaryRef": publication_payload.get("latestResetBoundaryRef")
+            or summary_payload.get("latestResetBoundaryRef"),
+        }
 
     @workflow.run
     async def run(
@@ -126,3 +229,93 @@ class MoonMindAgentSessionWorkflow:
             terminationRequested=self._termination_requested,
         )
         return snapshot.model_dump(mode="json", by_alias=True)
+
+    @workflow.update(name="SendFollowUp")
+    async def send_follow_up(self, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = payload or {}
+        message = require_non_blank(
+            str(payload.get("message") or ""),
+            field_name="message",
+        )
+        reason = payload.get("reason")
+        reason_text = (
+            require_non_blank(str(reason), field_name="reason")
+            if reason is not None
+            else None
+        )
+        locator = self._require_locator()
+        turn_response = await self._execute_routed_activity(
+            "agent_runtime.send_turn",
+            SendCodexManagedSessionTurnRequest(
+                sessionId=locator.session_id,
+                sessionEpoch=locator.session_epoch,
+                containerId=locator.container_id,
+                threadId=locator.thread_id,
+                instructions=message,
+                metadata={"reason": reason_text} if reason_text else {},
+            ).model_dump(by_alias=True),
+        )
+        turn_payload = dict(turn_response if isinstance(turn_response, dict) else {})
+        session_state = dict(turn_payload.get("sessionState") or {})
+        if session_state:
+            self._container_id = str(session_state.get("containerId") or self._container_id)
+            self._thread_id = str(session_state.get("threadId") or self._thread_id)
+            active_turn_id = session_state.get("activeTurnId")
+            self._active_turn_id = (
+                str(active_turn_id).strip() if active_turn_id else None
+            )
+        self._last_control_action = "send_turn"
+        self._last_control_reason = reason_text
+        continuity = await self._refresh_continuity_projection(
+            locator=self._require_locator(),
+            metadata={"action": "send_follow_up", "reason": reason_text},
+        )
+        return {
+            "turnId": turn_payload.get("turnId"),
+            "sessionState": session_state,
+            **continuity,
+        }
+
+    @workflow.update(name="ClearSession")
+    async def clear_session_update(
+        self, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        payload = payload or {}
+        reason = payload.get("reason")
+        reason_text = (
+            require_non_blank(str(reason), field_name="reason")
+            if reason is not None
+            else None
+        )
+        binding = self._require_binding()
+        locator = self._require_locator()
+        next_thread_id = f"thread:{binding.session_id}:{binding.session_epoch + 1}"
+        handle = await self._execute_routed_activity(
+            "agent_runtime.clear_session",
+            CodexManagedSessionClearRequest(
+                sessionId=locator.session_id,
+                sessionEpoch=locator.session_epoch,
+                containerId=locator.container_id,
+                threadId=locator.thread_id,
+                newThreadId=next_thread_id,
+                reason=reason_text,
+            ).model_dump(by_alias=True),
+        )
+        handle_payload = dict(handle if isinstance(handle, dict) else {})
+        session_state = dict(handle_payload.get("sessionState") or {})
+        self._binding = binding.model_copy(
+            update={"session_epoch": session_state.get("sessionEpoch", binding.session_epoch)}
+        )
+        self._container_id = str(session_state.get("containerId") or self._container_id)
+        self._thread_id = str(session_state.get("threadId") or self._thread_id)
+        self._active_turn_id = None
+        self._last_control_action = "clear_session"
+        self._last_control_reason = reason_text
+        continuity = await self._refresh_continuity_projection(
+            locator=self._require_locator(),
+            metadata={"action": "clear_session", "reason": reason_text},
+        )
+        return {
+            "sessionState": session_state,
+            **continuity,
+        }

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -117,6 +117,7 @@ class MoonMindAgentSessionWorkflow:
         locator: CodexManagedSessionLocator,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        binding = self._require_binding()
         summary = await self._execute_routed_activity(
             "agent_runtime.fetch_session_summary",
             FetchCodexManagedSessionSummaryRequest(
@@ -133,7 +134,7 @@ class MoonMindAgentSessionWorkflow:
                 sessionEpoch=locator.session_epoch,
                 containerId=locator.container_id,
                 threadId=locator.thread_id,
-                taskRunId=locator.session_id.split("sess:", 1)[-1].rsplit(":", 1)[0],
+                taskRunId=binding.task_run_id,
                 metadata=metadata or {},
             ).model_dump(by_alias=True),
         )
@@ -289,33 +290,37 @@ class MoonMindAgentSessionWorkflow:
         )
         binding = self._require_binding()
         locator = self._require_locator()
-        next_thread_id = f"thread:{binding.session_id}:{binding.session_epoch + 1}"
-        handle = await self._execute_routed_activity(
-            "agent_runtime.clear_session",
-            CodexManagedSessionClearRequest(
-                sessionId=locator.session_id,
-                sessionEpoch=locator.session_epoch,
-                containerId=locator.container_id,
-                threadId=locator.thread_id,
-                newThreadId=next_thread_id,
-                reason=reason_text,
-            ).model_dump(by_alias=True),
-        )
-        handle_payload = dict(handle if isinstance(handle, dict) else {})
-        session_state = dict(handle_payload.get("sessionState") or {})
-        self._binding = binding.model_copy(
-            update={"session_epoch": session_state.get("sessionEpoch", binding.session_epoch)}
-        )
-        self._container_id = str(session_state.get("containerId") or self._container_id)
-        self._thread_id = str(session_state.get("threadId") or self._thread_id)
-        self._active_turn_id = None
-        self._last_control_action = "clear_session"
-        self._last_control_reason = reason_text
-        continuity = await self._refresh_continuity_projection(
-            locator=self._require_locator(),
-            metadata={"action": "clear_session", "reason": reason_text},
-        )
-        return {
-            "sessionState": session_state,
-            **continuity,
-        }
+        self._status = AGENT_SESSION_STATUS_CLEARING
+        try:
+            next_thread_id = f"thread:{binding.session_id}:{binding.session_epoch + 1}"
+            handle = await self._execute_routed_activity(
+                "agent_runtime.clear_session",
+                CodexManagedSessionClearRequest(
+                    sessionId=locator.session_id,
+                    sessionEpoch=locator.session_epoch,
+                    containerId=locator.container_id,
+                    threadId=locator.thread_id,
+                    newThreadId=next_thread_id,
+                    reason=reason_text,
+                ).model_dump(by_alias=True),
+            )
+            handle_payload = dict(handle if isinstance(handle, dict) else {})
+            session_state = dict(handle_payload.get("sessionState") or {})
+            self._binding = binding.model_copy(
+                update={"session_epoch": session_state.get("sessionEpoch", binding.session_epoch)}
+            )
+            self._container_id = str(session_state.get("containerId") or self._container_id)
+            self._thread_id = str(session_state.get("threadId") or self._thread_id)
+            self._active_turn_id = None
+            self._last_control_action = "clear_session"
+            self._last_control_reason = reason_text
+            continuity = await self._refresh_continuity_projection(
+                locator=self._require_locator(),
+                metadata={"action": "clear_session", "reason": reason_text},
+            )
+            return {
+                "sessionState": session_state,
+                **continuity,
+            }
+        finally:
+            self._status = AGENT_SESSION_STATUS_ACTIVE

--- a/specs/136-codex-managed-session-plane-phase11/contracts/task-run-session-controls.md
+++ b/specs/136-codex-managed-session-plane-phase11/contracts/task-run-session-controls.md
@@ -1,0 +1,63 @@
+# Contract: Task-Run Session Controls
+
+## Existing Read Contract
+
+`GET /api/task-runs/{task_run_id}/artifact-sessions/{session_id}`
+
+Returns the current `ArtifactSessionProjectionModel` for one task-scoped managed session.
+
+## New Control Contract
+
+`POST /api/task-runs/{task_run_id}/artifact-sessions/{session_id}/control`
+
+### Request
+
+```json
+{
+  "action": "send_follow_up",
+  "message": "Continue using the existing task-scoped session.",
+  "reason": "Operator clarification"
+}
+```
+
+or
+
+```json
+{
+  "action": "clear_session",
+  "reason": "Reset stale context before the next step."
+}
+```
+
+### Validation Rules
+
+- `action` must be one of `send_follow_up` or `clear_session`
+- `message` is required for `send_follow_up`
+- blank `message` or `reason` values are rejected
+- the referenced session must belong to the requested `task_run_id`
+- the caller must own the task run unless they are a superuser
+
+### Response
+
+```json
+{
+  "action": "send_follow_up",
+  "projection": {
+    "task_run_id": "wf-task-1",
+    "session_id": "sess:wf-task-1:codex_cli",
+    "session_epoch": 2,
+    "grouped_artifacts": [],
+    "latest_summary_ref": null,
+    "latest_checkpoint_ref": null,
+    "latest_control_event_ref": null,
+    "latest_reset_boundary_ref": null
+  }
+}
+```
+
+### Behavioral Rules
+
+- The server targets the task-scoped `MoonMind.AgentSession` workflow for the session identified by `{task_run_id, session_id}`.
+- `send_follow_up` must execute through the managed session activity surface and then return the refreshed projection.
+- `clear_session` must execute through the managed session clear activity surface and then return the refreshed projection.
+- The control route must not call a worker-local Codex CLI path directly.

--- a/specs/136-codex-managed-session-plane-phase11/data-model.md
+++ b/specs/136-codex-managed-session-plane-phase11/data-model.md
@@ -1,0 +1,36 @@
+# Data Model: codex-managed-session-plane-phase11
+
+## TaskRunSessionControlRequest
+
+- `action`: one of `send_follow_up`, `clear_session`
+- `message`: required non-blank string for `send_follow_up`
+- `reason`: optional non-blank operator note
+
+## TaskRunSessionControlResult
+
+- `action`: echoed requested control action
+- `projection`: refreshed `ArtifactSessionProjectionModel`
+
+## Session Continuity View
+
+- `task_run_id`
+- `session_id`
+- `session_epoch`
+- `grouped_artifacts`
+  - runtime artifacts
+  - continuity artifacts
+  - control artifacts
+- `latest_summary_ref`
+- `latest_checkpoint_ref`
+- `latest_control_event_ref`
+- `latest_reset_boundary_ref`
+- `control_state`
+  - pending action
+  - error text
+  - follow-up draft
+
+## Behavioral Notes
+
+- The projection remains the durable read model.
+- Follow-up and clear/reset mutate the managed session through workflow/activity boundaries and then refresh the projection.
+- Cancel remains a task-level action and does not introduce a separate session-level termination UX in this phase.

--- a/specs/136-codex-managed-session-plane-phase11/plan.md
+++ b/specs/136-codex-managed-session-plane-phase11/plan.md
@@ -1,0 +1,93 @@
+# Implementation Plan: codex-managed-session-plane-phase11
+
+**Branch**: `136-codex-managed-session-plane-phase11` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/136-codex-managed-session-plane-phase11/spec.md`
+
+## Summary
+
+Implement Phase 11 by adding a minimal Session Continuity UI to the Mission Control task detail page and wiring it to the existing task-run session projection plus a new task-run session control endpoint. The control path will execute through `MoonMind.AgentSession` and the existing `agent_runtime.*` managed-session activities so follow-up and clear/reset remain session-plane actions rather than frontend-only affordances or worker-local Codex calls.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript/React
+**Primary Dependencies**: `MoonMind.AgentSession`, `agent_runtime.send_turn`, `agent_runtime.clear_session`, `agent_runtime.fetch_session_summary`, `agent_runtime.publish_session_artifacts`, task-runs router, Mission Control `task-detail.tsx`
+**Testing**: focused pytest + Vitest suites, then final verification via `./tools/test_unit.sh`
+**Project Type**: Temporal workflow/API plus Mission Control UI
+**Constraints**: preserve Phase 10 artifact-first observability; keep session controls container-first through the managed session workflow/activity boundary; do not add terminal attach or debug shell semantics
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Session controls route through the existing managed-session workflow/activity boundary rather than inventing a frontend-only control loop.
+- **II. One-Click Agent Deployment**: PASS. No new deployment dependency or operator prerequisite is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The UI consumes a task-run session projection/control surface rather than a raw image- or CLI-specific interface.
+- **IV. Own Your Data**: PASS. Continuity remains artifact-backed and readable after the session container is gone.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The new work extends the projection and session-control contracts instead of adding terminal scraping or hidden resets.
+- **VII. Powerful Runtime Configurability**: PASS. The implementation reuses existing runtime/image configuration.
+- **VIII. Modular and Extensible Architecture**: PASS. Workflow control, API routing, and task-detail rendering remain separate seams.
+- **IX. Resilient by Default**: PASS. Follow-up/reset actions execute through durable Temporal updates and publish refreshed continuity artifacts.
+- **XI. Spec-Driven Development**: PASS. Phase 11 artifacts define the UI/control slice before code changes.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. This plan is an implementation slice for an already-defined desired-state doc.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The phase adds no compatibility alias or shadow UI path.
+
+## Research
+
+- The Phase 9 projection API already returns the session epoch plus latest summary/checkpoint/control/reset refs, so the minimal UI can reuse it directly.
+- The generic task `SendMessage` path currently forwards operator messages only to Jules, so Codex managed-session follow-up needs a dedicated session-plane control path instead of reusing the old generic control semantics.
+- `MoonMind.AgentSession` already owns task-scoped session identity, and the `agent_runtime.send_turn` / `agent_runtime.clear_session` activities already exist, making the session workflow the correct place to execute follow-up/reset actions durably.
+- The task detail page already keeps logs and diagnostics separate from intervention controls, so the new Session Continuity panel can sit alongside those sections without redesigning the rest of Mission Control.
+
+## Project Structure
+
+- Update `moonmind/workflows/temporal/workflows/agent_session.py` to add session-control updates that execute the existing managed-session activity surface.
+- Update `api_service/api/routers/task_runs.py` to add a task-run session control endpoint and return the refreshed projection.
+- Update `frontend/src/entrypoints/task-detail.tsx` to render the Session Continuity panel and wire the follow-up/reset controls.
+- Extend:
+  - `tests/unit/workflows/temporal/workflows/test_agent_session.py`
+  - `tests/unit/api/routers/test_task_runs.py`
+  - `frontend/src/entrypoints/task-detail.test.tsx`
+
+## Data Model
+
+- **TaskRunSessionControlRequest**
+  - `action`: `send_follow_up` | `clear_session`
+  - `message`: required for `send_follow_up`
+  - `reason`: optional operator reason for either action
+- **TaskRunSessionControlResult**
+  - `action`: echoed requested action
+  - `projection`: refreshed `ArtifactSessionProjectionModel`
+- **Session Continuity View State**
+  - current `session_id`
+  - current `session_epoch`
+  - grouped runtime/continuity/control artifacts
+  - latest summary/checkpoint/control/reset badges
+  - pending/success/error state for follow-up/reset controls
+
+## Contracts
+
+- New control contract: [contracts/task-run-session-controls.md](./contracts/task-run-session-controls.md)
+
+## Implementation Plan
+
+1. Add failing workflow tests proving `MoonMind.AgentSession` cannot yet execute session follow-up/reset updates through `agent_runtime.*`.
+2. Add failing API tests for a new task-run session control route that validates ownership, routes `send_follow_up` and `clear_session`, and returns the refreshed projection.
+3. Implement `MoonMind.AgentSession` update handlers that execute routed `agent_runtime.send_turn`, `agent_runtime.fetch_session_summary`, `agent_runtime.publish_session_artifacts`, and `agent_runtime.clear_session`.
+4. Add the task-run session control route and use the managed session store plus Temporal update boundary to target the correct task-scoped session workflow.
+5. Add failing frontend tests for the Session Continuity panel, visible epoch/reset metadata, and the three control actions.
+6. Implement the Session Continuity panel in `task-detail.tsx`, preserving the existing logs/diagnostics panels and routing cancel through the existing execution cancel path.
+7. Run focused tests, run Spec Kit scope validation, rerun the full unit suite, and mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+2. `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Open a Codex managed-session task detail page and confirm the Session Continuity panel shows the current epoch plus latest summary/checkpoint/control/reset badges.
+2. Submit a follow-up from the panel and confirm the page refreshes with updated continuity metadata while the existing logs/diagnostics panels remain unchanged.
+3. Trigger `Clear / Reset` and confirm the visible epoch increments and the latest reset-boundary badge updates.
+4. Confirm `Cancel` from the Session Continuity panel reuses the normal task cancellation path and no terminal attach or debug shell controls appear.

--- a/specs/136-codex-managed-session-plane-phase11/quickstart.md
+++ b/specs/136-codex-managed-session-plane-phase11/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: codex-managed-session-plane-phase11
+
+## Goal
+
+Verify that Mission Control can display and control a task-scoped Codex managed session without replacing the existing step-level logs and diagnostics panels.
+
+## Steps
+
+1. Start a Codex managed-session task that produces a task run ID and session projection.
+2. Open the task detail page in Mission Control.
+3. Confirm `Session Continuity` appears with:
+   - the current session ID
+   - the current epoch
+   - latest summary/checkpoint/control/reset badges when available
+4. Confirm the page still shows:
+   - `Live Logs`
+   - `Stdout`
+   - `Stderr`
+   - `Diagnostics`
+5. Send a follow-up from the Session Continuity panel and confirm the panel refreshes successfully.
+6. Trigger `Clear / Reset` and confirm the displayed epoch increments.
+7. Trigger `Cancel` from the Session Continuity panel and confirm it uses the normal task cancellation flow.
+8. Confirm no terminal attach, debug shell, or transcript explorer controls were added.

--- a/specs/136-codex-managed-session-plane-phase11/research.md
+++ b/specs/136-codex-managed-session-plane-phase11/research.md
@@ -1,0 +1,19 @@
+# Research: codex-managed-session-plane-phase11
+
+## Key Decisions
+
+### 1. Reuse the Phase 9 session projection instead of inventing a UI-only session state model
+
+The existing task-run projection already exposes the current session epoch plus latest continuity and control refs. Phase 11 should consume that read model directly so the UI stays artifact-first.
+
+### 2. Do not reuse the old generic `SendMessage` path for Codex managed sessions
+
+The current task-level message forwarding path only reaches Jules. Codex managed-session follow-up needs a dedicated session-plane control path so the UI does not offer a misleading button that never reaches the session container.
+
+### 3. Put follow-up/reset execution in `MoonMind.AgentSession`
+
+`MoonMind.AgentSession` already owns task-scoped session identity. Executing follow-up/reset through that workflow keeps the session plane durable and consistent with the Phase 2 ownership model instead of scattering session mutations across UI or root-task shortcuts.
+
+### 4. Keep cancellation task-scoped, not session-shell-scoped
+
+Phase 11 only needs one cancel affordance in the panel. Reusing the existing task cancellation route keeps the operator model coherent and avoids adding a second, competing cancellation semantics for the same task detail page.

--- a/specs/136-codex-managed-session-plane-phase11/spec.md
+++ b/specs/136-codex-managed-session-plane-phase11/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: codex-managed-session-plane-phase11
+
+**Feature Branch**: `136-codex-managed-session-plane-phase11`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "Implement Phase 11 of the Codex Managed Session Plane MVP plan using test-driven development."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Show session continuity alongside existing step observability (Priority: P1)
+
+Operators need the task detail page to show that a Codex managed-session task reused one session across multiple steps without replacing the existing stdout, stderr, and diagnostics panels.
+
+**Why this priority**: Phase 11 is the first operator-visible proof that the managed session plane exists independently from one step while preserving the Phase 10 observability model.
+
+**Independent Test**: Render the task detail page for a Codex managed-session task run and verify it shows a Session Continuity panel with the current epoch, grouped continuity artifacts, and latest summary/checkpoint/control/reset badges while the step-level logs and diagnostics panels still render normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Codex managed-session task run has a session projection, **When** Mission Control loads the task detail page, **Then** the page shows a `Session Continuity` panel populated from `/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}` and still keeps the existing `Live Logs`, `Stdout`, `Stderr`, and `Diagnostics` panels.
+2. **Given** the session projection reports `session_epoch > 1` and a latest reset-boundary artifact, **When** the panel renders, **Then** the current epoch boundary is visible to the operator and the latest reset boundary is surfaced as a first-class badge/link instead of being hidden inside raw artifact tables.
+
+### User Story 2 - Let operators send follow-up turns through the managed session plane (Priority: P1)
+
+Operators need a session-level follow-up control that targets the task-scoped Codex session rather than pretending the old generic task controls are sufficient.
+
+**Why this priority**: The UI is incomplete if the Session Continuity panel is read-only; follow-up is the minimum interactive control that proves the UI talks to the session plane.
+
+**Independent Test**: Execute a session follow-up control request and verify MoonMind routes it through the task-scoped session workflow, publishes updated continuity artifacts, and returns the refreshed projection without querying a worker-local Codex process.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task-scoped Codex session exists for a task run, **When** the operator submits a follow-up message from Mission Control, **Then** MoonMind routes the request through the managed session workflow/activity surface and returns a refreshed session projection.
+2. **Given** the follow-up control succeeds, **When** the Session Continuity panel refreshes, **Then** the latest summary/checkpoint badges reflect the updated projection and the panel does not depend on a live terminal attachment.
+
+### User Story 3 - Let operators clear/reset the session without hiding the epoch boundary (Priority: P1)
+
+Operators need to reset a reused Codex session from Mission Control and immediately see the new epoch boundary reflected in the session continuity view.
+
+**Why this priority**: Reset/clear is a hard MVP requirement from Phase 7 and must be visible in the UI for the session plane to be operable.
+
+**Independent Test**: Execute a clear/reset control request and verify the session epoch increments, the latest reset-boundary artifact updates, and the Mission Control panel reflects the change after refresh.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Codex managed session is active, **When** the operator clicks `Clear / Reset`, **Then** MoonMind invokes the managed session clear control, increments `session_epoch`, and returns a refreshed projection with the new reset-boundary artifact.
+2. **Given** the reset succeeds, **When** the panel rerenders, **Then** the operator can see the new epoch number and latest control/reset badges without leaving the task detail page.
+
+### User Story 4 - Keep cancellation and observability aligned with existing task semantics (Priority: P2)
+
+Operators need the Session Continuity panel to expose cancellation without creating a new terminal-first or session-shell control model.
+
+**Why this priority**: Phase 11 adds UI support, not a new task orchestration model.
+
+**Independent Test**: Render the Session Continuity panel and verify it exposes `Cancel` through the existing task cancellation path while leaving terminal attach/debug shell features absent.
+
+**Acceptance Scenarios**:
+
+1. **Given** the task is still active, **When** the Session Continuity panel renders, **Then** it exposes `Cancel` by reusing the existing execution cancel route rather than a new terminal/session-shell endpoint.
+2. **Given** the operator inspects the page after Phase 11, **When** they review the available controls, **Then** there is no terminal attach, debug shell, transcript explorer, or branching UI added by this phase.
+
+## Edge Cases
+
+- The task detail page resolves a Codex task run ID but no managed-session projection exists; the UI must degrade cleanly and not break logs/diagnostics.
+- A follow-up or clear/reset control is requested after the task has already reached a terminal state; the server must reject the action instead of mutating stale session state.
+- The latest continuity artifacts are partially missing; the UI must render only the badges and grouped artifacts that exist and must not fabricate refs.
+- A reset occurs before the page refresh completes; the returned projection must show the updated `session_epoch` and latest reset-boundary ref deterministically.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mission Control task detail MUST load the existing task-run session projection for Codex managed-session task runs and present it in a dedicated `Session Continuity` panel.
+- **FR-002**: The `Session Continuity` panel MUST show `session_id`, `session_epoch`, grouped continuity/control/runtime artifacts, and latest summary/checkpoint/control-event/reset-boundary badges when those refs exist.
+- **FR-003**: The Session Continuity UI MUST preserve the existing step-level `Live Logs`, `Stdout`, `Stderr`, and `Diagnostics` panels; Phase 11 MUST NOT replace them with a session-only observability surface.
+- **FR-004**: MoonMind MUST expose a server-side session control endpoint for Codex managed-session task runs that accepts at least `send_follow_up` and `clear_session`.
+- **FR-005**: `send_follow_up` MUST route through the task-scoped managed session workflow/activity contract and MUST refresh continuity artifacts/projection without calling a worker-local Codex subprocess path.
+- **FR-006**: `clear_session` MUST invoke the managed session clear control, refresh the durable projection, and surface the new `session_epoch` plus latest reset-boundary artifact to the UI.
+- **FR-007**: The Session Continuity panel MUST expose `Cancel` by reusing the existing task cancellation path and MUST NOT introduce terminal attach, PTY embedding, debug shell, transcript explorer, or branch/fork controls.
+
+### Key Entities
+
+- **Task-Run Session Projection**: The Phase 9 read model returned by `/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}` that groups the current runtime, continuity, and control artifacts for one task-scoped session.
+- **Task-Run Session Control Request**: The Phase 11 operator request that targets one task-scoped Codex session using `{taskRunId, sessionId, action}` and causes the session workflow to execute a remote managed-session control.
+- **Session Continuity Panel**: The Mission Control task-detail UI section that displays session continuity metadata and exposes follow-up, clear/reset, and cancel controls without replacing existing step observability panels.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Backend tests verify the new task-run session control route executes `send_follow_up` and `clear_session` against the task-scoped session workflow and returns the refreshed session projection.
+- **SC-002**: Workflow tests verify `MoonMind.AgentSession` can execute follow-up and clear/reset updates through the existing `agent_runtime.*` activity surface while keeping session epoch state authoritative in workflow metadata.
+- **SC-003**: Frontend tests verify the task detail page renders a Session Continuity panel with visible epoch/badge metadata and preserves the existing logs/diagnostics panels.
+- **SC-004**: Frontend tests verify `Send follow-up`, `Clear / Reset`, and `Cancel` controls behave as intended, with cancel reusing the existing execution cancel route.

--- a/specs/136-codex-managed-session-plane-phase11/speckit_analyze_report.md
+++ b/specs/136-codex-managed-session-plane-phase11/speckit_analyze_report.md
@@ -1,0 +1,30 @@
+# Speckit Analyze Report: codex-managed-session-plane-phase11
+
+## Findings
+
+### spec.md
+
+- No blocking consistency issues found.
+- User stories, edge cases, requirements, and success criteria align with the requested Phase 11 scope.
+
+### plan.md
+
+- No blocking readiness issues found.
+- The plan keeps the control path on the managed session workflow/activity boundary and preserves the Phase 10 artifact-first observability model.
+
+### tasks.md
+
+- No blocking execution gaps found.
+- Tasks cover workflow boundary tests, API boundary tests, frontend UI tests, runtime code changes, and final scope validation.
+
+## Safe to Implement
+
+**YES**
+
+## Blocking Remediations
+
+- None.
+
+## Determination Rationale
+
+The artifacts define a coherent runtime implementation slice with explicit workflow, API, UI, and verification work, and they preserve the session-plane architectural constraints established in earlier phases.

--- a/specs/136-codex-managed-session-plane-phase11/tasks.md
+++ b/specs/136-codex-managed-session-plane-phase11/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Codex Managed Session Plane Phase 11
+
+## T001 — Add TDD coverage for session controls and continuity UI [P]
+- [X] T001a [P] Extend `tests/unit/workflows/temporal/workflows/test_agent_session.py` to assert `MoonMind.AgentSession` can execute follow-up and clear/reset updates through the `agent_runtime.*` session activity surface.
+- [X] T001b [P] Extend `tests/unit/api/routers/test_task_runs.py` to assert the new task-run session control route validates ownership, routes `send_follow_up` and `clear_session`, and returns the refreshed projection.
+- [X] T001c [P] Extend `frontend/src/entrypoints/task-detail.test.tsx` to assert the Session Continuity panel renders epoch/badge metadata, preserves the existing logs/diagnostics panels, and wires `Send follow-up`, `Clear / Reset`, and `Cancel`.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+## T002 — Add task-run session control orchestration [P]
+- [X] T002a [P] Update `moonmind/workflows/temporal/workflows/agent_session.py` with workflow updates that execute `agent_runtime.send_turn`, `agent_runtime.fetch_session_summary`, `agent_runtime.publish_session_artifacts`, and `agent_runtime.clear_session`.
+- [X] T002b [P] Update `api_service/api/routers/task_runs.py` to expose `POST /api/task-runs/{task_run_id}/artifact-sessions/{session_id}/control` and return the refreshed projection.
+- [X] T002c [P] Keep the control path session-plane-based and avoid worker-local Codex execution or terminal/session-shell semantics.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/api/routers/test_task_runs.py`
+
+## T003 — Ship the minimal Session Continuity panel [P]
+- [X] T003a [P] Update `frontend/src/entrypoints/task-detail.tsx` to fetch the task-run session projection for Codex managed-session runs and render a dedicated `Session Continuity` panel.
+- [X] T003b [P] Surface the current epoch plus latest summary/checkpoint/control/reset badges while preserving the existing `Live Logs`, `Stdout`, `Stderr`, and `Diagnostics` panels.
+- [X] T003c [P] Wire `Send follow-up` and `Clear / Reset` to the new task-run session control route and reuse the existing execution cancel route for `Cancel`.
+- [X] T003d [P] Do not add terminal attach, debug shell, rich transcript explorer, or branch/fork controls.
+
+**Independent Test**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+## T004 — Verify scope and finalize [P]
+- [X] T004a [P] Run `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T004b [P] Run `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+- [ ] T004c [P] Run `./tools/test_unit.sh`.
+
+**Independent Test**: Scope validation passes and `./tools/test_unit.sh` passes.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1019,3 +1019,126 @@ def test_get_task_run_artifact_session_projection_forbids_cross_owner_access() -
         response.json()["detail"]
         == "You do not have permission to access this task run or its session projection."
     )
+
+
+def test_post_task_run_artifact_session_control_routes_send_follow_up_and_returns_projection(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record()
+
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_stderr": _build_artifact("art_stderr", "runtime.stderr", label="stderr"),
+        "art_diag": _build_artifact("art_diag", "runtime.diagnostics", label="diagnostics"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+        "art_checkpoint": _build_artifact("art_checkpoint", "session.step_checkpoint", label="checkpoint"),
+        "art_control": _build_artifact("art_control", "session.control_event", label="control"),
+        "art_reset": _build_artifact("art_reset", "session.reset_boundary", label="reset"),
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == "service:task_runs"
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+    client_adapter = AsyncMock()
+    client_adapter.update_workflow.return_value = {"accepted": True}
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=record):
+        with patch("api_service.api.routers.task_runs.get_temporal_client_adapter", return_value=client_adapter):
+            response = test_client.post(
+                "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+                json={
+                    "action": "send_follow_up",
+                    "message": "Continue reusing the current session.",
+                    "reason": "Operator clarification",
+                },
+            )
+
+    assert response.status_code == 200
+    client_adapter.update_workflow.assert_awaited_once_with(
+        "wf-task-1:session:codex_cli",
+        "SendFollowUp",
+        {
+            "message": "Continue reusing the current session.",
+            "reason": "Operator clarification",
+        },
+    )
+    body = response.json()
+    assert body["action"] == "send_follow_up"
+    assert body["projection"]["session_epoch"] == 2
+    assert body["projection"]["latest_summary_ref"]["artifact_id"] == "art_summary"
+    assert body["projection"]["latest_checkpoint_ref"]["artifact_id"] == "art_checkpoint"
+
+
+def test_post_task_run_artifact_session_control_routes_clear_session_and_returns_projection(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, artifact_service = client
+    record = _build_session_record().model_copy(
+        update={
+            "session_epoch": 3,
+            "thread_id": "thread-3",
+            "latest_control_event_ref": "art_control",
+            "latest_reset_boundary_ref": "art_reset",
+        }
+    )
+
+    artifact_payloads = {
+        "art_stdout": _build_artifact("art_stdout", "runtime.stdout", label="stdout"),
+        "art_stderr": _build_artifact("art_stderr", "runtime.stderr", label="stderr"),
+        "art_diag": _build_artifact("art_diag", "runtime.diagnostics", label="diagnostics"),
+        "art_summary": _build_artifact("art_summary", "session.summary", label="summary"),
+        "art_checkpoint": _build_artifact("art_checkpoint", "session.step_checkpoint", label="checkpoint"),
+        "art_control": _build_artifact("art_control", "session.control_event", label="control"),
+        "art_reset": _build_artifact("art_reset", "session.reset_boundary", label="reset"),
+    }
+
+    async def _get_metadata(*, artifact_id: str, principal: str):
+        assert principal == "service:task_runs"
+        return artifact_payloads[artifact_id]
+
+    artifact_service.get_metadata.side_effect = _get_metadata
+    client_adapter = AsyncMock()
+    client_adapter.update_workflow.return_value = {"accepted": True}
+
+    with patch("api_service.api.routers.task_runs.ManagedSessionStore.load", return_value=record):
+        with patch("api_service.api.routers.task_runs.get_temporal_client_adapter", return_value=client_adapter):
+            response = test_client.post(
+                "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+                json={
+                    "action": "clear_session",
+                    "reason": "Reset stale context",
+                },
+            )
+
+    assert response.status_code == 200
+    client_adapter.update_workflow.assert_awaited_once_with(
+        "wf-task-1:session:codex_cli",
+        "ClearSession",
+        {
+            "reason": "Reset stale context",
+        },
+    )
+    body = response.json()
+    assert body["action"] == "clear_session"
+    assert body["projection"]["session_epoch"] == 3
+    assert body["projection"]["latest_control_event_ref"]["artifact_id"] == "art_control"
+    assert body["projection"]["latest_reset_boundary_ref"]["artifact_id"] == "art_reset"
+
+
+def test_post_task_run_artifact_session_control_rejects_blank_follow_up_message(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _artifact_service = client
+
+    response = test_client.post(
+        "/api/task-runs/wf-task-1/artifact-sessions/sess:wf-task-1:codex_cli/control",
+        json={
+            "action": "send_follow_up",
+            "message": "   ",
+        },
+    )
+
+    assert response.status_code == 422

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -12,6 +12,7 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.temporal.workflows import agent_session as agent_session_module
 from moonmind.workflows.temporal.workflows.agent_session import (
     AGENT_SESSION_STATUS_ACTIVE,
+    AGENT_SESSION_STATUS_CLEARING,
     AGENT_SESSION_STATUS_TERMINATING,
     MoonMindAgentSessionWorkflow,
 )
@@ -228,6 +229,88 @@ async def test_agent_session_send_follow_up_update_executes_session_activity_sur
 
 
 @pytest.mark.asyncio
+async def test_agent_session_refresh_projection_uses_authoritative_binding_task_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+            sessionId="custom-session-id",
+        )
+    )
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        }
+    )
+
+    publication_payloads: list[dict[str, object]] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        if activity_name == "agent_runtime.send_turn":
+            return {
+                "sessionState": {
+                    "sessionId": "custom-session-id",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "turn-2",
+                "status": "completed",
+            }
+        if activity_name == "agent_runtime.fetch_session_summary":
+            return {
+                "sessionState": {
+                    "sessionId": "custom-session-id",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+            }
+        if activity_name == "agent_runtime.publish_session_artifacts":
+            publication_payloads.append(payload)
+            return {
+                "sessionState": {
+                    "sessionId": "custom-session-id",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+            }
+        raise AssertionError(f"unexpected activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_session_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    await workflow.send_follow_up({"message": "Continue the custom session."})
+
+    assert len(publication_payloads) == 1
+    assert publication_payloads[0]["sessionId"] == "custom-session-id"
+    assert publication_payloads[0]["sessionEpoch"] == 1
+    assert publication_payloads[0]["containerId"] == "container-1"
+    assert publication_payloads[0]["threadId"] == "thread-1"
+    assert publication_payloads[0]["taskRunId"] == "wf-run-1"
+    assert publication_payloads[0]["metadata"] == {
+        "action": "send_follow_up",
+        "reason": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_agent_session_clear_session_update_executes_remote_clear_and_updates_epoch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -255,6 +338,7 @@ async def test_agent_session_clear_session_update_executes_remote_clear_and_upda
         **_kwargs: object,
     ) -> dict[str, object]:
         captured.append(activity_name)
+        assert workflow.get_status()["status"] == AGENT_SESSION_STATUS_CLEARING
         if activity_name == "agent_runtime.clear_session":
             assert payload["newThreadId"] == "thread:sess:wf-run-1:codex_cli:2"
             return {

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
+from temporalio.common import RetryPolicy
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionControlRequest,
@@ -117,3 +120,212 @@ def test_agent_session_terminate_control_action_marks_termination_requested(
     assert status["terminationRequested"] is True
     assert status["lastControlAction"] == "terminate_session"
     assert status["lastControlReason"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_agent_session_send_follow_up_update_executes_session_activity_surface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+        )
+    )
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        }
+    )
+
+    captured: list[tuple[str, dict[str, object], dict[str, object]]] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        captured.append((activity_name, payload, kwargs))
+        if activity_name == "agent_runtime.send_turn":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "turn-2",
+                "status": "completed",
+                "outputRefs": ["art-follow-up-output"],
+                "metadata": {},
+            }
+        if activity_name == "agent_runtime.fetch_session_summary":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "latestSummaryRef": "art-summary-2",
+                "latestCheckpointRef": "art-checkpoint-2",
+                "latestControlEventRef": None,
+                "latestResetBoundaryRef": None,
+                "metadata": {},
+            }
+        if activity_name == "agent_runtime.publish_session_artifacts":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "publishedArtifactRefs": [
+                    "art-follow-up-output",
+                    "art-summary-2",
+                    "art-checkpoint-2",
+                ],
+                "latestSummaryRef": "art-summary-2",
+                "latestCheckpointRef": "art-checkpoint-2",
+                "latestControlEventRef": None,
+                "latestResetBoundaryRef": None,
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_session_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    result = await workflow.send_follow_up(
+        {"message": "Continue the task-scoped session.", "reason": "Operator follow-up"}
+    )
+
+    assert result["turnId"] == "turn-2"
+    assert result["latestSummaryRef"] == "art-summary-2"
+    assert result["latestCheckpointRef"] == "art-checkpoint-2"
+    assert [name for name, _, _ in captured] == [
+        "agent_runtime.send_turn",
+        "agent_runtime.fetch_session_summary",
+        "agent_runtime.publish_session_artifacts",
+    ]
+    assert captured[0][1]["instructions"] == "Continue the task-scoped session."
+    assert workflow.get_status()["lastControlAction"] == "send_turn"
+
+    for _name, _payload, kwargs in captured:
+        assert kwargs["task_queue"] == "mm.activity.agent_runtime"
+        assert isinstance(kwargs["retry_policy"], RetryPolicy)
+        assert kwargs["start_to_close_timeout"] == timedelta(seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_agent_session_clear_session_update_executes_remote_clear_and_updates_epoch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindAgentSessionWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    workflow._initialize_session(
+        CodexManagedSessionWorkflowInput(
+            taskRunId="wf-run-1",
+            runtimeId="codex_cli",
+        )
+    )
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+            "activeTurnId": "turn-1",
+        }
+    )
+
+    captured: list[str] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        captured.append(activity_name)
+        if activity_name == "agent_runtime.clear_session":
+            assert payload["newThreadId"] == "thread:sess:wf-run-1:codex_cli:2"
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread-2",
+                    "activeTurnId": None,
+                },
+                "status": "ready",
+                "imageRef": "moonmind:latest",
+                "controlUrl": "http://session-control",
+                "metadata": {},
+            }
+        if activity_name == "agent_runtime.fetch_session_summary":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread-2",
+                    "activeTurnId": None,
+                },
+                "latestSummaryRef": "art-summary-epoch-2",
+                "latestCheckpointRef": "art-checkpoint-epoch-2",
+                "latestControlEventRef": "art-control-epoch-2",
+                "latestResetBoundaryRef": "art-reset-epoch-2",
+                "metadata": {},
+            }
+        if activity_name == "agent_runtime.publish_session_artifacts":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 2,
+                    "containerId": "container-1",
+                    "threadId": "thread-2",
+                    "activeTurnId": None,
+                },
+                "publishedArtifactRefs": [
+                    "art-summary-epoch-2",
+                    "art-checkpoint-epoch-2",
+                    "art-control-epoch-2",
+                    "art-reset-epoch-2",
+                ],
+                "latestSummaryRef": "art-summary-epoch-2",
+                "latestCheckpointRef": "art-checkpoint-epoch-2",
+                "latestControlEventRef": "art-control-epoch-2",
+                "latestResetBoundaryRef": "art-reset-epoch-2",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_session_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    result = await workflow.clear_session_update({"reason": "Reset stale context"})
+
+    assert result["sessionState"]["sessionEpoch"] == 2
+    assert result["latestResetBoundaryRef"] == "art-reset-epoch-2"
+    assert captured == [
+        "agent_runtime.clear_session",
+        "agent_runtime.fetch_session_summary",
+        "agent_runtime.publish_session_artifacts",
+    ]
+    status = workflow.get_status()
+    assert status["binding"]["sessionEpoch"] == 2
+    assert status["threadId"] == "thread-2"
+    assert status["activeTurnId"] is None
+    assert status["lastControlAction"] == "clear_session"
+    assert status["lastControlReason"] == "Reset stale context"


### PR DESCRIPTION
## Summary

Implements Phase 11 of the Codex Managed Session Plane MVP.

This adds the minimal Session Continuity UI and the backend/session-workflow control path needed to support it:
- add typed task-run artifact session control request/response models
- add `SendFollowUp` and `ClearSession` updates to `MoonMind.AgentSession`
- add `POST /api/task-runs/{task_run_id}/artifact-sessions/{session_id}/control`
- add a Session Continuity panel in the task detail UI with follow-up, clear/reset, and cancel controls
- add the Phase 11 spec bundle under `specs/136-codex-managed-session-plane-phase11`

## Why

Phase 11 requires operators to see that multiple steps reused the same Codex session, identify epoch boundaries, and issue minimal session controls without introducing terminal-attach or shell-first semantics.

## Impact

Operators can now:
- view session continuity metadata in the task detail page
- see the latest summary/checkpoint/control/reset references for a Codex managed session
- send a follow-up message to the session
- clear/reset the session and create a new epoch boundary
- cancel the managed execution from the same panel

## Validation

Passed:
- `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=136-codex-managed-session-plane-phase11 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`

Known unrelated failure when running the full unit suite:
- `./tools/test_unit.sh`
- `tests/unit/api/routers/test_task_dashboard.py::test_react_shell_renders_build_metadata_with_accurate_labels`
