### PR TITLE
[codex] Implement step ledger phase 1

### DIFF
--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1246,6 +1246,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/task-runs/{task_run_id}/artifact-sessions/{session_id}/control": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Control Task Run Artifact Session */
+        post: operations["control_task_run_artifact_session_api_task_runs__task_run_id__artifact_sessions__session_id__control_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/task-runs/{id}/logs/stream": {
         parameters: {
             query?: never;
@@ -2174,6 +2191,33 @@ export interface components {
             content_type?: string | null;
             /** Encryption */
             encryption: string;
+        };
+        /**
+         * ArtifactSessionControlRequest
+         * @description Operator control request for one task-scoped artifact session.
+         */
+        ArtifactSessionControlRequest: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "send_follow_up" | "clear_session";
+            /** Message */
+            message?: string | null;
+            /** Reason */
+            reason?: string | null;
+        };
+        /**
+         * ArtifactSessionControlResponse
+         * @description Control response envelope with the refreshed session projection.
+         */
+        ArtifactSessionControlResponse: {
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "send_follow_up" | "clear_session";
+            projection: components["schemas"]["ArtifactSessionProjectionModel"];
         };
         /**
          * ArtifactSessionGroupModel
@@ -8101,6 +8145,63 @@ export interface operations {
             };
             /** @description Session projection not found for this task run */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    control_task_run_artifact_session_api_task_runs__task_run_id__artifact_sessions__session_id__control_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                task_run_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ArtifactSessionControlRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactSessionControlResponse"];
+                };
+            };
+            /** @description You do not have permission to access this task run */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Session projection not found for this task run */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The managed session cannot accept this control action */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -383,6 +383,107 @@ class ExecutionDependencySummaryModel(BaseModel):
     workflow_type: Optional[str] = Field(None, alias="workflowType")
 
 
