### PR TITLE
[codex] Make Live Logs session-aware

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+from collections import deque
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -41,6 +42,8 @@ from moonmind.schemas.agent_runtime_models import is_terminal_agent_run_state
 from moonmind.observability.transport import SpoolLogReader
 
 router = APIRouter(prefix="/task-runs", tags=["task_runs"])
+
+_HISTORICAL_EVENT_CHUNK_SIZE = 65536
 
 
 # Live Session legacy endpoints removed in Phase 6. Use /observability-summary and /logs/stream.
@@ -275,9 +278,12 @@ def _load_task_run_session_record(task_run_id: str) -> CodexManagedSessionRecord
     if not store_root.exists():
         return None
 
+    targeted_paths = list(store_root.glob(f"sess:{task_run_id}:*.json"))
+    candidate_paths = targeted_paths if targeted_paths else store_root.rglob("*.json")
+
     best_record: CodexManagedSessionRecord | None = None
     best_updated_at: datetime | None = None
-    for path in store_root.rglob("*.json"):
+    for path in candidate_paths:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
             record = CodexManagedSessionRecord(**payload)
@@ -340,16 +346,24 @@ def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]
 
 def _coerce_utc_datetime(value: object) -> datetime | None:
     if isinstance(value, datetime):
-        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+        return (value if value.tzinfo is not None else value.replace(tzinfo=UTC)).astimezone(
+            UTC
+        )
 
     if not value:
         return None
 
+    raw_value = str(value).strip()
+    if raw_value.endswith("Z"):
+        raw_value = f"{raw_value[:-1]}+00:00"
+
     try:
