### PR TITLE
Fix Codex managed session rollout resume path handling

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -448,15 +448,26 @@ class CodexManagedSessionRuntime:
             return None
         return str(matches[-1])
 
+    @staticmethod
+    def _normalized_thread_path(path_value: str | None) -> str | None:
+        normalized = str(path_value or "").strip()
+        return normalized or None
+
+    def _existing_thread_path(self, path_value: str | None) -> str | None:
+        normalized = self._normalized_thread_path(path_value)
+        if normalized is None:
+            return None
+        return normalized if Path(normalized).is_file() else None
+
     def _resume_thread(
         self,
         *,
         client: CodexAppServerRpcClient,
         state: CodexSessionRuntimeState,
     ) -> str:
-        thread_path = state.vendor_thread_path or self._find_vendor_thread_path(
-            state.vendor_thread_id
-        )
+        thread_path = self._existing_thread_path(
+            state.vendor_thread_path
+        ) or self._find_vendor_thread_path(state.vendor_thread_id)
         params: dict[str, Any] = {"threadId": state.vendor_thread_id}
         if thread_path:
             params["path"] = thread_path
@@ -479,8 +490,8 @@ class CodexManagedSessionRuntime:
                 "codex app-server thread/resume returned a blank thread id"
             )
         state.vendor_thread_id = vendor_thread_id
