### PR TITLE
[codex] Fix managed session target branch checkout

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -7,6 +7,7 @@ import json
 import os
 import posixpath
 import re
+import shutil
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
@@ -36,6 +37,7 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+_GIT_COMMAND_LOCALE = {"LC_ALL": "C", "LANG": "C"}
 
 
 class CommandRunner(Protocol):
@@ -287,13 +289,94 @@ class DockerCodexManagedSessionController:
     async def _run_host_command(
         self,
         command: Sequence[str],
+        *,
+        extra_env: Mapping[str, str] | None = None,
     ) -> tuple[str, str]:
-        returncode, stdout, stderr = await self._command_runner(tuple(command))
+        env = None
+        if extra_env:
+            env = {str(key): str(value) for key, value in extra_env.items()}
+        returncode, stdout, stderr = await self._command_runner(tuple(command), env=env)
         if returncode != 0:
             raise RuntimeError(
                 f"{' '.join(command)} failed with exit code {returncode}: {stderr.strip() or stdout.strip()}"
             )
         return stdout, stderr
+
+    async def _run_git_host_command(
+        self,
+        command: Sequence[str],
+    ) -> tuple[str, str]:
+        return await self._run_host_command(command, extra_env=_GIT_COMMAND_LOCALE)
+
+    async def _git_command_result(
+        self,
+        command: Sequence[str],
+    ) -> tuple[int, str, str]:
+        return await self._command_runner(
+            tuple(command),
+            env=dict(_GIT_COMMAND_LOCALE),
+        )
+
+    async def _workspace_is_git_repository(self, *, workspace_path: Path) -> bool:
+        returncode, stdout, _stderr = await self._git_command_result(
+            [
+                "git",
+                "-C",
+                str(workspace_path),
+                "rev-parse",
+                "--is-inside-work-tree",
+            ]
+        )
+        return returncode == 0 and stdout.strip() == "true"
+
+    async def _remove_workspace_path(self, *, workspace_path: Path) -> None:
+        if not workspace_path.exists():
+            return
+        if workspace_path.is_dir():
+            shutil.rmtree(workspace_path)
+            return
+        workspace_path.unlink()
+
+    async def _clone_workspace(
+        self,
+        *,
+        workspace_path: Path,
+        request: LaunchCodexManagedSessionRequest,
+        repository: str,
+    ) -> None:
+        workspace_path.parent.mkdir(parents=True, exist_ok=True)
+        await self._remove_workspace_path(workspace_path=workspace_path)
+
+        from .launcher import ManagedRuntimeLauncher
+
+        source = ManagedRuntimeLauncher._resolve_repository_source(repository)
+        branch = str(
+            request.workspace_spec.get("startingBranch")
+            or request.workspace_spec.get("branch")
+            or ""
+        ).strip()
+
+        clone_command = ["git", "clone"]
+        if branch:
+            clone_command.extend(["--branch", branch, "--single-branch"])
+        clone_command.extend([source, str(workspace_path)])
+        await self._run_git_host_command(clone_command)
+
+    @staticmethod
+    def _branch_missing_checkout_failure(detail: str) -> bool:
+        normalized = detail.lower()
+        return (
+            "did not match any file(s) known to git" in normalized
+            or "pathspec" in normalized
+        )
+
+    @staticmethod
+    def _remote_branch_missing_failure(detail: str) -> bool:
+        normalized = detail.lower()
+        return (
+            "couldn't find remote ref" in normalized
+            or "remote ref does not exist" in normalized
+        )
 
     async def _ensure_workspace_paths(
         self,
@@ -313,31 +396,28 @@ class DockerCodexManagedSessionController:
         ).strip()
         if workspace_path.exists():
             if repository:
+                if not await self._workspace_is_git_repository(workspace_path=workspace_path):
+                    await self._clone_workspace(
+                        workspace_path=workspace_path,
+                        request=request,
+                        repository=repository,
+                    )
                 await self._ensure_target_branch(
                     workspace_path=workspace_path,
                     request=request,
                 )
             return
 
-        workspace_path.parent.mkdir(parents=True, exist_ok=True)
         if not repository:
