### PR TITLE
[codex] Avoid recursive workspace chown on startup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -615,7 +615,7 @@ services:
   agent-workspaces-init:
     image: alpine:3.20
     command: >-
-      sh -lc "mkdir -p /work/agent_jobs && chown -R 1000:1000 /work/agent_jobs && chmod 0775 /work/agent_jobs"
+      sh -lc "for dir in /work/agent_jobs /work/agent_jobs/artifacts /work/agent_jobs/managed_runs /work/agent_jobs/managed_sessions /work/agent_jobs/workspaces; do mkdir -p \"$dir\" && chown 1000:1000 \"$dir\" && chmod 0775 \"$dir\"; done"
     volumes:
       - agent_workspaces:/work/agent_jobs
     restart: "no"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -615,7 +615,7 @@ services:
   agent-workspaces-init:
     image: alpine:3.20
     command: >-
-      sh -lc "for dir in /work/agent_jobs /work/agent_jobs/artifacts /work/agent_jobs/managed_runs /work/agent_jobs/managed_sessions /work/agent_jobs/workspaces; do mkdir -p \"$dir\" && chown 1000:1000 \"$dir\" && chmod 0775 \"$dir\"; done"
+      sh -lc "set -e; for dir in /work/agent_jobs /work/agent_jobs/artifacts /work/agent_jobs/managed_runs /work/agent_jobs/managed_sessions /work/agent_jobs/workspaces; do mkdir -p \"$dir\" && chown 1000:1000 \"$dir\" && chmod 0775 \"$dir\"; done"
     volumes:
       - agent_workspaces:/work/agent_jobs
     restart: "no"

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -36,7 +36,11 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
-_MANAGED_SESSION_CONTAINER_USER = "1000:1000"
+_MANAGED_SESSION_CONTAINER_UID = 1000
+_MANAGED_SESSION_CONTAINER_GID = 1000
+_MANAGED_SESSION_CONTAINER_USER = (
+    f"{_MANAGED_SESSION_CONTAINER_UID}:{_MANAGED_SESSION_CONTAINER_GID}"
+)
 
 
 class CommandRunner(Protocol):
@@ -303,11 +307,17 @@ class DockerCodexManagedSessionController:
         workspace_path = Path(request.workspace_path)
         session_workspace_path = Path(request.session_workspace_path)
         artifact_spool_path = Path(request.artifact_spool_path)
+        created_paths: list[Path] = []
 
-        session_workspace_path.mkdir(parents=True, exist_ok=True)
-        artifact_spool_path.mkdir(parents=True, exist_ok=True)
+        if not session_workspace_path.exists():
+            session_workspace_path.mkdir(parents=True, exist_ok=True)
+            created_paths.append(session_workspace_path)
+        if not artifact_spool_path.exists():
+            artifact_spool_path.mkdir(parents=True, exist_ok=True)
+            created_paths.append(artifact_spool_path)
 
         if workspace_path.exists():
+            self._normalize_container_path_ownership(created_paths)
             return
 
         workspace_path.parent.mkdir(parents=True, exist_ok=True)
@@ -319,6 +329,8 @@ class DockerCodexManagedSessionController:
         ).strip()
         if not repository:
             workspace_path.mkdir(parents=True, exist_ok=True)
+            created_paths.append(workspace_path)
+            self._normalize_container_path_ownership(created_paths)
             return
 
         from .launcher import ManagedRuntimeLauncher
@@ -335,6 +347,33 @@ class DockerCodexManagedSessionController:
             clone_command.extend(["--branch", branch, "--single-branch"])
         clone_command.extend([source, str(workspace_path)])
         await self._run_host_command(clone_command)
+        created_paths.append(workspace_path)
+        self._normalize_container_path_ownership(created_paths)
+
+    @staticmethod
+    def _normalize_container_path_ownership(paths: Sequence[Path]) -> None:
+        geteuid = getattr(os, "geteuid", None)
+        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+            return
+        for path in paths:
+            if not path.exists():
+                continue
+            DockerCodexManagedSessionController._chown_path(path)
+            for root, dirnames, filenames in os.walk(path):
+                root_path = Path(root)
+                for dirname in dirnames:
+                    DockerCodexManagedSessionController._chown_path(root_path / dirname)
+                for filename in filenames:
+                    DockerCodexManagedSessionController._chown_path(root_path / filename)
+
+    @staticmethod
+    def _chown_path(path: Path) -> None:
+        os.chown(
+            path,
+            _MANAGED_SESSION_CONTAINER_UID,
+            _MANAGED_SESSION_CONTAINER_GID,
+            follow_symlinks=False,
+        )
 
     async def _invoke_json(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -36,6 +36,7 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+_MANAGED_SESSION_CONTAINER_USER = "1000:1000"
 
 
 class CommandRunner(Protocol):
@@ -470,6 +471,8 @@ class DockerCodexManagedSessionController:
             "-d",
             "--name",
             container_name,
+            "--user",
+            _MANAGED_SESSION_CONTAINER_USER,
             "--mount",
             self._volume_mount(self._workspace_volume_name, self._workspace_root),
             "--mount",

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -94,7 +94,8 @@ def test_agent_workspaces_init_avoids_recursive_permission_repair():
     ), "agent-workspaces-init service is missing from docker-compose.yaml"
 
     command = init_service.get("command", "")
