### PR TITLE
[codex] Prefer newer Mission Control asset bundle

### DIFF
--- a/api_service/ui_assets.py
+++ b/api_service/ui_assets.py
@@ -188,19 +188,21 @@ def resolve_mission_control_dist_root(entrypoint: str = "mission-control") -> Pa
     if configured_manifest_path:
         return _dist_root_for_manifest(configured_manifest_path)
 
-    usable_candidates: list[Path] = []
-    for candidate in (local_ui_dist_root(), bundled_ui_dist_root()):
-        if _manifest_tree_is_usable(candidate, entrypoint):
-            usable_candidates.append(candidate)
-
-    if usable_candidates:
-        return max(usable_candidates, key=_dist_root_manifest_mtime_ns)
-
     local_root = local_ui_dist_root()
+    bundled_root = bundled_ui_dist_root()
+    candidates = sorted(
+        (local_root, bundled_root),
+        key=_dist_root_manifest_mtime_ns,
+        reverse=True,
+    )
+    for candidate in candidates:
+        if _manifest_tree_is_usable(candidate, entrypoint):
+            return candidate
+
     if _manifest_path_for_dist_root(local_root).exists():
         return local_root
 
-    return bundled_ui_dist_root()
+    return bundled_root
 
 
 def _verify_asset_paths(dist_root: Path, asset_info: Dict[str, Any]) -> None:

