### PR TITLE
Implement Live Logs Phase 3 history filtering

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -792,7 +792,7 @@ def _filter_observability_events(
     filtered: list[dict[str, object]] = []
     for event in events:
         sequence = _coerce_sequence(event.get("sequence"))
-        if since is not None and sequence is not None and sequence <= since:
+        if since is not None and sequence is not None and sequence > 0 and sequence <= since:
             continue
         stream = str(event.get("stream") or "").strip()
         if streams and stream not in streams:
@@ -1059,7 +1059,7 @@ async def get_task_run_observability_events(
     events.sort(key=_event_sort_key)
     truncated = len(events) > limit
     if truncated:
-        events = events[-limit:]
+        events = events[:limit]
 
     return {
         "events": events,

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
@@ -781,6 +782,28 @@ def _load_task_run_observability_events(
     return events
 
 
+def _filter_observability_events(
+    events: list[dict[str, object]],
+    *,
+    since: int | None = None,
+    streams: set[str] | None = None,
+    kinds: set[str] | None = None,
+) -> list[dict[str, object]]:
+    filtered: list[dict[str, object]] = []
+    for event in events:
+        sequence = _coerce_sequence(event.get("sequence"))
+        if since is not None and sequence is not None and sequence <= since:
+            continue
+        stream = str(event.get("stream") or "").strip()
+        if streams and stream not in streams:
+            continue
+        kind = str(event.get("kind") or "").strip()
+        if kinds and kind not in kinds:
+            continue
+        filtered.append(event)
+    return filtered
+
+
 def _event_sort_key(payload: dict[str, object]) -> tuple[datetime, int]:
     sequence = _coerce_sequence(payload.get("sequence"))
     timestamp = _coerce_utc_datetime(payload.get("timestamp")) or datetime.min.replace(tzinfo=UTC)
@@ -1003,7 +1026,10 @@ async def control_task_run_artifact_session(
 )
 async def get_task_run_observability_events(
     id: UUID,
+    since: int | None = Query(default=None, ge=0),
     limit: int = Query(default=500, ge=1, le=5000),
+    stream: list[Literal["stdout", "stderr", "system", "session"]] | None = Query(default=None),
+    kind: list[str] | None = Query(default=None),
     _user: User = Depends(get_current_user()),
 ) -> dict:
     """Return structured observability history for one task run."""
@@ -1023,6 +1049,12 @@ async def get_task_run_observability_events(
         session_record=session_record,
         limit=limit,
     )
+    events = _filter_observability_events(
+        events,
+        since=since,
+        streams=set(stream or []),
+        kinds={item for item in (kind or []) if item},
+    )
 
     events.sort(key=_event_sort_key)
     truncated = len(events) > limit
@@ -1032,7 +1064,8 @@ async def get_task_run_observability_events(
     return {
         "events": events,
         "truncated": truncated,
-        "sessionSnapshot": _build_session_snapshot(session_record),
+        "sessionSnapshot": _build_session_snapshot(session_record)
+        or _build_record_session_snapshot(record),
     }
 
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8474,7 +8474,10 @@ export interface operations {
     get_task_run_observability_events_api_task_runs__id__observability_events_get: {
         parameters: {
             query?: {
+                since?: number | null;
                 limit?: number;
+                stream?: ("stdout" | "stderr" | "system" | "session")[] | null;
+                kind?: string[] | null;
             };
             header?: never;
             path: {

--- a/specs/141-live-logs-history-events/checklists/requirements.md
+++ b/specs/141-live-logs-history-events/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Live Logs History Events
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-08  
+**Feature**: [spec.md](/mnt/d/code/MoonMind/specs/141-live-logs-history-events/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Phase 3 is intentionally scoped to backend observability surfaces and compatibility behavior; frontend timeline rendering remains Phase 4 work.

--- a/specs/141-live-logs-history-events/checklists/requirements.md
+++ b/specs/141-live-logs-history-events/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning  
 **Created**: 2026-04-08  
-**Feature**: [spec.md](/mnt/d/code/MoonMind/specs/141-live-logs-history-events/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/141-live-logs-history-events/contracts/observability-history-contract.md
+++ b/specs/141-live-logs-history-events/contracts/observability-history-contract.md
@@ -1,0 +1,56 @@
+# Contract: Observability History Contract
+
+## Goal
+
+Define the Phase 3 task-run observability history contract without changing the existing route family.
+
+## Route
+
+`GET /api/task-runs/{id}/observability/events`
+
+## Query Parameters
+
+| Parameter | Type | Required | Meaning |
+| --- | --- | --- | --- |
+| `since` | integer | no | Return only rows with `sequence > since` |
+| `limit` | integer | no | Maximum number of rows returned |
+| `stream` | repeated string | no | Restrict rows to the requested canonical streams |
+| `kind` | repeated string | no | Restrict rows to the requested canonical event kinds |
+
+## Response
+
+```json
+{
+  "events": [
+    {
+      "runId": "run-1",
+      "sequence": 12,
+      "timestamp": "2026-04-08T00:00:12Z",
+      "stream": "session",
+      "text": "Epoch boundary reached.",
+      "kind": "session_reset_boundary",
+      "sessionId": "sess:wf-task-1:codex_cli",
+      "sessionEpoch": 2,
+      "threadId": "thread-2"
+    }
+  ],
+  "truncated": false,
+  "sessionSnapshot": {
+    "sessionId": "sess:wf-task-1:codex_cli",
+    "sessionEpoch": 2,
+    "containerId": "ctr-1",
+    "threadId": "thread-2",
+    "activeTurnId": null
+  }
+}
+```
+
+## Fallback Rules
+
+Historical loading priority:
+
+1. `observability.events.jsonl`
+2. spool-backed event history
+3. artifact-backed synthesis
+
+`/logs/merged` remains outside this route and continues to serve as the human-readable fallback surface for consumers that cannot use structured history.

--- a/specs/141-live-logs-history-events/data-model.md
+++ b/specs/141-live-logs-history-events/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: Live Logs History Events
+
+## Historical Observability Query
+
+Phase 3 hardens the existing historical retrieval surface:
+
+- `task_run_id`
+- `since`: optional sequence floor for historical event retrieval
+- `limit`: bounded response size
+- `stream`: optional repeated filter across `stdout`, `stderr`, `system`, `session`
+- `kind`: optional repeated filter across canonical observability event kinds
+
+Filtering semantics:
+
+- `since` excludes rows with `sequence <= since`
+- `stream` matches only rows whose canonical `stream` is in the requested set
+- `kind` matches only rows whose canonical `kind` is in the requested set
+- when both `stream` and `kind` are present, a row must satisfy both filters
+
+## Historical Response Envelope
+
+The response remains a simple envelope:
+
+- `events`: list of canonical `RunObservabilityEvent` rows
+- `truncated`: whether the response was trimmed to the requested limit
+- `sessionSnapshot`: latest known bounded session identity when available
+
+## Session Snapshot Precedence
+
+For summary and historical responses:
+
+1. prefer the managed-session record snapshot when available
+2. otherwise use the durable session fields persisted on `ManagedRunRecord`
+3. otherwise omit the session snapshot
+
+This preserves truthful session context for completed or partially migrated runs without depending on live container state.
+
+## Historical Source Priority
+
+Historical retrieval remains additive and deterministic:
+
+1. durable `observability.events.jsonl`
+2. live spool history when the durable journal is absent
+3. artifact-backed synthesis from diagnostics/stdout/stderr and continuity artifacts
+
+Only one source tier should win for a given request.
+
+## SSE Compatibility
+
+`/logs/stream` continues to serialize `RunObservabilityEvent` rows with the same field names and optional session metadata used by historical retrieval. Phase 3 does not introduce a second live-only event schema.

--- a/specs/141-live-logs-history-events/plan.md
+++ b/specs/141-live-logs-history-events/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: live-logs-history-events
+
+**Branch**: `141-live-logs-history-events` | **Date**: 2026-04-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/141-live-logs-history-events/spec.md`
+
+## Summary
+
+Implement the Phase 3 structured-history slice by hardening the existing task-run observability APIs instead of inventing a new surface. The work will extend `/api/task-runs/{id}/observability/events` with the missing query contract (`since`, `limit`, stream filters, kind filters), keep `/logs/stream` on the canonical `RunObservabilityEvent` payload shape, and ensure `/observability-summary` returns a truthful session snapshot and live-stream status for both active and completed runs. The existing merged-log endpoint remains the human-readable fallback path.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript consumer unchanged for this slice  
+**Primary Dependencies**: FastAPI task-runs router, `ManagedRunStore`, `ManagedSessionStore`, `RunObservabilityEvent`, `SpoolLogReader`, task-detail Live Logs consumer expectations  
+**Storage**: file-backed managed-run/session JSON records plus artifact-backed `observability.events.jsonl` history and existing stdout/stderr/diagnostics artifacts  
+**Testing**: pytest unit tests via `./tools/test_unit.sh`  
+**Target Platform**: Docker/Compose-hosted MoonMind API and worker services  
+**Project Type**: backend observability API contract hardening  
+**Performance Goals**: bounded filtered history reads for up to the route limit without regressing current artifact-first fallback behavior  
+**Constraints**: keep the existing route path, keep `/logs/merged` stable, preserve shared run authorization, do not add a second observability event model, do not require frontend phase-4 rendering changes  
+**Scale/Scope**: Phase 3 only; no new frontend timeline renderer work and no session-plane producer changes beyond verifying SSE contract compatibility
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The work strengthens MoonMind-owned observability surfaces rather than exposing provider-native history payloads.
+- **II. One-Click Agent Deployment**: PASS. No new infrastructure or dependency is added; this stays within the current API/store/artifact stack.
+- **III. Avoid Vendor Lock-In**: PASS. The route contract stays on `RunObservabilityEvent`, which remains runtime-neutral.
+- **IV. Own Your Data**: PASS. Historical timeline loading continues to prefer MoonMind-owned durable journals and artifact-backed fallbacks.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No agent-skill runtime or resolution behavior changes are introduced.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. This slice is contract hardening on top of existing APIs, not a new parallel observability mechanism.
+- **VII. Powerful Runtime Configurability**: PASS. Existing live-log transport and timeline rollout flags remain unchanged.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay inside the task-runs observability router and its helper functions.
+- **IX. Resilient by Default**: PASS. Structured history continues to degrade through spool and artifact-backed fallbacks for older runs.
+- **XI. Spec-Driven Development**: PASS. Phase 3 is isolated in its own spec/plan/tasks slice before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs remain declarative; only spec artifacts describe this implementation slice.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The route hardening reuses the existing canonical event model and removes ad hoc retrieval assumptions directly.
+
+## Research
+
+- See [research.md](./research.md) for the decisions that keep Phase 3 additive and aligned with the shipped Phase 1/2 backend.
+- The current code already exposes `/observability/events`, `/observability-summary`, and `/logs/stream`, so the gap is contract completeness, not route existence.
+- Mission Control already requests `/observability/events` before `/logs/merged`, which means backend correctness on filtering, fallback, and summary truthfulness is the main blocker for this slice.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/141-live-logs-history-events/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── observability-history-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/
+    └── routers/
+        └── task_runs.py
+
+moonmind/
+├── observability/
+│   └── transport.py
+└── schemas/
+    └── agent_runtime_models.py
+
+tests/
+└── unit/
+    └── api/
+        └── routers/
+            └── test_task_runs.py
+```
+
+**Structure Decision**: This slice is intentionally router-centric. The canonical event model already exists in `moonmind/schemas/agent_runtime_models.py`, and the current consumer contract already flows through [`task_runs.py`](../../api_service/api/routers/task_runs.py). The implementation should only touch lower layers if a router helper cannot express the required filtering or normalization cleanly.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the historical query parameters, response envelope, session snapshot precedence, and fallback ordering semantics.
+
+## Contracts
+
+- [contracts/observability-history-contract.md](./contracts/observability-history-contract.md)
+
+## Implementation Plan
+
+1. Add failing router tests for the missing Phase 3 contract:
+   - `/observability/events` supports `since`, `limit`, stream filters, and kind filters,
+   - durable event journals remain the preferred source,
+   - summary returns a truthful session snapshot and live-stream status,
+   - `/logs/stream` remains compatible with `RunObservabilityEvent`.
+2. Extend the task-runs observability helpers so historical loading can filter by sequence, stream, and kind after the canonical event normalization step.
+3. Keep the durable-source priority explicit: event journal first, spool second, artifact synthesis last.
+4. Tighten summary shaping so record-backed and session-backed session snapshots remain truthful for active and completed runs.
+5. Verify the SSE route still serializes the canonical event contract and does not drift from the historical schema.
+6. Run focused router tests, Spec Kit scope validation, and the full unit suite, then mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
+2. `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+3. `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+4. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Request `/api/task-runs/{id}/observability/events` with and without `since`, stream, and kind filters and confirm the response shape stays on the canonical event contract.
+2. Request `/api/task-runs/{id}/observability-summary` for an active run, a completed run, and a run with only record-backed session fields; confirm the session snapshot and live-stream status are truthful.
+3. Open the task detail page for an active run and confirm Live Logs still loads history first, then attaches `/logs/stream` without a schema mismatch.

--- a/specs/141-live-logs-history-events/quickstart.md
+++ b/specs/141-live-logs-history-events/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Live Logs History Events
+
+## Focused verification
+
+Run the Phase 3 router test slice:
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py
+```
+
+Run the Spec Kit scope checks:
+
+```bash
+./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+## Expected behavior
+
+1. `/api/task-runs/{id}/observability/events` returns canonical structured history and supports `since`, `limit`, stream filters, and kind filters.
+2. Historical retrieval prefers the durable observability journal and degrades through spool or artifact-backed synthesis when necessary.
+3. `/api/task-runs/{id}/observability-summary` exposes the latest available session snapshot and truthful live-stream status.
+4. `/api/task-runs/{id}/logs/stream` continues to emit canonical `RunObservabilityEvent` payloads compatible with the historical route.

--- a/specs/141-live-logs-history-events/research.md
+++ b/specs/141-live-logs-history-events/research.md
@@ -1,0 +1,29 @@
+# Research: Live Logs History Events
+
+## Decision 1: Reuse the existing `/observability/events` route instead of adding a new endpoint
+
+- **Decision**: Keep the existing task-run historical route and extend its query contract rather than introducing a second Phase 3-only endpoint.
+- **Rationale**: The router already has the correct path and the frontend already consumes it. Phase 3 is contract completion, not route proliferation.
+- **Alternatives considered**:
+  - Add a new history endpoint and leave the current route frozen. Rejected because it would create avoidable compatibility and rollout churn immediately before Phase 4.
+
+## Decision 2: Filter after canonical event normalization
+
+- **Decision**: Apply `since`, stream, and kind filters after the route has normalized durable journal, spool, or artifact-backed rows into the canonical `RunObservabilityEvent` shape.
+- **Rationale**: This keeps filtering consistent across all history sources and avoids source-specific query behavior.
+- **Alternatives considered**:
+  - Filter journal rows, spool rows, and artifact synthesis independently before normalization. Rejected because each source would need duplicate logic and would drift more easily.
+
+## Decision 3: Keep durable-source priority explicit and additive
+
+- **Decision**: Historical loading continues to prefer `observability.events.jsonl`, then spool history, then artifact-backed synthesis.
+- **Rationale**: The event journal is the authoritative structured source from Phase 1, while spool and artifact synthesis are compatibility fallbacks for older or partial runs.
+- **Alternatives considered**:
+  - Merge journal and spool rows together. Rejected because it risks duplicate or out-of-order historical playback.
+
+## Decision 4: Treat summary and SSE as compatibility surfaces on the same event model
+
+- **Decision**: Keep `/observability-summary` and `/logs/stream` on the existing routes, but verify and harden them against the same canonical event/session snapshot contract used by historical retrieval.
+- **Rationale**: Operators need one coherent mental model across summary, history, and live follow. The routes already exist; the missing work is truthfulness and parity.
+- **Alternatives considered**:
+  - Defer summary and SSE validation entirely to Phase 4. Rejected because Phase 3 explicitly calls for tests covering all three backend surfaces together.

--- a/specs/141-live-logs-history-events/spec.md
+++ b/specs/141-live-logs-history-events/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Live Logs History Events
+
+**Feature Branch**: `141-live-logs-history-events`  
+**Created**: 2026-04-08  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 3 using test-driven development from the Live Logs plan. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query durable observability history for the timeline (Priority: P1)
+
+MoonMind operators and the Live Logs viewer need a structured historical timeline endpoint that can load durable session-aware observability rows for completed and active runs without depending on live SSE.
+
+**Why this priority**: Phase 3 exists so the UI can load a truthful timeline from durable history first. Without a real historical query contract, the session-aware timeline still depends on transient live transport.
+
+**Independent Test**: Request structured observability history for one run with mixed stdout, stderr, system, and session rows, then verify the API returns correctly filtered, limited, ordered rows from durable history or the documented fallback sources.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed run has a persisted observability event journal, **When** the client requests historical events, **Then** MoonMind returns session-aware timeline rows from that durable history instead of requiring live transport.
+2. **Given** the client supplies `since`, `limit`, stream filters, or kind filters, **When** MoonMind loads historical observability events, **Then** the response includes only the matching rows in the shared run timeline order.
+3. **Given** a historical run does not yet have a structured observability journal, **When** the client requests historical events, **Then** MoonMind degrades through the existing spool and artifact-backed history sources without fabricating missing session facts.
+
+---
+
+### User Story 2 - Keep summary and live streaming aligned with the same observability contract (Priority: P1)
+
+Operators need `/observability-summary` and `/logs/stream` to stay aligned with the same session-aware observability model so the panel header and live follow path remain truthful while historical loading moves to structured events first.
+
+**Why this priority**: The historical endpoint is not sufficient if summary and SSE still drift from the session-aware contract or misreport live capability for ended and non-stream-capable runs.
+
+**Independent Test**: Load observability summary for active and completed runs, then attach to live SSE for an active run and verify both surfaces use the same normalized event/session fields and truthful live-stream status.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed run record or session projection contains the latest bounded session identity, **When** `/observability-summary` is fetched, **Then** the response includes the latest session snapshot fields needed by the timeline header.
+2. **Given** a run is terminal or does not support live follow, **When** `/observability-summary` is fetched, **Then** the response truthfully reports that live streaming is ended or unavailable rather than implying that SSE is still authoritative.
+3. **Given** `/logs/stream` emits live rows for an active run, **When** the browser receives those rows, **Then** the payload shape matches the canonical observability event contract used by historical retrieval.
+
+---
+
+### User Story 3 - Preserve compatibility and fallback ordering across observability surfaces (Priority: P2)
+
+Current Mission Control consumers need the structured history endpoint to land without breaking the existing merged-log fallback, task-run authorization model, or durable continuity drill-down behavior for older runs.
+
+**Why this priority**: Phase 3 is an additive backend upgrade. It must not strand historical runs or force a frontend cutover before the session-aware timeline renderer is fully complete.
+
+**Independent Test**: Exercise summary, structured history, merged logs, and authorization behavior together for runs with and without event journals and verify the API follows the documented fallback order.
+
+**Acceptance Scenarios**:
+
+1. **Given** the client can read structured history for a run, **When** historical content is available from `/observability/events`, **Then** the UI does not need to parse merged text as the primary timeline source.
+2. **Given** structured history is missing or partial, **When** the client falls back to `/logs/merged` and continuity drill-down, **Then** the run remains observable without breaking existing merged-tail behavior.
+3. **Given** the requesting user already has access to the task run, **When** they request summary, structured history, or merged logs, **Then** MoonMind authorizes those surfaces consistently for the same run.
+
+### Edge Cases
+
+- A run has a durable event journal plus a newer live spool file; historical requests must prefer the durable journal rather than mixing sources out of order.
+- `since` is provided for a run with sparse or non-contiguous sequence numbers; the API must filter correctly without assuming continuous numbering.
+- Stream and kind filters are combined in one request; only rows matching all provided filters should be returned.
+- A run has only merged stdout/stderr artifacts and no structured journal or continuity projection; the API must degrade cleanly instead of returning fabricated session events.
+- A run has record-backed session snapshot fields but no managed-session store record; summary must still expose the latest bounded session identity from the durable run record.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST provide a structured historical observability endpoint at `/api/task-runs/{id}/observability/events` for managed runs.
+- **FR-002**: The structured historical observability endpoint MUST support `since` and `limit` query parameters.
+- **FR-003**: The structured historical observability endpoint MUST support optional filtering by stream and by event kind.
+- **FR-004**: Historical observability retrieval MUST prefer durable structured event history when available and otherwise degrade through existing spool or artifact-backed sources without breaking current run observability.
+- **FR-005**: `/observability-summary` MUST include the latest session snapshot fields when present from durable session or run metadata.
+- **FR-006**: `/observability-summary` MUST report live-stream capability truthfully for active, ended, and non-stream-capable runs.
+- **FR-007**: `/logs/stream` MUST continue to emit the same canonical observability event shape used by structured historical retrieval.
+- **FR-008**: `/logs/merged` MUST remain available as a human-readable fallback surface during the Phase 3 rollout.
+- **FR-009**: Summary, structured history, merged logs, and live streaming MUST continue to enforce the same task-run observability authorization rules.
+- **FR-010**: The Phase 3 slice MUST include production runtime code changes plus automated validation tests covering summary, structured history, and SSE compatibility together.
+
+### Key Entities *(include if feature involves data)*
+
+- **Historical Observability Query**: A task-run-scoped request for structured timeline rows with pagination and optional stream/kind filters.
+- **Session Snapshot**: The latest bounded session identity attached to observability summary and historical retrieval responses.
+- **Canonical Observability Event**: The normalized event row shared by historical retrieval and live SSE payloads across stdout, stderr, system, and session streams.
+- **Fallback Order**: The documented retrieval priority of structured history first, merged log fallback second, and continuity drill-down when historical session facts are unavailable.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated tests verify `/observability/events` returns correctly ordered historical rows from durable event history and supports `since`, `limit`, stream filters, and kind filters.
+- **SC-002**: Automated tests verify `/observability/events` degrades through current spool or artifact-backed fallback behavior when no event journal is present.
+- **SC-003**: Automated tests verify `/observability-summary` exposes the latest session snapshot and truthful live-stream status for active and completed runs.
+- **SC-004**: Automated tests verify `/logs/stream` remains compatible with the canonical observability event contract used by historical retrieval.

--- a/specs/141-live-logs-history-events/tasks.md
+++ b/specs/141-live-logs-history-events/tasks.md
@@ -1,0 +1,113 @@
+# Tasks: Live Logs History Events
+
+**Input**: Design documents from `/specs/141-live-logs-history-events/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: This feature is explicitly TDD-driven. Write or update failing tests before the corresponding implementation tasks.
+
+**Organization**: Tasks are grouped by user story so each slice can be implemented and validated independently.
+
+## Phase 1: Setup (Shared Test Baseline)
+
+**Purpose**: Establish failing tests for the missing Phase 3 observability-history contract before router code is updated.
+
+- [X] T001 Add failing history-query coverage for `since`, `limit`, stream filters, kind filters, and durable-source preference in `tests/unit/api/routers/test_task_runs.py`
+- [X] T002 Add failing summary and SSE-compatibility coverage for session snapshot truthfulness and canonical event serialization in `tests/unit/api/routers/test_task_runs.py`
+
+---
+
+## Phase 2: Foundational (Blocking Router Helpers)
+
+**Purpose**: Add the shared filtering and response-shaping helpers that every Phase 3 story depends on.
+
+**⚠️ CRITICAL**: User-story implementation should not begin until these shared router helpers are complete.
+
+- [X] T003 Implement reusable historical-event filtering and limiting helpers in `api_service/api/routers/task_runs.py`
+
+**Checkpoint**: The router has one shared helper layer for filtered historical event retrieval.
+
+---
+
+## Phase 3: User Story 1 - Query durable observability history for the timeline (Priority: P1)
+
+**Goal**: Make `/observability/events` a complete structured-history contract instead of a fixed unfiltered dump.
+
+**Independent Test**: Request historical events with mixed streams and kinds and confirm the API honors `since`, `limit`, and the optional filters while preserving durable-source priority.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Implement `since`, stream, and kind query handling for `/api/task-runs/{id}/observability/events` in `api_service/api/routers/task_runs.py`
+- [X] T005 [US1] Preserve explicit event-journal -> spool -> artifact fallback ordering in `api_service/api/routers/task_runs.py`
+
+**Checkpoint**: Historical timeline consumers can request bounded, filtered, canonical event history.
+
+---
+
+## Phase 4: User Story 2 - Keep summary and live streaming aligned with the same observability contract (Priority: P1)
+
+**Goal**: Keep summary and SSE truthful and compatible with the historical event contract.
+
+**Independent Test**: Load summary for active and completed runs and confirm `/logs/stream` still serializes canonical event rows without a schema mismatch.
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Implement session snapshot precedence and truthful live-stream status shaping in `api_service/api/routers/task_runs.py`
+- [X] T007 [US2] Preserve canonical `RunObservabilityEvent` serialization for `/api/task-runs/{id}/logs/stream` in `api_service/api/routers/task_runs.py`
+
+**Checkpoint**: Summary and live follow remain consistent with the structured-history contract.
+
+---
+
+## Phase 5: User Story 3 - Preserve compatibility and fallback ordering across observability surfaces (Priority: P2)
+
+**Goal**: Keep current merged fallback and authorization behavior stable while the structured-history contract becomes the preferred source.
+
+**Independent Test**: Exercise summary, structured history, and merged fallback together for runs with and without durable event journals and confirm access control remains consistent.
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] Extend compatibility and fallback coverage for `/observability/events`, `/observability-summary`, and `/logs/merged` in `tests/unit/api/routers/test_task_runs.py`
+
+**Checkpoint**: Older runs still degrade cleanly and authorized consumers retain the same observability access.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verify the feature end to end and close the execution loop.
+
+- [X] T009 Run focused Phase 3 verification in `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
+- [X] T010 Run runtime scope validation in `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime` and `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+- [X] T011 Run full regression verification in `./tools/test_unit.sh`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on the failing tests from Phase 1.
+- **User Story 1 (Phase 3)**: Depends on Phase 2.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and can land after the shared filtering helpers are in place.
+- **User Story 3 (Phase 5)**: Depends on Phase 3 and Phase 4 because it validates the combined compatibility behavior.
+- **Polish (Phase 6)**: Depends on all implementation phases completing.
+
+### Parallel Opportunities
+
+- `T001` and `T002` can be staged together as one TDD pass before implementation begins.
+- `T004` and `T006` can be developed in sequence on the same router file but validated independently by story.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add the failing router tests for historical query behavior, summary truthfulness, and SSE compatibility.
+2. Land the shared filtering helper.
+3. Complete User Story 1 so historical retrieval is a real structured contract.
+4. Complete User Story 2 so summary and SSE remain aligned with that contract.
+5. Validate compatibility behavior for User Story 3, then run the required verification gates.
+
+### Notes
+
+- Keep `/observability/events` as the canonical historical route.
+- Keep `/logs/merged` stable as the human-readable fallback surface.
+- Do not add a second observability event model or a Phase 3-only route family.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -20,6 +20,7 @@ from api_service.auth_providers import get_current_user
 from api_service.api.routers.worker_auth import _require_worker_auth, _WorkerRequestAuth
 from api_service.db import models as db_models
 from api_service.db.models import User
+from moonmind.schemas.agent_runtime_models import RunObservabilityEvent
 from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
 
 
@@ -865,6 +866,67 @@ def test_get_task_run_observability_events_reads_structured_spool_history(
     assert "session_id" not in body["events"][1]
 
 
+def test_get_task_run_observability_events_filters_spool_fallback_rows(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+    (workspace_path / "live_streams.spool").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "sequence": 1,
+                        "stream": "stdout",
+                        "text": "stdout line\n",
+                        "timestamp": "2026-04-08T00:00:00Z",
+                        "kind": "stdout_chunk",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "sequence": 2,
+                        "stream": "session",
+                        "text": "boundary\n",
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "kind": "session_reset_boundary",
+                        "session_id": "sess:wf-task-1:codex_cli",
+                        "session_epoch": 2,
+                        "thread_id": "thread-2",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "sequence": 3,
+                        "stream": "system",
+                        "text": "annotation\n",
+                        "timestamp": "2026-04-08T00:00:02Z",
+                        "kind": "system_annotation",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(workspace_path)
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(
+            f"/api/task-runs/{uuid4()}/observability/events?since=1&stream=session&kind=session_reset_boundary"
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [event["sequence"] for event in body["events"]] == [2]
+    assert body["events"][0]["stream"] == "session"
+    assert body["events"][0]["kind"] == "session_reset_boundary"
+
+
 def test_get_task_run_observability_events_prefers_persisted_event_artifact(
     client: tuple[TestClient, AsyncMock],
     tmp_path,
@@ -940,6 +1002,184 @@ def test_get_task_run_observability_events_prefers_persisted_event_artifact(
     assert body["events"][1]["sessionId"] == "sess-1"
     assert body["events"][1]["sessionEpoch"] == 2
     assert "run_id" not in body["events"][0]
+
+
+def test_get_task_run_observability_events_applies_since_stream_and_kind_filters(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 4,
+                        "stream": "stdout",
+                        "text": "older stdout\n",
+                        "timestamp": "2026-04-08T00:00:00Z",
+                        "kind": "stdout_chunk",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 6,
+                        "stream": "session",
+                        "text": "boundary\n",
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "kind": "session_reset_boundary",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 7,
+                        "stream": "session",
+                        "text": "summary\n",
+                        "timestamp": "2026-04-08T00:00:02Z",
+                        "kind": "summary_published",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 8,
+                        "stream": "session",
+                        "text": "session started\n",
+                        "timestamp": "2026-04-08T00:00:03Z",
+                        "kind": "session_started",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(
+                f"/api/task-runs/{uuid4()}/observability/events?since=5&stream=session&kind=session_reset_boundary&kind=summary_published&limit=5"
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [event["sequence"] for event in body["events"]] == [6, 7]
+    assert {event["kind"] for event in body["events"]} == {
+        "session_reset_boundary",
+        "summary_published",
+    }
+    assert all(event["stream"] == "session" for event in body["events"])
+
+
+def test_get_task_run_observability_events_uses_record_snapshot_when_session_record_missing(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        json.dumps(
+            {
+                "runId": "run-1",
+                "sequence": 5,
+                "stream": "session",
+                "text": "summary\n",
+                "timestamp": "2026-04-08T00:00:00Z",
+                "kind": "summary_published",
+                "sessionId": "sess-1",
+                "sessionEpoch": 3,
+                "threadId": "thread-3",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+    mock_record.session_id = "sess-1"
+    mock_record.session_epoch = 3
+    mock_record.container_id = "ctr-1"
+    mock_record.thread_id = "thread-3"
+    mock_record.active_turn_id = "turn-9"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_task_run_session_record",
+                return_value=None,
+            ):
+                response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sessionSnapshot"]["sessionId"] == "sess-1"
+    assert body["sessionSnapshot"]["sessionEpoch"] == 3
+    assert body["sessionSnapshot"]["containerId"] == "ctr-1"
+    assert body["sessionSnapshot"]["threadId"] == "thread-3"
+    assert body["sessionSnapshot"]["activeTurnId"] == "turn-9"
+
+
+def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    mock_record = MagicMock()
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.workspace_path = "/tmp/workspace"
+
+    async def _follow(*args, **kwargs):
+        yield RunObservabilityEvent(
+            runId="run-1",
+            sequence=11,
+            stream="session",
+            text="boundary\n",
+            timestamp="2026-04-08T00:00:01Z",
+            kind="session_reset_boundary",
+            sessionId="sess-1",
+            sessionEpoch=2,
+            containerId="ctr-1",
+            threadId="thread-2",
+            activeTurnId="turn-3",
+        )
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch("api_service.api.routers.task_runs.SpoolLogReader.follow", new=_follow):
+            response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stream?since=10")
+
+    assert response.status_code == 200
+    assert '"sessionId":"sess-1"' in response.text
+    assert '"activeTurnId":"turn-3"' in response.text
+    assert '"session_id"' not in response.text
 
 
 def test_load_task_run_session_record_uses_targeted_standard_paths(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1091,6 +1091,88 @@ def test_get_task_run_observability_events_applies_since_stream_and_kind_filters
     assert all(event["stream"] == "session" for event in body["events"])
 
 
+def test_get_task_run_observability_events_limits_to_oldest_matching_rows_after_since(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": sequence,
+                        "stream": "stdout",
+                        "text": f"event-{sequence}\n",
+                        "timestamp": f"2026-04-08T00:00:0{sequence - 5}Z",
+                        "kind": "stdout_chunk",
+                    }
+                )
+                for sequence in (6, 7, 8, 9)
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(
+                f"/api/task-runs/{uuid4()}/observability/events?since=5&limit=2"
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["truncated"] is True
+    assert [event["sequence"] for event in body["events"]] == [6, 7]
+
+
+def test_get_task_run_observability_events_keeps_artifact_fallback_rows_when_since_is_present(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "stdout.log").write_text("artifact stdout\n", encoding="utf-8")
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = None
+    mock_record.diagnostics_ref = None
+    mock_record.stdout_artifact_ref = "run-1/stdout.log"
+    mock_record.stderr_artifact_ref = None
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(
+                f"/api/task-runs/{uuid4()}/observability/events?since=5"
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [event["kind"] for event in body["events"]] == ["stdout_chunk"]
+    assert body["events"][0]["sequence"] == 0
+    assert body["events"][0]["text"] == "artifact stdout\n"
+
+
 def test_get_task_run_observability_events_uses_record_snapshot_when_session_record_missing(
     client: tuple[TestClient, AsyncMock],
     tmp_path,


### PR DESCRIPTION
## Summary
- add the Phase 3 Spec Kit artifact set for `141-live-logs-history-events`
- extend `/api/task-runs/{id}/observability/events` with `since`, stream, and kind filtering while preserving journal -> spool -> artifact fallback order
- preserve record-backed session snapshots in structured history responses and lock `/logs/stream` to canonical event alias serialization with router tests

## Remediation outcomes
- no critical spec/plan/tasks gaps remained after the artifact pass, so no extra remediation cycle was needed before implementation
- implementation stayed inside the existing task-runs observability router rather than introducing a second history route or event model

## Verification
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_task_runs.py`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh`

## Notes
- the worktree still contains an unrelated pre-existing edit to `docs/ManagedAgents/DockerOutOfDocker.md`; it was intentionally left out of this branch commit