### PR TITLE
[codex] fix managed codex session workflow failures

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -489,6 +489,8 @@ services:
       - TEMPORAL_ARTIFACT_S3_BUCKET=${TEMPORAL_ARTIFACT_S3_BUCKET:-moonmind-temporal-artifacts}
       - TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID=${TEMPORAL_ARTIFACT_S3_ACCESS_KEY_ID:-minioadmin}
       - TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY=${TEMPORAL_ARTIFACT_S3_SECRET_ACCESS_KEY:-minioadmin}
+      - SYSTEM_DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
+      - DOCKER_HOST=${SYSTEM_DOCKER_HOST:-tcp://docker-proxy:2375}
     env_file:
       - .env
     volumes:
@@ -521,8 +523,11 @@ services:
         condition: service_completed_successfully
       gemini-auth-init:
         condition: service_completed_successfully
+      docker-proxy:
+        condition: service_started
     networks:
       - local-network
+      - docker-proxy-network
     restart: unless-stopped
 
   temporal-worker-integrations:
@@ -646,8 +651,10 @@ services:
     environment:
       INFO: 1
       CONTAINERS: 1
+      EXEC: 1
       IMAGES: 1
       NETWORKS: 1
+      POST: 1
       VOLUMES: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -204,8 +204,7 @@ class SendCodexManagedSessionTurnRequest(CodexManagedSessionLocator):
     """Send a new turn to the remote session container."""
 
     instructions: NonBlankStr = Field(..., alias="instructions")
-    input_refs: tuple[NonBlankStr, ...] = Field(default=(), alias="inputRefs")
-    metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+    reason: NonBlankStr | None = Field(None, alias="reason")
 
 
 class SteerCodexManagedSessionTurnRequest(CodexManagedSessionLocator):

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -183,6 +183,7 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
     codex_home_path: NonBlankStr = Field(..., alias="codexHomePath")
     image_ref: NonBlankStr = Field(..., alias="imageRef")
     environment: dict[str, str] = Field(default_factory=dict, alias="environment")
+    workspace_spec: dict[str, Any] = Field(default_factory=dict, alias="workspaceSpec")
 
     @model_validator(mode="after")
     def _normalize_environment(self) -> "LaunchCodexManagedSessionRequest":
@@ -191,6 +192,11 @@ class LaunchCodexManagedSessionRequest(_CodexManagedSessionRemoteContract):
             key = require_non_blank(str(raw_key), field_name="environment key")
             normalized[key] = str(raw_value)
         self.environment = normalized
+        self.workspace_spec = (
+            dict(self.workspace_spec)
+            if isinstance(self.workspace_spec, dict)
+            else {}
+        )
         return self
 
 

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -42,6 +42,9 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     build_managed_profile_launch_context,
     default_credential_source_for_runtime,
 )
+from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+    append_managed_codex_runtime_note,
+)
 
 
 SessionSnapshotLoader = Callable[
@@ -487,20 +490,13 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         binding: CodexManagedSessionBinding,
         request: AgentExecutionRequest,
     ) -> str:
-        workspace_path = Path(self._workspace_path_for_request(binding=binding, request=request))
-        if str(request.instruction_ref or "").strip():
-            from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
-                CodexCliStrategy,
-            )
-
-            await CodexCliStrategy().prepare_workspace(workspace_path, request)
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
-            return instruction_ref
+            return append_managed_codex_runtime_note(instruction_ref)
         parameters = request.parameters if isinstance(request.parameters, dict) else {}
         instructions = str(parameters.get("instructions") or "").strip()
         if instructions:
-            return instructions
+            return append_managed_codex_runtime_note(instructions)
         raise ValueError("CodexSessionAdapter requires instructionRef or parameters.instructions")
 
     def _require_binding(self, request: AgentExecutionRequest) -> CodexManagedSessionBinding:
@@ -542,6 +538,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             codexHomePath=str(self._session_root(binding) / ".moonmind" / "codex-home"),
             imageRef=self._session_image_ref,
             environment=environment,
+            workspaceSpec=(
+                dict(request.workspace_spec)
+                if isinstance(request.workspace_spec, dict)
+                else {}
+            ),
         )
         handle = await self._coerce_handle(self._launch_session(launch_request))
         await self._attach_runtime_handles(

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -180,6 +180,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         started_at = _current_time()
         original_instruction_ref = str(request.instruction_ref or "").strip() or None
         original_skillset_ref = str(request.resolved_skillset_ref or "").strip() or None
+        if request.input_refs:
+            raise ValueError(
+                "CodexSessionAdapter does not support inputRefs for managed session turns"
+            )
         session_handle = await self._ensure_remote_session(
             binding=binding,
             request=request,
@@ -201,11 +205,6 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     containerId=locator.container_id,
                     threadId=locator.thread_id,
                     instructions=instructions,
-                    inputRefs=tuple(request.input_refs),
-                    metadata={
-                        "correlationId": request.correlation_id,
-                        "idempotencyKey": request.idempotency_key,
-                    },
                 )
             )
         )
@@ -492,7 +491,19 @@ class CodexSessionAdapter(ManagedAgentAdapter):
     ) -> str:
         instruction_ref = str(request.instruction_ref or "").strip()
         if instruction_ref:
-            return append_managed_codex_runtime_note(instruction_ref)
+            from moonmind.rag.context_injection import ContextInjectionService
+
+            workspace_path = Path(
+                self._workspace_path_for_request(binding=binding, request=request)
+            )
+            service = ContextInjectionService()
+            await service.inject_context(
+                request=request,
+                workspace_path=workspace_path,
+            )
+            return append_managed_codex_runtime_note(
+                str(request.instruction_ref or instruction_ref).strip()
+            )
         parameters = request.parameters if isinstance(request.parameters, dict) else {}
         instructions = str(parameters.get("instructions") or "").strip()
         if instructions:

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -795,7 +795,7 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(60, 240, heartbeat_timeout_seconds=30),
+            timeouts=TemporalActivityTimeouts(360, 600, heartbeat_timeout_seconds=30),
             retries=_activity_retries(max_attempts=1, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -780,7 +780,7 @@ async def _await_with_activity_heartbeats(
 ) -> Any:
     from temporalio import activity
 
-    task = asyncio.create_task(awaitable)
+    task = asyncio.ensure_future(awaitable)
     try:
         if not activity.in_activity():
             return await task

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import inspect
 import json
@@ -157,6 +158,7 @@ _PUBLISH_GIT_ADD_EXCLUDES: tuple[str, ...] = (
     ":(exclude)live_streams.spool",
     ":(exclude).agents/skills/active",
 )
+_SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
 
 
 class ManagedSessionController(Protocol):
@@ -768,6 +770,36 @@ async def _maybe_call_heartbeat(
     result = callback(payload)
     if inspect.isawaitable(result):
         await result
+
+
+async def _await_with_activity_heartbeats(
+    awaitable: Awaitable[Any],
+    *,
+    heartbeat_payload: Mapping[str, Any],
+    interval_seconds: float | None = None,
+) -> Any:
+    from temporalio import activity
+
+    task = asyncio.create_task(awaitable)
+    try:
+        if not activity.in_activity():
+            return await task
+
+        heartbeat_interval = (
+            interval_seconds
+            if interval_seconds is not None
+            else _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS
+        )
+        while True:
+            done, _ = await asyncio.wait({task}, timeout=heartbeat_interval)
+            if task in done:
+                return await task
+            activity.heartbeat(dict(heartbeat_payload))
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 class TemporalPlanActivities:
@@ -2735,7 +2767,15 @@ class TemporalAgentRuntimeActivities:
             activity_type="agent_runtime.send_turn",
             model_type=SendCodexManagedSessionTurnRequest,
         )
-        response = await controller.send_turn(validated)
+        response = await _await_with_activity_heartbeats(
+            controller.send_turn(validated),
+            heartbeat_payload={
+                "activityType": "agent_runtime.send_turn",
+                "sessionId": validated.session_id,
+                "containerId": validated.container_id,
+                "threadId": validated.thread_id,
+            },
+        )
         return self._validate_session_response(
             response,
             activity_type="agent_runtime.send_turn",

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -51,6 +51,7 @@ class CodexSessionRuntimeState(BaseModel):
     session_epoch: int = Field(..., alias="sessionEpoch", ge=1)
     logical_thread_id: str = Field(..., alias="logicalThreadId")
     vendor_thread_id: str = Field(..., alias="vendorThreadId")
+    vendor_thread_path: str | None = Field(None, alias="vendorThreadPath")
     container_id: str = Field(..., alias="containerId")
     active_turn_id: str | None = Field(None, alias="activeTurnId")
     launched_at: float | None = Field(None, alias="launchedAt")
@@ -225,7 +226,10 @@ class CodexAppServerRpcClient:
                 "clientInfo": {
                     "name": self._client_name,
                     "version": self._client_version,
-                }
+                },
+                "capabilities": {
+                    "experimentalApi": True,
+                },
             },
         )
         return self._initialize_result
@@ -435,6 +439,51 @@ class CodexManagedSessionRuntime:
                     return text.strip()
         return ""
 
+    def _find_vendor_thread_path(self, vendor_thread_id: str) -> str | None:
+        sessions_root = self._codex_home_path / "sessions"
+        if not sessions_root.is_dir():
+            return None
+        matches = sorted(sessions_root.rglob(f"*{vendor_thread_id}.jsonl"))
+        if not matches:
+            return None
+        return str(matches[-1])
+
+    def _resume_thread(
+        self,
+        *,
+        client: CodexAppServerRpcClient,
+        state: CodexSessionRuntimeState,
+    ) -> str:
+        thread_path = state.vendor_thread_path or self._find_vendor_thread_path(
+            state.vendor_thread_id
+        )
+        params: dict[str, Any] = {"threadId": state.vendor_thread_id}
+        if thread_path:
+            params["path"] = thread_path
+        try:
+            resumed = client.request("thread/resume", params)
+            thread_payload = resumed.get("thread")
+        except RuntimeError as exc:
+            message = str(exc)
+            if "no rollout found" not in message and "thread not found" not in message:
+                raise
+            started = client.request("thread/start", {"cwd": str(self._workspace_path)})
+            thread_payload = started.get("thread")
+        if not isinstance(thread_payload, Mapping):
+            raise RuntimeError(
+                "codex app-server thread/resume did not return a thread"
+            )
+        vendor_thread_id = str(thread_payload.get("id") or "").strip()
+        if not vendor_thread_id:
+            raise RuntimeError(
+                "codex app-server thread/resume returned a blank thread id"
+            )
+        state.vendor_thread_id = vendor_thread_id
+        state.vendor_thread_path = (
+            str(thread_payload.get("path") or thread_path or "").strip() or None
+        )
+        return vendor_thread_id
+
     def launch_session(
         self,
         request: LaunchCodexManagedSessionRequest,
@@ -449,12 +498,14 @@ class CodexManagedSessionRuntime:
         vendor_thread_id = str(thread_payload.get("id") or "").strip()
         if not vendor_thread_id:
             raise RuntimeError("codex app-server thread/start returned a blank thread id")
+        vendor_thread_path = str(thread_payload.get("path") or "").strip() or None
 
         state = CodexSessionRuntimeState(
             sessionId=request.session_id,
             sessionEpoch=request.session_epoch,
             logicalThreadId=request.thread_id,
             vendorThreadId=vendor_thread_id,
+            vendorThreadPath=vendor_thread_path,
             containerId=self._container_id,
             activeTurnId=None,
             launchedAt=time.time(),
@@ -490,14 +541,18 @@ class CodexManagedSessionRuntime:
         state = self._validate_locator(request)
         client = self._app_server_client()
         client.initialize()
+        vendor_thread_id = self._resume_thread(client=client, state=state)
 
         started = client.request(
             "turn/start",
             {
-                "threadId": state.vendor_thread_id,
-                "instructions": request.instructions,
-                "inputRefs": list(request.input_refs),
-                "metadata": request.metadata,
+                "threadId": vendor_thread_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": request.instructions,
+                    }
+                ],
             },
         )
         turn_payload = started.get("turn")