-        state.vendor_thread_path = (
-            str(thread_payload.get("path") or thread_path or "").strip() or None
+        state.vendor_thread_path = self._normalized_thread_path(
+            thread_payload.get("path") or thread_path
         )
         return vendor_thread_id
 
@@ -498,7 +509,7 @@ class CodexManagedSessionRuntime:
         vendor_thread_id = str(thread_payload.get("id") or "").strip()
         if not vendor_thread_id:
             raise RuntimeError("codex app-server thread/start returned a blank thread id")
-        vendor_thread_path = str(thread_payload.get("path") or "").strip() or None
+        vendor_thread_path = self._existing_thread_path(thread_payload.get("path"))
 
         state = CodexSessionRuntimeState(
             sessionId=request.session_id,
@@ -666,7 +677,7 @@ class CodexManagedSessionRuntime:
         vendor_thread_id = str(thread_payload.get("id") or "").strip()
         if not vendor_thread_id:
             raise RuntimeError("codex app-server thread/start returned a blank thread id")
-        vendor_thread_path = str(thread_payload.get("path") or "").strip() or None
+        vendor_thread_path = self._existing_thread_path(thread_payload.get("path"))
 
         state.session_epoch += 1
         state.logical_thread_id = request.new_thread_id

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -453,8 +453,9 @@ class CodexManagedSessionRuntime:
         normalized = str(path_value or "").strip()
         return normalized or None
 
-    def _existing_thread_path(self, path_value: str | None) -> str | None:
-        normalized = self._normalized_thread_path(path_value)
+    @staticmethod
+    def _existing_thread_path(path_value: str | None) -> str | None:
+        normalized = CodexManagedSessionRuntime._normalized_thread_path(path_value)
         if normalized is None:
             return None
         return normalized if Path(normalized).is_file() else None
@@ -489,9 +490,12 @@ class CodexManagedSessionRuntime:
             raise RuntimeError(
                 "codex app-server thread/resume returned a blank thread id"
             )
+        recovered_thread_path = (
+            thread_path if vendor_thread_id == state.vendor_thread_id else None
+        )
         state.vendor_thread_id = vendor_thread_id
         state.vendor_thread_path = self._normalized_thread_path(
-            thread_payload.get("path") or thread_path
+            thread_payload.get("path") or recovered_thread_path
         )
         return vendor_thread_id
 

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -429,7 +429,7 @@ def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
     assert updated_state["vendorThreadId"] == "vendor-thread-1"
 
 
-def test_runtime_send_turn_ignores_missing_vendor_thread_path_from_state(
+def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(
     tmp_path: Path,
 ) -> None:
     script = _write_fake_app_server(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -24,6 +24,8 @@ def _write_fake_app_server(
     emit_completion: bool = True,
     fail_thread_resume: bool = False,
     resume_requires_existing_rollout_path: bool = False,
+    start_thread_id: str = "vendor-thread-1",
+    start_thread_path: str | None = "/tmp/vendor-thread-1.jsonl",
     interrupt_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
 ) -> Path:
@@ -48,6 +50,8 @@ INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
 CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
 FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
 RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
+START_THREAD_ID = __START_THREAD_ID__
+START_THREAD_PATH = __START_THREAD_PATH__
 
 for line in sys.stdin:
     message = json.loads(line)
@@ -79,14 +83,14 @@ for line in sys.stdin:
             "id": msg_id,
             "result": {
                 "thread": {
-                    "id": "vendor-thread-1",
+                    "id": START_THREAD_ID,
                     "preview": "",
                     "ephemeral": False,
                     "modelProvider": "openai",
                     "createdAt": 1,
                     "updatedAt": 1,
                     "status": {"type": "idle"},
-                    "path": "/tmp/vendor-thread-1.jsonl",
+                    "path": START_THREAD_PATH,
                     "cwd": "/work/repo",
                     "cliVersion": "0.118.0",
                     "source": "app-server",
@@ -189,18 +193,19 @@ __COMPLETION_BLOCK__
         }) + "\\n")
         sys.stdout.flush()
     elif method == "thread/read":
+        thread_id = message["params"]["threadId"]
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {
                 "thread": {
-                    "id": "vendor-thread-1",
+                    "id": thread_id,
                     "preview": "OK",
                     "ephemeral": False,
                     "modelProvider": "openai",
                     "createdAt": 1,
                     "updatedAt": 2,
                     "status": {"type": "idle"},
-                    "path": "/tmp/vendor-thread-1.jsonl",
+                    "path": f"/tmp/{thread_id}.jsonl",
                     "cwd": "/work/repo",
                     "cliVersion": "0.118.0",
                     "source": "app-server",
@@ -240,6 +245,8 @@ __COMPLETION_BLOCK__
             "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
             "True" if resume_requires_existing_rollout_path else "False",
         )
+        .replace("__START_THREAD_ID__", repr(start_thread_id))
+        .replace("__START_THREAD_PATH__", repr(start_thread_path))
         .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )
@@ -427,6 +434,48 @@ def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
         )
     )
     assert updated_state["vendorThreadId"] == "vendor-thread-1"
+
+
+def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_new_thread(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(
+        tmp_path,
+        fail_thread_resume=True,
+        start_thread_id="vendor-thread-2",
+        start_thread_path=None,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    updated_state = json.loads(
+        (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert updated_state["vendorThreadId"] == "vendor-thread-2"
+    assert "vendorThreadPath" not in updated_state
 
 
 def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -23,6 +23,7 @@ def _write_fake_app_server(
     *,
     emit_completion: bool = True,
     fail_thread_resume: bool = False,
+    resume_requires_existing_rollout_path: bool = False,
     interrupt_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
 ) -> Path:
@@ -46,6 +47,7 @@ import sys
 INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
 CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
 FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
+RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
 
 for line in sys.stdin:
     message = json.loads(line)
@@ -113,6 +115,25 @@ for line in sys.stdin:
         }) + "\\n")
         sys.stdout.flush()
     elif method == "thread/resume":
+        thread_path = message["params"].get("path")
+        if RESUME_REQUIRES_EXISTING_ROLLOUT_PATH:
+            if not thread_path:
+                sys.stdout.write(json.dumps({
+                    "id": msg_id,
+                    "error": {"code": -32600, "message": "thread not found"},
+                }) + "\\n")
+                sys.stdout.flush()
+                continue
+            if not os.path.isfile(thread_path):
+                sys.stdout.write(json.dumps({
+                    "id": msg_id,
+                    "error": {
+                        "code": -32600,
+                        "message": f"failed to load rollout `{thread_path}`: No such file or directory (os error 2)",
+                    },
+                }) + "\\n")
+                sys.stdout.flush()
+                continue
         if FAIL_THREAD_RESUME:
             sys.stdout.write(json.dumps({
                 "id": msg_id,
@@ -120,7 +141,6 @@ for line in sys.stdin:
             }) + "\\n")
             sys.stdout.flush()
             continue
-        thread_path = message["params"].get("path")
         if thread_path is not None:
             assert str(thread_path).endswith("vendor-thread-1.jsonl")
         sys.stdout.write(json.dumps({
@@ -216,6 +236,10 @@ __COMPLETION_BLOCK__
             repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
         )
         .replace("__FAIL_THREAD_RESUME__", "True" if fail_thread_resume else "False")
+        .replace(
+            "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
+            "True" if resume_requires_existing_rollout_path else "False",
+        )
         .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )
@@ -285,7 +309,7 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
     )
     assert state_payload["logicalThreadId"] == "logical-thread-1"
     assert state_payload["vendorThreadId"] == "vendor-thread-1"
-    assert state_payload["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
+    assert "vendorThreadPath" not in state_payload
 
 
 def test_runtime_send_turn_returns_completed_response_with_assistant_text(
@@ -403,6 +427,47 @@ def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
         )
     )
     assert updated_state["vendorThreadId"] == "vendor-thread-1"
+
+
+def test_runtime_send_turn_ignores_missing_vendor_thread_path_from_state(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(
+        tmp_path,
+        resume_requires_existing_rollout_path=True,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    state_path = Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+    state_payload["vendorThreadPath"] = "/tmp/vendor-thread-1.jsonl"
+    state_path.write_text(json.dumps(state_payload) + "\n", encoding="utf-8")
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    updated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert updated_state["vendorThreadId"] == "vendor-thread-1"
+    assert updated_state["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
 
 
 def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stop persisting a managed Codex rollout path at session launch unless the rollout file already exists
- ignore stale persisted rollout paths during resume and fall back to a discovered session rollout when available
- add unit coverage for the missing-rollout-path failure that was causing managed session `send_turn` to fail on first resume

## Context
This fixes the managed Codex session failure where `thread/resume` was called with a persisted rollout path that had not actually been materialized yet, producing a `No such file or directory` error inside the session container.

## Testing
- not run