-        parsed = datetime.fromisoformat(str(value).strip())
+        parsed = datetime.fromisoformat(raw_value)
     except ValueError:
         return None
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return (parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)).astimezone(
+        UTC
+    )
 
 
 def _iter_run_spool_chunks(
@@ -424,6 +438,19 @@ def _iter_file_chunks(path: Path, *, chunk_size: int = 8192) -> Iterator[bytes]:
             yield chunk.encode("utf-8")
 
 
+def _iter_text_chunks(
+    path: Path,
+    *,
+    chunk_size: int = _HISTORICAL_EVENT_CHUNK_SIZE,
+) -> Iterator[str]:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+
+
 def _read_json_payload(path: Path | None) -> dict[str, object] | None:
     if path is None or not path.is_file():
         return None
@@ -453,6 +480,7 @@ def _iter_diagnostics_observability_events(
     if diagnostics is None:
         return
 
+    seen_system_annotations: set[tuple[object, object, object]] = set()
     observed_events = diagnostics.get("observability_events")
     if isinstance(observed_events, list):
         for raw_event in observed_events:
@@ -460,6 +488,14 @@ def _iter_diagnostics_observability_events(
                 continue
             normalized = _normalize_live_event(raw_event)
             if normalized is not None:
+                if normalized.get("kind") == "system_annotation":
+                    seen_system_annotations.add(
+                        (
+                            normalized.get("sequence"),
+                            normalized.get("timestamp"),
+                            normalized.get("text"),
+                        )
+                    )
                 yield normalized
 
     annotations = diagnostics.get("annotations")
@@ -482,20 +518,51 @@ def _iter_diagnostics_observability_events(
         )
         if normalized is None:
             continue
+        dedupe_key = (
+            normalized.get("sequence"),
+            normalized.get("timestamp"),
+            normalized.get("text"),
+        )
+        if dedupe_key in seen_system_annotations:
+            continue
         yield normalized
 
 
-def _read_event_text_artifact(
+def _iter_text_artifact_events(
     ref: str | None,
     artifacts_root: Path,
-) -> str | None:
+    *,
+    stream: str,
+    kind: str,
+    timestamp: str | None,
+    limit_per_stream: int | None,
+) -> Iterator[dict[str, object]]:
     artifact_path = _resolve_safe_artifact_path(ref, artifacts_root)
     if artifact_path is None:
-        return None
+        return
+
+    chunk_events: deque[dict[str, object]] = deque(maxlen=limit_per_stream)
+    offset = 0
+    normalized_timestamp = timestamp or datetime.now(tz=UTC).isoformat()
     try:
-        return artifact_path.read_text(encoding="utf-8", errors="replace")
+        for text_chunk in _iter_text_chunks(artifact_path):
+            normalized = _normalize_live_event(
+                {
+                    "sequence": 0,
+                    "timestamp": normalized_timestamp,
+                    "stream": stream,
+                    "text": text_chunk,
+                    "offset": offset,
+                    "kind": kind,
+                }
+            )
+            offset += len(text_chunk.encode("utf-8", errors="replace"))
+            if normalized is not None:
+                chunk_events.append(normalized)
     except OSError:
-        return None
+        return
+
+    yield from chunk_events
 
 
 def _build_session_artifact_event(
@@ -532,6 +599,8 @@ def _build_session_artifact_event(
 def _iter_historical_artifact_events(
     record: object,
     session_record: CodexManagedSessionRecord | None,
+    *,
+    limit_per_stream: int | None = None,
 ) -> Iterator[dict[str, object]]:
     artifacts_root = Path(_get_agent_runtime_artifacts_root()).resolve()
     diagnostics_path = _resolve_safe_artifact_path(
@@ -540,45 +609,29 @@ def _iter_historical_artifact_events(
     )
     yield from _iter_diagnostics_observability_events(diagnostics_path)
 
-    stdout_text = _read_event_text_artifact(
+    stdout_timestamp = getattr(record, "started_at", None)
+    if isinstance(stdout_timestamp, datetime):
+        stdout_timestamp = stdout_timestamp.isoformat()
+    yield from _iter_text_artifact_events(
         getattr(record, "stdout_artifact_ref", None),
         artifacts_root,
+        stream="stdout",
+        kind="stdout_chunk",
+        timestamp=stdout_timestamp,
+        limit_per_stream=limit_per_stream,
     )
-    if stdout_text:
-        stdout_timestamp = getattr(record, "started_at", None)
-        if isinstance(stdout_timestamp, datetime):
-            stdout_timestamp = stdout_timestamp.isoformat()
-        normalized = _normalize_live_event(
-            {
-                "sequence": 0,
-                "timestamp": stdout_timestamp or datetime.now(tz=UTC).isoformat(),
-                "stream": "stdout",
-                "text": stdout_text,
-                "kind": "stdout_chunk",
-            }
-        )
-        if normalized is not None:
-            yield normalized
 
-    stderr_text = _read_event_text_artifact(
+    stderr_timestamp = getattr(record, "started_at", None)
+    if isinstance(stderr_timestamp, datetime):
+        stderr_timestamp = stderr_timestamp.isoformat()
+    yield from _iter_text_artifact_events(
         getattr(record, "stderr_artifact_ref", None),
         artifacts_root,
+        stream="stderr",
+        kind="stderr_chunk",
+        timestamp=stderr_timestamp,
+        limit_per_stream=limit_per_stream,
     )
-    if stderr_text:
-        stderr_timestamp = getattr(record, "started_at", None)
-        if isinstance(stderr_timestamp, datetime):
-            stderr_timestamp = stderr_timestamp.isoformat()
-        normalized = _normalize_live_event(
-            {
-                "sequence": 0,
-                "timestamp": stderr_timestamp or datetime.now(tz=UTC).isoformat(),
-                "stream": "stderr",
-                "text": stderr_text,
-                "kind": "stderr_chunk",
-            }
-        )
-        if normalized is not None:
-            yield normalized
 
     if session_record is None:
         return
@@ -631,8 +684,8 @@ def _iter_historical_artifact_events(
         ("summary_published", session_record.latest_summary_ref, "Session summary published."),
         ("checkpoint_published", session_record.latest_checkpoint_ref, "Session checkpoint published."),
     ):
-        artifact_text = _read_event_text_artifact(ref_attr, artifacts_root)
-        if artifact_text is None:
+        artifact_path = _resolve_safe_artifact_path(ref_attr, artifacts_root)
+        if artifact_path is None:
             continue
         yield _build_session_artifact_event(
             kind=kind,
@@ -643,12 +696,10 @@ def _iter_historical_artifact_events(
         )
 
 
-def _event_sort_key(payload: dict[str, object]) -> tuple[int, datetime, int]:
+def _event_sort_key(payload: dict[str, object]) -> tuple[datetime, int]:
     sequence = _coerce_sequence(payload.get("sequence"))
     timestamp = _coerce_utc_datetime(payload.get("timestamp")) or datetime.min.replace(tzinfo=UTC)
-    if sequence is not None and sequence > 0:
-        return (0, timestamp, sequence)
-    return (1, timestamp, 0)
+    return (timestamp, sequence if sequence is not None and sequence > 0 else 2**31 - 1)
 
 
 def _iter_artifact_fallback_content(
@@ -891,7 +942,13 @@ async def get_task_run_observability_events(
             if normalized is not None:
                 events.append(normalized)
     else:
-        events.extend(_iter_historical_artifact_events(record, session_record))
+        events.extend(
+            _iter_historical_artifact_events(
+                record,
+                session_record,
+                limit_per_stream=limit,
+            )
+        )
 
     events.sort(key=_event_sort_key)
     truncated = len(events) > limit

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -24,6 +24,8 @@ from moonmind.schemas.temporal_artifact_models import (
     ArtifactSessionGroupModel,
     ArtifactSessionProjectionModel,
 )
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.schemas.agent_runtime_models import LiveLogChunk
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
@@ -268,6 +270,50 @@ def _task_run_session_workflow_id(*, task_run_id: str, runtime_id: str) -> str:
     return f"{task_run_id}:session:{runtime_id}"
 
 
+def _load_task_run_session_record(task_run_id: str) -> CodexManagedSessionRecord | None:
+    store_root = Path(_get_managed_session_store_root())
+    if not store_root.exists():
+        return None
+
+    best_record: CodexManagedSessionRecord | None = None
+    best_updated_at: datetime | None = None
+    for path in store_root.rglob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            record = CodexManagedSessionRecord(**payload)
+        except (OSError, json.JSONDecodeError, ValueError, TypeError):
+            continue
+        if record.task_run_id != task_run_id:
+            continue
+        candidate_updated_at = record.updated_at or record.started_at
+        if best_record is None or (
+            candidate_updated_at is not None
+            and (best_updated_at is None or candidate_updated_at > best_updated_at)
+        ):
+            best_record = record
+            best_updated_at = candidate_updated_at
+    return best_record
+
+
+def _build_session_snapshot(
+    record: CodexManagedSessionRecord | None,
+) -> dict[str, object] | None:
+    if record is None:
+        return None
+    return {
+        "sessionId": record.session_id,
+        "sessionEpoch": record.session_epoch,
+        "containerId": record.container_id,
+        "threadId": record.thread_id,
+        "activeTurnId": record.active_turn_id,
+        "status": record.status,
+        "latestSummaryRef": record.latest_summary_ref,
+        "latestCheckpointRef": record.latest_checkpoint_ref,
+        "latestControlEventRef": record.latest_control_event_ref,
+        "latestResetBoundaryRef": record.latest_reset_boundary_ref,
+    }
+
+
 def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]]:
     if not workspace_path:
         return
@@ -378,6 +424,233 @@ def _iter_file_chunks(path: Path, *, chunk_size: int = 8192) -> Iterator[bytes]:
             yield chunk.encode("utf-8")
 
 
+def _read_json_payload(path: Path | None) -> dict[str, object] | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _coerce_sequence(value: object) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _normalize_live_event(payload: dict[str, object]) -> dict[str, object] | None:
+    try:
+        chunk = LiveLogChunk.model_validate(payload)
+    except Exception:
+        return None
+    return chunk.model_dump(mode="json", exclude_none=True)
+
+
+def _iter_diagnostics_observability_events(
+    diagnostics_path: Path | None,
+) -> Iterator[dict[str, object]]:
+    diagnostics = _read_json_payload(diagnostics_path)
+    if diagnostics is None:
+        return
+
+    observed_events = diagnostics.get("observability_events")
+    if isinstance(observed_events, list):
+        for raw_event in observed_events:
+            if not isinstance(raw_event, dict):
+                continue
+            normalized = _normalize_live_event(raw_event)
+            if normalized is not None:
+                yield normalized
+
+    annotations = diagnostics.get("annotations")
+    if not isinstance(annotations, list):
+        return
+
+    for annotation in annotations:
+        if not isinstance(annotation, dict):
+            continue
+        normalized = _normalize_live_event(
+            {
+                "sequence": annotation.get("sequence") or 0,
+                "timestamp": annotation.get("timestamp")
+                or datetime.now(tz=UTC).isoformat(),
+                "stream": "system",
+                "text": str(annotation.get("text") or ""),
+                "kind": "system_annotation",
+                "metadata": annotation.get("metadata") or {},
+            }
+        )
+        if normalized is None:
+            continue
+        yield normalized
+
+
+def _read_event_text_artifact(
+    ref: str | None,
+    artifacts_root: Path,
+) -> str | None:
+    artifact_path = _resolve_safe_artifact_path(ref, artifacts_root)
+    if artifact_path is None:
+        return None
+    try:
+        return artifact_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _build_session_artifact_event(
+    *,
+    kind: str,
+    text: str,
+    timestamp: str | None,
+    session_record: CodexManagedSessionRecord,
+    metadata: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if isinstance(timestamp, datetime):
+        normalized_timestamp = timestamp.isoformat()
+    else:
+        normalized_timestamp = str(timestamp or (session_record.updated_at or session_record.started_at).isoformat())
+    payload = {
+        "sequence": 0,
+        "timestamp": normalized_timestamp,
+        "stream": "session",
+        "text": text,
+        "kind": kind,
+        "session_id": session_record.session_id,
+        "session_epoch": session_record.session_epoch,
+        "container_id": session_record.container_id,
+        "thread_id": session_record.thread_id,
+        "active_turn_id": session_record.active_turn_id,
+        "metadata": metadata or {},
+    }
+    normalized = _normalize_live_event(payload)
+    if normalized is None:
+        raise ValueError("failed to normalize session artifact event")
+    return normalized
+
+
+def _iter_historical_artifact_events(
+    record: object,
+    session_record: CodexManagedSessionRecord | None,
+) -> Iterator[dict[str, object]]:
+    artifacts_root = Path(_get_agent_runtime_artifacts_root()).resolve()
+    diagnostics_path = _resolve_safe_artifact_path(
+        getattr(record, "diagnostics_ref", None),
+        artifacts_root,
+    )
+    yield from _iter_diagnostics_observability_events(diagnostics_path)
+
+    stdout_text = _read_event_text_artifact(
+        getattr(record, "stdout_artifact_ref", None),
+        artifacts_root,
+    )
+    if stdout_text:
+        stdout_timestamp = getattr(record, "started_at", None)
+        if isinstance(stdout_timestamp, datetime):
+            stdout_timestamp = stdout_timestamp.isoformat()
+        normalized = _normalize_live_event(
+            {
+                "sequence": 0,
+                "timestamp": stdout_timestamp or datetime.now(tz=UTC).isoformat(),
+                "stream": "stdout",
+                "text": stdout_text,
+                "kind": "stdout_chunk",
+            }
+        )
+        if normalized is not None:
+            yield normalized
+
+    stderr_text = _read_event_text_artifact(
+        getattr(record, "stderr_artifact_ref", None),
+        artifacts_root,
+    )
+    if stderr_text:
+        stderr_timestamp = getattr(record, "started_at", None)
+        if isinstance(stderr_timestamp, datetime):
+            stderr_timestamp = stderr_timestamp.isoformat()
+        normalized = _normalize_live_event(
+            {
+                "sequence": 0,
+                "timestamp": stderr_timestamp or datetime.now(tz=UTC).isoformat(),
+                "stream": "stderr",
+                "text": stderr_text,
+                "kind": "stderr_chunk",
+            }
+        )
+        if normalized is not None:
+            yield normalized
+
+    if session_record is None:
+        return
+
+    yield _build_session_artifact_event(
+        kind="session_started",
+        text=(
+            f"Session started. Epoch {session_record.session_epoch} "
+            f"thread {session_record.thread_id}."
+        ),
+        timestamp=session_record.started_at.isoformat(),
+        session_record=session_record,
+        metadata={"status": session_record.status},
+    )
+
+    control_payload = _read_json_payload(
+        _resolve_safe_artifact_path(session_record.latest_control_event_ref, artifacts_root)
+    )
+    if control_payload is not None:
+        action = str(control_payload.get("action") or "").strip().lower()
+        if action == "clear_session":
+            yield _build_session_artifact_event(
+                kind="session_cleared",
+                text=(
+                    f"Session cleared. Epoch {control_payload.get('previousSessionEpoch')} "
+                    f"-> {control_payload.get('newSessionEpoch')}; thread "
+                    f"{control_payload.get('previousThreadId')} -> {control_payload.get('newThreadId')}."
+                ),
+                timestamp=str(control_payload.get("recordedAt") or ""),
+                session_record=session_record,
+                metadata={**control_payload, "artifactRef": session_record.latest_control_event_ref},
+            )
+
+    boundary_payload = _read_json_payload(
+        _resolve_safe_artifact_path(session_record.latest_reset_boundary_ref, artifacts_root)
+    )
+    if boundary_payload is not None:
+        yield _build_session_artifact_event(
+            kind="session_reset_boundary",
+            text=(
+                f"Epoch boundary reached. Session {session_record.session_id} is now on "
+                f"epoch {boundary_payload.get('sessionEpoch')} thread {boundary_payload.get('threadId')}."
+            ),
+            timestamp=str(boundary_payload.get("recordedAt") or ""),
+            session_record=session_record,
+            metadata={**boundary_payload, "artifactRef": session_record.latest_reset_boundary_ref},
+        )
+
+    for kind, ref_attr, label in (
+        ("summary_published", session_record.latest_summary_ref, "Session summary published."),
+        ("checkpoint_published", session_record.latest_checkpoint_ref, "Session checkpoint published."),
+    ):
+        artifact_text = _read_event_text_artifact(ref_attr, artifacts_root)
+        if artifact_text is None:
+            continue
+        yield _build_session_artifact_event(
+            kind=kind,
+            text=label,
+            timestamp=(session_record.updated_at or session_record.started_at).isoformat(),
+            session_record=session_record,
+            metadata={"artifactRef": ref_attr},
+        )
+
+
+def _event_sort_key(payload: dict[str, object]) -> tuple[int, datetime, int]:
+    sequence = _coerce_sequence(payload.get("sequence"))
+    timestamp = _coerce_utc_datetime(payload.get("timestamp")) or datetime.min.replace(tzinfo=UTC)
+    if sequence is not None and sequence > 0:
+        return (0, timestamp, sequence)
+    return (1, timestamp, 0)
+
+
 def _iter_artifact_fallback_content(
     stdout_path: Path | None,
     stderr_path: Path | None,
@@ -485,8 +758,10 @@ async def get_observability_summary(
         live_stream_status = "unavailable"
 
     base = record.model_dump(by_alias=True)
+    session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
     base["supportsLiveStreaming"] = supports_live
     base["liveStreamStatus"] = live_stream_status
+    base["sessionSnapshot"] = _build_session_snapshot(session_record)
     return {"summary": base}
 
 
@@ -581,6 +856,53 @@ async def control_task_run_artifact_session(
     if projection is None:
         _session_projection_not_found()
     return ArtifactSessionControlResponse(action=payload.action, projection=projection)
+
+
+@router.get(
+    "/{id}/observability/events",
+    response_model=dict,
+    responses={
+        404: {"description": "Observability record not found for this task run"},
+    },
+)
+async def get_task_run_observability_events(
+    id: UUID,
+    limit: int = Query(default=500, ge=1, le=5000),
+    _user: User = Depends(get_current_user()),
+) -> dict:
+    """Return structured observability history for one task run."""
+    store = ManagedRunStore(_get_agent_runtime_store_root())
+    record = await asyncio.to_thread(store.load, str(id))
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Observability record not found for this task run",
+        )
+    await _require_observability_access(record, _user)
+
+    workspace_path = getattr(record, "workspace_path", None)
+    started_at = getattr(record, "started_at", None)
+    session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
+
+    events: list[dict[str, object]] = []
+    if _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
+        for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
+            normalized = _normalize_live_event(payload)
+            if normalized is not None:
+                events.append(normalized)
+    else:
+        events.extend(_iter_historical_artifact_events(record, session_record))
+
+    events.sort(key=_event_sort_key)
+    truncated = len(events) > limit
+    if truncated:
+        events = events[-limit:]
+
+    return {
+        "events": events,
+        "truncated": truncated,
+        "sessionSnapshot": _build_session_snapshot(session_record),
+    }
 
 
 @router.get(

--- a/docs/ManagedAgents/LiveLogs.md
+++ b/docs/ManagedAgents/LiveLogs.md
@@ -13,6 +13,7 @@ For managed agent runs, live visibility should be based on:
 
 * durable stdout/stderr artifact capture
 * structured diagnostics
+* continuity-aware session/control boundary artifacts when the runtime exposes a managed session plane
 * optional MoonMind-owned live log streaming to Mission Control
 * explicit intervention controls separate from logging
 
@@ -20,7 +21,7 @@ With this design:
 
 * **OAuth** uses `xterm.js` plus a MoonMind PTY/WebSocket bridge because OAuth is an interactive terminal flow
 * **managed run logs** do **not** use `xterm.js` and do **not** use terminal embedding
-* Mission Control shows logs through a MoonMind-native React log viewer backed by MoonMind APIs and artifacts, implemented with `react-virtuoso` for virtualized rendering, `anser` for ANSI parsing, TanStack Query for retrieval state, and SSE via `EventSource` for live follow mode.
+* Mission Control shows logs through a MoonMind-native React log viewer backed by MoonMind APIs and artifacts, implemented as a continuity-aware observability timeline with TanStack Query for retrieval state and SSE via `EventSource` for live follow mode.
 
 This keeps logging deterministic, persistent, auditable, and independent from interactive terminal transport.
 
@@ -65,6 +66,7 @@ Every managed run should produce:
 * durable stdout artifact
 * durable stderr artifact
 * durable diagnostics artifact
+* durable continuity/control-boundary artifacts when a managed session plane is active
 * structured run state and summary metadata
 * optional live streaming through MoonMind APIs
 
@@ -135,11 +137,14 @@ Behavior:
 
 * initially loads the most recent tail from MoonMind APIs — **initial visible content must not depend on SSE success**
 * upgrades to a live stream when the run is active and live streaming is supported
-* shows stream origin per line or chunk (`stdout`, `stderr`, `system`)
+* shows stream origin per line or chunk (`stdout`, `stderr`, `system`, `session`)
+* renders session lifecycle boundaries, thread swaps, and epoch resets as explicit timeline rows rather than burying them inside plain system text
 * can reconnect from last known sequence or offset — resume is best-effort; artifacts are the durable fallback
 * falls back to artifact tail if live streaming is unavailable — stream errors must transition to artifact-backed mode rather than leaving the panel blank
 * stops streaming when collapsed or when the tab is backgrounded
 * **ended runs never attempt live stream connection**; the final artifact-backed tail is always available
+
+When a managed session plane is active, the Live Logs panel should also expose the current bounded session snapshot (`session_id`, `session_epoch`, `container_id`, `thread_id`, and `active_turn_id` when present) so the operator sees continuity state and runtime output in one place.
 
 ## 5.3 Stdout and Stderr panels
 
@@ -183,6 +188,7 @@ Components:
 * supervisor
 * log capture pipeline
 * diagnostics builder
+* session-plane observability publisher
 * live log stream publisher
 * Mission Control log APIs
 * artifact-backed log retrieval

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -41,13 +41,29 @@ class MockEventSource {
     this.onopen?.(new Event('open'));
   }
 
-  triggerLogChunk(data: { sequence: number; stream: string; text: string }) {
-    const event = new MessageEvent('log_chunk', { data: JSON.stringify(data) });
+  triggerLogChunk(
+    data: { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
+  ) {
+    const event = new MessageEvent('log_chunk', {
+      data: JSON.stringify({
+        timestamp: '2026-04-08T00:00:00Z',
+        ...data,
+      }),
+    });
     for (const listener of this.listeners.get('log_chunk') ?? []) listener(event);
   }
 
-  triggerMessage(data: { sequence: number; stream: string; text: string }) {
-    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }));
+  triggerMessage(
+    data: { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
+  ) {
+    this.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          timestamp: '2026-04-08T00:00:00Z',
+          ...data,
+        }),
+      }),
+    );
   }
 
   triggerError() {
@@ -1192,10 +1208,68 @@ describe('LiveLogsPanel', () => {
     summary: object,
     tailContent: string = '',
   ) {
+    const buildHistoryPayload = () => {
+      const lines = tailContent.split('\n');
+      const events: Array<{ sequence: number; timestamp: string; stream: string; text: string }> = [];
+      let currentStream = 'stdout';
+      let sequence = 1;
+      let buffer: string[] = [];
+
+      const flushBuffer = () => {
+        if (buffer.length === 0) return;
+        events.push({
+          sequence,
+          timestamp: `2026-04-08T00:00:${String(sequence).padStart(2, '0')}Z`,
+          stream: currentStream,
+          text: `${buffer.join('\n')}\n`,
+        });
+        sequence += 1;
+        buffer = [];
+      };
+
+      for (const line of lines) {
+        if (line === '--- stdout ---') {
+          flushBuffer();
+          currentStream = 'stdout';
+          continue;
+        }
+        if (line === '--- stderr ---') {
+          flushBuffer();
+          currentStream = 'stderr';
+          continue;
+        }
+        if (line === '--- system ---') {
+          flushBuffer();
+          currentStream = 'system';
+          continue;
+        }
+        if (line.length === 0) continue;
+        buffer.push(line);
+      }
+      flushBuffer();
+
+      if (events.length === 0 && tailContent) {
+        events.push({
+          sequence: 1,
+          timestamp: '2026-04-08T00:00:01Z',
+          stream: 'stdout',
+          text: tailContent,
+        });
+      }
+
+      return { events, truncated: false };
+    };
+
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/observability-summary')) {
         return Promise.resolve({ ok: true, json: async () => summary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => buildHistoryPayload(),
+        } as Response);
       }
       if (url.includes('/logs/merged')) {
         return Promise.resolve({
@@ -1313,6 +1387,9 @@ describe('LiveLogsPanel', () => {
       const url = String(input);
       if (url.includes('/observability-summary')) {
         return Promise.resolve({ ok: true, json: async () => currentSummary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({ ok: true, json: async () => ({ events: [], truncated: false }) } as Response);
       }
       if (url.includes('/logs/merged')) {
         return Promise.resolve({ ok: true, text: async () => '' } as unknown as Response);
@@ -1456,6 +1533,75 @@ describe('LiveLogsPanel', () => {
     expect(systemLine?.getAttribute('data-stream')).toBe('system');
   });
 
+  it('renders session reset boundaries as explicit timeline rows with session badges', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 2,
+                containerId: 'ctr-1',
+                threadId: 'thread-2',
+                activeTurnId: null,
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'session',
+                text: 'Epoch boundary reached. Session sess:wf-task-1:codex_cli is now on epoch 2 thread thread-2.',
+                kind: 'session_reset_boundary',
+                session_id: 'sess:wf-task-1:codex_cli',
+                session_epoch: 2,
+                thread_id: 'thread-2',
+              },
+            ],
+            truncated: false,
+            sessionSnapshot: {
+              sessionId: 'sess:wf-task-1:codex_cli',
+              sessionEpoch: 2,
+              containerId: 'ctr-1',
+              threadId: 'thread-2',
+              activeTurnId: null,
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Epoch boundary reached/)).toBeTruthy();
+      expect(screen.getByText('sess:wf-task-1:codex_cli')).toBeTruthy();
+      expect(screen.getByText('thread-2')).toBeTruthy();
+    });
+
+    const boundaryRow = screen.getByText(/Epoch boundary reached/).closest('div');
+    expect(boundaryRow?.getAttribute('data-kind')).toBe('session_reset_boundary');
+    expect(boundaryRow?.getAttribute('data-stream')).toBe('session');
+  });
+
   it('renders Stdout, Stderr, and Diagnostics panels', async () => {
     // Setup fetch mock to also return stdout, stderr, and diagnostics
     const stdoutContent = 'stdout line 1\nstdout line 2';
@@ -1467,6 +1613,7 @@ describe('LiveLogsPanel', () => {
       if (url.includes('/logs/stdout')) return Promise.resolve({ ok: true, text: async () => stdoutContent } as Response);
       if (url.includes('/logs/stderr')) return Promise.resolve({ ok: true, text: async () => stderrContent } as Response);
       if (url.includes('/diagnostics')) return Promise.resolve({ ok: true, text: async () => diagnosticsContent } as Response);
+      if (url.includes('/observability/events')) return Promise.resolve({ ok: true, json: async () => ({ events: [], truncated: false }) } as Response);
       if (url.includes('/logs/merged')) return Promise.resolve({ ok: true, text: async () => '' } as Response);
       if (url.includes('/observability-summary')) return Promise.resolve({ ok: true, json: async () => ({ summary: { status: 'completed' } }) } as Response);
       if (url.includes('/artifacts')) return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
@@ -1513,6 +1660,22 @@ describe('LiveLogsPanel', () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/logs/stdout')) return Promise.resolve({ ok: true, text: async () => 'stdout data' } as Response);
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'stdout',
+                text: 'live log data\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
       if (url.includes('/logs/merged')) return Promise.resolve({ ok: true, text: async () => 'live log data' } as Response);
       if (url.includes('/observability-summary')) return Promise.resolve({ ok: true, json: async () => ({ summary: { status: 'completed' } }) } as Response);
       return Promise.resolve({
@@ -1566,6 +1729,22 @@ describe('LiveLogsPanel', () => {
       const url = String(input);
       if (url.includes('/logs/stdout')) return Promise.resolve({ ok: true, text: async () => 'stdout data' } as Response);
       if (url.includes('/diagnostics')) return Promise.resolve({ ok: true, text: async () => '{"diag":true}' } as Response);
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'stdout',
+                text: 'live log data\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
       if (url.includes('/logs/merged')) return Promise.resolve({ ok: true, text: async () => 'live log data' } as Response);
       if (url.includes('/observability-summary')) {
         return Promise.resolve({ ok: true, json: async () => ({ summary: { status: 'completed' } }) } as Response);
@@ -1620,6 +1799,22 @@ describe('LiveLogsPanel', () => {
       const url = String(input);
       if (url.includes('/observability-summary')) {
         return Promise.resolve({ ok: true, json: async () => activeSummary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'stdout',
+                text: 'attached tail\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
       }
       if (url.includes('/logs/merged')) {
         return Promise.resolve({ ok: true, text: async () => 'attached tail\n' } as unknown as Response);

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1380,6 +1380,35 @@ describe('LiveLogsPanel', () => {
     expect(MockEventSource.instances.length).toBe(0);
   });
 
+  it('falls back to merged logs when structured history returns 404', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({ ok: true, json: async () => noStreamSummary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }
+      if (url.includes('/logs/merged')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => 'merged fallback line\n',
+        } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => activeExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => expect(screen.getByText(/merged fallback line/)).toBeTruthy());
+    expect(MockEventSource.instances.length).toBe(0);
+  });
+
   it('closes stream and shows Stream ended when task transitions to terminal', async () => {
     let currentExecution = activeExecution;
     let currentSummary = activeSummary;

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -796,6 +796,7 @@ function LiveLogsPanel({
     staleTime: Infinity,
     retry: false,
   });
+  const historyUnavailable = historyQuery.isError || historyQuery.data === null;
 
   // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({
@@ -805,7 +806,7 @@ function LiveLogsPanel({
       !!taskRunId &&
       expanded &&
       summaryQuery.isSuccess &&
-      historyQuery.isError,
+      historyUnavailable,
     staleTime: Infinity,
     retry: false,
   });
@@ -874,12 +875,12 @@ function LiveLogsPanel({
 
   // Sync legacy merged-text fallback only when structured history is unavailable.
   useEffect(() => {
-    if (tailQuery.isSuccess && tailQuery.data && historyQuery.isError) {
+    if (tailQuery.isSuccess && tailQuery.data && historyUnavailable) {
       if (lastSeqRef.current === null) {
         setLogContent(parseArtifactToRows(tailQuery.data));
       }
     }
-  }, [historyQuery.isError, tailQuery.data, tailQuery.isSuccess]);
+  }, [historyUnavailable, tailQuery.data, tailQuery.isSuccess]);
 
   // Connect to SSE only after tail succeeds, if streaming is supported and active
   useEffect(() => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -230,6 +230,52 @@ const ArtifactSessionControlResponseSchema = z.object({
   projection: ArtifactSessionProjectionSchema,
 });
 
+const SessionSnapshotSchema = z
+  .object({
+    sessionId: z.string(),
+    sessionEpoch: z.number(),
+    containerId: z.string(),
+    threadId: z.string(),
+    activeTurnId: z.string().nullable().optional(),
+    status: z.string().optional(),
+    latestSummaryRef: z.string().nullable().optional(),
+    latestCheckpointRef: z.string().nullable().optional(),
+    latestControlEventRef: z.string().nullable().optional(),
+    latestResetBoundaryRef: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const ObservabilitySummarySchema = z.object({
+  supportsLiveStreaming: z.boolean().default(false),
+  liveStreamStatus: z.string().default('unavailable'),
+  status: z.string().default(''),
+  sessionSnapshot: SessionSnapshotSchema.nullable().optional(),
+});
+
+const ObservabilityEventSchema = z
+  .object({
+    sequence: z.number(),
+    timestamp: z.string(),
+    stream: z.enum(['stdout', 'stderr', 'system', 'session']),
+    text: z.string(),
+    offset: z.number().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    session_id: z.string().nullable().optional(),
+    session_epoch: z.number().nullable().optional(),
+    container_id: z.string().nullable().optional(),
+    thread_id: z.string().nullable().optional(),
+    turn_id: z.string().nullable().optional(),
+    active_turn_id: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const ObservabilityEventsResponseSchema = z.object({
+  events: z.array(ObservabilityEventSchema).default([]),
+  truncated: z.boolean().default(false),
+  sessionSnapshot: SessionSnapshotSchema.nullable().optional(),
+});
+
 const ArtifactListSchema = z.object({
   artifacts: z
     .array(
@@ -547,7 +593,7 @@ async function controlArtifactSession(
 async function fetchObservabilitySummary(
   apiBase: string,
   taskRunId: string,
-): Promise<{ supportsLiveStreaming: boolean; liveStreamStatus: string; status: string } | null> {
+): Promise<z.infer<typeof ObservabilitySummarySchema> | null> {
   const resp = await fetch(
     `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/observability-summary`,
     { credentials: 'include' },
@@ -557,12 +603,22 @@ async function fetchObservabilitySummary(
     throw buildObservabilityRequestError(resp.status);
   }
   const body = (await resp.json()) as { summary: Record<string, unknown> };
-  const s = body.summary;
-  return {
-    supportsLiveStreaming: Boolean(s.supportsLiveStreaming),
-    liveStreamStatus: String(s.liveStreamStatus ?? 'unavailable'),
-    status: String(s.status ?? ''),
-  };
+  return ObservabilitySummarySchema.parse(body.summary);
+}
+
+async function fetchObservabilityEvents(
+  apiBase: string,
+  taskRunId: string,
+): Promise<z.infer<typeof ObservabilityEventsResponseSchema> | null> {
+  const resp = await fetch(
+    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/observability/events`,
+    { credentials: 'include' },
+  );
+  if (!resp.ok) {
+    if (resp.status === 404) return null;
+    throw buildObservabilityRequestError(resp.status);
+  }
+  return ObservabilityEventsResponseSchema.parse(await resp.json());
 }
 
 const TERMINAL_RUN_STATUSES = new Set([
@@ -589,10 +645,22 @@ function usePageVisibility() {
   return isVisible;
 }
 
-type LogLine = {
+type ObservabilityEvent = z.infer<typeof ObservabilityEventSchema>;
+type SessionSnapshot = z.infer<typeof SessionSnapshotSchema>;
+type TimelineStream = 'stdout' | 'stderr' | 'system' | 'session' | 'unknown';
+type TimelineRow = {
   id: string;
   text: string;
-  stream: 'stdout' | 'stderr' | 'system' | 'unknown';
+  stream: TimelineStream;
+  kind: string | null;
+  sequence: number | null;
+  timestamp: string | null;
+  sessionId: string | null;
+  sessionEpoch: number | null;
+  threadId: string | null;
+  turnId: string | null;
+  metadata: Record<string, unknown>;
+  rowType: 'line' | 'boundary';
 };
 
 function splitLogText(content: string): string[] {
@@ -619,17 +687,59 @@ function copyTextToClipboard(text: string): void {
   }
 }
 
-function parseArtifactToLines(content: string): LogLine[] {
+function parseArtifactToRows(content: string): TimelineRow[] {
   const lines = splitLogText(content);
-  let currentStream: LogLine['stream'] = 'unknown';
+  let currentStream: TimelineStream = 'unknown';
 
   return lines.map((line, i) => {
     if (line.startsWith('--- stdout ---')) currentStream = 'stdout';
     else if (line.startsWith('--- stderr ---')) currentStream = 'stderr';
     else if (line.startsWith('--- system ---')) currentStream = 'system';
+    else if (line.startsWith('--- session ---')) currentStream = 'session';
 
-    return { id: `artifact-${i}`, text: line, stream: currentStream };
+    return {
+      id: `artifact-${i}`,
+      text: line,
+      stream: currentStream,
+      kind: null,
+      sequence: null,
+      timestamp: null,
+      sessionId: null,
+      sessionEpoch: null,
+      threadId: null,
+      turnId: null,
+      metadata: {},
+      rowType: 'line',
+    };
   });
+}
+
+function eventToTimelineRows(event: ObservabilityEvent): TimelineRow[] {
+  const stream = event.stream as TimelineStream;
+  const rowType = event.kind === 'session_reset_boundary' ? 'boundary' : 'line';
+  const lines = splitLogText(event.text);
+  const sourceLines = lines.length > 0 ? lines : [event.text];
+  return sourceLines.map((line, index) => ({
+    id: `${event.sequence}-${index}-${event.kind ?? 'event'}`,
+    text: line,
+    stream,
+    kind: event.kind ?? null,
+    sequence: event.sequence,
+    timestamp: event.timestamp ?? null,
+    sessionId: event.session_id ?? null,
+    sessionEpoch: event.session_epoch ?? null,
+    threadId: event.thread_id ?? null,
+    turnId: event.turn_id ?? null,
+    metadata: event.metadata ?? {},
+    rowType,
+  }));
+}
+
+function mapEventsToTimelineRows(
+  payload: z.infer<typeof ObservabilityEventsResponseSchema> | null | undefined,
+): TimelineRow[] {
+  if (!payload) return [];
+  return payload.events.flatMap((event) => eventToTimelineRows(event));
 }
 
 function LiveLogsPanel({
@@ -643,13 +753,14 @@ function LiveLogsPanel({
   isTerminal: boolean;
   autoExpand?: boolean;
 }) {
-  const [logContent, setLogContent] = useState<LogLine[]>([]);
+  const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
   const [expanded, setExpanded] = useState(false);
   const isVisible = usePageVisibility();
   const lastSeqRef = useRef<number | null>(null);
   const esRef = useRef<EventSource | null>(null);
   const isTerminalRef = useRef(isTerminal);
+  const [sessionSnapshot, setSessionSnapshot] = useState<SessionSnapshot | null>(null);
 
   // Keep isTerminalRef current so the onerror handler always sees the latest value.
   useEffect(() => {
@@ -678,11 +789,23 @@ function LiveLogsPanel({
     staleTime: 1000 * 10,
   });
 
-  // Query for the artifact-backed tail (runs after summary resolves)
+  const historyQuery = useQuery({
+    queryKey: ['task-run-observability-events', taskRunId],
+    queryFn: () => fetchObservabilityEvents(apiBase, taskRunId),
+    enabled: !!taskRunId && expanded && summaryQuery.isSuccess,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({
     queryKey: ['task-run-tail', taskRunId],
     queryFn: () => fetchMergedTail(apiBase, taskRunId),
-    enabled: !!taskRunId && expanded && summaryQuery.isSuccess,
+    enabled:
+      !!taskRunId &&
+      expanded &&
+      summaryQuery.isSuccess &&
+      historyQuery.isError,
     staleTime: Infinity,
     retry: false,
   });
@@ -693,37 +816,79 @@ function LiveLogsPanel({
       setViewerState('starting');
       return;
     }
-    if (tailQuery.isError) {
+    if (historyQuery.isError && tailQuery.isError) {
       setViewerState('error');
-    } else if (summaryQuery.isSuccess && tailQuery.isSuccess) {
+    } else if (
+      summaryQuery.isSuccess &&
+      (historyQuery.isSuccess || tailQuery.isSuccess)
+    ) {
       const summary = summaryQuery.data;
-      const runIsTerminal = isTerminalRef.current || (summary ? TERMINAL_RUN_STATUSES.has(summary.status) : false);
+      const runIsTerminal =
+        isTerminalRef.current || (summary ? TERMINAL_RUN_STATUSES.has(summary.status) : false);
       const supportsStreaming = summary?.supportsLiveStreaming ?? false;
 
       if (!supportsStreaming) {
-        setViewerState(tailQuery.data ? 'ended' : 'not_available');
+        setViewerState(
+          (historyQuery.data?.events.length ?? 0) > 0 || Boolean(tailQuery.data)
+            ? 'ended'
+            : 'not_available',
+        );
       } else if (runIsTerminal) {
         setViewerState('ended');
       }
     }
-  }, [expanded, summaryQuery.isSuccess, summaryQuery.data, tailQuery.isError, tailQuery.isSuccess, tailQuery.data]);
+  }, [
+    expanded,
+    historyQuery.data,
+    historyQuery.isError,
+    historyQuery.isSuccess,
+    summaryQuery.data,
+    summaryQuery.isSuccess,
+    tailQuery.data,
+    tailQuery.isError,
+    tailQuery.isSuccess,
+  ]);
 
-  // Sync tail content into the local log buffer when tail fetch completes.
   useEffect(() => {
-    if (tailQuery.isSuccess && tailQuery.data) {
-      setLogContent((prev) => {
-        if (lastSeqRef.current !== null) return prev;
-        return parseArtifactToLines(tailQuery.data);
-      });
+    if (summaryQuery.data?.sessionSnapshot) {
+      setSessionSnapshot(summaryQuery.data.sessionSnapshot);
     }
-  }, [tailQuery.isSuccess, tailQuery.data]);
+  }, [summaryQuery.data]);
+
+  // Sync structured history into the local timeline when history fetch completes.
+  useEffect(() => {
+    if (historyQuery.isSuccess) {
+      const rows = mapEventsToTimelineRows(historyQuery.data);
+      const sequences = historyQuery.data?.events
+        .map((event) => event.sequence)
+        .filter((sequence) => Number.isFinite(sequence));
+      if (lastSeqRef.current === null) {
+        setLogContent(rows);
+      }
+      lastSeqRef.current = sequences && sequences.length > 0 ? Math.max(...sequences) : null;
+      if (historyQuery.data?.sessionSnapshot) {
+        setSessionSnapshot(historyQuery.data.sessionSnapshot);
+      }
+    }
+  }, [historyQuery.data, historyQuery.isSuccess]);
+
+  // Sync legacy merged-text fallback only when structured history is unavailable.
+  useEffect(() => {
+    if (tailQuery.isSuccess && tailQuery.data && historyQuery.isError) {
+      if (lastSeqRef.current === null) {
+        setLogContent(parseArtifactToRows(tailQuery.data));
+      }
+    }
+  }, [historyQuery.isError, tailQuery.data, tailQuery.isSuccess]);
 
   // Connect to SSE only after tail succeeds, if streaming is supported and active
   useEffect(() => {
-    if (!taskRunId || !expanded || !summaryQuery.isSuccess || !tailQuery.isSuccess || !isVisible) return;
+    if (!taskRunId || !expanded || !summaryQuery.isSuccess || !isVisible) return;
+    if (!historyQuery.isSuccess && !tailQuery.isSuccess) return;
 
     const summary = summaryQuery.data;
-    const runIsTerminal = isTerminalRef.current || (summary ? TERMINAL_RUN_STATUSES.has(summary.status) : false);
+    const runIsTerminal =
+      isTerminalRef.current || (summary ? TERMINAL_RUN_STATUSES.has(summary.status) : false);
     const supportsStreaming = summary?.supportsLiveStreaming ?? false;
 
     if (runIsTerminal || !supportsStreaming) return;
@@ -743,18 +908,29 @@ function LiveLogsPanel({
     const handleLogChunk = (event: MessageEvent) => {
       if (cancelled) return;
       try {
-        const data = JSON.parse(event.data) as { sequence: number; text: string; stream?: string };
+        const data = ObservabilityEventSchema.parse(JSON.parse(event.data));
         lastSeqRef.current = data.sequence;
 
         setLogContent((prev) => {
-          const lines = splitLogText(data.text);
-          const mapped: LogLine[] = lines.map((l, i) => ({
-            id: `live-${data.sequence}-${i}`,
-            text: l,
-            stream: (data.stream as LogLine['stream']) || 'unknown',
-          }));
-          return [...prev, ...mapped];
+          return [...prev, ...eventToTimelineRows(data)];
         });
+        if (data.session_id && data.session_epoch) {
+          const nextSessionId = data.session_id;
+          const nextSessionEpoch = data.session_epoch;
+          setSessionSnapshot((prev) => ({
+            ...(prev ?? {
+              sessionId: nextSessionId,
+              sessionEpoch: nextSessionEpoch,
+              containerId: data.container_id ?? '',
+              threadId: data.thread_id ?? '',
+            }),
+            sessionId: nextSessionId,
+            sessionEpoch: nextSessionEpoch,
+            containerId: data.container_id ?? prev?.containerId ?? '',
+            threadId: data.thread_id ?? prev?.threadId ?? '',
+            activeTurnId: data.active_turn_id ?? prev?.activeTurnId ?? null,
+          }));
+        }
       } catch {
         // ignore malformed events
       }
@@ -778,7 +954,16 @@ function LiveLogsPanel({
         esRef.current = null;
       }
     };
-  }, [apiBase, taskRunId, expanded, isVisible, summaryQuery.isSuccess, summaryQuery.data, tailQuery.isSuccess]);
+  }, [
+    apiBase,
+    expanded,
+    historyQuery.isSuccess,
+    isVisible,
+    summaryQuery.data,
+    summaryQuery.isSuccess,
+    tailQuery.isSuccess,
+    taskRunId,
+  ]);
 
   // Close the stream once the task reaches a terminal state.
   useEffect(() => {
@@ -814,6 +999,14 @@ function LiveLogsPanel({
 
   const downloadUrl = `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/merged`;
   const summaryErrorMessage = summaryQuery.isError ? (summaryQuery.error as Error).message : null;
+  const sessionBadges = sessionSnapshot
+    ? [
+        ['Session', sessionSnapshot.sessionId],
+        ['Epoch', String(sessionSnapshot.sessionEpoch)],
+        ['Thread', sessionSnapshot.threadId],
+        ['Active Turn', sessionSnapshot.activeTurnId ?? null],
+      ].filter(([, value]) => value) as Array<[string, string]>
+    : [];
 
   return (
     <details
@@ -844,6 +1037,15 @@ function LiveLogsPanel({
         <p className="small">
           Task run <code className="text-xs">{taskRunId}</code> — {statusLabel}
         </p>
+        {sessionBadges.length > 0 ? (
+          <div className="actions">
+            {sessionBadges.map(([label, value]) => (
+              <span key={`${label}-${value}`} className="card">
+                <strong>{label}:</strong> <code className="text-xs break-all">{value}</code>
+              </span>
+            ))}
+          </div>
+        ) : null}
         <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
           <div
             style={{
@@ -863,25 +1065,45 @@ function LiveLogsPanel({
               <div>{emptyLabel}</div>
             ) : (
               logContent.map((line) => (
-                <div
-                  key={line.id}
-                  data-stream={line.stream}
-                  style={{
-                    borderLeft:
-                      line.stream === 'stdout'
-                        ? '2px solid #3b82f6'
-                        : line.stream === 'stderr'
-                          ? '2px solid #ef4444'
-                          : line.stream === 'system'
-                            ? '2px solid #22c55e'
-                            : '2px solid transparent',
-                    paddingLeft: '6px',
-                    // dim system messages
-                    opacity: line.stream === 'system' ? 0.7 : 1,
-                  }}
-                >
-                  {line.text}
-                </div>
+                line.rowType === 'boundary' ? (
+                  <div
+                    key={line.id}
+                    data-stream={line.stream}
+                    data-kind={line.kind ?? undefined}
+                    style={{
+                      margin: '0.35rem 0',
+                      padding: '0.5rem 0.75rem',
+                      border: '1px solid #f59e0b',
+                      background: 'rgba(245, 158, 11, 0.12)',
+                      color: '#fde68a',
+                      borderRadius: '4px',
+                    }}
+                  >
+                    {line.text}
+                  </div>
+                ) : (
+                  <div
+                    key={line.id}
+                    data-stream={line.stream}
+                    data-kind={line.kind ?? undefined}
+                    style={{
+                      borderLeft:
+                        line.stream === 'stdout'
+                          ? '2px solid #3b82f6'
+                          : line.stream === 'stderr'
+                            ? '2px solid #ef4444'
+                            : line.stream === 'system'
+                              ? '2px solid #22c55e'
+                              : line.stream === 'session'
+                                ? '2px solid #f59e0b'
+                                : '2px solid transparent',
+                      paddingLeft: '6px',
+                      opacity: line.stream === 'system' ? 0.7 : 1,
+                    }}
+                  >
+                    {line.text}
+                  </div>
+                )
               ))
             )}
           </div>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1246,6 +1246,43 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/task-runs/{task_run_id}/artifact-sessions/{session_id}/control": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Control Task Run Artifact Session */
+        post: operations["control_task_run_artifact_session_api_task_runs__task_run_id__artifact_sessions__session_id__control_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/task-runs/{id}/observability/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Task Run Observability Events
+         * @description Return structured observability history for one task run.
+         */
+        get: operations["get_task_run_observability_events_api_task_runs__id__observability_events_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/task-runs/{id}/logs/stream": {
         parameters: {
             query?: never;
@@ -2174,6 +2211,33 @@ export interface components {
             content_type?: string | null;
             /** Encryption */
             encryption: string;
+        };
+        /**
+         * ArtifactSessionControlRequest
+         * @description Operator control request for one task-scoped artifact session.
+         */
+        ArtifactSessionControlRequest: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "send_follow_up" | "clear_session";
+            /** Message */
+            message?: string | null;
+            /** Reason */
+            reason?: string | null;
+        };
+        /**
+         * ArtifactSessionControlResponse
+         * @description Control response envelope with the refreshed session projection.
+         */
+        ArtifactSessionControlResponse: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "send_follow_up" | "clear_session";
+            projection: components["schemas"]["ArtifactSessionProjectionModel"];
         };
         /**
          * ArtifactSessionGroupModel
@@ -8100,6 +8164,105 @@ export interface operations {
                 content?: never;
             };
             /** @description Session projection not found for this task run */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    control_task_run_artifact_session_api_task_runs__task_run_id__artifact_sessions__session_id__control_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                task_run_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ArtifactSessionControlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactSessionControlResponse"];
+                };
+            };
+            /** @description You do not have permission to access this task run */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session projection not found for this task run */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The managed session cannot accept this control action */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_task_run_observability_events_api_task_runs__id__observability_events_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Observability record not found for this task run */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -590,18 +590,68 @@ class ManagedRunRecord(BaseModel):
                 
         return self
 
+ObservabilityEventKind = Literal[
+    "stdout_chunk",
+    "stderr_chunk",
+    "system_annotation",
+    "session_started",
+    "turn_started",
+    "turn_completed",
+    "turn_interrupted",
+    "session_cleared",
+    "session_reset_boundary",
+    "approval_requested",
+    "approval_resolved",
+    "summary_published",
+    "checkpoint_published",
+]
+
+
 class LiveLogChunk(BaseModel):
     """A single atomic chunk of live log output pushed over the stream."""
 
     model_config = ConfigDict(populate_by_name=True, frozen=True)
 
     sequence: int = Field(..., description="Monotonically increasing sequence number")
-    stream: Literal["stdout", "stderr", "system"] = Field(
+    stream: Literal["stdout", "stderr", "system", "session"] = Field(
         ..., description="Standard output, standard error, or system event log"
     )
     timestamp: str = Field(..., description="ISO-8601 formatted timestamp")
     text: str = Field(..., description="Decoded output text buffer content")
     offset: int | None = Field(None, description="Global byte offset of this chunk")
+    kind: ObservabilityEventKind | None = Field(
+        None,
+        description="Optional structured observability event kind",
+    )
+    session_id: str | None = Field(
+        None,
+        description="Managed-session id when the event is session-scoped",
+    )
+    session_epoch: int | None = Field(
+        None,
+        ge=1,
+        description="Managed-session epoch when the event is session-scoped",
+    )
+    container_id: str | None = Field(
+        None,
+        description="Managed-session container id when available",
+    )
+    thread_id: str | None = Field(
+        None,
+        description="Managed-session logical thread id when available",
+    )
+    turn_id: str | None = Field(
+        None,
+        description="Managed-session turn id when available",
+    )
+    active_turn_id: str | None = Field(
+        None,
+        description="Currently active managed-session turn id when available",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional structured metadata for the event row",
+    )
 
 
 class ProviderCapabilityDescriptor(BaseModel):

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -331,6 +331,7 @@ class CodexManagedSessionRecord(BaseModel):
     latest_checkpoint_ref: str | None = Field(None, alias="latestCheckpointRef")
     latest_control_event_ref: str | None = Field(None, alias="latestControlEventRef")
     latest_reset_boundary_ref: str | None = Field(None, alias="latestResetBoundaryRef")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
     last_log_offset: int | None = Field(None, alias="lastLogOffset", ge=0)
     last_log_at: datetime | None = Field(None, alias="lastLogAt")
     error_message: str | None = Field(None, alias="errorMessage")
@@ -393,6 +394,11 @@ class CodexManagedSessionRecord(BaseModel):
                 self.latest_reset_boundary_ref,
                 field_name="latestResetBoundaryRef",
             )
+        if self.active_turn_id is not None:
+            self.active_turn_id = require_non_blank(
+                self.active_turn_id,
+                field_name="activeTurnId",
+            )
         if self.error_message is not None:
             self.error_message = require_non_blank(
                 self.error_message,
@@ -412,7 +418,7 @@ class CodexManagedSessionRecord(BaseModel):
             sessionEpoch=self.session_epoch,
             containerId=self.container_id,
             threadId=self.thread_id,
-            activeTurnId=None,
+            activeTurnId=self.active_turn_id,
         )
 
     def published_artifact_refs(self) -> tuple[str, ...]:

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -32,10 +32,15 @@ class RuntimeLogStreamer:
         self.publisher = publisher
         self._sequence_counter = 0
         self._annotations_by_run: dict[str, list[dict[str, Any]]] = {}
+        self._observability_events_by_run: dict[str, list[dict[str, Any]]] = {}
 
     def _next_sequence(self) -> int:
         self._sequence_counter += 1
         return self._sequence_counter
+
+    @staticmethod
+    def _current_timestamp() -> str:
+        return datetime.now(timezone.utc).isoformat()
 
     async def stream_to_artifact(
         self,
@@ -92,9 +97,10 @@ class RuntimeLogStreamer:
                     obj = LiveLogChunk(
                         sequence=self._next_sequence(),
                         stream=stream_name,  # type: ignore
-                        timestamp=datetime.now(timezone.utc).isoformat(),
+                        timestamp=self._current_timestamp(),
                         text=text_content,
                         offset=current_offset,
+                        kind=f"{stream_name}_chunk",
                     )
                     live_publisher.publish(obj)
                 except Exception:
@@ -153,31 +159,101 @@ class RuntimeLogStreamer:
             return
 
         sequence = self._next_sequence()
+        timestamp = self._current_timestamp()
         annotation_record = {
             "annotation_type": annotation_type or metadata.get("annotation_type", "system"),
             "text": text,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": timestamp,
             "sequence": sequence,
             "metadata": metadata,
         }
         self._annotations_by_run.setdefault(run_id, []).append(annotation_record)
+        self._observability_events_by_run.setdefault(run_id, []).append(
+            {
+                "sequence": sequence,
+                "timestamp": timestamp,
+                "stream": "system",
+                "text": text,
+                "kind": "system_annotation",
+                "metadata": metadata,
+            }
+        )
 
-        live_publisher = self.publisher
-        if live_publisher is None and workspace_path:
-            live_publisher = SpoolLogPublisher(workspace_path=workspace_path)
-
-        if live_publisher is None:
-            return
-
-        try:
-            obj = LiveLogChunk(
+        self._publish_observability_chunk(
+            workspace_path=workspace_path,
+            chunk=LiveLogChunk(
                 sequence=sequence,
                 stream="system",
-                timestamp=datetime.now(timezone.utc).isoformat(),
+                timestamp=timestamp,
                 text=text,
                 offset=None,
-            )
-            live_publisher.publish(obj)
+                kind="system_annotation",
+                metadata=metadata,
+            ),
+        )
+
+    def emit_observability_event(
+        self,
+        *,
+        run_id: str,
+        workspace_path: str | None,
+        stream: str,
+        text: str,
+        kind: str | None = None,
+        offset: int | None = None,
+        session_id: str | None = None,
+        session_epoch: int | None = None,
+        container_id: str | None = None,
+        thread_id: str | None = None,
+        turn_id: str | None = None,
+        active_turn_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit a structured observability event into the shared live stream."""
+        normalized_text = str(text or "").strip()
+        if not normalized_text:
+            return
+        timestamp = self._current_timestamp()
+        sequence = self._next_sequence()
+        chunk = LiveLogChunk(
+            sequence=sequence,
+            stream=stream,  # type: ignore[arg-type]
+            timestamp=timestamp,
+            text=normalized_text,
+            offset=offset,
+            kind=kind,
+            session_id=session_id,
+            session_epoch=session_epoch,
+            container_id=container_id,
+            thread_id=thread_id,
+            turn_id=turn_id,
+            active_turn_id=active_turn_id,
+            metadata=dict(metadata or {}),
+        )
+        self._observability_events_by_run.setdefault(run_id, []).append(
+            chunk.model_dump(mode="json", exclude_none=True)
+        )
+        self._publish_observability_chunk(
+            workspace_path=workspace_path,
+            chunk=chunk,
+        )
+
+    def _publish_observability_chunk(
+        self,
+        *,
+        workspace_path: str | None,
+        chunk: LiveLogChunk,
+    ) -> None:
+        live_publisher = self.publisher
+        if live_publisher is None and workspace_path:
+            try:
+                live_publisher = SpoolLogPublisher(workspace_path=workspace_path)
+            except Exception:
+                return
+        if live_publisher is None:
+            return
+        try:
+            live_publisher.publish(chunk)
         except Exception:
             # Failures in observability publishing are non-fatal for runtime control.
             return
@@ -186,6 +262,11 @@ class RuntimeLogStreamer:
         """Return and clear persisted in-memory supervisor annotations for a run."""
         annotations = self._annotations_by_run.pop(run_id, None)
         return list(annotations or [])
+
+    def consume_observability_events(self, run_id: str) -> list[dict[str, Any]]:
+        """Return and clear persisted in-memory observability events for a run."""
+        events = self._observability_events_by_run.pop(run_id, None)
+        return list(events or [])
 
     async def stream_and_parse(
         self,
@@ -268,6 +349,7 @@ class RuntimeLogStreamer:
         annotations: list[dict] | None = None,
         parsed_output: ParsedOutput | None = None,
         events: list[dict] | None = None,
+        observability_events: list[dict] | None = None,
     ) -> str:
         """Write a diagnostics JSON bundle and return the storage reference."""
         diagnostics: dict[str, Any] = {
@@ -279,6 +361,8 @@ class RuntimeLogStreamer:
             diagnostics["annotations"] = annotations
         if events is not None:
             diagnostics["events"] = events
+        if observability_events is not None:
+            diagnostics["observability_events"] = observability_events
         if parsed_output is not None:
             diagnostics["parsed_output"] = {
                 "has_structured_output": parsed_output.has_structured_output,

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -33,6 +33,7 @@ class RuntimeLogStreamer:
         self._sequence_counter = 0
         self._annotations_by_run: dict[str, list[dict[str, Any]]] = {}
         self._observability_events_by_run: dict[str, list[dict[str, Any]]] = {}
+        self._spool_publishers_by_workspace: dict[str, SpoolLogPublisher] = {}
 
     def _next_sequence(self) -> int:
         self._sequence_counter += 1
@@ -71,9 +72,7 @@ class RuntimeLogStreamer:
         # Carry-over buffer for incomplete lines when the parser is active.
         _line_buf: str = ""
         current_offset: int = 0
-        live_publisher = self.publisher
-        if live_publisher is None and workspace_path:
-            live_publisher = SpoolLogPublisher(workspace_path=workspace_path)
+        live_publisher = self._resolve_live_publisher(workspace_path)
 
         while True:
             chunk = await reader.read(_STREAM_CHUNK_SIZE)
@@ -168,16 +167,6 @@ class RuntimeLogStreamer:
             "metadata": metadata,
         }
         self._annotations_by_run.setdefault(run_id, []).append(annotation_record)
-        self._observability_events_by_run.setdefault(run_id, []).append(
-            {
-                "sequence": sequence,
-                "timestamp": timestamp,
-                "stream": "system",
-                "text": text,
-                "kind": "system_annotation",
-                "metadata": metadata,
-            }
-        )
 
         self._publish_observability_chunk(
             workspace_path=workspace_path,
@@ -238,18 +227,30 @@ class RuntimeLogStreamer:
             chunk=chunk,
         )
 
+    def _resolve_live_publisher(
+        self,
+        workspace_path: str | None,
+    ) -> Any | None:
+        if self.publisher is not None:
+            return self.publisher
+        if not workspace_path:
+            return None
+        publisher = self._spool_publishers_by_workspace.get(workspace_path)
+        if publisher is None:
+            publisher = SpoolLogPublisher(workspace_path=workspace_path)
+            self._spool_publishers_by_workspace[workspace_path] = publisher
+        return publisher
+
     def _publish_observability_chunk(
         self,
         *,
         workspace_path: str | None,
         chunk: LiveLogChunk,
     ) -> None:
-        live_publisher = self.publisher
-        if live_publisher is None and workspace_path:
-            try:
-                live_publisher = SpoolLogPublisher(workspace_path=workspace_path)
-            except Exception:
-                return
+        try:
+            live_publisher = self._resolve_live_publisher(workspace_path)
+        except Exception:
+            return
         if live_publisher is None:
             return
         try:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -7,6 +7,7 @@ import json
 import os
 import posixpath
 import re
+import inspect
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
@@ -211,6 +212,7 @@ class DockerCodexManagedSessionController:
             taskRunId=request.task_run_id,
             containerId=handle.session_state.container_id,
             threadId=handle.session_state.thread_id,
+            activeTurnId=handle.session_state.active_turn_id,
             runtimeId="codex_cli",
             imageRef=handle.image_ref or request.image_ref,
             controlUrl=handle.control_url or f"docker-exec://{handle.session_state.container_id}",
@@ -358,6 +360,29 @@ class DockerCodexManagedSessionController:
             error_message=None,
         )
 
+    async def _emit_session_event(
+        self,
+        *,
+        record: CodexManagedSessionRecord,
+        text: str,
+        kind: str,
+        turn_id: str | None = None,
+        active_turn_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        if self._session_supervisor is None:
+            return
+        emit_result = self._session_supervisor.emit_session_event(
+            record=record,
+            text=text,
+            kind=kind,
+            turn_id=turn_id,
+            active_turn_id=active_turn_id,
+            metadata=dict(metadata or {}),
+        )
+        if inspect.isawaitable(emit_result):
+            await emit_result
+
     async def _container_exists(self, container_id: str) -> bool:
         returncode, stdout, stderr = await self._command_runner(
             (
@@ -441,6 +466,15 @@ class DockerCodexManagedSessionController:
             self._session_store.save(record)
             if self._session_supervisor is not None:
                 await self._session_supervisor.start(record)
+                await self._emit_session_event(
+                    record=record,
+                    kind="session_started",
+                    text=(
+                        f"Session started. Epoch {record.session_epoch} "
+                        f"thread {record.thread_id}."
+                    ),
+                    metadata={"action": "start_session"},
+                )
         return handle
 
     async def session_status(
@@ -478,10 +512,34 @@ class DockerCodexManagedSessionController:
                 session_epoch=response.session_state.session_epoch,
                 container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
+                active_turn_id=response.session_state.active_turn_id,
                 status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=self._turn_error_message(response),
             )
+            if self._session_supervisor is not None:
+                record = self._session_store.load(request.session_id)
+                if record is not None:
+                    await self._emit_session_event(
+                        record=record,
+                        kind="turn_started",
+                        text=f"Turn started: {response.turn_id}.",
+                        turn_id=response.turn_id,
+                        active_turn_id=response.turn_id,
+                        metadata={"action": "send_turn"},
+                    )
+                    if response.status == "completed":
+                        await self._emit_session_event(
+                            record=record,
+                            kind="turn_completed",
+                            text=f"Turn completed: {response.turn_id}.",
+                            turn_id=response.turn_id,
+                            active_turn_id=record.active_turn_id,
+                            metadata={
+                                "action": "send_turn",
+                                "assistantText": response.metadata.get("assistantText"),
+                            },
+                        )
         return response
 
     async def steer_turn(
@@ -514,10 +572,24 @@ class DockerCodexManagedSessionController:
                 session_epoch=response.session_state.session_epoch,
                 container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
+                active_turn_id=response.session_state.active_turn_id,
                 status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=self._turn_error_message(response),
             )
+            if self._session_supervisor is not None and response.status == "interrupted":
+                record = self._session_store.load(request.session_id)
+                if record is not None:
+                    await self._emit_session_event(
+                        record=record,
+                        kind="turn_interrupted",
+                        text=f"Turn interrupted: {response.turn_id}.",
+                        turn_id=response.turn_id,
+                        metadata={
+                            "action": "interrupt_turn",
+                            "reason": response.metadata.get("reason"),
+                        },
+                    )
         return response
 
     async def clear_session(
@@ -543,6 +615,7 @@ class DockerCodexManagedSessionController:
                 session_epoch=handle.session_state.session_epoch,
                 container_id=handle.session_state.container_id,
                 thread_id=handle.session_state.thread_id,
+                active_turn_id=handle.session_state.active_turn_id,
                 image_ref=handle.image_ref or previous_record.image_ref,
                 control_url=handle.control_url or previous_record.control_url,
                 status=self._record_status_from_handle_status(handle.status),
@@ -580,6 +653,19 @@ class DockerCodexManagedSessionController:
         )
         if self._session_store is not None:
             if self._session_supervisor is not None:
+                record = self._session_store.load(request.session_id)
+                if record is not None:
+                    await self._session_store.update(
+                        request.session_id,
+                        active_turn_id=None,
+                    )
+                    refreshed = self._session_store.load(request.session_id) or record
+                    await self._emit_session_event(
+                        record=refreshed,
+                        kind="system_annotation",
+                        text=f"Session terminated: {request.session_id}.",
+                        metadata={"action": "terminate_session"},
+                    )
                 await self._session_supervisor.finalize(
                     request.session_id,
                     status="terminated",
@@ -588,6 +674,7 @@ class DockerCodexManagedSessionController:
                 await self._session_store.update(
                     request.session_id,
                     status="terminated",
+                    active_turn_id=None,
                     updated_at=datetime.now(tz=UTC),
                 )
         return handle

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -7,7 +7,6 @@ import json
 import os
 import posixpath
 import re
-import inspect
 from datetime import UTC, datetime
 from pathlib import PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
@@ -372,7 +371,7 @@ class DockerCodexManagedSessionController:
     ) -> None:
         if self._session_supervisor is None:
             return
-        emit_result = self._session_supervisor.emit_session_event(
+        self._session_supervisor.emit_session_event(
             record=record,
             text=text,
             kind=kind,
@@ -380,8 +379,6 @@ class DockerCodexManagedSessionController:
             active_turn_id=active_turn_id,
             metadata=dict(metadata or {}),
         )
-        if inspect.isawaitable(emit_result):
-            await emit_result
 
     async def _container_exists(self, container_id: str) -> bool:
         returncode, stdout, stderr = await self._command_runner(

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -170,7 +170,7 @@ class ManagedSessionSupervisor:
             log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
             annotations=[],
             events=[],
-            observability_events=self._log_streamer.consume_observability_events(record.session_id),
+            observability_events=self._log_streamer.consume_observability_events(record.task_run_id),
         )
         summary_ref = self._write_json_artifact(
             job_id=record.session_id,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -62,6 +62,32 @@ class ManagedSessionSupervisor:
                 total += path.stat().st_size
         return total
 
+    def emit_session_event(
+        self,
+        *,
+        record: CodexManagedSessionRecord,
+        text: str,
+        kind: str,
+        turn_id: str | None = None,
+        active_turn_id: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
+        """Publish one session-aware observability row into the run-level stream."""
+        self._log_streamer.emit_observability_event(
+            run_id=record.task_run_id,
+            workspace_path=record.workspace_path,
+            stream="session",
+            text=text,
+            kind=kind,
+            session_id=record.session_id,
+            session_epoch=record.session_epoch,
+            container_id=record.container_id,
+            thread_id=record.thread_id,
+            turn_id=turn_id,
+            active_turn_id=active_turn_id if active_turn_id is not None else record.active_turn_id,
+            metadata=dict(metadata or {}),
+        )
+
     async def _watch(self, session_id: str) -> None:
         stop_event = self._stop_events[session_id]
         while not stop_event.is_set():
@@ -144,6 +170,7 @@ class ManagedSessionSupervisor:
             log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
             annotations=[],
             events=[],
+            observability_events=self._log_streamer.consume_observability_events(record.session_id),
         )
         summary_ref = self._write_json_artifact(
             job_id=record.session_id,
@@ -261,6 +288,40 @@ class ManagedSessionSupervisor:
                 + "\n"
             ).encode("utf-8"),
         )[1]
+        self.emit_session_event(
+            record=record,
+            kind="session_cleared",
+            text=(
+                f"Session cleared. Epoch {previous_record.session_epoch} -> "
+                f"{record.session_epoch}; thread {previous_record.thread_id} -> {record.thread_id}."
+            ),
+            metadata={
+                "action": action,
+                "reason": reason,
+                "previousSessionEpoch": previous_record.session_epoch,
+                "newSessionEpoch": record.session_epoch,
+                "previousThreadId": previous_record.thread_id,
+                "newThreadId": record.thread_id,
+                "controlEventRef": control_ref,
+            },
+        )
+        self.emit_session_event(
+            record=record,
+            kind="session_reset_boundary",
+            text=(
+                f"Epoch boundary reached. Session {record.session_id} is now on "
+                f"epoch {record.session_epoch} thread {record.thread_id}."
+            ),
+            metadata={
+                "action": action,
+                "reason": reason,
+                "previousSessionEpoch": previous_record.session_epoch,
+                "newSessionEpoch": record.session_epoch,
+                "previousThreadId": previous_record.thread_id,
+                "newThreadId": record.thread_id,
+                "resetBoundaryRef": boundary_ref,
+            },
+        )
         return await self._store.update(
             record.session_id,
             latest_control_event_ref=control_ref,

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -481,6 +481,7 @@ class ManagedRunSupervisor:
                 reason="diagnostics",
             )
             annotations = self._log_streamer.consume_annotations(run_id)
+            observability_events = self._log_streamer.consume_observability_events(run_id)
 
             diagnostics_ref = self._log_streamer.collect_diagnostics(
                 run_id=run_id,
@@ -490,6 +491,7 @@ class ManagedRunSupervisor:
                 annotations=annotations,
                 parsed_output=parsed_output,
                 events=events,
+                observability_events=observability_events,
             )
 
             record = self._store.update_status(
@@ -521,6 +523,7 @@ class ManagedRunSupervisor:
             return record
         finally:
             self._log_streamer.consume_annotations(run_id)
+            self._log_streamer.consume_observability_events(run_id)
             self._active_processes.pop(run_id, None)
             self._cleanup_runtime_files(self._cleanup_paths.pop(run_id, ()))
 

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -141,6 +141,30 @@ def test_get_observability_summary_includes_live_stream_fields_for_active_run(
     assert body["liveStreamStatus"] == "available"
 
 
+def test_get_observability_summary_includes_session_snapshot(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_session_record",
+            return_value=_build_session_record(),
+        ):
+            response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    snapshot = response.json()["summary"]["sessionSnapshot"]
+    assert snapshot["sessionId"] == "sess:wf-task-1:codex_cli"
+    assert snapshot["sessionEpoch"] == 2
+    assert snapshot["threadId"] == "thread-2"
+
+
 def test_get_observability_summary_live_stream_ended_for_terminal_run(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -744,6 +768,57 @@ def test_get_task_run_diagnostics_uses_supported_artifact_root_layouts(
 # ---------------------------------------------------------------------------
 
 # Tests removed due to an AnyIO test transport deadlock with fake streaming generators
+
+
+def test_get_task_run_observability_events_reads_structured_spool_history(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    (workspace_path / "live_streams.spool").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "sequence": 10,
+                        "stream": "stdout",
+                        "text": "stdout line\n",
+                        "timestamp": "2026-04-08T00:00:00Z",
+                        "kind": "stdout_chunk",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "sequence": 11,
+                        "stream": "session",
+                        "text": "Epoch boundary reached.",
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "kind": "session_reset_boundary",
+                        "session_id": "sess:wf-task-1:codex_cli",
+                        "session_epoch": 2,
+                        "thread_id": "thread-2",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(workspace_path)
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["truncated"] is False
+    assert [event["sequence"] for event in body["events"]] == [10, 11]
+    assert body["events"][1]["stream"] == "session"
+    assert body["events"][1]["kind"] == "session_reset_boundary"
 
 
 def _build_session_record() -> CodexManagedSessionRecord:

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -13,6 +13,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from api_service.api.routers import task_runs as task_runs_router
 from api_service.api.routers.task_runs import router
 from api_service.api.routers.temporal_artifacts import _get_temporal_artifact_service
 from api_service.auth_providers import get_current_user
@@ -819,6 +820,132 @@ def test_get_task_run_observability_events_reads_structured_spool_history(
     assert [event["sequence"] for event in body["events"]] == [10, 11]
     assert body["events"][1]["stream"] == "session"
     assert body["events"][1]["kind"] == "session_reset_boundary"
+
+
+def test_load_task_run_session_record_uses_targeted_standard_paths(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    managed_sessions = tmp_path / "managed_sessions"
+    managed_sessions.mkdir()
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path))
+
+    older = _build_session_record().model_copy(
+        update={
+            "session_id": "sess:wf-task-1:codex_cli",
+            "updated_at": datetime(2026, 4, 8, 0, 0, tzinfo=UTC),
+        }
+    )
+    newer = _build_session_record().model_copy(
+        update={
+            "session_id": "sess:wf-task-1:codex_cli-2",
+            "updated_at": datetime(2026, 4, 8, 1, 0, tzinfo=UTC),
+        }
+    )
+    (managed_sessions / "sess:wf-task-1:codex_cli.json").write_text(
+        json.dumps(older.model_dump(mode="json", by_alias=True)),
+        encoding="utf-8",
+    )
+    (managed_sessions / "sess:wf-task-1:codex_cli-2.json").write_text(
+        json.dumps(newer.model_dump(mode="json", by_alias=True)),
+        encoding="utf-8",
+    )
+
+    with patch("pathlib.Path.rglob", side_effect=AssertionError("unexpected recursive scan")):
+        record = task_runs_router._load_task_run_session_record("wf-task-1")
+
+    assert record is not None
+    assert record.session_id == "sess:wf-task-1:codex_cli-2"
+
+
+def test_iter_diagnostics_observability_events_dedupes_system_annotations(tmp_path) -> None:
+    diagnostics_path = tmp_path / "diagnostics.json"
+    diagnostics_path.write_text(
+        json.dumps(
+            {
+                "observability_events": [
+                    {
+                        "sequence": 7,
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "stream": "system",
+                        "text": "Session reset",
+                        "kind": "system_annotation",
+                    }
+                ],
+                "annotations": [
+                    {
+                        "sequence": 7,
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "text": "Session reset",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    events = list(task_runs_router._iter_diagnostics_observability_events(diagnostics_path))
+
+    assert len(events) == 1
+    assert events[0]["kind"] == "system_annotation"
+
+
+def test_event_sort_key_uses_timestamp_before_sequence() -> None:
+    later_sequenced = {
+        "sequence": 1,
+        "timestamp": "2026-04-08T00:00:02Z",
+        "stream": "system",
+        "text": "later",
+        "kind": "system_annotation",
+    }
+    earlier_unsequenced = {
+        "sequence": 0,
+        "timestamp": "2026-04-08T00:00:01Z",
+        "stream": "stdout",
+        "text": "earlier",
+        "kind": "stdout_chunk",
+    }
+
+    ordered = sorted(
+        [later_sequenced, earlier_unsequenced],
+        key=task_runs_router._event_sort_key,
+    )
+
+    assert ordered[0]["text"] == "earlier"
+
+
+def test_iter_historical_artifact_events_chunks_large_logs_and_keeps_tail(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+
+    stdout_text = ("A" * 65536) + ("B" * 65536) + ("C" * 65536)
+    (artifacts_root / "run").mkdir()
+    (artifacts_root / "run" / "stdout.log").write_text(stdout_text, encoding="utf-8")
+
+    record = SimpleNamespace(
+        diagnostics_ref=None,
+        stdout_artifact_ref="run/stdout.log",
+        stderr_artifact_ref=None,
+        started_at=datetime(2026, 4, 8, 0, 0, tzinfo=UTC),
+    )
+
+    events = list(
+        task_runs_router._iter_historical_artifact_events(
+            record,
+            None,
+            limit_per_stream=2,
+        )
+    )
+
+    assert len(events) == 2
+    assert all(event["kind"] == "stdout_chunk" for event in events)
+    assert events[0]["offset"] > 0
+    assert events[0]["text"] == "B" * 65536
+    assert events[1]["text"] == "C" * 65536
 
 
 def _build_session_record() -> CodexManagedSessionRecord:

--- a/tests/unit/schemas/test_agent_runtime_models.py
+++ b/tests/unit/schemas/test_agent_runtime_models.py
@@ -305,7 +305,10 @@ def test_build_canonical_result_maps_provider_fields_into_metadata() -> None:
     }
 
 def test_live_log_chunk_requires_valid_stream() -> None:
-    with pytest.raises(ValidationError, match="Input should be 'stdout', 'stderr' or 'system'"):
+    with pytest.raises(
+        ValidationError,
+        match="Input should be 'stdout', 'stderr', 'system' or 'session'",
+    ):
         LiveLogChunk(sequence=1, stream="invalid_stream", text="test\n", timestamp="2026-03-31T00:00:00Z")
 
 def test_live_log_chunk_accepts_valid_data() -> None:

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -318,6 +318,35 @@ async def test_stream_to_artifact_calls_publisher(streamer):
     assert combined_text == "chunk1\nchunk2\n"
 
 
+def test_emit_observability_event_publishes_session_metadata(streamer):
+    log_streamer, _ = streamer
+    mock_publisher = Mock()
+    log_streamer.publisher = mock_publisher
+
+    log_streamer.emit_observability_event(
+        run_id="run-session-event",
+        workspace_path=None,
+        stream="session",
+        text="Session cleared.",
+        kind="session_reset_boundary",
+        session_id="sess-1",
+        session_epoch=2,
+        container_id="ctr-1",
+        thread_id="thread-2",
+        turn_id="turn-7",
+        active_turn_id=None,
+        metadata={"reason": "operator_reset"},
+    )
+
+    published_chunk = mock_publisher.publish.call_args[0][0]
+    assert published_chunk.stream == "session"
+    assert published_chunk.kind == "session_reset_boundary"
+    assert published_chunk.session_id == "sess-1"
+    assert published_chunk.session_epoch == 2
+    assert published_chunk.thread_id == "thread-2"
+    assert published_chunk.metadata["reason"] == "operator_reset"
+
+
 @pytest.mark.asyncio
 async def test_stream_and_parse_uses_one_global_sequence_across_streams(tmp_path):
     from unittest.mock import Mock

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from moonmind.workflows.temporal.runtime import log_streamer as log_streamer_module
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.output_parser import (
     GeminiCliOutputParser,
@@ -345,6 +346,61 @@ def test_emit_observability_event_publishes_session_metadata(streamer):
     assert published_chunk.session_epoch == 2
     assert published_chunk.thread_id == "thread-2"
     assert published_chunk.metadata["reason"] == "operator_reset"
+
+
+def test_emit_system_annotation_keeps_annotations_out_of_observability_events(streamer):
+    log_streamer, _ = streamer
+
+    log_streamer.emit_system_annotation(
+        run_id="run-annotations",
+        workspace_path=None,
+        text="Supervisor started.",
+        annotation_type="run_started",
+    )
+
+    annotations = log_streamer.consume_annotations("run-annotations")
+    observability_events = log_streamer.consume_observability_events("run-annotations")
+
+    assert len(annotations) == 1
+    assert annotations[0]["annotation_type"] == "run_started"
+    assert observability_events == []
+
+
+def test_observability_publish_reuses_one_spool_publisher_per_workspace(
+    streamer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_streamer, _ = streamer
+    created_publishers: list[object] = []
+
+    class _FakePublisher:
+        def __init__(self, workspace_path: str) -> None:
+            self.workspace_path = workspace_path
+            self.published: list[object] = []
+            created_publishers.append(self)
+
+        def publish(self, chunk: object) -> None:
+            self.published.append(chunk)
+
+    monkeypatch.setattr(log_streamer_module, "SpoolLogPublisher", _FakePublisher)
+
+    log_streamer.emit_observability_event(
+        run_id="run-cache",
+        workspace_path="/tmp/workspace",
+        stream="session",
+        text="event one",
+        kind="session_started",
+    )
+    log_streamer.emit_observability_event(
+        run_id="run-cache",
+        workspace_path="/tmp/workspace",
+        stream="session",
+        text="event two",
+        kind="session_started",
+    )
+
+    assert len(created_publishers) == 1
+    assert len(created_publishers[0].published) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -54,6 +54,7 @@ async def test_controller_launches_container_and_returns_typed_handle(
     workspace_root = tmp_path / "agent_jobs"
     session_store = ManagedSessionStore(tmp_path / "session-store")
     session_supervisor = AsyncMock()
+    session_supervisor.emit_session_event = Mock()
     request = LaunchCodexManagedSessionRequest(
         taskRunId="task-1",
         sessionId="sess-1",
@@ -199,6 +200,7 @@ async def test_controller_clear_and_terminate_preserve_container_boundary(
     )
     commands: list[tuple[str, ...]] = []
     session_supervisor = AsyncMock()
+    session_supervisor.emit_session_event = Mock()
 
     async def _publish_reset_artifacts(
         *,

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -131,6 +131,39 @@ async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
+async def test_publish_snapshot_persists_run_keyed_session_events(tmp_path: Path) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    log_streamer = RuntimeLogStreamer(artifact_storage)
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=log_streamer,
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+
+    supervisor.emit_session_event(
+        record=record,
+        text="Session cleared.",
+        kind="session_cleared",
+        metadata={"reason": "operator_reset"},
+    )
+
+    snapshot = await supervisor.publish_snapshot("sess-1")
+    diagnostics_payload = json.loads(
+        artifact_storage.resolve_storage_path(snapshot.diagnostics_ref).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert diagnostics_payload["observability_events"][0]["stream"] == "session"
+    assert diagnostics_payload["observability_events"][0]["kind"] == "session_cleared"
+    assert diagnostics_payload["observability_events"][0]["metadata"]["reason"] == "operator_reset"
+
+
+@pytest.mark.asyncio
 async def test_publish_reset_artifacts_writes_epoch_specific_control_and_boundary_refs(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
This updates managed-run Live Logs from a run-centric line list into a session-aware observability timeline.

## What changed
- Enriched the shared live-log event contract with `kind`, `session_*`, turn, and metadata fields.
- Added run-level session snapshot data to `/api/task-runs/{id}/observability-summary`.
- Added `/api/task-runs/{id}/observability/events` for structured historical timeline retrieval.
- Published Codex managed-session lifecycle events into the same run-wide live stream and surfaced reset boundaries as explicit timeline rows in Mission Control.
- Updated the canonical Live Logs doc and regenerated frontend OpenAPI types.

## Root cause
The existing Live Logs path only modeled merged stdout/stderr/system text, while the Codex managed session plane introduced continuity concepts such as epochs, thread swaps, and reset boundaries that were either invisible or only recoverable from a separate continuity projection.

## Operator impact
Mission Control now shows one continuity-aware live timeline for runtime output plus session lifecycle, and ended runs can reload structured history without reparsing merged text markers.

## Validation
- `./tools/test_unit.sh`
- `npm run ui:typecheck`
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `npm run generate`