@@ -518,7 +573,7 @@ class CodexManagedSessionRuntime:
                 "turn/completed",
                 predicate=lambda message: (
                     isinstance(message.get("params"), Mapping)
-                    and message["params"].get("threadId") == state.vendor_thread_id
+                    and message["params"].get("threadId") == vendor_thread_id
                 ),
                 timeout_seconds=self._turn_completion_timeout_seconds,
             )
@@ -527,7 +582,7 @@ class CodexManagedSessionRuntime:
                 "timed out waiting for codex app-server turn/completed notification "
                 f"after {self._turn_completion_timeout_seconds} seconds"
             ) from exc
-        thread_payload = client.request("thread/read", {"threadId": state.vendor_thread_id})
+        thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
         assistant_text = self._extract_assistant_text(thread_payload)
 
         state.active_turn_id = None
@@ -611,10 +666,12 @@ class CodexManagedSessionRuntime:
         vendor_thread_id = str(thread_payload.get("id") or "").strip()
         if not vendor_thread_id:
             raise RuntimeError("codex app-server thread/start returned a blank thread id")
+        vendor_thread_path = str(thread_payload.get("path") or "").strip() or None
 
         state.session_epoch += 1
         state.logical_thread_id = request.new_thread_id
         state.vendor_thread_id = vendor_thread_id
+        state.vendor_thread_path = vendor_thread_path
         state.active_turn_id = None
         state.last_control_action = "clear_session"
         state.last_control_at = time.time()

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -36,122 +36,6 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
-_SEND_TURN_INLINE_SCRIPT = """
-import json
-import importlib
-from pathlib import Path
-import sys
-import time
-from collections.abc import Mapping
-
-runtime_mod = importlib.import_module(
-    "moonmind.workflows.temporal.runtime.codex_session_runtime"
-)
-
-
-request = runtime_mod.SendCodexManagedSessionTurnRequest.model_validate(
-    json.loads(sys.stdin.read() or "{}")
-)
-runtime = runtime_mod._runtime_from_environment()
-try:
-    state = runtime._validate_locator(request)
-    client = runtime._app_server_client()
-    client._initialize_result = client.request(
-        "initialize",
-        {
-            "clientInfo": {
-                "name": "MoonMind",
-                "version": "phase4",
-            },
-            "capabilities": {
-                "experimentalApi": True,
-            },
-        },
-    )
-
-    sessions_root = Path(runtime._codex_home_path) / "sessions"
-    thread_path = None
-    if sessions_root.is_dir():
-        matches = sorted(sessions_root.rglob(f"*{state.vendor_thread_id}.jsonl"))
-        if matches:
-            thread_path = str(matches[-1])
-    resume_params = {"threadId": state.vendor_thread_id}
-    if thread_path:
-        resume_params["path"] = thread_path
-    try:
-        resumed = client.request("thread/resume", resume_params)
-        resumed_thread = resumed.get("thread")
-    except RuntimeError as exc:
-        message = str(exc)
-        if "no rollout found" not in message and "thread not found" not in message:
-            raise
-        started_thread = client.request(
-            "thread/start",
-            {"cwd": str(runtime._workspace_path)},
-        )
-        resumed_thread = started_thread.get("thread")
-    if not isinstance(resumed_thread, Mapping):
-        raise RuntimeError("codex app-server thread/resume did not return a thread")
-    vendor_thread_id = str(resumed_thread.get("id") or "").strip()
-    if not vendor_thread_id:
-        raise RuntimeError("codex app-server thread/resume returned a blank thread id")
-    state.vendor_thread_id = vendor_thread_id
-
-    started = client.request(
-        "turn/start",
-        {
-            "threadId": vendor_thread_id,
-            "input": [{"type": "text", "text": request.instructions}],
-        },
-    )
-    turn_payload = started.get("turn")
-    if not isinstance(turn_payload, Mapping):
-        raise RuntimeError("codex app-server turn/start did not return a turn")
-    vendor_turn_id = str(turn_payload.get("id") or "").strip()
-    if not vendor_turn_id:
-        raise RuntimeError("codex app-server turn/start returned a blank turn id")
-
-    state.active_turn_id = vendor_turn_id
-    state.last_control_action = "send_turn"
-    state.last_control_at = time.time()
-    runtime._save_state(state)
-    runtime._append_spool("stdout", f"turn started: {vendor_turn_id}\\n")
-
-    try:
-        client.wait_for_notification(
-            "turn/completed",
-            predicate=lambda message: (
-                isinstance(message.get("params"), Mapping)
-                and message["params"].get("threadId") == vendor_thread_id
-            ),
-            timeout_seconds=runtime._turn_completion_timeout_seconds,
-        )
-    except TimeoutError as exc:
-        raise RuntimeError(
-            "timed out waiting for codex app-server turn/completed notification "
-            f"after {runtime._turn_completion_timeout_seconds} seconds"
-        ) from exc
-
-    thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
-    assistant_text = runtime._extract_assistant_text(thread_payload)
-
-    state.active_turn_id = None
-    state.last_assistant_text = assistant_text or None
-    runtime._save_state(state)
-    if assistant_text:
-        runtime._append_spool("stdout", f"assistant: {assistant_text}\\n")
-
-    response = runtime_mod.CodexManagedSessionTurnResponse(
-        sessionState=runtime._session_state(state),
-        turnId=vendor_turn_id,
-        status="completed",
-        metadata={"assistantText": assistant_text},
-    )
-    sys.stdout.write(response.model_dump_json(by_alias=True, exclude_none=True) + "\\n")
-    sys.stdout.flush()
-finally:
-    runtime.close()
-""".strip()
 
 
 class CommandRunner(Protocol):
@@ -483,29 +367,6 @@ class DockerCodexManagedSessionController:
         )
         return json.loads(stdout.strip() or "{}")
 
