### PR TITLE
Implement live logs session timeline phase 0 and 1

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -223,6 +223,12 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 os.environ.get("MOONMIND_LOG_STREAMING_ENABLED", "true").strip().lower()
                 not in ("0", "false", "no", "off")
             ),
+            "liveLogsSessionTimelineEnabled": bool(
+                settings.feature_flags.live_logs_session_timeline_enabled
+            ),
+            "liveLogsSessionTimelineRollout": str(
+                settings.feature_flags.live_logs_session_timeline_rollout
+            ),
         },
         "system": {
             **system_metadata,

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -26,7 +26,7 @@ from moonmind.schemas.temporal_artifact_models import (
     ArtifactSessionProjectionModel,
 )
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
-from moonmind.schemas.agent_runtime_models import LiveLogChunk
+from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
@@ -320,6 +320,19 @@ def _build_session_snapshot(
     }
 
 
+def _build_record_session_snapshot(record: object) -> dict[str, object] | None:
+    session_id = str(getattr(record, "session_id", "") or "").strip()
+    if not session_id:
+        return None
+    return {
+        "sessionId": session_id,
+        "sessionEpoch": getattr(record, "session_epoch", None),
+        "containerId": getattr(record, "container_id", None),
+        "threadId": getattr(record, "thread_id", None),
+        "activeTurnId": getattr(record, "active_turn_id", None),
+    }
+
+
 def _iter_spool_chunks(workspace_path: str | None) -> Iterator[dict[str, object]]:
     if not workspace_path:
         return
@@ -467,7 +480,7 @@ def _coerce_sequence(value: object) -> int | None:
 
 def _normalize_live_event(payload: dict[str, object]) -> dict[str, object] | None:
     try:
-        chunk = LiveLogChunk.model_validate(payload)
+        chunk = RunObservabilityEvent.model_validate(payload)
     except Exception:
         return None
     return chunk.model_dump(mode="json", exclude_none=True)
@@ -526,6 +539,39 @@ def _iter_diagnostics_observability_events(
         if dedupe_key in seen_system_annotations:
             continue
         yield normalized
+
+
+def _iter_event_journal(
+    event_path: Path | None,
+    *,
+    run_id: str | None = None,
+) -> Iterator[dict[str, object]]:
+    if event_path is None or not event_path.is_file():
+        return
+    normalized_run_id = str(run_id or "").strip() or None
+    try:
+        with event_path.open("r", encoding="utf-8", errors="replace") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                normalized = _normalize_live_event(payload)
+                if normalized is None:
+                    continue
+                payload_run_id = str(
+                    normalized.get("run_id") or normalized.get("runId") or ""
+                ).strip()
+                if normalized_run_id and payload_run_id and payload_run_id != normalized_run_id:
+                    continue
+                yield normalized
+    except OSError:
+        return
 
 
 def _iter_text_artifact_events(
@@ -812,7 +858,7 @@ async def get_observability_summary(
     session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
     base["supportsLiveStreaming"] = supports_live
     base["liveStreamStatus"] = live_stream_status
-    base["sessionSnapshot"] = _build_session_snapshot(session_record)
+    base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
     return {"summary": base}
 
 
@@ -936,7 +982,20 @@ async def get_task_run_observability_events(
     session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
 
     events: list[dict[str, object]] = []
-    if _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
+    artifacts_root = Path(_get_agent_runtime_artifacts_root()).resolve()
+    event_journal_path = _resolve_safe_artifact_path(
+        getattr(record, "observability_events_ref", None),
+        artifacts_root,
+    )
+    raw_record_run_id = getattr(record, "run_id", None)
+    record_run_id = (
+        raw_record_run_id.strip()
+        if isinstance(raw_record_run_id, str) and raw_record_run_id.strip()
+        else None
+    )
+    if event_journal_path is not None:
+        events.extend(_iter_event_journal(event_journal_path, run_id=record_run_id))
+    elif _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
         for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
             normalized = _normalize_live_event(payload)
             if normalized is not None:
@@ -1029,7 +1088,7 @@ async def stream_task_run_live_logs(
             ):
                 if await request.is_disconnected():
                     break
-                json_str = chunk.model_dump_json(by_alias=True)
+                json_str = chunk.model_dump_json(exclude_none=True)
                 yield f"data: {json_str}\n\n".encode("utf-8")
                 
                 # Check terminal status once every few chunks if possible or dynamically,

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -483,7 +483,7 @@ def _normalize_live_event(payload: dict[str, object]) -> dict[str, object] | Non
         chunk = RunObservabilityEvent.model_validate(payload)
     except Exception:
         return None
-    return chunk.model_dump(mode="json", exclude_none=True)
+    return chunk.model_dump(mode="json", by_alias=True, exclude_none=True)
 
 
 def _iter_diagnostics_observability_events(
@@ -742,6 +742,45 @@ def _iter_historical_artifact_events(
         )
 
 
+def _load_task_run_observability_events(
+    *,
+    record: object,
+    session_record: CodexManagedSessionRecord | None,
+    limit: int,
+) -> list[dict[str, object]]:
+    workspace_path = getattr(record, "workspace_path", None)
+    started_at = getattr(record, "started_at", None)
+
+    events: list[dict[str, object]] = []
+    artifacts_root = Path(_get_agent_runtime_artifacts_root()).resolve()
+    event_journal_path = _resolve_safe_artifact_path(
+        getattr(record, "observability_events_ref", None),
+        artifacts_root,
+    )
+    raw_record_run_id = getattr(record, "run_id", None)
+    record_run_id = (
+        raw_record_run_id.strip()
+        if isinstance(raw_record_run_id, str) and raw_record_run_id.strip()
+        else None
+    )
+    if event_journal_path is not None:
+        events.extend(_iter_event_journal(event_journal_path, run_id=record_run_id))
+    elif _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
+        for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
+            normalized = _normalize_live_event(payload)
+            if normalized is not None:
+                events.append(normalized)
+    else:
+        events.extend(
+            _iter_historical_artifact_events(
+                record,
+                session_record,
+                limit_per_stream=limit,
+            )
+        )
+    return events
+
+
 def _event_sort_key(payload: dict[str, object]) -> tuple[datetime, int]:
     sequence = _coerce_sequence(payload.get("sequence"))
     timestamp = _coerce_utc_datetime(payload.get("timestamp")) or datetime.min.replace(tzinfo=UTC)
@@ -977,37 +1016,13 @@ async def get_task_run_observability_events(
         )
     await _require_observability_access(record, _user)
 
-    workspace_path = getattr(record, "workspace_path", None)
-    started_at = getattr(record, "started_at", None)
     session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
-
-    events: list[dict[str, object]] = []
-    artifacts_root = Path(_get_agent_runtime_artifacts_root()).resolve()
-    event_journal_path = _resolve_safe_artifact_path(
-        getattr(record, "observability_events_ref", None),
-        artifacts_root,
+    events = await asyncio.to_thread(
+        _load_task_run_observability_events,
+        record=record,
+        session_record=session_record,
+        limit=limit,
     )
-    raw_record_run_id = getattr(record, "run_id", None)
-    record_run_id = (
-        raw_record_run_id.strip()
-        if isinstance(raw_record_run_id, str) and raw_record_run_id.strip()
-        else None
-    )
-    if event_journal_path is not None:
-        events.extend(_iter_event_journal(event_journal_path, run_id=record_run_id))
-    elif _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
-        for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
-            normalized = _normalize_live_event(payload)
-            if normalized is not None:
-                events.append(normalized)
-    else:
-        events.extend(
-            _iter_historical_artifact_events(
-                record,
-                session_record,
-                limit_per_stream=limit,
-            )
-        )
 
     events.sort(key=_event_sort_key)
     truncated = len(events) > limit
@@ -1088,7 +1103,7 @@ async def stream_task_run_live_logs(
             ):
                 if await request.is_disconnected():
                     break
-                json_str = chunk.model_dump_json(exclude_none=True)
+                json_str = chunk.model_dump_json(by_alias=True, exclude_none=True)
                 yield f"data: {json_str}\n\n".encode("utf-8")
                 
                 # Check terminal status once every few chunks if possible or dynamically,

--- a/api_service/config.template.toml
+++ b/api_service/config.template.toml
@@ -23,3 +23,6 @@ moonmind_severity_floor_default = "high"
 [feature_flags]
 # Disable the Task Preset Catalog (UI + API) when required.
 disable_task_template_catalog = false
+# Rollout scope for the session-aware Live Logs timeline contract:
+# off | internal | codex_managed | all_managed
+live_logs_session_timeline_rollout = "off"

--- a/docs/tmp/009-LiveLogsPlan.md
+++ b/docs/tmp/009-LiveLogsPlan.md
@@ -1,421 +1,442 @@
-# Live Logs Implementation Plan
+# Live Logs Session-Aware Implementation Plan
 
-This document turns `docs/ManagedAgents/LiveLogs.md` into a phased implementation plan for MoonMind.
+Status: Proposed
+Owners: MoonMind Platform
+Last updated: 2026-04-08
+Related:
+- `docs/ManagedAgents/LiveLogs.md`
+- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/tmp/009-LiveLogsPlan.md`
 
-## Objective
+## 1. Objective
 
-Implement MoonMind-managed live logs for managed agent runs using an artifact-first model with:
+Evolve the current functional Live Logs stack into the desired final state:
 
-- durable `stdout`, `stderr`, and diagnostics artifacts
-- MoonMind-owned observability APIs
-- optional live streaming for active runs
-- a Mission Control log viewer for passive observation
-- explicit separation between logs, intervention controls, and OAuth terminal flows
+- still artifact-first
+- still MoonMind-owned
+- still spool/SSE backed for live follow
+- but no longer only a merged stdout/stderr/system tail
+- instead, a continuity-aware observability timeline for Codex managed sessions
 
-## Guiding decisions
+This plan starts from the codebase as it exists today and avoids replacing working pieces unless the new session-plane contract requires it.
 
-- Managed run logs are **not** terminal sessions.
-- `xterm.js` is reserved for **OAuth** and other interactive auth flows, not run logs.
-- Managed runs must always capture raw `stdout` and `stderr` directly from subprocess pipes.
-- Durable artifacts are the source of truth; live streaming is a convenience layer.
-- Logging and intervention must be modeled separately in the backend and UI.
-- Legacy `tmate`, `web_ro`, and terminal-embed assumptions must be removed from the managed-run log path.
-- The live stream transport must be cross-process; an API-local in-memory publisher is not the architecture boundary.
+## 2. Honest current baseline
 
-## Scope
+The current project is not starting from zero.
 
-This plan covers:
+Already in place:
 
-- managed runtime launcher and supervisor changes
-- data model and persistence updates
-- artifact production and retrieval APIs
-- live log streaming
-- Mission Control UI work
-- migration away from `TaskRunLiveSession`-style terminal-session assumptions for observability
-- rollout, testing, and cleanup
+- durable `stdout`, `stderr`, and diagnostics artifact production
+- run-level observability summary and artifact-backed log retrieval APIs
+- shared append-only spool transport for live chunks
+- SSE endpoint for active runs
+- Mission Control Live Logs panel with summary -> merged-tail -> optional SSE lifecycle
+- run-global sequence numbering across `stdout` / `stderr` / `system`
+- session continuity projection and control APIs for Codex-style session artifacts
 
-This plan does **not** cover implementing the OAuth browser terminal itself beyond preserving the boundary that OAuth remains separate from run logging.
+Still missing for the desired final state:
 
-## Known current state (as of 2026-04-01)
+- a canonical session-aware observability event model
+- session-plane lifecycle events in the same run-global timeline as stdout/stderr/system
+- explicit reset-boundary rows in the Live Logs timeline
+- structured historical event retrieval for the timeline
+- frontend rendering beyond line-centric `stdout` / `stderr` / `system`
+- `react-virtuoso` and `anser` adoption for the long-term viewer baseline
+- hardening/performance work for large logs and long-lived sessions
 
-This section captures an honest snapshot of the implementation, to prevent future confusion about what is and is not done:
+## 3. Delta from current state
 
-Canonical architecture and operator-visible contract text lives in [`docs/ManagedAgents/LiveLogs.md`](../ManagedAgents/LiveLogs.md). This tmp plan owns rollout tracking and implementation status.
+The Codex Managed Session Plane adds four requirements that the shipped line-centric Live Logs stack does not yet model as first-class timeline facts:
 
-- **Done**: Durable stdout/stderr/diagnostics artifact production is substantially implemented in the managed runtime supervisor.
-- **Done**: Data model fields (`stdout_artifact_ref`, `stderr_artifact_ref`, `diagnostics_ref`, `last_log_at`, `last_log_offset`) exist and are populated.
-- **Done**: Observability read APIs (summary, tail endpoints, downloads, diagnostics) are consumed by the Mission Control task detail page through durable `taskRunId` resolution from execution detail.
-- **Done**: The runtime supervisor emits live log records into the shared append-only spool transport consumed by the API SSE endpoint.
-- **Done**: The launcher persists `liveStreamCapable` for workspace-backed managed runs so summary metadata truthfully reports stream availability.
-- **Done**: Live log sequence assignment is one run-global namespace across stdout/stderr/system, so reconnect-by-sequence now matches the API contract.
-- **Partial**: The merged endpoint now prefers chronological synthesis from spool metadata; historical runs without spool metadata still degrade to labeled artifact concatenation with a warning.
-- **Done**: Historical runs that only persisted legacy `logArtifactRef` now degrade through the merged-log endpoint instead of any session-viewer path.
-- **Done**: The full Mission Control observability panel now handles delayed managed-run attachment, launch-failed states, binding-missing states, and owner-visible authorization failures without falling back to the Temporal run id.
+- bounded session identity: `session_id`, `session_epoch`, `container_id`, `thread_id`, and `active_turn_id`
+- control vocabulary: `start_session`, `resume_session`, `send_turn`, `steer_turn`, `interrupt_turn`, `clear_session`, `cancel_session`, and `terminate_session`
+- reset-boundary semantics: `clear_session` must produce a visible epoch/thread boundary instead of hiding the change inside plain text
+- durable continuity artifacts: summary, checkpoint, control-event, and reset-boundary artifacts remain the authoritative drill-down evidence
 
-## Completed implementation slice that made Mission Control live logs functional
+## 4. Guiding migration rules
 
-This slice completed the contract that was previously blocking real Mission Control usage:
+1. Keep the current transport boundary.
+   - Do not replace the spool/SSE architecture unless it blocks the new contract.
+   - Extend it to carry richer events.
 
-### Workstream A - Complete
+2. Preserve artifact-first semantics.
+   - Every new live-visible fact must also be reconstructable from artifacts or bounded workflow metadata.
 
-- `ManagedRunRecord` now persists `workflow_id`.
-- Managed launch now saves the managed run record before binding it back to the execution.
-- The managed launch path now binds the parent logical `MoonMind.Run` workflow id so Mission Control resolves the correct live-log record for task detail.
-- `/api/executions/{workflowId}` now derives `taskRunId` from the durable managed-run store when the memo/search-attribute path does not already provide it.
+3. Do not merge logging and control.
+   - Session controls remain separate.
+   - Live Logs only reflects those controls as passive observability rows.
 
-### Workstream B - Complete
+4. Prefer additive, backward-compatible changes first.
+   - Enrich payloads before replacing endpoints.
+   - Dual-read and dual-write where helpful.
 
-- Mission Control no longer falls back to the Temporal run id as a fake task-run id.
-- The task-detail page now distinguishes waiting-for-launch, launch-failed, binding-missing, and authorization-failed observability states.
-- When a delayed `taskRunId` appears, the page automatically attaches the live-log panel and immediately proceeds through summary and merged-tail retrieval.
+5. Keep historical runs usable.
+   - Runs without session-aware history must continue to degrade through merged artifacts and continuity drill-down.
 
-### Workstream C - Complete
+## 5. Rollout flag
 
-- `/api/task-runs/*` observability routes now allow both superusers and the owning execution user, matching the surrounding Mission Control visibility model.
-- The React panel now surfaces 403 authorization failures with explicit operator-facing copy instead of silently degrading to an empty log view.
+The new timeline contract is gated behind `liveLogsSessionTimelineEnabled`.
 
-### Workstream D - Complete
+Rollout scopes:
 
-- Backend coverage now includes a long-running managed-runtime integration test that simulates real streaming output while the process is still active.
-- Browser-facing coverage now exercises delayed `taskRunId` attachment and the Mission Control state transitions that were previously missing.
+- `off`
+- `internal`
+- `codex_managed`
+- `all_managed`
 
-### Workstream E - Finish the remaining viewer and rollout hardening after the contract works
+`logStreamingEnabled` remains the transport toggle for existing spool/SSE behavior. The new flag controls session-aware timeline semantics independently from live transport availability.
 
-Workstreams A-D are complete. The remaining work is optional hardening and presentation polish:
+## 6. Desired end state
 
-- adopt the planned `react-virtuoso` viewer baseline for long logs,
-- adopt `anser` for ANSI rendering,
-- complete Phase 7 response-time / large-log validation,
-- remove any "done" markings in this tmp plan that still depend on the above contract being proven in Mission Control.
+By the end of this plan:
 
-### Status
-
-Workstreams A-D are complete. The feature is now functional in Mission Control when the updated backend and frontend are deployed together.
+- `/observability-summary` returns both live-stream status and the latest session snapshot when present
+- Live streaming still uses `/logs/stream`, but events can include session metadata and event kinds
+- the UI prefers a structured event-history endpoint for initial load when available
+- Live Logs renders a unified timeline of `stdout`, `stderr`, `system`, and `session`
+- `clear_session` appears as a visible epoch-boundary banner, not just a text line or a separate side panel artifact
+- Session Continuity remains as drill-down evidence, but the main operator experience is the unified timeline
 
 ---
 
-## Phase 0 — Design alignment and implementation scaffolding
+## Phase 0 — Re-baseline the implementation plan
 
 ### Goal
 
-Align the codebase, docs, and feature boundaries before changing runtime behavior.
+Reset the project plan so it reflects what is already shipped versus what is newly required by the Codex Managed Session Plane.
 
 ### Tasks
 
-- [x] Confirm the canonical implementation target is `docs/ManagedAgents/LiveLogs.md`.
-- [x] Inventory current managed-run logging, transcript, `tmate`, `web_ro`, and terminal-embed code paths.
-- [x] Identify all UI surfaces that currently present "Live Output", embedded terminals, or session-viewer semantics.
-- [x] Identify current data models and DTOs that store log/session metadata for managed runs.
-- [x] Identify current artifact-writing paths for stdout, stderr, transcripts, and diagnostics.
-- [x] Decide where the new observability service layer will live in the backend.
-- [x] Define feature flags for incremental rollout, including a `logStreamingEnabled` flag.
-- [x] Define the migration boundary between legacy session-based observability and the new MoonMind-owned log model.
-- [x] Update any stale docs/specs that still describe `tmate web_ro` as the primary live-log path.
-- [x] Create implementation issues/tasks for each phase in this plan.
+- [x] Replace the old line-centric `docs/tmp/009-LiveLogsPlan.md` with this session-aware migration plan.
+- [x] Mark the original line-centric Live Logs phases as baseline-complete for the shipped artifact/spool/SSE architecture.
+- [x] Document the delta from current state:
+  - bounded session identity
+  - control vocabulary
+  - reset-boundary semantics
+  - durable continuity artifacts
+- [x] Introduce one feature flag for the new timeline contract:
+  - `liveLogsSessionTimelineEnabled`
+- [x] Define explicit rollout scopes:
+  - `off`
+  - `internal`
+  - `codex_managed`
+  - `all_managed`
 
 ### Exit criteria
 
-- [x] The team has a single agreed backend architecture for artifact-backed logs and SSE streaming.
-- [x] The team has a list of current files/modules that must be changed.
-- [x] Legacy terminal assumptions are explicitly marked deprecated for managed-run observability.
+- [x] The current spool/SSE/artifact stack is treated as the baseline, not a prototype to be replaced.
+- [x] The remaining work is clearly framed as a session-aware upgrade rather than "build Live Logs from scratch."
 
 ---
 
-## Phase 1 — Runtime capture contract and durable artifact production
+## Phase 1 — Define and persist the canonical observability event model
 
 ### Goal
 
-Make managed runs always capture raw `stdout` and `stderr` durably, independent of any UI attachment.
+Introduce a stable MoonMind event model that can represent both existing log chunks and new session-plane lifecycle facts.
 
 ### Tasks
 
-- [x] Update the managed launcher to always start subprocesses with piped `stdout` and `stderr`.
-- [x] Remove any requirement that managed runs be wrapped in `tmate` or similar terminal relays for visibility.
-- [x] Ensure the supervisor drains `stdout` and `stderr` concurrently and continuously.
-- [x] Preserve raw stream fidelity; do not normalize subprocess output into framework logs before persistence.
-- [x] Implement or finalize spool/buffer handling for long-running streams.
-- [x] Write durable stdout artifacts for every managed run.
-- [x] Write durable stderr artifacts for every managed run.
-- [x] Write diagnostics artifacts for every managed run.
-- [x] Optionally generate a merged log artifact if that materially simplifies retrieval or support workflows.
-- [x] Record artifact refs and summary metadata when the run ends.
-- [x] Capture and persist exit code, failure class, timestamps, and run summary fields needed by the UI.
-- [x] Ensure artifact generation succeeds even when the frontend never connects.
-- [x] Ensure supervisor heartbeat and timeout handling integrate cleanly with log capture.
-- [x] Add tests for successful runs, failed runs, timed-out runs, and abrupt process termination.
-- [x] Add tests for high-volume log output and interleaved stdout/stderr.
+- [x] Define a canonical browser/backend contract: `RunObservabilityEvent`
+- [x] Keep current live-log payloads readable during migration while the canonical event contract becomes the source of truth.
+- [x] Persist structured historical event reconstruction via an artifact-backed JSONL journal.
+- [x] Extend the managed-run persistence model with session snapshot and historical event refs:
+  - `session_id`
+  - `session_epoch`
+  - `container_id`
+  - `thread_id`
+  - `active_turn_id`
+  - `observability_events_ref`
+- [x] Keep sequence numbering run-global across all streams, including `session` rows.
 
 ### Exit criteria
 
-- [x] Every managed run produces durable stdout, stderr, and diagnostics outputs.
-- [x] Log capture no longer depends on interactive terminal infrastructure.
-- [x] Raw stdout/stderr fidelity is preserved well enough for replay, download, and troubleshooting.
+- [x] A single event model can represent current stdout/stderr/system chunks and future session lifecycle rows.
+- [x] No frontend work depends on provider-native event payloads.
+- [x] The backend can persist enough structured history to reconstruct the timeline after the run ends.
+
+### Notes
+
+This phase is the contract anchor. Everything after this becomes simpler once the browser sees one unified event shape.
 
 ---
 
-## Phase 2 — Observability data model and backend read APIs
+## Phase 2 — Make the Codex Managed Session Plane a first-class observability producer
 
 ### Goal
 
-Expose artifact-backed observability through MoonMind-owned backend APIs and records.
-
-### Completion status of tasks (honest labels)
-
-- [x] **complete** — Add or update the managed run persistence model to store `stdout_artifact_ref`, `stderr_artifact_ref`, optional `merged_log_artifact_ref`, `diagnostics_ref`, `last_log_offset`, and `last_log_at`.
-- [x] **complete** — Add any missing fields for `exit_code`, `failure_class`, `error_message`, and live-stream capability metadata.
-- [x] **complete** — Design and implement the replacement or successor to terminal-session-style observability records.
-- [x] **complete** — Deprecate use of `TaskRunLiveSession`-style fields for managed-run log viewing.
-- [x] **complete** — Add an observability summary endpoint for task runs.
-- [x] **complete** — Add stdout tail retrieval endpoint(s).
-- [x] **complete** — Add stderr tail retrieval endpoint(s).
-- [x] **complete** — Add merged tail retrieval endpoint(s). Endpoint exists and merged-tail contract semantics (ordering guarantees, fallback from stdout/stderr when no merged artifact exists) have been hardened.
-- [x] **complete** — Add diagnostics retrieval endpoint(s).
-- [x] **complete** — Add full stdout/stderr download endpoint(s).
-- [x] **complete** — Ensure API responses are stable, typed, and suitable for Mission Control consumption.
-- [x] **complete** — Define the API payload shape for log records, including sequence, stream, offset, timestamp, and text.
-- [x] **complete** — Add authorization checks for observability endpoints.
-- [x] **complete** — Add tests for ended runs, missing artifacts, partial artifacts, and failed diagnostics generation.
-- [x] **complete** — Add tests for tail semantics, pagination/range behavior, and large artifacts.
-- [x] **complete** — Mission Control calls the summary and tail APIs from the main task detail page.
-
-### Exit criteria
-
-- [x] **complete** — Mission Control can fetch observability metadata without relying on terminal-session endpoints.
-- [x] **complete** — Stdout, stderr, diagnostics, and merged-tail retrieval all work from MoonMind APIs.
-- [x] **complete** — The persisted model matches the contract described in `LiveLogs.md`.
-- [x] **complete** — Mission Control actually consumes the observability APIs on task detail page load. This is required before Phase 2 exit criteria are fully met.
-
----
-
-## Phase 3 — Live log stream pipeline
-
-### Goal
-
-Add MoonMind-owned live log delivery for active runs, with artifacts still remaining authoritative.
-
-### Pre-step: Choose the shared live-stream transport
-
-Before implementing the publisher, an explicit design decision must be made and documented:
-
-- [x] Choose the real cross-process streaming mechanism.
-  - Options: Redis pub/sub, shared append-only spool file, DB-backed tailing (e.g. polling a log records table), or another MoonMind-owned mechanism.
-  - **Reject**: API-local singleton memory is not a valid architecture boundary (see `LiveLogs.md` §6.4).
-- [x] Document the chosen mechanism in a short ADR or inline note in this plan.
-  - Current choice: shared append-only spool file under the run workspace, consumed by the API SSE endpoint via `SpoolLogReader`.
-- [x] Confirm the chosen mechanism works when the managed runtime supervisor runs in a different process or container from the API service.
+Have the session plane publish passive lifecycle events into the same run-global observability stream already used by Live Logs.
 
 ### Tasks
 
-- [x] Choose the first transport as SSE over `text/event-stream` (client-side delivery — already decided).
-- [x] Implement a live log publisher that fans out log chunks to active subscribers via the chosen cross-process transport.
-- [x] Assign monotonically increasing sequence values for emitted log records.
-- [x] Include `stream`, `offset`, `timestamp`, and raw `text` for each event.
-- [x] Wire the runtime supervisor to actually emit live log records into the shared transport (this is the key missing producer-to-stream link).
-- [x] Add a `GET /api/task-runs/{id}/logs/stream` endpoint or equivalent that consumes from the shared transport (not from an API-local buffer).
-- [x] Support filtering by stream where practical.
-- [x] Support resume semantics using `since=<sequence_or_offset>` or equivalent; resume is best-effort.
-- [x] Ensure reconnect behavior works after transient disconnects; artifacts are the durable fallback when the resume window has expired.
-- [x] Ensure closed/collapsed clients stop receiving live updates promptly.
-- [x] Ensure stream lifecycle metadata (`live_stream_status`, `supports_live_streaming`) is reflected in the observability summary.
-- [x] Implement graceful fallback to artifact-backed tail retrieval when live streaming is unavailable.
-- [x] Add supervisor/system events to the merged stream only as clearly identified `system` entries.
-- [x] Add tests for reconnection, sequence continuity, run completion, and stream shutdown.
-- [x] Add tests for multiple concurrent viewers observing the same run.
-- [x] Add tests for runs with no live-stream support and for viewers that connect after the run has already ended.
+- Add an observability sink/adapter at the session-plane boundary.
+- For each stable session-plane action, emit a normalized `session` event:
+  - `start_session`
+  - `resume_session`
+  - `send_turn`
+  - `steer_turn`
+  - `interrupt_turn`
+  - `clear_session`
+  - `cancel_session`
+  - `terminate_session`
+- Emit session events for major session lifecycle transitions:
+  - session started
+  - session resumed
+  - turn started
+  - turn completed
+  - turn interrupted
+  - approval requested
+  - approval resolved
+  - summary published
+  - checkpoint published
+- For `clear_session`, emit both:
+  - a passive control event row, and
+  - a dedicated `session_reset_boundary` row carrying the new epoch/thread info
+- Ensure each emitted session event includes the latest known session snapshot fields when available.
+- Update the managed session store/workflow adapter so the latest session snapshot is mirrored onto the run record or other summary source.
+- Sanity-check that session-plane publishing failures do not break runtime control or artifact persistence.
 
 ### Exit criteria
 
-- [x] Supervised runtime chunks are actually published into the shared transport consumed by the API endpoint.
-- [x] Operators can open a live stream for an active run and receive appended log records that came from actual process output.
-- [x] Reconnect-from-last-sequence behavior works reliably enough for normal browser refreshes and short disconnects.
-- [x] When streaming is unavailable, the UX still works via artifact-backed retrieval.
-- [x] Endpoint presence alone does not satisfy exit criteria; real emitted events from managed runs are required.
+- Session-plane lifecycle facts show up in the same sequence namespace as stdout/stderr/system.
+- `clear_session` produces an explicit boundary event with epoch/thread changes.
+- Live observability no longer depends on the separate continuity panel for the operator to notice a reset.
+
+### Risk to watch
+
+Avoid turning the session-plane adapter into a mirror of raw Codex provider events. The emitted contract should stay MoonMind-normalized.
 
 ---
 
-## Phase 4 — Mission Control observability UI
+## Phase 3 — Add structured historical event retrieval while preserving current APIs
 
 ### Goal
 
-Replace terminal-style live output with a MoonMind-native observability surface.
-
-### Dependency chain
-
-Before this phase can be considered complete, all of the following must exist:
-
-1. backend live event production (Phase 3)
-2. backend stream delivery to API via cross-process transport (Phase 3)
-3. observability summary and tail fallback (Phase 2 fully consumed by UI)
-4. Mission Control panel behavior and state model (this phase)
-5. ended-run behavior (this phase)
-6. collapse/background lifecycle (this phase)
-7. artifact-only degraded mode (this phase)
+Give the UI a durable structured history source for the timeline, without breaking the existing merged-tail and SSE behavior.
 
 ### Tasks
 
-- [x] Create or update the task detail page Observability section.
-- [x] Implement the **Live Logs** panel using a native React log viewer.
-- [x] Implement the **Stdout** panel backed by stdout retrieval/download APIs.
-- [x] Implement the **Stderr** panel backed by stderr retrieval/download APIs.
-- [x] Implement the **Diagnostics** panel backed by diagnostics APIs.
-- [x] Keep **Artifacts** visible and consistent with the rest of Mission Control.
-- [ ] Use `react-virtuoso` or the chosen virtualized rendering base for long/growing log streams.
-- [ ] Use `anser` or the chosen ANSI parser for styled rendering of ANSI output.
-- [x] Use TanStack Query for initial tail fetches, cache invalidation, and fallback retrieval.
-- [x] Use `EventSource` for live follow mode.
-- [x] Default the Live Logs panel to collapsed with no active connection.
-- [x] On open, fetch observability summary and merged tail before connecting to live updates. Initial content must not depend on SSE success.
-- [x] Stop streaming when the panel is collapsed.
-- [x] Stop or pause streaming when the tab is backgrounded; reconnect when visibility returns only if run is still active.
-- [x] Surface viewer states: `not_available`, `starting`, `live`, `ended`, `error` (defined in `LiveLogs.md` §12.3).
-- [x] Show per-line stream provenance (`stdout`, `stderr`, `system`).
-- [x] Add wrap toggle, copy support, and download affordances.
-- [x] Ensure ended runs show useful artifact-backed logs without attempting live streaming.
-- [x] Remove any thin UI assumptions that SSE alone is sufficient (e.g. current thin SSE tail view on task detail).
-- [x] Remove any remaining implicit dependence on legacy session semantics for managed-run logs.
-- [x] Add UI tests for load states, reconnect behavior, collapse behavior, and ended-run behavior.
+- Add a historical retrieval endpoint:
+  - `GET /api/task-runs/{id}/observability/events`
+- Support:
+  - `since=`
+  - `limit=`
+  - optional stream filtering
+  - optional kind filtering
+- Keep `/logs/stream` as the live endpoint, but enrich its payload to use the same event schema.
+- Keep `/logs/merged` as a human-readable fallback/download surface.
+- Decide and document fallback order for historical load:
+  1. structured events endpoint
+  2. merged artifact-backed tail
+  3. continuity artifact drill-down if necessary for missing session facts
+- Enrich `/observability-summary` to include latest session snapshot fields when present.
+- Ensure the summary endpoint remains truthful for ended runs and non-stream-capable runs.
 
 ### Exit criteria
 
-- [x] The task detail page no longer depends on an embedded terminal for managed-run logs.
-- [x] Operators can inspect live logs, stdout, stderr, diagnostics, and artifacts in one coherent area.
-- [x] Opening and closing the panel has the expected connection lifecycle behavior.
-- [x] Artifact-backed initial load works independently of whether live streaming succeeds.
-- [x] Completed runs remain fully inspectable without ever having had a live stream connection.
+- The UI can render a session-aware historical timeline without depending on live transport.
+- `/logs/stream` and `/logs/merged` remain compatible with current consumers.
+- Summary payloads expose enough session snapshot data for compact header rendering.
 
 ---
 
-## Phase 5 — Intervention separation and control-surface cleanup
+## Phase 4 — Upgrade the frontend from line viewer to observability timeline
 
 ### Goal
 
-Make sure logging remains passive observation while intervention uses explicit workflow/provider controls.
+Preserve the current panel lifecycle while replacing the underlying row model and rendering logic.
 
 ### Tasks
 
-- [x] Audit the current UI and backend for places where live output and intervention are coupled.
-- [x] Remove assumptions that a live log session implies shell access or operator control access.
-- [x] Define the Intervention panel or controls separately from the log viewer.
-- [x] Ensure Pause/Resume/Cancel/Approve/Reject/Send Message actions route through Temporal signals/updates or provider-native adapters rather than terminal transport.
-- [x] Ensure intervention actions are logged/audited separately from stdout/stderr.
-- [x] Ensure the live log viewer can show future inline system annotations without becoming an intervention mechanism itself.
-- [x] Add tests verifying intervention actions do not require a live log connection.
-- [x] Update UI language to clearly distinguish observation from control.
+- Replace the current `LogLine` model with a richer timeline row model.
+- Keep the current lifecycle:
+  - fetch summary
+  - fetch historical content
+  - attach live SSE only when panel is open, visible, and active
+- Change initial load order to:
+  1. summary
+  2. structured history if available
+  3. fallback to merged text if not
+- Render distinct row types:
+  - stdout line
+  - stderr line
+  - system annotation
+  - session lifecycle row
+  - reset boundary banner
+  - summary/checkpoint publication marker
+  - approval row
+- Add a compact header snapshot for session context:
+  - session ID
+  - epoch
+  - container ID
+  - thread ID
+  - active turn ID
+  - live status
+- Keep Session Continuity as a drill-down area, but reduce duplication with the main timeline.
+- Decide whether to:
+  - keep a separate "Session Continuity" panel, or
+  - collapse it into "Artifacts / Session drill-down" once timeline integration lands
+- Finish the viewer hardening work already open in the previous plan:
+  - adopt `react-virtuoso`
+  - adopt `anser`
+- Add stream/session filters if cheap enough in the first pass.
 
 ### Exit criteria
 
-- [x] Managed-run logs are a passive observability surface only.
-- [x] Intervention is explicit, auditable, and transport-independent.
-- [x] No managed-run operator action depends on a terminal embed or log session attachment.
+- The Live Logs panel renders a unified timeline of `stdout`, `stderr`, `system`, and `session`.
+- Reset boundaries are visually obvious.
+- The current passive-observation UX remains intact.
+- Large logs no longer depend on naive DOM growth.
 
 ---
 
-## Phase 6 — Migration off legacy session-based observability
+## Phase 5 — Unify continuity artifacts with timeline semantics
 
 ### Goal
 
-Retire legacy `tmate`/terminal-session assumptions for managed-run log viewing without breaking existing runs.
+Make the continuity artifact system and Live Logs feel like one observability model instead of two parallel ones.
 
 ### Tasks
 
-- [x] Add compatibility handling for historical runs that only have legacy session/transcript data.
-- [x] Decide how old runs should appear in the new Observability UI when stdout/stderr artifacts are missing.
-- [x] Mark legacy terminal-session observability records as deprecated in code and docs.
-- [x] Remove or gate old `web_ro`-driven viewer paths for managed runs.
-- [x] Remove launcher/runtime branches that enabled `tmate` only for live-log visibility.
-- [x] Remove obsolete DTOs, frontend state, and API paths once replacement coverage is complete.
-- [x] Update docs that previously described terminal embedding as the standard managed-run observability path.
-- [x] Ensure OAuth docs still retain `xterm.js` where interactive terminal behavior is actually needed.
-- [x] Add migration notes for operators and contributors.
-- [x] Add regression tests covering both migrated and non-migrated runs.
+- Add explicit links from timeline rows to continuity artifacts where relevant.
+- Ensure the session projection remains the source for artifact drill-down, not for the main operator timeline.
+- Add helper APIs or response shaping if the UI needs artifact refs attached directly to timeline events.
+- Decide whether the current artifact session projection polling should remain separate or be folded into summary/history refresh paths.
+- Ensure artifact groups still cover:
+  - summary
+  - checkpoint
+  - control
+  - reset boundary
+- Update copy and panel labels so operators understand that:
+  - timeline = what happened
+  - continuity artifacts = durable evidence / drill-down
 
 ### Exit criteria
 
-- [x] Managed-run observability no longer depends on legacy session-viewer infrastructure.
-- [x] Historical runs degrade gracefully.
-- [x] The docs consistently describe the new architecture.
+- Operators can move from a timeline event to the related artifact without context switching.
+- Continuity artifacts remain available for audit/postmortem even if the main timeline is enough for most usage.
+- The UI no longer feels split between logs and session continuity as separate worlds.
 
 ---
 
-## Phase 7 — Hardening, performance, and rollout
+## Phase 6 — Compatibility, migration, and cleanup
 
 ### Goal
 
-Make the system production-ready and safe to enable by default.
+Roll out the new timeline without breaking existing active runs, historical runs, or non-session-managed runs.
 
 ### Tasks
 
-- [ ] Measure initial-tail response times against the success target.
-- [ ] Load test large logs and long-running streams.
-- [ ] Validate that the UI remains responsive with very large merged tails.
-- [ ] Tune tail sizes, buffering, and reconnect windows.
-- [ ] Add observability for the observability system itself, including structured supervisor events and metrics.
-- [ ] Correlate log-streaming operations with OpenTelemetry traces/metrics where applicable.
-- [ ] Add alerting or health indicators for stream failures, artifact write failures, and diagnostics generation failures.
-- [ ] Validate security and authorization on all observability and download endpoints.
-- [ ] Validate behavior across browser refreshes, tab visibility changes, and network interruptions.
-- [ ] Keep `MOONMIND_LOG_STREAMING_ENABLED` as an operator disable switch, with default-on behavior preserved.
-- [ ] Validate the default-on path in local/dev, then broader internal usage.
-- [ ] Remove any stale default-off or staged-rollout assumptions from related docs and UI copy.
+- Support a compatibility mode where `/logs/stream` may still emit old minimal events while the new UI can read both shapes.
+- Support a compatibility mode where the UI can synthesize timeline rows from merged text if structured history is absent.
+- Keep `/logs/merged` and existing stream-name endpoints stable during rollout.
+- Avoid backfilling old runs unless needed; degrade them gracefully.
+- Gate the new timeline rendering behind `liveLogsSessionTimelineEnabled` until dev/internal validation is complete.
+- Roll out in stages:
+  1. dev/internal only
+  2. Codex-managed runs
+  3. all managed runs that emit session events
+- Remove obsolete assumptions once the new path is stable:
+  - plain `LogLine`-only UI logic
+  - ad hoc merged-text parsing as the primary model
+  - duplication between separate continuity banners and the main timeline
 
 ### Exit criteria
 
-- [ ] The feature meets the core success criteria from `LiveLogs.md`.
-- [ ] Operators can reliably observe active and completed runs.
-- [ ] The system is stable enough to become the default managed-run log experience.
+- Existing runs remain observable during deployment transitions.
+- The frontend and backend can be deployed independently for a short window without catastrophic breakage.
+- Historical runs still work, even if they render a degraded timeline.
 
 ---
 
-## Cross-phase engineering checklist
+## Phase 7 — Hardening, performance, and operational rollout
 
-### Backend
+### Goal
 
-- [ ] Launcher uses direct subprocess pipe capture for all managed runs.
-- [ ] Supervisor owns draining, durability, diagnostics, and live fan-out via shared cross-process transport.
-- [ ] Observability APIs are MoonMind-owned and artifact-backed.
-- [ ] Live streaming is optional and never authoritative.
-- [x] Legacy terminal/session models are deprecated for managed-run observability.
+Make the session-aware timeline robust enough to be the default managed-run observability experience.
 
-### Frontend
+### Tasks
 
-- [ ] Live Logs is a native log viewer, not a terminal emulator.
-- [ ] Stdout, Stderr, Diagnostics, and Artifacts are separate operator surfaces.
-- [ ] Connection lifecycle follows panel-open and tab-visibility behavior.
-- [ ] Ended runs remain fully inspectable without live transport.
-- [ ] Thin SSE-only assumptions in current task detail UI are removed or replaced.
+- Add backend tests for:
+  - session event publication
+  - reset boundary publication
+  - dual live + historical reconstruction
+  - missing partial continuity artifacts
+  - ended-run reloads
+- Add frontend tests for:
+  - boundary rendering
+  - session snapshot header
+  - fallback from structured history to merged text
+  - reconnect after visibility change
+  - mixed stdout/stderr/system/session ordering
+- Load test:
+  - large merged histories
+  - long-running live streams
+  - runs with many boundary/system/session rows
+- Instrument the observability system itself:
+  - event journal write failures
+  - SSE disconnect rates
+  - journal read latency
+  - summary endpoint latency
+  - timeline render performance on large datasets
+- Validate auth and ownership checks for all new structured history surfaces.
+- Define rollback behavior:
+  - disable structured history endpoint usage in UI
+  - fall back to current merged-tail behavior
+- Remove the feature flag only after internal Codex-managed runs look stable.
 
-### Architecture boundaries
+### Exit criteria
 
-- [ ] Logging is separated from intervention.
-- [ ] OAuth remains the only place where `xterm.js` is required.
-- [ ] Durable artifacts remain the source of truth.
-- [ ] Live stream transport is cross-process; API-local singleton memory is not used as the architecture boundary.
+- The UI remains responsive for large timelines.
+- Operators can reliably observe active and completed Codex-managed runs.
+- Reset boundaries and session lifecycle are consistently visible in both live and historical views.
+- The new timeline path is safe to enable by default.
 
 ---
 
-## Suggested implementation order
+## 7. Smallest safe PR sequence
 
-1. Phase 0 — doc alignment (**this pass**)
-2. Phase 2 fully consumed — artifact-first UI baseline (Mission Control calls observability APIs)
-3. Phase 3 pre-step — choose and document cross-process transport
-4. Phase 3 — real producer-to-stream plumbing (supervisor emits; API consumes from shared transport)
-5. Phase 4 — live-follow integration in Mission Control
-6. Phase 5 + Phase 6 — cleanup of legacy assumptions and session migration
-7. Phase 7 — hardening and rollout
+1. **Contract PR**
+   - add `RunObservabilityEvent`
+   - update `docs/tmp/009-LiveLogsPlan.md`
+   - keep current payload readers working
 
-This order gives Mission Control a usable artifact-backed viewer before SSE live follow is fully complete.
+2. **Summary PR**
+   - enrich `/observability-summary` with session snapshot fields
 
----
+3. **Session-plane producer PR**
+   - emit `session` rows for start/resume/turn/clear events
+   - emit explicit reset-boundary rows
 
-## Definition of done
+4. **Structured-history PR**
+   - persist/read observability events
+   - add `/observability/events`
 
-The Live Logs implementation is done when all of the following are true:
+5. **Frontend model PR**
+   - replace `LogLine` with timeline rows
+   - still render mostly like today
 
-- [x] Every managed run produces durable stdout, stderr, and diagnostics artifacts.
-- [x] Mission Control can display artifact-backed log tails and diagnostics for completed runs.
-- [x] Mission Control can live-follow active runs through MoonMind-owned streaming fed by actual supervised runtime output.
-- [x] Managed-run log viewing no longer depends on `tmate`, `web_ro`, or terminal embedding.
-- [x] Intervention is separate from logging in both UI and backend contracts.
-- [x] `xterm.js` remains limited to OAuth/interactive auth terminal flows.
-- [x] Legacy session-based observability for managed-run logs has been removed or cleanly deprecated.
-- [x] The live stream transport works across the supervisor-to-API process boundary.
+6. **Frontend UX PR**
+   - boundary banners
+   - session snapshot header
+   - continuity artifact links
+
+7. **Viewer-hardening PR**
+   - `react-virtuoso`
+   - `anser`
+
+8. **Cleanup PR**
+   - remove old-only assumptions
+   - simplify continuity-panel duplication
+
+## 8. Definition of done
+
+This migration is done when all of the following are true:
+
+- Live Logs still works for today’s active and completed runs.
+- Codex-managed runs surface session identity in summary and timeline.
+- `clear_session` produces an explicit epoch-boundary row in both live and historical views.
+- The main operator experience is a unified timeline, not separate mental models for logs and continuity.
+- Session continuity artifacts remain available as durable drill-down evidence.
+- The viewer is virtualized and ANSI-aware.
+- Large-log and long-session behavior has been tested and is operationally acceptable.

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Annotated, Any, Optional, Sequence
+from typing import Annotated, Any, Literal, Optional, Sequence
 from urllib.parse import urlsplit
 
 from pydantic import AliasChoices, Field, field_validator
@@ -1588,6 +1588,23 @@ class OIDCSettings(BaseSettings):
 class FeatureFlagsSettings(BaseSettings):
     """Feature flag toggles for runtime surfaces."""
 
+    live_logs_session_timeline_rollout: Literal[
+        "off",
+        "internal",
+        "codex_managed",
+        "all_managed",
+    ] = Field(
+        "off",
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__LIVE_LOGS_SESSION_TIMELINE_ROLLOUT",
+            "LIVE_LOGS_SESSION_TIMELINE_ROLLOUT",
+        ),
+        description=(
+            "Rollout scope for the session-aware Live Logs timeline contract. "
+            "Allowed values: off, internal, codex_managed, all_managed."
+        ),
+    )
+
     task_template_catalog: bool = Field(
         True,
         validation_alias=AliasChoices(
@@ -1615,6 +1632,12 @@ class FeatureFlagsSettings(BaseSettings):
         return bool(
             self.task_template_catalog and not self.disable_task_template_catalog
         )
+
+    @property
+    def live_logs_session_timeline_enabled(self) -> bool:
+        """Return whether the session-aware timeline contract is enabled."""
+
+        return self.live_logs_session_timeline_rollout != "off"
 
     model_config = SettingsConfigDict(
         populate_by_name=True,

--- a/moonmind/observability/transport.py
+++ b/moonmind/observability/transport.py
@@ -18,7 +18,7 @@ class SpoolLogPublisher:
 
     def publish(self, chunk: RunObservabilityEvent) -> None:
         """Append a JSON-serialized observability event to the spool file."""
-        payload = chunk.model_dump_json(exclude_none=True)
+        payload = chunk.model_dump_json(by_alias=True, exclude_none=True)
         # Using open with 'a' guarantees O_APPEND semantics.
         # This allows multiple writers (if any) to safely append on POSIX,
         # but in our architecture, only the single supervisor writes to it.

--- a/moonmind/observability/transport.py
+++ b/moonmind/observability/transport.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import AsyncIterator
 
-from moonmind.schemas.agent_runtime_models import LiveLogChunk
+from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 
 
 class SpoolLogPublisher:
@@ -16,10 +16,9 @@ class SpoolLogPublisher:
         # Ensure the filename is absolute or relative to a known path.
         self._spool_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def publish(self, chunk: LiveLogChunk) -> None:
-        """Append a JSON-serialized LiveLogChunk to the spool file."""
-        # We write each chunk as a JSON Lines payload
-        payload = chunk.model_dump_json(by_alias=True)
+    def publish(self, chunk: RunObservabilityEvent) -> None:
+        """Append a JSON-serialized observability event to the spool file."""
+        payload = chunk.model_dump_json(exclude_none=True)
         # Using open with 'a' guarantees O_APPEND semantics.
         # This allows multiple writers (if any) to safely append on POSIX,
         # but in our architecture, only the single supervisor writes to it.
@@ -43,7 +42,7 @@ class SpoolLogReader:
         since_sequence: int = 0,
         *,
         start_at_end: bool = False,
-    ) -> AsyncIterator[LiveLogChunk]:
+    ) -> AsyncIterator[RunObservabilityEvent]:
         """Asynchronously follow the spool file, yielding new chunks.
 
         If since_sequence is provided, any chunk with sequence <= since_sequence
@@ -72,7 +71,7 @@ class SpoolLogReader:
 
                 try:
                     payload = json.loads(line)
-                    chunk = LiveLogChunk.model_validate(payload)
+                    chunk = RunObservabilityEvent.model_validate(payload)
                 except Exception:
                     # Ignore corrupted line
                     continue

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -551,6 +551,7 @@ class ManagedRunRecord(BaseModel):
     stderr_artifact_ref: str | None = Field(None, alias="stderrArtifactRef")
     merged_log_artifact_ref: str | None = Field(None, alias="mergedLogArtifactRef")
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
+    observability_events_ref: str | None = Field(None, alias="observabilityEventsRef")
     last_log_offset: int | None = Field(None, alias="lastLogOffset")
     last_log_at: datetime | None = Field(None, alias="lastLogAt")
     error_message: str | None = Field(None, alias="errorMessage")
@@ -558,6 +559,11 @@ class ManagedRunRecord(BaseModel):
     provider_error_code: str | None = Field(None, alias="providerErrorCode")
     # Capability metadata indicating if live streaming is supported for this run
     live_stream_capable: bool | None = Field(None, alias="liveStreamCapable")
+    session_id: str | None = Field(None, alias="sessionId")
+    session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    container_id: str | None = Field(None, alias="containerId")
+    thread_id: str | None = Field(None, alias="threadId")
+    active_turn_id: str | None = Field(None, alias="activeTurnId")
 
     @model_validator(mode="after")
     def _normalize(self) -> "ManagedRunRecord":
@@ -566,10 +572,29 @@ class ManagedRunRecord(BaseModel):
             self.workflow_id = require_non_blank(
                 self.workflow_id, field_name="workflowId"
             )
+        if self.observability_events_ref is not None:
+            self.observability_events_ref = require_non_blank(
+                self.observability_events_ref,
+                field_name="observabilityEventsRef",
+            )
         self.agent_id = require_non_blank(self.agent_id, field_name="agentId")
         self.runtime_id = require_non_blank(
             self.runtime_id, field_name="runtimeId"
         )
+        if self.session_id is not None:
+            self.session_id = require_non_blank(self.session_id, field_name="sessionId")
+        if self.container_id is not None:
+            self.container_id = require_non_blank(
+                self.container_id,
+                field_name="containerId",
+            )
+        if self.thread_id is not None:
+            self.thread_id = require_non_blank(self.thread_id, field_name="threadId")
+        if self.active_turn_id is not None:
+            self.active_turn_id = require_non_blank(
+                self.active_turn_id,
+                field_name="activeTurnId",
+            )
         if self.started_at.tzinfo is None:
             self.started_at = self.started_at.replace(tzinfo=UTC)
         
@@ -595,26 +620,34 @@ ObservabilityEventKind = Literal[
     "stderr_chunk",
     "system_annotation",
     "session_started",
+    "session_resumed",
     "turn_started",
     "turn_completed",
     "turn_interrupted",
     "session_cleared",
+    "session_terminated",
     "session_reset_boundary",
     "approval_requested",
     "approval_resolved",
     "summary_published",
     "checkpoint_published",
+    "reset_boundary_published",
 ]
 
 
-class LiveLogChunk(BaseModel):
-    """A single atomic chunk of live log output pushed over the stream."""
+class RunObservabilityEvent(BaseModel):
+    """Canonical MoonMind-owned observability event for live and historical logs."""
 
-    model_config = ConfigDict(populate_by_name=True, frozen=True)
+    model_config = ConfigDict(populate_by_name=True, frozen=True, extra="forbid")
 
+    run_id: str | None = Field(
+        None,
+        alias="runId",
+        description="Task-run identifier for filtering shared observability history",
+    )
     sequence: int = Field(..., description="Monotonically increasing sequence number")
     stream: Literal["stdout", "stderr", "system", "session"] = Field(
-        ..., description="Standard output, standard error, or system event log"
+        ..., description="Standard output, standard error, system, or session event log"
     )
     timestamp: str = Field(..., description="ISO-8601 formatted timestamp")
     text: str = Field(..., description="Decoded output text buffer content")
@@ -625,33 +658,42 @@ class LiveLogChunk(BaseModel):
     )
     session_id: str | None = Field(
         None,
+        alias="sessionId",
         description="Managed-session id when the event is session-scoped",
     )
     session_epoch: int | None = Field(
         None,
+        alias="sessionEpoch",
         ge=1,
         description="Managed-session epoch when the event is session-scoped",
     )
     container_id: str | None = Field(
         None,
+        alias="containerId",
         description="Managed-session container id when available",
     )
     thread_id: str | None = Field(
         None,
+        alias="threadId",
         description="Managed-session logical thread id when available",
     )
     turn_id: str | None = Field(
         None,
+        alias="turnId",
         description="Managed-session turn id when available",
     )
     active_turn_id: str | None = Field(
         None,
+        alias="activeTurnId",
         description="Currently active managed-session turn id when available",
     )
     metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Optional structured metadata for the event row",
     )
+
+
+LiveLogChunk = RunObservabilityEvent
 
 
 class ProviderCapabilityDescriptor(BaseModel):
@@ -769,6 +811,7 @@ __all__ = [
     "ExternalExecutionStyle",
     "AgentRunHandle",
     "AgentRunResult",
+    "RunObservabilityEvent",
     "LiveLogChunk",
     "AgentRunState",
     "AgentRunStatus",

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -327,6 +327,10 @@ class CodexManagedSessionRecord(BaseModel):
     stdout_artifact_ref: str | None = Field(None, alias="stdoutArtifactRef")
     stderr_artifact_ref: str | None = Field(None, alias="stderrArtifactRef")
     diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
+    observability_events_ref: str | None = Field(
+        None,
+        alias="observabilityEventsRef",
+    )
     latest_summary_ref: str | None = Field(None, alias="latestSummaryRef")
     latest_checkpoint_ref: str | None = Field(None, alias="latestCheckpointRef")
     latest_control_event_ref: str | None = Field(None, alias="latestControlEventRef")
@@ -373,6 +377,11 @@ class CodexManagedSessionRecord(BaseModel):
             self.diagnostics_ref = require_non_blank(
                 self.diagnostics_ref,
                 field_name="diagnosticsRef",
+            )
+        if self.observability_events_ref is not None:
+            self.observability_events_ref = require_non_blank(
+                self.observability_events_ref,
+                field_name="observabilityEventsRef",
             )
         if self.latest_summary_ref is not None:
             self.latest_summary_ref = require_non_blank(

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -436,6 +436,7 @@ class CodexManagedSessionRecord(BaseModel):
             self.stdout_artifact_ref,
             self.stderr_artifact_ref,
             self.diagnostics_ref,
+            self.observability_events_ref,
             self.latest_summary_ref,
             self.latest_checkpoint_ref,
             self.latest_control_event_ref,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -707,6 +707,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     return ref
                 if normalized_kind == "diagnostics" and "diagnostics" in lowered:
                     return ref
+                if (
+                    normalized_kind == "observability"
+                    and "observability.events" in lowered
+                ):
+                    return ref
             return fallback
 
         runtime_id = self._runtime_id or "codex_cli"
@@ -751,9 +756,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             observabilityEventsRef=_artifact_ref(
                 session_artifact_metadata.get("observabilityEventsRef"),
                 fallback=(
-                    existing.observability_events_ref
-                    if existing is not None
-                    else None
+                    _infer_runtime_artifact_ref(
+                        "observability",
+                        fallback=(
+                            existing.observability_events_ref
+                            if existing is not None
+                            else None
+                        ),
+                    )
                 ),
             ),
             errorMessage=summary if status != "completed" else None,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -647,6 +647,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             agent_id=agent_id,
             managed_run_id=managed_run_id,
             binding=binding,
+            locator=locator,
+            active_turn_id=active_turn_id,
             result=result,
             status=status,
             started_at=started_at,
@@ -660,6 +662,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         agent_id: str,
         managed_run_id: str | None,
         binding: CodexManagedSessionBinding | None,
+        locator: Mapping[str, Any],
+        active_turn_id: str | None,
         result: Mapping[str, Any],
         status: AgentRunState,
         started_at: datetime,
@@ -712,6 +716,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             if binding is not None
             else (existing.workspace_path if existing is not None else None)
         )
+        container_id = str(locator.get("containerId") or "").strip() or None
+        thread_id = str(locator.get("threadId") or "").strip() or None
         record = ManagedRunRecord(
             runId=record_key,
             workflowId=self._workflow_id,
@@ -742,10 +748,23 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     fallback=existing.diagnostics_ref if existing is not None else None,
                 ),
             ),
+            observabilityEventsRef=_artifact_ref(
+                session_artifact_metadata.get("observabilityEventsRef"),
+                fallback=(
+                    existing.observability_events_ref
+                    if existing is not None
+                    else None
+                ),
+            ),
             errorMessage=summary if status != "completed" else None,
             failureClass=result.get("failureClass"),
             providerErrorCode=_artifact_ref(result.get("providerErrorCode")),
             liveStreamCapable=False,
+            sessionId=binding.session_id if binding is not None else None,
+            sessionEpoch=binding.session_epoch if binding is not None else None,
+            containerId=container_id or (existing.container_id if existing is not None else None),
+            threadId=thread_id or (existing.thread_id if existing is not None else None),
+            activeTurnId=active_turn_id or (existing.active_turn_id if existing is not None else None),
         )
         self._run_store.save(record)
 

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import inspect
-from typing import Any
-from pathlib import Path
+import json
+import shutil
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
 from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 from moonmind.observability.transport import SpoolLogPublisher
@@ -22,6 +23,7 @@ from moonmind.workflows.temporal.runtime.output_parser import (
 # produce long lines (base64, JSON blobs, our large-output tests) never
 # trigger LimitOverrunError.
 _STREAM_CHUNK_SIZE = 65536
+_ARTIFACT_COPY_CHUNK_SIZE = 1024 * 1024
 
 
 class RuntimeLogStreamer:
@@ -223,7 +225,7 @@ class RuntimeLogStreamer:
             metadata=dict(metadata or {}),
         )
         self._observability_events_by_run.setdefault(run_id, []).append(
-            chunk.model_dump(mode="json", exclude_none=True)
+            chunk.model_dump(mode="json", by_alias=True, exclude_none=True)
         )
         self._publish_observability_chunk(
             workspace_path=workspace_path,
@@ -284,16 +286,35 @@ class RuntimeLogStreamer:
         if not normalized_workspace:
             return None
         spool_path = Path(normalized_workspace) / "live_streams.spool"
-        if not spool_path.is_file():
+        storage_ref = f"{artifact_job_id or run_id}/observability.events.jsonl"
+        try:
+            if not spool_path.is_file():
+                return None
+            if spool_path.stat().st_size <= 0:
+                return None
+            resolve_storage_path = getattr(self._storage, "resolve_storage_path", None)
+            if callable(resolve_storage_path):
+                target_path = Path(resolve_storage_path(storage_ref))
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                with spool_path.open("rb") as source, target_path.open("wb") as target:
+                    shutil.copyfileobj(
+                        source,
+                        target,
+                        length=_ARTIFACT_COPY_CHUNK_SIZE,
+                    )
+                return storage_ref
+
+            with spool_path.open("rb") as handle:
+                data = handle.read()
+            if not data:
+                return None
+            _, storage_ref = self._storage.write_artifact(
+                job_id=artifact_job_id or run_id,
+                artifact_name="observability.events.jsonl",
+                data=data,
+            )
+        except OSError:
             return None
-        data = spool_path.read_bytes()
-        if not data:
-            return None
-        _, storage_ref = self._storage.write_artifact(
-            job_id=artifact_job_id or run_id,
-            artifact_name="observability.events.jsonl",
-            data=data,
-        )
         return storage_ref
 
     async def stream_and_parse(

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -6,10 +6,10 @@ import asyncio
 import json
 import inspect
 from typing import Any
-
+from pathlib import Path
 from datetime import datetime, timezone
 
-from moonmind.schemas.agent_runtime_models import LiveLogChunk
+from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 from moonmind.observability.transport import SpoolLogPublisher
 from moonmind.workflows.temporal.runtime.output_parser import (
     ParsedOutput,
@@ -93,7 +93,8 @@ class RuntimeLogStreamer:
             
             if live_publisher is not None:
                 try:
-                    obj = LiveLogChunk(
+                    obj = RunObservabilityEvent(
+                        run_id=run_id,
                         sequence=self._next_sequence(),
                         stream=stream_name,  # type: ignore
                         timestamp=self._current_timestamp(),
@@ -170,7 +171,8 @@ class RuntimeLogStreamer:
 
         self._publish_observability_chunk(
             workspace_path=workspace_path,
-            chunk=LiveLogChunk(
+            chunk=RunObservabilityEvent(
+                run_id=run_id,
                 sequence=sequence,
                 stream="system",
                 timestamp=timestamp,
@@ -204,7 +206,8 @@ class RuntimeLogStreamer:
             return
         timestamp = self._current_timestamp()
         sequence = self._next_sequence()
-        chunk = LiveLogChunk(
+        chunk = RunObservabilityEvent(
+            run_id=run_id,
             sequence=sequence,
             stream=stream,  # type: ignore[arg-type]
             timestamp=timestamp,
@@ -245,7 +248,7 @@ class RuntimeLogStreamer:
         self,
         *,
         workspace_path: str | None,
-        chunk: LiveLogChunk,
+        chunk: RunObservabilityEvent,
     ) -> None:
         try:
             live_publisher = self._resolve_live_publisher(workspace_path)
@@ -268,6 +271,30 @@ class RuntimeLogStreamer:
         """Return and clear persisted in-memory observability events for a run."""
         events = self._observability_events_by_run.pop(run_id, None)
         return list(events or [])
+
+    def persist_observability_events(
+        self,
+        *,
+        run_id: str,
+        workspace_path: str | None,
+        artifact_job_id: str | None = None,
+    ) -> str | None:
+        """Persist the workspace spool JSONL as a durable artifact when available."""
+        normalized_workspace = str(workspace_path or "").strip()
+        if not normalized_workspace:
+            return None
+        spool_path = Path(normalized_workspace) / "live_streams.spool"
+        if not spool_path.is_file():
+            return None
+        data = spool_path.read_bytes()
+        if not data:
+            return None
+        _, storage_ref = self._storage.write_artifact(
+            job_id=artifact_job_id or run_id,
+            artifact_name="observability.events.jsonl",
+            data=data,
+        )
+        return storage_ref
 
     async def stream_and_parse(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -699,6 +699,7 @@ class DockerCodexManagedSessionController:
                 "stdoutArtifactRef": record.stdout_artifact_ref,
                 "stderrArtifactRef": record.stderr_artifact_ref,
                 "diagnosticsRef": record.diagnostics_ref,
+                "observabilityEventsRef": record.observability_events_ref,
                 "errorMessage": record.error_message,
             },
         )
@@ -733,6 +734,7 @@ class DockerCodexManagedSessionController:
                 "stdoutArtifactRef": record.stdout_artifact_ref,
                 "stderrArtifactRef": record.stderr_artifact_ref,
                 "diagnosticsRef": record.diagnostics_ref,
+                "observabilityEventsRef": record.observability_events_ref,
             },
         )
 

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -152,6 +152,11 @@ class ManagedSessionSupervisor:
         status: str,
         error_message: str | None,
     ) -> CodexManagedSessionRecord:
+        observability_events_ref = self._log_streamer.persist_observability_events(
+            run_id=record.task_run_id,
+            workspace_path=record.workspace_path,
+            artifact_job_id=record.session_id,
+        )
         stdout_bytes, stderr_bytes = self._read_spool_bytes(record)
         _, stdout_ref = self._artifact_storage.write_artifact(
             job_id=record.session_id,
@@ -210,6 +215,7 @@ class ManagedSessionSupervisor:
             stdout_artifact_ref=stdout_ref,
             stderr_artifact_ref=stderr_ref,
             diagnostics_ref=diagnostics_ref,
+            observability_events_ref=observability_events_ref,
             latest_summary_ref=summary_ref,
             latest_checkpoint_ref=checkpoint_ref,
             last_log_offset=len(stdout_bytes) + len(stderr_bytes),

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -152,7 +152,8 @@ class ManagedSessionSupervisor:
         status: str,
         error_message: str | None,
     ) -> CodexManagedSessionRecord:
-        observability_events_ref = self._log_streamer.persist_observability_events(
+        observability_events_ref = await asyncio.to_thread(
+            self._log_streamer.persist_observability_events,
             run_id=record.task_run_id,
             workspace_path=record.workspace_path,
             artifact_job_id=record.session_id,

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -493,7 +493,8 @@ class ManagedRunSupervisor:
                 events=events,
                 observability_events=observability_events,
             )
-            observability_events_ref = self._log_streamer.persist_observability_events(
+            observability_events_ref = await asyncio.to_thread(
+                self._log_streamer.persist_observability_events,
                 run_id=run_id,
                 workspace_path=record.workspace_path if record else None,
             )

--- a/moonmind/workflows/temporal/runtime/supervisor.py
+++ b/moonmind/workflows/temporal/runtime/supervisor.py
@@ -493,6 +493,10 @@ class ManagedRunSupervisor:
                 events=events,
                 observability_events=observability_events,
             )
+            observability_events_ref = self._log_streamer.persist_observability_events(
+                run_id=run_id,
+                workspace_path=record.workspace_path if record else None,
+            )
 
             record = self._store.update_status(
                 run_id,
@@ -506,6 +510,7 @@ class ManagedRunSupervisor:
                 failure_class=failure_class,
                 provider_error_code=exit_result.provider_error_code,
                 error_message=error_message,
+                observability_events_ref=observability_events_ref,
             )
 
             # Fire completion callback (best-effort, never crashes the supervisor).

--- a/specs/138-live-logs-session-timeline/checklists/requirements.md
+++ b/specs/138-live-logs-session-timeline/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Live Logs Session Timeline
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-07  
+**Feature**: [spec.md](/mnt/d/code/MoonMind/specs/138-live-logs-session-timeline/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Scope is intentionally limited to the Phase 0 and Phase 1 slice of the session-aware Live Logs migration: rollout re-baselining, feature-flag wiring, canonical event modeling, durable event persistence, and compatibility coverage.

--- a/specs/138-live-logs-session-timeline/contracts/run-observability-event.md
+++ b/specs/138-live-logs-session-timeline/contracts/run-observability-event.md
@@ -1,0 +1,34 @@
+# Contract: Run Observability Event
+
+Phase 1 standardizes one MoonMind-owned event contract for both live and historical observability.
+
+## Canonical shape
+
+```json
+{
+  "runId": "task-run-123",
+  "sequence": 17,
+  "timestamp": "2026-04-08T01:23:45Z",
+  "stream": "session",
+  "kind": "reset_boundary_published",
+  "text": "Epoch boundary reached. Session sess-1 is now on epoch 2 thread thread-2.",
+  "offset": null,
+  "sessionId": "sess-1",
+  "sessionEpoch": 2,
+  "containerId": "ctr-1",
+  "threadId": "thread-2",
+  "turnId": null,
+  "activeTurnId": null,
+  "metadata": {
+    "resetBoundaryRef": "sess-1/observability/session.reset_boundary.epoch-2.json"
+  }
+}
+```
+
+## Contract rules
+
+- One shared `sequence` namespace spans stdout, stderr, system, and session rows.
+- The payload is MoonMind-normalized and must not expose provider-native event envelopes as the browser contract.
+- Live transport and historical retrieval use the same event shape.
+- Existing live-log consumers remain readable because the canonical event shape preserves the current stream/text/timestamp/offset semantics while adding formal kind and session metadata.
+- Ended runs should prefer the durable `observability.events.jsonl` artifact before falling back to spool or merged-artifact synthesis.

--- a/specs/138-live-logs-session-timeline/contracts/task-dashboard-session-timeline-flag.md
+++ b/specs/138-live-logs-session-timeline/contracts/task-dashboard-session-timeline-flag.md
@@ -1,0 +1,23 @@
+# Contract: Task Dashboard Session Timeline Rollout Flag
+
+Phase 0 adds a dedicated runtime-config surface for the session-aware timeline rollout.
+
+## Runtime config fields
+
+- `features.liveLogsSessionTimelineEnabled`
+- `features.liveLogsSessionTimelineRollout`
+
+## Semantics
+
+- `liveLogsSessionTimelineEnabled` is `false` only when rollout is `off`.
+- `liveLogsSessionTimelineRollout` is one of:
+  - `off`
+  - `internal`
+  - `codex_managed`
+  - `all_managed`
+- Existing `features.logStreamingEnabled` remains present and continues to describe live transport availability, not timeline rollout.
+
+## Consumer expectations
+
+- The UI can hide or show timeline-specific behavior based on the new rollout fields without inferring session-timeline state from the older log-streaming toggle.
+- Backend rollout checks can reuse the same enumerated scope value used by the boot payload.

--- a/specs/138-live-logs-session-timeline/data-model.md
+++ b/specs/138-live-logs-session-timeline/data-model.md
@@ -1,0 +1,92 @@
+# Data Model: Live Logs Session Timeline
+
+## RunObservabilityEvent
+
+The canonical event entity for Phase 1 is `RunObservabilityEvent`.
+
+### Required fields
+
+- `runId`: task-run identifier used by observability APIs
+- `sequence`: run-global monotonically increasing sequence number
+- `timestamp`: ISO-8601 event timestamp
+- `stream`: `stdout | stderr | system | session`
+- `kind`: normalized MoonMind event kind
+- `text`: display text for the timeline row
+
+### Optional fields
+
+- `offset`: byte offset for stream-backed output rows when known
+- `sessionId`
+- `sessionEpoch`
+- `containerId`
+- `threadId`
+- `turnId`
+- `activeTurnId`
+- `metadata`
+
+### Event kind set in scope for this slice
+
+- `stdout_chunk`
+- `stderr_chunk`
+- `system_annotation`
+- `session_started`
+- `session_resumed`
+- `session_cleared`
+- `session_terminated`
+- `turn_started`
+- `turn_completed`
+- `turn_interrupted`
+- `approval_requested`
+- `approval_resolved`
+- `summary_published`
+- `checkpoint_published`
+- `reset_boundary_published`
+
+## ManagedRunRecord extensions
+
+Phase 1 extends the durable managed-run record with two groups of fields.
+
+### Structured history fields
+
+- `observabilityEventsRef`: durable artifact ref for `observability.events.jsonl`
+
+### Latest session snapshot fields
+
+- `sessionId`
+- `sessionEpoch`
+- `containerId`
+- `threadId`
+- `activeTurnId`
+
+These fields are optional and only populated when the run is session-aware.
+
+## SessionTimelineRollout
+
+Phase 0 introduces one rollout configuration value for the session-aware timeline contract.
+
+### Allowed values
+
+- `off`
+- `internal`
+- `codex_managed`
+- `all_managed`
+
+### Derived values exposed to the UI
+
+- `liveLogsSessionTimelineEnabled`: boolean derived from rollout not being `off`
+- `liveLogsSessionTimelineRollout`: the exact rollout scope
+
+## Persistence mapping
+
+### Active live transport
+
+- `RunObservabilityEvent` rows are appended to `live_streams.spool` as JSONL during execution.
+
+### Ended-run durable history
+
+- `live_streams.spool` content is promoted to an artifact-backed `observability.events.jsonl` file during publication/finalization.
+- The resulting artifact ref is written to `ManagedRunRecord.observabilityEventsRef`.
+
+### Summary snapshot
+
+- The latest known session identity from managed-session publication/runtime state is mirrored onto the managed-run record at the time the durable history ref is written or updated.

--- a/specs/138-live-logs-session-timeline/plan.md
+++ b/specs/138-live-logs-session-timeline/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: live-logs-session-timeline
+
+**Branch**: `138-live-logs-session-timeline` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/138-live-logs-session-timeline/spec.md`
+
+## Summary
+
+Implement the Phase 0 and Phase 1 slice of the session-aware Live Logs migration by: 1) replacing the outdated tmp implementation tracker with the new session-aware rollout baseline, 2) wiring a dedicated session-timeline rollout flag into settings and the task-dashboard boot payload, and 3) introducing one canonical structured observability event contract plus durable JSONL history artifacts referenced from `ManagedRunRecord`. The backend will continue to use the existing spool/SSE transport, but the persisted and API-facing source-of-truth becomes one normalized event model that covers stdout, stderr, system, and session rows.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript for existing dashboard boot payload types  
+**Primary Dependencies**: FastAPI task-runs router, Pydantic schemas, `ManagedRunRecord` / `ManagedRunStore`, `RuntimeLogStreamer`, spool transport, Mission Control runtime-config boot payload  
+**Storage**: file-backed managed-run JSON records plus artifact-backed JSONL observability history  
+**Testing**: pytest unit tests plus final verification via `./tools/test_unit.sh`  
+**Target Platform**: Docker/Compose-hosted MoonMind services with artifact-first managed-run observability  
+**Project Type**: backend runtime observability contract + API/config wiring  
+**Performance Goals**: preserve current live-log behavior while making historical timeline reconstruction deterministic for completed runs  
+**Constraints**: keep spool/SSE transport, keep artifact-first semantics, avoid provider-native payloads, keep existing live-log consumers readable during migration, do not break non-session-managed runs  
+**Scale/Scope**: Phase 0 and Phase 1 only; no frontend timeline renderer changes beyond boot-payload flag exposure
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The implementation keeps MoonMind-owned observability contracts instead of leaking provider-specific events into the browser.
+- **II. One-Click Agent Deployment**: PASS. No new infrastructure dependency is introduced; the change stays within existing file/artifact storage and API surfaces.
+- **III. Avoid Vendor Lock-In**: PASS. The canonical event model is runtime-neutral even though Codex session fields are optionally populated.
+- **IV. Own Your Data**: PASS. Structured observability history is persisted as MoonMind-owned JSONL artifacts and run metadata.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill-system behavior changes are introduced.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The main change is the normalized event contract and durable event ref, not new ad hoc parsing or UI heuristics.
+- **VII. Powerful Runtime Configurability**: PASS. The rollout boundary is expressed as a first-class feature flag setting and boot payload field.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay within config, schema, transport, runtime persistence, and task-runs observability boundaries.
+- **IX. Resilient by Default**: PASS. Structured history persistence must remain non-fatal to runtime control, and ended runs become more observable, not less.
+- **XI. Spec-Driven Development**: PASS. Spec, plan, tasks, and tests are defined before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs stay declarative; only `docs/tmp/009-LiveLogsPlan.md` is rewritten as the migration tracker.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. We will replace old-only internal assumptions directly rather than adding a second long-lived event model.
+
+## Research
+
+- `docs/ManagedAgents/LiveLogs.md` already defines the target `RunObservabilityEvent` shape and explicitly keeps spool/SSE as the live transport boundary.
+- The current code already emits session-aware rows through `RuntimeLogStreamer.emit_observability_event`, but the canonical persisted/API contract is still centered on `LiveLogChunk` and diagnostics fallback.
+- The task-runs router already has `GET /api/task-runs/{id}/observability/events`, so the Phase 1 gap is not a brand-new endpoint; it is the durable canonical event contract and event-history persistence.
+- `ManagedRunRecord` does not yet persist `observability_events_ref` or inline session snapshot fields, so history and summary still depend on spool files and separate session-store lookups.
+- The dashboard boot payload already exposes `logStreamingEnabled` through ad hoc env parsing; Phase 0 can add a dedicated session-timeline rollout field without changing the current log-streaming gate.
+- To respect the repo’s compatibility policy, payload compatibility should come from the new canonical event shape remaining a superset of the current live-log fields, not from maintaining a second old-only internal contract.
+
+## Project Structure
+
+- Update `docs/tmp/009-LiveLogsPlan.md` to the new session-aware rollout tracker.
+- Extend `moonmind/config/settings.py` with a session-timeline rollout flag and expose it from `api_service/api/routers/task_dashboard_view_model.py`.
+- Replace chunk-centric internal event typing in `moonmind/schemas/agent_runtime_models.py`, `moonmind/observability/transport.py`, `moonmind/workflows/temporal/runtime/log_streamer.py`, and `api_service/api/routers/task_runs.py`.
+- Extend `moonmind/workflows/temporal/runtime/store.py`, `moonmind/workflows/temporal/runtime/supervisor.py`, and `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to persist durable event-history refs and latest session snapshot fields on `ManagedRunRecord`.
+- Add or update tests in `tests/unit/services/temporal/runtime/test_log_streamer.py`, `tests/unit/services/temporal/runtime/test_store.py`, `tests/unit/services/temporal/runtime/test_supervisor_live_output.py`, `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py`, and `tests/unit/api/routers/test_task_runs.py`.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the canonical event, managed-run record extensions, and rollout-flag model.
+
+## Contracts
+
+- [contracts/run-observability-event.md](./contracts/run-observability-event.md)
+- [contracts/task-dashboard-session-timeline-flag.md](./contracts/task-dashboard-session-timeline-flag.md)
+
+## Implementation Plan
+
+1. Add failing tests for the Phase 0 and Phase 1 contract changes:
+   - settings + boot payload expose the session-timeline rollout flag,
+   - the canonical event model supports the full stream/kind/session field set,
+   - managed-run persistence stores a durable observability-history ref and session snapshot fields,
+   - task-runs history retrieval prefers structured event history when present.
+2. Replace `docs/tmp/009-LiveLogsPlan.md` with the new session-aware rollout tracker from the user’s plan and align rollout wording with the shipped baseline.
+3. Introduce the session-timeline rollout setting in `FeatureFlagsSettings` and expose both rollout scope and enabled/disabled state from the task-dashboard runtime config.
+4. Introduce `RunObservabilityEvent` as the canonical internal contract, update transport and runtime streamer code to publish/read that model, and keep payload compatibility by preserving the current event fields on the wire.
+5. Persist structured observability history as `observability.events.jsonl` artifacts during run/session publication and store the resulting ref plus latest session snapshot fields on `ManagedRunRecord`.
+6. Update summary/history readers to surface the new record fields and prefer the durable event-history ref before falling back to spool/artifact synthesis.
+7. Run focused tests, Spec Kit scope validation, the full unit suite, then mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/services/temporal/runtime/test_store.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/api/routers/test_task_runs.py`
+2. `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Inspect the boot payload and confirm `liveLogsSessionTimelineEnabled` and its rollout scope are present without removing `logStreamingEnabled`.
+2. Execute or simulate a managed run that emits stdout, stderr, system, and session rows; confirm a durable `observability.events.jsonl` artifact is written and referenced by the managed-run record.
+3. Load `/api/task-runs/{taskRunId}/observability-summary` and `/api/task-runs/{taskRunId}/observability/events` for a completed run and confirm they surface the durable session snapshot and structured event history without requiring live streaming.

--- a/specs/138-live-logs-session-timeline/quickstart.md
+++ b/specs/138-live-logs-session-timeline/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: Live Logs Session Timeline
+
+1. Run the focused Phase 0 and Phase 1 verification:
+
+```bash
+./tools/test_unit.sh tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/services/temporal/runtime/test_store.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/api/routers/test_task_runs.py
+```
+
+2. Validate Spec Kit runtime scope:
+
+```bash
+./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+3. Run the full unit suite before finalizing:
+
+```bash
+./tools/test_unit.sh
+```
+
+4. Manual smoke check:
+
+```text
+Inspect the task dashboard boot payload and confirm it includes liveLogsSessionTimelineEnabled and liveLogsSessionTimelineRollout.
+Execute or simulate one managed run with mixed stdout/stderr/system/session rows and confirm the managed-run record points to observability.events.jsonl.
+Load /api/task-runs/{taskRunId}/observability-summary and /api/task-runs/{taskRunId}/observability/events for the completed run and confirm they surface the durable session snapshot and structured timeline history.
+```

--- a/specs/138-live-logs-session-timeline/research.md
+++ b/specs/138-live-logs-session-timeline/research.md
@@ -1,0 +1,46 @@
+# Research: Live Logs Session Timeline
+
+## Decision: Add a dedicated session-timeline rollout setting
+
+### Rationale
+
+The boot payload currently exposes `logStreamingEnabled` through direct environment parsing. Phase 0 needs a separate rollout boundary for the session-aware timeline contract so operators can enable the timeline independently from the existing spool/SSE transport.
+
+### Alternatives considered
+
+- Reuse `logStreamingEnabled`: rejected because the existing flag describes transport availability, not timeline semantics or rollout scope.
+- Hardcode the timeline as always on: rejected because the plan explicitly requires staged rollout scopes.
+
+## Decision: Use one canonical `RunObservabilityEvent` model internally
+
+### Rationale
+
+The code already carries session-aware fields on `LiveLogChunk`, but the model name and persistence flow still imply chunk-only transport rather than a canonical MoonMind observability contract. A single `RunObservabilityEvent` model aligns the code with the canonical docs and keeps one contract across live and historical reads.
+
+### Alternatives considered
+
+- Keep `LiveLogChunk` as the canonical model forever: rejected because the remaining migration work is explicitly timeline-oriented, not chunk-oriented.
+- Maintain parallel `LiveLogChunk` and `RunObservabilityEvent` models with translation layers: rejected because the repo compatibility policy prefers deleting old-only internal assumptions rather than keeping a second internal contract.
+
+## Decision: Persist structured observability history as an artifact-backed JSONL file
+
+### Rationale
+
+The shared spool file already serializes live observability rows as JSON lines. Persisting that content to an `observability.events.jsonl` artifact at publication/finalization time gives ended runs a durable structured history source without adding a new database or holding every event in workflow history.
+
+### Alternatives considered
+
+- Keep relying on spool files under the workspace only: rejected because the plan wants artifact-backed reconstruction for ended runs.
+- Persist structured rows only inside `diagnostics.json`: rejected because diagnostics should remain a compact bundle, not the primary timeline-history container.
+- Add a database-backed observability table in this phase: rejected because Phase 1 only needs durable reconstruction, not a new storage substrate.
+
+## Decision: Persist the latest session snapshot directly on `ManagedRunRecord`
+
+### Rationale
+
+The summary router already builds `sessionSnapshot` through a separate session-store lookup. Storing the latest bounded session identity on the managed-run record reduces coupling, makes ended-run summaries self-contained, and gives future timeline/history readers a single durable summary source.
+
+### Alternatives considered
+
+- Keep all session summary data in the separate session store only: rejected because Phase 1 explicitly calls for managed-run record support for session snapshot fields.
+- Persist only `observability_events_ref` and derive the current session snapshot every time from the event journal: rejected because summary surfaces need a compact durable snapshot without replaying the full journal.

--- a/specs/138-live-logs-session-timeline/spec.md
+++ b/specs/138-live-logs-session-timeline/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Live Logs Session Timeline
+
+**Feature Branch**: `138-live-logs-session-timeline`  
+**Created**: 2026-04-07  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 0 and Phase 1 using test-driven development from the Live Logs Session-Aware Implementation Plan. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Re-baseline the rollout around the shipped live logs stack (Priority: P1)
+
+MoonMind engineers need the implementation tracker and runtime boot payload to reflect that artifact capture, spool transport, SSE follow mode, and merged-tail retrieval already exist so the remaining work is clearly framed as a session-aware observability upgrade.
+
+**Why this priority**: If the rollout plan and feature gating still describe Live Logs as a greenfield build, follow-on implementation work will target the wrong baseline and regress shipped operator behavior.
+
+**Independent Test**: Load the implementation tracker and runtime boot payload and confirm they expose the new session-timeline rollout contract without removing the existing live-log transport baseline.
+
+**Acceptance Scenarios**:
+
+1. **Given** the current repository state already ships artifact-backed stdout, stderr, diagnostics, merged-tail retrieval, spool transport, and SSE follow mode, **When** the implementation tracker is refreshed, **Then** those capabilities are marked as baseline-complete and the remaining work is described as a session-aware upgrade.
+2. **Given** Mission Control needs an explicit rollout boundary for the new timeline contract, **When** runtime configuration is built, **Then** the boot payload exposes a dedicated session-timeline feature flag and rollout scope instead of overloading the older log-streaming toggle.
+
+---
+
+### User Story 2 - Persist one canonical observability timeline contract (Priority: P1)
+
+Backend and frontend engineers need one MoonMind-defined observability event shape that represents stdout, stderr, system annotations, and session-plane lifecycle rows so historical and live views can use the same contract.
+
+**Why this priority**: The session-aware timeline cannot be implemented safely if browser and backend surfaces still depend on chunk-specific or provider-specific payload assumptions.
+
+**Independent Test**: Produce and persist mixed stdout, stderr, system, and session events for one managed run, then confirm the durable history can be reconstructed from a single normalized event contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed run emits output bytes and session-plane lifecycle events, **When** MoonMind records observability history, **Then** every row is represented in one run-global sequence using a single normalized event shape that includes stream, kind, text, timestamp, offset, and optional session snapshot metadata.
+2. **Given** the run has already ended, **When** historical observability is loaded later, **Then** MoonMind reconstructs the timeline from durable structured history instead of requiring a live stream or provider-native payload replay.
+3. **Given** existing consumers still expect the current live-log chunk shape during migration, **When** the new event contract is introduced, **Then** current live-log retrieval remains readable while the normalized timeline contract becomes the canonical representation.
+
+---
+
+### User Story 3 - Preserve session context in observability summaries and records (Priority: P2)
+
+Operators and future timeline work need the latest session identity snapshot attached to managed-run observability records so resets and thread changes are available without re-querying transient container state.
+
+**Why this priority**: The timeline contract is incomplete unless the durable run record can identify which session, epoch, container, thread, and active turn the operator is looking at.
+
+**Independent Test**: Persist a managed-run observability record with session metadata and verify summary/history readers surface the latest session snapshot and durable event history reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed session is active for a run, **When** the run record is stored or updated, **Then** the latest bounded session identity is stored with the observability record.
+2. **Given** a structured observability history file exists for a run, **When** the summary or history reader loads that run later, **Then** the reader can surface the latest session snapshot and durable observability-history reference without inspecting container-local runtime state.
+
+### Edge Cases
+
+- A historical run has stdout/stderr artifacts but no structured observability history yet; the system must continue to degrade gracefully through existing artifact-backed retrieval.
+- A run emits only system or session events during a short interval; sequence ordering must still remain run-global and deterministic.
+- A session reset occurs while the run is still active; the durable session snapshot and structured event history must remain consistent about the new epoch and thread boundary.
+- Structured event persistence fails while artifact capture succeeds; runtime control and durable stdout/stderr/diagnostics capture must remain intact and the failure must not fabricate successful event persistence.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The implementation tracker for Live Logs MUST treat the shipped artifact-first spool/SSE stack as the baseline and MUST describe the remaining work as a session-aware observability upgrade rather than a greenfield build.
+- **FR-002**: MoonMind MUST expose a dedicated feature flag for the session-aware timeline contract, including explicit rollout scopes for disabled, internal-only, Codex-managed, and all managed-session-capable runs.
+- **FR-003**: MoonMind MUST define one canonical observability event model that can represent stdout, stderr, system annotations, and session-plane lifecycle rows in a shared run-global sequence.
+- **FR-004**: The canonical observability event model MUST include sequence, timestamp, stream, kind, text, offset, and optional session identity metadata needed to describe the current session context.
+- **FR-005**: MoonMind MUST persist structured observability history durably enough to reconstruct the timeline after the run ends without depending on live transport or provider-native event replay.
+- **FR-006**: Managed-run observability records MUST store the latest durable session snapshot and a durable reference to the structured observability history when available.
+- **FR-007**: Existing live-log consumers MUST remain readable during migration while the canonical observability event model becomes the source-of-truth contract for timeline history and live streaming.
+- **FR-008**: The Phase 0 and Phase 1 slice MUST include production runtime code changes and automated validation tests that prove the new flag wiring, event persistence, and compatibility behavior.
+
+### Key Entities *(include if feature involves data)*
+
+- **Run Observability Event**: One normalized timeline row representing output, supervision, or session lifecycle activity in a shared run-global sequence.
+- **Session Snapshot**: The latest bounded session identity attached to a managed run, including session, epoch, container, thread, and active turn context when present.
+- **Observability History Reference**: The durable pointer to the structured event history used to reconstruct the timeline after live streaming ends.
+- **Session Timeline Rollout Flag**: The explicit runtime toggle that determines whether the session-aware timeline contract is hidden, internal-only, Codex-managed-only, or broadly enabled.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The implementation tracker is rewritten so previously shipped artifact/spool/SSE capabilities are marked baseline-complete and the remaining work is clearly scoped to the session-aware upgrade.
+- **SC-002**: Automated tests verify the runtime boot payload exposes the new session-timeline flag and preserves the current live-log transport metadata.
+- **SC-003**: Automated tests verify one persisted observability history can reconstruct mixed stdout, stderr, system, and session rows in shared sequence order for a completed run.
+- **SC-004**: Automated tests verify managed-run observability records preserve the latest session snapshot and structured event-history reference without breaking current live-log readers.

--- a/specs/138-live-logs-session-timeline/tasks.md
+++ b/specs/138-live-logs-session-timeline/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: Live Logs Session Timeline
+
+**Input**: Design documents from `/specs/138-live-logs-session-timeline/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature is explicitly TDD-driven. Write or update failing tests before the corresponding implementation tasks.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Phase 1: Setup (Shared Test Baseline)
+
+**Purpose**: Establish failing tests for the Phase 0 and Phase 1 contract changes before runtime code is updated.
+
+- [X] T001 [P] Add session-timeline rollout-setting coverage in `tests/unit/config/test_settings.py`
+- [X] T002 [P] Add task-dashboard runtime-config coverage for `liveLogsSessionTimelineEnabled` and rollout scope in `tests/unit/api/routers/test_task_dashboard_view_model.py`
+- [X] T003 [P] Add canonical observability-event contract and durable-history tests in `tests/unit/services/temporal/runtime/test_log_streamer.py`
+- [X] T004 [P] Add managed-run record persistence coverage for event-history refs and session snapshot fields in `tests/unit/services/temporal/runtime/test_store.py`
+- [X] T005 [P] Add task-runs router coverage for structured observability-history reads and summary snapshot fallback in `tests/unit/api/routers/test_task_runs.py`
+- [X] T006 [P] Add managed-run/session publication coverage for `observability.events.jsonl` persistence in `tests/unit/services/temporal/runtime/test_supervisor_live_output.py` and `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py`
+
+---
+
+## Phase 2: Foundational (Blocking Contract Changes)
+
+**Purpose**: Introduce the shared config and schema contracts needed by every user story.
+
+**⚠️ CRITICAL**: User-story implementation should not begin until these contract changes are complete.
+
+- [X] T007 Implement the session-timeline rollout setting in `moonmind/config/settings.py`
+- [X] T008 Implement task-dashboard runtime-config exposure for the session-timeline rollout fields in `api_service/api/routers/task_dashboard_view_model.py`
+- [X] T009 Implement `RunObservabilityEvent`, expand event kinds, and extend `ManagedRunRecord` with session snapshot + `observabilityEventsRef` fields in `moonmind/schemas/agent_runtime_models.py`
+
+**Checkpoint**: The repo has one shared rollout/config contract and one shared observability-event contract.
+
+---
+
+## Phase 3: User Story 1 - Re-baseline the rollout around the shipped live logs stack (Priority: P1)
+
+**Goal**: Make the implementation tracker and runtime config accurately describe the shipped Live Logs baseline and the new session-timeline rollout boundary.
+
+**Independent Test**: Inspect the tmp plan and runtime-config tests to confirm the shipped artifact/spool/SSE baseline is preserved and the session-timeline rollout fields are exposed independently from `logStreamingEnabled`.
+
+### Implementation for User Story 1
+
+- [X] T010 [US1] Replace `docs/tmp/009-LiveLogsPlan.md` with the session-aware rollout tracker aligned to the shipped baseline
+- [X] T011 [US1] Align feature-flag defaults and sample config documentation for the new rollout field in `api_service/config.template.toml` and `moonmind/config/settings.py`
+
+**Checkpoint**: The migration tracker and runtime boot payload both describe the session-aware upgrade rather than a greenfield live-logs build.
+
+---
+
+## Phase 4: User Story 2 - Persist one canonical observability timeline contract (Priority: P1)
+
+**Goal**: Publish, persist, and store one canonical event history for stdout, stderr, system, and session rows.
+
+**Independent Test**: Generate mixed observability rows for a managed run and confirm the runtime writes `observability.events.jsonl` plus a corresponding ref on the managed-run record.
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Update spool transport to read and write the canonical observability-event contract in `moonmind/observability/transport.py`
+- [X] T013 [US2] Update runtime event publication and durable event-history artifact creation in `moonmind/workflows/temporal/runtime/log_streamer.py`
+- [X] T014 [US2] Persist `observabilityEventsRef` and latest session snapshot fields during managed-run finalization in `moonmind/workflows/temporal/runtime/supervisor.py`
+- [X] T015 [US2] Persist `observabilityEventsRef` and latest session snapshot fields during managed-session publication in `moonmind/workflows/temporal/runtime/managed_session_supervisor.py`
+- [X] T016 [US2] Keep file-backed managed-run persistence compatible with the new record fields in `moonmind/workflows/temporal/runtime/store.py`
+
+**Checkpoint**: Completed runs have durable structured event history and record-level session context without depending on live transport.
+
+---
+
+## Phase 5: User Story 3 - Preserve session context in observability summaries and records (Priority: P2)
+
+**Goal**: Make summary/history readers prefer durable event history and record-backed session context while keeping existing live-log consumers readable.
+
+**Independent Test**: Load observability summary and history for completed runs with and without event-history artifacts and confirm the router prefers structured history first, then degrades cleanly.
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Update task-run observability normalization, summary shaping, and structured-history retrieval in `api_service/api/routers/task_runs.py`
+- [X] T018 [US3] Regenerate or update any affected API/runtime payload expectations in `frontend/src/generated/openapi.ts` if the backend contract changes require it
+
+**Checkpoint**: Task-run observability APIs surface durable event-history refs and record-backed session snapshots while preserving current live-log readability.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the feature end to end and close the execution loop.
+
+- [X] T019 Run focused Phase 0 and Phase 1 verification in `./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/services/temporal/runtime/test_store.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/api/routers/test_task_runs.py`
+- [X] T020 Run runtime scope validation in `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime` and `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+- [X] T021 Run full regression verification in `./tools/test_unit.sh`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on the failing tests from Phase 1.
+- **User Story 1 (Phase 3)**: Depends on Phase 2.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and should land before User Story 3 because the router changes consume the new record/event fields.
+- **User Story 3 (Phase 5)**: Depends on Phase 4.
+- **Polish (Phase 6)**: Depends on all implementation phases completing.
+
+### Parallel Opportunities
+
+- `T001` through `T006` can run in parallel because they touch different test files.
+- `T007` through `T009` can proceed in parallel only where file ownership does not overlap.
+- `T014`, `T015`, and `T016` can be staged independently after `T009`, then integrated before `T017`.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Write all failing tests.
+2. Land the foundational config and schema contracts.
+3. Replace the tmp rollout tracker and flag wiring.
+4. Persist structured event history and record-level session snapshots.
+5. Update summary/history readers and verify the focused test slice.
+
+### Notes
+
+- Keep the spool/SSE transport boundary intact.
+- Do not add a second long-lived internal event model for compatibility.
+- Mark each task `[X]` in this file as it completes.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -314,6 +314,32 @@ def test_build_runtime_config_log_streaming_disabled_via_env(monkeypatch) -> Non
     assert config["features"]["logStreamingEnabled"] is False
 
 
+def test_build_runtime_config_session_timeline_rollout_defaults_off(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_session_timeline_rollout",
+        "off",
+    )
+
+    config = build_runtime_config("/tasks")
+
+    assert config["features"]["liveLogsSessionTimelineEnabled"] is False
+    assert config["features"]["liveLogsSessionTimelineRollout"] == "off"
+
+
+def test_build_runtime_config_session_timeline_rollout_is_exposed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_session_timeline_rollout",
+        "codex_managed",
+    )
+
+    config = build_runtime_config("/tasks")
+
+    assert config["features"]["liveLogsSessionTimelineEnabled"] is True
+    assert config["features"]["liveLogsSessionTimelineRollout"] == "codex_managed"
+
+
 def test_build_runtime_config_omits_temporal_live_session_endpoint() -> None:
     config = build_runtime_config("/tasks")
     assert "liveSession" not in config["sources"]["temporal"]

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -859,6 +859,10 @@ def test_get_task_run_observability_events_reads_structured_spool_history(
     assert [event["sequence"] for event in body["events"]] == [10, 11]
     assert body["events"][1]["stream"] == "session"
     assert body["events"][1]["kind"] == "session_reset_boundary"
+    assert body["events"][1]["sessionId"] == "sess:wf-task-1:codex_cli"
+    assert body["events"][1]["sessionEpoch"] == 2
+    assert body["events"][1]["threadId"] == "thread-2"
+    assert "session_id" not in body["events"][1]
 
 
 def test_get_task_run_observability_events_prefers_persisted_event_artifact(
@@ -932,6 +936,10 @@ def test_get_task_run_observability_events_prefers_persisted_event_artifact(
     body = response.json()
     assert [event["sequence"] for event in body["events"]] == [5, 6]
     assert body["events"][1]["kind"] == "reset_boundary_published"
+    assert body["events"][0]["runId"] == "run-1"
+    assert body["events"][1]["sessionId"] == "sess-1"
+    assert body["events"][1]["sessionEpoch"] == 2
+    assert "run_id" not in body["events"][0]
 
 
 def test_load_task_run_session_record_uses_targeted_standard_paths(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -166,6 +166,45 @@ def test_get_observability_summary_includes_session_snapshot(
     assert snapshot["threadId"] == "thread-2"
 
 
+def test_get_observability_summary_uses_record_snapshot_when_session_record_missing(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {
+        "status": "completed",
+        "sessionId": "sess-1",
+        "sessionEpoch": 3,
+        "containerId": "ctr-1",
+        "threadId": "thread-3",
+        "activeTurnId": "turn-9",
+        "observabilityEventsRef": "run-1/observability.events.jsonl",
+    }
+    mock_record.status = "completed"
+    mock_record.live_stream_capable = False
+    mock_record.session_id = "sess-1"
+    mock_record.session_epoch = 3
+    mock_record.container_id = "ctr-1"
+    mock_record.thread_id = "thread-3"
+    mock_record.active_turn_id = "turn-9"
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_session_record",
+            return_value=None,
+        ):
+            response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    body = response.json()["summary"]
+    assert body["observabilityEventsRef"] == "run-1/observability.events.jsonl"
+    assert body["sessionSnapshot"]["sessionId"] == "sess-1"
+    assert body["sessionSnapshot"]["sessionEpoch"] == 3
+    assert body["sessionSnapshot"]["threadId"] == "thread-3"
+
+
 def test_get_observability_summary_live_stream_ended_for_terminal_run(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -820,6 +859,79 @@ def test_get_task_run_observability_events_reads_structured_spool_history(
     assert [event["sequence"] for event in body["events"]] == [10, 11]
     assert body["events"][1]["stream"] == "session"
     assert body["events"][1]["kind"] == "session_reset_boundary"
+
+
+def test_get_task_run_observability_events_prefers_persisted_event_artifact(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 5,
+                        "stream": "stdout",
+                        "text": "persisted stdout\n",
+                        "timestamp": "2026-04-08T00:00:00Z",
+                        "kind": "stdout_chunk",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 6,
+                        "stream": "session",
+                        "text": "Persisted reset boundary.",
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "kind": "reset_boundary_published",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    (workspace_path / "live_streams.spool").write_text(
+        json.dumps(
+            {
+                "sequence": 99,
+                "stream": "stdout",
+                "text": "spool fallback should not win\n",
+                "timestamp": "2026-04-08T00:10:00Z",
+                "kind": "stdout_chunk",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(workspace_path)
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [event["sequence"] for event in body["events"]] == [5, 6]
+    assert body["events"][1]["kind"] == "reset_boundary_published"
 
 
 def test_load_task_run_session_record_uses_targeted_standard_paths(

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -229,6 +229,42 @@ class TestFeatureFlagsSettings:
 
         monkeypatch.delenv("DISABLE_TASK_TEMPLATE_CATALOG", raising=False)
 
+    def test_live_logs_session_timeline_rollout_defaults_off(self, monkeypatch):
+        monkeypatch.delenv(
+            "FEATURE_FLAGS__LIVE_LOGS_SESSION_TIMELINE_ROLLOUT", raising=False
+        )
+        monkeypatch.delenv("LIVE_LOGS_SESSION_TIMELINE_ROLLOUT", raising=False)
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.live_logs_session_timeline_rollout == "off"
+        assert settings.live_logs_session_timeline_enabled is False
+
+    def test_live_logs_session_timeline_rollout_accepts_prefixed_env(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "FEATURE_FLAGS__LIVE_LOGS_SESSION_TIMELINE_ROLLOUT",
+            "codex_managed",
+        )
+        monkeypatch.delenv("LIVE_LOGS_SESSION_TIMELINE_ROLLOUT", raising=False)
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.live_logs_session_timeline_rollout == "codex_managed"
+        assert settings.live_logs_session_timeline_enabled is True
+
+    def test_live_logs_session_timeline_rollout_rejects_unknown_values(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(
+            "FEATURE_FLAGS__LIVE_LOGS_SESSION_TIMELINE_ROLLOUT",
+            "maybe",
+        )
+
+        with pytest.raises(ValidationError):
+            FeatureFlagsSettings(_env_file=None)
+
 
 class TestWorkflowSettings:
     @pytest.fixture(autouse=True)

--- a/tests/unit/observability/test_transport.py
+++ b/tests/unit/observability/test_transport.py
@@ -17,6 +17,7 @@ def test_spool_log_publisher_appends_json_chunks(tmp_path: Path) -> None:
     publisher = SpoolLogPublisher(workspace_path=str(workspace_dir))
     
     chunk1 = LiveLogChunk(
+        runId="run-123",
         sequence=1,
         stream="stdout",
         text="Hello\n",
@@ -24,11 +25,13 @@ def test_spool_log_publisher_appends_json_chunks(tmp_path: Path) -> None:
         offset=0,
     )
     chunk2 = LiveLogChunk(
+        runId="run-123",
         sequence=2,
         stream="stderr",
         text="Error!\n",
         timestamp="2026-03-31T00:00:01Z",
         offset=6,
+        sessionId="sess-1",
     )
     
     publisher.publish(chunk1)
@@ -44,10 +47,13 @@ def test_spool_log_publisher_appends_json_chunks(tmp_path: Path) -> None:
     parsed1 = json.loads(lines[0])
     assert parsed1["sequence"] == 1
     assert parsed1["stream"] == "stdout"
-    
+    assert parsed1["runId"] == "run-123"
+
     parsed2 = json.loads(lines[1])
     assert parsed2["sequence"] == 2
     assert parsed2["stream"] == "stderr"
+    assert parsed2["runId"] == "run-123"
+    assert parsed2["sessionId"] == "sess-1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -350,6 +350,12 @@ def test_emit_observability_event_publishes_session_metadata(streamer):
     assert published_chunk.thread_id == "thread-2"
     assert published_chunk.metadata["reason"] == "operator_reset"
 
+    persisted_events = log_streamer.consume_observability_events("run-session-event")
+    assert persisted_events[0]["runId"] == "run-session-event"
+    assert persisted_events[0]["sessionId"] == "sess-1"
+    assert persisted_events[0]["sessionEpoch"] == 2
+    assert "session_id" not in persisted_events[0]
+
 
 def test_persist_observability_events_promotes_spool_to_artifact(
     streamer,
@@ -395,6 +401,30 @@ def test_persist_observability_events_promotes_spool_to_artifact(
     assert ref == "run-journal/observability.events.jsonl"
     persisted = storage.resolve_storage_path(ref).read_text(encoding="utf-8")
     assert persisted == spool_payload + "\n"
+
+
+def test_persist_observability_events_returns_none_on_io_error(
+    streamer,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    log_streamer, _ = streamer
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    spool_path = workspace_path / "live_streams.spool"
+    spool_path.write_text("{}", encoding="utf-8")
+
+    def _raise_io_error(*args: object, **kwargs: object) -> object:
+        raise OSError("disk error")
+
+    monkeypatch.setattr(Path, "open", _raise_io_error)
+
+    ref = log_streamer.persist_observability_events(
+        run_id="run-journal",
+        workspace_path=str(workspace_path),
+    )
+
+    assert ref is None
 
 
 def test_emit_system_annotation_keeps_annotations_out_of_observability_events(streamer):

--- a/tests/unit/services/temporal/runtime/test_log_streamer.py
+++ b/tests/unit/services/temporal/runtime/test_log_streamer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 from moonmind.workflows.temporal.runtime import log_streamer as log_streamer_module
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
 from moonmind.workflows.temporal.runtime.output_parser import (
@@ -340,12 +341,60 @@ def test_emit_observability_event_publishes_session_metadata(streamer):
     )
 
     published_chunk = mock_publisher.publish.call_args[0][0]
+    assert isinstance(published_chunk, RunObservabilityEvent)
+    assert published_chunk.run_id == "run-session-event"
     assert published_chunk.stream == "session"
     assert published_chunk.kind == "session_reset_boundary"
     assert published_chunk.session_id == "sess-1"
     assert published_chunk.session_epoch == 2
     assert published_chunk.thread_id == "thread-2"
     assert published_chunk.metadata["reason"] == "operator_reset"
+
+
+def test_persist_observability_events_promotes_spool_to_artifact(
+    streamer,
+    tmp_path: Path,
+) -> None:
+    log_streamer, storage = streamer
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    spool_path = workspace_path / "live_streams.spool"
+    spool_payload = "\n".join(
+        [
+            json.dumps(
+                {
+                    "runId": "run-journal",
+                    "sequence": 1,
+                    "stream": "stdout",
+                    "text": "hello\n",
+                    "timestamp": "2026-04-08T00:00:00Z",
+                    "kind": "stdout_chunk",
+                }
+            ),
+            json.dumps(
+                {
+                    "runId": "run-journal",
+                    "sequence": 2,
+                    "stream": "session",
+                    "text": "Session started.",
+                    "timestamp": "2026-04-08T00:00:01Z",
+                    "kind": "session_started",
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                }
+            ),
+        ]
+    )
+    spool_path.write_text(spool_payload + "\n", encoding="utf-8")
+
+    ref = log_streamer.persist_observability_events(
+        run_id="run-journal",
+        workspace_path=str(workspace_path),
+    )
+
+    assert ref == "run-journal/observability.events.jsonl"
+    persisted = storage.resolve_storage_path(ref).read_text(encoding="utf-8")
+    assert persisted == spool_payload + "\n"
 
 
 def test_emit_system_annotation_keeps_annotations_out_of_observability_events(streamer):

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -472,6 +472,7 @@ async def test_controller_summary_and_publication_read_from_durable_record(
             stdoutArtifactRef="sess-1/stdout.log",
             stderrArtifactRef="sess-1/stderr.log",
             diagnosticsRef="sess-1/diagnostics.json",
+            observabilityEventsRef="sess-1/observability.events.jsonl",
             latestSummaryRef="sess-1/session.summary.json",
             latestCheckpointRef="sess-1/session.step_checkpoint.json",
             latestControlEventRef="sess-1/session.control_event.epoch-2.json",
@@ -511,10 +512,12 @@ async def test_controller_summary_and_publication_read_from_durable_record(
     assert summary.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert summary.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
     assert summary.metadata["stdoutArtifactRef"] == "sess-1/stdout.log"
+    assert summary.metadata["observabilityEventsRef"] == "sess-1/observability.events.jsonl"
     assert publication.published_artifact_refs == (
         "sess-1/stdout.log",
         "sess-1/stderr.log",
         "sess-1/diagnostics.json",
+        "sess-1/observability.events.jsonl",
         "sess-1/session.summary.json",
         "sess-1/session.step_checkpoint.json",
         "sess-1/session.control_event.epoch-2.json",
@@ -523,6 +526,7 @@ async def test_controller_summary_and_publication_read_from_durable_record(
     assert publication.latest_checkpoint_ref == "sess-1/session.step_checkpoint.json"
     assert publication.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert publication.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
+    assert publication.metadata["observabilityEventsRef"] == "sess-1/observability.events.jsonl"
 
 
 @pytest.mark.asyncio
@@ -564,6 +568,7 @@ async def test_controller_publication_uses_snapshot_without_stopping_supervision
         stdoutArtifactRef="sess-1/stdout.log",
         stderrArtifactRef="sess-1/stderr.log",
         diagnosticsRef="sess-1/diagnostics.json",
+        observabilityEventsRef="sess-1/observability.events.jsonl",
         latestSummaryRef="sess-1/session.summary.json",
         latestCheckpointRef="sess-1/session.step_checkpoint.json",
         startedAt="2026-04-06T12:00:00Z",
@@ -594,9 +599,11 @@ async def test_controller_publication_uses_snapshot_without_stopping_supervision
         "sess-1/stdout.log",
         "sess-1/stderr.log",
         "sess-1/diagnostics.json",
+        "sess-1/observability.events.jsonl",
         "sess-1/session.summary.json",
         "sess-1/session.step_checkpoint.json",
     )
+    assert publication.metadata["observabilityEventsRef"] == "sess-1/observability.events.jsonl"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -161,6 +161,10 @@ async def test_publish_snapshot_persists_run_keyed_session_events(tmp_path: Path
     assert diagnostics_payload["observability_events"][0]["stream"] == "session"
     assert diagnostics_payload["observability_events"][0]["kind"] == "session_cleared"
     assert diagnostics_payload["observability_events"][0]["metadata"]["reason"] == "operator_reset"
+    assert snapshot.observability_events_ref == "sess-1/observability.events.jsonl"
+    journal = artifact_storage.resolve_storage_path(snapshot.observability_events_ref)
+    assert journal.exists()
+    assert '"stream":"session"' in journal.read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_store.py
+++ b/tests/unit/services/temporal/runtime/test_store.py
@@ -16,7 +16,17 @@ def _make_record(run_id: str = "test-run-1", status: str = "running") -> Managed
 
 def test_save_and_load_round_trip(tmp_path):
     store = ManagedRunStore(tmp_path)
-    record = _make_record().model_copy(update={"workflow_id": "mm:wf-1"})
+    record = _make_record().model_copy(
+        update={
+            "workflow_id": "mm:wf-1",
+            "observability_events_ref": "test-run-1/observability.events.jsonl",
+            "session_id": "sess-1",
+            "session_epoch": 2,
+            "container_id": "ctr-1",
+            "thread_id": "thread-2",
+            "active_turn_id": "turn-7",
+        }
+    )
     store.save(record)
 
     loaded = store.load("test-run-1")
@@ -26,6 +36,12 @@ def test_save_and_load_round_trip(tmp_path):
     assert loaded.runtime_id == "codex-cli"
     assert loaded.status == "running"
     assert loaded.workflow_id == "mm:wf-1"
+    assert loaded.observability_events_ref == "test-run-1/observability.events.jsonl"
+    assert loaded.session_id == "sess-1"
+    assert loaded.session_epoch == 2
+    assert loaded.container_id == "ctr-1"
+    assert loaded.thread_id == "thread-2"
+    assert loaded.active_turn_id == "turn-7"
 
 
 def test_load_missing_returns_none(tmp_path):

--- a/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
+++ b/tests/unit/services/temporal/runtime/test_supervisor_live_output.py
@@ -60,6 +60,8 @@ def _make_supervisor(
 
 
 def _save_record(store: ManagedRunStore, run_id: str) -> ManagedRunRecord:
+    workspace_path = store.store_root.parent / "workspace" / run_id
+    workspace_path.mkdir(parents=True, exist_ok=True)
     record = ManagedRunRecord(
         run_id=run_id,
         agent_id="test-agent",
@@ -67,6 +69,7 @@ def _save_record(store: ManagedRunStore, run_id: str) -> ManagedRunRecord:
         status="launching",
         pid=12345,
         started_at=datetime.now(tz=UTC),
+        workspace_path=str(workspace_path),
     )
     store.save(record)
     return record
@@ -197,6 +200,11 @@ async def test_supervise_captures_stdout_normal_process(tmp_path: Path):
     stdout_artifact = storage.resolve_storage_path(f"{run_id}/stdout.log")
     assert stdout_artifact.exists()
     assert "live-output-works" in stdout_artifact.read_text()
+    assert result.observability_events_ref == f"{run_id}/observability.events.jsonl"
+    journal = storage.resolve_storage_path(result.observability_events_ref)
+    assert journal.exists()
+    payload = journal.read_text(encoding="utf-8")
+    assert '"stream":"stdout"' in payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -178,6 +178,7 @@ def _publication(
             "artifact:stdout",
             "artifact:stderr",
             "artifact:diagnostics",
+            "artifact:observability.events.jsonl",
             "artifact:session-summary",
             "artifact:session-checkpoint",
         ),
@@ -299,6 +300,10 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert persisted_record.stdout_artifact_ref == "artifact:stdout"
     assert persisted_record.stderr_artifact_ref == "artifact:stderr"
     assert persisted_record.diagnostics_ref == "artifact:diagnostics"
+    assert (
+        persisted_record.observability_events_ref
+        == "artifact:observability.events.jsonl"
+    )
     assert persisted_record.live_stream_capable is False
     assert status.status == "completed"
     assert result.summary == "Implemented through the session container."
@@ -307,6 +312,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
         "artifact:stdout",
         "artifact:stderr",
         "artifact:diagnostics",
+        "artifact:observability.events.jsonl",
         "artifact:session-summary",
         "artifact:session-checkpoint",
     ]


### PR DESCRIPTION
## Summary
- re-baseline the Live Logs migration plan around the existing artifact/spool/SSE stack and add the session timeline rollout flag
- introduce the canonical `RunObservabilityEvent` model and extend managed run/session persistence with session snapshot and observability event refs
- persist structured observability history, keep `/logs/stream` compatible, and teach observability summary/history APIs to surface the new contract

## Testing
- `./tools/test_unit.sh tests/unit/config/test_settings.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/services/temporal/runtime/test_store.py tests/unit/services/temporal/runtime/test_supervisor_live_output.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/api/routers/test_task_runs.py`
- `./tools/test_unit.sh`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`