--- a/api_service/ui_assets.py
+++ b/api_service/ui_assets.py
@@ -175,14 +175,26 @@ def _manifest_tree_is_usable(
     return True
 
 
+def _dist_root_manifest_mtime_ns(dist_root: Path) -> int:
+    manifest_path = _manifest_path_for_dist_root(dist_root)
+    try:
+        return manifest_path.stat().st_mtime_ns
+    except OSError:
+        return -1
+
+
 def resolve_mission_control_dist_root(entrypoint: str = "mission-control") -> Path:
     configured_manifest_path = _configured_manifest_path()
     if configured_manifest_path:
         return _dist_root_for_manifest(configured_manifest_path)
 
+    usable_candidates: list[Path] = []
     for candidate in (local_ui_dist_root(), bundled_ui_dist_root()):
         if _manifest_tree_is_usable(candidate, entrypoint):
-            return candidate
+            usable_candidates.append(candidate)
+
+    if usable_candidates:
+        return max(usable_candidates, key=_dist_root_manifest_mtime_ns)
 
     local_root = local_ui_dist_root()
     if _manifest_path_for_dist_root(local_root).exists():

--- a/tests/api_service/test_ui_assets_strict.py
+++ b/tests/api_service/test_ui_assets_strict.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,74 @@ def test_ui_assets_falls_back_to_bundled_dist_when_local_manifest_is_stale(
     html = ui_assets("mission-control")
 
     assert 'src="/static/task_dashboard/dist/assets/mission-control.js"' in html
+    assert resolve_mission_control_dist_root() == bundled_dist_root
+
+
+def test_ui_assets_prefers_newer_usable_bundled_dist_over_older_local_dist(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_dist_root = tmp_path / "local-dist"
+    local_manifest_dir = local_dist_root / ".vite"
+    local_assets_dir = local_dist_root / "assets"
+    local_manifest_dir.mkdir(parents=True)
+    local_assets_dir.mkdir()
+    (local_manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "entrypoints/mission-control.tsx": {
+                    "file": "assets/mission-control.js",
+                    "css": ["assets/mission-control.css"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (local_assets_dir / "mission-control.js").write_text(
+        "console.log('older local dist');", encoding="utf-8"
+    )
+    (local_assets_dir / "mission-control.css").write_text(
+        "body { color: red; }", encoding="utf-8"
+    )
+
+    bundled_dist_root = tmp_path / "bundled-dist"
+    bundled_manifest_dir = bundled_dist_root / ".vite"
+    bundled_assets_dir = bundled_dist_root / "assets"
+    bundled_manifest_dir.mkdir(parents=True)
+    bundled_assets_dir.mkdir()
+    (bundled_manifest_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "entrypoints/mission-control.tsx": {
+                    "file": "assets/mission-control.js",
+                    "css": ["assets/mission-control.css"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (bundled_assets_dir / "mission-control.js").write_text(
+        "console.log('newer bundled dist');", encoding="utf-8"
+    )
+    (bundled_assets_dir / "mission-control.css").write_text(
+        "body { color: blue; }", encoding="utf-8"
+    )
+
+    older = 1_700_000_000
+    newer = older + 300
+    local_manifest = local_manifest_dir / "manifest.json"
+    bundled_manifest = bundled_manifest_dir / "manifest.json"
+    os.utime(local_manifest, (older, older))
+    os.utime(bundled_manifest, (newer, newer))
+
+    monkeypatch.delenv("VITE_MANIFEST_PATH", raising=False)
+    monkeypatch.delenv("MOONMIND_LENIENT_UI_ASSETS", raising=False)
+    monkeypatch.setenv("MOONMIND_BUNDLED_UI_DIST_ROOT", str(bundled_dist_root))
+    monkeypatch.setattr(ui_assets_module, "local_ui_dist_root", lambda: local_dist_root)
+
+    html = ui_assets("mission-control")
+
+    assert 'src="/static/task_dashboard/dist/assets/mission-control.js"' in html
+    assert 'href="/static/task_dashboard/dist/assets/mission-control.css"' in html
     assert resolve_mission_control_dist_root() == bundled_dist_root
 
 

--- a/tests/api_service/test_ui_assets_strict.py
+++ b/tests/api_service/test_ui_assets_strict.py
@@ -263,6 +263,44 @@ def test_ui_assets_prefers_newer_usable_bundled_dist_over_older_local_dist(
     assert resolve_mission_control_dist_root() == bundled_dist_root
 
 
+def test_resolve_mission_control_dist_root_returns_after_newest_usable_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    local_dist_root = tmp_path / "local-dist"
+    bundled_dist_root = tmp_path / "bundled-dist"
+    local_dist_root.mkdir()
+    bundled_dist_root.mkdir()
+
+    monkeypatch.delenv("VITE_MANIFEST_PATH", raising=False)
+    monkeypatch.setattr(ui_assets_module, "local_ui_dist_root", lambda: local_dist_root)
+    monkeypatch.setenv("MOONMIND_BUNDLED_UI_DIST_ROOT", str(bundled_dist_root))
+
+    mtimes = {
+        local_dist_root: 1,
+        bundled_dist_root: 2,
+    }
+    monkeypatch.setattr(
+        ui_assets_module,
+        "_dist_root_manifest_mtime_ns",
+        lambda dist_root: mtimes[dist_root],
+    )
+
+    checked_candidates: list[Path] = []
+
+    def fake_manifest_tree_is_usable(dist_root: Path, entrypoint: str | None = None) -> bool:
+        checked_candidates.append(dist_root)
+        return dist_root == bundled_dist_root
+
+    monkeypatch.setattr(
+        ui_assets_module,
+        "_manifest_tree_is_usable",
+        fake_manifest_tree_is_usable,
+    )
+
+    assert resolve_mission_control_dist_root() == bundled_dist_root
+    assert checked_candidates == [bundled_dist_root]
+
+
 def test_bundled_dist_root_can_serve_static_assets_when_repo_dist_is_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- prefer the newest usable Mission Control Vite dist root instead of always preferring the bind-mounted local `api_service/static/task_dashboard/dist`
- keep stale repo `dist/` output from shadowing the newer bundled image assets in `/opt/moonmind_static/task_dashboard/dist`
- add regression coverage for the case where both local and bundled builds are valid but the bundled manifest is newer

## Root Cause
Mission Control asset resolution returned the local repo `dist/` tree first whenever it was usable. In the docker-compose setup, that local tree can be older than the UI bundle baked into the running image, which caused stale CSS and JS to be served. That left the header version badge using outdated styling and made the displayed UI look behind the current code.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/api_service/test_ui_assets.py tests/api_service/test_ui_assets_strict.py tests/api_service/test_task_dashboard_ui_assets_errors.py`
- manually confirmed the running API resolver switched from `/app/api_service/static/task_dashboard/dist` to `/opt/moonmind_static/task_dashboard/dist` after restart