-    async def _invoke_inline_python_json(
-        self,
-        *,
-        container_id: str,
-        program: str,
-        payload: Mapping[str, Any],
-        extra_env: Mapping[str, str] | None = None,
-    ) -> dict[str, Any]:
-        command = [
-            self._docker_binary,
-            "exec",
-            "-i",
-        ]
-        if extra_env:
-            for key, value in extra_env.items():
-                command.extend(["-e", f"{key}={value}"])
-        command.extend([container_id, "python3", "-c", program])
-        stdout, _stderr = await self._run(
-            command,
-            input_text=json.dumps(payload),
-        )
-        return json.loads(stdout.strip() or "{}")
-
     async def _wait_ready(self, *, container_id: str) -> None:
         command = (
             self._docker_binary,
@@ -693,9 +554,9 @@ class DockerCodexManagedSessionController:
         self,
         request: SendCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
-        payload = await self._invoke_inline_python_json(
+        payload = await self._invoke_json(
             container_id=request.container_id,
-            program=_SEND_TURN_INLINE_SCRIPT,
+            action="send_turn",
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
@@ -722,7 +583,10 @@ class DockerCodexManagedSessionController:
                         text=f"Turn started: {response.turn_id}.",
                         turn_id=response.turn_id,
                         active_turn_id=response.turn_id,
-                        metadata={"action": "send_turn"},
+                        metadata={
+                            "action": "send_turn",
+                            "reason": request.reason,
+                        },
                     )
                     if response.status == "completed":
                         await self._emit_session_event(
@@ -734,6 +598,7 @@ class DockerCodexManagedSessionController:
                             metadata={
                                 "action": "send_turn",
                                 "assistantText": response.metadata.get("assistantText"),
+                                "reason": request.reason,
                             },
                         )
         return response

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -8,7 +8,7 @@ import os
 import posixpath
 import re
 from datetime import UTC, datetime
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
 
 from moonmind.schemas.managed_session_models import (
@@ -36,6 +36,122 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+_SEND_TURN_INLINE_SCRIPT = """
+import json
+import importlib
+from pathlib import Path
+import sys
+import time
+from collections.abc import Mapping
+
+runtime_mod = importlib.import_module(
+    "moonmind.workflows.temporal.runtime.codex_session_runtime"
+)
+
+
+request = runtime_mod.SendCodexManagedSessionTurnRequest.model_validate(
+    json.loads(sys.stdin.read() or "{}")
+)
+runtime = runtime_mod._runtime_from_environment()
+try:
+    state = runtime._validate_locator(request)
+    client = runtime._app_server_client()
+    client._initialize_result = client.request(
+        "initialize",
+        {
+            "clientInfo": {
+                "name": "MoonMind",
+                "version": "phase4",
+            },
+            "capabilities": {
+                "experimentalApi": True,
+            },
+        },
+    )
+
+    sessions_root = Path(runtime._codex_home_path) / "sessions"
+    thread_path = None
+    if sessions_root.is_dir():
+        matches = sorted(sessions_root.rglob(f"*{state.vendor_thread_id}.jsonl"))
+        if matches:
+            thread_path = str(matches[-1])
+    resume_params = {"threadId": state.vendor_thread_id}
+    if thread_path:
+        resume_params["path"] = thread_path
+    try:
+        resumed = client.request("thread/resume", resume_params)
+        resumed_thread = resumed.get("thread")
+    except RuntimeError as exc:
+        message = str(exc)
+        if "no rollout found" not in message and "thread not found" not in message:
+            raise
+        started_thread = client.request(
+            "thread/start",
+            {"cwd": str(runtime._workspace_path)},
+        )
+        resumed_thread = started_thread.get("thread")
+    if not isinstance(resumed_thread, Mapping):
+        raise RuntimeError("codex app-server thread/resume did not return a thread")
+    vendor_thread_id = str(resumed_thread.get("id") or "").strip()
+    if not vendor_thread_id:
+        raise RuntimeError("codex app-server thread/resume returned a blank thread id")
+    state.vendor_thread_id = vendor_thread_id
+
+    started = client.request(
+        "turn/start",
+        {
+            "threadId": vendor_thread_id,
+            "input": [{"type": "text", "text": request.instructions}],
+        },
+    )
+    turn_payload = started.get("turn")
+    if not isinstance(turn_payload, Mapping):
+        raise RuntimeError("codex app-server turn/start did not return a turn")
+    vendor_turn_id = str(turn_payload.get("id") or "").strip()
+    if not vendor_turn_id:
+        raise RuntimeError("codex app-server turn/start returned a blank turn id")
+
+    state.active_turn_id = vendor_turn_id
+    state.last_control_action = "send_turn"
+    state.last_control_at = time.time()
+    runtime._save_state(state)
+    runtime._append_spool("stdout", f"turn started: {vendor_turn_id}\\n")
+
+    try:
+        client.wait_for_notification(
+            "turn/completed",
+            predicate=lambda message: (
+                isinstance(message.get("params"), Mapping)
+                and message["params"].get("threadId") == vendor_thread_id
+            ),
+            timeout_seconds=runtime._turn_completion_timeout_seconds,
+        )
+    except TimeoutError as exc:
+        raise RuntimeError(
+            "timed out waiting for codex app-server turn/completed notification "
+            f"after {runtime._turn_completion_timeout_seconds} seconds"
+        ) from exc
+
+    thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
+    assistant_text = runtime._extract_assistant_text(thread_payload)
+
+    state.active_turn_id = None
+    state.last_assistant_text = assistant_text or None
+    runtime._save_state(state)
+    if assistant_text:
+        runtime._append_spool("stdout", f"assistant: {assistant_text}\\n")
+
+    response = runtime_mod.CodexManagedSessionTurnResponse(
+        sessionState=runtime._session_state(state),
+        turnId=vendor_turn_id,
+        status="completed",
+        metadata={"assistantText": assistant_text},
+    )
+    sys.stdout.write(response.model_dump_json(by_alias=True, exclude_none=True) + "\\n")
+    sys.stdout.flush()
+finally:
+    runtime.close()
+""".strip()
 
 
 class CommandRunner(Protocol):
@@ -156,6 +272,10 @@ class DockerCodexManagedSessionController:
                 "launch_session environment cannot override reserved session keys: "
                 + ", ".join(reserved_keys)
             )
+
+    @staticmethod
+    def _volume_mount(volume_name: str, target_path: str) -> str:
+        return f"type=volume,src={volume_name},dst={target_path}"
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:
@@ -280,6 +400,57 @@ class DockerCodexManagedSessionController:
             )
         return stdout, stderr
 
+    async def _run_host_command(
+        self,
+        command: Sequence[str],
+    ) -> tuple[str, str]:
+        returncode, stdout, stderr = await self._command_runner(tuple(command))
+        if returncode != 0:
+            raise RuntimeError(
+                f"{' '.join(command)} failed with exit code {returncode}: {stderr.strip() or stdout.strip()}"
+            )
+        return stdout, stderr
+
+    async def _ensure_workspace_paths(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> None:
+        workspace_path = Path(request.workspace_path)
+        session_workspace_path = Path(request.session_workspace_path)
+        artifact_spool_path = Path(request.artifact_spool_path)
+
+        session_workspace_path.mkdir(parents=True, exist_ok=True)
+        artifact_spool_path.mkdir(parents=True, exist_ok=True)
+
+        if workspace_path.exists():
+            return
+
+        workspace_path.parent.mkdir(parents=True, exist_ok=True)
+
+        repository = str(
+            request.workspace_spec.get("repository")
+            or request.workspace_spec.get("repo")
+            or ""
+        ).strip()
+        if not repository:
+            workspace_path.mkdir(parents=True, exist_ok=True)
+            return
+
+        from .launcher import ManagedRuntimeLauncher
+
+        source = ManagedRuntimeLauncher._resolve_repository_source(repository)
+        branch = str(
+            request.workspace_spec.get("startingBranch")
+            or request.workspace_spec.get("branch")
+            or ""
+        ).strip()
+
+        clone_command = ["git", "clone"]
+        if branch:
+            clone_command.extend(["--branch", branch, "--single-branch"])
+        clone_command.extend([source, str(workspace_path)])
+        await self._run_host_command(clone_command)
+
     async def _invoke_json(
         self,
         *,
@@ -306,6 +477,29 @@ class DockerCodexManagedSessionController:
                 action,
             ]
         )
+        stdout, _stderr = await self._run(
+            command,
+            input_text=json.dumps(payload),
+        )
+        return json.loads(stdout.strip() or "{}")
+
+    async def _invoke_inline_python_json(
+        self,
+        *,
+        container_id: str,
+        program: str,
+        payload: Mapping[str, Any],
+        extra_env: Mapping[str, str] | None = None,
+    ) -> dict[str, Any]:
+        command = [
+            self._docker_binary,
+            "exec",
+            "-i",
+        ]
+        if extra_env:
+            for key, value in extra_env.items():
+                command.extend(["-e", f"{key}={value}"])
+        command.extend([container_id, "python3", "-c", program])
         stdout, _stderr = await self._run(
             command,
             input_text=json.dumps(payload),
@@ -406,6 +600,7 @@ class DockerCodexManagedSessionController:
         request: LaunchCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
         self._validate_launch_request(request)
+        await self._ensure_workspace_paths(request)
         container_name = self._container_name(request.session_id)
         await self._remove_container(container_name, ignore_failure=True)
         run_command = [
@@ -414,10 +609,10 @@ class DockerCodexManagedSessionController:
             "-d",
             "--name",
             container_name,
-            "-v",
-            f"{self._workspace_volume_name}:{self._workspace_root}",
-            "-v",
-            f"{self._codex_volume_name}:{request.codex_home_path}",
+            "--mount",
+            self._volume_mount(self._workspace_volume_name, self._workspace_root),
+            "--mount",
+            self._volume_mount(self._codex_volume_name, request.codex_home_path),
             "-e",
             f"MOONMIND_SESSION_WORKSPACE_PATH={request.workspace_path}",
             "-e",
@@ -448,10 +643,14 @@ class DockerCodexManagedSessionController:
             raise RuntimeError("docker run returned a blank container id")
         try:
             await self._wait_ready(container_id=container_id)
+            container_payload = request.model_dump(
+                by_alias=True,
+                exclude={"workspace_spec"},
+            )
             payload = await self._invoke_json(
                 container_id=container_id,
                 action="launch_session",
-                payload=request.model_dump(by_alias=True),
+                payload=container_payload,
                 extra_env={"MOONMIND_SESSION_CONTAINER_ID": container_id},
             )
         except Exception:
@@ -494,9 +693,9 @@ class DockerCodexManagedSessionController:
         self,
         request: SendCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
-        payload = await self._invoke_json(
+        payload = await self._invoke_inline_python_json(
             container_id=request.container_id,
-            action="send_turn",
+            program=_SEND_TURN_INLINE_SCRIPT,
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)

--- a/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
+++ b/moonmind/workflows/temporal/runtime/strategies/codex_cli.py
@@ -50,6 +50,13 @@ _CODEX_MANAGED_RUNTIME_NOTE = (
 _CODEX_MANAGED_RUNTIME_NOTE_HEADER = "Managed Codex CLI note:\n"
 
 
+def append_managed_codex_runtime_note(instruction: str) -> str:
+    normalized = str(instruction or "")
+    if normalized and _CODEX_MANAGED_RUNTIME_NOTE_HEADER not in normalized:
+        return normalized + _CODEX_MANAGED_RUNTIME_NOTE
+    return normalized
+
+
 class CodexCliStrategy(ManagedRuntimeStrategy):
     """Strategy for launching ``codex`` CLI runs."""
 
@@ -181,8 +188,8 @@ class CodexCliStrategy(ManagedRuntimeStrategy):
             workspace_path=workspace_path,
         )
         instruction = request.instruction_ref or ""
-        if instruction and _CODEX_MANAGED_RUNTIME_NOTE_HEADER not in instruction:
-            request.instruction_ref = instruction + _CODEX_MANAGED_RUNTIME_NOTE
+        if instruction:
+            request.instruction_ref = append_managed_codex_runtime_note(instruction)
 
     def classify_result(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -253,7 +253,7 @@ class MoonMindAgentSessionWorkflow:
                 containerId=locator.container_id,
                 threadId=locator.thread_id,
                 instructions=message,
-                metadata={"reason": reason_text} if reason_text else {},
+                reason=reason_text,
             ).model_dump(by_alias=True),
         )
         turn_payload = dict(turn_response if isinstance(turn_response, dict) else {})

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -280,15 +280,15 @@ def test_codex_managed_session_summary_and_publication_allow_artifact_refs() -> 
     assert publication.published_artifact_refs == ("art-summary", "art-checkpoint")
 
 
-def test_send_codex_managed_session_turn_request_trims_instruction_and_refs() -> None:
+def test_send_codex_managed_session_turn_request_trims_instruction_and_reason() -> None:
     request = SendCodexManagedSessionTurnRequest(
         sessionId="sess-123",
         sessionEpoch=1,
         containerId="ctr-123",
         threadId="thread-1",
         instructions="  Investigate the failing test  ",
-        inputRefs=["art-1", "art-2"],
+        reason="  Operator follow-up  ",
     )
 
     assert request.instructions == "Investigate the failing test"
-    assert request.input_refs == ("art-1", "art-2")
+    assert request.reason == "Operator follow-up"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -22,6 +22,7 @@ def _write_fake_app_server(
     tmp_path: Path,
     *,
     emit_completion: bool = True,
+    fail_thread_resume: bool = False,
     interrupt_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
 ) -> Path:
@@ -44,12 +45,15 @@ import sys
 
 INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
 CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
+FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
 
 for line in sys.stdin:
     message = json.loads(line)
     msg_id = message.get("id")
     method = message.get("method")
     if method == "initialize":
+        capabilities = message["params"].get("capabilities") or {}
+        assert capabilities.get("experimentalApi") is True
         if CODEX_HOME_RECORD_PATH:
             with open(CODEX_HOME_RECORD_PATH, "w", encoding="utf-8") as handle:
                 handle.write(sys.argv[0] + "\\n")
@@ -108,8 +112,47 @@ for line in sys.stdin:
             },
         }) + "\\n")
         sys.stdout.flush()
