### PR TITLE
Inject GitHub auth into Codex session launch

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -28,7 +28,6 @@ from moonmind.schemas.temporal_activity_models import (
     PlanGenerateInput,
 )
 from moonmind.workflows.tasks.routing import _coerce_bool
-from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 from moonmind.auth.env_shaping import _should_filter_base_env_var
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
@@ -99,6 +98,8 @@ from moonmind.workflows.temporal.manifest_ingest import (
     compile_manifest_plan,
     plan_nodes_to_runtime_nodes,
 )
+from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 
 
 
@@ -2719,6 +2720,26 @@ class TemporalAgentRuntimeActivities:
                 f"{activity_type} returned an invalid session contract payload"
             ) from exc
 
+    @staticmethod
+    async def _shape_launch_session_request(
+        request: LaunchCodexManagedSessionRequest,
+    ) -> LaunchCodexManagedSessionRequest:
+        """Resolve runtime-only auth immediately before remote session launch."""
+
+        environment = dict(request.environment)
+        ambient_github_token = str(os.environ.get("GITHUB_TOKEN", "")).strip()
+        if ambient_github_token and not str(
+            environment.get("GITHUB_TOKEN", "")
+        ).strip():
+            environment["GITHUB_TOKEN"] = ambient_github_token
+        github_token = await ManagedRuntimeLauncher._resolve_github_token_for_launch(
+            environment
+        )
+        if github_token:
+            environment["GITHUB_TOKEN"] = github_token
+            environment.setdefault("GIT_TERMINAL_PROMPT", "0")
+        return request.model_copy(update={"environment": environment})
+
     async def agent_runtime_launch_session(
         self,
         request: Mapping[str, Any] | LaunchCodexManagedSessionRequest | None = None,
@@ -2732,6 +2753,7 @@ class TemporalAgentRuntimeActivities:
             activity_type="agent_runtime.launch_session",
             model_type=LaunchCodexManagedSessionRequest,
         )
+        validated = await self._shape_launch_session_request(validated)
         response = await controller.launch_session(validated)
         return self._validate_session_response(
             response,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -98,7 +98,6 @@ from moonmind.workflows.temporal.manifest_ingest import (
     compile_manifest_plan,
     plan_nodes_to_runtime_nodes,
 )
-from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
     shape_launch_github_auth_environment,
 )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -99,6 +99,9 @@ from moonmind.workflows.temporal.manifest_ingest import (
     plan_nodes_to_runtime_nodes,
 )
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
+from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    shape_launch_github_auth_environment,
+)
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
 
 
@@ -2726,18 +2729,10 @@ class TemporalAgentRuntimeActivities:
     ) -> LaunchCodexManagedSessionRequest:
         """Resolve runtime-only auth immediately before remote session launch."""
 