-    assert "chown -R 1000:1000 /work/agent_jobs" not in command
+    assert "set -e" in command
+    assert "chown -R" not in command
     for expected_dir in (
         "/work/agent_jobs",
         "/work/agent_jobs/artifacts",

--- a/tests/test_local_dev.py
+++ b/tests/test_local_dev.py
@@ -77,3 +77,29 @@ def test_api_service_mounts_agent_runtime_workspace_volume():
     assert (
         found_mount
     ), "api service must mount agent_workspaces at /work/agent_jobs so observability APIs can read managed-run records"
+
+
+def test_agent_workspaces_init_avoids_recursive_permission_repair():
+    """Workspace init should only normalize hot directories, not recurse the whole volume."""
+    compose_path = Path("docker-compose.yaml")
+    assert (
+        compose_path.exists()
+    ), "docker-compose.yaml must exist at the repository root"
+
+    compose_data = yaml.safe_load(compose_path.read_text())
+    services = compose_data.get("services", {})
+    init_service = services.get("agent-workspaces-init")
+    assert isinstance(
+        init_service, dict
+    ), "agent-workspaces-init service is missing from docker-compose.yaml"
+
+    command = init_service.get("command", "")
+    assert "chown -R 1000:1000 /work/agent_jobs" not in command
+    for expected_dir in (
+        "/work/agent_jobs",
+        "/work/agent_jobs/artifacts",
+        "/work/agent_jobs/managed_runs",
+        "/work/agent_jobs/managed_sessions",
+        "/work/agent_jobs/workspaces",
+    ):
+        assert expected_dir in command

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -114,6 +114,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert commands[0] == ("docker", "rm", "-f", "mm-codex-session-sess-1")
     run_command = commands[1]
     assert "--name" in run_command
+    assert "--user" in run_command
+    assert "1000:1000" in run_command
     assert "--mount" in run_command
     assert "-v" not in run_command
     assert request.image_ref in run_command
@@ -1254,6 +1256,8 @@ async def test_controller_launch_uses_mount_syntax_for_colon_scoped_paths(
 
     run_command = commands[1]
     assert "-v" not in run_command
+    assert "--user" in run_command
+    assert "1000:1000" in run_command
     assert "--mount" in run_command
     assert (
         "type=volume,src=codex_auth_volume,"

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -130,7 +130,95 @@ async def test_controller_launches_container_and_returns_typed_handle(
 
 
 @pytest.mark.asyncio
+async def test_controller_launch_normalizes_created_paths_for_container_user(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    commands: list[tuple[str, ...]] = []
+    chown_calls: list[tuple[Path, int, int, bool]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        _fake_chown,
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    chowned_paths = {path for path, _uid, _gid, _follow_symlinks in chown_calls}
+    assert {
+        Path(request.workspace_path),
+        Path(request.session_workspace_path),
+        Path(request.artifact_spool_path),
+    } <= chowned_paths
+    assert all(uid == 1000 and gid == 1000 for _path, uid, gid, _follow in chown_calls)
+    assert all(follow_symlinks is False for _path, _uid, _gid, follow_symlinks in chown_calls)
+    assert commands[1][:2] == ("docker", "run")
+
+
+@pytest.mark.asyncio
 async def test_controller_launch_clones_workspace_before_starting_container(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "agent_jobs"
@@ -149,6 +237,26 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         },
     )
     commands: list[tuple[str, ...]] = []
+    chown_calls: list[tuple[Path, int, int, bool]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        _fake_chown,
+    )
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -161,6 +269,8 @@ async def test_controller_launch_clones_workspace_before_starting_container(
             return 1, "", "No such container"
         if command[:2] == ("git", "clone"):
             Path(request.workspace_path).mkdir(parents=True, exist_ok=True)
+            tracked_file = Path(request.workspace_path) / "README.md"
+            tracked_file.write_text("content", encoding="utf-8")
             return 0, "", ""
         if command[:2] == ("docker", "run"):
             return 0, "ctr-1\n", ""
@@ -201,6 +311,11 @@ async def test_controller_launch_clones_workspace_before_starting_container(
     assert Path(request.workspace_path).exists()
     assert Path(request.session_workspace_path).exists()
     assert Path(request.artifact_spool_path).exists()
+    chowned_paths = {path for path, _uid, _gid, _follow_symlinks in chown_calls}
+    assert Path(request.workspace_path) in chowned_paths
+    assert Path(request.workspace_path, "README.md") in chowned_paths
+    assert Path(request.session_workspace_path) in chowned_paths
+    assert Path(request.artifact_spool_path) in chowned_paths
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This change removes the recursive `chown -R` from the `agent-workspaces-init` startup container so relaunch time no longer scales with the full persisted `agent_workspaces` volume.

It also updates managed Codex session containers to run as `1000:1000`, which keeps newly written workspace content aligned with the worker user instead of relying on a full-volume permission repair on the next compose restart.

## Root Cause
The compose init container was recursively re-owning `/work/agent_jobs` on every startup. On hosts with large persisted managed-run data, that forced Docker to walk a large workspace tree before dependent worker containers could start.

## Changes
- Limit `agent-workspaces-init` to creating and normalizing only the hot top-level workspace directories.
- Launch managed Codex session containers with `--user 1000:1000`.
- Add regression coverage for both the compose init command and the managed-session launch command.

## Validation
- `./tools/test_unit.sh`

## Impact
MoonMind relaunches should no longer pay a multi-minute startup penalty just to repair permissions on historical workspace data. Existing preserved nested root-owned files are no longer auto-repaired on boot, so they may still need a one-time manual cleanup if encountered.