### PR TITLE
Implement step ledger phase 2 evidence wiring

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2507,6 +2507,26 @@ class TemporalAgentRuntimeActivities:
             if isinstance(result_dict.get("metadata"), Mapping)
             else {}
         )
+        moonmind_metadata = (
+            metadata.get("moonmind")
+            if isinstance(metadata.get("moonmind"), Mapping)
+            else {}
+        )
+        step_ledger_metadata = (
+            moonmind_metadata.get("stepLedger")
+            if isinstance(moonmind_metadata.get("stepLedger"), Mapping)
+            else {}
+        )
+        step_artifact_metadata: dict[str, Any] = {}
+        logical_step_id = str(step_ledger_metadata.get("logicalStepId") or "").strip()
+        if logical_step_id:
+            step_artifact_metadata["step_id"] = logical_step_id
+        attempt = step_ledger_metadata.get("attempt")
+        if isinstance(attempt, (int, float)) and not isinstance(attempt, bool):
+            step_artifact_metadata["attempt"] = int(attempt)
+        scope = str(step_ledger_metadata.get("scope") or "").strip()
+        if scope:
+            step_artifact_metadata["scope"] = scope
 
         async def _write_reference_artifact(
             *,
@@ -2525,6 +2545,7 @@ class TemporalAgentRuntimeActivities:
                     "name": link_type.replace(".", "_") + ".json",
                     "producer": "activity:agent_runtime.publish_artifacts",
                     "labels": ["agent_runtime", link_type],
+                    **step_artifact_metadata,
                 },
             )
             return ref.artifact_id
@@ -2564,6 +2585,7 @@ class TemporalAgentRuntimeActivities:
                     "name": "agent_run_summary.json",
                     "producer": "activity:agent_runtime.publish_artifacts",
                     "labels": ["agent_runtime", "output.summary"],
+                    **step_artifact_metadata,
                 },
             )
             agent_result_ref = await _write_json_artifact(
@@ -2575,6 +2597,7 @@ class TemporalAgentRuntimeActivities:
                     "name": "agent_run_result.json",
                     "producer": "activity:agent_runtime.publish_artifacts",
                     "labels": ["agent_runtime", "output.agent_result"],
+                    **step_artifact_metadata,
                 },
             )
             # Enrich result with the diagnostics ref
@@ -3052,6 +3075,18 @@ class TemporalAgentRuntimeActivities:
             # push/PR URL info using model_copy to preserve the typed contract.
             meta = dict(result.metadata or {})
             if record is not None:
+                meta.setdefault("taskRunId", record.run_id)
+                if record.stdout_artifact_ref:
+                    meta.setdefault("stdoutArtifactRef", record.stdout_artifact_ref)
+                if record.stderr_artifact_ref:
+                    meta.setdefault("stderrArtifactRef", record.stderr_artifact_ref)
+                if record.merged_log_artifact_ref:
+                    meta.setdefault(
+                        "mergedLogArtifactRef",
+                        record.merged_log_artifact_ref,
+                    )
+                if record.diagnostics_ref:
+                    meta.setdefault("diagnosticsRef", record.diagnostics_ref)
                 operator_summary = await self._collect_operator_summary(
                     record=record,
                     result=result,

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
@@ -139,6 +140,8 @@ def update_step_row(
     waiting_reason: str | None | object = _UNSET,
     attention_required: bool | None = None,
     last_error: str | None | object = _UNSET,
+    refs: Mapping[str, Any] | object = _UNSET,
+    artifacts: Mapping[str, Any] | object = _UNSET,
     increment_attempt: bool = False,
     set_started_at: bool = False,
 ) -> dict[str, Any]:
@@ -159,6 +162,26 @@ def update_step_row(
             row["attentionRequired"] = attention_required
         if last_error is not _UNSET:
             row["lastError"] = last_error
+        if refs is not _UNSET:
+            merged_refs = default_step_refs()
+            current_refs = row.get("refs")
+            if isinstance(current_refs, dict):
+                merged_refs.update(current_refs)
+            if isinstance(refs, Mapping):
+                for key, value in refs.items():
+                    if key in merged_refs:
+                        merged_refs[key] = value
+            row["refs"] = merged_refs
+        if artifacts is not _UNSET:
+            merged_artifacts = default_step_artifacts()
+            current_artifacts = row.get("artifacts")
+            if isinstance(current_artifacts, dict):
+                merged_artifacts.update(current_artifacts)
+            if isinstance(artifacts, Mapping):
+                for key, value in artifacts.items():
+                    if key in merged_artifacts:
+                        merged_artifacts[key] = value
+            row["artifacts"] = merged_artifacts
         if status in TERMINAL_STEP_STATUSES:
             row["waitingReason"] = None
             row["attentionRequired"] = False

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -131,6 +131,34 @@ def _request_selected_skill(request: AgentExecutionRequest) -> str | None:
     ).strip()
     return selected_skill or None
 
+
+def _request_step_ledger_context(
+    request: AgentExecutionRequest,
+) -> dict[str, Any] | None:
+    """Return compact step-ledger context carried from the parent workflow."""
+
+    parameters = request.parameters if isinstance(request.parameters, dict) else {}
+    metadata = parameters.get("metadata")
+    metadata_map = metadata if isinstance(metadata, Mapping) else {}
+    moonmind = metadata_map.get("moonmind")
+    moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+    raw_context = moonmind_map.get("stepLedger")
+    if not isinstance(raw_context, Mapping):
+        return None
+
+    logical_step_id = str(raw_context.get("logicalStepId") or "").strip()
+    if not logical_step_id:
+        return None
+
+    context: dict[str, Any] = {"logicalStepId": logical_step_id}
+    attempt = raw_context.get("attempt")
+    if isinstance(attempt, (int, float)) and not isinstance(attempt, bool):
+        context["attempt"] = int(attempt)
+    scope = str(raw_context.get("scope") or "").strip()
+    if scope:
+        context["scope"] = scope
+    return context
+
 def _legacy_manager_workflow_id(runtime_id: str) -> str:
     return f"auth-profile-manager:{runtime_id}"
 
@@ -312,23 +340,46 @@ class MoonMindAgentRun:
             f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
         )
 