-        environment = dict(request.environment)
-        ambient_github_token = str(os.environ.get("GITHUB_TOKEN", "")).strip()
-        if ambient_github_token and not str(
-            environment.get("GITHUB_TOKEN", "")
-        ).strip():
-            environment["GITHUB_TOKEN"] = ambient_github_token
-        github_token = await ManagedRuntimeLauncher._resolve_github_token_for_launch(
-            environment
+        environment = await shape_launch_github_auth_environment(
+            request.environment,
+            ambient_github_token=os.environ.get("GITHUB_TOKEN"),
         )
-        if github_token:
-            environment["GITHUB_TOKEN"] = github_token
-            environment.setdefault("GIT_TERMINAL_PROMPT", "0")
         return request.model_copy(update={"environment": environment})
 
     async def agent_runtime_launch_session(
@@ -2754,7 +2749,13 @@ class TemporalAgentRuntimeActivities:
             model_type=LaunchCodexManagedSessionRequest,
         )
         validated = await self._shape_launch_session_request(validated)
-        response = await controller.launch_session(validated)
+        try:
+            response = await controller.launch_session(validated)
+        except Exception as exc:
+            detail = self._sanitize_operator_summary(str(exc)) or "managed session launch failed"
+            raise TemporalActivityRuntimeError(
+                f"agent_runtime.launch_session failed: {detail}"
+            ) from exc
         return self._validate_session_response(
             response,
             activity_type="agent_runtime.launch_session",

--- a/moonmind/workflows/temporal/runtime/launcher.py
+++ b/moonmind/workflows/temporal/runtime/launcher.py
@@ -25,6 +25,7 @@ from moonmind.utils.logging import SecretRedactor
 from .github_auth_broker import GitHubAuthBrokerManager
 from .store import ManagedRunStore
 from .log_streamer import RuntimeLogStreamer
+from .managed_api_key_resolve import resolve_github_token_for_launch
 
 _OWNER_REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 _MANAGED_RUNTIME_ATLASSIAN_ENV_PREFIX_BLOCKLIST: frozenset[str] = frozenset(
@@ -394,44 +395,6 @@ class ManagedRuntimeLauncher:
                 )
 
         return str(repo_path)
-
-    @staticmethod
-    async def _resolve_github_token_for_launch(env: dict[str, str]) -> str | None:
-        token = env.get("GITHUB_TOKEN", "").strip()
-        if token:
-            return token
-
-        from moonmind.config.settings import settings as _mm_settings
-        from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
-            resolve_managed_api_key_reference,
-            resolve_managed_github_token_from_store,
-        )
-
-        secret_ref = str(
-            getattr(_mm_settings.github, "github_token_secret_ref", "") or ""
-        ).strip()
-        if secret_ref:
-            try:
-                return await resolve_managed_api_key_reference(secret_ref)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning(
-                    "Failed to resolve GitHub token secret ref for managed runtime launch",
-                    exc_info=True,
-                )
-
-        try:
-            store_token = await resolve_managed_github_token_from_store()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Failed to resolve GitHub token from managed secrets store",
-                exc_info=True,
-            )
-            return None
-        return store_token
 
     @staticmethod
     def _runtime_requires_direct_github_env(runtime_id: str | None) -> bool:
@@ -829,7 +792,7 @@ class ManagedRuntimeLauncher:
             env_overrides.setdefault("GIT_AUTHOR_EMAIL", _git_email)
             env_overrides.setdefault("GIT_COMMITTER_EMAIL", _git_email)
 
-        github_token = await self._resolve_github_token_for_launch(env_overrides)
+        github_token = await resolve_github_token_for_launch(env_overrides)
         cleanup_paths: list[str] = list(materializer.generated_files)
         cleanup_paths.extend(reversed(materializer.generated_dirs))
         deferred_cleanup_paths: list[str] = []

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 from pathlib import Path
+from typing import Mapping
 
 from sqlalchemy import select
 