+class ExecutionProgressModel(BaseModel):
+    """Bounded latest-run progress summary derived from workflow-owned step state."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    total: int = Field(0, alias="total", ge=0)
+    pending: int = Field(0, alias="pending", ge=0)
+    ready: int = Field(0, alias="ready", ge=0)
+    running: int = Field(0, alias="running", ge=0)
+    awaiting_external: int = Field(0, alias="awaitingExternal", ge=0)
+    reviewing: int = Field(0, alias="reviewing", ge=0)
+    succeeded: int = Field(0, alias="succeeded", ge=0)
+    failed: int = Field(0, alias="failed", ge=0)
+    skipped: int = Field(0, alias="skipped", ge=0)
+    canceled: int = Field(0, alias="canceled", ge=0)
+    current_step_title: str | None = Field(None, alias="currentStepTitle")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+
+class StepLedgerCheckModel(BaseModel):
+    """Structured step-level review or check result."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    kind: str = Field(..., alias="kind", min_length=1)
+    status: str = Field(..., alias="status", min_length=1)
+    summary: str | None = Field(None, alias="summary")
+    retry_count: int = Field(0, alias="retryCount", ge=0)
+    artifact_ref: str | None = Field(None, alias="artifactRef")
+
+
+class StepLedgerRefsModel(BaseModel):
+    """Stable ref slots for child workflow and task-run linkage."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    child_workflow_id: str | None = Field(None, alias="childWorkflowId")
+    child_run_id: str | None = Field(None, alias="childRunId")
+    task_run_id: str | None = Field(None, alias="taskRunId")
+
+
+class StepLedgerArtifactsModel(BaseModel):
+    """Stable semantic artifact slots for step evidence."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    output_summary: str | None = Field(None, alias="outputSummary")
+    output_primary: str | None = Field(None, alias="outputPrimary")
+    runtime_stdout: str | None = Field(None, alias="runtimeStdout")
+    runtime_stderr: str | None = Field(None, alias="runtimeStderr")
+    runtime_merged_logs: str | None = Field(None, alias="runtimeMergedLogs")
+    runtime_diagnostics: str | None = Field(None, alias="runtimeDiagnostics")
+    provider_snapshot: str | None = Field(None, alias="providerSnapshot")
+
+
+class StepLedgerRowModel(BaseModel):
+    """Current/latest attempt state for one logical step in the active run."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    logical_step_id: str = Field(..., alias="logicalStepId", min_length=1)
+    order: int = Field(..., alias="order", ge=1)
+    title: str = Field(..., alias="title", min_length=1)
+    tool: dict[str, Any] = Field(default_factory=dict, alias="tool")
+    depends_on: list[str] = Field(default_factory=list, alias="dependsOn")
+    status: Literal[
+        "pending",
+        "ready",
+        "running",
+        "awaiting_external",
+        "reviewing",
+        "succeeded",
+        "failed",
+        "skipped",
+        "canceled",
+    ] = Field(..., alias="status")
+    waiting_reason: str | None = Field(None, alias="waitingReason")
+    attention_required: bool = Field(False, alias="attentionRequired")
+    attempt: int = Field(0, alias="attempt", ge=0)
+    started_at: datetime | None = Field(None, alias="startedAt")
+    updated_at: datetime = Field(..., alias="updatedAt")
+    summary: str | None = Field(None, alias="summary")
+    checks: list[StepLedgerCheckModel] = Field(default_factory=list, alias="checks")
+    refs: StepLedgerRefsModel = Field(default_factory=StepLedgerRefsModel, alias="refs")
+    artifacts: StepLedgerArtifactsModel = Field(
+        default_factory=StepLedgerArtifactsModel, alias="artifacts"
+    )
+    last_error: str | None = Field(None, alias="lastError")
+
+
+class StepLedgerSnapshotModel(BaseModel):
+    """Latest-run step-ledger query payload."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    workflow_id: str = Field(..., alias="workflowId", min_length=1)
+    run_id: str = Field(..., alias="runId", min_length=1)
+    run_scope: Literal["latest"] = Field("latest", alias="runScope")
+    steps: list[StepLedgerRowModel] = Field(default_factory=list, alias="steps")
+
+
 class ExecutionModel(BaseModel):
     """Materialized execution view returned by lifecycle APIs."""
 

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -1,0 +1,180 @@
+"""Pure helpers for workflow-owned step ledger state."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+ACTIVE_STEP_STATUSES = ("running", "reviewing", "awaiting_external", "ready")
+TERMINAL_STEP_STATUSES = {"succeeded", "failed", "skipped", "canceled"}
+READY_DEPENDENCY_STATUSES = {"succeeded", "skipped"}
+_UNSET = object()
+
+
+def default_step_refs() -> dict[str, Any]:
+    return {
+        "childWorkflowId": None,
+        "childRunId": None,
+        "taskRunId": None,
+    }
+
+
+def default_step_artifacts() -> dict[str, Any]:
+    return {
+        "outputSummary": None,
+        "outputPrimary": None,
+        "runtimeStdout": None,
+        "runtimeStderr": None,
+        "runtimeMergedLogs": None,
+        "runtimeDiagnostics": None,
+        "providerSnapshot": None,
+    }
+
+
+def build_initial_step_rows(
+    *,
+    ordered_nodes: list[dict[str, Any]],
+    dependency_map: dict[str, list[str]],
+    updated_at: datetime,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    updated_at_iso = updated_at.isoformat()
+    for order, node in enumerate(ordered_nodes, start=1):
+        node_id = str(node.get("id") or "").strip()
+        tool = dict(node.get("tool") or node.get("skill") or {})
+        inputs = dict(node.get("inputs") or {})
+        title = (
+            str(node.get("title") or inputs.get("title") or tool.get("name") or node_id)
+            .strip()
+        )
+        depends_on = list(dependency_map.get(node_id) or [])
+        rows.append(
+            {
+                "logicalStepId": node_id,
+                "order": order,
+                "title": title,
+                "tool": {
+                    "type": str(tool.get("type") or tool.get("kind") or "skill"),
+                    "name": str(tool.get("name") or tool.get("id") or ""),
+                    "version": str(tool.get("version") or ""),
+                },
+                "dependsOn": depends_on,
+                "status": "ready" if not depends_on else "pending",
+                "waitingReason": None,
+                "attentionRequired": False,
+                "attempt": 0,
+                "startedAt": None,
+                "updatedAt": updated_at_iso,
+                "summary": None,
+                "checks": [],
+                "refs": default_step_refs(),
+                "artifacts": default_step_artifacts(),
+                "lastError": None,
+            }
+        )
+    return rows
+
+
+def build_step_ledger_snapshot(
+    *,
+    workflow_id: str,
+    run_id: str,
+    rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "workflowId": workflow_id,
+        "runId": run_id,
+        "runScope": "latest",
+        "steps": deepcopy(rows),
+    }
+
+
+def build_progress_summary(
+    rows: list[dict[str, Any]],
+    *,
+    updated_at: datetime,
+) -> dict[str, Any]:
+    counts = {
+        "total": len(rows),
+        "pending": 0,
+        "ready": 0,
+        "running": 0,
+        "awaitingExternal": 0,
+        "reviewing": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "skipped": 0,
+        "canceled": 0,
+    }
+    current_step_title: str | None = None
+    for active_status in ACTIVE_STEP_STATUSES:
+        match = next((row for row in rows if row.get("status") == active_status), None)
+        if match is not None:
+            current_step_title = str(match.get("title") or "").strip() or None
+            break
+
+    for row in rows:
+        status = str(row.get("status") or "").strip()
+        if status == "awaiting_external":
+            counts["awaitingExternal"] += 1
+        elif status in counts:
+            counts[status] += 1
+
+    counts["currentStepTitle"] = current_step_title
+    counts["updatedAt"] = updated_at.isoformat()
+    return counts
+
+
+def update_step_row(
+    rows: list[dict[str, Any]],
+    logical_step_id: str,
+    *,
+    updated_at: datetime,
+    status: str | None = None,
+    summary: str | None | object = _UNSET,
+    waiting_reason: str | None | object = _UNSET,
+    attention_required: bool | None = None,
+    last_error: str | None | object = _UNSET,
+    increment_attempt: bool = False,
+    set_started_at: bool = False,
+) -> dict[str, Any]:
+    for row in rows:
+        if row.get("logicalStepId") != logical_step_id:
+            continue
+        if status is not None:
+            row["status"] = status
+        if increment_attempt:
+            row["attempt"] = int(row.get("attempt") or 0) + 1
+        if set_started_at:
+            row["startedAt"] = updated_at.isoformat()
+        if summary is not _UNSET:
+            row["summary"] = summary
+        if waiting_reason is not _UNSET:
+            row["waitingReason"] = waiting_reason
+        if attention_required is not None:
+            row["attentionRequired"] = attention_required
+        if last_error is not _UNSET:
+            row["lastError"] = last_error
+        if status in TERMINAL_STEP_STATUSES:
+            row["waitingReason"] = None
+            row["attentionRequired"] = False
+        row["updatedAt"] = updated_at.isoformat()
+        return row
+    raise KeyError(f"Unknown logical step id: {logical_step_id}")
+
+
+def refresh_ready_steps(rows: list[dict[str, Any]], *, updated_at: datetime) -> None:
+    statuses = {
+        str(row.get("logicalStepId")): str(row.get("status") or "")
+        for row in rows
+    }
+    for row in rows:
+        if row.get("status") != "pending":
+            continue
+        dependencies = list(row.get("dependsOn") or [])
+        if dependencies and all(
+            statuses.get(dep_id) in READY_DEPENDENCY_STATUSES for dep_id in dependencies
+        ):
+            row["status"] = "ready"
+            row["updatedAt"] = updated_at.isoformat()

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -40,8 +40,11 @@ def build_initial_step_rows(
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     updated_at_iso = updated_at.isoformat()
-    for order, node in enumerate(ordered_nodes, start=1):
+    for node in ordered_nodes:
         node_id = str(node.get("id") or "").strip()
+        if not node_id:
+            continue
+        order = len(rows) + 1
         tool = dict(node.get("tool") or node.get("skill") or {})
         inputs = dict(node.get("inputs") or {})
         title = (

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -39,11 +39,20 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.schemas.temporal_models import (
         DependencyResolvedSignalPayload,
+        ExecutionProgressModel,
+        StepLedgerSnapshotModel,
         normalize_dependency_ids,
     )
 
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
 from moonmind.workflows.skills.skill_registry import parse_skill_registry
+from moonmind.workflows.temporal.step_ledger import (
+    build_initial_step_rows,
+    build_progress_summary,
+    build_step_ledger_snapshot,
+    refresh_ready_steps,
+    update_step_row,
+)
 from moonmind.workflows.temporal.activity_catalog import (
     ARTIFACTS_TASK_QUEUE,
     INTEGRATIONS_TASK_QUEUE,
@@ -208,6 +217,7 @@ class MoonMindRunWorkflow:
         self._last_step_id: Optional[str] = None
         self._last_step_summary: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
+        self._active_step_id: Optional[str] = None
         self._declared_dependencies: list[str] = []
         self._dependency_wait_occurred: bool = False
         self._dependency_wait_duration_ms: int = 0
@@ -262,6 +272,21 @@ class MoonMindRunWorkflow:
         self._active_agent_id: Optional[str] = None
         self._codex_session_handle: Any | None = None
         self._codex_session_binding: CodexManagedSessionBinding | None = None
+        self._step_ledger_rows: list[dict[str, Any]] = []
+        self._progress_snapshot: dict[str, Any] = {
+            "total": 0,
+            "pending": 0,
+            "ready": 0,
+            "running": 0,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": None,
+            "updatedAt": "1970-01-01T00:00:00+00:00",
+        }
 
     def _retry_policy_for_route(self, route: TemporalActivityRoute) -> RetryPolicy:
         return RetryPolicy(
@@ -435,6 +460,115 @@ class MoonMindRunWorkflow:
                 "plan edges contain at least one cycle; execution order is undefined"
             )
         return [payload_by_id[node_id] for node_id in ordered_node_ids]
+
+    def _plan_dependency_map(
+        self,
+        *,
+        ordered_nodes: list[dict[str, Any]],
+        edges: tuple[Any, ...],
+    ) -> dict[str, list[str]]:
+        dependency_map = {
+            str(node.get("id") or "").strip(): []
+            for node in ordered_nodes
+            if str(node.get("id") or "").strip()
+        }
+        for edge in edges:
+            from_node = str(getattr(edge, "from_node", "") or "").strip()
+            to_node = str(getattr(edge, "to_node", "") or "").strip()
+            if to_node in dependency_map and from_node:
+                dependency_map[to_node].append(from_node)
+        return dependency_map
+
+    def _sync_progress_snapshot(self, *, updated_at: datetime) -> None:
+        self._progress_snapshot = build_progress_summary(
+            self._step_ledger_rows,
+            updated_at=updated_at,
+        )
+
+    def _initialize_step_ledger(
+        self,
+        *,
+        ordered_nodes: list[dict[str, Any]],
+        dependency_map: dict[str, list[str]],
+        updated_at: datetime,
+    ) -> None:
+        self._step_ledger_rows = build_initial_step_rows(
+            ordered_nodes=ordered_nodes,
+            dependency_map=dependency_map,
+            updated_at=updated_at,
+        )
+        self._sync_progress_snapshot(updated_at=updated_at)
+
+    def _mark_step_running(
+        self,
+        logical_step_id: str,
+        *,
+        updated_at: datetime,
+        summary: str | None = None,
+    ) -> None:
+        self._active_step_id = logical_step_id
+        update_step_row(
+            self._step_ledger_rows,
+            logical_step_id,
+            updated_at=updated_at,
+            status="running",
+            summary=summary,
+            waiting_reason=None,
+            attention_required=False,
+            increment_attempt=True,
+            set_started_at=True,
+        )
+        self._sync_progress_snapshot(updated_at=updated_at)
+
+    def _mark_step_waiting(
+        self,
+        logical_step_id: str,
+        *,
+        status: str,
+        updated_at: datetime,
+        waiting_reason: str | None,
+        summary: str | None = None,
+        attention_required: bool = False,
+    ) -> None:
+        update_step_row(
+            self._step_ledger_rows,
+            logical_step_id,
+            updated_at=updated_at,
+            status=status,
+            summary=summary,
+            waiting_reason=waiting_reason,
+            attention_required=attention_required,
+        )
+        self._sync_progress_snapshot(updated_at=updated_at)
+
+    def _mark_step_terminal(
+        self,
+        logical_step_id: str,
+        *,
+        status: str,
+        updated_at: datetime,
+        summary: str | None = None,
+        last_error: str | None | object = None,
+    ) -> None:
+        update_kwargs: dict[str, Any] = {
+            "updated_at": updated_at,
+            "status": status,
+            "summary": summary,
+        }
+        if last_error is not None:
+            update_kwargs["last_error"] = last_error
+        update_step_row(
+            self._step_ledger_rows,
+            logical_step_id,
+            **update_kwargs,
+        )
+        if self._active_step_id == logical_step_id:
+            self._active_step_id = None
+        self._sync_progress_snapshot(updated_at=updated_at)
+
+    def _refresh_step_readiness(self, *, updated_at: datetime) -> None:
+        refresh_ready_steps(self._step_ledger_rows, updated_at=updated_at)
+        self._sync_progress_snapshot(updated_at=updated_at)
 
     def _dependency_ids_from_parameters(self, parameters: Mapping[str, Any]) -> list[str]:
         task_payload = parameters.get("task")
@@ -1159,6 +1293,15 @@ class MoonMindRunWorkflow:
             ordered_nodes = await self._bundle_ordered_nodes_for_execution(
                 ordered_nodes
             )
+        dependency_map = self._plan_dependency_map(
+            ordered_nodes=ordered_nodes,
+            edges=plan_definition.edges,
+        )
+        self._initialize_step_ledger(
+            ordered_nodes=ordered_nodes,
+            dependency_map=dependency_map,
+            updated_at=workflow.now(),
+        )
 
         registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         failure_mode = plan_definition.policy.failure_mode
@@ -1227,6 +1370,12 @@ class MoonMindRunWorkflow:
                 f"Executing plan step {index}/{len(ordered_nodes)}: {tool_name}"
             )
             self._update_memo()
+            self._refresh_step_readiness(updated_at=workflow.now())
+            self._mark_step_running(
+                node_id,
+                updated_at=workflow.now(),
+                summary=self._summary,
+            )
 
             system_retries = 0
             while system_retries <= 3:
@@ -1249,6 +1398,13 @@ class MoonMindRunWorkflow:
                             )
                         self._active_agent_child_workflow_id = child_workflow_id
                         self._active_agent_id = request.agent_id
+                        self._mark_step_waiting(
+                            node_id,
+                            status="awaiting_external",
+                            updated_at=workflow.now(),
+                            waiting_reason="Awaiting child workflow progress",
+                            summary=f"Awaiting child workflow for {tool_name}",
+                        )
                         try:
                             child_result = await workflow.execute_child_workflow(
                                 "MoonMind.AgentRun",
@@ -1261,6 +1417,13 @@ class MoonMindRunWorkflow:
                             self._active_agent_id = None
                         execution_result = self._map_agent_run_result(child_result)
                     except Exception:
+                        self._mark_step_terminal(
+                            node_id,
+                            status="failed",
+                            updated_at=workflow.now(),
+                            summary=f"{tool_name} failed",
+                            last_error="execution_error",
+                        )
                         if failure_mode == "FAIL_FAST":
                             raise
                         result_status = "FAILED"
@@ -1328,6 +1491,13 @@ class MoonMindRunWorkflow:
                             **self._execute_kwargs_for_route(route),
                         )
                     except Exception:
+                        self._mark_step_terminal(
+                            node_id,
+                            status="failed",
+                            updated_at=workflow.now(),
+                            summary=f"{tool_name} failed",
+                            last_error="execution_error",
+                        )
                         if failure_mode == "FAIL_FAST":
                             raise
                         result_status = "FAILED"
@@ -1356,13 +1526,32 @@ class MoonMindRunWorkflow:
                         and tool_type == "agent_runtime"
                     )
                     if retryable and system_retries < 3:
+                        self._mark_step_terminal(
+                            node_id,
+                            status="failed",
+                            updated_at=workflow.now(),
+                            summary=f"{tool_name} failed",
+                            last_error=failure_message,
+                        )
                         system_retries += 1
                         self._get_logger().info(
                             f"Retrying plan node {node_id} after {failure_message} "
                             f"(attempt {system_retries} of 3)"
                         )
+                        self._mark_step_running(
+                            node_id,
+                            updated_at=workflow.now(),
+                            summary=self._summary,
+                        )
                         continue
 
+                    self._mark_step_terminal(
+                        node_id,
+                        status="failed",
+                        updated_at=workflow.now(),
+                        summary=f"{tool_name} failed",
+                        last_error=failure_message,
+                    )
                     if failure_mode == "FAIL_FAST":
                         detail = (
                             f" with error '{failure_message}'"
@@ -1379,6 +1568,15 @@ class MoonMindRunWorkflow:
             if result_status is None or result_status != "COMPLETED":
                 continue
 
+            self._mark_step_terminal(
+                node_id,
+                status="succeeded",
+                updated_at=workflow.now(),
+                summary=self._get_from_result(execution_result, "summary")
+                or self._summary,
+                last_error=None,
+            )
+            self._refresh_step_readiness(updated_at=workflow.now())
             self._record_execution_context(
                 node_id=node_id,
                 execution_result=execution_result,
@@ -3434,3 +3632,22 @@ class MoonMindRunWorkflow:
             "awaiting_external": self._awaiting_external,
             "waiting_reason": self._waiting_reason,
         }
+
+    @workflow.query
+    def get_progress(self) -> dict[str, Any]:
+        return ExecutionProgressModel.model_validate(self._progress_snapshot).model_dump(
+            by_alias=True,
+            mode="json",
+        )
+
+    @workflow.query
+    def get_step_ledger(self) -> dict[str, Any]:
+        snapshot = build_step_ledger_snapshot(
+            workflow_id=workflow.info().workflow_id,
+            run_id=workflow.info().run_id,
+            rows=self._step_ledger_rows,
+        )
+        return StepLedgerSnapshotModel.model_validate(snapshot).model_dump(
+            by_alias=True,
+            mode="json",
+        )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -76,6 +76,7 @@ DEFAULT_ACTIVITY_RETRY_POLICY = RetryPolicy(
     maximum_attempts=5,
 )
 DEPENDENCY_RECONCILE_INTERVAL = timedelta(seconds=30)
+_TERMINAL_LAST_ERROR_UNSET = object()
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
 
@@ -217,7 +218,6 @@ class MoonMindRunWorkflow:
         self._last_step_id: Optional[str] = None
         self._last_step_summary: Optional[str] = None
         self._last_diagnostics_ref: Optional[str] = None
-        self._active_step_id: Optional[str] = None
         self._declared_dependencies: list[str] = []
         self._dependency_wait_occurred: bool = False
         self._dependency_wait_duration_ms: int = 0
@@ -468,16 +468,78 @@ class MoonMindRunWorkflow:
         edges: tuple[Any, ...],
     ) -> dict[str, list[str]]:
         dependency_map = {
-            str(node.get("id") or "").strip(): []
+            str(node.get("id") or "").strip(): set()
             for node in ordered_nodes
             if str(node.get("id") or "").strip()
         }
+        bundle_id_by_member_id: dict[str, str] = {}
+        for node in ordered_nodes:
+            node_id = str(node.get("id") or "").strip()
+            if not node_id:
+                continue
+            node_inputs = node.get("inputs")
+            candidates: list[Any] = [
+                node.get("bundledNodeIds"),
+                node.get("bundled_node_ids"),
+            ]
+            if isinstance(node_inputs, Mapping):
+                candidates.extend(
+                    [
+                        node_inputs.get("bundledNodeIds"),
+                        node_inputs.get("bundled_node_ids"),
+                        node_inputs.get("bundleNodeIds"),
+                        node_inputs.get("bundle_node_ids"),
+                    ]
+                )
+            for candidate in candidates:
+                if not isinstance(candidate, (list, tuple, set)):
+                    continue
+                for member_id in candidate:
+                    normalized_member_id = str(member_id or "").strip()
+                    if normalized_member_id and normalized_member_id != node_id:
+                        bundle_id_by_member_id[normalized_member_id] = node_id
         for edge in edges:
             from_node = str(getattr(edge, "from_node", "") or "").strip()
             to_node = str(getattr(edge, "to_node", "") or "").strip()
-            if to_node in dependency_map and from_node:
-                dependency_map[to_node].append(from_node)
-        return dependency_map
+            if not from_node or not to_node:
+                continue
+            mapped_from_node = bundle_id_by_member_id.get(from_node, from_node)
+            mapped_to_node = bundle_id_by_member_id.get(to_node, to_node)
+            if mapped_from_node == mapped_to_node:
+                continue
+            if (
+                mapped_to_node not in dependency_map
+                or mapped_from_node not in dependency_map
+            ):
+                continue
+            dependency_map[mapped_to_node].add(mapped_from_node)
+        return {
+            node_id: sorted(dependencies)
+            for node_id, dependencies in dependency_map.items()
+        }
+
+    def _try_update_step_row(
+        self,
+        logical_step_id: str,
+        **update_kwargs: Any,
+    ) -> bool:
+        try:
+            update_step_row(
+                self._step_ledger_rows,
+                logical_step_id,
+                **update_kwargs,
+            )
+        except KeyError:
+            self._get_logger().warning(
+                "Skipping step-ledger update for unknown logical step id %s",
+                logical_step_id,
+                extra={
+                    "event": "step_ledger_unknown_step",
+                    "logical_step_id": logical_step_id,
+                },
+            )
+            return False
+        return True
 
     def _sync_progress_snapshot(self, *, updated_at: datetime) -> None:
         self._progress_snapshot = build_progress_summary(
@@ -506,9 +568,7 @@ class MoonMindRunWorkflow:
         updated_at: datetime,
         summary: str | None = None,
     ) -> None:
-        self._active_step_id = logical_step_id
-        update_step_row(
-            self._step_ledger_rows,
+        if not self._try_update_step_row(
             logical_step_id,
             updated_at=updated_at,
             status="running",
@@ -517,7 +577,8 @@ class MoonMindRunWorkflow:
             attention_required=False,
             increment_attempt=True,
             set_started_at=True,
-        )
+        ):
+            return
         self._sync_progress_snapshot(updated_at=updated_at)
 
     def _mark_step_waiting(
@@ -530,15 +591,15 @@ class MoonMindRunWorkflow:
         summary: str | None = None,
         attention_required: bool = False,
     ) -> None:
-        update_step_row(
-            self._step_ledger_rows,
+        if not self._try_update_step_row(
             logical_step_id,
             updated_at=updated_at,
             status=status,
             summary=summary,
             waiting_reason=waiting_reason,
             attention_required=attention_required,
-        )
+        ):
+            return
         self._sync_progress_snapshot(updated_at=updated_at)
 
     def _mark_step_terminal(
@@ -548,22 +609,20 @@ class MoonMindRunWorkflow:
         status: str,
         updated_at: datetime,
         summary: str | None = None,
-        last_error: str | None | object = None,
+        last_error: str | None | object = _TERMINAL_LAST_ERROR_UNSET,
     ) -> None:
         update_kwargs: dict[str, Any] = {
             "updated_at": updated_at,
             "status": status,
             "summary": summary,
         }
-        if last_error is not None:
+        if last_error is not _TERMINAL_LAST_ERROR_UNSET:
             update_kwargs["last_error"] = last_error
-        update_step_row(
-            self._step_ledger_rows,
+        if not self._try_update_step_row(
             logical_step_id,
             **update_kwargs,
-        )
-        if self._active_step_id == logical_step_id:
-            self._active_step_id = None
+        ):
+            return
         self._sync_progress_snapshot(updated_at=updated_at)
 
     def _refresh_step_readiness(self, *, updated_at: datetime) -> None:

--- a/specs/137-step-ledger-phase1/checklists/requirements.md
+++ b/specs/137-step-ledger-phase1/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Step Ledger Phase 1
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-07  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent is explicit: the feature requires workflow/runtime code changes plus validation tests, while API/UI rollout is deferred to later phases.

--- a/specs/137-step-ledger-phase1/contracts/requirements-traceability.md
+++ b/specs/137-step-ledger-phase1/contracts/requirements-traceability.md
@@ -1,0 +1,17 @@
+# Requirements Traceability: Step Ledger Phase 1
+
+| Requirement ID | Maps To FRs | Planned Implementation Surface | Validation Strategy |
+| --- | --- | --- | --- |
+| DOC-REQ-001 | FR-002 | Initialize ledger rows from `parse_plan_definition()` output in `moonmind/workflows/temporal/workflows/run.py` with helper support in `moonmind/workflows/temporal/step_ledger.py` | Unit tests assert plan-node metadata populates `logicalStepId`, `title`, `tool`, and dependencies |
+| DOC-REQ-002 | FR-002, FR-003 | Add workflow-owned ledger state to `MoonMind.Run` using `moonmind/workflows/temporal/step_ledger.py` | Workflow-boundary tests assert state transitions and query output |
+| DOC-REQ-003 | FR-006 | Keep only bounded refs/placeholders in workflow state and avoid storing logs/diagnostics bodies | Unit tests verify artifact slots/ref fields are scalar refs/defaults only |
+| DOC-REQ-004 | FR-005 | Query responses include stable `workflowId`, active `runId`, and `runScope: "latest"` | Workflow query tests assert latest-run semantics during execution and after completion |
+| DOC-REQ-005 | FR-001, FR-005 | Add canonical bounded progress model to `moonmind/schemas/temporal_models.py` and workflow reducer | Golden fixture tests plus workflow progress query coverage |
+| DOC-REQ-006 | FR-001, FR-005 | Add canonical step-ledger snapshot/row models and workflow query payloads | Golden fixture tests plus workflow query coverage |
+| DOC-REQ-007 | FR-001, FR-006, FR-008 | Freeze row field set including checks/refs/artifacts placeholders | Schema validation tests for representative row fixtures |
+| DOC-REQ-008 | FR-001, FR-003 | Encode canonical status vocabulary in schema/helper layer and workflow transitions | Transition tests cover each required status |
+| DOC-REQ-009 | FR-001, FR-008 | Keep `checks[]` as a structured field on rows even when empty/default | Schema fixture tests assert `checks` presence and shape |
+| DOC-REQ-010 | FR-004 | Track attempts in workflow state keyed by logical step and current run | Retry-oriented workflow tests assert attempt increments without cross-run merge |
+| DOC-REQ-011 | FR-007 | Restrict Memo/Search Attribute writes to compact summary data in `run.py` | Tests assert no full rows/attempts/checks are mirrored |
+| DOC-REQ-012 | FR-003, FR-009 | Add workflow lifecycle transition coverage for ready/running/waiting/reviewing/terminal states | Workflow-boundary tests cover the full transition matrix |
+| DOC-REQ-013 | FR-001 | Freeze bounded progress and ledger contract now so later API routes can reuse it | Golden fixture tests and schema model validation |

--- a/specs/137-step-ledger-phase1/contracts/step-ledger-query-contract.md
+++ b/specs/137-step-ledger-phase1/contracts/step-ledger-query-contract.md
@@ -1,0 +1,78 @@
+# Step Ledger Query Contract
+
+## Progress Query
+
+Representative payload:
+
+```json
+{
+  "total": 6,
+  "pending": 2,
+  "ready": 0,
+  "running": 1,
+  "awaitingExternal": 0,
+  "reviewing": 0,
+  "succeeded": 3,
+  "failed": 0,
+  "skipped": 0,
+  "canceled": 0,
+  "currentStepTitle": "Run test suite",
+  "updatedAt": "2026-04-04T18:11:15Z"
+}
+```
+
+## Step Ledger Query
+
+Representative payload:
+
+```json
+{
+  "workflowId": "wf_123",
+  "runId": "run_456",
+  "runScope": "latest",
+  "steps": [
+    {
+      "logicalStepId": "run-tests",
+      "order": 4,
+      "title": "Run test suite",
+      "tool": {
+        "type": "skill",
+        "name": "repo.run_tests",
+        "version": "1"
+      },
+      "dependsOn": ["apply-patch"],
+      "status": "running",
+      "waitingReason": null,
+      "attentionRequired": false,
+      "attempt": 1,
+      "startedAt": "2026-04-04T18:10:00Z",
+      "updatedAt": "2026-04-04T18:11:15Z",
+      "summary": "Executing tests in sandbox",
+      "checks": [],
+      "refs": {
+        "childWorkflowId": null,
+        "childRunId": null,
+        "taskRunId": null
+      },
+      "artifacts": {
+        "outputSummary": null,
+        "outputPrimary": null,
+        "runtimeStdout": null,
+        "runtimeStderr": null,
+        "runtimeMergedLogs": null,
+        "runtimeDiagnostics": null,
+        "providerSnapshot": null
+      },
+      "lastError": null
+    }
+  ]
+}
+```
+
+## Invariants
+
+- `runScope` is `"latest"` for v1.
+- Rows are ordered by resolved plan order.
+- Field names and status values are frozen in this phase and may be consumed unchanged by later API/UI work.
+- `checks`, `refs`, and `artifacts` are always present even when empty/default.
+- Query payloads remain bounded and do not inline large evidence bodies.

--- a/specs/137-step-ledger-phase1/data-model.md
+++ b/specs/137-step-ledger-phase1/data-model.md
@@ -1,0 +1,114 @@
+# Data Model: Step Ledger Phase 1
+
+## ExecutionProgress
+
+Represents the bounded execution-level progress snapshot surfaced by workflow queries now and by execution detail later.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `total` | int | Total planned logical steps for the active run |
+| `pending` | int | Steps planned but not yet ready |
+| `ready` | int | Steps eligible for dispatch |
+| `running` | int | Steps actively executing |
+| `awaitingExternal` | int | Steps waiting on external/runtime progress |
+| `reviewing` | int | Steps in structured review/check processing |
+| `succeeded` | int | Terminal succeeded count |
+| `failed` | int | Terminal failed count |
+| `skipped` | int | Terminal skipped count |
+| `canceled` | int | Terminal canceled count |
+| `currentStepTitle` | string or null | Operator-facing title of the most relevant active step |
+| `updatedAt` | datetime | Last meaningful user-visible ledger mutation |
+
+Rules:
+
+- Derived entirely from compact workflow state.
+- No artifact reads are required.
+- Counts must always sum to `total`.
+
+## StepLedgerSnapshot
+
+Latest-run query response for `MoonMind.Run`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `workflowId` | string | Stable logical task identity |
+| `runId` | string | Current/latest Temporal run ID |
+| `runScope` | string | Fixed to `"latest"` in v1 |
+| `steps` | list[`StepLedgerRow`] | Ordered step rows for the active/latest run |
+
+## StepLedgerRow
+
+Compact current/latest attempt view for one logical step in the active run.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `logicalStepId` | string | Stable plan-node identifier |
+| `order` | int | Stable display order |
+| `title` | string | Operator-facing step title |
+| `tool` | object | Display-safe tool descriptor |
+| `dependsOn` | list[string] | Upstream logical step IDs |
+| `status` | enum | One of the canonical v1 statuses |
+| `waitingReason` | string or null | Bounded blocked-state reason |
+| `attentionRequired` | bool | Whether operator action is currently needed |
+| `attempt` | int | Current/latest attempt number for this run |
+| `startedAt` | datetime or null | Start time for the current attempt |
+| `updatedAt` | datetime | Last meaningful step mutation |
+| `summary` | string or null | Short bounded operator summary |
+| `checks` | list[`StepCheck`] | Structured check rows |
+| `refs` | `StepRefs` | Child-workflow and task-run refs |
+| `artifacts` | `StepArtifactSlots` | Semantic artifact refs |
+| `lastError` | string or null | Bounded latest error summary |
+
+Rules:
+
+- Rows are keyed by `(workflowId, runId, logicalStepId)`; the active attempt number disambiguates retries.
+- `summary` and `lastError` are bounded display strings only.
+- Default empty/default values are returned for `checks`, `refs`, and `artifacts`.
+
+## StepCheck
+
+Structured per-step check or review state.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `kind` | string | Check producer identifier |
+| `status` | string | `pending`, `passed`, `failed`, or future bounded statuses |
+| `summary` | string or null | Short display summary |
+| `retryCount` | int | Count of retries triggered by the check |
+| `artifactRef` | string or null | External evidence reference |
+
+## StepRefs
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `childWorkflowId` | string or null | Child workflow ID when relevant |
+| `childRunId` | string or null | Child run ID when relevant |
+| `taskRunId` | string or null | Managed/runtime observability ID when relevant |
+
+## StepArtifactSlots
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `outputSummary` | string or null | Ref for summary evidence |
+| `outputPrimary` | string or null | Ref for primary output |
+| `runtimeStdout` | string or null | Ref for stdout artifact |
+| `runtimeStderr` | string or null | Ref for stderr artifact |
+| `runtimeMergedLogs` | string or null | Ref for merged logs |
+| `runtimeDiagnostics` | string or null | Ref for diagnostics bundle |
+| `providerSnapshot` | string or null | Ref for provider payload snapshot |
+
+## Transition Rules
+
+- Initial state after plan resolution:
+  - Dependency-free nodes become `ready`.
+  - Dependent nodes remain `pending`.
+- Dispatch transition:
+  - `ready -> running`
+  - increment attempt if this is a retry
+  - set `startedAt` and refresh `updatedAt`
+- Waiting transitions:
+  - `running -> awaiting_external`
+  - `running -> reviewing`
+- Terminal transitions:
+  - `running|awaiting_external|reviewing -> succeeded|failed|skipped|canceled`
+- A successful upstream completion may transition downstream steps from `pending -> ready`.

--- a/specs/137-step-ledger-phase1/plan.md
+++ b/specs/137-step-ledger-phase1/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Step Ledger Phase 1
+
+**Branch**: `137-step-ledger-phase1` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/137-step-ledger-phase1/spec.md`
+
+## Summary
+
+Implement Phases 0 and 1 of the step-ledger rollout by freezing the v1 step-ledger/progress contract and moving live per-step state ownership into `MoonMind.Run`. The workflow will initialize compact ledger rows from resolved plan metadata, maintain deterministic state transitions and run-scoped attempts during execution, expose query-safe latest-run ledger/progress snapshots, and keep Memo/Search Attribute mirrors compact.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Temporal Python SDK, Pydantic v2, existing MoonMind workflow/plan contracts  
+**Storage**: Temporal workflow state for compact ledger/progress; existing artifacts for large evidence; Memo/Search Attributes for compact execution summary only  
+**Testing**: `pytest` via `./tools/test_unit.sh`; targeted workflow-boundary unit tests; existing Temporal integration workflow tests where useful  
+**Target Platform**: Linux server workers running MoonMind Temporal workflows  
+**Project Type**: Backend workflow/runtime implementation  
+**Performance Goals**: Ledger/progress queries remain bounded and cheap for normal polling; no artifact hydration required for progress reads  
+**Constraints**: Preserve workflow determinism and replay safety; keep large logs/diagnostics out of workflow state; do not ship Phase 2+ API/UI work in this change  
+**Scale/Scope**: Phase 0 contract freeze and Phase 1 workflow-owned ledger only; no `/api/executions/{workflowId}/steps` route or Mission Control steps UI yet
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. This change strengthens orchestration state in `MoonMind.Run` without adding provider-specific behavior.
+- **IV. Own Your Data**: PASS. Large logs and diagnostics remain in artifacts or task-run observability; the workflow stores only compact refs and summaries.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The phase is contract-first and pushes UI/API consumers to stable workflow/query contracts rather than ad hoc status strings.
+- **IX. Resilient by Default**: PASS. Deterministic workflow-owned state plus boundary tests improve replay safety and unattended execution visibility.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Scope is explicitly limited to Phases 0 and 1 and captured in the spec, plan, tasks, and traceability docs.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical semantics remain in `docs/Temporal/StepLedgerAndProgressModel.md`; rollout-only work stays scoped here and in remaining-work trackers.
+- **XIII. Pre-Release Delete, Don't Deprecate**: PASS. The phase adds the new canonical ledger model directly without introducing compatibility aliases for superseded internal state shapes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/137-step-ledger-phase1/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── requirements-traceability.md
+│   └── step-ledger-query-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/schemas/temporal_models.py                         # MODIFY: progress + ledger/query contract models
+moonmind/workflows/temporal/step_ledger.py                  # NEW: pure ledger/progress state helpers
+moonmind/workflows/temporal/workflows/run.py                # MODIFY: initialize/update/query ledger state
+tests/unit/workflows/temporal/test_step_ledger.py           # NEW: ledger state/reducer contract tests
+tests/unit/workflows/temporal/workflows/test_run_step_ledger.py  # NEW: workflow-owned ledger lifecycle/query tests
+tests/unit/api/routers/test_executions.py                   # MODIFY: progress model serialization coverage only if schema wiring changes
+tests/integration/workflows/temporal/workflows/test_run.py  # MODIFY: latest-run query availability where targeted integration coverage adds value
+```
+
+**Structure Decision**: Keep pure ledger/progress state logic in a dedicated backend helper module so `MoonMind.Run` stays orchestration-focused. Keep externally consumable schema contracts in `moonmind/schemas/temporal_models.py` so later API phases can reuse the same models unchanged.
+
+## Complexity Tracking
+
+No constitution violations currently require mitigation. The only elevated risk is workflow contract compatibility for in-flight runs; mitigation is boundary-level coverage around query payload shapes and internal defaults rather than introducing compatibility aliases.

--- a/specs/137-step-ledger-phase1/quickstart.md
+++ b/specs/137-step-ledger-phase1/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Step Ledger Phase 1
+
+## Goal
+
+Validate the phase-0 contract freeze and the phase-1 workflow-owned ledger implementation before any API or UI work ships.
+
+## Commands
+
+1. Run targeted ledger unit tests during TDD:
+
+```bash
+pytest tests/unit/workflows/temporal/test_step_ledger.py -q
+pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q
+```
+
+2. Run the full required unit suite for final verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Expected Behaviors
+
+- Contract fixture tests pass for progress and representative step rows.
+- Workflow-boundary tests cover plan resolved, ready, started, waiting, reviewing, succeeded, failed, skipped, and canceled transitions.
+- Query tests return latest-run ledger/progress during execution and after completion.
+- No test depends on full logs or diagnostics being stored in workflow state.

--- a/specs/137-step-ledger-phase1/research.md
+++ b/specs/137-step-ledger-phase1/research.md
@@ -1,0 +1,39 @@
+# Research: Step Ledger Phase 1
+
+## Decision 1: Keep step ledger state in a workflow-local pure helper module
+
+- **Decision**: Introduce a pure Python helper module dedicated to compact step-ledger state, transitions, and progress reduction, then have `MoonMind.Run` call it.
+- **Rationale**: The existing workflow currently spreads coarse summary state across `_summary`, `_waiting_reason`, `_attention_required`, and `_step_count`. A pure helper isolates bounded state rules from workflow dispatch logic and makes TDD practical without starting Temporal.
+- **Alternatives considered**:
+  - Store the ledger directly as ad hoc dict mutations inside `run.py`: rejected because the state machine would become harder to validate and reason about.
+  - Add full ledger models only in API/router code: rejected because the workflow must own truth before any API phase.
+
+## Decision 2: Use workflow queries for ledger and progress reads
+
+- **Decision**: Expose latest-run progress and step-ledger state through workflow queries and keep those queries readable after workflow completion.
+- **Rationale**: Queries do not add event-history noise and align with the canonical design in `docs/Temporal/StepLedgerAndProgressModel.md`.
+- **Alternatives considered**:
+  - Use Memo/Search Attributes as the source of truth: rejected because they are intentionally bounded and lossy.
+  - Materialize a projection first: rejected for this phase because workflow-owned truth is the primary deliverable.
+
+## Decision 3: Mirror only compact operator-visible summary data into Memo/Search Attributes
+
+- **Decision**: Continue using Memo/Search Attributes for compact summary state only, and do not embed step rows, attempts, or checks there.
+- **Rationale**: This preserves current operational surfaces while keeping Temporal payload budgets healthy and aligns with the normative doc.
+- **Alternatives considered**:
+  - Store the full ledger in Memo for easy UI reads: rejected because it violates the canonical design and risks bloating payloads.
+  - Store per-step counts in Search Attributes: rejected because step-row state is not a visibility index.
+
+## Decision 4: Freeze step-ledger and progress shape now via schema models plus golden fixtures
+
+- **Decision**: Add canonical schema models and golden fixture coverage for `progress` and representative step rows before wiring the workflow implementation.
+- **Rationale**: Phase 0 is explicitly a contract freeze. Golden fixtures provide a stable review surface and prevent field drift before API/UI work begins.
+- **Alternatives considered**:
+  - Defer schema models until the API phase: rejected because that would let workflow code invent private shapes that later consumers must adapt to.
+
+## Decision 5: Keep evidence slots as structured placeholders in Phase 1
+
+- **Decision**: Include stable `checks`, `refs`, and `artifacts` fields in every row now, but allow them to remain empty/default until Phase 2 evidence wiring is implemented.
+- **Rationale**: The user asked to freeze the v1 contract first. Stable placeholders let later phases add data without changing the shape.
+- **Alternatives considered**:
+  - Omit fields until populated: rejected because it would force later breaking schema changes.

--- a/specs/137-step-ledger-phase1/spec.md
+++ b/specs/137-step-ledger-phase1/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Step Ledger Phase 1
+
+**Feature Branch**: `137-step-ledger-phase1`  
+**Created**: 2026-04-07  
+**Status**: Draft  
+**Input**: User description: "Implement Phases 0 and 1 of the step ledger and progress rollout using test-driven development where feasible. Freeze the v1 execution progress and step-ledger contract, then implement workflow-owned deterministic step ledger state and workflow queries in MoonMind.Run without shipping the API or UI phases yet."
+
+## Source Document Requirements
+
+Source: `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/tmp/remaining-work/Temporal-WorkflowTypeCatalogAndLifecycle.md`, `docs/tmp/remaining-work/Api-ExecutionsApiContract.md`
+
+| ID | Source Section | Requirement Summary |
+| --- | --- | --- |
+| DOC-REQ-001 | `StepLedgerAndProgressModel` §3.1 | Planned step identity, order, title, tool, and dependencies must come from resolved plan-node metadata, not from logs or ad hoc counters. |
+| DOC-REQ-002 | `StepLedgerAndProgressModel` §3.2 | `MoonMind.Run` must own compact step status, attempt, waiting state, check state, and current refs as workflow state. |
+| DOC-REQ-003 | `StepLedgerAndProgressModel` §3.3 | Large outputs, logs, diagnostics, provider payloads, and long review bodies must stay out of workflow state. |
+| DOC-REQ-004 | `StepLedgerAndProgressModel` §4 | Task detail and default step reads are anchored on `workflowId` and return latest/current run state only. |
+| DOC-REQ-005 | `StepLedgerAndProgressModel` §5 | Execution detail progress must be a bounded summary object derivable from workflow state without artifact hydration. |
+| DOC-REQ-006 | `StepLedgerAndProgressModel` §6 | `MoonMind.Run` must expose a query-safe step-ledger response that includes `workflowId`, `runId`, `runScope`, and `steps`. |
+| DOC-REQ-007 | `StepLedgerAndProgressModel` §7 | Each step row must include stable identity, current attempt, timestamps, bounded summary/error, checks, refs, and artifact slots. |
+| DOC-REQ-008 | `StepLedgerAndProgressModel` §8 | The canonical v1 step status vocabulary is `pending`, `ready`, `running`, `awaiting_external`, `reviewing`, `succeeded`, `failed`, `skipped`, `canceled`. |
+| DOC-REQ-009 | `StepLedgerAndProgressModel` §9 | `checks[]` is the canonical structured check/review surface on a step row. |
+| DOC-REQ-010 | `StepLedgerAndProgressModel` §10 | Step attempts are scoped by `(workflowId, runId, logicalStepId, attempt)` and do not merge across run IDs. |
+| DOC-REQ-011 | `StepLedgerAndProgressModel` §12 | Step rows, attempts, and checks must stay out of Search Attributes and Memo; only compact user-visible summaries may be mirrored there. |
+| DOC-REQ-012 | `Temporal-WorkflowTypeCatalogAndLifecycle` remaining work | Lifecycle coverage must include plan resolved, step ready, step started, step reviewing, step succeeded, step failed, and step canceled transitions. |
+| DOC-REQ-013 | `Api-ExecutionsApiContract` remaining work | The phase-0 contract freeze must include a bounded execution `progress` payload and a step-ledger response shape that later API routes can expose unchanged. |
+
+## User Scenarios & Testing
+
+### User Story 1 - Freeze the v1 step-ledger contract (Priority: P1)
+
+A platform developer needs one canonical, testable step-ledger and progress contract so workflow, API, and UI work can converge on the same field names, statuses, and bounded payload rules.
+
+**Why this priority**: Phase 1 implementation is risky without a frozen contract; otherwise backend and frontend will diverge and later phases will rework state shapes.
+
+**Independent Test**: Can be tested by validating golden fixtures for `progress` and representative step rows against the new workflow-owned contract models without starting the API or UI layers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resolved plan with two executable nodes, **When** the workflow creates its initial ledger state, **Then** each row uses plan-node `id`, `title`, `tool`, and dependencies rather than derived display text from logs.
+2. **Given** a representative retrying step, child-runtime step, and reviewed step, **When** the contract fixtures are validated, **Then** they expose the frozen v1 field names, status vocabulary, checks shape, refs shape, and artifact slot names.
+3. **Given** a workflow step mutation, **When** the workflow mirrors operator-visible state into Memo or Search Attributes, **Then** it does not embed full step rows, attempts, or checks there.
+
+---
+
+### User Story 2 - Track deterministic workflow-owned step state (Priority: P1)
+
+An operator monitoring a run needs `MoonMind.Run` to own the live step ledger so the workflow can report deterministic step status, attempts, waiting state, and bounded progress during execution and after completion.
+
+**Why this priority**: This is the core Phase 1 implementation deliverable and the prerequisite for later API and UI rollout.
+
+**Independent Test**: Can be tested by executing the workflow against a resolved plan and asserting deterministic transitions through `pending`, `ready`, `running`, `awaiting_external`, `reviewing`, and terminal states.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resolved linear plan, **When** execution begins, **Then** the workflow marks only dependency-free steps as `ready` and leaves blocked steps as `pending`.
+2. **Given** a step begins execution, **When** the workflow dispatches the step, **Then** the ledger records `running`, increments the run-scoped attempt number, sets `startedAt`, and updates bounded progress.
+3. **Given** a step enters external wait or review processing, **When** the workflow transitions state, **Then** the ledger records `awaiting_external` or `reviewing` without storing large observability payloads in workflow state.
+4. **Given** a step succeeds, fails, is skipped, or is canceled, **When** the workflow updates the ledger, **Then** the row ends in the canonical terminal status and the workflow summary/progress remain deterministic.
+
+---
+
+### User Story 3 - Query the latest-run ledger and progress (Priority: P2)
+
+A control-plane consumer needs workflow queries that return the current/latest run ledger and bounded progress without reading Temporal history, artifacts, or Search Attributes.
+
+**Why this priority**: Query surfaces are the contract that later API work depends on, and they must be safe during execution and after completion.
+
+**Independent Test**: Can be tested by querying the workflow while it is executing and after it finishes, verifying the same latest-run ledger remains available with stable `workflowId` and `runId`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a running workflow, **When** a caller queries step ledger state, **Then** the workflow returns `workflowId`, `runId`, `runScope: "latest"`, and the current rows without reading artifacts.
+2. **Given** a completed workflow, **When** a caller queries progress or the step ledger, **Then** the same bounded progress and latest-run ledger remain available.
+3. **Given** a run with multiple attempts for one logical step, **When** a caller reads the latest-run ledger, **Then** the row shows the current/latest attempt for that `runId` and does not merge prior run history.
+
+### Edge Cases
+
+- What happens when the plan contains dependency edges? The workflow must keep blocked nodes in `pending` and move them to `ready` only after upstream logical step completion is recorded.
+- What happens when a step fails before returning outputs? The row must still end in `failed` with a bounded `lastError` summary and no large error body in workflow state.
+- What happens when the workflow is canceled while a step is active? The current step must end in `canceled`, later nodes remain non-terminal, and query results must stay readable after workflow completion.
+- What happens when a step has no checks or refs yet? The ledger must return empty/default structured values rather than omitting the fields.
+- What happens when the workflow continues to update generic summary strings? Those summary updates must not become the source of truth for per-step identity or status.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST define a canonical v1 step-ledger contract and bounded `progress` contract for execution detail, including golden JSON fixtures for progress and representative step rows. Mappings: DOC-REQ-005, DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-009, DOC-REQ-013.
+- **FR-002**: System MUST initialize workflow-owned ledger rows from resolved plan-node metadata (`id`, `title`, `tool`, dependency data) after plan resolution. Mappings: DOC-REQ-001, DOC-REQ-002.
+- **FR-003**: System MUST track step lifecycle transitions in `MoonMind.Run` across `pending`, `ready`, `running`, `awaiting_external`, `reviewing`, `succeeded`, `failed`, `skipped`, and `canceled`. Mappings: DOC-REQ-002, DOC-REQ-008, DOC-REQ-012.
+- **FR-004**: System MUST track run-scoped attempt numbers and timestamps per logical step without merging attempt history across run IDs. Mappings: DOC-REQ-010.
+- **FR-005**: System MUST expose workflow queries for full latest-run step-ledger state and bounded progress while the workflow is running and after it completes. Mappings: DOC-REQ-004, DOC-REQ-005, DOC-REQ-006.
+- **FR-006**: System MUST keep logs, diagnostics, provider dumps, and other large evidence out of workflow state, storing only bounded summaries, refs, and artifact-slot placeholders in the ledger. Mappings: DOC-REQ-003, DOC-REQ-007.
+- **FR-007**: System MUST keep Memo and Search Attribute updates compact and user-visible, and MUST NOT store full step rows, attempts, or checks in either surface. Mappings: DOC-REQ-011.
+- **FR-008**: System MUST provide structured default values for `checks`, `refs`, and `artifacts` so later API and UI phases can consume a stable schema immediately. Mappings: DOC-REQ-007, DOC-REQ-009.
+- **FR-009**: System MUST add workflow-boundary tests covering plan resolved, step ready, step started, waiting, reviewing, succeeded, failed, skipped, canceled, and post-completion query behavior. Mappings: DOC-REQ-012.
+- **FR-010**: System MUST implement production runtime code changes and validation tests in this phase; documentation-only changes are insufficient. Mappings: DOC-REQ-002, DOC-REQ-005, DOC-REQ-009.
+
+### Key Entities
+
+- **ExecutionProgress**: Bounded execution-level summary of step counts by canonical status plus the current step title and last update timestamp.
+- **StepLedgerSnapshot**: Query response containing `workflowId`, `runId`, `runScope`, and ordered latest-run step rows.
+- **StepLedgerRow**: Compact workflow-owned representation of one logical step's current/latest attempt for the active run.
+- **StepLedgerRefs**: Structured parent/child linkage fields reserved for `childWorkflowId`, `childRunId`, and `taskRunId`.
+- **StepLedgerArtifacts**: Structured semantic artifact slots reserved for summary, primary output, logs, diagnostics, and provider snapshot refs.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Golden fixture tests validate the canonical `progress` object and representative step rows for retrying, child-runtime, and reviewed steps.
+- **SC-002**: Workflow-boundary tests cover plan resolved, step ready, step started, waiting, reviewing, succeeded, failed, skipped, and canceled transitions.
+- **SC-003**: Step-ledger and progress queries return deterministic latest-run data during execution and after completion without reading artifacts.
+- **SC-004**: Memo/Search Attribute tests prove only compact summaries are mirrored there and full step rows are not.
+- **SC-005**: Final verification passes through `./tools/test_unit.sh`.
+
+## Assumptions
+
+- Phase 0 and Phase 1 stop at workflow-owned state and queries; `/api/executions/{workflowId}/steps`, `ExecutionModel.progress`, and Mission Control UI changes remain explicitly out of scope for this change.
+- Existing plan artifacts already contain stable node IDs, titles, tool descriptors, and dependency edges sufficient to seed the ledger.
+- Child workflow refs and artifact slots may remain empty/default in this phase as long as their schema is frozen and query-safe.

--- a/specs/137-step-ledger-phase1/speckit_analyze_report.md
+++ b/specs/137-step-ledger-phase1/speckit_analyze_report.md
@@ -1,0 +1,42 @@
+# Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| None | None | None | N/A | No cross-artifact consistency, coverage, or constitution issues were detected in the current `spec.md`, `plan.md`, and `tasks.md` set. | Proceed to implementation. |
+
+## Coverage Summary Table
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --- | --- | --- | --- |
+| freeze-progress-and-ledger-contract | Yes | T003, T004, T005, T006 | Contract fixtures, schema models, pure helper defaults, and bounded visibility checks are present. |
+| initialize-ledger-from-plan-metadata | Yes | T007, T009 | Workflow tests and implementation both anchor rows on resolved plan metadata. |
+| deterministic-step-status-transitions | Yes | T007, T008, T010 | Transition coverage includes ready, running, waiting, reviewing, and terminal states. |
+| run-scoped-attempt-tracking | Yes | T005, T007, T010, T016 | Attempts are modeled in helpers and validated at the workflow boundary. |
+| query-latest-run-progress-and-ledger | Yes | T013, T014, T015, T016 | Query tests and implementation tasks cover running and completed workflow reads. |
+| keep-evidence-out-of-workflow-state | Yes | T008, T011 | Tests and implementation both enforce bounded refs/placeholders only. |
+| keep-memo-and-search-attributes-compact | Yes | T006, T012 | Explicit validation and implementation tasks cover compact visibility surfaces. |
+| keep-structured-checks-refs-artifacts-stable | Yes | T003, T004, T005 | Phase 0 contract freeze tasks lock the schema before later evidence wiring. |
+| workflow-boundary-transition-coverage | Yes | T007, T008, T013, T014, T019, T020 | Unit and targeted integration coverage are planned before final suite validation. |
+| runtime-implementation-plus-validation | Yes | T001, T004, T005, T009, T010, T011, T012, T015, T016, T018, T019, T020 | Tasks satisfy the runtime code and validation minimums. |
+
+## Constitution Alignment Issues
+
+None.
+
+## Unmapped Tasks
+
+None.
+
+## Metrics
+
+- Total Requirements: 10 functional requirements
+- Total Tasks: 20
+- Coverage %: 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Proceed with TDD in the order captured by `tasks.md`: contract fixtures first, workflow lifecycle tests second, query tests third.
+- Keep Phase 2+ API/UI work out of the implementation diff for this feature branch.

--- a/specs/137-step-ledger-phase1/tasks.md
+++ b/specs/137-step-ledger-phase1/tasks.md
@@ -1,0 +1,121 @@
+# Tasks: Step Ledger Phase 1
+
+**Input**: Design documents from `/specs/137-step-ledger-phase1/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing contract/workflow tests before implementing the corresponding ledger behavior.
+
+**Organization**: Tasks are grouped by user story so the contract freeze, workflow-owned ledger, and query surfaces can be implemented and validated incrementally.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+**Purpose**: Establish the runtime files and test files used by the phase-0/phase-1 rollout.
+
+- [X] T001 Create the step-ledger helper module scaffold in `moonmind/workflows/temporal/step_ledger.py` for compact workflow-owned ledger state and reducers (DOC-REQ-002, DOC-REQ-005, DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-010)
+- [X] T002 [P] Create the ledger contract test file `tests/unit/workflows/temporal/test_step_ledger.py` and workflow-boundary test file `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` (DOC-REQ-005, DOC-REQ-006, DOC-REQ-012, DOC-REQ-013)
+
+---
+
+## Phase 2: Foundational Contract Freeze (Blocking Prerequisites)
+
+**Purpose**: Freeze the v1 progress and step-ledger contract before workflow behavior changes.
+
+**⚠️ CRITICAL**: No workflow implementation work should begin until these contract tests exist and fail first.
+
+- [X] T003 [P] [US1] Write failing contract fixture tests in `tests/unit/workflows/temporal/test_step_ledger.py` for bounded `progress` and representative retrying, child-runtime, and reviewed step rows (DOC-REQ-005, DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-009, DOC-REQ-013)
+- [X] T004 [US1] Add canonical `ExecutionProgress`, step-ledger snapshot/row, check, refs, and artifact-slot schema models to `moonmind/schemas/temporal_models.py` (DOC-REQ-005, DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-009, DOC-REQ-013)
+- [X] T005 [US1] Implement pure default builders and progress reducer helpers in `moonmind/workflows/temporal/step_ledger.py` to satisfy the frozen contract tests (DOC-REQ-005, DOC-REQ-006, DOC-REQ-007, DOC-REQ-008, DOC-REQ-009, DOC-REQ-010)
+- [X] T006 [P] [US1] Add validation coverage in `tests/unit/workflows/temporal/test_step_ledger.py` proving full step rows, attempts, and checks are not mirrored into Memo/Search Attribute payloads (DOC-REQ-011, DOC-REQ-013)
+
+**Checkpoint**: Contract models and helpers are frozen and validated before workflow orchestration changes.
+
+---
+
+## Phase 3: User Story 2 - Deterministic Workflow-Owned Step State (Priority: P1) 🎯 MVP
+
+**Goal**: `MoonMind.Run` owns compact step truth derived from resolved plan metadata and tracks deterministic step transitions and attempts.
+
+**Independent Test**: Execute the workflow against resolved plans and verify ready/running/waiting/reviewing/terminal transitions plus run-scoped attempts.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Write failing workflow tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` for plan-resolved initialization plus `pending -> ready -> running -> succeeded` transitions sourced from plan-node metadata (DOC-REQ-001, DOC-REQ-002, DOC-REQ-008, DOC-REQ-010, DOC-REQ-012)
+- [X] T008 [P] [US2] Write failing workflow tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` for `awaiting_external`, `reviewing`, `failed`, `skipped`, and `canceled` transitions with bounded error/summary fields (DOC-REQ-002, DOC-REQ-003, DOC-REQ-007, DOC-REQ-008, DOC-REQ-012)
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Initialize ordered latest-run ledger rows from resolved plan-node metadata in `moonmind/workflows/temporal/workflows/run.py` using `moonmind/workflows/temporal/step_ledger.py` after `parse_plan_definition()` (DOC-REQ-001, DOC-REQ-002, DOC-REQ-006)
+- [X] T010 [US2] Update `moonmind/workflows/temporal/workflows/run.py` to apply deterministic step transition helpers for ready/running/waiting/reviewing/terminal states and run-scoped attempt increments (DOC-REQ-002, DOC-REQ-008, DOC-REQ-010, DOC-REQ-012)
+- [X] T011 [US2] Keep workflow-owned rows bounded in `moonmind/workflows/temporal/workflows/run.py` by storing only compact summaries, refs, and artifact-slot placeholders instead of logs or diagnostics bodies (DOC-REQ-003, DOC-REQ-007)
+- [X] T012 [US2] Restrict Memo/Search Attribute updates in `moonmind/workflows/temporal/workflows/run.py` to compact user-visible summaries and counters while leaving full ledger state in workflow memory only (DOC-REQ-011)
+
+**Checkpoint**: The workflow owns deterministic step state and bounded progress without leaking full rows into visibility surfaces.
+
+---
+
+## Phase 4: User Story 3 - Query the Latest-Run Ledger and Progress (Priority: P2)
+
+**Goal**: Expose query-safe latest-run progress and step-ledger snapshots during execution and after completion.
+
+**Independent Test**: Query the workflow while it is executing and after completion, confirming latest-run scope and stable `workflowId`/`runId` output.
+
+### Tests for User Story 3
+
+- [X] T013 [P] [US3] Write failing query tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` covering progress and step-ledger reads while executing and after completion (DOC-REQ-004, DOC-REQ-005, DOC-REQ-006, DOC-REQ-012, DOC-REQ-013)
+- [X] T014 [P] [US3] Extend `tests/integration/workflows/temporal/workflows/test_run.py` with latest-run query coverage when the integration harness materially increases confidence (DOC-REQ-004, DOC-REQ-005, DOC-REQ-006)
+
+### Implementation for User Story 3
+
+- [X] T015 [US3] Add workflow queries for bounded progress and full latest-run step-ledger state in `moonmind/workflows/temporal/workflows/run.py` (DOC-REQ-004, DOC-REQ-005, DOC-REQ-006)
+- [X] T016 [US3] Ensure the query payloads in `moonmind/workflows/temporal/workflows/run.py` remain readable after terminal completion and preserve latest-run-only semantics (DOC-REQ-004, DOC-REQ-005, DOC-REQ-006, DOC-REQ-010)
+
+**Checkpoint**: Later API phases can consume stable workflow query contracts without changing the payload shape.
+
+---
+
+## Phase 5: Polish & Validation
+
+**Purpose**: Final verification and scope enforcement for the phase-0/phase-1 rollout.
+
+- [X] T017 [P] Add any required serialization regression coverage to `tests/unit/api/routers/test_executions.py` if the execution schema changes surface through existing detail serialization (DOC-REQ-005, DOC-REQ-013)
+- [X] T018 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T019 Run targeted ledger tests via `pytest tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`
+- [X] T020 Run `./tools/test_unit.sh`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational Contract Freeze (Phase 2)**: Depends on Setup and blocks workflow implementation.
+- **User Story 2 (Phase 3)**: Depends on Phase 2.
+- **User Story 3 (Phase 4)**: Depends on Phase 3 state ownership and may overlap with late-cycle integration coverage.
+- **Polish (Phase 5)**: Depends on all prior implementation work.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel.
+- T003 and T006 can run in parallel once the test files exist.
+- T007 and T008 can run in parallel before workflow implementation.
+- T013 and T014 can run in parallel before query implementation.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Freeze the contract with failing tests and schema/helper implementations.
+2. Implement workflow-owned deterministic ledger state.
+3. Add query surfaces for progress and latest-run step state.
+4. Run targeted tests, then the full unit suite.
+
+### TDD Notes
+
+- Prefer Red → Green sequencing for T003 before T004/T005, T007/T008 before T009–T012, and T013/T014 before T015/T016.
+- If a change is not practical to drive entirely from a failing test first, add the closest boundary-level regression test immediately after the minimal implementation.

--- a/tests/integration/workflows/temporal/workflows/test_run.py
+++ b/tests/integration/workflows/temporal/workflows/test_run.py
@@ -336,6 +336,58 @@ class TestMoonMindRunWorkflow(unittest.IsolatedAsyncioTestCase):
                     INTEGRATION_START_CALLS[0]["principal"], "trusted-owner"
                 )
 
+    async def test_moonmind_run_workflow_queries_step_ledger_after_completion(self) -> None:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            await _register_test_search_attributes(env)
+            async with (
+                Worker(
+                    env.client,
+                    task_queue=LLM_TASK_QUEUE,
+                    activities=[
+                        mock_plan_generate,
+                    ],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=ARTIFACTS_TASK_QUEUE,
+                    activities=[mock_artifact_read],
+                ),
+                Worker(
+                    env.client,
+                    task_queue=SANDBOX_TASK_QUEUE,
+                    activities=[mock_sandbox_command, mock_skill_execute],
+                ),
+                Worker(
+                    env.client,
+                    task_queue="test-task-queue",
+                    workflows=[MoonMindRunWorkflow],
+                    workflow_runner=UnsandboxedWorkflowRunner(),
+                ),
+            ):
+                handle = await env.client.start_workflow(
+                    MoonMindRunWorkflow.run,
+                    {
+                        "workflowType": "MoonMind.Run",
+                        "title": "Queryable run",
+                    },
+                    id="test-workflow-ledger-query",
+                    task_queue="test-task-queue",
+                    search_attributes=_trusted_search_attributes(),
+                )
+
+                result = await handle.result()
+                progress = await handle.query("get_progress")
+                ledger = await handle.query("get_step_ledger")
+
+                self.assertEqual(result["status"], "success")
+                self.assertEqual(progress["total"], 1)
+                self.assertEqual(progress["succeeded"], 1)
+                self.assertEqual(ledger["workflowId"], "test-workflow-ledger-query")
+                self.assertEqual(ledger["runScope"], "latest")
+                self.assertEqual(len(ledger["steps"]), 1)
+                self.assertEqual(ledger["steps"][0]["logicalStepId"], "step-1")
+                self.assertEqual(ledger["steps"][0]["status"], "succeeded")
+
     async def test_moonmind_run_workflow_ignores_untrusted_owner_payload(self) -> None:
         async with await WorkflowEnvironment.start_time_skipping() as env:
             await _register_test_search_attributes(env)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -27,6 +27,10 @@ from moonmind.workflows.temporal import (
     TemporalExecutionNotFoundError,
     TemporalExecutionValidationError,
 )
+from moonmind.schemas.temporal_models import (
+    ExecutionProgressModel,
+    StepLedgerSnapshotModel,
+)
 
 
 def _override_user_dependencies(app: FastAPI, *, is_superuser: bool) -> SimpleNamespace:
@@ -216,6 +220,69 @@ def test_list_executions_rejects_non_admin_owner_type_override() -> None:
     assert response.status_code == 403
     assert response.json()["detail"]["code"] == "execution_forbidden"
     mock_service.list_executions.assert_not_awaited()
+
+
+def test_step_ledger_contract_models_serialize_using_public_aliases() -> None:
+    progress = ExecutionProgressModel.model_validate(
+        {
+            "total": 1,
+            "pending": 0,
+            "ready": 0,
+            "running": 0,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 1,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Prepare workspace",
+            "updatedAt": "2026-04-07T12:00:00Z",
+        }
+    )
+    snapshot = StepLedgerSnapshotModel.model_validate(
+        {
+            "workflowId": "wf-1",
+            "runId": "run-1",
+            "runScope": "latest",
+            "steps": [
+                {
+                    "logicalStepId": "prepare",
+                    "order": 1,
+                    "title": "Prepare workspace",
+                    "tool": {"type": "skill", "name": "repo.prepare", "version": "1"},
+                    "dependsOn": [],
+                    "status": "succeeded",
+                    "waitingReason": None,
+                    "attentionRequired": False,
+                    "attempt": 1,
+                    "startedAt": "2026-04-07T12:00:00Z",
+                    "updatedAt": "2026-04-07T12:00:00Z",
+                    "summary": "Workspace prepared",
+                    "checks": [],
+                    "refs": {
+                        "childWorkflowId": None,
+                        "childRunId": None,
+                        "taskRunId": None,
+                    },
+                    "artifacts": {
+                        "outputSummary": None,
+                        "outputPrimary": None,
+                        "runtimeStdout": None,
+                        "runtimeStderr": None,
+                        "runtimeMergedLogs": None,
+                        "runtimeDiagnostics": None,
+                        "providerSnapshot": None,
+                    },
+                    "lastError": None,
+                }
+            ],
+        }
+    )
+
+    assert progress.model_dump(by_alias=True, mode="json")["awaitingExternal"] == 0
+    dumped_snapshot = snapshot.model_dump(by_alias=True, mode="json")
+    assert dumped_snapshot["runScope"] == "latest"
+    assert dumped_snapshot["steps"][0]["logicalStepId"] == "prepare"
 
 
 def test_list_executions_uses_owner_id_without_owner_type_for_non_admin() -> None:

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -13,6 +13,7 @@ from moonmind.schemas.temporal_models import (
 from moonmind.workflows.temporal.step_ledger import (
     build_initial_step_rows,
     build_progress_summary,
+    update_step_row,
 )
 
 
@@ -47,6 +48,59 @@ def test_build_initial_step_rows_uses_plan_metadata_and_dependencies() -> None:
     assert rows[1]["status"] == "pending"
     assert rows[1]["dependsOn"] == ["step-1"]
     assert rows[1]["tool"] == {"type": "skill", "name": "repo.test", "version": "1"}
+
+
+def test_build_initial_step_rows_skips_blank_node_ids() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {
+                "id": "",
+                "tool": {"type": "skill", "name": "repo.invalid", "version": "1"},
+            },
+            {
+                "id": "step-2",
+                "tool": {"type": "skill", "name": "repo.test", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            },
+        ],
+        dependency_map={"step-2": []},
+        updated_at=updated_at,
+    )
+
+    assert rows == [
+        {
+            "logicalStepId": "step-2",
+            "order": 1,
+            "title": "Run tests",
+            "tool": {"type": "skill", "name": "repo.test", "version": "1"},
+            "dependsOn": [],
+            "status": "ready",
+            "waitingReason": None,
+            "attentionRequired": False,
+            "attempt": 0,
+            "startedAt": None,
+            "updatedAt": updated_at.isoformat(),
+            "summary": None,
+            "checks": [],
+            "refs": {
+                "childWorkflowId": None,
+                "childRunId": None,
+                "taskRunId": None,
+            },
+            "artifacts": {
+                "outputSummary": None,
+                "outputPrimary": None,
+                "runtimeStdout": None,
+                "runtimeStderr": None,
+                "runtimeMergedLogs": None,
+                "runtimeDiagnostics": None,
+                "providerSnapshot": None,
+            },
+            "lastError": None,
+        }
+    ]
 
 
 def test_progress_summary_prefers_active_step_title_and_counts_statuses() -> None:
@@ -252,3 +306,36 @@ def test_row_defaults_remain_bounded_and_structured() -> None:
         "runtimeDiagnostics": None,
         "providerSnapshot": None,
     }
+
+
+def test_update_step_row_allows_explicit_last_error_clear() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 12, tzinfo=UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {
+                "id": "run-tests",
+                "tool": {"type": "skill", "name": "repo.test", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            }
+        ],
+        dependency_map={"run-tests": []},
+        updated_at=updated_at,
+    )
+
+    update_step_row(
+        rows,
+        "run-tests",
+        updated_at=updated_at,
+        status="failed",
+        last_error="pytest failed",
+    )
+    update_step_row(
+        rows,
+        "run-tests",
+        updated_at=updated_at,
+        status="succeeded",
+        last_error=None,
+    )
+
+    assert rows[0]["status"] == "succeeded"
+    assert rows[0]["lastError"] is None

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from moonmind.schemas.temporal_models import (
+    ExecutionProgressModel,
+    StepLedgerArtifactsModel,
+    StepLedgerCheckModel,
+    StepLedgerRefsModel,
+    StepLedgerRowModel,
+    StepLedgerSnapshotModel,
+)
+from moonmind.workflows.temporal.step_ledger import (
+    build_initial_step_rows,
+    build_progress_summary,
+)
+
+
+def test_build_initial_step_rows_uses_plan_metadata_and_dependencies() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {
+                "id": "step-1",
+                "tool": {"type": "skill", "name": "repo.setup", "version": "1"},
+                "inputs": {"title": "Prepare workspace"},
+            },
+            {
+                "id": "step-2",
+                "tool": {"type": "skill", "name": "repo.test", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            },
+        ],
+        dependency_map={
+            "step-1": [],
+            "step-2": ["step-1"],
+        },
+        updated_at=updated_at,
+    )
+
+    assert [row["logicalStepId"] for row in rows] == ["step-1", "step-2"]
+    assert rows[0]["title"] == "Prepare workspace"
+    assert rows[0]["status"] == "ready"
+    assert rows[0]["attempt"] == 0
+    assert rows[0]["dependsOn"] == []
+    assert rows[1]["title"] == "Run tests"
+    assert rows[1]["status"] == "pending"
+    assert rows[1]["dependsOn"] == ["step-1"]
+    assert rows[1]["tool"] == {"type": "skill", "name": "repo.test", "version": "1"}
+
+
+def test_progress_summary_prefers_active_step_title_and_counts_statuses() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 5, tzinfo=UTC)
+    progress = build_progress_summary(
+        [
+            {
+                "logicalStepId": "step-1",
+                "status": "succeeded",
+                "title": "Prepare workspace",
+                "updatedAt": updated_at.isoformat(),
+            },
+            {
+                "logicalStepId": "step-2",
+                "status": "running",
+                "title": "Run tests",
+                "updatedAt": updated_at.isoformat(),
+            },
+            {
+                "logicalStepId": "step-3",
+                "status": "pending",
+                "title": "Publish summary",
+                "updatedAt": updated_at.isoformat(),
+            },
+        ],
+        updated_at=updated_at,
+    )
+
+    assert progress == {
+        "total": 3,
+        "pending": 1,
+        "ready": 0,
+        "running": 1,
+        "awaitingExternal": 0,
+        "reviewing": 0,
+        "succeeded": 1,
+        "failed": 0,
+        "skipped": 0,
+        "canceled": 0,
+        "currentStepTitle": "Run tests",
+        "updatedAt": updated_at.isoformat(),
+    }
+
+
+def test_contract_models_accept_representative_rows_and_progress() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 10, tzinfo=UTC)
+
+    progress = ExecutionProgressModel.model_validate(
+        {
+            "total": 3,
+            "pending": 0,
+            "ready": 0,
+            "running": 0,
+            "awaitingExternal": 1,
+            "reviewing": 1,
+            "succeeded": 1,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Review patch",
+            "updatedAt": updated_at.isoformat(),
+        }
+    )
+    retrying_row = StepLedgerRowModel.model_validate(
+        {
+            "logicalStepId": "run-tests",
+            "order": 2,
+            "title": "Run tests",
+            "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+            "dependsOn": ["prepare-workspace"],
+            "status": "running",
+            "waitingReason": None,
+            "attentionRequired": False,
+            "attempt": 2,
+            "startedAt": updated_at.isoformat(),
+            "updatedAt": updated_at.isoformat(),
+            "summary": "Retrying after a bounded failure",
+            "checks": [],
+            "refs": {"childWorkflowId": None, "childRunId": None, "taskRunId": None},
+            "artifacts": {
+                "outputSummary": None,
+                "outputPrimary": None,
+                "runtimeStdout": None,
+                "runtimeStderr": None,
+                "runtimeMergedLogs": None,
+                "runtimeDiagnostics": None,
+                "providerSnapshot": None,
+            },
+            "lastError": "pytest previously failed",
+        }
+    )
+    child_runtime_row = StepLedgerRowModel.model_validate(
+        {
+            "logicalStepId": "delegate-agent",
+            "order": 3,
+            "title": "Delegate agent run",
+            "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+            "dependsOn": ["run-tests"],
+            "status": "awaiting_external",
+            "waitingReason": "Awaiting child workflow progress",
+            "attentionRequired": False,
+            "attempt": 1,
+            "startedAt": updated_at.isoformat(),
+            "updatedAt": updated_at.isoformat(),
+            "summary": "Child workflow launched",
+            "checks": [],
+            "refs": {
+                "childWorkflowId": "wf-child",
+                "childRunId": "run-child",
+                "taskRunId": "task-run-1",
+            },
+            "artifacts": {
+                "outputSummary": None,
+                "outputPrimary": None,
+                "runtimeStdout": None,
+                "runtimeStderr": None,
+                "runtimeMergedLogs": None,
+                "runtimeDiagnostics": None,
+                "providerSnapshot": None,
+            },
+            "lastError": None,
+        }
+    )
+    reviewed_row = StepLedgerRowModel.model_validate(
+        {
+            "logicalStepId": "review-patch",
+            "order": 4,
+            "title": "Review patch",
+            "tool": {"type": "skill", "name": "repo.review_patch", "version": "1"},
+            "dependsOn": ["delegate-agent"],
+            "status": "reviewing",
+            "waitingReason": "Awaiting structured review result",
+            "attentionRequired": False,
+            "attempt": 1,
+            "startedAt": updated_at.isoformat(),
+            "updatedAt": updated_at.isoformat(),
+            "summary": "Structured review in progress",
+            "checks": [
+                {
+                    "kind": "approval_policy",
+                    "status": "pending",
+                    "summary": None,
+                    "retryCount": 0,
+                    "artifactRef": None,
+                }
+            ],
+            "refs": {"childWorkflowId": None, "childRunId": None, "taskRunId": None},
+            "artifacts": {
+                "outputSummary": None,
+                "outputPrimary": None,
+                "runtimeStdout": None,
+                "runtimeStderr": None,
+                "runtimeMergedLogs": None,
+                "runtimeDiagnostics": None,
+                "providerSnapshot": None,
+            },
+            "lastError": None,
+        }
+    )
+    snapshot = StepLedgerSnapshotModel.model_validate(
+        {
+            "workflowId": "wf-1",
+            "runId": "run-1",
+            "runScope": "latest",
+            "steps": [
+                retrying_row.model_dump(by_alias=True),
+                child_runtime_row.model_dump(by_alias=True),
+                reviewed_row.model_dump(by_alias=True),
+            ],
+        }
+    )
+
+    assert progress.current_step_title == "Review patch"
+    assert retrying_row.attempt == 2
+    assert child_runtime_row.refs.task_run_id == "task-run-1"
+    assert reviewed_row.checks == [
+        StepLedgerCheckModel(
+            kind="approval_policy",
+            status="pending",
+            summary=None,
+            retry_count=0,
+            artifact_ref=None,
+        )
+    ]
+    assert snapshot.run_scope == "latest"
+
+
+def test_row_defaults_remain_bounded_and_structured() -> None:
+    refs = StepLedgerRefsModel()
+    artifacts = StepLedgerArtifactsModel()
+
+    assert refs.model_dump(by_alias=True) == {
+        "childWorkflowId": None,
+        "childRunId": None,
+        "taskRunId": None,
+    }
+    assert artifacts.model_dump(by_alias=True) == {
+        "outputSummary": None,
+        "outputPrimary": None,
+        "runtimeStdout": None,
+        "runtimeStderr": None,
+        "runtimeMergedLogs": None,
+        "runtimeDiagnostics": None,
+        "providerSnapshot": None,
+    }

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -1,6 +1,6 @@
 import asyncio
 from unittest.mock import AsyncMock
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -78,8 +78,18 @@ def mock_run_environment(monkeypatch):
     async def fake_planning_stage(*args, **kwargs):
         return "ref-123"
 
-    async def fake_execution_stage(*args, **kwargs):
-        pass
+    async def fake_execution_stage(self, *args, **kwargs):
+        try:
+            await workflow.wait_condition(
+                lambda: self._paused or self._cancel_requested,
+                timeout=timedelta(seconds=1),
+            )
+        except asyncio.TimeoutError:
+            return
+        while self._paused and not self._cancel_requested:
+            await workflow.wait_condition(
+                lambda: not self._paused or self._cancel_requested
+            )
 
     monkeypatch.setattr(MoonMindRunWorkflow, "_run_planning_stage", fake_planning_stage)
     monkeypatch.setattr(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.workflows.temporal.workflows import run as run_module
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+
+def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-run-1",
+        run_id="run-1",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["user-1"]},
+    )
+    logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+        isEnabledFor=lambda *_args, **_kwargs: False,
+    )
+    memo_updates: list[dict] = []
+    search_updates: list[object] = []
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "logger", logger)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "now",
+        lambda: datetime(2026, 4, 7, 12, 0, tzinfo=UTC),
+    )
+    monkeypatch.setattr(run_module.workflow, "upsert_memo", memo_updates.append)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "upsert_search_attributes",
+        search_updates.append,
+    )
+    return memo_updates
+
+
+def _ordered_nodes() -> list[dict]:
+    return [
+        {
+            "id": "prepare",
+            "tool": {"type": "skill", "name": "repo.prepare", "version": "1"},
+            "inputs": {"title": "Prepare workspace"},
+        },
+        {
+            "id": "run-tests",
+            "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+            "inputs": {"title": "Run tests"},
+        },
+    ]
+
+
+def _dependency_map() -> dict[str, list[str]]:
+    return {"prepare": [], "run-tests": ["prepare"]}
+
+
+def test_run_initializes_latest_run_step_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    ledger = workflow.get_step_ledger()
+    progress = workflow.get_progress()
+
+    assert ledger["workflowId"] == "wf-run-1"
+    assert ledger["runId"] == "run-1"
+    assert ledger["runScope"] == "latest"
+    assert [step["logicalStepId"] for step in ledger["steps"]] == [
+        "prepare",
+        "run-tests",
+    ]
+    assert ledger["steps"][0]["status"] == "ready"
+    assert ledger["steps"][1]["status"] == "pending"
+    assert progress["total"] == 2
+    assert progress["ready"] == 1
+    assert progress["pending"] == 1
+
+
+def test_run_tracks_status_transitions_and_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+    workflow._mark_step_running("prepare", updated_at=now, summary="Preparing workspace")
+    workflow._mark_step_terminal(
+        "prepare",
+        status="succeeded",
+        updated_at=now,
+        summary="Workspace ready",
+    )
+    workflow._refresh_step_readiness(updated_at=now)
+    workflow._mark_step_running("run-tests", updated_at=now, summary="Running tests")
+    workflow._mark_step_waiting(
+        "run-tests",
+        status="reviewing",
+        updated_at=now,
+        waiting_reason="Awaiting structured review result",
+        summary="Structured review in progress",
+    )
+    workflow._mark_step_terminal(
+        "run-tests",
+        status="failed",
+        updated_at=now,
+        summary="Tests failed",
+        last_error="pytest failed",
+    )
+    workflow._mark_step_running("run-tests", updated_at=now, summary="Retrying tests")
+    workflow._mark_step_waiting(
+        "run-tests",
+        status="awaiting_external",
+        updated_at=now,
+        waiting_reason="Awaiting child workflow progress",
+        summary="Child runtime launched",
+    )
+    workflow._mark_step_terminal(
+        "run-tests",
+        status="canceled",
+        updated_at=now,
+        summary="Canceled by operator",
+    )
+
+    ledger = workflow.get_step_ledger()
+    step = ledger["steps"][1]
+    progress = workflow.get_progress()
+
+    assert step["attempt"] == 2
+    assert step["status"] == "canceled"
+    assert step["waitingReason"] is None
+    assert step["lastError"] == "pytest failed"
+    assert progress["succeeded"] == 1
+    assert progress["canceled"] == 1
+
+
+def test_run_queries_remain_available_after_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+    workflow._mark_step_running("prepare", updated_at=now, summary="Preparing workspace")
+    workflow._mark_step_terminal(
+        "prepare",
+        status="skipped",
+        updated_at=now,
+        summary="Skipped after reuse",
+    )
+    workflow._state = run_module.STATE_COMPLETED
+
+    assert workflow.get_progress()["skipped"] == 1
+    assert workflow.get_step_ledger()["steps"][0]["status"] == "skipped"
+
+
+def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> None:
+    memo_updates = _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._title = "Ledger run"
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+    workflow._summary = "Executing step ledger tests."
+    workflow._update_memo()
+    workflow._update_search_attributes()
+
+    latest_memo = next(memo for memo in reversed(memo_updates) if "title" in memo)
+    assert latest_memo["title"] == "Ledger run"
+    assert latest_memo["summary"] == "Executing step ledger tests."
+    assert "steps" not in latest_memo
+    assert "progress" not in latest_memo
+    assert "checks" not in latest_memo

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -149,6 +149,113 @@ def test_run_tracks_status_transitions_and_attempts(monkeypatch: pytest.MonkeyPa
     assert progress["canceled"] == 1
 
 
+def test_run_terminal_success_clears_previous_last_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+    workflow._mark_step_running("prepare", updated_at=now, summary="Preparing workspace")
+    workflow._mark_step_terminal(
+        "prepare",
+        status="failed",
+        updated_at=now,
+        summary="Workspace failed",
+        last_error="pytest failed",
+    )
+    workflow._mark_step_running("prepare", updated_at=now, summary="Retrying workspace")
+    workflow._mark_step_terminal(
+        "prepare",
+        status="succeeded",
+        updated_at=now,
+        summary="Workspace ready",
+        last_error=None,
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["status"] == "succeeded"
+    assert step["lastError"] is None
+
+
+def test_run_missing_step_ledger_updates_do_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    workflow._mark_step_running("missing-step", updated_at=now, summary="Ignored")
+    workflow._mark_step_waiting(
+        "missing-step",
+        status="reviewing",
+        updated_at=now,
+        waiting_reason="Ignored",
+        summary="Ignored",
+    )
+    workflow._mark_step_terminal(
+        "missing-step",
+        status="failed",
+        updated_at=now,
+        summary="Ignored",
+        last_error="ignored",
+    )
+
+    progress = workflow.get_progress()
+    assert progress["ready"] == 1
+    assert progress["pending"] == 1
+    assert progress["running"] == 0
+
+
+def test_plan_dependency_map_rewrites_bundled_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    bundle_id = "wf-run-1:jules-bundle:step-1:step-2"
+
+    dependency_map = workflow._plan_dependency_map(
+        ordered_nodes=[
+            {
+                "id": "prepare",
+                "tool": {"type": "skill", "name": "repo.prepare", "version": "1"},
+            },
+            {
+                "id": bundle_id,
+                "tool": {"type": "agent_runtime", "name": "jules", "version": ""},
+                "inputs": {"bundledNodeIds": ["step-1", "step-2"]},
+            },
+            {
+                "id": "publish",
+                "tool": {"type": "skill", "name": "repo.publish", "version": "1"},
+            },
+        ],
+        edges=(
+            SimpleNamespace(from_node="prepare", to_node="step-1"),
+            SimpleNamespace(from_node="step-1", to_node="step-2"),
+            SimpleNamespace(from_node="step-2", to_node="publish"),
+        ),
+    )
+
+    assert dependency_map == {
+        "prepare": [],
+        bundle_id: ["prepare"],
+        "publish": [bundle_id],
+    }
+
+
 def test_run_queries_remain_available_after_completion(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- freeze the phase 0 step-ledger and bounded progress contract in spec artifacts and backend schema models
- add workflow-owned step ledger helpers plus `MoonMind.Run` progress and step-ledger queries for latest-run state
- add unit and workflow-boundary coverage for ledger transitions, compact memo/search attribute behavior, and query serialization

## Why
Phases 0 and 1 of the step-ledger rollout need a stable workflow-owned contract before API and UI work can build on it. This change makes `MoonMind.Run` the source of truth for compact per-step state and exposes query-safe latest-run snapshots without storing large evidence in workflow state.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/workflows/test_run_signals_updates.py`
- `./tools/test_unit.sh`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`

## Notes
- The diff-scope helper script could not run on the local macOS Bash 3.2 shell because it depends on `mapfile`; the equivalent diff check was verified manually against `origin/main` before publishing.
- This PR intentionally stops before the Phase 2+ API route and Mission Control UI rollout.