+            workspace_path.parent.mkdir(parents=True, exist_ok=True)
             workspace_path.mkdir(parents=True, exist_ok=True)
             return
 
-        from .launcher import ManagedRuntimeLauncher
-
-        source = ManagedRuntimeLauncher._resolve_repository_source(repository)
-        branch = str(
-            request.workspace_spec.get("startingBranch")
-            or request.workspace_spec.get("branch")
-            or ""
-        ).strip()
-
-        clone_command = ["git", "clone"]
-        if branch:
-            clone_command.extend(["--branch", branch, "--single-branch"])
-        clone_command.extend([source, str(workspace_path)])
-        await self._run_host_command(clone_command)
+        await self._clone_workspace(
+            workspace_path=workspace_path,
+            request=request,
+            repository=repository,
+        )
         await self._ensure_target_branch(
             workspace_path=workspace_path,
             request=request,
@@ -360,22 +440,50 @@ class DockerCodexManagedSessionController:
             "checkout",
             target_branch,
         )
-        returncode, stdout, stderr = await self._command_runner(checkout_command)
+        returncode, stdout, stderr = await self._git_command_result(checkout_command)
         if returncode == 0:
             return
 
-        failure_detail = (stderr or stdout).lower()
-        branch_missing = (
-            "did not match any file(s) known to git" in failure_detail
-            or "pathspec" in failure_detail
-        )
-        if not branch_missing:
+        failure_detail = stderr or stdout
+        if not self._branch_missing_checkout_failure(failure_detail):
             raise RuntimeError(
                 f"{' '.join(checkout_command)} failed with exit code {returncode}: "
                 f"{stderr.strip() or stdout.strip()}"
             )
 