@@ -22,6 +25,8 @@ _MANAGED_GITHUB_TOKEN_SLUGS: tuple[str, ...] = (
     "GITHUB_TOKEN",
     "GITHUB_PAT",
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def resolve_managed_github_token_from_store() -> str | None:
@@ -48,6 +53,73 @@ async def resolve_managed_github_token_from_store() -> str | None:
             if candidate:
                 return candidate
     return None
+
+
+async def resolve_github_token_for_launch(
+    environment: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve the GitHub token used for launch-time auth seeding.
+
+    Precedence is:
+    1. Existing ``GITHUB_TOKEN`` already present in the launch environment.
+    2. Explicit ``settings.github.github_token_secret_ref``.
+    3. Managed secret store fallback (well-known GitHub token slugs).
+    """
+
+    launch_environment = environment or {}
+    token = str(launch_environment.get("GITHUB_TOKEN", "")).strip()
+    if token:
+        return token
+
+    from moonmind.config.settings import settings as _mm_settings
+
+    secret_ref = str(
+        getattr(_mm_settings.github, "github_token_secret_ref", "") or ""
+    ).strip()
+    if secret_ref:
+        try:
+            return await resolve_managed_api_key_reference(secret_ref)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Failed to resolve GitHub token secret ref for managed runtime launch",
+                exc_info=True,
+            )
+
+    try:
+        return await resolve_managed_github_token_from_store()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning(
+            "Failed to resolve GitHub token from managed secrets store",
+            exc_info=True,
+        )
+        return None
+
+
+async def shape_launch_github_auth_environment(
+    environment: Mapping[str, str] | None = None,
+    *,
+    ambient_github_token: str | None = None,
+) -> dict[str, str]:
+    """Return launch env with GitHub auth seeded using explicit precedence."""
+
+    shaped_environment = {
+        str(key): str(value) for key, value in (environment or {}).items()
+    }
+    ambient_token = str(ambient_github_token or "").strip()
+
+    if ambient_token and not str(shaped_environment.get("GITHUB_TOKEN", "")).strip():
+        shaped_environment["GITHUB_TOKEN"] = ambient_token
+
+    github_token = await resolve_github_token_for_launch(shaped_environment)
+    if github_token:
+        shaped_environment["GITHUB_TOKEN"] = github_token
+        shaped_environment.setdefault("GIT_TERMINAL_PROMPT", "0")
+
+    return shaped_environment
 
 
 async def resolve_managed_api_key_reference(ref: str) -> str:
@@ -128,6 +200,8 @@ async def resolve_managed_api_key_reference(ref: str) -> str:
 
 
 __all__ = [
+    "resolve_github_token_for_launch",
     "resolve_managed_api_key_reference",
     "resolve_managed_github_token_from_store",
+    "shape_launch_github_auth_environment",
 ]

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -28,6 +28,7 @@ from moonmind.schemas.managed_session_models import (
     SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
 )
+from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 
 from .managed_session_store import ManagedSessionStore
 from .managed_session_supervisor import ManagedSessionSupervisor
@@ -36,6 +37,9 @@ from .managed_session_supervisor import ManagedSessionSupervisor
 _RUNTIME_MODULE = "moonmind.workflows.temporal.runtime.codex_session_runtime"
 _CONTAINER_NAME_SANITIZER = re.compile(r"[^a-zA-Z0-9_.-]+")
 _RESERVED_SESSION_ENV_PREFIX = "MOONMIND_SESSION_"
+_SENSITIVE_ENV_KEY_PATTERN = re.compile(
+    r"(?i)(?:token|secret|password|key|credential|auth)"
+)
 
 
 class CommandRunner(Protocol):
@@ -77,6 +81,10 @@ def _normalize_absolute_posix_path(value: str, *, field_name: str) -> PurePosixP
     if not normalized.is_absolute():
         raise RuntimeError(f"{field_name} must be an absolute path: {value}")
     return normalized
+
+
+def _is_sensitive_env_key(key: str) -> bool:
+    return bool(_SENSITIVE_ENV_KEY_PATTERN.search(key))
 
 
 class DockerCodexManagedSessionController:
@@ -251,6 +259,50 @@ class DockerCodexManagedSessionController:
         self._matches_locator(record, locator)
         return record
 
+    @staticmethod
+    def _command_secrets(
+        command: Sequence[str],
+        *,
+        extra_env: Mapping[str, str] | None = None,
+    ) -> list[str]:
+        secrets: list[str] = []
+
+        def _append_assignment(assignment: str) -> None:
+            if "=" not in assignment:
+                return
+            key, value = assignment.split("=", 1)
+            if _is_sensitive_env_key(key) and value:
+                secrets.append(value)
+
+        for index, part in enumerate(command):
+            if part in {"-e", "--env"} and index + 1 < len(command):
+                _append_assignment(command[index + 1])
+                continue
+            if part.startswith("--env="):
+                _append_assignment(part[len("--env="):])
+
+        for key, value in (extra_env or {}).items():
+            if _is_sensitive_env_key(str(key)) and value:
+                secrets.append(str(value))
+
+        return secrets
+
+    @classmethod
+    def _scrub_command_failure(
+        cls,
+        command: Sequence[str],
+        detail: str,
+        *,
+        extra_env: Mapping[str, str] | None = None,
+    ) -> tuple[str, str]:
+        redactor = SecretRedactor.from_environ(
+            placeholder="[REDACTED]",
+            extra_secrets=cls._command_secrets(command, extra_env=extra_env),
+        )
+        rendered_command = scrub_github_tokens(redactor.scrub(" ".join(command)))
+        rendered_detail = scrub_github_tokens(redactor.scrub(detail))
+        return rendered_command, rendered_detail
+
     async def _remove_container(
         self,
         container_identifier: str,
@@ -279,8 +331,13 @@ class DockerCodexManagedSessionController:
             env=env,
         )
         if returncode != 0:
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                command,
+                stderr.strip() or stdout.strip(),
+                extra_env=extra_env,
+            )
             raise RuntimeError(
-                f"{' '.join(command)} failed with exit code {returncode}: {stderr.strip() or stdout.strip()}"
+                f"{rendered_command} failed with exit code {returncode}: {rendered_detail}"
             )
         return stdout, stderr
 
@@ -290,8 +347,12 @@ class DockerCodexManagedSessionController:
     ) -> tuple[str, str]:
         returncode, stdout, stderr = await self._command_runner(tuple(command))
         if returncode != 0:
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                command,
+                stderr.strip() or stdout.strip(),
+            )
             raise RuntimeError(
-                f"{' '.join(command)} failed with exit code {returncode}: {stderr.strip() or stdout.strip()}"
+                f"{rendered_command} failed with exit code {returncode}: {rendered_detail}"
             )
         return stdout, stderr
 

--- a/tests/unit/services/temporal/runtime/test_launcher.py
+++ b/tests/unit/services/temporal/runtime/test_launcher.py
@@ -199,7 +199,7 @@ async def test_launch_injects_secret_passthrough_env_keys(tmp_path, monkeypatch)
         return None
 
     monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._resolve_github_token_for_launch",
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
         _fake_resolve,
     )
 
@@ -255,7 +255,7 @@ async def test_launch_registers_generated_support_dir_for_cleanup(tmp_path, monk
         return None
 
     monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._resolve_github_token_for_launch",
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
         _fake_resolve,
     )
 
@@ -338,7 +338,7 @@ async def test_launch_builds_codex_command_after_workspace_preparation(
         return None
 
     monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._resolve_github_token_for_launch",
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
         _fake_resolve,
     )
 
@@ -404,7 +404,7 @@ async def test_launch_resets_stale_live_log_spool(tmp_path, monkeypatch):
         return None
 
     monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.launcher.ManagedRuntimeLauncher._resolve_github_token_for_launch",
+        "moonmind.workflows.temporal.runtime.launcher.resolve_github_token_for_launch",
         _fake_resolve,
     )
 
@@ -1485,45 +1485,6 @@ async def test_launch_keeps_direct_github_env_for_codex_cli_managed_runs(
 
 
 @pytest.mark.asyncio
-async def test_resolve_github_token_for_launch_propagates_cancellation_from_secret_ref(
-    monkeypatch,
-):
-    from moonmind.config.settings import settings as app_settings
-
-    async def _fake_resolve(_secret_name: str) -> str:
-        raise asyncio.CancelledError()
-
-    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", "db://github-pat")
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
-        _fake_resolve,
-    )
-
-    with pytest.raises(asyncio.CancelledError):
-        await ManagedRuntimeLauncher._resolve_github_token_for_launch({})
-
-
-@pytest.mark.asyncio
-async def test_resolve_github_token_for_launch_propagates_cancellation_from_store(
-    monkeypatch,
-):
-    from moonmind.config.settings import settings as app_settings
-
-    async def _fake_store_token() -> str:
-        raise asyncio.CancelledError()
-
-    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
-        _fake_store_token,
-    )
-
-    with pytest.raises(asyncio.CancelledError):
-        await ManagedRuntimeLauncher._resolve_github_token_for_launch({})
-
-
 @pytest.mark.asyncio
 async def test_launch_privilege_drop_for_claude_code_as_root(tmp_path, monkeypatch):
     """When launched as root for claude_code runtime, the process should:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -202,6 +202,55 @@ async def test_controller_launch_clones_workspace_before_starting_container(
 
 
 @pytest.mark.asyncio
+async def test_controller_launch_redacts_github_token_from_command_failures(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"GITHUB_TOKEN": "ghp_inline_secret_token_12345678901234567890"},
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return (
+                1,
+                "",
+                "docker run rejected GITHUB_TOKEN=ghp_inline_secret_token_12345678901234567890",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await controller.launch_session(request)
+
+    message = str(exc_info.value)
+    assert "ghp_inline_secret_token_12345678901234567890" not in message
+    assert "[REDACTED]" in message
+
+
+@pytest.mark.asyncio
 async def test_controller_send_turn_executes_inside_container(tmp_path: Path) -> None:
     commands: list[tuple[str, ...]] = []
 

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_github_token_for_launch,
     resolve_managed_api_key_reference,
     resolve_managed_github_token_from_store,
+    shape_launch_github_auth_environment,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -118,3 +121,86 @@ async def test_resolve_managed_github_token_from_store_stops_after_lookup_failur
 
     assert session_maker.calls == 1
     assert session.seen_slugs == ["GITHUB_TOKEN"]
+
+
+async def test_resolve_github_token_for_launch_prefers_existing_environment_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings as app_settings
+
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", "db://unused")
+
+    async def _unexpected_resolve(_secret_ref: str) -> str:
+        raise AssertionError("secret ref lookup should not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
+        _unexpected_resolve,
+    )
+
+    out = await resolve_github_token_for_launch({"GITHUB_TOKEN": "ghp-inline-token"})
+
+    assert out == "ghp-inline-token"
+
+
+async def test_shape_launch_github_auth_environment_uses_ambient_token_before_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings as app_settings
+
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
+
+    async def _unexpected_store() -> str:
+        raise AssertionError("managed store lookup should not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _unexpected_store,
+    )
+
+    shaped = await shape_launch_github_auth_environment(
+        {"PATH": "/usr/bin"},
+        ambient_github_token="ghp-ambient-token",
+    )
+
+    assert shaped["PATH"] == "/usr/bin"
+    assert shaped["GITHUB_TOKEN"] == "ghp-ambient-token"
+    assert shaped["GIT_TERMINAL_PROMPT"] == "0"
+
+
+async def test_resolve_github_token_for_launch_propagates_cancellation_from_secret_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings as app_settings
+
+    async def _fake_resolve(_secret_name: str) -> str:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", "db://github-pat")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_api_key_reference",
+        _fake_resolve,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await resolve_github_token_for_launch({})
+
+
+async def test_resolve_github_token_for_launch_propagates_cancellation_from_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings as app_settings
+
+    async def _fake_store_token() -> str:
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _fake_store_token,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await resolve_github_token_for_launch({})

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -362,6 +362,92 @@ async def test_launch_session_delegates_to_remote_session_controller() -> None:
     controller.launch_session.assert_awaited_once()
 
 
+async def test_launch_session_injects_github_token_from_activity_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp-ambient-token")
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    await activities.agent_runtime_launch_session(
+        {
+            "taskRunId": "task-1",
+            "sessionId": "sess-1",
+            "threadId": "thread-1",
+            "workspacePath": "/work/task/repo",
+            "sessionWorkspacePath": "/work/task/session",
+            "artifactSpoolPath": "/work/task/artifacts",
+            "codexHomePath": "/work/task/codex-home",
+            "imageRef": "moonmind:latest",
+            "environment": {"PATH": "/usr/bin"},
+        }
+    )
+
+    launched_request = controller.launch_session.await_args.args[0]
+    assert launched_request.environment["PATH"] == "/usr/bin"
+    assert launched_request.environment["GITHUB_TOKEN"] == "ghp-ambient-token"
+    assert launched_request.environment["GIT_TERMINAL_PROMPT"] == "0"
+
+
+async def test_launch_session_injects_github_token_from_managed_secret_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from moonmind.config.settings import settings as app_settings
+
+    async def _fake_store_token() -> str:
+        return "ghp-managed-secret"
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(app_settings.github, "github_token_secret_ref", None)
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _fake_store_token,
+    )
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    await activities.agent_runtime_launch_session(
+        {
+            "taskRunId": "task-1",
+            "sessionId": "sess-1",
+            "threadId": "thread-1",
+            "workspacePath": "/work/task/repo",
+            "sessionWorkspacePath": "/work/task/session",
+            "artifactSpoolPath": "/work/task/artifacts",
+            "codexHomePath": "/work/task/codex-home",
+            "imageRef": "moonmind:latest",
+        }
+    )
+
+    launched_request = controller.launch_session.await_args.args[0]
+    assert launched_request.environment["GITHUB_TOKEN"] == "ghp-managed-secret"
+    assert launched_request.environment["GIT_TERMINAL_PROMPT"] == "0"
+
+
 async def test_load_session_snapshot_queries_session_workflow_via_client_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1212,12 +1298,19 @@ class AgentRuntimeSendTurnBoundaryTest:
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_launch_session_temporal_boundary() -> None:
+async def test_agent_runtime_launch_session_temporal_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from temporalio import activity
 
-    controller = AsyncMock()
-    controller.launch_session = AsyncMock(
-        return_value=CodexManagedSessionHandle(
+    monkeypatch.setenv("GITHUB_TOKEN", "ghs-boundary-token")
+    captured_request: dict[str, Any] = {}
+
+    async def _capture_launch_session(
+        request: Any,
+    ) -> CodexManagedSessionHandle:
+        captured_request["request"] = request
+        return CodexManagedSessionHandle(
             sessionState={
                 "sessionId": "sess-boundary",
                 "sessionEpoch": 1,
@@ -1227,7 +1320,9 @@ async def test_agent_runtime_launch_session_temporal_boundary() -> None:
             status="ready",
             imageRef="moonmind:latest",
         )
-    )
+
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(side_effect=_capture_launch_session)
     activities_impl = TemporalAgentRuntimeActivities(session_controller=controller)
 
     @activity.defn(name="agent_runtime.launch_session")
@@ -1262,6 +1357,9 @@ async def test_agent_runtime_launch_session_temporal_boundary() -> None:
 
             assert isinstance(result, CodexManagedSessionHandle)
             assert result.session_state.container_id == "ctr-boundary"
+            launch_request = captured_request["request"]
+            assert launch_request.environment["GITHUB_TOKEN"] == "ghs-boundary-token"
+            assert launch_request.environment["GIT_TERMINAL_PROMPT"] == "0"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -29,6 +29,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionSnapshot,
     CodexManagedSessionSummary,
     CodexManagedSessionTurnResponse,
+    LaunchCodexManagedSessionRequest,
 )
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal import client as temporal_client_module
@@ -446,6 +447,38 @@ async def test_launch_session_injects_github_token_from_managed_secret_store(
     launched_request = controller.launch_session.await_args.args[0]
     assert launched_request.environment["GITHUB_TOKEN"] == "ghp-managed-secret"
     assert launched_request.environment["GIT_TERMINAL_PROMPT"] == "0"
+
+
+async def test_launch_session_redacts_github_token_in_failure_details() -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        side_effect=RuntimeError(
+            "docker run -e GITHUB_TOKEN=ghp_inline_secret_token_12345678901234567890 failed"
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="agent_runtime\\.launch_session failed:",
+    ) as exc_info:
+        await activities.agent_runtime_launch_session(
+            {
+                "taskRunId": "task-1",
+                "sessionId": "sess-1",
+                "threadId": "thread-1",
+                "workspacePath": "/work/task/repo",
+                "sessionWorkspacePath": "/work/task/session",
+                "artifactSpoolPath": "/work/task/artifacts",
+                "codexHomePath": "/work/task/codex-home",
+                "imageRef": "moonmind:latest",
+                "environment": {"PATH": "/usr/bin"},
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "ghp_inline_secret_token_12345678901234567890" not in message
+    assert "[REDACTED]" in message
 
 
 async def test_load_session_snapshot_queries_session_workflow_via_client_boundary(
@@ -1307,7 +1340,7 @@ async def test_agent_runtime_launch_session_temporal_boundary(
     captured_request: dict[str, Any] = {}
 
     async def _capture_launch_session(
-        request: Any,
+        request: LaunchCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
         captured_request["request"] = request
         return CodexManagedSessionHandle(


### PR DESCRIPTION
## Summary
- resolve GitHub auth for Codex managed-session launches at the activity boundary
- seed ambient `GITHUB_TOKEN` before reusing the shared managed-runtime token resolver
- inject `GIT_TERMINAL_PROMPT=0` and add activity plus Temporal boundary coverage for the session launch path

## Testing
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_agent_runtime_activities.py`
- `./tools/test_unit.sh`