### PR TITLE
[codex] Implement Live Logs Phase 2 session-plane observability producer

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -525,7 +525,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
     ) -> CodexManagedSessionHandle:
         snapshot = await self._load_snapshot(binding.workflow_id)
         if snapshot.container_id and snapshot.thread_id:
-            return await self._coerce_handle(
+            handle = await self._coerce_handle(
                 self._session_status(
                     CodexManagedSessionLocator(
                         sessionId=binding.session_id,
@@ -535,6 +535,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     )
                 )
             )
+            await self._signal_control_action(
+                action="resume_session",
+                reason=None,
+                container_id=handle.session_state.container_id,
+                thread_id=handle.session_state.thread_id,
+                active_turn_id=handle.session_state.active_turn_id,
+            )
+            return handle
 
         active_binding = snapshot.binding
         launch_request = LaunchCodexManagedSessionRequest(
@@ -561,6 +569,13 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 "containerId": handle.session_state.container_id,
                 "threadId": handle.session_state.thread_id,
             }
+        )
+        await self._signal_control_action(
+            action="start_session",
+            reason=None,
+            container_id=handle.session_state.container_id,
+            thread_id=handle.session_state.thread_id,
+            active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -401,16 +401,18 @@ class DockerCodexManagedSessionController:
         *,
         locator: CodexManagedSessionLocator,
         status: str,
-    ) -> None:
+        active_turn_id: str | None,
+    ) -> CodexManagedSessionRecord | None:
         if self._session_store is None:
-            return
+            return None
         if self._session_store.load(locator.session_id) is None:
-            return
-        await self._session_store.update(
+            return None
+        return await self._session_store.update(
             locator.session_id,
             session_epoch=locator.session_epoch,
             container_id=locator.container_id,
             thread_id=locator.thread_id,
+            active_turn_id=active_turn_id,
             status=self._record_status_from_handle_status(status),
             updated_at=datetime.now(tz=UTC),
             error_message=None,
@@ -554,26 +556,22 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         handle = CodexManagedSessionHandle.model_validate(payload)
-        await self._persist_handle_transition(
+        record = await self._persist_handle_transition(
             locator=self._locator_from_session_state(handle.session_state),
             status=handle.status,
+            active_turn_id=handle.session_state.active_turn_id,
         )
-        if (
-            self._session_store is not None
-            and self._session_store.load(request.session_id) is not None
-        ):
-            record = self._session_store.load(request.session_id)
-            if record is not None:
-                await self._emit_session_event(
-                    record=record,
-                    kind="session_resumed",
-                    text=(
-                        f"Session resumed. Epoch {record.session_epoch} "
-                        f"thread {record.thread_id}."
-                    ),
-                    active_turn_id=record.active_turn_id,
-                    metadata={"action": "resume_session"},
-                )
+        if record is not None:
+            await self._emit_session_event(
+                record=record,
+                kind="session_resumed",
+                text=(
+                    f"Session resumed. Epoch {record.session_epoch} "
+                    f"thread {record.thread_id}."
+                ),
+                active_turn_id=handle.session_state.active_turn_id,
+                metadata={"action": "resume_session"},
+            )
         return handle
 
     async def send_turn(
@@ -586,25 +584,22 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
-        if (
-            self._session_store is not None
-            and self._session_store.load(request.session_id) is not None
-        ):
-            await self._session_store.update(
-                request.session_id,
-                session_epoch=response.session_state.session_epoch,
-                container_id=response.session_state.container_id,
+        if self._session_store is not None:
+            record = self._session_store.load(request.session_id)
+            if record is not None:
+                updated_record = await self._session_store.update(
+                    request.session_id,
+                    session_epoch=response.session_state.session_epoch,
+                    container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
                 active_turn_id=response.session_state.active_turn_id,
                 status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=self._turn_error_message(response),
-            )
-            if self._session_supervisor is not None:
-                record = self._session_store.load(request.session_id)
-                if record is not None:
+                )
+                if self._session_supervisor is not None:
                     await self._emit_session_event(
-                        record=record,
+                        record=updated_record,
                         kind="turn_started",
                         text=f"Turn started: {response.turn_id}.",
                         turn_id=response.turn_id,
@@ -616,11 +611,11 @@ class DockerCodexManagedSessionController:
                     )
                     if response.status == "completed":
                         await self._emit_session_event(
-                            record=record,
+                            record=updated_record,
                             kind="turn_completed",
                             text=f"Turn completed: {response.turn_id}.",
                             turn_id=response.turn_id,
-                            active_turn_id=record.active_turn_id,
+                            active_turn_id=updated_record.active_turn_id,
                             metadata={
                                 "action": "send_turn",
                                 "assistantText": response.metadata.get("assistantText"),
@@ -639,34 +634,30 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
-        if (
-            self._session_store is not None
-            and self._session_store.load(request.session_id) is not None
-        ):
-            await self._session_store.update(
-                request.session_id,
-                session_epoch=response.session_state.session_epoch,
-                container_id=response.session_state.container_id,
+        if self._session_store is not None:
+            record = self._session_store.load(request.session_id)
+            if record is not None:
+                updated_record = await self._session_store.update(
+                    request.session_id,
+                    session_epoch=response.session_state.session_epoch,
+                    container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
                 active_turn_id=response.session_state.active_turn_id,
                 status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=self._turn_error_message(response),
-            )
-            if self._session_supervisor is not None:
-                record = self._session_store.load(request.session_id)
-                if record is not None:
+                )
+                if self._session_supervisor is not None:
+                    metadata = dict(request.metadata or {})
+                    metadata["action"] = "steer_turn"
                     await self._emit_session_event(
-                        record=record,
+                        record=updated_record,
                         kind="system_annotation",
                         text=f"Turn steered: {request.turn_id}.",
                         turn_id=request.turn_id,
                         active_turn_id=response.session_state.active_turn_id
                         or request.turn_id,
-                        metadata={
-                            "action": "steer_turn",
-                            **dict(request.metadata),
-                        },
+                        metadata=metadata,
                     )
         return response
 
@@ -680,25 +671,22 @@ class DockerCodexManagedSessionController:
             payload=request.model_dump(by_alias=True),
         )
         response = CodexManagedSessionTurnResponse.model_validate(payload)
-        if (
-            self._session_store is not None
-            and self._session_store.load(request.session_id) is not None
-        ):
-            await self._session_store.update(
-                request.session_id,
-                session_epoch=response.session_state.session_epoch,
-                container_id=response.session_state.container_id,
+        if self._session_store is not None:
+            record = self._session_store.load(request.session_id)
+            if record is not None:
+                updated_record = await self._session_store.update(
+                    request.session_id,
+                    session_epoch=response.session_state.session_epoch,
+                    container_id=response.session_state.container_id,
                 thread_id=response.session_state.thread_id,
                 active_turn_id=response.session_state.active_turn_id,
                 status=self._record_status_from_turn_status(response.status),
                 updated_at=datetime.now(tz=UTC),
                 error_message=self._turn_error_message(response),
-            )
-            if self._session_supervisor is not None and response.status == "interrupted":
-                record = self._session_store.load(request.session_id)
-                if record is not None:
+                )
+                if self._session_supervisor is not None and response.status == "interrupted":
                     await self._emit_session_event(
-                        record=record,
+                        record=updated_record,
                         kind="turn_interrupted",
                         text=f"Turn interrupted: {response.turn_id}.",
                         turn_id=response.turn_id,
@@ -750,6 +738,7 @@ class DockerCodexManagedSessionController:
             await self._persist_handle_transition(
                 locator=self._locator_from_session_state(handle.session_state),
                 status=handle.status,
+                active_turn_id=handle.session_state.active_turn_id,
             )
         return handle
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import posixpath
 import re
@@ -36,6 +37,7 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+logger = logging.getLogger(__name__)
 
 
 class CommandRunner(Protocol):
@@ -426,14 +428,22 @@ class DockerCodexManagedSessionController:
     ) -> None:
         if self._session_supervisor is None:
             return
-        self._session_supervisor.emit_session_event(
-            record=record,
-            text=text,
-            kind=kind,
-            turn_id=turn_id,
-            active_turn_id=active_turn_id,
-            metadata=dict(metadata or {}),
-        )
+        try:
+            self._session_supervisor.emit_session_event(
+                record=record,
+                text=text,
+                kind=kind,
+                turn_id=turn_id,
+                active_turn_id=active_turn_id,
+                metadata=dict(metadata or {}),
+            )
+        except Exception:
+            logger.warning(
+                "Managed session event publication failed for session %s kind %s",
+                record.session_id,
+                kind,
+                exc_info=True,
+            )
 
     async def _container_exists(self, container_id: str) -> bool:
         returncode, stdout, stderr = await self._command_runner(
@@ -548,6 +558,22 @@ class DockerCodexManagedSessionController:
             locator=self._locator_from_session_state(handle.session_state),
             status=handle.status,
         )
+        if (
+            self._session_store is not None
+            and self._session_store.load(request.session_id) is not None
+        ):
+            record = self._session_store.load(request.session_id)
+            if record is not None:
+                await self._emit_session_event(
+                    record=record,
+                    kind="session_resumed",
+                    text=(
+                        f"Session resumed. Epoch {record.session_epoch} "
+                        f"thread {record.thread_id}."
+                    ),
+                    active_turn_id=record.active_turn_id,
+                    metadata={"action": "resume_session"},
+                )
         return handle
 
     async def send_turn(
@@ -612,7 +638,37 @@ class DockerCodexManagedSessionController:
             action="steer_turn",
             payload=request.model_dump(by_alias=True),
         )
-        return CodexManagedSessionTurnResponse.model_validate(payload)
+        response = CodexManagedSessionTurnResponse.model_validate(payload)
+        if (
+            self._session_store is not None
+            and self._session_store.load(request.session_id) is not None
+        ):
+            await self._session_store.update(
+                request.session_id,
+                session_epoch=response.session_state.session_epoch,
+                container_id=response.session_state.container_id,
+                thread_id=response.session_state.thread_id,
+                active_turn_id=response.session_state.active_turn_id,
+                status=self._record_status_from_turn_status(response.status),
+                updated_at=datetime.now(tz=UTC),
+                error_message=self._turn_error_message(response),
+            )
+            if self._session_supervisor is not None:
+                record = self._session_store.load(request.session_id)
+                if record is not None:
+                    await self._emit_session_event(
+                        record=record,
+                        kind="system_annotation",
+                        text=f"Turn steered: {request.turn_id}.",
+                        turn_id=request.turn_id,
+                        active_turn_id=response.session_state.active_turn_id
+                        or request.turn_id,
+                        metadata={
+                            "action": "steer_turn",
+                            **dict(request.metadata),
+                        },
+                    )
+        return response
 
     async def interrupt_turn(
         self,
@@ -723,9 +779,12 @@ class DockerCodexManagedSessionController:
                     refreshed = self._session_store.load(request.session_id) or record
                     await self._emit_session_event(
                         record=refreshed,
-                        kind="system_annotation",
+                        kind="session_terminated",
                         text=f"Session terminated: {request.session_id}.",
-                        metadata={"action": "terminate_session"},
+                        metadata={
+                            "action": "terminate_session",
+                            "reason": request.reason,
+                        },
                     )
                 await self._session_supervisor.finalize(
                     request.session_id,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -157,6 +157,50 @@ class ManagedSessionSupervisor:
         )
         return ref
 
+    @staticmethod
+    def _summary_payload(
+        *,
+        record: CodexManagedSessionRecord,
+        status: str,
+        stdout_ref: str,
+        stderr_ref: str,
+        diagnostics_ref: str | None,
+        error_message: str | None,
+    ) -> dict[str, object]:
+        return {
+            "sessionId": record.session_id,
+            "sessionEpoch": record.session_epoch,
+            "containerId": record.container_id,
+            "threadId": record.thread_id,
+            "status": status,
+            "stdoutArtifactRef": stdout_ref,
+            "stderrArtifactRef": stderr_ref,
+            "diagnosticsRef": diagnostics_ref,
+            "errorMessage": error_message,
+        }
+
+    @staticmethod
+    def _checkpoint_payload(
+        *,
+        record: CodexManagedSessionRecord,
+        status: str,
+        stdout_ref: str,
+        stderr_ref: str,
+        diagnostics_ref: str | None,
+    ) -> dict[str, object]:
+        return {
+            "sessionState": record.session_state().model_dump(
+                mode="json", by_alias=True, exclude_none=True
+            ),
+            "status": status,
+            "runtimeArtifacts": {
+                "stdout": stdout_ref,
+                "stderr": stderr_ref,
+                "diagnostics": diagnostics_ref,
+            },
+            "recordUpdatedAt": datetime.now(tz=UTC).isoformat(),
+        }
+
     async def _publish_record(
         self,
         record: CodexManagedSessionRecord,
@@ -175,45 +219,29 @@ class ManagedSessionSupervisor:
             artifact_name="stderr.log",
             data=stderr_bytes,
         )
-        diagnostics_ref = self._log_streamer.collect_diagnostics(
-            run_id=record.session_id,
-            exit_code=None,
-            duration_seconds=0.0,
-            log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
-            annotations=[],
-            events=[],
-            observability_events=self._log_streamer.consume_observability_events(record.task_run_id),
-        )
+        observability_events = self._log_streamer.consume_observability_events(record.task_run_id)
         summary_ref = self._write_json_artifact(
             job_id=record.session_id,
             artifact_name="session.summary.json",
-            payload={
-                "sessionId": record.session_id,
-                "sessionEpoch": record.session_epoch,
-                "containerId": record.container_id,
-                "threadId": record.thread_id,
-                "status": status,
-                "stdoutArtifactRef": stdout_ref,
-                "stderrArtifactRef": stderr_ref,
-                "diagnosticsRef": diagnostics_ref,
-                "errorMessage": error_message,
-            },
+            payload=self._summary_payload(
+                record=record,
+                status=status,
+                stdout_ref=stdout_ref,
+                stderr_ref=stderr_ref,
+                diagnostics_ref=None,
+                error_message=error_message,
+            ),
         )
         checkpoint_ref = self._write_json_artifact(
             job_id=record.session_id,
             artifact_name="session.step_checkpoint.json",
-            payload={
-                "sessionState": record.session_state().model_dump(
-                    mode="json", by_alias=True, exclude_none=True
-                ),
-                "status": status,
-                "runtimeArtifacts": {
-                    "stdout": stdout_ref,
-                    "stderr": stderr_ref,
-                    "diagnostics": diagnostics_ref,
-                },
-                "recordUpdatedAt": datetime.now(tz=UTC).isoformat(),
-            },
+            payload=self._checkpoint_payload(
+                record=record,
+                status=status,
+                stdout_ref=stdout_ref,
+                stderr_ref=stderr_ref,
+                diagnostics_ref=None,
+            ),
         )
         self.emit_session_event(
             record=record,
@@ -226,6 +254,41 @@ class ManagedSessionSupervisor:
             kind="checkpoint_published",
             text=f"Session checkpoint published for {record.session_id}.",
             metadata={"checkpointRef": checkpoint_ref, "status": status},
+        )
+        observability_events.extend(
+            self._log_streamer.consume_observability_events(record.task_run_id)
+        )
+        diagnostics_ref = self._log_streamer.collect_diagnostics(
+            run_id=record.session_id,
+            exit_code=None,
+            duration_seconds=0.0,
+            log_refs={"stdout": stdout_ref, "stderr": stderr_ref},
+            annotations=[],
+            events=[],
+            observability_events=observability_events,
+        )
+        summary_ref = self._write_json_artifact(
+            job_id=record.session_id,
+            artifact_name="session.summary.json",
+            payload=self._summary_payload(
+                record=record,
+                status=status,
+                stdout_ref=stdout_ref,
+                stderr_ref=stderr_ref,
+                diagnostics_ref=diagnostics_ref,
+                error_message=error_message,
+            ),
+        )
+        checkpoint_ref = self._write_json_artifact(
+            job_id=record.session_id,
+            artifact_name="session.step_checkpoint.json",
+            payload=self._checkpoint_payload(
+                record=record,
+                status=status,
+                stdout_ref=stdout_ref,
+                stderr_ref=stderr_ref,
+                diagnostics_ref=diagnostics_ref,
+            ),
         )
         observability_events_ref = await asyncio.to_thread(
             self._log_streamer.persist_observability_events,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
@@ -12,6 +13,8 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 
 from .log_streamer import RuntimeLogStreamer
 from .managed_session_store import ManagedSessionStore
+
+logger = logging.getLogger(__name__)
 
 
 class ArtifactStorageWriter(Protocol):
@@ -73,20 +76,29 @@ class ManagedSessionSupervisor:
         metadata: dict[str, object] | None = None,
     ) -> None:
         """Publish one session-aware observability row into the run-level stream."""
-        self._log_streamer.emit_observability_event(
-            run_id=record.task_run_id,
-            workspace_path=record.workspace_path,
-            stream="session",
-            text=text,
-            kind=kind,
-            session_id=record.session_id,
-            session_epoch=record.session_epoch,
-            container_id=record.container_id,
-            thread_id=record.thread_id,
-            turn_id=turn_id,
-            active_turn_id=active_turn_id if active_turn_id is not None else record.active_turn_id,
-            metadata=dict(metadata or {}),
-        )
+        try:
+            self._log_streamer.emit_observability_event(
+                run_id=record.task_run_id,
+                workspace_path=record.workspace_path,
+                stream="session",
+                text=text,
+                kind=kind,
+                session_id=record.session_id,
+                session_epoch=record.session_epoch,
+                container_id=record.container_id,
+                thread_id=record.thread_id,
+                turn_id=turn_id,
+                active_turn_id=active_turn_id if active_turn_id is not None else record.active_turn_id,
+                metadata=dict(metadata or {}),
+            )
+        except Exception:
+            logger.warning(
+                "Session observability publication failed for task run %s session %s kind %s",
+                record.task_run_id,
+                record.session_id,
+                kind,
+                exc_info=True,
+            )
 
     async def _watch(self, session_id: str) -> None:
         stop_event = self._stop_events[session_id]
@@ -152,12 +164,6 @@ class ManagedSessionSupervisor:
         status: str,
         error_message: str | None,
     ) -> CodexManagedSessionRecord:
-        observability_events_ref = await asyncio.to_thread(
-            self._log_streamer.persist_observability_events,
-            run_id=record.task_run_id,
-            workspace_path=record.workspace_path,
-            artifact_job_id=record.session_id,
-        )
         stdout_bytes, stderr_bytes = self._read_spool_bytes(record)
         _, stdout_ref = self._artifact_storage.write_artifact(
             job_id=record.session_id,
@@ -208,6 +214,24 @@ class ManagedSessionSupervisor:
                 },
                 "recordUpdatedAt": datetime.now(tz=UTC).isoformat(),
             },
+        )
+        self.emit_session_event(
+            record=record,
+            kind="summary_published",
+            text=f"Session summary published for {record.session_id}.",
+            metadata={"summaryRef": summary_ref, "status": status},
+        )
+        self.emit_session_event(
+            record=record,
+            kind="checkpoint_published",
+            text=f"Session checkpoint published for {record.session_id}.",
+            metadata={"checkpointRef": checkpoint_ref, "status": status},
+        )
+        observability_events_ref = await asyncio.to_thread(
+            self._log_streamer.persist_observability_events,
+            run_id=record.task_run_id,
+            workspace_path=record.workspace_path,
+            artifact_job_id=record.session_id,
         )
         now = datetime.now(tz=UTC)
         return await self._store.update(

--- a/specs/140-live-logs-session-plane-producer/contracts/session-plane-observability-events.md
+++ b/specs/140-live-logs-session-plane-producer/contracts/session-plane-observability-events.md
@@ -1,0 +1,27 @@
+# Contract: Session Plane Observability Events
+
+## Goal
+
+Define the Phase 2 production mapping between managed-session actions and the shared `RunObservabilityEvent` timeline contract.
+
+## Control/lifecycle mapping
+
+| Boundary | Event stream | Event kind | Notes |
+| --- | --- | --- | --- |
+| fresh session launch | `session` | `session_started` | emitted from the controller after launch succeeds |
+| reuse existing runtime handles | `session` | `session_resumed` | emitted from the controller when `session_status` is used to resume an existing session |
+| send turn accepted/completed | `session` | `turn_started`, `turn_completed` | emitted from the controller with current turn and session snapshot metadata |
+| steer active turn | `session` | `system_annotation` | normalized passive row with `metadata.action = "steer_turn"` |
+| interrupt active turn | `session` | `turn_interrupted` | emitted when interruption succeeds |
+| clear session | `session` | `session_cleared`, `session_reset_boundary` | clear row plus explicit epoch boundary row |
+| terminate session | `session` | `session_terminated` | explicit lifecycle row instead of a generic system line |
+| publish summary | `session` | `summary_published` | emitted from supervisor publication path |
+| publish checkpoint | `session` | `checkpoint_published` | emitted from supervisor publication path |
+
+## Failure rule
+
+Session-event publication is best-effort:
+
+- log the failure locally
+- do not mutate the control result into a failure
+- do not suppress durable summary/checkpoint/control/reset artifact writes that otherwise succeeded

--- a/specs/140-live-logs-session-plane-producer/data-model.md
+++ b/specs/140-live-logs-session-plane-producer/data-model.md
@@ -1,0 +1,59 @@
+# Data Model: Live Logs Session Plane Producer
+
+## Session Lifecycle Row
+
+Phase 2 continues to use `RunObservabilityEvent` from Phase 1.
+
+Relevant rows in this slice:
+
+- `session_started`
+- `session_resumed`
+- `turn_started`
+- `turn_completed`
+- `turn_interrupted`
+- `session_cleared`
+- `session_reset_boundary`
+- `session_terminated`
+- `summary_published`
+- `checkpoint_published`
+
+Common fields:
+
+- `sequence`
+- `timestamp`
+- `stream="session"`
+- `kind`
+- `text`
+- optional session snapshot fields:
+  - `session_id`
+  - `session_epoch`
+  - `container_id`
+  - `thread_id`
+  - `turn_id`
+  - `active_turn_id`
+- `metadata`
+
+## Publication Row Metadata
+
+`summary_published` metadata:
+
+- `summaryRef`
+- `status`
+
+`checkpoint_published` metadata:
+
+- `checkpointRef`
+- `status`
+
+## Control-Signal Mapping
+
+The adapter mirrors control intent into the workflow/session control path with:
+
+- `start_session`
+- `resume_session`
+- `send_turn`
+- `clear_session`
+- `interrupt_turn`
+- `terminate_session`
+
+Phase 2 does not add a separate run-record schema. It relies on the Phase 1 managed-run/session snapshot fields and makes the missing control/lifecycle/publication facts visible in the observability journal.

--- a/specs/140-live-logs-session-plane-producer/plan.md
+++ b/specs/140-live-logs-session-plane-producer/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: live-logs-session-plane-producer
+
+**Branch**: `140-live-logs-session-plane-producer` | **Date**: 2026-04-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/140-live-logs-session-plane-producer/spec.md`
+
+## Summary
+
+Implement the Phase 2 session-plane producer slice by extending the existing managed-session controller, supervisor, and Codex session adapter so the session plane emits normalized observability rows for resume, steering, interruption, clear/reset, termination, and continuity publication. The shared `RunObservabilityEvent` contract from Phase 1 remains unchanged; this slice focuses on producing the missing events and making event publication best-effort so runtime control and artifact persistence remain reliable.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: `DockerCodexManagedSessionController`, `ManagedSessionSupervisor`, `CodexSessionAdapter`, `ManagedSessionStore`, `ManagedRunStore`, `RuntimeLogStreamer`  
+**Storage**: file-backed managed-session store, file-backed managed-run store, artifact-backed `observability.events.jsonl` journal  
+**Testing**: pytest unit tests plus focused final verification via `./tools/test_unit.sh`  
+**Target Platform**: Docker/Compose-hosted MoonMind managed-runtime workers  
+**Project Type**: backend managed-session runtime and workflow adapter  
+**Performance Goals**: keep session-event publication cheap and non-blocking relative to control actions; preserve shared run-global sequence semantics  
+**Constraints**: keep the Phase 1 event contract, keep artifact-first semantics, do not leak provider-native payloads, do not make observability publication authoritative for control success  
+**Scale/Scope**: Phase 2 only; no historical events endpoint changes and no frontend timeline rendering work
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The session plane emits MoonMind-normalized observability rows rather than raw provider events.
+- **II. One-Click Agent Deployment**: PASS. No new infrastructure or external service is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The rows stay in the shared `RunObservabilityEvent` contract with optional session metadata only.
+- **IV. Own Your Data**: PASS. Timeline facts remain artifact-backed and MoonMind-owned.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill-runtime storage or resolution changes are introduced.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. This slice extends one existing event contract rather than adding a parallel session-event model.
+- **VII. Powerful Runtime Configurability**: PASS. The existing feature-flag boundary remains intact; no new rollout switches are needed.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay inside the controller/supervisor/adapter boundaries that already own session control and publication.
+- **IX. Resilient by Default**: PASS. Event publication becomes explicitly best-effort so failures do not break control flows or artifact persistence.
+- **XI. Spec-Driven Development**: PASS. Phase 2 is isolated into a new spec/plan/tasks slice instead of mutating the completed Phase 0/1 feature.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Only `specs/140-*` captures this implementation slice; canonical docs stay declarative.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. This slice reuses the Phase 1 event kinds already in the schema and removes generic termination-only assumptions where superseded by explicit session lifecycle rows.
+
+## Research
+
+- `ManagedSessionSupervisor.emit_session_event()` already writes `RunObservabilityEvent` rows with session snapshot fields, so the missing work is production at the controller/supervisor boundary rather than contract design.
+- `DockerCodexManagedSessionController` already emits `session_started`, `turn_started`, `turn_completed`, `turn_interrupted`, and clear/reset rows in part, but it does not yet emit resume, steer, or explicit terminate rows, and event publication is still able to break control flows.
+- `CodexSessionAdapter._ensure_remote_session()` already distinguishes reuse of existing runtime handles from fresh launch, which makes it the correct place to signal `resume_session` versus `start_session` through the workflow control boundary.
+- `ManagedSessionSupervisor._publish_record()` already writes durable summary/checkpoint artifacts and observability history, making it the correct place to emit `summary_published` and `checkpoint_published` timeline rows.
+- `RunObservabilityEvent` already supports `session_resumed`, `session_terminated`, `summary_published`, and `checkpoint_published`, so Phase 2 should not introduce new top-level schema kinds unless a real gap appears.
+- There is no implemented managed-session approval control surface in the current code paths, so this slice covers the stable actions and lifecycle transitions the runtime currently exposes today and leaves approval-specific production for the later approval-capable slice.
+
+## Project Structure
+
+- Add the Phase 2 spec artifact set under `specs/140-live-logs-session-plane-producer/`.
+- Update `moonmind/workflows/temporal/runtime/managed_session_controller.py` to emit the missing normalized session rows and make controller-side event emission best-effort.
+- Update `moonmind/workflows/temporal/runtime/managed_session_supervisor.py` to emit summary/checkpoint publication rows and make supervisor-side event emission best-effort.
+- Update `moonmind/workflows/adapters/codex_session_adapter.py` to signal `start_session` and `resume_session` through the workflow control boundary.
+- Extend unit coverage in `tests/unit/services/temporal/runtime/test_managed_session_controller.py`, `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py`, and `tests/unit/workflows/adapters/test_codex_session_adapter.py`.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the Phase 2 session event mapping and publication-row semantics.
+
+## Contracts
+
+- [contracts/session-plane-observability-events.md](./contracts/session-plane-observability-events.md)
+
+## Implementation Plan
+
+1. Add failing tests for the missing Phase 2 production behavior:
+   - resumed sessions emit `session_resumed`,
+   - steer/terminate paths emit normalized session rows,
+   - supervisor publication emits `summary_published` and `checkpoint_published`,
+   - publication failures do not break successful control/artifact paths,
+   - adapter reuse/launch signaling differentiates `resume_session` from `start_session`.
+2. Extend the controller’s best-effort session-event helper and wire the missing resume, steer, and terminate rows through it.
+3. Extend the supervisor publication path so summary/checkpoint artifact publication writes corresponding observability rows with refs in metadata.
+4. Update the Codex session adapter to mirror `start_session` and `resume_session` through the existing workflow/session control signaling path when session handles are launched or reused.
+5. Run focused tests and runtime scope validation, then mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/workflows/adapters/test_codex_session_adapter.py`
+2. `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+### Manual Validation
+
+1. Reuse an existing managed-session snapshot and confirm the adapter signals `resume_session` instead of relaunching a container.
+2. Clear a session and confirm the observability journal still contains the clear row plus the explicit `session_reset_boundary` row.
+3. Publish session artifacts and confirm the durable observability history includes `summary_published` and `checkpoint_published` rows with the current session snapshot metadata.

--- a/specs/140-live-logs-session-plane-producer/quickstart.md
+++ b/specs/140-live-logs-session-plane-producer/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Live Logs Session Plane Producer
+
+## Focused verification
+
+Run the Phase 2 unit-test slice:
+
+```bash
+./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/workflows/adapters/test_codex_session_adapter.py
+```
+
+Run the Spec Kit scope checks:
+
+```bash
+./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+## Expected behavior
+
+1. Reusing existing runtime handles emits a `session_resumed` row and signals `resume_session`.
+2. Steering and termination produce normalized `session`-stream rows.
+3. Publishing session artifacts adds `summary_published` and `checkpoint_published` rows to durable observability history.
+4. Session-event publication failures do not break successful control actions or reset-boundary artifact persistence.

--- a/specs/140-live-logs-session-plane-producer/research.md
+++ b/specs/140-live-logs-session-plane-producer/research.md
@@ -1,0 +1,29 @@
+# Research: Live Logs Session Plane Producer
+
+## Decision 1: Reuse the Phase 1 event kinds instead of adding a second session-event model
+
+- **Decision**: Keep `RunObservabilityEvent` as the sole event model and use the existing session/publication kinds already added in Phase 1.
+- **Rationale**: Phase 2 is about producing missing rows, not redesigning the contract again.
+- **Alternatives considered**:
+  - Add dedicated action kinds for every control verb. Rejected because Phase 1 already shipped lifecycle/publication kinds and a generic `system_annotation` is sufficient for steer-only control facts.
+
+## Decision 2: Make session-event publication best-effort at both controller and supervisor boundaries
+
+- **Decision**: Catch and log exceptions during session-event publication so successful control actions and artifact publication continue.
+- **Rationale**: The plan explicitly requires publishing failures to avoid breaking runtime control or durable artifact persistence.
+- **Alternatives considered**:
+  - Let event publication failures fail the control action. Rejected because it incorrectly makes observability authoritative over runtime state changes.
+
+## Decision 3: Signal `start_session` and `resume_session` from the adapter when launch/reuse is decided
+
+- **Decision**: Mirror `start_session` and `resume_session` through the adapter’s existing control signal path at the moment `_ensure_remote_session()` chooses launch vs reuse.
+- **Rationale**: The adapter already owns that decision and is the correct place to keep workflow/session projection state consistent with the actual runtime path.
+- **Alternatives considered**:
+  - Infer resume from generic `session_status` polling later. Rejected because it loses the explicit control intent and is harder to keep deterministic.
+
+## Decision 4: Emit publication rows from `ManagedSessionSupervisor._publish_record()`
+
+- **Decision**: Emit `summary_published` and `checkpoint_published` immediately after the summary/checkpoint artifacts are written.
+- **Rationale**: That method already owns the authoritative publication refs and the run-global observability journal.
+- **Alternatives considered**:
+  - Emit publication rows from the controller after `publish_session_artifacts()`. Rejected because the controller may return an already-published record and does not own artifact creation.

--- a/specs/140-live-logs-session-plane-producer/spec.md
+++ b/specs/140-live-logs-session-plane-producer/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Live Logs Session Plane Producer
+
+**Feature Branch**: `140-live-logs-session-plane-producer`  
+**Created**: 2026-04-08  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 2 using test-driven development from the Live Logs Session-Aware Implementation Plan. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Session lifecycle controls publish timeline-visible events (Priority: P1)
+
+MoonMind operators need the Codex managed session plane to publish normalized session lifecycle rows into the existing run-global observability stream so resets, resumes, interruptions, and termination are visible in Live Logs without relying on the separate continuity panel.
+
+**Why this priority**: Phase 2 is the contract slice that turns the session plane into a first-class observability producer instead of a separate control surface with hidden state changes.
+
+**Independent Test**: Exercise launch/resume, steer, interrupt, clear, and terminate boundaries through the managed-session controller and adapter, then confirm the emitted session rows are normalized and non-fatal when event publication fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task-scoped session already has durable runtime handles, **When** the adapter resumes that session instead of launching a new container, **Then** MoonMind records a `session_resumed` row in the run-global observability stream and signals `resume_session` through the workflow control boundary.
+2. **Given** an operator steers or interrupts an active turn, **When** the managed-session controller handles the request, **Then** MoonMind emits normalized `session`-stream rows describing the steering/interruption action and resulting lifecycle transition using the current session snapshot fields.
+3. **Given** a session is terminated through the managed-session control surface, **When** the controller finalizes the session, **Then** MoonMind emits a `session_terminated` row instead of hiding the state change as a generic system annotation.
+4. **Given** the observability publisher throws while writing a session event, **When** a lifecycle control action still succeeds, **Then** runtime control and durable artifact publication continue without surfacing a false success for the failed event row.
+
+---
+
+### User Story 2 - Session artifact publication becomes visible in the observability timeline (Priority: P1)
+
+Operators need summary and checkpoint publication to appear in the same timeline as stdout, stderr, system, and session lifecycle rows so durable continuity evidence is visible inline with the session story.
+
+**Why this priority**: The timeline remains incomplete if the system writes continuity artifacts but hides their publication from the main observability surface.
+
+**Independent Test**: Publish session artifacts for one managed session and confirm the durable observability history contains `summary_published` and `checkpoint_published` rows with the latest session snapshot and artifact refs.
+
+**Acceptance Scenarios**:
+
+1. **Given** MoonMind publishes a session summary artifact, **When** the managed-session supervisor writes the artifact-backed publication record, **Then** the observability journal includes a `summary_published` row that links to the latest summary ref.
+2. **Given** MoonMind publishes a session checkpoint artifact, **When** the same publication path completes, **Then** the observability journal includes a `checkpoint_published` row that links to the latest checkpoint ref.
+3. **Given** a completed run later reloads its structured observability history, **When** the timeline is reconstructed, **Then** the publication rows appear in the same shared sequence namespace as stdout/stderr/system/session events.
+
+### Edge Cases
+
+- A session event publication fails while `clear_session` still rotates epoch/thread and reset-boundary artifacts are written; the control action must still succeed.
+- A session is resumed from existing runtime handles instead of being launched fresh; the observability row must reflect `resume_session`, not `start_session`.
+- Summary/checkpoint publication may happen multiple times across a long-lived session; each publication remains a passive observability fact and must not mutate control behavior.
+- Steering a turn may carry arbitrary metadata; observability rows must stay MoonMind-normalized and must not dump raw provider payloads into the timeline.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Codex managed session plane MUST publish normalized `session`-stream observability rows for the stable lifecycle/control boundaries it currently exposes: start, resume, send-turn, steer-turn, interrupt-turn, clear-session, and terminate-session.
+- **FR-002**: `clear_session` MUST continue to emit both a passive clear/control row and a dedicated `session_reset_boundary` row carrying the new epoch/thread context.
+- **FR-003**: The session-plane boundary MUST emit `session_resumed`, `turn_started`, `turn_completed`, `turn_interrupted`, and `session_terminated` lifecycle rows when those transitions occur.
+- **FR-004**: Session summary and checkpoint artifact publication MUST emit `summary_published` and `checkpoint_published` rows in the shared observability sequence.
+- **FR-005**: Every emitted session publication row MUST include the latest known session snapshot fields when available.
+- **FR-006**: Session-event publication failures MUST be treated as non-fatal best-effort failures and MUST NOT break runtime control actions or durable artifact publication.
+- **FR-007**: The workflow adapter MUST mirror `start_session` and `resume_session` through the existing session-control signaling boundary so summary/projection surfaces observe the latest control transition consistently.
+- **FR-008**: The Phase 2 slice MUST include automated validation tests for controller publication, supervisor publication, adapter signaling, and non-fatal publication failure behavior.
+
+### Key Entities *(include if feature involves data)*
+
+- **Session Lifecycle Row**: A `RunObservabilityEvent` with `stream="session"` representing one MoonMind-normalized session control or lifecycle fact.
+- **Publication Row**: A `RunObservabilityEvent` emitted when MoonMind publishes a session summary or checkpoint artifact.
+- **Session Control Signal**: The adapter-to-workflow payload that mirrors `start_session` or `resume_session` through the managed-session control boundary.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated tests verify resumed sessions emit a timeline-visible `session_resumed` row and signal `resume_session` without relaunching a container.
+- **SC-002**: Automated tests verify steering, interruption, clear, and termination produce normalized session observability rows instead of generic hidden state changes.
+- **SC-003**: Automated tests verify session artifact publication writes `summary_published` and `checkpoint_published` rows into durable observability history.
+- **SC-004**: Automated tests verify observability publication failures do not break successful control actions or reset-boundary artifact persistence.

--- a/specs/140-live-logs-session-plane-producer/tasks.md
+++ b/specs/140-live-logs-session-plane-producer/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: Live Logs Session Plane Producer
+
+**Input**: Design documents from `/specs/140-live-logs-session-plane-producer/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature is explicitly TDD-driven. Write or update failing tests before the corresponding implementation tasks.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Phase 1: Setup (Shared Test Baseline)
+
+**Purpose**: Establish failing tests for the missing Phase 2 observability-producer behavior before runtime code is updated.
+
+- [X] T001 [P] Add controller coverage for resume, steer, terminate, and non-fatal event publication behavior in `tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+- [X] T002 [P] Add supervisor coverage for summary/checkpoint publication rows and non-fatal event publication behavior in `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py`
+- [X] T003 [P] Add adapter coverage for `start_session` versus `resume_session` control signaling in `tests/unit/workflows/adapters/test_codex_session_adapter.py`
+
+---
+
+## Phase 2: Foundational (Blocking Producer Changes)
+
+**Purpose**: Wire the missing event-production and control-signaling boundaries used by every Phase 2 story.
+
+**⚠️ CRITICAL**: User-story implementation should not begin until these producer changes are complete.
+
+- [X] T004 Implement best-effort session-event emission and missing resume/steer/terminate rows in `moonmind/workflows/temporal/runtime/managed_session_controller.py`
+- [X] T005 Implement summary/checkpoint publication rows and best-effort supervisor emission in `moonmind/workflows/temporal/runtime/managed_session_supervisor.py`
+- [X] T006 Implement `start_session` / `resume_session` workflow control signaling in `moonmind/workflows/adapters/codex_session_adapter.py`
+
+**Checkpoint**: The controller, supervisor, and adapter all emit or signal the missing Phase 2 session-plane observability facts.
+
+---
+
+## Phase 3: User Story 1 - Session lifecycle controls publish timeline-visible events (Priority: P1)
+
+**Goal**: Make resume, steer, interrupt, clear, and termination visible in the run-global timeline.
+
+**Independent Test**: Exercise the controller and adapter tests to confirm the normalized rows and control signals are emitted without breaking successful control actions.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Emit `session_resumed` on runtime-handle reuse and signal `resume_session` from the adapter/controller boundary
+- [X] T008 [US1] Emit normalized steering and termination rows while preserving existing clear/reset and interrupt behavior
+- [X] T009 [US1] Make observability publication failures non-fatal to successful control actions
+
+**Checkpoint**: Lifecycle control actions are visible in Live Logs as session-aware facts rather than hidden controller state changes.
+
+---
+
+## Phase 4: User Story 2 - Session artifact publication becomes visible in the observability timeline (Priority: P1)
+
+**Goal**: Make summary/checkpoint publication rows part of the same durable timeline as other session events.
+
+**Independent Test**: Publish session artifacts and confirm `summary_published` and `checkpoint_published` appear in durable observability history.
+
+### Implementation for User Story 2
+
+- [X] T010 [US2] Emit `summary_published` and `checkpoint_published` during managed-session publication in `moonmind/workflows/temporal/runtime/managed_session_supervisor.py`
+
+**Checkpoint**: Continuity publication is visible inline in the session-aware observability stream.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the feature end to end and close the execution loop.
+
+- [X] T011 Run focused Phase 2 verification in `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/workflows/adapters/test_codex_session_adapter.py`
+- [X] T012 Run runtime scope validation in `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime` and `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on the failing tests from Phase 1.
+- **User Story 1 (Phase 3)**: Depends on Phase 2.
+- **User Story 2 (Phase 4)**: Depends on Phase 2.
+- **Polish (Phase 5)**: Depends on all implementation phases completing.
+
+### Parallel Opportunities
+
+- `T001`, `T002`, and `T003` can run in parallel because they touch different test files.
+- `T004`, `T005`, and `T006` can proceed independently after the tests are in place.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing tests for the missing Phase 2 producer behavior.
+2. Wire the controller and supervisor emission boundaries.
+3. Wire adapter control signaling for session start/resume.
+4. Run the focused verification and scope checks.
+
+### Notes
+
+- Keep the Phase 1 `RunObservabilityEvent` contract unchanged.
+- Keep reset-boundary semantics explicit and session-plane publishing best-effort.
+- Do not introduce provider-native event rows or a second session-event model.

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -351,6 +351,7 @@ async def test_controller_session_status_emits_session_resumed_event(
             imageRef="img",
             controlUrl="docker-exec://ctr-1",
             status="ready",
+            activeTurnId="turn-stale",
             workspacePath="/work/repo",
             sessionWorkspacePath="/work/session",
             artifactSpoolPath="/work/artifacts",
@@ -373,7 +374,7 @@ async def test_controller_session_status_emits_session_resumed_event(
                     "sessionEpoch": 1,
                     "containerId": "ctr-1",
                     "threadId": "thread-1",
-                    "activeTurnId": None,
+                    "activeTurnId": "turn-fresh",
                 },
                 "status": "ready",
                 "imageRef": "img",
@@ -402,7 +403,11 @@ async def test_controller_session_status_emits_session_resumed_event(
 
     emitted_call = session_supervisor.emit_session_event.call_args
     assert emitted_call.kwargs["kind"] == "session_resumed"
+    assert emitted_call.kwargs["active_turn_id"] == "turn-fresh"
     assert emitted_call.kwargs["metadata"] == {"action": "resume_session"}
+    refreshed = store.load("sess-1")
+    assert refreshed is not None
+    assert refreshed.active_turn_id == "turn-fresh"
 
 
 @pytest.mark.asyncio
@@ -469,7 +474,7 @@ async def test_controller_steer_turn_emits_normalized_session_annotation(
             threadId="thread-1",
             turnId="turn-1",
             instructions="Revise the plan",
-            metadata={"reason": "operator_steer"},
+            metadata={"reason": "operator_steer", "action": "override_attempt"},
         )
     )
 

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -16,6 +16,7 @@ from moonmind.schemas.managed_session_models import (
     LaunchCodexManagedSessionRequest,
     PublishCodexManagedSessionArtifactsRequest,
     SendCodexManagedSessionTurnRequest,
+    SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
@@ -335,6 +336,153 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
 
 
 @pytest.mark.asyncio
+async def test_controller_session_status_emits_session_resumed_event(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+    session_supervisor.emit_session_event = Mock()
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "ready",
+                "imageRef": "img",
+                "controlUrl": "docker-exec://ctr-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    await controller.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+        )
+    )
+
+    emitted_call = session_supervisor.emit_session_event.call_args
+    assert emitted_call.kwargs["kind"] == "session_resumed"
+    assert emitted_call.kwargs["metadata"] == {"action": "resume_session"}
+
+
+@pytest.mark.asyncio
+async def test_controller_steer_turn_emits_normalized_session_annotation(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="busy",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+    session_supervisor.emit_session_event = Mock()
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "steer_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": "turn-1",
+                },
+                "turnId": "turn-1",
+                "status": "running",
+                "metadata": {},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    await controller.steer_turn(
+        SteerCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            turnId="turn-1",
+            instructions="Revise the plan",
+            metadata={"reason": "operator_steer"},
+        )
+    )
+
+    emitted_call = session_supervisor.emit_session_event.call_args
+    assert emitted_call.kwargs["kind"] == "system_annotation"
+    assert emitted_call.kwargs["turn_id"] == "turn-1"
+    assert emitted_call.kwargs["metadata"] == {
+        "action": "steer_turn",
+        "reason": "operator_steer",
+    }
+
+
+@pytest.mark.asyncio
 async def test_controller_clear_and_terminate_preserve_container_boundary(
     tmp_path: Path,
 ) -> None:
@@ -446,6 +594,12 @@ async def test_controller_clear_and_terminate_preserve_container_boundary(
     assert publish_kwargs["record"].session_epoch == 2
     assert publish_kwargs["record"].thread_id == "logical-thread-2"
     assert terminated.status == "terminated"
+    emitted_call = session_supervisor.emit_session_event.call_args
+    assert emitted_call.kwargs["kind"] == "session_terminated"
+    assert emitted_call.kwargs["metadata"] == {
+        "action": "terminate_session",
+        "reason": None,
+    }
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
 
 
@@ -557,6 +711,77 @@ async def test_controller_clear_session_publishes_durable_reset_artifacts(
     assert summary.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
     assert publication.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert publication.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_tolerates_event_publication_failure(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath="/work/session",
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    session_supervisor = Mock()
+    session_supervisor.emit_session_event = Mock(
+        side_effect=RuntimeError("publisher unavailable")
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "completed",
+                "metadata": {"assistantText": "OK"},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -161,6 +161,13 @@ async def test_publish_snapshot_persists_run_keyed_session_events(tmp_path: Path
     assert diagnostics_payload["observability_events"][0]["stream"] == "session"
     assert diagnostics_payload["observability_events"][0]["kind"] == "session_cleared"
     assert diagnostics_payload["observability_events"][0]["metadata"]["reason"] == "operator_reset"
+    assert [
+        event["kind"] for event in diagnostics_payload["observability_events"]
+    ] == [
+        "session_cleared",
+        "summary_published",
+        "checkpoint_published",
+    ]
     assert snapshot.observability_events_ref == "sess-1/observability.events.jsonl"
     journal = artifact_storage.resolve_storage_path(snapshot.observability_events_ref)
     assert journal.exists()
@@ -168,6 +175,7 @@ async def test_publish_snapshot_persists_run_keyed_session_events(tmp_path: Path
     assert '"stream":"session"' in journal_text
     assert '"kind":"summary_published"' in journal_text
     assert '"kind":"checkpoint_published"' in journal_text
+    assert log_streamer.consume_observability_events(record.task_run_id) == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -164,7 +164,10 @@ async def test_publish_snapshot_persists_run_keyed_session_events(tmp_path: Path
     assert snapshot.observability_events_ref == "sess-1/observability.events.jsonl"
     journal = artifact_storage.resolve_storage_path(snapshot.observability_events_ref)
     assert journal.exists()
-    assert '"stream":"session"' in journal.read_text(encoding="utf-8")
+    journal_text = journal.read_text(encoding="utf-8")
+    assert '"stream":"session"' in journal_text
+    assert '"kind":"summary_published"' in journal_text
+    assert '"kind":"checkpoint_published"' in journal_text
 
 
 @pytest.mark.asyncio
@@ -286,5 +289,44 @@ async def test_publish_reset_artifacts_preserves_newer_store_fields(tmp_path: Pa
 
     assert published.last_log_offset == 77
     assert published.last_log_at == datetime(2026, 4, 7, 8, 1, tzinfo=UTC)
+    assert published.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
+    assert published.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"
+
+
+@pytest.mark.asyncio
+async def test_publish_reset_artifacts_tolerates_event_publication_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    previous = _record(tmp_path)
+    store.save(previous)
+    current = previous.model_copy(
+        update={
+            "session_epoch": 2,
+            "thread_id": "thread-2",
+            "updated_at": datetime(2026, 4, 7, 8, 0, tzinfo=UTC),
+        }
+    )
+
+    def _raise(*args, **kwargs) -> None:
+        raise RuntimeError("publisher unavailable")
+
+    monkeypatch.setattr(supervisor._log_streamer, "emit_observability_event", _raise)
+
+    published = await supervisor.publish_reset_artifacts(
+        previous_record=previous,
+        record=current,
+        action="clear_session",
+        reason="reset stale context",
+    )
+
     assert published.latest_control_event_ref == "sess-1/session.control_event.epoch-2.json"
     assert published.latest_reset_boundary_ref == "sess-1/session.reset_boundary.epoch-2.json"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -321,6 +321,11 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert result.metadata["sessionArtifacts"]["latestCheckpointRef"] == "artifact:session-checkpoint"
 
     assert attach_calls == [{"containerId": "container-1", "threadId": "thread-1"}]
+    assert control_calls[0] == {
+        "action": "start_session",
+        "containerId": "container-1",
+        "threadId": "thread-1",
+    }
     assert control_calls[-1]["action"] == "send_turn"
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
@@ -457,6 +462,7 @@ async def test_start_reuses_existing_task_scoped_session_without_launching(
 ) -> None:
     binding = _binding()
     session_status_calls: list[Any] = []
+    control_calls: list[dict[str, Any]] = []
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(
@@ -501,6 +507,9 @@ async def test_start_reuses_existing_task_scoped_session_without_launching(
             thread_id="thread-existing",
         )
 
+    async def _apply_control_action(payload: dict[str, Any]) -> None:
+        control_calls.append(payload)
+
     adapter = CodexSessionAdapter(
         profile_fetcher=_fake_profiles(
             [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
@@ -521,7 +530,7 @@ async def test_start_reuses_existing_task_scoped_session_without_launching(
         fetch_remote_summary=_fetch_summary,
         publish_remote_artifacts=_publish_artifacts,
         attach_runtime_handles=_async_noop,
-        apply_session_control_action=_async_noop,
+        apply_session_control_action=_apply_control_action,
         workspace_root=str(tmp_path / "agent_jobs"),
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
     )
@@ -532,6 +541,11 @@ async def test_start_reuses_existing_task_scoped_session_without_launching(
     assert len(session_status_calls) == 1
     assert session_status_calls[0].container_id == "container-existing"
     assert session_status_calls[0].thread_id == "thread-existing"
+    assert control_calls[0] == {
+        "action": "resume_session",
+        "containerId": "container-existing",
+        "threadId": "thread-existing",
+    }
 
 
 async def test_clear_session_rotates_epoch_and_signals_session_workflow(


### PR DESCRIPTION
## Summary
- implement the Live Logs Phase 2 session-plane producer slice for Codex managed sessions
- emit normalized session observability rows for resume, steer, terminate, and existing lifecycle transitions without making observability authoritative over control success
- emit `summary_published` and `checkpoint_published` rows during managed-session publication and add the Spec Kit artifacts for feature 140

## Why
Phase 1 established the canonical `RunObservabilityEvent` contract, but the session plane still was not a first-class producer for several control and publication boundaries. This change makes those lifecycle facts visible in the shared run-global timeline and keeps publication failures non-fatal.

## User impact
- resumed sessions now surface a `session_resumed` event
- steering and termination now produce normalized session timeline rows
- summary/checkpoint publication is visible in durable observability history
- reset/control flows still succeed even if observability publication fails

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `SPECIFY_FEATURE=140-live-logs-session-plane-producer ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`

## Notes
- the focused unit runner also completed the frontend unit suite successfully in this environment
- approval event production is still out of scope for this slice because the current managed-session path does not yet expose an approval control surface