+    elif method == "thread/resume":
+        if FAIL_THREAD_RESUME:
+            sys.stdout.write(json.dumps({
+                "id": msg_id,
+                "error": {"code": -32600, "message": "no rollout found for thread id vendor-thread-1"},
+            }) + "\\n")
+            sys.stdout.flush()
+            continue
+        thread_path = message["params"].get("path")
+        if thread_path is not None:
+            assert str(thread_path).endswith("vendor-thread-1.jsonl")
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": "vendor-thread-1",
+                    "preview": "",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 1,
+                    "status": {"type": "idle"},
+                    "path": thread_path or "/tmp/vendor-thread-1.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [],
+                }
+            },
+        }) + "\\n")
+        sys.stdout.flush()
     elif method == "turn/start":
         thread_id = message["params"]["threadId"]
+        input_items = message["params"]["input"]
+        assert isinstance(input_items, list)
+        assert input_items[0]["type"] == "text"
+        assert input_items[0]["text"] == "Reply with exactly the word OK"
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
@@ -172,6 +215,7 @@ __COMPLETION_BLOCK__
             "__CODEX_HOME_RECORD_PATH__",
             repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
         )
+        .replace("__FAIL_THREAD_RESUME__", "True" if fail_thread_resume else "False")
         .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )
@@ -241,6 +285,7 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
     )
     assert state_payload["logicalThreadId"] == "logical-thread-1"
     assert state_payload["vendorThreadId"] == "vendor-thread-1"