-        await self._run_host_command(
+        fetch_command = [
+            "git",
+            "-C",
+            str(workspace_path),
+            "fetch",
+            "origin",
+            target_branch,
+        ]
+        fetch_returncode, fetch_stdout, fetch_stderr = await self._git_command_result(
+            fetch_command
+        )
+        if fetch_returncode == 0:
+            await self._run_git_host_command(
+                [
+                    "git",
+                    "-C",
+                    str(workspace_path),
+                    "checkout",
+                    "-B",
+                    target_branch,
+                    f"origin/{target_branch}",
+                ]
+            )
+            return
+
+        fetch_detail = fetch_stderr or fetch_stdout
+        if not self._remote_branch_missing_failure(fetch_detail):
+            raise RuntimeError(
+                f"{' '.join(fetch_command)} failed with exit code {fetch_returncode}: "
+                f"{fetch_stderr.strip() or fetch_stdout.strip()}"
+            )
+
+        await self._run_git_host_command(
             [
                 "git",
                 "-C",

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -306,16 +306,20 @@ class DockerCodexManagedSessionController:
         session_workspace_path.mkdir(parents=True, exist_ok=True)
         artifact_spool_path.mkdir(parents=True, exist_ok=True)
 
-        if workspace_path.exists():
-            return
-
-        workspace_path.parent.mkdir(parents=True, exist_ok=True)
-
         repository = str(
             request.workspace_spec.get("repository")
             or request.workspace_spec.get("repo")
             or ""
         ).strip()
+        if workspace_path.exists():
+            if repository:
+                await self._ensure_target_branch(
+                    workspace_path=workspace_path,
+                    request=request,
+                )
+            return
+
+        workspace_path.parent.mkdir(parents=True, exist_ok=True)
         if not repository:
             workspace_path.mkdir(parents=True, exist_ok=True)
             return
@@ -334,6 +338,53 @@ class DockerCodexManagedSessionController:
             clone_command.extend(["--branch", branch, "--single-branch"])
         clone_command.extend([source, str(workspace_path)])
         await self._run_host_command(clone_command)
+        await self._ensure_target_branch(
+            workspace_path=workspace_path,
+            request=request,
+        )
+
+    async def _ensure_target_branch(
+        self,
+        *,
+        workspace_path: Path,
+        request: LaunchCodexManagedSessionRequest,
+    ) -> None:
+        target_branch = str(request.workspace_spec.get("targetBranch") or "").strip()
+        if not target_branch:
+            return
+
+        checkout_command = (
+            "git",
+            "-C",
+            str(workspace_path),
+            "checkout",
+            target_branch,
+        )
+        returncode, stdout, stderr = await self._command_runner(checkout_command)
+        if returncode == 0:
+            return
+
+        failure_detail = (stderr or stdout).lower()
+        branch_missing = (
+            "did not match any file(s) known to git" in failure_detail
+            or "pathspec" in failure_detail
+        )
+        if not branch_missing:
+            raise RuntimeError(
+                f"{' '.join(checkout_command)} failed with exit code {returncode}: "
+                f"{stderr.strip() or stdout.strip()}"
+            )
+
+        await self._run_host_command(
+            [
+                "git",
+                "-C",
+                str(workspace_path),
+                "checkout",
+                "-b",
+                target_branch,
+            ]
+        )
 
     async def _invoke_json(
         self,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -144,6 +144,7 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         workspaceSpec={
             "repository": "MoonLadderStudios/MoonMind",
             "startingBranch": "dependabot/pip/requests-2.33.1",
+            "targetBranch": "codex/session-fix",
         },
     )
     commands: list[tuple[str, ...]] = []
@@ -160,6 +161,11 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         if command[:2] == ("git", "clone"):
             Path(request.workspace_path).mkdir(parents=True, exist_ok=True)
             return 0, "", ""
+        if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
+            if command[4:] == ("codex/session-fix",):
+                return 1, "", "error: pathspec 'codex/session-fix' did not match any file(s) known to git"
+            if command[4:] == ("-b", "codex/session-fix"):
+                return 0, "", ""
         if command[:2] == ("docker", "run"):
             return 0, "ctr-1\n", ""
         if "ready" in command:
@@ -196,9 +202,99 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         "https://github.com/MoonLadderStudios/MoonMind.git" in commands[0]
     )
     assert request.workspace_path in commands[0]
+    assert commands[1] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "checkout",
+        "codex/session-fix",
+    )
+    assert commands[2] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "checkout",
+        "-b",
+        "codex/session-fix",
+    )
     assert Path(request.workspace_path).exists()
     assert Path(request.session_workspace_path).exists()
     assert Path(request.artifact_spool_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_reuses_existing_workspace_and_checks_out_target_branch(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "mm:task-1" / "repo"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(workspace_root / "mm:task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "mm:task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "startingBranch": "main",
+            "targetBranch": "codex/session-fix",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
+            if command[4:] == ("codex/session-fix",):
+                return 0, "", ""
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    assert all(command[:2] != ("git", "clone") for command in commands)
+    assert commands[0] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "checkout",
+        "codex/session-fix",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -148,6 +148,7 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         },
     )
     commands: list[tuple[str, ...]] = []
+    git_envs: list[dict[str, str] | None] = []
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -156,6 +157,8 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         env: dict[str, str] | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
+        if command[0] == "git":
+            git_envs.append(env)
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
         if command[:2] == ("git", "clone"):
@@ -164,8 +167,10 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
             if command[4:] == ("codex/session-fix",):
                 return 1, "", "error: pathspec 'codex/session-fix' did not match any file(s) known to git"
-            if command[4:] == ("-b", "codex/session-fix"):
+            if command[4:] == ("-B", "codex/session-fix", "origin/codex/session-fix"):
                 return 0, "", ""
+        if command[:4] == ("git", "-C", request.workspace_path, "fetch"):
+            return 0, "", ""
         if command[:2] == ("docker", "run"):
             return 0, "ctr-1\n", ""
         if "ready" in command:
@@ -213,13 +218,116 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         "git",
         "-C",
         request.workspace_path,
+        "fetch",
+        "origin",
+        "codex/session-fix",
+    )
+    assert commands[3] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "checkout",
+        "-B",
+        "codex/session-fix",
+        "origin/codex/session-fix",
+    )
+    assert git_envs == [
+        {"LC_ALL": "C", "LANG": "C"},
+        {"LC_ALL": "C", "LANG": "C"},
+        {"LC_ALL": "C", "LANG": "C"},
+        {"LC_ALL": "C", "LANG": "C"},
+    ]
+    assert Path(request.workspace_path).exists()
+    assert Path(request.session_workspace_path).exists()
+    assert Path(request.artifact_spool_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_creates_target_branch_when_remote_branch_missing(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "mm:task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "mm:task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "mm:task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "startingBranch": "dependabot/pip/requests-2.33.1",
+            "targetBranch": "codex/session-fix",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("git", "clone"):
+            Path(request.workspace_path).mkdir(parents=True, exist_ok=True)
+            return 0, "", ""
+        if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
+            if command[4:] == ("codex/session-fix",):
+                return 1, "", "error: pathspec 'codex/session-fix' did not match any file(s) known to git"
+            if command[4:] == ("-b", "codex/session-fix"):
+                return 0, "", ""
+        if command[:4] == ("git", "-C", request.workspace_path, "fetch"):
+            return 128, "", "fatal: couldn't find remote ref codex/session-fix"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    assert commands[2] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "fetch",
+        "origin",
+        "codex/session-fix",
+    )
+    assert commands[3] == (
+        "git",
+        "-C",
+        request.workspace_path,
         "checkout",
         "-b",
         "codex/session-fix",
     )
-    assert Path(request.workspace_path).exists()
-    assert Path(request.session_workspace_path).exists()
-    assert Path(request.artifact_spool_path).exists()
 
 
 @pytest.mark.asyncio
@@ -255,6 +363,14 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
         commands.append(command)
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
+        if command[:5] == (
+            "git",
+            "-C",
+            request.workspace_path,
+            "rev-parse",
+            "--is-inside-work-tree",
+        ):
+            return 0, "true\n", ""
         if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
             if command[4:] == ("codex/session-fix",):
                 return 0, "", ""
@@ -289,6 +405,109 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
 
     assert all(command[:2] != ("git", "clone") for command in commands)
     assert commands[0] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "rev-parse",
+        "--is-inside-work-tree",
+    )
+    assert commands[1] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "checkout",
+        "codex/session-fix",
+    )
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_reclones_invalid_workspace_before_target_checkout(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_path = workspace_root / "mm:task-1" / "repo"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    stale_file = workspace_path / "stale.txt"
+    stale_file.write_text("stale")
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(workspace_root / "mm:task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "mm:task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "startingBranch": "main",
+            "targetBranch": "codex/session-fix",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:5] == (
+            "git",
+            "-C",
+            request.workspace_path,
+            "rev-parse",
+            "--is-inside-work-tree",
+        ):
+            return 128, "", "fatal: not a git repository"
+        if command[:2] == ("git", "clone"):
+            assert not stale_file.exists()
+            Path(request.workspace_path).mkdir(parents=True, exist_ok=True)
+            return 0, "", ""
+        if command[:4] == ("git", "-C", request.workspace_path, "checkout"):
+            if command[4:] == ("codex/session-fix",):
+                return 0, "", ""
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    assert commands[0] == (
+        "git",
+        "-C",
+        request.workspace_path,
+        "rev-parse",
+        "--is-inside-work-tree",
+    )
+    assert commands[1][:2] == ("git", "clone")
+    assert commands[2] == (
         "git",
         "-C",
         request.workspace_path,


### PR DESCRIPTION
## Summary
Managed Codex task-scoped sessions now honor `workspaceSpec.targetBranch` during workspace setup.

## Root Cause
The managed-session controller cloned the requested `startingBranch`, but it never checked out or created the requested `targetBranch`. As a result, Codex could commit on `main` while the parent workflow later attempted to create a PR from a different head branch, which led to GitHub `422` responses and terminal workflow failures such as `publishMode 'pr' requested but no PR was created`.

## Changes
- add managed-session workspace setup logic to check out `targetBranch` when present
- fall back to `git checkout -b <targetBranch>` when the branch does not yet exist
- apply the same behavior when the workspace already exists and is being reused
- add regression tests for both fresh-clone and existing-workspace managed-session launches

## Validation
- `pytest -q tests/unit/services/temporal/runtime/test_managed_session_controller.py -q`
- restarted `moonmind-temporal-worker-agent-runtime-1` so new managed-session launches pick up the patched controller