-    @staticmethod
-    def _merge_managed_session_metadata(
+    def _enrich_result_metadata(
+        self,
         *,
         request: AgentExecutionRequest,
         result: AgentRunResult | None,
     ) -> AgentRunResult | None:
-        if result is None or request.managed_session is None:
+        if result is None:
             return result
+
         metadata = dict(result.metadata or {})
-        metadata["managedSession"] = request.managed_session.model_dump(
-            mode="json",
-            by_alias=True,
-        )
-        if request.instruction_ref:
-            metadata.setdefault("instructionRef", request.instruction_ref)
-        if request.resolved_skillset_ref:
-            metadata.setdefault("resolvedSkillsetRef", request.resolved_skillset_ref)
+        metadata.setdefault("childWorkflowId", workflow.info().workflow_id)
+        metadata.setdefault("childRunId", workflow.info().run_id)
+
+        task_run_id = ""
+        if request.managed_session is not None:
+            task_run_id = str(request.managed_session.task_run_id or "").strip()
+            metadata["managedSession"] = request.managed_session.model_dump(
+                mode="json",
+                by_alias=True,
+            )
+            if request.instruction_ref:
+                metadata.setdefault("instructionRef", request.instruction_ref)
+            if request.resolved_skillset_ref:
+                metadata.setdefault("resolvedSkillsetRef", request.resolved_skillset_ref)
+        elif request.agent_kind == "managed":
+            task_run_id = str(self.run_id or "").strip()
+
+        if task_run_id:
+            metadata.setdefault("taskRunId", task_run_id)
+
+        step_ledger_context = _request_step_ledger_context(request)
+        if step_ledger_context is not None:
+            moonmind_payload = (
+                metadata.get("moonmind")
+                if isinstance(metadata.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload["stepLedger"] = step_ledger_context
+            metadata["moonmind"] = moonmind_payload
+
         return result.model_copy(update={"metadata": metadata})
 
     @staticmethod
@@ -1489,7 +1540,7 @@ class MoonMindAgentRun:
                 if manager_handle and request.execution_profile_ref:
                     await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
 
-                self.final_result = self._merge_managed_session_metadata(
+                self.final_result = self._enrich_result_metadata(
                     request=request,
                     result=self.final_result,
                 )

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -625,6 +625,94 @@ class MoonMindRunWorkflow:
             return
         self._sync_progress_snapshot(updated_at=updated_at)
 
+    def _step_attempt_for(self, logical_step_id: str) -> int | None:
+        for row in self._step_ledger_rows:
+            if row.get("logicalStepId") == logical_step_id:
+                attempt = row.get("attempt")
+                if isinstance(attempt, bool):
+                    return None
+                if isinstance(attempt, (int, float)):
+                    return int(attempt)
+                return None
+        return None
+
+    def _record_step_result_evidence(
+        self,
+        logical_step_id: str,
+        *,
+        execution_result: Any,
+        updated_at: datetime,
+    ) -> None:
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return
+
+        def _output_ref(*keys: str) -> str | None:
+            for key in keys:
+                value = outputs.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+            return None
+
+        output_refs_raw = outputs.get("outputRefs")
+        if not isinstance(output_refs_raw, list):
+            output_refs_raw = outputs.get("output_refs")
+        output_refs = [
+            str(item).strip()
+            for item in (output_refs_raw or [])
+            if isinstance(item, str) and item.strip()
+        ]
+
+        refs = {
+            "childWorkflowId": _output_ref("childWorkflowId", "child_workflow_id"),
+            "childRunId": _output_ref("childRunId", "child_run_id"),
+            "taskRunId": _output_ref("taskRunId", "task_run_id"),
+        }
+        artifacts = {
+            "outputSummary": _output_ref("outputSummaryRef", "output_summary_ref"),
+            "outputPrimary": _output_ref(
+                "outputPrimaryRef",
+                "output_primary_ref",
+                "outputAgentResultRef",
+                "output_agent_result_ref",
+            ),
+            "runtimeStdout": _output_ref("stdoutArtifactRef", "stdout_artifact_ref"),
+            "runtimeStderr": _output_ref("stderrArtifactRef", "stderr_artifact_ref"),
+            "runtimeMergedLogs": _output_ref(
+                "mergedLogArtifactRef",
+                "merged_log_artifact_ref",
+                "logArtifactRef",
+                "log_artifact_ref",
+            ),
+            "runtimeDiagnostics": _output_ref("diagnosticsRef", "diagnostics_ref"),
+            "providerSnapshot": _output_ref(
+                "providerSnapshotRef",
+                "provider_snapshot_ref",
+            ),
+        }
+
+        if artifacts["outputPrimary"] is None:
+            reserved_refs = {
+                value
+                for value in artifacts.values()
+                if isinstance(value, str) and value.strip()
+            }
+            fallback_primary = next(
+                (ref for ref in output_refs if ref not in reserved_refs),
+                None,
+            )
+            if fallback_primary is not None:
+                artifacts["outputPrimary"] = fallback_primary
+
+        if not self._try_update_step_row(
+            logical_step_id,
+            updated_at=updated_at,
+            refs=refs,
+            artifacts=artifacts,
+        ):
+            return
+        self._sync_progress_snapshot(updated_at=updated_at)
+
     def _refresh_step_readiness(self, *, updated_at: datetime) -> None:
         refresh_ready_steps(self._step_ledger_rows, updated_at=updated_at)
         self._sync_progress_snapshot(updated_at=updated_at)
@@ -1575,6 +1663,11 @@ class MoonMindRunWorkflow:
                             "plan node execution result is missing required status field"
                         )
                     break
+                self._record_step_result_evidence(
+                    node_id,
+                    execution_result=execution_result,
+                    updated_at=workflow.now(),
+                )
                 if result_status != "COMPLETED":
                     failure_message = self._activity_result_failure_message(
                         execution_result
@@ -2431,6 +2524,26 @@ class MoonMindRunWorkflow:
                 else {}
             )
             moonmind_payload.update(bundle_payload)
+            metadata_payload["moonmind"] = moonmind_payload
+            parameters["metadata"] = metadata_payload
+
+        step_attempt = self._step_attempt_for(node_id)
+        if step_attempt is not None:
+            metadata_payload = (
+                parameters.get("metadata")
+                if isinstance(parameters.get("metadata"), dict)
+                else {}
+            )
+            moonmind_payload = (
+                metadata_payload.get("moonmind")
+                if isinstance(metadata_payload.get("moonmind"), dict)
+                else {}
+            )
+            moonmind_payload["stepLedger"] = {
+                "logicalStepId": node_id,
+                "attempt": step_attempt,
+                "scope": "step",
+            }
             metadata_payload["moonmind"] = moonmind_payload
             parameters["metadata"] = metadata_payload
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -590,15 +590,21 @@ class MoonMindRunWorkflow:
         waiting_reason: str | None,
         summary: str | None = None,
         attention_required: bool = False,
+        refs: Mapping[str, Any] | None = None,
+        artifacts: Mapping[str, Any] | None = None,
     ) -> None:
-        if not self._try_update_step_row(
-            logical_step_id,
-            updated_at=updated_at,
-            status=status,
-            summary=summary,
-            waiting_reason=waiting_reason,
-            attention_required=attention_required,
-        ):
+        update_kwargs: dict[str, Any] = {
+            "updated_at": updated_at,
+            "status": status,
+            "summary": summary,
+            "waiting_reason": waiting_reason,
+            "attention_required": attention_required,
+        }
+        if refs is not None:
+            update_kwargs["refs"] = refs
+        if artifacts is not None:
+            update_kwargs["artifacts"] = artifacts
+        if not self._try_update_step_row(logical_step_id, **update_kwargs):
             return
         self._sync_progress_snapshot(updated_at=updated_at)
 
@@ -654,14 +660,22 @@ class MoonMindRunWorkflow:
                     return value.strip()
             return None
 
-        output_refs_raw = outputs.get("outputRefs")
-        if not isinstance(output_refs_raw, list):
-            output_refs_raw = outputs.get("output_refs")
-        output_refs = [
-            str(item).strip()
-            for item in (output_refs_raw or [])
-            if isinstance(item, str) and item.strip()
-        ]
+        def _output_ref_list(*keys: str) -> list[str]:
+            for key in keys:
+                value = outputs.get(key)
+                if isinstance(value, (list, tuple)):
+                    return [
+                        item.strip()
+                        for item in value
+                        if isinstance(item, str) and item.strip()
+                    ]
+            return []
+
+        output_refs = _output_ref_list("outputRefs", "output_refs")
+        agent_result_ref = _output_ref(
+            "outputAgentResultRef",
+            "output_agent_result_ref",
+        )
 
         refs = {
             "childWorkflowId": _output_ref("childWorkflowId", "child_workflow_id"),
@@ -673,8 +687,6 @@ class MoonMindRunWorkflow:
             "outputPrimary": _output_ref(
                 "outputPrimaryRef",
                 "output_primary_ref",
-                "outputAgentResultRef",
-                "output_agent_result_ref",
             ),
             "runtimeStdout": _output_ref("stdoutArtifactRef", "stdout_artifact_ref"),
             "runtimeStderr": _output_ref("stderrArtifactRef", "stderr_artifact_ref"),
@@ -703,6 +715,8 @@ class MoonMindRunWorkflow:
             )
             if fallback_primary is not None:
                 artifacts["outputPrimary"] = fallback_primary
+            elif agent_result_ref is not None:
+                artifacts["outputPrimary"] = agent_result_ref
 
         if not self._try_update_step_row(
             logical_step_id,
@@ -1551,6 +1565,7 @@ class MoonMindRunWorkflow:
                             updated_at=workflow.now(),
                             waiting_reason="Awaiting child workflow progress",
                             summary=f"Awaiting child workflow for {tool_name}",
+                            refs={"childWorkflowId": child_workflow_id},
                         )
                         try:
                             child_result = await workflow.execute_child_workflow(

--- a/specs/138-step-ledger-phase2/checklists/requirements.md
+++ b/specs/138-step-ledger-phase2/checklists/requirements.md
@@ -1,0 +1,19 @@
+# Specification Quality Checklist: Step Ledger Phase 2
+
+## Completeness
+
+- [x] Scope is limited to workflow/runtime evidence wiring.
+- [x] Source document requirements map to explicit functional requirements.
+- [x] Acceptance scenarios cover lineage refs, artifact grouping, and step-scoped metadata.
+
+## Testability
+
+- [x] Independent tests are defined per user story.
+- [x] Final verification includes targeted tests plus `./tools/test_unit.sh`.
+- [x] Large evidence remains out of workflow state by contract and test plan.
+
+## Traceability
+
+- [x] Source `DOC-REQ-*` mappings are captured.
+- [x] Planned implementation files are identified in the plan.
+- [x] No API/UI scope has been pulled into this phase.

--- a/specs/138-step-ledger-phase2/contracts/requirements-traceability.md
+++ b/specs/138-step-ledger-phase2/contracts/requirements-traceability.md
@@ -1,0 +1,12 @@
+# Requirements Traceability: Step Ledger Phase 2
+
+| Source Requirement | Spec Mapping | Planned Implementation | Validation Strategy |
+| --- | --- | --- | --- |
+| DOC-REQ-001 | FR-001, FR-002 | Enrich child results with workflow/task-run lineage and project them into parent step rows | Workflow boundary tests for child refs |
+| DOC-REQ-002 | FR-002, FR-003 | Group result metadata into canonical step artifact slots inside `MoonMind.Run` | Workflow boundary tests for artifact slot grouping |
+| DOC-REQ-003 | FR-005 | Stamp `step_id`, `attempt`, and `scope` in published artifact metadata | Activity unit test capturing artifact metadata |
+| DOC-REQ-004 | FR-004 | Keep workflow state bounded and avoid log bodies in row/memo/search attributes | Step-ledger tests asserting refs only |
+| DOC-REQ-005 | FR-001, FR-003, FR-004 | Surface managed-run/session observability refs without duplicating logs | Activity + workflow tests |
+| DOC-REQ-006 | FR-003, FR-005 | Use artifact-backed summary/result publication plus step-scoped metadata | Activity unit test plus workflow grouping tests |
+| DOC-REQ-007 | FR-001 | Carry the managed-run observability handle into parent step rows as `taskRunId` | Agent-run/runtime tests and workflow step-row assertions |
+| DOC-REQ-008 | FR-002, FR-006 | Reuse the Phase 1 row schema unchanged while filling reserved fields | Schema-preserving workflow tests |

--- a/specs/138-step-ledger-phase2/contracts/step-ledger-evidence-contract.md
+++ b/specs/138-step-ledger-phase2/contracts/step-ledger-evidence-contract.md
@@ -1,0 +1,33 @@
+# Step Ledger Evidence Contract
+
+Phase 2 keeps the Phase 1 row schema unchanged and adds population rules only.
+
+## Parent step refs
+
+- `refs.childWorkflowId`: child `MoonMind.AgentRun` workflow ID
+- `refs.childRunId`: child `MoonMind.AgentRun` run ID
+- `refs.taskRunId`: managed-run observability identifier when available
+
+## Parent step artifacts
+
+- `artifacts.outputSummary`: durable summary artifact for the child/runtime result
+- `artifacts.outputPrimary`: deterministic primary durable output ref
+- `artifacts.runtimeStdout`: stdout artifact ref
+- `artifacts.runtimeStderr`: stderr artifact ref
+- `artifacts.runtimeMergedLogs`: merged log artifact ref when available
+- `artifacts.runtimeDiagnostics`: diagnostics artifact ref
+- `artifacts.providerSnapshot`: provider snapshot artifact ref when available
+
+## Artifact metadata
+
+When `agent_runtime.publish_artifacts` receives step context, it writes:
+
+```json
+{
+  "step_id": "logical-step-id",
+  "attempt": 2,
+  "scope": "step"
+}
+```
+
+These keys are additive metadata only. Artifact publication remains valid when they are absent.

--- a/specs/138-step-ledger-phase2/data-model.md
+++ b/specs/138-step-ledger-phase2/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: Step Ledger Phase 2
+
+## 1. StepLedgerEvidenceContext
+
+Compact metadata carried from the parent step into child/runtime artifact publication.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `logicalStepId` | string | Stable plan-node ID from the parent step row |
+| `attempt` | integer | Current latest-run attempt number for the logical step |
+| `scope` | string or null | Optional bounded scope value; Phase 2 uses `"step"` when present |
+
+Storage posture:
+
+- carried in request/result metadata only
+- mirrored into artifact metadata when available
+- never stored as a separate workflow payload blob
+
+## 2. StepLedgerRefs
+
+Phase 1 already froze the shape. Phase 2 fills it.
+
+| Field | Source |
+| --- | --- |
+| `childWorkflowId` | Parent launch context and/or child result lineage metadata |
+| `childRunId` | Child `MoonMind.AgentRun` result lineage metadata |
+| `taskRunId` | Managed-run/session observability metadata from the child runtime result |
+
+## 3. StepLedgerArtifacts
+
+Phase 2 populates the reserved slots below without changing the schema:
+
+| Slot | Primary source | Fallback |
+| --- | --- | --- |
+| `outputSummary` | `outputSummaryRef` from child/runtime metadata | `null` |
+| `outputPrimary` | explicit `outputPrimaryRef` | first unassigned durable `outputRefs[]`, then `outputAgentResultRef` |
+| `runtimeStdout` | `stdoutArtifactRef` | session artifact metadata |
+| `runtimeStderr` | `stderrArtifactRef` | session artifact metadata |
+| `runtimeMergedLogs` | `mergedLogArtifactRef` | `null` |
+| `runtimeDiagnostics` | `diagnosticsRef` | session artifact metadata |
+| `providerSnapshot` | explicit provider snapshot ref | `null` |
+
+## 4. Parent Result Grouping Inputs
+
+The parent workflow groups evidence from compact result metadata only:
+
+- top-level flattened metadata fields produced by `_map_agent_run_result()`
+- `outputRefs[]`
+- `diagnosticsRef` / `diagnostics_ref`
+- nested `sessionSummary` / `sessionArtifacts` metadata for Codex session-backed runs
+
+The parent does not read artifact bodies when populating the row.

--- a/specs/138-step-ledger-phase2/plan.md
+++ b/specs/138-step-ledger-phase2/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Step Ledger Phase 2
+
+**Branch**: `138-step-ledger-phase2` | **Date**: 2026-04-08 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/138-step-ledger-phase2/spec.md`
+
+## Summary
+
+Implement the step-ledger evidence phase by carrying child-run lineage and canonical evidence refs into `MoonMind.Run` step rows without moving large logs or diagnostics into workflow state. The child `MoonMind.AgentRun` workflow and agent-runtime activities will enrich compact result metadata, and the parent workflow will deterministically group that metadata into `refs` and `artifacts` fields on the latest-run step ledger.
+
+## Technical Context
+
+**Language/Version**: Python 3.11  
+**Primary Dependencies**: Temporal Python SDK, Pydantic v2, existing managed-run/session runtime stores and artifact services  
+**Storage**: Workflow state for compact step refs; managed-run/session stores and artifact storage for runtime evidence; artifact metadata for step-scoped linkage  
+**Testing**: `pytest` via targeted unit/workflow tests and `./tools/test_unit.sh`  
+**Target Platform**: Linux server workers running MoonMind Temporal workflows  
+**Project Type**: Backend workflow/runtime implementation  
+**Performance Goals**: Step-ledger queries remain bounded and artifact-body-free; evidence grouping does not require artifact hydration during workflow execution  
+**Constraints**: Preserve replay determinism; keep API/UI rollout out of scope; do not add compatibility alias fields; do not store raw logs/diagnostics in workflow state  
+**Scale/Scope**: Parent-child lineage, grouped evidence refs, and step-scoped artifact metadata only
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The change improves orchestration lineage and evidence boundaries without adding provider-specific orchestration logic to the core workflow.
+- **IV. Own Your Data**: PASS. Large logs and diagnostics stay in artifacts and managed-run/session stores, with the workflow carrying only compact refs.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The work fills the frozen step-ledger contract rather than introducing new UI-specific evidence shapes.
+- **IX. Resilient by Default**: PASS. Evidence grouping is derived from compact refs and deterministic metadata, preserving replay-safe workflow state.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This phase has its own feature artifacts and implementation tasks instead of extending Phase 1 informally.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical semantics stay in `docs/Temporal/StepLedgerAndProgressModel.md`; rollout-specific work is captured here.
+- **XIII. Pre-Release Delete, Don't Deprecate**: PASS. The change fills existing canonical fields directly and does not add compatibility wrappers.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/138-step-ledger-phase2/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── requirements-traceability.md
+│   └── step-ledger-evidence-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/workflows/run.py                 # MODIFY: map child results into step refs/artifact slots
+moonmind/workflows/temporal/step_ledger.py                   # MODIFY: merge structured refs/artifacts/checks into rows
+moonmind/workflows/temporal/workflows/agent_run.py           # MODIFY: enrich child results with lineage/task-run metadata
+moonmind/workflows/temporal/activity_runtime.py              # MODIFY: publish/fetch compact step-scoped observability metadata
+tests/unit/workflows/temporal/test_step_ledger.py            # MODIFY: structured row merge coverage
+tests/unit/workflows/temporal/workflows/test_run_step_ledger.py  # MODIFY: parent evidence/lineage coverage
+tests/unit/workflows/temporal/test_agent_runtime_activities.py    # MODIFY: artifact metadata + managed-run metadata coverage
+tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py # MODIFY: child lineage metadata coverage
+tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py # MODIFY: session-backed lineage/task-run metadata coverage
+```
+
+**Structure Decision**: Keep step-row mutation logic in the pure `step_ledger.py` helper and keep workflow-specific result grouping in `MoonMind.Run`. Runtime activities and `MoonMind.AgentRun` provide compact metadata only; they do not own parent step-row state.
+
+## Complexity Tracking
+
+The main risk is contract drift between parent workflow grouping and runtime metadata emission. Mitigation: add boundary tests on both sides and keep the parent grouping logic tolerant of missing optional refs while remaining fail-fast on unsupported shape assumptions.

--- a/specs/138-step-ledger-phase2/quickstart.md
+++ b/specs/138-step-ledger-phase2/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: Step Ledger Phase 2
+
+## Verify the feature
+
+1. Run the focused TDD coverage:
+
+```bash
+pytest \
+  tests/unit/workflows/temporal/test_step_ledger.py \
+  tests/unit/workflows/temporal/workflows/test_run_step_ledger.py \
+  tests/unit/workflows/temporal/test_agent_runtime_activities.py \
+  tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py \
+  tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py \
+  -q
+```
+
+2. Run the full required unit suite:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Manual inspection checklist
+
+1. Start from a plan with an `agent_runtime` node.
+2. Confirm the parent step row exposes `refs.childWorkflowId`, `refs.childRunId`, and `refs.taskRunId`.
+3. Confirm the same row exposes grouped artifact slots for summary/output/logs/diagnostics using refs only.
+4. Confirm no raw log or diagnostics body appears in the step row, Memo, or Search Attributes.

--- a/specs/138-step-ledger-phase2/research.md
+++ b/specs/138-step-ledger-phase2/research.md
@@ -1,0 +1,30 @@
+# Research: Step Ledger Phase 2
+
+## Decision 1: Group evidence in the parent workflow from compact result metadata
+
+- **Decision**: Keep the parent `MoonMind.Run` workflow responsible for translating child/activity result metadata into `refs` and `artifacts` slots on the step ledger.
+- **Rationale**: The step ledger is the canonical live-state owner. Grouping evidence there lets later API/UI phases reuse the same latest-run contract without adding a second grouping layer first.
+- **Alternatives considered**:
+  - Group evidence only in a later API service projection: rejected because Phase 2 is explicitly the workflow/runtime evidence phase and later layers should consume the same row shape unchanged.
+  - Read artifact metadata inside the workflow to derive slots: rejected because it would add avoidable IO and coupling during execution.
+
+## Decision 2: Enrich `MoonMind.AgentRun` results with lineage and task-run metadata before returning to the parent
+
+- **Decision**: Attach `childWorkflowId`, `childRunId`, and best-available `taskRunId` metadata inside `MoonMind.AgentRun` before the parent consumes the result.
+- **Rationale**: The child workflow is the authoritative source for its own workflow identity and the managed-run/session identifiers it orchestrates.
+- **Alternatives considered**:
+  - Infer child run identity only in the parent: rejected because the parent does not always have the child run instance ID after completion.
+
+## Decision 3: Stamp step-scoped metadata on published agent-runtime artifacts using request-carried step context
+
+- **Decision**: Carry compact step context (`logicalStepId`, `attempt`, `scope`) through `AgentExecutionRequest.parameters.metadata.moonmind.stepLedger`, then copy that into artifact metadata during `agent_runtime.publish_artifacts`.
+- **Rationale**: The parent already knows the current logical step and attempt, and artifact publication already writes the canonical summary/result artifacts for later grouping and projection.
+- **Alternatives considered**:
+  - Derive step identity from artifact names: rejected because it is brittle and violates the explicit metadata requirement in the normative doc.
+
+## Decision 4: Prefer explicit runtime refs, then deterministic fallback selection for `outputPrimary`
+
+- **Decision**: Slot grouping should first use explicit refs from metadata (`outputSummaryRef`, stdout/stderr/merged/diagnostics refs, provider snapshot refs). If `outputPrimary` is still missing, choose the first durable output ref that is not already assigned to a runtime log or diagnostics slot, falling back to the agent-result artifact when necessary.
+- **Rationale**: This keeps grouping deterministic without artifact hydration while still giving later consumers a useful primary output ref.
+- **Alternatives considered**:
+  - Leave `outputPrimary` empty unless a provider names it directly: rejected because it would make Phase 2 materially less useful for later API/UI work.

--- a/specs/138-step-ledger-phase2/spec.md
+++ b/specs/138-step-ledger-phase2/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Step Ledger Phase 2
+
+**Feature Branch**: `138-step-ledger-phase2`  
+**Created**: 2026-04-08  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 2 using test-driven development of the step ledger plan. Wire evidence and parent/child refs into the workflow-owned step ledger without bloating workflow history, keeping API and UI phase work out of scope."
+
+## Source Document Requirements
+
+Source: `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, `docs/Temporal/WorkflowArtifactSystemDesign.md`, `docs/tmp/remaining-work/Temporal-WorkflowArtifactSystemDesign.md`, `docs/Tasks/TaskRunsApi.md`
+
+| ID | Source Section | Requirement Summary |
+| --- | --- | --- |
+| DOC-REQ-001 | `StepLedgerAndProgressModel` §11.1 | `MoonMind.Run` step rows must carry bounded `childWorkflowId`, `childRunId`, and `taskRunId` refs rather than inferring lineage from logs. |
+| DOC-REQ-002 | `StepLedgerAndProgressModel` §11.2 | The workflow/server side must group step evidence into canonical artifact slots `outputSummary`, `outputPrimary`, `runtimeStdout`, `runtimeStderr`, `runtimeMergedLogs`, `runtimeDiagnostics`, and `providerSnapshot`. |
+| DOC-REQ-003 | `StepLedgerAndProgressModel` §11.2 | Step-scoped artifact linkage metadata should include `step_id`, `attempt`, and optional `scope`. |
+| DOC-REQ-004 | `StepLedgerAndProgressModel` §3.3, §13 | Logs, diagnostics, provider payloads, and other large evidence must stay out of workflow state and out of Memo/Search Attributes. |
+| DOC-REQ-005 | `ManagedAndExternalAgentExecutionModel` §10.1, §10.2 | The parent step ledger should point at observability refs from managed/external agent runs instead of duplicating log bodies, and managed-run metadata should surface stdout/stderr/merged/diagnostics refs. |
+| DOC-REQ-006 | `WorkflowArtifactSystemDesign` §5.2, remaining work | Artifact publication should keep durable evidence in artifacts while exposing compact refs, and Phase 2 should standardize step-scoped metadata for those artifacts. |
+| DOC-REQ-007 | `TaskRunsApi` §3-§4 | `taskRunId` on a step row is the managed-run observability handle used for task-run log and diagnostics surfaces. |
+| DOC-REQ-008 | `StepLedgerAndProgressModel` §12 | Later API/UI phases must be able to consume the workflow-owned step rows unchanged, so Phase 2 must keep the Phase 1 row schema stable while filling the reserved refs/artifact fields. |
+
+## User Scenarios & Testing
+
+### User Story 1 - Parent steps expose child lineage refs (Priority: P1)
+
+A platform developer needs parent step rows to include child workflow and task-run lineage so later API/UI work can expand one step without guessing runtime ancestry from logs.
+
+**Why this priority**: Child lineage is the core Phase 2 prerequisite for observability drilldown and latest-run-only task detail.
+
+**Independent Test**: Can be tested by executing or simulating an `agent_runtime` step and asserting that the step row exposes bounded `childWorkflowId`, `childRunId`, and `taskRunId` fields while leaving log bodies out of workflow state.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `agent_runtime` plan node launches `MoonMind.AgentRun`, **When** the parent step enters its waiting state, **Then** the row captures the child workflow lineage refs without waiting for artifacts or log hydration.
+2. **Given** the child workflow completes and exposes managed-run observability metadata, **When** the parent updates the latest step row, **Then** the row includes the canonical `taskRunId` used by task-run observability routes.
+3. **Given** child execution fails with diagnostics available, **When** the parent stores evidence refs, **Then** only bounded refs and summaries are stored in workflow state.
+
+---
+
+### User Story 2 - Parent steps expose grouped evidence slots (Priority: P1)
+
+An operator needs one canonical step-evidence grouping so later API/UI phases can expand a step row into logs, diagnostics, and outputs without client-side artifact guessing.
+
+**Why this priority**: Phase 2 is the server-side evidence wiring phase; later API/UI work depends on these slots already being deterministically populated.
+
+**Independent Test**: Can be tested by feeding representative managed-runtime and skill execution results into the workflow and asserting that `artifacts.*` slots are filled deterministically from compact refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed-runtime result includes summary and runtime observability refs, **When** the parent records the result, **Then** `outputSummary`, `outputPrimary`, `runtimeStdout`, `runtimeStderr`, and `runtimeDiagnostics` are grouped into the step row.
+2. **Given** a result exposes only generic `outputRefs` plus a diagnostics ref, **When** the parent groups evidence, **Then** it picks deterministic canonical slots without reading artifact bodies.
+3. **Given** a step has no ref for one or more evidence types, **When** the row is returned, **Then** the corresponding slots remain present and `null`.
+
+---
+
+### User Story 3 - Published artifacts carry step-scoped metadata (Priority: P2)
+
+A backend consumer needs artifact publication to stamp step identity and attempt metadata so later projection/API layers can group evidence per step without reverse-engineering artifact names.
+
+**Why this priority**: Server-side grouping is more durable when the artifact layer carries explicit step metadata instead of path heuristics.
+
+**Independent Test**: Can be tested by publishing agent-runtime result artifacts with step context and asserting the artifact create metadata includes `step_id`, `attempt`, and `scope`.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `agent_runtime` step publishes summary/result artifacts, **When** the activity writes those artifacts, **Then** the artifact metadata includes `step_id`, `attempt`, and `scope: "step"`.
+2. **Given** an already-running retry attempt publishes artifacts, **When** metadata is written, **Then** the stamped attempt number matches the current parent-step attempt.
+3. **Given** step context is absent, **When** publication still succeeds, **Then** artifact publishing remains backward-safe and simply omits the optional step metadata.
+
+### Edge Cases
+
+- What happens when a child workflow succeeds but has no managed-run observability record yet? The row should still preserve `childWorkflowId`/`childRunId` and keep `taskRunId`/artifact slots null until a later result carries them.
+- What happens when a managed-session-backed step returns session artifacts rather than classic managed-run refs? The parent should still group the available stdout/stderr/diagnostics refs without inventing merged/provider refs.
+- What happens when `outputRefs` contains runtime logs and output artifacts together? The grouping logic must prefer explicit metadata refs first and only use deterministic fallback selection for `outputPrimary`.
+- What happens when a step retries? The row should expose only the current attempt's refs, and step-scoped artifact metadata must use the current attempt number.
+- What happens when a result contains a large nested payload? The workflow must reduce it to bounded summaries and refs before mutating step state.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST enrich `MoonMind.AgentRun` results with bounded lineage metadata sufficient for a parent step row to capture `childWorkflowId`, `childRunId`, and `taskRunId`. Mappings: DOC-REQ-001, DOC-REQ-005, DOC-REQ-007.
+- **FR-002**: System MUST update `MoonMind.Run` step rows from compact execution-result metadata so the latest row for a step exposes canonical `refs` and `artifacts` fields without reading artifact bodies. Mappings: DOC-REQ-001, DOC-REQ-002, DOC-REQ-004, DOC-REQ-008.
+- **FR-003**: System MUST deterministically map managed-run/session refs into `runtimeStdout`, `runtimeStderr`, `runtimeMergedLogs`, and `runtimeDiagnostics`, and map durable summary/output refs into `outputSummary` and `outputPrimary`. Mappings: DOC-REQ-002, DOC-REQ-005, DOC-REQ-006.
+- **FR-004**: System MUST keep step rows, Memo, Search Attributes, and workflow payloads free of raw log bodies, diagnostics bodies, and provider dumps. Mappings: DOC-REQ-004, DOC-REQ-005.
+- **FR-005**: System MUST stamp step-scoped metadata (`step_id`, `attempt`, optional `scope`) onto published agent-runtime artifacts when step context is available. Mappings: DOC-REQ-003, DOC-REQ-006.
+- **FR-006**: System MUST preserve the Phase 1 step-ledger schema unchanged, filling only the previously reserved `refs` and `artifacts` fields. Mappings: DOC-REQ-008.
+- **FR-007**: System MUST implement production runtime code changes plus validation tests in this phase; documentation-only work is insufficient. Mappings: DOC-REQ-001, DOC-REQ-002, DOC-REQ-005.
+
+### Key Entities
+
+- **StepLedgerEvidenceContext**: Compact step-scoped context containing `logicalStepId`, current `attempt`, and optional `scope` for artifact publication.
+- **StepLedgerRefs**: Parent-visible lineage refs populated from child workflow execution and managed-run observability metadata.
+- **StepLedgerArtifacts**: Canonical grouped evidence slots on a latest-run step row.
+- **ManagedRunObservabilityMetadata**: Compact runtime metadata exposing `taskRunId` plus stdout/stderr/merged/diagnostics refs without embedding those artifacts in workflow history.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Workflow tests prove an `agent_runtime` step row captures `childWorkflowId`, `childRunId`, and `taskRunId` while keeping log/diagnostic bodies out of workflow state.
+- **SC-002**: Workflow tests prove canonical artifact slots are populated from representative managed-runtime and skill execution results using refs only.
+- **SC-003**: Activity/runtime tests prove published agent-runtime artifacts receive step-scoped metadata when context is available.
+- **SC-004**: Final verification passes through targeted step-ledger/activity tests and `./tools/test_unit.sh`.
+
+## Assumptions
+
+- Phase 2 stops at workflow/runtime evidence wiring; adding `ExecutionModel.progress`, `GET /api/executions/{workflowId}/steps`, and Mission Control step UI work remains out of scope for this change.
+- Existing managed-run/session systems already publish durable stdout/stderr/diagnostics artifacts; Phase 2 only needs to surface their refs through the step ledger.
+- When a provider-specific snapshot ref does not yet exist, `providerSnapshot` may remain `null` as long as the slot remains stable.

--- a/specs/138-step-ledger-phase2/speckit_analyze_report.md
+++ b/specs/138-step-ledger-phase2/speckit_analyze_report.md
@@ -1,0 +1,37 @@
+# Speckit Analyze Report: Step Ledger Phase 2
+
+## Findings
+
+### spec.md
+
+- Severity: LOW
+- Location: User Story 2 / Acceptance Scenarios
+- Problem: `providerSnapshot` is intentionally nullable in this phase.
+- Remediation: Keep the slot stable and document the null posture, which is already done.
+- Rationale: The design stays internally consistent without forcing a premature provider-snapshot implementation.
+
+### plan.md
+
+- Severity: LOW
+- Location: Project Structure
+- Problem: The plan includes both workflow/runtime and test files.
+- Remediation: No change required.
+- Rationale: This is expected for runtime-mode implementation and matches the scope validator.
+
+### tasks.md
+
+- Severity: LOW
+- Location: Phase ordering
+- Problem: Artifact metadata work depends on child/request metadata wiring.
+- Remediation: Keep `T013` after the lineage/evidence implementation tasks, which is already reflected in the task order.
+- Rationale: The dependency chain is explicit and executable.
+
+## Safe to Implement
+
+Safe to Implement: YES
+
+Blocking Remediations:
+
+- None.
+
+Determination Rationale: The spec, plan, and tasks are consistent, runtime-scoped, and testable without unresolved contract gaps.

--- a/specs/138-step-ledger-phase2/tasks.md
+++ b/specs/138-step-ledger-phase2/tasks.md
@@ -1,0 +1,71 @@
+# Tasks: Step Ledger Phase 2
+
+**Input**: Design documents from `/specs/138-step-ledger-phase2/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing tests before implementing the corresponding lineage/evidence behavior.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create or extend the Phase 2 test targets in `tests/unit/workflows/temporal/test_step_ledger.py`, `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, and the relevant `test_agent_run_*` workflow files.
+
+---
+
+## Phase 2: User Story 1 - Parent steps expose child lineage refs (Priority: P1)
+
+**Goal**: Parent step rows capture stable child workflow lineage and task-run observability refs.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Write failing workflow tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` covering child workflow refs and `taskRunId` projection onto the latest step row.
+- [X] T003 [P] [US1] Write failing `MoonMind.AgentRun` tests in `tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py` and `tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py` covering returned lineage/task-run metadata.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Update `moonmind/workflows/temporal/workflows/agent_run.py` to enrich returned result metadata with child workflow lineage and best-available task-run identifiers.
+- [X] T005 [US1] Update `moonmind/workflows/temporal/workflows/run.py` to store child workflow refs and task-run refs on parent step rows from compact result metadata only.
+
+---
+
+## Phase 3: User Story 2 - Parent steps expose grouped evidence slots (Priority: P1)
+
+**Goal**: Parent step rows expose canonical grouped evidence refs without artifact hydration.
+
+### Tests for User Story 2
+
+- [X] T006 [P] [US2] Write failing structured-row merge tests in `tests/unit/workflows/temporal/test_step_ledger.py` for refs/artifact slot updates.
+- [X] T007 [P] [US2] Write failing workflow tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` covering deterministic slot grouping from managed-runtime and generic execution results.
+- [X] T008 [P] [US2] Write failing managed-run metadata tests in `tests/unit/workflows/temporal/test_agent_runtime_activities.py` covering stdout/stderr/merged/diagnostics/task-run metadata enrichment.
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Extend `moonmind/workflows/temporal/step_ledger.py` to merge structured refs/artifacts onto existing rows without replacing the frozen schema.
+- [X] T010 [US2] Update `moonmind/workflows/temporal/activity_runtime.py` to enrich managed-run fetch results with compact observability refs and task-run metadata.
+- [X] T011 [US2] Update `moonmind/workflows/temporal/workflows/run.py` to group compact result metadata into canonical step artifact slots while keeping workflow state bounded.
+
+---
+
+## Phase 4: User Story 3 - Published artifacts carry step-scoped metadata (Priority: P2)
+
+**Goal**: Agent-runtime artifact publication stamps explicit step identity/attempt metadata for later grouping and projection.
+
+### Tests for User Story 3
+
+- [X] T012 [P] [US3] Write failing activity tests in `tests/unit/workflows/temporal/test_agent_runtime_activities.py` asserting summary/result artifact metadata includes `step_id`, `attempt`, and `scope` when step context exists.
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Carry compact step context from `moonmind/workflows/temporal/workflows/run.py` into child request metadata and stamp that metadata during `agent_runtime.publish_artifacts` in `moonmind/workflows/temporal/activity_runtime.py`.
+
+---
+
+## Phase 5: Validation
+
+- [X] T014 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T015 Run targeted Phase 2 tests via `pytest tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py -q`
+- [X] T016 Run `./tools/test_unit.sh`

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -28,6 +29,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionSummary,
     CodexManagedSessionTurnResponse,
 )
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal import client as temporal_client_module
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalActivityRuntimeError,
@@ -217,6 +219,85 @@ async def test_publish_artifacts_none_input_returns_none() -> None:
     activities = TemporalAgentRuntimeActivities()
     result = await activities.agent_runtime_publish_artifacts(None)
     assert result is None
+
+
+async def test_publish_artifacts_stamps_step_metadata_when_context_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_metadata: list[dict[str, object] | None] = []
+
+    async def fake_write_json_artifact(
+        _service: object,
+        *,
+        principal: str,
+        payload: object,
+        execution_ref: object = None,
+        metadata_json: dict[str, object] | None = None,
+    ) -> SimpleNamespace:
+        del principal, payload, execution_ref
+        captured_metadata.append(metadata_json)
+        return SimpleNamespace(artifact_id=f"art_{len(captured_metadata)}")
+
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_write_json_artifact",
+        fake_write_json_artifact,
+    )
+
+    activities = TemporalAgentRuntimeActivities(artifact_service=object())
+    result = await activities.agent_runtime_publish_artifacts(
+        AgentRunResult(
+            summary="done",
+            metadata={
+                "moonmind": {
+                    "stepLedger": {
+                        "logicalStepId": "delegate-agent",
+                        "attempt": 2,
+                        "scope": "step",
+                    }
+                }
+            },
+        )
+    )
+
+    assert isinstance(result, AgentRunResult)
+    assert len(captured_metadata) == 2
+    assert captured_metadata[0]["step_id"] == "delegate-agent"
+    assert captured_metadata[0]["attempt"] == 2
+    assert captured_metadata[0]["scope"] == "step"
+    assert captured_metadata[1]["step_id"] == "delegate-agent"
+
+
+async def test_fetch_result_exposes_task_run_and_runtime_artifact_metadata(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    store.save(
+        ManagedRunRecord(
+            runId="550e8400-e29b-41d4-a716-446655440000",
+            workflowId="wf-parent-1",
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=datetime.now(tz=UTC),
+            stdoutArtifactRef="art_stdout_1",
+            stderrArtifactRef="art_stderr_1",
+            mergedLogArtifactRef="art_merged_1",
+            diagnosticsRef="art_diag_1",
+        )
+    )
+
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+    result = await activities.agent_runtime_fetch_result(
+        {"run_id": "550e8400-e29b-41d4-a716-446655440000", "agent_id": "codex_cli"}
+    )
+
+    assert isinstance(result, AgentRunResult)
+    assert result.metadata["taskRunId"] == "550e8400-e29b-41d4-a716-446655440000"
+    assert result.metadata["stdoutArtifactRef"] == "art_stdout_1"
+    assert result.metadata["stderrArtifactRef"] == "art_stderr_1"
+    assert result.metadata["mergedLogArtifactRef"] == "art_merged_1"
+    assert result.metadata["diagnosticsRef"] == "art_diag_1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -339,3 +339,50 @@ def test_update_step_row_allows_explicit_last_error_clear() -> None:
 
     assert rows[0]["status"] == "succeeded"
     assert rows[0]["lastError"] is None
+
+
+def test_update_step_row_merges_structured_refs_and_artifacts() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 15, tzinfo=UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {
+                "id": "delegate-agent",
+                "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+                "inputs": {"title": "Delegate agent"},
+            }
+        ],
+        dependency_map={"delegate-agent": []},
+        updated_at=updated_at,
+    )
+
+    row = update_step_row(
+        rows,
+        "delegate-agent",
+        updated_at=updated_at,
+        refs={
+            "childWorkflowId": "wf-child-1",
+            "childRunId": "run-child-1",
+            "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+        },
+        artifacts={
+            "outputSummary": "art_summary_1",
+            "outputPrimary": "art_primary_1",
+            "runtimeStdout": "art_stdout_1",
+            "runtimeDiagnostics": "art_diag_1",
+        },
+    )
+
+    assert row["refs"] == {
+        "childWorkflowId": "wf-child-1",
+        "childRunId": "run-child-1",
+        "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+    }
+    assert row["artifacts"] == {
+        "outputSummary": "art_summary_1",
+        "outputPrimary": "art_primary_1",
+        "runtimeStdout": "art_stdout_1",
+        "runtimeStderr": None,
+        "runtimeMergedLogs": None,
+        "runtimeDiagnostics": "art_diag_1",
+        "providerSnapshot": None,
+    }

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -215,6 +215,9 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     assert run.run_id == "managed-session-run-1"
     assert result.summary == "Session-backed Codex step completed."
     assert result.metadata["resultSource"] == "codex-session-adapter"
+    assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
+    assert result.metadata["childRunId"] == "run-1"
+    assert result.metadata["taskRunId"] == "wf-task-1"
     assert result.metadata["managedSession"]["sessionId"] == "sess:wf-task-1:codex_cli"
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.load_session_snapshot",
@@ -310,6 +313,7 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
     assert len(managed_requests) == 1
     assert managed_requests[0].managed_session is None
     assert result.summary == "Managed adapter path"
+    assert result.metadata["taskRunId"] == "managed-run-1"
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.fetch_result",
         "agent_runtime.publish_artifacts",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -107,6 +107,8 @@ async def test_agent_run_jules_starts_new_run_instead_of_continuation(
     assert all(name != "integration.jules.send_message" for name, _ in routed_calls)
     assert run.run_id == "new-session-1"
     assert result.failure_class is None
+    assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
+    assert result.metadata["childRunId"] == "run-1"
 
 
 async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -371,6 +371,48 @@ def test_run_groups_child_lineage_and_evidence_into_step_row(
     }
 
 
+def test_run_waiting_state_captures_child_workflow_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "delegate-agent",
+                "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+                "inputs": {"title": "Delegate agent"},
+            }
+        ],
+        dependency_map={"delegate-agent": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "delegate-agent",
+        updated_at=now,
+        summary="Launching child runtime",
+    )
+    workflow._mark_step_waiting(
+        "delegate-agent",
+        status="awaiting_external",
+        updated_at=now,
+        waiting_reason="Awaiting child workflow progress",
+        summary="Child runtime launched",
+        refs={"childWorkflowId": "wf-child-1"},
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["status"] == "awaiting_external"
+    assert step["refs"] == {
+        "childWorkflowId": "wf-child-1",
+        "childRunId": None,
+        "taskRunId": None,
+    }
+
+
 def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -399,6 +441,7 @@ def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
                     "art_primary_1",
                     "art_secondary_1",
                 ],
+                "outputAgentResultRef": "art_agent_result_1",
                 "stdoutArtifactRef": "art_stdout_1",
                 "diagnosticsRef": "art_diag_1",
             },
@@ -411,3 +454,45 @@ def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
     assert step["artifacts"]["outputPrimary"] == "art_primary_1"
     assert step["artifacts"]["runtimeStdout"] == "art_stdout_1"
     assert step["artifacts"]["runtimeDiagnostics"] == "art_diag_1"
+
+
+def test_run_accepts_tuple_output_refs_and_ignores_string_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "run-tests",
+                "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            }
+        ],
+        dependency_map={"run-tests": []},
+        updated_at=now,
+    )
+    workflow._record_step_result_evidence(
+        "run-tests",
+        execution_result={
+            "status": "FAILED",
+            "outputs": {
+                "outputRefs": "art_primary_1",
+                "output_refs": (
+                    "art_stdout_1",
+                    "art_primary_1",
+                    "",
+                    7,
+                ),
+                "stdoutArtifactRef": "art_stdout_1",
+            },
+        },
+        updated_at=now,
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["artifacts"]["outputPrimary"] == "art_primary_1"
+    assert step["artifacts"]["runtimeStdout"] == "art_stdout_1"

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -302,3 +302,112 @@ def test_run_memo_updates_remain_compact(monkeypatch: pytest.MonkeyPatch) -> Non
     assert "steps" not in latest_memo
     assert "progress" not in latest_memo
     assert "checks" not in latest_memo
+
+
+def test_run_groups_child_lineage_and_evidence_into_step_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "delegate-agent",
+                "tool": {"type": "agent_runtime", "name": "codex", "version": ""},
+                "inputs": {"title": "Delegate agent"},
+            }
+        ],
+        dependency_map={"delegate-agent": []},
+        updated_at=now,
+    )
+    workflow._mark_step_running(
+        "delegate-agent",
+        updated_at=now,
+        summary="Launching child runtime",
+    )
+    workflow._record_step_result_evidence(
+        "delegate-agent",
+        execution_result={
+            "status": "COMPLETED",
+            "outputs": {
+                "childWorkflowId": "wf-child-1",
+                "childRunId": "run-child-1",
+                "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+                "outputSummaryRef": "art_summary_1",
+                "outputAgentResultRef": "art_primary_1",
+                "stdoutArtifactRef": "art_stdout_1",
+                "stderrArtifactRef": "art_stderr_1",
+                "mergedLogArtifactRef": "art_merged_1",
+                "diagnosticsRef": "art_diag_1",
+                "providerSnapshotRef": "art_provider_1",
+                "outputRefs": [
+                    "art_stdout_1",
+                    "art_stderr_1",
+                    "art_diag_1",
+                    "art_primary_1",
+                ],
+            },
+        },
+        updated_at=now,
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["refs"] == {
+        "childWorkflowId": "wf-child-1",
+        "childRunId": "run-child-1",
+        "taskRunId": "550e8400-e29b-41d4-a716-446655440000",
+    }
+    assert step["artifacts"] == {
+        "outputSummary": "art_summary_1",
+        "outputPrimary": "art_primary_1",
+        "runtimeStdout": "art_stdout_1",
+        "runtimeStderr": "art_stderr_1",
+        "runtimeMergedLogs": "art_merged_1",
+        "runtimeDiagnostics": "art_diag_1",
+        "providerSnapshot": "art_provider_1",
+    }
+
+
+def test_run_uses_deterministic_output_primary_fallback_for_generic_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=[
+            {
+                "id": "run-tests",
+                "tool": {"type": "skill", "name": "repo.run_tests", "version": "1"},
+                "inputs": {"title": "Run tests"},
+            }
+        ],
+        dependency_map={"run-tests": []},
+        updated_at=now,
+    )
+    workflow._record_step_result_evidence(
+        "run-tests",
+        execution_result={
+            "status": "FAILED",
+            "outputs": {
+                "outputRefs": [
+                    "art_stdout_1",
+                    "art_primary_1",
+                    "art_secondary_1",
+                ],
+                "stdoutArtifactRef": "art_stdout_1",
+                "diagnosticsRef": "art_diag_1",
+            },
+        },
+        updated_at=now,
+    )
+
+    step = workflow.get_step_ledger()["steps"][0]
+
+    assert step["artifacts"]["outputPrimary"] == "art_primary_1"
+    assert step["artifacts"]["runtimeStdout"] == "art_stdout_1"
+    assert step["artifacts"]["runtimeDiagnostics"] == "art_diag_1"


### PR DESCRIPTION
## Summary
- implement workflow-owned Phase 2 step-ledger evidence mapping in `MoonMind.Run`, including canonical refs/artifact slot grouping and deterministic `outputPrimary` fallback
- enrich `MoonMind.AgentRun` result metadata with `childWorkflowId`, `childRunId`, best-available `taskRunId`, and propagated `moonmind.stepLedger` context
- enrich `agent_runtime` activities to surface managed-run observability refs (`stdout/stderr/merged/diagnostics`) and stamp `step_id`/`attempt`/`scope` on published summary/result artifacts
- add/update Phase 2 TDD coverage across step-ledger, run workflow, agent run workflow, and runtime activity tests
- add complete Spec Kit artifacts for feature `138-step-ledger-phase2` and mark all tasks complete

## Validation
- `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
- `./tools/test_unit.sh`