+    assert state_payload["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
 
 
 def test_runtime_send_turn_returns_completed_response_with_assistant_text(
@@ -274,6 +319,90 @@ def test_runtime_send_turn_returns_completed_response_with_assistant_text(
     assert response.turn_id == "vendor-turn-1"
     assert response.session_state.active_turn_id is None
     assert response.metadata["assistantText"] == "OK"
+
+
+def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    state_path = Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+    state_payload.pop("vendorThreadPath", None)
+    state_path.write_text(json.dumps(state_payload) + "\n", encoding="utf-8")
+
+    recovered_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "08"
+        / "rollout-2026-04-08T00-00-00-vendor-thread-1.jsonl"
+    )
+    recovered_path.parent.mkdir(parents=True, exist_ok=True)
+    recovered_path.write_text("", encoding="utf-8")
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated_state["vendorThreadPath"] == str(recovered_path)
+
+
+def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path, fail_thread_resume=True)
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    updated_state = json.loads(
+        (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert updated_state["vendorThreadId"] == "vendor-thread-1"
 
 
 def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -114,6 +114,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert commands[0] == ("docker", "rm", "-f", "mm-codex-session-sess-1")
     run_command = commands[1]
     assert "--name" in run_command
+    assert "--mount" in run_command
+    assert "-v" not in run_command
     assert request.image_ref in run_command
     assert "python3" in run_command
     assert "moonmind.workflows.temporal.runtime.codex_session_runtime" in run_command
@@ -123,6 +125,80 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert stored.container_id == "ctr-1"
     assert stored.runtime_id == "codex_cli"
     session_supervisor.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_clones_workspace_before_starting_container(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "mm:task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "mm:task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "mm:task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "startingBranch": "dependabot/pip/requests-2.33.1",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("git", "clone"):
+            Path(request.workspace_path).mkdir(parents=True, exist_ok=True)
+            return 0, "", ""
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload_input = json.loads(input_text or "{}")
+            assert "workspaceSpec" not in payload_input
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    assert commands[0][:2] == ("git", "clone")
+    assert (
+        "https://github.com/MoonLadderStudios/MoonMind.git" in commands[0]
+    )
+    assert request.workspace_path in commands[0]
+    assert Path(request.workspace_path).exists()
+    assert Path(request.session_workspace_path).exists()
+    assert Path(request.artifact_spool_path).exists()
 
 
 @pytest.mark.asyncio
@@ -136,7 +212,7 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
-        if "send_turn" in command:
+        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -173,7 +249,11 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
     assert response.metadata["assistantText"] == "OK"
     exec_command = commands[0]
     assert exec_command[:3] == ("docker", "exec", "-i")
-    assert "send_turn" in exec_command
+    assert "-c" in exec_command
+    assert "invoke" not in exec_command
+    assert "thread/resume" in exec_command[-1]
+    assert "turn/start" in exec_command[-1]
+    assert '"input"' in exec_command[-1]
 
 
 @pytest.mark.asyncio
@@ -795,7 +875,7 @@ async def test_controller_send_turn_skips_missing_durable_record(tmp_path: Path)
         input_text: str | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        if "send_turn" in command:
+        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -860,7 +940,7 @@ async def test_controller_send_turn_persists_failed_turn_status(tmp_path: Path) 
         input_text: str | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        if "send_turn" in command:
+        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -1030,6 +1110,71 @@ async def test_controller_launch_retries_ready_probe_errors(tmp_path: Path) -> N
 
     assert handle.status == "ready"
     assert ready_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_uses_mount_syntax_for_colon_scoped_paths(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:c8a52a0a-66ec-4796-91a4-76568c17159a",
+        sessionId="sess-mm-c8a52a0a-66ec-4796-91a4-76568c17159a-codex_cli",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "mm:c8a52a0a-66ec-4796-91a4-76568c17159a" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "mm:c8a52a0a-66ec-4796-91a4-76568c17159a" / "session"),
+        artifactSpoolPath=str(workspace_root / "mm:c8a52a0a-66ec-4796-91a4-76568c17159a" / "artifacts"),
+        codexHomePath=str(workspace_root / "mm:c8a52a0a-66ec-4796-91a4-76568c17159a" / ".moonmind" / "codex-home"),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-mm-c8a52a0a-66ec-4796-91a4-76568c17159a-codex_cli",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    run_command = commands[1]
+    assert "-v" not in run_command
+    assert "--mount" in run_command
+    assert (
+        "type=volume,src=codex_auth_volume,"
+        f"dst={request.codex_home_path}"
+        in run_command
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -212,7 +212,7 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
-        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -249,11 +249,89 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
     assert response.metadata["assistantText"] == "OK"
     exec_command = commands[0]
     assert exec_command[:3] == ("docker", "exec", "-i")
-    assert "-c" in exec_command
-    assert "invoke" not in exec_command
-    assert "thread/resume" in exec_command[-1]
-    assert "turn/start" in exec_command[-1]
-    assert '"input"' in exec_command[-1]
+    assert "-c" not in exec_command
+    assert exec_command[-2:] == ("invoke", "send_turn")
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+    session_supervisor.emit_session_event = Mock()
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "completed",
+                "metadata": {"assistantText": "OK"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Reply with exactly the word OK",
+            reason="Operator follow-up",
+        )
+    )
+
+    emitted_metadata = [
+        call.kwargs.get("metadata")
+        for call in session_supervisor.emit_session_event.call_args_list
+    ]
+    assert emitted_metadata == [
+        {"action": "send_turn", "reason": "Operator follow-up"},
+        {
+            "action": "send_turn",
+            "assistantText": "OK",
+            "reason": "Operator follow-up",
+        },
+    ]
 
 
 @pytest.mark.asyncio
@@ -875,7 +953,7 @@ async def test_controller_send_turn_skips_missing_durable_record(tmp_path: Path)
         input_text: str | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",
@@ -940,7 +1018,7 @@ async def test_controller_send_turn_persists_failed_turn_status(tmp_path: Path) 
         input_text: str | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
-        if command[:3] == ("docker", "exec", "-i") and "-c" in command:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
             payload = {
                 "sessionState": {
                     "sessionId": "sess-1",

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -284,6 +284,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert launch_request.artifact_spool_path.endswith(f"{binding.task_run_id}/artifacts")
     assert launch_request.codex_home_path.endswith(f"{binding.task_run_id}/.moonmind/codex-home")
     assert launch_request.image_ref == "ghcr.io/moonladderstudios/moonmind:latest"
+    assert launch_request.workspace_spec == {"workspacePath": str(workspace_path)}
     assert send_turn_calls[0].instructions.startswith("artifact:instructions")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
     assert send_turn_calls[0].input_refs == ("artifact:input-1",)

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -83,7 +84,6 @@ def _request(
         idempotencyKey="idem-1",
         instructionRef="artifact:instructions",
         managedSession=binding,
-        inputRefs=["artifact:input-1"],
         workspaceSpec=workspace_spec,
         parameters={"publishMode": "none"},
     )
@@ -287,7 +287,6 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert launch_request.workspace_spec == {"workspacePath": str(workspace_path)}
     assert send_turn_calls[0].instructions.startswith("artifact:instructions")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
-    assert send_turn_calls[0].input_refs == ("artifact:input-1",)
 
     assert handle.status == "completed"
     assert handle.metadata["sessionId"] == binding.session_id
@@ -319,6 +318,132 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["action"] == "send_turn"
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
+
+
+async def test_start_restores_context_injection_before_sending_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    binding = _binding()
+    expected_workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    send_turn_calls: list[Any] = []
+
+    class _FakeContextInjectionService:
+        async def inject_context(
+            self,
+            *,
+            request: AgentExecutionRequest,
+            workspace_path: Path,
+        ) -> None:
+            assert workspace_path == expected_workspace_path
+            request.instruction_ref = "Injected context instruction"
+
+    monkeypatch.setattr(
+        "moonmind.rag.context_injection.ContextInjectionService",
+        _FakeContextInjectionService,
+    )
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_calls.append(request)
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed-runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    await adapter.start(_request(binding, workspace_path=str(expected_workspace_path)))
+
+    assert send_turn_calls
+    assert send_turn_calls[0].instructions.startswith("Injected context instruction")
+    assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
+
+
+async def test_start_rejects_non_text_input_refs_for_session_turns(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed-runs"),
+        load_session_snapshot=AsyncMock(),
+        launch_session=AsyncMock(),
+        session_status=AsyncMock(),
+        send_turn=AsyncMock(),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=AsyncMock(),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    request = _request(binding).model_copy(update={"input_refs": ["artifact:input-1"]})
+
+    with pytest.raises(
+        ValueError,
+        match="does not support inputRefs",
+    ):
+        await adapter.start(request)
 
 
 async def test_start_reuses_existing_task_scoped_session_without_launching(

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1312,3 +1312,6 @@ async def test_agent_runtime_send_turn_disables_catalog_retries(
             send_turn = catalog.resolve_activity("agent_runtime.send_turn")
 
             assert send_turn.retries.max_attempts == 1
+            assert send_turn.timeouts.start_to_close_seconds == 360
+            assert send_turn.timeouts.schedule_to_close_seconds == 600
+            assert send_turn.timeouts.heartbeat_timeout_seconds == 30

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -545,6 +545,26 @@ async def test_send_turn_heartbeats_while_waiting_for_remote_session_controller(
     )
 
 
+async def test_await_with_activity_heartbeats_accepts_existing_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from temporalio import activity as temporal_activity
+
+    monkeypatch.setattr(temporal_activity, "in_activity", lambda: False)
+
+    async def _complete() -> str:
+        await asyncio.sleep(0)
+        return "done"
+
+    task = asyncio.create_task(_complete())
+    result = await activity_runtime_module._await_with_activity_heartbeats(
+        task,
+        heartbeat_payload={"activityType": "agent_runtime.send_turn"},
+    )
+
+    assert result == "done"
+
+
 async def test_steer_turn_delegates_to_remote_session_controller() -> None:
     controller = AsyncMock()
     controller.steer_turn = AsyncMock(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -7,6 +7,7 @@ agent_runtime_publish_artifacts return typed Pydantic contracts
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionTurnResponse,
 )
 from moonmind.workflows.temporal import client as temporal_client_module
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal.activity_runtime import (
     TemporalActivityRuntimeError,
     TemporalAgentRuntimeActivities,
@@ -487,6 +489,60 @@ async def test_send_turn_delegates_to_remote_session_controller() -> None:
 
     assert isinstance(result, CodexManagedSessionTurnResponse)
     assert result.turn_id == "turn-1"
+
+
+async def test_send_turn_heartbeats_while_waiting_for_remote_session_controller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from temporalio import activity as temporal_activity
+
+    heartbeats: list[dict[str, Any]] = []
+
+    async def _slow_send_turn(
+        _request: Any,
+    ) -> CodexManagedSessionTurnResponse:
+        await asyncio.sleep(0.03)
+        return CodexManagedSessionTurnResponse(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+                "activeTurnId": "turn-1",
+            },
+            turnId="turn-1",
+            status="completed",
+        )
+
+    monkeypatch.setattr(
+        activity_runtime_module,
+        "_SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr(temporal_activity, "in_activity", lambda: True)
+    monkeypatch.setattr(temporal_activity, "heartbeat", heartbeats.append)
+
+    controller = AsyncMock()
+    controller.send_turn = AsyncMock(side_effect=_slow_send_turn)
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    result = await activities.agent_runtime_send_turn(
+        {
+            "sessionId": "sess-1",
+            "sessionEpoch": 1,
+            "containerId": "ctr-1",
+            "threadId": "thread-1",
+            "instructions": "Inspect the workspace",
+        }
+    )
+
+    assert isinstance(result, CodexManagedSessionTurnResponse)
+    assert result.status == "completed"
+    assert heartbeats
+    assert all(
+        heartbeat["activityType"] == "agent_runtime.send_turn"
+        for heartbeat in heartbeats
+    )
 
 
 async def test_steer_turn_delegates_to_remote_session_controller() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -220,12 +220,16 @@ async def test_agent_session_send_follow_up_update_executes_session_activity_sur
         "agent_runtime.publish_session_artifacts",
     ]
     assert captured[0][1]["instructions"] == "Continue the task-scoped session."
+    assert captured[0][1]["reason"] == "Operator follow-up"
     assert workflow.get_status()["lastControlAction"] == "send_turn"
 
-    for _name, _payload, kwargs in captured:
+    for name, _payload, kwargs in captured:
         assert kwargs["task_queue"] == "mm.activity.agent_runtime"
         assert isinstance(kwargs["retry_policy"], RetryPolicy)
-        assert kwargs["start_to_close_timeout"] == timedelta(seconds=60)
+        route = agent_session_module.DEFAULT_ACTIVITY_CATALOG.resolve_activity(name)
+        assert kwargs["start_to_close_timeout"] == timedelta(
+            seconds=route.timeouts.start_to_close_seconds
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed
This fixes the managed Codex session failure chain that blocked workflow execution before or during the first `send_turn` call.

The change set:
- enables the agent runtime worker to reach the Docker proxy and required exec/post routes
- preserves `workspaceSpec` through launch, prepares the repo workspace before session start, and switches session mounts to `--mount`
- updates the managed Codex controller/runtime to handle the current app-server contract, persist vendor thread metadata, resume threads when possible, and fall back to starting a new thread when resume data is stale or missing
- adds Temporal heartbeating around long-running managed `send_turn` activity waits
- increases the `agent_runtime.send_turn` timeout budget to fit real Codex turn latency

## Why
The original failure was not a single bug. Fresh replays showed a sequence of issues:
- Docker connectivity from the agent runtime worker to the proxy was incomplete
- the proxy was not allowing required routes
- workflow IDs containing `:` broke Docker volume syntax
- session launch could lose required workspace information
- the in-container runtime used a stale request contract for `turn/start`
- long Codex turns could exceed the activity heartbeat window and then the 60 second start-to-close timeout

This PR fixes those failures end-to-end so managed Codex workflows can launch and remain alive through long first-turn execution.

## Impact
Managed Codex workflows now:
- launch session containers with a prepared workspace
- recover more safely when Codex thread resume data is incomplete
- avoid false Temporal timeouts during long `send_turn` waits

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- live workflow replay verification against the same execution shape used by the reported failure
- confirmed a fresh replay progressed past the old heartbeat timeout and old 60 second start-to-close failure window, with `agent_runtime.send_turn` still heartbeating and running under the expanded timeout budget