### PR TITLE
[codex] Implement step ledger phase 4 task detail UI

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -205,6 +205,17 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "artifactPresignDownload": temporal_dashboard.artifact_presign_download_endpoint,
                 "artifactDownload": temporal_dashboard.artifact_download_endpoint,
             },
+            "taskRuns": {
+                "observabilitySummary": "/api/task-runs/{taskRunId}/observability-summary",
+                "observabilityEvents": "/api/task-runs/{taskRunId}/observability/events",
+                "logsStream": "/api/task-runs/{taskRunId}/logs/stream",
+                "logsStdout": "/api/task-runs/{taskRunId}/logs/stdout",
+                "logsStderr": "/api/task-runs/{taskRunId}/logs/stderr",
+                "logsMerged": "/api/task-runs/{taskRunId}/logs/merged",
+                "diagnostics": "/api/task-runs/{taskRunId}/diagnostics",
+                "artifactSession": "/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}",
+                "artifactSessionControl": "/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}/control",
+            },
 
         },
         "features": {

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
-import { getSessionProjectionRefetchInterval, TaskDetailPage } from './task-detail';
+import { expandRouteTemplate, getSessionProjectionRefetchInterval, TaskDetailPage } from './task-detail';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
@@ -204,6 +204,20 @@ describe('Task Detail Entrypoint', () => {
     window.history.pushState({}, 'Test', '/tasks/test-123?source=temporal');
     fetchSpy = vi.spyOn(window, 'fetch');
     fetchSpy.mockClear();
+  });
+
+  it('returns null for route templates with missing parameters', () => {
+    expect(
+      expandRouteTemplate('/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}', {
+        taskRunId: 'task-run-1',
+        sessionId: null,
+      }),
+    ).toBeNull();
+    expect(
+      expandRouteTemplate('/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}', {
+        taskRunId: 'task-run-1',
+      }),
+    ).toBeNull();
   });
 
   it('renders a Steps section above Timeline and Artifacts and loads steps before execution-wide artifacts', async () => {

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -76,12 +76,387 @@ describe('Task Detail Entrypoint', () => {
     page: 'task-detail',
     apiBase: '/api',
   };
+  const stepsPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        pollIntervalsMs: { detail: 1 },
+        sources: {
+          taskRuns: {
+            observabilitySummary: '/api/task-runs/{taskRunId}/observability-summary',
+            logsStream: '/api/task-runs/{taskRunId}/logs/stream',
+            logsStdout: '/api/task-runs/{taskRunId}/logs/stdout',
+            logsStderr: '/api/task-runs/{taskRunId}/logs/stderr',
+            logsMerged: '/api/task-runs/{taskRunId}/logs/merged',
+            diagnostics: '/api/task-runs/{taskRunId}/diagnostics',
+            artifactSession: '/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}',
+            artifactSessionControl: '/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}/control',
+          },
+        },
+      },
+    },
+  };
+
+  const latestStepsSnapshot = {
+    workflowId: 'test-123',
+    runId: '02-run',
+    runScope: 'latest',
+    steps: [
+      {
+        logicalStepId: 'plan',
+        order: 1,
+        title: 'Plan work',
+        tool: { type: 'skill', name: 'plan.generate', version: '1' },
+        dependsOn: [],
+        status: 'succeeded',
+        waitingReason: null,
+        attentionRequired: false,
+        attempt: 1,
+        startedAt: '2026-04-09T00:00:01Z',
+        updatedAt: '2026-04-09T00:00:02Z',
+        summary: 'Plan complete',
+        checks: [],
+        refs: { childWorkflowId: null, childRunId: null, taskRunId: null },
+        artifacts: {
+          outputSummary: 'art-step-plan',
+          outputPrimary: null,
+          runtimeStdout: null,
+          runtimeStderr: null,
+          runtimeMergedLogs: null,
+          runtimeDiagnostics: null,
+          providerSnapshot: null,
+        },
+        lastError: null,
+      },
+      {
+        logicalStepId: 'apply',
+        order: 2,
+        title: 'Apply patch',
+        tool: { type: 'agent_runtime', name: 'codex_cli', version: '1' },
+        dependsOn: ['plan'],
+        status: 'running',
+        waitingReason: null,
+        attentionRequired: false,
+        attempt: 1,
+        startedAt: '2026-04-09T00:00:03Z',
+        updatedAt: '2026-04-09T00:00:04Z',
+        summary: 'Applying repository changes',
+        checks: [
+          {
+            kind: 'approval_policy',
+            status: 'passed',
+            summary: 'Auto-approved',
+            retryCount: 0,
+            artifactRef: null,
+          },
+        ],
+        refs: {
+          childWorkflowId: 'child-wf-1',
+          childRunId: 'child-run-1',
+          taskRunId: 'task-run-step-1',
+        },
+        artifacts: {
+          outputSummary: 'art-step-summary',
+          outputPrimary: 'art-step-output',
+          runtimeStdout: null,
+          runtimeStderr: null,
+          runtimeMergedLogs: null,
+          runtimeDiagnostics: 'art-step-diagnostics',
+          providerSnapshot: null,
+        },
+        lastError: null,
+      },
+      {
+        logicalStepId: 'verify',
+        order: 3,
+        title: 'Verify tests',
+        tool: { type: 'skill', name: 'repo.run_tests', version: '1' },
+        dependsOn: ['apply'],
+        status: 'ready',
+        waitingReason: null,
+        attentionRequired: false,
+        attempt: 0,
+        startedAt: null,
+        updatedAt: '2026-04-09T00:00:04Z',
+        summary: 'Ready to start',
+        checks: [],
+        refs: { childWorkflowId: null, childRunId: null, taskRunId: null },
+        artifacts: {
+          outputSummary: null,
+          outputPrimary: null,
+          runtimeStdout: null,
+          runtimeStderr: null,
+          runtimeMergedLogs: null,
+          runtimeDiagnostics: null,
+          providerSnapshot: null,
+        },
+        lastError: null,
+      },
+    ],
+  };
 
   let fetchSpy: MockInstance;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     window.history.pushState({}, 'Test', '/tasks/test-123?source=temporal');
     fetchSpy = vi.spyOn(window, 'fetch');
+    fetchSpy.mockClear();
+  });
+
+  it('renders a Steps section above Timeline and Artifacts and loads steps before execution-wide artifacts', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Step detail task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+      expect(screen.getByText('Plan work')).toBeTruthy();
+      expect(screen.getByText('Apply patch')).toBeTruthy();
+      expect(screen.getByText('Verify tests')).toBeTruthy();
+      expect(screen.getByText('Latest run')).toBeTruthy();
+      expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
+    });
+
+    const stepsHeading = screen.getByRole('heading', { name: 'Steps' });
+    const timelineHeading = screen.getByRole('heading', { name: 'Timeline' });
+    const artifactsHeading = screen.getByRole('heading', { name: 'Artifacts' });
+
+    const positions: [number, number] = [
+      stepsHeading.compareDocumentPosition(timelineHeading),
+      timelineHeading.compareDocumentPosition(artifactsHeading),
+    ];
+    expect(positions[0] & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(positions[1] & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await waitFor(() => {
+      const urls = fetchSpy.mock.calls.map(([input]) => String(input));
+      const detailIndex = urls.findIndex((url) => url.includes('/api/executions/test-123?source=temporal'));
+      const stepsIndex = urls.findIndex((url) => url.includes('/api/executions/test-123/steps'));
+      const artifactsIndex = urls.findIndex((url) => url.includes('/artifacts'));
+      expect(detailIndex).toBeGreaterThanOrEqual(0);
+      expect(stepsIndex).toBeGreaterThan(detailIndex);
+      expect(artifactsIndex).toBeGreaterThan(stepsIndex);
+    });
+  });
+
+  it('expands a bound step into grouped step details and lazily attaches row-scoped observability', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Step detail task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({ ok: true, json: async () => latestStepsSnapshot } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-09T00:00:05Z',
+                stream: 'stdout',
+                text: 'step scoped log line\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => 'step scoped log line\n' } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
+    ).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand step Apply patch' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('heading', { name: 'Summary' }).length).toBeGreaterThan(0);
+      expect(screen.getByRole('heading', { name: 'Checks' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Logs & Diagnostics' })).toBeTruthy();
+      expect(screen.getAllByRole('heading', { name: 'Artifacts' }).length).toBeGreaterThan(0);
+      expect(screen.getByRole('heading', { name: 'Metadata' })).toBeTruthy();
+      expect(screen.getByText('Auto-approved')).toBeTruthy();
+      expect(screen.getByText('art-step-summary')).toBeTruthy();
+      expect(screen.getByText('child-wf-1')).toBeTruthy();
+      expect(screen.getByText('step scoped log line')).toBeTruthy();
+    });
+
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
+    ).toBe(true);
+  });
+
+  it('keeps unbound rows free of task-run requests and upgrades expanded rows when taskRunId arrives later', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Delayed binding task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+    let stepCalls = 0;
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        stepCalls += 1;
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            stepCalls === 1
+              ? {
+                  ...latestStepsSnapshot,
+                  steps: latestStepsSnapshot.steps.map((step) =>
+                    step.logicalStepId === 'apply'
+                      ? {
+                          ...step,
+                          refs: {
+                            ...step.refs,
+                            taskRunId: null,
+                          },
+                        }
+                      : step,
+                  ),
+                }
+              : latestStepsSnapshot,
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/observability/events')) {
+        return Promise.resolve({ ok: false, status: 404 } as Response);
+      }
+      if (url.includes('/task-runs/task-run-step-1/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => 'attached after refresh\n' } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand step Apply patch' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/waiting for managed runtime launch to create live logs/i)).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('attached after refresh')).toBeTruthy();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
+    ).toBe(true);
   });
 
   it('renders loading state initially', () => {

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -365,7 +365,7 @@ describe('Task Detail Entrypoint', () => {
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
     ).toBe(false);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(screen.getAllByRole('heading', { name: 'Summary' }).length).toBeGreaterThan(0);
@@ -461,12 +461,11 @@ describe('Task Detail Entrypoint', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
     });
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
+    ).toBe(false);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/waiting for managed runtime launch to create live logs/i)).toBeTruthy();
-    });
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(screen.getByText('attached after refresh')).toBeTruthy();
@@ -538,7 +537,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(
@@ -676,7 +675,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(screen.getByText(/live log streaming is disabled in the server dashboard config/i)).toBeTruthy();

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -85,6 +85,7 @@ describe('Task Detail Entrypoint', () => {
         sources: {
           taskRuns: {
             observabilitySummary: '/api/task-runs/{taskRunId}/observability-summary',
+            observabilityEvents: '/api/task-runs/{taskRunId}/observability/events',
             logsStream: '/api/task-runs/{taskRunId}/logs/stream',
             logsStdout: '/api/task-runs/{taskRunId}/logs/stdout',
             logsStderr: '/api/task-runs/{taskRunId}/logs/stderr',
@@ -350,7 +351,7 @@ describe('Task Detail Entrypoint', () => {
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
     ).toBe(false);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand step Apply patch' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(screen.getAllByRole('heading', { name: 'Summary' }).length).toBeGreaterThan(0);
@@ -362,7 +363,9 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByText('art-step-summary')).toBeTruthy();
       expect(screen.getByText('child-wf-1')).toBeTruthy();
       expect(screen.getByText('step scoped log line')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Hide details for Apply patch' })).toBeTruthy();
     });
+    expect(screen.getAllByText('approval policy: passed')[0]?.className).toContain('check-passed');
 
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
@@ -445,7 +448,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand step Apply patch' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
 
     await waitFor(() => {
       expect(screen.getByText(/waiting for managed runtime launch to create live logs/i)).toBeTruthy();
@@ -457,6 +460,216 @@ describe('Task Detail Entrypoint', () => {
     expect(
       fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
     ).toBe(true);
+  });
+
+  it('resolves step-level task-run routes against apiBase', async () => {
+    const apiBasePayload: BootPayload = {
+      ...stepsPayload,
+      apiBase: '/tenant/api',
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/tenant/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Task behind apiBase',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/tenant/api/executions/test-123/steps')) {
+        return Promise.resolve({ ok: true, json: async () => latestStepsSnapshot } as Response);
+      }
+      if (url.includes('/tenant/api/task-runs/task-run-step-1/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/tenant/api/task-runs/task-run-step-1/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events: [], truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/tenant/api/task-runs/task-run-step-1/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => '' } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={apiBasePayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) =>
+          String(url).includes('/tenant/api/task-runs/task-run-step-1/observability-summary'),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it('shows the execution Observation fallback when the steps endpoint fails', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      taskRunId: 'task-run-root',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Fallback observation task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({ ok: false, status: 403, statusText: '' } as Response);
+      }
+      if (url.includes('/task-runs/task-run-root/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'unavailable',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-root/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-09T00:00:05Z',
+                stream: 'stdout',
+                text: 'root observation log\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/task-runs/task-run-root/logs/merged')) {
+        return Promise.resolve({ ok: true, text: async () => 'root observation log\n' } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Steps: 403 (/api/executions/test-123/steps)')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Observation' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-root/observability-summary')),
+      ).toBe(true);
+    });
+  });
+
+  it('does not attach step-level observability when log streaming is disabled', async () => {
+    const logStreamingDisabledPayload: BootPayload = {
+      ...stepsPayload,
+      initialData: {
+        dashboardConfig: {
+          ...((stepsPayload.initialData as { dashboardConfig: unknown }).dashboardConfig as Record<string, unknown>),
+          features: {
+            logStreamingEnabled: false,
+          },
+        },
+      },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Streaming disabled task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({ ok: true, json: async () => latestStepsSnapshot } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={logStreamingDisabledPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details for Apply patch' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/live log streaming is disabled in the server dashboard config/i)).toBeTruthy();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/task-runs/task-run-step-1/observability-summary')),
+    ).toBe(false);
   });
 
   it('renders loading state initially', () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -449,13 +449,41 @@ function expandRouteTemplate(
   }, template);
 }
 
+function joinApiBasePath(apiBase: string, path: string): string {
+  const base = apiBase.replace(/\/+$/g, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+function resolveApiBaseTemplate(apiBase: string, expandedTemplate: string): string {
+  const template = expandedTemplate.trim();
+  if (!template) return template;
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(template)) return template;
+
+  const normalizedApiBase = apiBase.replace(/\/+$/g, '');
+  if (!normalizedApiBase) return template;
+  if (template.startsWith(normalizedApiBase)) return template;
+
+  if (template === '/api') {
+    return normalizedApiBase;
+  }
+  if (template.startsWith('/api/')) {
+    return joinApiBasePath(normalizedApiBase, template.slice('/api'.length));
+  }
+  return joinApiBasePath(normalizedApiBase, template);
+}
+
 function taskRunRoute(
   apiBase: string,
   template: string | null | undefined,
   fallback: string,
   params: Record<string, string | null | undefined>,
 ): string {
-  return expandRouteTemplate(template, params) ?? `${apiBase}${fallback}`;
+  const expandedTemplate = expandRouteTemplate(template, params);
+  if (expandedTemplate) {
+    return resolveApiBaseTemplate(apiBase, expandedTemplate);
+  }
+  return joinApiBasePath(apiBase, fallback);
 }
 
 function formatWhen(iso: string | null | undefined): string {
@@ -769,7 +797,9 @@ async function fetchObservabilityEvents(
 async function fetchStepLedger(stepsHref: string): Promise<z.infer<typeof StepLedgerSnapshotSchema>> {
   const resp = await fetch(stepsHref, { credentials: 'include' });
   if (!resp.ok) {
-    throw new Error(`Steps: ${resp.statusText}`);
+    const statusText = resp.statusText.trim();
+    const detail = statusText ? ` ${statusText}` : '';
+    throw new Error(`Steps: ${resp.status}${detail} (${stepsHref})`);
   }
   return StepLedgerSnapshotSchema.parse(await resp.json());
 }
@@ -949,9 +979,19 @@ function stepTerminal(status: string | null | undefined): boolean {
     || normalized === 'skipped';
 }
 
+function stepCheckStatusClass(status: string | null | undefined): string {
+  const normalized = String(status || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return `check-${normalized || 'unknown'}`;
+}
+
 function StepCheckBadge({ check }: { check: z.infer<typeof StepLedgerCheckSchema> }) {
+  const checkStatusClass = stepCheckStatusClass(check.status);
   return (
-    <span className={`step-check-badge ${executionStatusPillClasses(check.status)}`}>
+    <span className={`step-check-badge ${checkStatusClass} ${executionStatusPillClasses(check.status)}`}>
       {check.kind.replaceAll('_', ' ')}: {check.status.replaceAll('_', ' ')}
     </span>
   );
@@ -1012,13 +1052,21 @@ function StepMetadataList({
 
 function StepObservabilityGroup({
   apiBase,
+  logStreamingEnabled,
   row,
   routes,
 }: {
   apiBase: string;
+  logStreamingEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   routes: TaskRunRouteTemplates;
 }) {
+  if (!logStreamingEnabled) {
+    return (
+      <p className="small">Live log streaming is disabled in the server dashboard config.</p>
+    );
+  }
+
   const taskRunId = row.refs.taskRunId;
   if (!taskRunId) {
     return (
@@ -1064,6 +1112,7 @@ function StepObservabilityGroup({
 
 function StepLedgerRowCard({
   apiBase,
+  logStreamingEnabled,
   row,
   runId,
   expanded,
@@ -1071,6 +1120,7 @@ function StepLedgerRowCard({
   routes,
 }: {
   apiBase: string;
+  logStreamingEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   runId: string;
   expanded: boolean;
@@ -1088,7 +1138,7 @@ function StepLedgerRowCard({
             className="step-row-toggle"
             onClick={onToggle}
             aria-expanded={expanded}
-            aria-label={`Expand step ${row.title}`}
+            aria-label={expanded ? `Hide details for ${row.title}` : `Show details for ${row.title}`}
           >
             {expanded ? 'Hide details' : 'Show details'}
           </button>
@@ -1140,7 +1190,12 @@ function StepLedgerRowCard({
           </section>
           <section className="stack">
             <h4>Logs & Diagnostics</h4>
-            <StepObservabilityGroup apiBase={apiBase} row={row} routes={routes} />
+            <StepObservabilityGroup
+              apiBase={apiBase}
+              logStreamingEnabled={logStreamingEnabled}
+              row={row}
+              routes={routes}
+            />
           </section>
           <section className="stack">
             <h4>Artifacts</h4>
@@ -2214,7 +2269,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
         execution.prerequisites.length > 0 ||
         execution.dependents.length > 0),
   );
-  const shouldShowSteps = Boolean(execution?.stepsHref);
+  const hasStepsEndpoint = Boolean(execution?.stepsHref);
+  const showExecutionObservationFallback =
+    !hasStepsEndpoint || (!stepsQuery.isLoading && (stepsQuery.isError || !stepsQuery.data));
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['task-detail', encodedTaskId] });
@@ -2537,7 +2594,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             </section>
           ) : null}
 
-          {shouldShowSteps ? (
+          {hasStepsEndpoint ? (
             <section className="stack">
               <div className="step-ledger-header">
                 <div>
@@ -2562,6 +2619,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                     <StepLedgerRowCard
                       key={row.logicalStepId}
                       apiBase={payload.apiBase}
+                      logStreamingEnabled={logStreamingEnabled}
                       row={row}
                       runId={stepsQuery.data?.runId || runId}
                       expanded={Boolean(expandedSteps[row.logicalStepId])}
@@ -2811,7 +2869,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             )}
           </section>
 
-          {!shouldShowSteps ? (
+          {showExecutionObservationFallback ? (
             <section className="stack">
               <div>
                 <h3>Observation</h3>

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -439,14 +439,19 @@ function decodeTaskPathSegment(segment: string | null | undefined): string | nul
   }
 }
 
-function expandRouteTemplate(
+export function expandRouteTemplate(
   template: string | null | undefined,
   params: Record<string, string | null | undefined>,
 ): string | null {
   if (!template) return null;
-  return Object.entries(params).reduce((path, [key, value]) => {
-    return path.replaceAll(`{${key}}`, encodeURIComponent(value ?? ''));
-  }, template);
+  let path = template;
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    path = path.replaceAll(`{${key}}`, encodeURIComponent(value));
+  }
+  return path.includes('{') && path.includes('}') ? null : path;
 }
 
 function joinApiBasePath(apiBase: string, path: string): string {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -17,6 +17,7 @@ type DashboardConfig = {
   };
   sources?: {
     temporal?: Record<string, string>;
+    taskRuns?: Record<string, string>;
   };
 };
 
@@ -130,6 +131,7 @@ const ExecutionDetailSchema = z
     closedAt: z.string().nullable().optional(),
     taskRunId: z.string().nullable().optional(),
     task_run_id: z.string().nullable().optional(),
+    stepsHref: z.string().nullable().optional(),
     debugFields: z
       .object({
         workflowId: z.string().optional(),
@@ -305,6 +307,84 @@ const ArtifactListSchema = z.object({
     .default([]),
 });
 
+const StepLedgerToolSchema = z
+  .object({
+    type: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    version: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const StepLedgerCheckSchema = z
+  .object({
+    kind: z.string(),
+    status: z.string(),
+    summary: z.string().nullable().optional(),
+    retryCount: z.number().default(0),
+    artifactRef: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const StepLedgerRefsSchema = z
+  .object({
+    childWorkflowId: z.string().nullable().optional(),
+    childRunId: z.string().nullable().optional(),
+    taskRunId: z.string().nullable().optional(),
+  })
+  .default({
+    childWorkflowId: null,
+    childRunId: null,
+    taskRunId: null,
+  });
+
+const StepLedgerArtifactsSchema = z
+  .object({
+    outputSummary: z.string().nullable().optional(),
+    outputPrimary: z.string().nullable().optional(),
+    runtimeStdout: z.string().nullable().optional(),
+    runtimeStderr: z.string().nullable().optional(),
+    runtimeMergedLogs: z.string().nullable().optional(),
+    runtimeDiagnostics: z.string().nullable().optional(),
+    providerSnapshot: z.string().nullable().optional(),
+  })
+  .default({
+    outputSummary: null,
+    outputPrimary: null,
+    runtimeStdout: null,
+    runtimeStderr: null,
+    runtimeMergedLogs: null,
+    runtimeDiagnostics: null,
+    providerSnapshot: null,
+  });
+
+const StepLedgerRowSchema = z
+  .object({
+    logicalStepId: z.string(),
+    order: z.number(),
+    title: z.string(),
+    tool: StepLedgerToolSchema.default({}),
+    dependsOn: z.array(z.string()).default([]),
+    status: z.string(),
+    waitingReason: z.string().nullable().optional(),
+    attentionRequired: z.boolean().optional(),
+    attempt: z.number().default(0),
+    startedAt: z.string().nullable().optional(),
+    updatedAt: z.string().nullable().optional(),
+    summary: z.string().nullable().optional(),
+    checks: z.array(StepLedgerCheckSchema).default([]),
+    refs: StepLedgerRefsSchema,
+    artifacts: StepLedgerArtifactsSchema,
+    lastError: z.unknown().nullable().optional(),
+  })
+  .passthrough();
+
+const StepLedgerSnapshotSchema = z.object({
+  workflowId: z.string(),
+  runId: z.string(),
+  runScope: z.string().default('latest'),
+  steps: z.array(StepLedgerRowSchema).default([]),
+});
+
 const RunSummaryArtifactSchema = z
   .object({
     finishOutcome: z
@@ -357,6 +437,25 @@ function decodeTaskPathSegment(segment: string | null | undefined): string | nul
   } catch {
     return segment;
   }
+}
+
+function expandRouteTemplate(
+  template: string | null | undefined,
+  params: Record<string, string | null | undefined>,
+): string | null {
+  if (!template) return null;
+  return Object.entries(params).reduce((path, [key, value]) => {
+    return path.replaceAll(`{${key}}`, encodeURIComponent(value ?? ''));
+  }, template);
+}
+
+function taskRunRoute(
+  apiBase: string,
+  template: string | null | undefined,
+  fallback: string,
+  params: Record<string, string | null | undefined>,
+): string {
+  return expandRouteTemplate(template, params) ?? `${apiBase}${fallback}`;
 }
 
 function formatWhen(iso: string | null | undefined): string {
@@ -485,10 +584,15 @@ function buildObservabilityRequestError(status: number): ObservabilityRequestErr
   return new ObservabilityRequestError(status, `Observability request failed: ${status}`);
 }
 
-/** Fetch the plain-text merged-tail from the artifact-backed API. */
-async function fetchMergedTail(apiBase: string, taskRunId: string): Promise<string> {
+async function fetchMergedTail(
+  apiBase: string,
+  taskRunId: string,
+  routeTemplate?: string | null,
+): Promise<string> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/merged`,
+    taskRunRoute(apiBase, routeTemplate, `/task-runs/${encodeURIComponent(taskRunId)}/logs/merged`, {
+      taskRunId,
+    }),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -498,10 +602,19 @@ async function fetchMergedTail(apiBase: string, taskRunId: string): Promise<stri
   return resp.text();
 }
 
-/** Fetch specific static stream (stdout or stderr) */
-async function fetchStream(apiBase: string, taskRunId: string, stream: 'stdout' | 'stderr'): Promise<string> {
+async function fetchStream(
+  apiBase: string,
+  taskRunId: string,
+  stream: 'stdout' | 'stderr',
+  routeTemplate?: string | null,
+): Promise<string> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/${stream}`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/logs/${stream}`,
+      { taskRunId },
+    ),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -511,10 +624,18 @@ async function fetchStream(apiBase: string, taskRunId: string, stream: 'stdout' 
   return resp.text();
 }
 
-/** Fetch diagnostics JSON */
-async function fetchDiagnostics(apiBase: string, taskRunId: string): Promise<string> {
+async function fetchDiagnostics(
+  apiBase: string,
+  taskRunId: string,
+  routeTemplate?: string | null,
+): Promise<string> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/diagnostics`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/diagnostics`,
+      { taskRunId },
+    ),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -556,9 +677,15 @@ async function fetchArtifactSessionProjection(
   apiBase: string,
   taskRunId: string,
   sessionId: string,
+  routeTemplate?: string | null,
 ): Promise<z.infer<typeof ArtifactSessionProjectionSchema> | null> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}`,
+      { taskRunId, sessionId },
+    ),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -573,9 +700,15 @@ async function controlArtifactSession(
   taskRunId: string,
   sessionId: string,
   body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string },
+  routeTemplate?: string | null,
 ): Promise<z.infer<typeof ArtifactSessionControlResponseSchema>> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}/control`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/artifact-sessions/${encodeURIComponent(sessionId)}/control`,
+      { taskRunId, sessionId },
+    ),
     {
       method: 'POST',
       credentials: 'include',
@@ -593,9 +726,15 @@ async function controlArtifactSession(
 async function fetchObservabilitySummary(
   apiBase: string,
   taskRunId: string,
+  routeTemplate?: string | null,
 ): Promise<z.infer<typeof ObservabilitySummarySchema> | null> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/observability-summary`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/observability-summary`,
+      { taskRunId },
+    ),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -609,9 +748,15 @@ async function fetchObservabilitySummary(
 async function fetchObservabilityEvents(
   apiBase: string,
   taskRunId: string,
+  routeTemplate?: string | null,
 ): Promise<z.infer<typeof ObservabilityEventsResponseSchema> | null> {
   const resp = await fetch(
-    `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/observability/events`,
+    taskRunRoute(
+      apiBase,
+      routeTemplate,
+      `/task-runs/${encodeURIComponent(taskRunId)}/observability/events`,
+      { taskRunId },
+    ),
     { credentials: 'include' },
   );
   if (!resp.ok) {
@@ -619,6 +764,14 @@ async function fetchObservabilityEvents(
     throw buildObservabilityRequestError(resp.status);
   }
   return ObservabilityEventsResponseSchema.parse(await resp.json());
+}
+
+async function fetchStepLedger(stepsHref: string): Promise<z.infer<typeof StepLedgerSnapshotSchema>> {
+  const resp = await fetch(stepsHref, { credentials: 'include' });
+  if (!resp.ok) {
+    throw new Error(`Steps: ${resp.statusText}`);
+  }
+  return StepLedgerSnapshotSchema.parse(await resp.json());
 }
 
 const TERMINAL_RUN_STATUSES = new Set([
@@ -742,16 +895,279 @@ function mapEventsToTimelineRows(
   return payload.events.flatMap((event) => eventToTimelineRows(event));
 }
 
+type TaskRunRouteTemplates = {
+  observabilitySummary?: string | undefined;
+  observabilityEvents?: string | undefined;
+  logsStream?: string | undefined;
+  logsStdout?: string | undefined;
+  logsStderr?: string | undefined;
+  logsMerged?: string | undefined;
+  diagnostics?: string | undefined;
+  artifactSession?: string | undefined;
+  artifactSessionControl?: string | undefined;
+};
+
+function readTaskRunRouteTemplates(config: DashboardConfig | undefined): TaskRunRouteTemplates {
+  return {
+    observabilitySummary: config?.sources?.taskRuns?.observabilitySummary,
+    observabilityEvents: config?.sources?.taskRuns?.observabilityEvents,
+    logsStream: config?.sources?.taskRuns?.logsStream,
+    logsStdout: config?.sources?.taskRuns?.logsStdout,
+    logsStderr: config?.sources?.taskRuns?.logsStderr,
+    logsMerged: config?.sources?.taskRuns?.logsMerged,
+    diagnostics: config?.sources?.taskRuns?.diagnostics,
+    artifactSession: config?.sources?.taskRuns?.artifactSession,
+    artifactSessionControl: config?.sources?.taskRuns?.artifactSessionControl,
+  };
+}
+
+function formatStepToolLabel(tool: z.infer<typeof StepLedgerToolSchema>): string {
+  const name = String(tool.name || '').trim();
+  const type = String(tool.type || '').trim();
+  if (name) return name;
+  if (type) return type;
+  return 'unknown';
+}
+
+function formatStepLastError(lastError: unknown): string | null {
+  if (!lastError) return null;
+  if (typeof lastError === 'string') return lastError;
+  if (typeof lastError === 'object') {
+    const candidate = (lastError as { summary?: unknown; message?: unknown }).summary
+      ?? (lastError as { summary?: unknown; message?: unknown }).message;
+    return candidate ? String(candidate) : JSON.stringify(lastError);
+  }
+  return String(lastError);
+}
+
+function stepTerminal(status: string | null | undefined): boolean {
+  const normalized = String(status || '').trim().toLowerCase();
+  return normalized === 'succeeded'
+    || normalized === 'failed'
+    || normalized === 'canceled'
+    || normalized === 'cancelled'
+    || normalized === 'skipped';
+}
+
+function StepCheckBadge({ check }: { check: z.infer<typeof StepLedgerCheckSchema> }) {
+  return (
+    <span className={`step-check-badge ${executionStatusPillClasses(check.status)}`}>
+      {check.kind.replaceAll('_', ' ')}: {check.status.replaceAll('_', ' ')}
+    </span>
+  );
+}
+
+function StepArtifactsList({
+  artifacts,
+}: {
+  artifacts: z.infer<typeof StepLedgerArtifactsSchema>;
+}) {
+  const entries = [
+    ['Output summary', artifacts.outputSummary],
+    ['Output primary', artifacts.outputPrimary],
+    ['Runtime stdout', artifacts.runtimeStdout],
+    ['Runtime stderr', artifacts.runtimeStderr],
+    ['Runtime merged logs', artifacts.runtimeMergedLogs],
+    ['Runtime diagnostics', artifacts.runtimeDiagnostics],
+    ['Provider snapshot', artifacts.providerSnapshot],
+  ].filter(([, value]) => Boolean(value)) as Array<[string, string]>;
+
+  if (entries.length === 0) {
+    return <p className="small">No step artifacts linked yet.</p>;
+  }
+
+  return (
+    <ul className="step-detail-list">
+      {entries.map(([label, value]) => (
+        <li key={`${label}-${value}`}>
+          <strong>{label}:</strong> <code className="text-xs break-all">{value}</code>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function StepMetadataList({
+  row,
+  runId,
+}: {
+  row: z.infer<typeof StepLedgerRowSchema>;
+  runId: string;
+}) {
+  return (
+    <ul className="step-detail-list">
+      <li><strong>Logical step id:</strong> <code className="text-xs break-all">{row.logicalStepId}</code></li>
+      <li><strong>Run id:</strong> <code className="text-xs break-all">{runId}</code></li>
+      <li><strong>Tool:</strong> <code className="text-xs break-all">{formatStepToolLabel(row.tool)}</code></li>
+      <li><strong>Attempt:</strong> {row.attempt}</li>
+      <li><strong>Depends on:</strong> {row.dependsOn.length > 0 ? row.dependsOn.join(', ') : 'None'}</li>
+      <li><strong>Child workflow:</strong> {row.refs.childWorkflowId ? <code className="text-xs break-all">{row.refs.childWorkflowId}</code> : '—'}</li>
+      <li><strong>Child run:</strong> {row.refs.childRunId ? <code className="text-xs break-all">{row.refs.childRunId}</code> : '—'}</li>
+      <li><strong>Task run:</strong> {row.refs.taskRunId ? <code className="text-xs break-all">{row.refs.taskRunId}</code> : '—'}</li>
+      <li><strong>Started:</strong> {formatWhen(row.startedAt)}</li>
+      <li><strong>Updated:</strong> {formatWhen(row.updatedAt)}</li>
+    </ul>
+  );
+}
+
+function StepObservabilityGroup({
+  apiBase,
+  row,
+  routes,
+}: {
+  apiBase: string;
+  row: z.infer<typeof StepLedgerRowSchema>;
+  routes: TaskRunRouteTemplates;
+}) {
+  const taskRunId = row.refs.taskRunId;
+  if (!taskRunId) {
+    return (
+      <p className="small">
+        {renderMissingTaskRunCopy(
+          row.status === 'running' || row.status === 'awaiting_external'
+            ? 'waiting_for_launch'
+            : 'binding_missing',
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div className="stack">
+      <LiveLogsPanel
+        apiBase={apiBase}
+        taskRunId={taskRunId}
+        isTerminal={stepTerminal(row.status)}
+        autoExpand
+        routes={routes}
+      />
+      <StaticLogPanel
+        apiBase={apiBase}
+        taskRunId={taskRunId}
+        stream="stdout"
+        routes={routes}
+      />
+      <StaticLogPanel
+        apiBase={apiBase}
+        taskRunId={taskRunId}
+        stream="stderr"
+        routes={routes}
+      />
+      <DiagnosticsPanel
+        apiBase={apiBase}
+        taskRunId={taskRunId}
+        routes={routes}
+      />
+    </div>
+  );
+}
+
+function StepLedgerRowCard({
+  apiBase,
+  row,
+  runId,
+  expanded,
+  onToggle,
+  routes,
+}: {
+  apiBase: string;
+  row: z.infer<typeof StepLedgerRowSchema>;
+  runId: string;
+  expanded: boolean;
+  onToggle: () => void;
+  routes: TaskRunRouteTemplates;
+}) {
+  const lastError = formatStepLastError(row.lastError);
+
+  return (
+    <article className="step-row-card">
+      <div className="step-row-header">
+        <div className="step-row-header-main">
+          <button
+            type="button"
+            className="step-row-toggle"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-label={`Expand step ${row.title}`}
+          >
+            {expanded ? 'Hide details' : 'Show details'}
+          </button>
+          <div className="step-row-title-block">
+            <strong>{row.title}</strong>
+            <div className="step-row-meta">
+              <code className="text-xs break-all">{row.logicalStepId}</code>
+              <code className="text-xs break-all">{formatStepToolLabel(row.tool)}</code>
+            </div>
+          </div>
+        </div>
+        <div className="step-row-statuses">
+          <span className={executionStatusPillClasses(row.status)}>{row.status.replaceAll('_', ' ')}</span>
+          <span className="step-attempt-pill">Attempt {row.attempt}</span>
+        </div>
+      </div>
+      <div className="step-row-summary">
+        <p className="small">{row.summary || 'No step summary yet.'}</p>
+        {row.checks.length > 0 ? (
+          <div className="step-check-badges">
+            {row.checks.map((check, index) => (
+              <StepCheckBadge key={`${check.kind}-${check.status}-${index}`} check={check} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+      {expanded ? (
+        <div className="step-row-details stack">
+          <section className="stack">
+            <h4>Summary</h4>
+            <p className="small">{row.summary || 'No step summary yet.'}</p>
+            {row.waitingReason ? <p className="small">Waiting reason: {row.waitingReason}</p> : null}
+            {lastError ? <p className="small">Last error: {lastError}</p> : null}
+          </section>
+          <section className="stack">
+            <h4>Checks</h4>
+            {row.checks.length > 0 ? (
+              <ul className="step-detail-list">
+                {row.checks.map((check, index) => (
+                  <li key={`${check.kind}-${check.status}-${index}`}>
+                    <StepCheckBadge check={check} />
+                    {check.summary ? <span className="small"> {check.summary}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="small">No structured checks for this step yet.</p>
+            )}
+          </section>
+          <section className="stack">
+            <h4>Logs & Diagnostics</h4>
+            <StepObservabilityGroup apiBase={apiBase} row={row} routes={routes} />
+          </section>
+          <section className="stack">
+            <h4>Artifacts</h4>
+            <StepArtifactsList artifacts={row.artifacts} />
+          </section>
+          <section className="stack">
+            <h4>Metadata</h4>
+            <StepMetadataList row={row} runId={runId} />
+          </section>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
 function LiveLogsPanel({
   apiBase,
   taskRunId,
   isTerminal,
   autoExpand = false,
+  routes,
 }: {
   apiBase: string;
   taskRunId: string;
   isTerminal: boolean;
   autoExpand?: boolean;
+  routes: TaskRunRouteTemplates;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
@@ -783,7 +1199,7 @@ function LiveLogsPanel({
   // Query for observability summary
   const summaryQuery = useQuery({
     queryKey: ['observability-summary', taskRunId],
-    queryFn: () => fetchObservabilitySummary(apiBase, taskRunId),
+    queryFn: () => fetchObservabilitySummary(apiBase, taskRunId, routes.observabilitySummary),
     enabled: !!taskRunId && expanded,
     // The summary indicates stream availability; refetch occasionally if not terminal
     staleTime: 1000 * 10,
@@ -791,7 +1207,7 @@ function LiveLogsPanel({
 
   const historyQuery = useQuery({
     queryKey: ['task-run-observability-events', taskRunId],
-    queryFn: () => fetchObservabilityEvents(apiBase, taskRunId),
+    queryFn: () => fetchObservabilityEvents(apiBase, taskRunId, routes.observabilityEvents),
     enabled: !!taskRunId && expanded && summaryQuery.isSuccess,
     staleTime: Infinity,
     retry: false,
@@ -801,7 +1217,7 @@ function LiveLogsPanel({
   // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({
     queryKey: ['task-run-tail', taskRunId],
-    queryFn: () => fetchMergedTail(apiBase, taskRunId),
+    queryFn: () => fetchMergedTail(apiBase, taskRunId, routes.logsMerged),
     enabled:
       !!taskRunId &&
       expanded &&
@@ -898,7 +1314,13 @@ function LiveLogsPanel({
 
     const nextSince = lastSeqRef.current != null ? lastSeqRef.current + 1 : null;
     const since = nextSince != null ? `?since=${nextSince}` : '';
-    const url = `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/stream${since}`;
+    const streamUrl = taskRunRoute(
+      apiBase,
+      routes.logsStream,
+      `/task-runs/${encodeURIComponent(taskRunId)}/logs/stream`,
+      { taskRunId },
+    );
+    const url = `${streamUrl}${since}`;
     const es = new EventSource(url, { withCredentials: true });
     esRef.current = es;
 
@@ -998,7 +1420,12 @@ function LiveLogsPanel({
     copyTextToClipboard(logContent.map((line) => line.text).join('\n'));
   };
 
-  const downloadUrl = `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/merged`;
+  const downloadUrl = taskRunRoute(
+    apiBase,
+    routes.logsMerged,
+    `/task-runs/${encodeURIComponent(taskRunId)}/logs/merged`,
+    { taskRunId },
+  );
   const summaryErrorMessage = summaryQuery.isError ? (summaryQuery.error as Error).message : null;
   const sessionBadges = sessionSnapshot
     ? [
@@ -1258,18 +1685,26 @@ function InterventionPanel({
 function StaticLogPanel({
   apiBase,
   taskRunId,
-  stream
+  stream,
+  routes,
 }: {
   apiBase: string;
   taskRunId: string;
   stream: 'stdout' | 'stderr';
+  routes: TaskRunRouteTemplates;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [wrapLines, setWrapLines] = useState(true);
 
   const streamQuery = useQuery({
     queryKey: ['task-run-stream', taskRunId, stream],
-    queryFn: () => fetchStream(apiBase, taskRunId, stream),
+    queryFn: () =>
+      fetchStream(
+        apiBase,
+        taskRunId,
+        stream,
+        stream === 'stdout' ? routes.logsStdout : routes.logsStderr,
+      ),
     enabled: !!taskRunId && expanded,
     retry: false,
   });
@@ -1281,7 +1716,12 @@ function StaticLogPanel({
     copyTextToClipboard(streamQuery.data);
   };
 
-  const downloadUrl = `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/logs/${stream}`;
+  const downloadUrl = taskRunRoute(
+    apiBase,
+    stream === 'stdout' ? routes.logsStdout : routes.logsStderr,
+    `/task-runs/${encodeURIComponent(taskRunId)}/logs/${stream}`,
+    { taskRunId },
+  );
 
   return (
     <details className="stack" open={expanded}>
@@ -1329,17 +1769,19 @@ function StaticLogPanel({
 
 function DiagnosticsPanel({
   apiBase,
-  taskRunId
+  taskRunId,
+  routes,
 }: {
   apiBase: string;
   taskRunId: string;
+  routes: TaskRunRouteTemplates;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [wrapLines, setWrapLines] = useState(true);
 
   const diagQuery = useQuery({
     queryKey: ['task-run-diagnostics', taskRunId],
-    queryFn: () => fetchDiagnostics(apiBase, taskRunId),
+    queryFn: () => fetchDiagnostics(apiBase, taskRunId, routes.diagnostics),
     enabled: !!taskRunId && expanded,
     retry: false,
   });
@@ -1349,7 +1791,12 @@ function DiagnosticsPanel({
     copyTextToClipboard(diagQuery.data);
   };
 
-  const downloadUrl = `${apiBase}/task-runs/${encodeURIComponent(taskRunId)}/diagnostics`;
+  const downloadUrl = taskRunRoute(
+    apiBase,
+    routes.diagnostics,
+    `/task-runs/${encodeURIComponent(taskRunId)}/diagnostics`,
+    { taskRunId },
+  );
 
   return (
     <details className="stack" open={expanded}>
@@ -1403,6 +1850,7 @@ function SessionContinuityPanel({
   onCancel,
   invalidateTaskDetail,
   cancelBusy,
+  routes,
 }: {
   apiBase: string;
   taskRunId: string;
@@ -1411,6 +1859,7 @@ function SessionContinuityPanel({
   onCancel: () => void;
   invalidateTaskDetail: () => void;
   cancelBusy: boolean;
+  routes: TaskRunRouteTemplates;
 }) {
   const queryClient = useQueryClient();
   const sessionId = deriveCodexSessionId(taskRunId, targetRuntime);
@@ -1421,7 +1870,7 @@ function SessionContinuityPanel({
     queryKey: ['task-run-session-projection', taskRunId, sessionId],
     queryFn: () => {
       if (!sessionId) return Promise.resolve(null);
-      return fetchArtifactSessionProjection(apiBase, taskRunId, sessionId);
+      return fetchArtifactSessionProjection(apiBase, taskRunId, sessionId, routes.artifactSession);
     },
     enabled: Boolean(taskRunId && sessionId),
     refetchInterval: (query) => {
@@ -1437,7 +1886,7 @@ function SessionContinuityPanel({
   const controlMutation = useMutation({
     mutationFn: async (body: { action: 'send_follow_up' | 'clear_session'; message?: string; reason?: string }) => {
       if (!sessionId) throw new Error('Managed session is unavailable.');
-      return controlArtifactSession(apiBase, taskRunId, sessionId, body);
+      return controlArtifactSession(apiBase, taskRunId, sessionId, body, routes.artifactSessionControl);
     },
     onSuccess: (result) => {
       setPanelError(null);
@@ -1637,6 +2086,7 @@ function renderMissingTaskRunCopy(state: MissingTaskRunState): string {
 export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const queryClient = useQueryClient();
   const cfg = readDashboardConfig(payload);
+  const taskRunRoutes = readTaskRunRouteTemplates(cfg);
   const detailPoll = cfg?.pollIntervalsMs?.detail ?? 2000;
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
   const debugOn = Boolean(cfg?.features?.temporalDashboard?.debugFieldsEnabled);
@@ -1652,6 +2102,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
 
   const [actionError, setActionError] = useState<string | null>(null);
   const [liveUpdates, setLiveUpdates] = useState(true);
+  const [expandedSteps, setExpandedSteps] = useState<Record<string, boolean>>({});
 
   const detailQuery = useQuery({
     queryKey: ['task-detail', encodedTaskId, sourceTemporal],
@@ -1701,6 +2152,13 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
 
   const missingTaskRunState = execution && !resolvedTaskRunId ? inferMissingTaskRunState(execution) : null;
 
+  const stepsQuery = useQuery({
+    queryKey: ['task-detail-steps', workflowId, execution?.stepsHref],
+    queryFn: () => fetchStepLedger(String(execution?.stepsHref || '')),
+    enabled: Boolean(execution?.stepsHref),
+    refetchInterval: liveUpdates && execution?.stepsHref ? detailPoll : false,
+  });
+
   const artifactsQuery = useQuery({
     queryKey: ['task-detail-artifacts', namespace, workflowId, runId],
     queryFn: async () => {
@@ -1711,7 +2169,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       }
       return ArtifactListSchema.parse(await response.json());
     },
-    enabled: Boolean(namespace && workflowId && runId),
+    enabled:
+      Boolean(namespace && workflowId && runId)
+      && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
     refetchInterval: liveUpdates && namespace && workflowId && runId ? detailPoll : false,
   });
 
@@ -1754,9 +2214,11 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
         execution.prerequisites.length > 0 ||
         execution.dependents.length > 0),
   );
+  const shouldShowSteps = Boolean(execution?.stepsHref);
 
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['task-detail', encodedTaskId] });
+    void queryClient.invalidateQueries({ queryKey: ['task-detail-steps', workflowId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-artifacts', namespace, workflowId, runId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-run-summary', summaryArtifactRef] });
   };
@@ -1898,6 +2360,12 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
         (execution?.interventionAudit?.length ?? 0) > 0
       ),
   );
+  const toggleStep = (logicalStepId: string) => {
+    setExpandedSteps((prev) => ({
+      ...prev,
+      [logicalStepId]: !prev[logicalStepId],
+    }));
+  };
 
   return (
     <div className="stack">
@@ -2069,6 +2537,45 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             </section>
           ) : null}
 
+          {shouldShowSteps ? (
+            <section className="stack">
+              <div className="step-ledger-header">
+                <div>
+                  <h3>Steps</h3>
+                  <p className="small">
+                    Latest run <code className="text-xs break-all">{stepsQuery.data?.runId || runId || '—'}</code>
+                  </p>
+                </div>
+                {stepsQuery.data ? (
+                  <p className="small">
+                    {stepsQuery.data.steps.length} step{stepsQuery.data.steps.length === 1 ? '' : 's'} in {stepsQuery.data.runScope}
+                  </p>
+                ) : null}
+              </div>
+              {stepsQuery.isLoading ? (
+                <p className="loading">Loading steps...</p>
+              ) : stepsQuery.isError ? (
+                <div className="notice error">{(stepsQuery.error as Error).message}</div>
+              ) : stepsQuery.data ? (
+                <div className="step-ledger-list">
+                  {stepsQuery.data.steps.map((row) => (
+                    <StepLedgerRowCard
+                      key={row.logicalStepId}
+                      apiBase={payload.apiBase}
+                      row={row}
+                      runId={stepsQuery.data?.runId || runId}
+                      expanded={Boolean(expandedSteps[row.logicalStepId])}
+                      onToggle={() => toggleStep(row.logicalStepId)}
+                      routes={taskRunRoutes}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="small">No step ledger available for this execution.</p>
+              )}
+            </section>
+          ) : null}
+
           {execution.attentionRequired ? (
             <section className="notice">
               <strong>Attention required.</strong> This task is waiting for external input before it can continue.
@@ -2202,6 +2709,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               onCancel={onCancel}
               invalidateTaskDetail={invalidate}
               cancelBusy={cancelMutation.isPending}
+              routes={taskRunRoutes}
             />
           ) : null}
 
@@ -2303,42 +2811,59 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             )}
           </section>
 
-          <section className="stack">
-            <div>
-              <h3>Observation</h3>
-              <p className="small">
-                Live logs are passive observation only. Use the Intervention panel for control actions.
-              </p>
-            </div>
-            {logStreamingEnabled ? (
-              resolvedTaskRunId ? (
-                <>
-                  {showTaskRunAttachNotice ? (
-                    <p className="small">Waiting for managed runtime launch to create live logs.</p>
-                  ) : null}
-                  <LiveLogsPanel
-                    apiBase={payload.apiBase}
-                    taskRunId={resolvedTaskRunId}
-                    isTerminal={isTerminalExecution}
-                    autoExpand={showTaskRunAttachNotice}
-                  />
-                  <StaticLogPanel apiBase={payload.apiBase} taskRunId={resolvedTaskRunId} stream="stdout" />
-                  <StaticLogPanel apiBase={payload.apiBase} taskRunId={resolvedTaskRunId} stream="stderr" />
-                  <DiagnosticsPanel apiBase={payload.apiBase} taskRunId={resolvedTaskRunId} />
-                </>
+          {!shouldShowSteps ? (
+            <section className="stack">
+              <div>
+                <h3>Observation</h3>
+                <p className="small">
+                  Live logs are passive observation only. Use the Intervention panel for control actions.
+                </p>
+              </div>
+              {logStreamingEnabled ? (
+                resolvedTaskRunId ? (
+                  <>
+                    {showTaskRunAttachNotice ? (
+                      <p className="small">Waiting for managed runtime launch to create live logs.</p>
+                    ) : null}
+                    <LiveLogsPanel
+                      apiBase={payload.apiBase}
+                      taskRunId={resolvedTaskRunId}
+                      isTerminal={isTerminalExecution}
+                      autoExpand={showTaskRunAttachNotice}
+                      routes={taskRunRoutes}
+                    />
+                    <StaticLogPanel
+                      apiBase={payload.apiBase}
+                      taskRunId={resolvedTaskRunId}
+                      stream="stdout"
+                      routes={taskRunRoutes}
+                    />
+                    <StaticLogPanel
+                      apiBase={payload.apiBase}
+                      taskRunId={resolvedTaskRunId}
+                      stream="stderr"
+                      routes={taskRunRoutes}
+                    />
+                    <DiagnosticsPanel
+                      apiBase={payload.apiBase}
+                      taskRunId={resolvedTaskRunId}
+                      routes={taskRunRoutes}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <h3>Live Logs</h3>
+                    <p className="small">{missingTaskRunState ? renderMissingTaskRunCopy(missingTaskRunState) : 'Waiting for task details...'}</p>
+                  </>
+                )
               ) : (
                 <>
                   <h3>Live Logs</h3>
-                  <p className="small">{missingTaskRunState ? renderMissingTaskRunCopy(missingTaskRunState) : 'Waiting for task details...'}</p>
+                  <p className="small">Live log streaming is disabled in the server dashboard config.</p>
                 </>
-              )
-            ) : (
-              <>
-                <h3>Live Logs</h3>
-                <p className="small">Live log streaming is disabled in the server dashboard config.</p>
-              </>
-            )}
-          </section>
+              )}
+            </section>
+          ) : null}
 
           {debugOn && execution.debugFields ? (
             <section className="stack">

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -955,6 +955,184 @@ button.secondary:hover {
   --queue-action-color: var(--mm-danger);
 }
 
+.step-row-card {
+  border: 1px solid rgb(var(--mm-border) / 0.68);
+  border-radius: 0.9rem;
+  padding: 0.9rem 1rem;
+  background:
+    linear-gradient(
+      180deg,
+      rgb(var(--mm-panel) / 0.9) 0%,
+      rgb(var(--mm-panel) / 0.72) 100%
+    );
+  box-shadow: 0 10px 24px -22px rgb(var(--mm-ink) / 0.35);
+}
+
+.step-row-card + .step-row-card {
+  margin-top: 0.85rem;
+}
+
+.step-row-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.step-row-header-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  min-width: 0;
+  flex: 1 1 24rem;
+}
+
+.step-row-toggle {
+  flex: 0 0 auto;
+  min-width: 7.25rem;
+}
+
+.step-row-title-block {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.step-row-title-block strong {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.step-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  color: rgb(var(--mm-muted));
+}
+
+.step-row-statuses {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.step-attempt-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  background: rgb(var(--mm-panel) / 0.72);
+  color: rgb(var(--mm-muted));
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.step-row-summary {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.step-row-summary > p {
+  flex: 1 1 20rem;
+  margin: 0;
+}
+
+.step-check-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.step-check-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border-radius: 999px;
+  padding: 0.18rem 0.62rem;
+  border: 1px solid rgb(var(--mm-border) / 0.72);
+  background: rgb(var(--mm-panel) / 0.75);
+  color: rgb(var(--mm-ink) / 0.84);
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: none;
+}
+
+.step-check-badge.check-passed,
+.step-check-badge.check-approved {
+  border-color: rgb(var(--mm-ok) / 0.45);
+  background: rgb(var(--mm-ok) / 0.12);
+}
+
+.step-check-badge.check-failed,
+.step-check-badge.check-rejected {
+  border-color: rgb(var(--mm-danger) / 0.48);
+  background: rgb(var(--mm-danger) / 0.12);
+}
+
+.step-check-badge.check-reviewing,
+.step-check-badge.check-pending {
+  border-color: rgb(var(--mm-warn) / 0.45);
+  background: rgb(var(--mm-warn) / 0.12);
+}
+
+.step-row-details {
+  margin-top: 0.95rem;
+  padding-top: 0.95rem;
+  border-top: 1px solid rgb(var(--mm-border) / 0.52);
+}
+
+.step-row-details section {
+  border: 1px solid rgb(var(--mm-border) / 0.58);
+  border-radius: 0.8rem;
+  padding: 0.85rem 0.9rem;
+  background: rgb(var(--mm-panel) / 0.56);
+}
+
+.step-row-details h4 {
+  margin: 0 0 0.4rem;
+  font-size: 0.88rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.step-detail-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+@media (max-width: 720px) {
+  .step-row-card {
+    padding: 0.85rem;
+  }
+
+  .step-row-header-main {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .step-row-toggle {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .step-row-summary {
+    gap: 0.7rem;
+  }
+}
+
 .queue-step-instructions {
   min-height: 120px;
 }

--- a/specs/141-step-ledger-phase4/checklists/requirements.md
+++ b/specs/141-step-ledger-phase4/checklists/requirements.md
@@ -1,0 +1,7 @@
+# Specification Quality Checklist: Step Ledger Phase 4
+
+- [x] Runtime scope includes production frontend code changes.
+- [x] Validation tasks include browser/frontend verification.
+- [x] Source requirements map to functional requirements and planned implementation.
+- [x] Latest-run-only semantics are explicit.
+- [x] Step-scoped observability attachment and delayed `taskRunId` handling are explicit.

--- a/specs/141-step-ledger-phase4/contracts/requirements-traceability.md
+++ b/specs/141-step-ledger-phase4/contracts/requirements-traceability.md
@@ -1,0 +1,13 @@
+# Requirements Traceability: Step Ledger Phase 4
+
+| Source Requirement | Spec Mapping | Planned Implementation | Validation Strategy |
+| --- | --- | --- | --- |
+| DOC-REQ-001 | FR-001, FR-003 | Render latest-run step rows from `/api/executions/{workflowId}/steps` as the primary task-detail execution surface | Browser tests validate latest-run-only steps and visible current run id context |
+| DOC-REQ-002 | FR-001 | Reframe task detail around step ledger state, checks, and evidence on the detail page | Browser tests validate the Steps-first hierarchy and row content |
+| DOC-REQ-003 | FR-001, FR-002 | Place the Steps section above Timeline and generic Artifacts | Browser tests assert section ordering |
+| DOC-REQ-004 | FR-001, FR-002 | Fetch execution detail first, then the step ledger, while keeping generic artifact reads secondary | Browser tests assert fetch ordering and separate reads |
+| DOC-REQ-005 | FR-003, FR-004, FR-006 | Render stable expanded row groups and attach row-level observability only when needed | Browser tests validate expanded groups and row-scoped observability calls |
+| DOC-REQ-006 | FR-004, FR-005 | Use `taskRunId` as a row-level observability binding and show delayed-binding copy when absent | Browser tests validate bound/unbound step behavior and delayed attachment |
+| DOC-REQ-007 | FR-003, FR-006 | Consume bounded summaries/checks/refs/artifacts without treating logs or workflow history as inline state | Browser tests validate checks/artifact groups and scoped observability requests |
+| DOC-REQ-008 | FR-007 | Style dense step chips and compact check badges with the existing Mission Control design system | Browser rendering checks plus CSS/type/test verification |
+| DOC-REQ-009 | FR-005, FR-008 | Add browser coverage for latest-run-only steps, delayed `taskRunId`, and step-scoped observability attachment | Targeted `task-detail` browser tests plus final verification commands |

--- a/specs/141-step-ledger-phase4/contracts/task-detail-steps-ui.md
+++ b/specs/141-step-ledger-phase4/contracts/task-detail-steps-ui.md
@@ -1,0 +1,31 @@
+# Task Detail Steps UI Contract
+
+## Read sequence
+
+1. `GET /api/executions/{workflowId}`
+2. `GET /api/executions/{workflowId}/steps`
+3. Optional row-level `/api/task-runs/{taskRunId}/*` fetches only after a row expands and exposes `taskRunId`
+
+## Section order
+
+1. Summary / top-level execution metadata
+2. Steps
+3. Timeline
+4. Execution-wide Artifacts
+5. Observation / debug / other secondary panels
+
+## Expanded row groups
+
+Each expanded step row renders the following groups in order:
+
+1. Summary
+2. Checks
+3. Logs & Diagnostics
+4. Artifacts
+5. Metadata
+
+## Row-level observability rules
+
+- If `refs.taskRunId` is present, expanded rows may fetch observability summary and logs/diagnostics.
+- If `refs.taskRunId` is absent, expanded rows show delayed-binding or unavailable copy and must not call `/api/task-runs/*`.
+- Expanded rows remain keyed by `logicalStepId` so ordinary polling does not collapse operator context.

--- a/specs/141-step-ledger-phase4/data-model.md
+++ b/specs/141-step-ledger-phase4/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Step Ledger Phase 4
+
+## Task detail read order
+
+1. `GET /api/executions/{workflowId}` for bounded execution metadata and `progress`
+2. `GET /api/executions/{workflowId}/steps` for the latest/current run step ledger
+3. `GET /api/task-runs/{taskRunId}/*` only when an expanded row exposes `taskRunId`
+4. Execution-wide artifact browsing remains separate and secondary
+
+## TaskDetailStepLedger
+
+Uses the existing `StepLedgerSnapshotModel` response unchanged.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `workflowId` | string | Durable task/execution identity |
+| `runId` | string | Latest/current run identity |
+| `runScope` | `"latest"` | Phase 4 continues latest-run-only behavior |
+| `steps` | `StepLedgerRowModel[]` | Ordered latest/current run rows |
+
+## TaskDetailStepRowView
+
+Derived frontend state per `logicalStepId`.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `row` | `StepLedgerRowModel` | Canonical API row |
+| `expanded` | boolean | Whether the row panel is open |
+| `hasObservability` | boolean | Whether `refs.taskRunId` exists |
+| `observabilityState` | idle/loading/ready/error | Row-level `/api/task-runs/*` drilldown state |
+
+## Expanded step evidence groups
+
+Each expanded row renders the same semantic groups in a stable order:
+
+1. **Summary**: row summary, waiting reason, last error, current attempt, status
+2. **Checks**: structured `checks[]` badges and summaries
+3. **Logs & Diagnostics**: live logs, stdout, stderr, diagnostics when `taskRunId` exists; delayed-binding copy otherwise
+4. **Artifacts**: grouped artifact slot refs from `row.artifacts`
+5. **Metadata**: logical step id, tool, dependencies, refs, timestamps, current run id
+
+## Latest-run rules
+
+- The task detail page stays anchored on `workflowId`.
+- The Steps section surfaces the latest/current run only.
+- Expanded-row state is keyed by `logicalStepId`, but step attempt identity continues to come from the API row fields (`runId`, `attempt`).

--- a/specs/141-step-ledger-phase4/plan.md
+++ b/specs/141-step-ledger-phase4/plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Step Ledger Phase 4
+
+**Branch**: `141-step-ledger-phase4` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/141-step-ledger-phase4/spec.md`
+
+## Summary
+
+Pivot Mission Control task detail to a Steps-first experience backed by the existing `/api/executions/{workflowId}/steps` contract. The frontend will fetch execution detail first, then the latest-run step ledger, render the step ledger above Timeline and generic Artifacts, and lazily attach step-scoped observability and artifact evidence only when a row expands.
+
+## Technical Context
+
+**Language/Version**: TypeScript + React 18, Vitest, existing Mission Control CSS tokens  
+**Primary Dependencies**: TanStack Query, Zod, generated OpenAPI shapes already checked in, existing `/api/executions` and `/api/task-runs` APIs, dashboard runtime config route templates from FastAPI  
+**Storage**: Browser query cache only; latest-run step state continues to come from workflow-backed API reads and task-run observability endpoints  
+**Testing**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`  
+**Target Platform**: Mission Control React/Vite frontend served by FastAPI  
+**Project Type**: Frontend task-detail UI plus backend runtime-config support and browser-test coverage  
+**Performance Goals**: Initial task detail remains bounded; step observability fetches only occur for expanded rows that expose `taskRunId`; expanded-row state survives ordinary polling  
+**Constraints**: Preserve latest-run-only semantics; reuse existing `/api/task-runs/*` observability routes instead of inventing new browser contracts; keep the generic Artifacts panel secondary; keep existing Mission Control semantic classes and tokenized styling  
+**Scale/Scope**: Task-detail page, related CSS, browser tests, and dashboard runtime-config route-template delivery
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The UI consumes the workflow-owned/API-owned step ledger directly instead of inventing a parallel client state model.
+- **IV. Own Your Data**: PASS. Logs and diagnostics stay on artifact-backed observability routes; the UI links to them per step.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The work reuses the frozen step-ledger contract and Phase 3 API routes unchanged.
+- **IX. Resilient by Default**: PASS. Latest-run reads stay keyed by `workflowId`, expanded step panels degrade safely when `taskRunId` is absent or observability fetches fail, and browser tests cover delayed binding.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Phase 4 has a dedicated feature package with explicit acceptance and validation gates.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical semantics remain in the UI and step-ledger docs; this plan captures only the rollout work.
+- **XIII. Pre-Release Delete, Don't Deprecate**: PASS. The page pivots to the canonical Steps surface instead of preserving the old observability-first model as an equal primary view.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/141-step-ledger-phase4/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── requirements-traceability.md
+│   └── task-detail-steps-ui.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-detail.tsx        # MODIFY: fetch/render the Steps-first task-detail experience
+frontend/src/entrypoints/task-detail.test.tsx   # MODIFY: browser tests for Steps-first layout and row-level observability
+frontend/src/styles/mission-control.css         # MODIFY: dense step rows, status chips, check badges, expanded evidence groups
+api_service/api/routers/task_dashboard_view_model.py   # MODIFY: expose task-run route templates to the task-detail runtime config
+tests/unit/api/routers/test_task_dashboard_view_model.py   # MODIFY: cover runtime-config route-template delivery
+```
+
+**Structure Decision**: Keep the task-detail page as the only owner of the new Steps-first composition. Do not create a new page route or alternate detail entrypoint; instead, factor row-level helpers/components inside `task-detail.tsx` as needed and keep styling in the shared Mission Control stylesheet.
+
+## Complexity Tracking
+
+The main risk is stale or noisy polling causing expanded rows to collapse or observability fetches to fire too aggressively. Mitigation: separate execution-detail and step-ledger queries, key row-level observability on the row `taskRunId`, and preserve expansion state by logical step id instead of array position alone.

--- a/specs/141-step-ledger-phase4/quickstart.md
+++ b/specs/141-step-ledger-phase4/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Step Ledger Phase 4
+
+## 1. Run targeted task-detail browser tests
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
+```
+
+## 2. Run frontend type-checking
+
+```bash
+npm run ui:typecheck
+```
+
+## 3. Run the Spec Kit task-scope gate
+
+```bash
+.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+```
+
+## 4. Run the required final verification path
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+```
+
+## Expected verification
+
+- Task detail renders Steps above Timeline and Artifacts.
+- Latest-run step rows come from `/api/executions/{workflowId}/steps`.
+- Expanding a row fetches step-scoped observability only when `taskRunId` exists.
+- Delayed `taskRunId` arrival upgrades an expanded row from waiting copy to observability-backed panels.

--- a/specs/141-step-ledger-phase4/research.md
+++ b/specs/141-step-ledger-phase4/research.md
@@ -1,0 +1,30 @@
+# Research: Step Ledger Phase 4
+
+## Decision 1: Treat `/api/executions/{workflowId}/steps` as the primary task-detail dataset
+
+- **Decision**: Load execution detail first for top-level metadata, then load the latest-run step ledger as the primary task-detail execution surface.
+- **Rationale**: The canonical docs explicitly position step ledger state as detail-page evidence and require the Steps section to appear above Timeline and generic Artifacts.
+- **Alternatives considered**:
+  - **Keep the current observability-first page and add Steps below it**: rejected because it preserves the wrong information hierarchy and leaves the new API underused.
+  - **Inline steps into execution detail polling only**: rejected because the full ledger belongs on its own read path and would bloat common polling.
+
+## Decision 2: Scope observability fetches to expanded rows only
+
+- **Decision**: Use row expansion to trigger `/api/task-runs/{taskRunId}/observability-summary`, `/logs/*`, and `/diagnostics` requests only for steps that expose `taskRunId`.
+- **Rationale**: This keeps the default page cheap and matches the Task Runs API identity model, where `taskRunId` is the observability handle for a specific managed run bound to a step.
+- **Alternatives considered**:
+  - **Fetch observability for the first step automatically**: rejected because many rows may have no binding yet and eager observability calls recreate the old whole-page model.
+
+## Decision 3: Preserve expanded-row state by logical step id
+
+- **Decision**: Track expanded step rows by `logicalStepId` so polling and latest-run refreshes do not collapse or remount the operator’s current focus unnecessarily.
+- **Rationale**: The step-ledger contract requires clients not to infer identity from array position alone, and latest-run polling can update row order/state over time.
+- **Alternatives considered**:
+  - **Track expansion by row index**: rejected because it is fragile across rerenders and violates the stable-identity guidance.
+
+## Decision 4: Keep generic execution-wide Artifacts and Timeline as secondary surfaces
+
+- **Decision**: Retain the existing Timeline and Artifacts sections, but move them below Steps and make them clearly secondary to step-scoped detail.
+- **Rationale**: This delivers the requested product pivot without deleting useful secondary evidence surfaces that still matter for debugging and coarse execution history.
+- **Alternatives considered**:
+  - **Delete Timeline/Artifacts entirely**: rejected because Phase 4 is a priority shift, not a removal phase.

--- a/specs/141-step-ledger-phase4/spec.md
+++ b/specs/141-step-ledger-phase4/spec.md
@@ -1,0 +1,114 @@
+# Feature Specification: Step Ledger Phase 4
+
+**Feature Branch**: `141-step-ledger-phase4`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 4 using test-driven development of the step-ledger rollout plan. Make Steps the primary Mission Control task-detail surface, reusing step-scoped observability and artifact refs instead of treating task-run observability as the whole-page model."
+
+## Source Document Requirements
+
+Source: `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/UI/MissionControlArchitecture.md`, `docs/tmp/remaining-work/UI-MissionControlArchitecture.md`, `docs/Tasks/TaskRunsApi.md`, `docs/UI/MissionControlStyleGuide.md`
+
+| ID | Source Section | Requirement Summary |
+| --- | --- | --- |
+| DOC-REQ-001 | `StepLedgerAndProgressModel` §4, §6, §7 | Task detail must treat the latest/current run step ledger as the primary step surface, keyed by `workflowId`, with stable row fields and latest-run semantics. |
+| DOC-REQ-002 | `MissionControlArchitecture` §9.2 | Task detail pages are the place for step ledger state, checks, managed-run observability, and artifact evidence. |
+| DOC-REQ-003 | `MissionControlArchitecture` implementation tracking | The Steps section must appear above Timeline and generic Artifacts on task detail. |
+| DOC-REQ-004 | `MissionControlArchitecture` implementation tracking | The browser must fetch execution detail first, then `/api/executions/{workflowId}/steps`, before falling back to execution-wide artifact browsing. |
+| DOC-REQ-005 | `MissionControlArchitecture` implementation tracking | Expanded step rows must group Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata. |
+| DOC-REQ-006 | `TaskRunsApi` §2-§4 | Step-scoped `taskRunId` is the canonical handle for `/api/task-runs/*` observability drilldown and should only be used when a row exposes it. |
+| DOC-REQ-007 | `StepLedgerAndProgressModel` §3.3, §9 | Checks, logs, diagnostics, and large evidence remain external surfaces; the UI consumes bounded summaries, checks, refs, and artifact slots without parsing workflow history. |
+| DOC-REQ-008 | `MissionControlStyleGuide` §4-§5 | Mission Control must render dense, readable step status chips and compact review/check badges that work in light and dark themes. |
+| DOC-REQ-009 | `MissionControlArchitecture` implementation tracking | Browser tests must cover latest-run-only steps, delayed `taskRunId` arrival, and step-scoped observability attachment. |
+
+## User Scenarios & Testing
+
+### User Story 1 - Steps become the primary task-detail surface (Priority: P1)
+
+An operator needs the task detail page to show the latest/current run step ledger as the main execution surface instead of forcing them to interpret execution-wide timeline and task-run observability first.
+
+**Why this priority**: This is the Phase 4 product outcome. Without it, the backend contract added in Phase 3 remains underused and the page still treats managed-run observability as the primary model.
+
+**Independent Test**: Render the task-detail page for a Temporal run with step-ledger data and assert the Steps section appears above Timeline and Artifacts, showing latest-run rows and progress without requiring observability fetches to render the section.
+
+**Acceptance Scenarios**:
+
+1. **Given** execution detail includes `progress` and `stepsHref`, **When** the task-detail page loads, **Then** it fetches execution detail first and then loads the latest-run step ledger into a primary Steps section above Timeline and Artifacts.
+2. **Given** a latest-run step ledger with multiple statuses, **When** the page renders, **Then** each row shows the canonical title, status, attempt, summary, and compact progress-oriented metadata without flattening the whole ledger into generic timeline rows.
+3. **Given** the page is viewing a rerun or Continue-As-New execution, **When** the step ledger loads, **Then** it shows only the latest/current run rows and labels them with the current `runId`.
+
+---
+
+### User Story 2 - Expanded steps attach observability and evidence lazily (Priority: P1)
+
+An operator needs step drilldown panels that attach observability and evidence only when a row is expanded, so the page remains cheap while still exposing detailed logs, diagnostics, checks, and artifacts when needed.
+
+**Why this priority**: The current page eagerly centers task-run observability. Phase 4 must demote that to row-level drilldown and keep the default page bounded.
+
+**Independent Test**: Expand step rows in browser tests and assert observability summary/log/diagnostic fetches only occur for rows with `taskRunId`, while rows without a binding show the delayed-launch messaging and still render other metadata/artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step row has a `taskRunId`, **When** the operator expands it, **Then** the page fetches observability summary and logs/diagnostics for that step only.
+2. **Given** a running step row has no `taskRunId` yet, **When** the operator expands it, **Then** the row shows launch/binding status copy and later attaches observability once a refreshed latest-run ledger exposes the binding.
+3. **Given** a step row exposes canonical artifact refs but no task-run observability, **When** the row is expanded, **Then** Summary, Artifacts, and Metadata still render without requesting `/api/task-runs/*`.
+
+---
+
+### User Story 3 - Steps remain dense and readable across desktop/mobile themes (Priority: P2)
+
+An operator needs compact step chips, check badges, and readable expanded evidence sections that fit existing Mission Control density on desktop and mobile in both light and dark themes.
+
+**Why this priority**: The page already has a rich layout system, so the new steps surface must fit the existing visual system instead of looking bolted on.
+
+**Independent Test**: Browser tests can assert the semantic groups and chips/badges render, while CSS verification and build checks prove the UI compiles cleanly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step row has status and checks, **When** it renders, **Then** the row shows compact status chips and check badges with readable labels.
+2. **Given** the page is narrow or wide, **When** the step row expands, **Then** Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata remain readable without hiding critical step context.
+3. **Given** the generic execution-wide artifact table still exists, **When** the page renders, **Then** it appears below Steps and reads clearly as secondary evidence rather than the primary execution model.
+
+### Edge Cases
+
+- What happens when `/api/executions/{workflowId}/steps` is unavailable while execution detail still loads? The page should show an error state for Steps without breaking the rest of the detail view.
+- What happens when a step row has no checks, refs, or artifact slots yet? The expanded groups should stay stable and render explicit empty-state copy.
+- What happens when a row has `taskRunId` but observability summary returns 403 or 404? The row should show scoped error or unavailable messaging without collapsing the rest of the step panel.
+- What happens when the execution detail poll updates but the latest step ledger is unchanged? The page should preserve expanded-row state and avoid re-centering the UI on execution-wide panels.
+- What happens when the latest-run ledger rotates `runId` after Continue-As-New? The Steps section should replace the old run rows with the latest run only and continue using per-row observability handles from the new ledger.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST render a primary Steps section on task detail above Timeline and generic Artifacts, using `GET /api/executions/{workflowId}/steps` as the authoritative row source. Mappings: DOC-REQ-001, DOC-REQ-002, DOC-REQ-003, DOC-REQ-004.
+- **FR-002**: System MUST fetch execution detail before the step ledger, keep execution detail polling bounded, and keep step-ledger reads separate from generic artifact reads. Mappings: DOC-REQ-003, DOC-REQ-004.
+- **FR-003**: System MUST render step rows with latest-run identity, canonical step status, attempt, summary, checks, refs, and grouped artifact slots from the frozen step-ledger contract. Mappings: DOC-REQ-001, DOC-REQ-005, DOC-REQ-007.
+- **FR-004**: System MUST lazily attach step-scoped observability using `taskRunId` only for expanded rows that expose a binding, reusing `/api/task-runs/*` endpoints as row-level drilldown rather than whole-page state. Mappings: DOC-REQ-005, DOC-REQ-006.
+- **FR-005**: System MUST show stable empty-state or delayed-binding copy for expanded rows without current `taskRunId`, and MUST attach observability automatically when a later latest-run ledger refresh exposes the binding. Mappings: DOC-REQ-006, DOC-REQ-009.
+- **FR-006**: System MUST render the expanded step panel using explicit groups for Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata. Mappings: DOC-REQ-005, DOC-REQ-007.
+- **FR-007**: System MUST style status chips, check badges, and step rows using existing Mission Control design tokens and readable density patterns for light and dark themes. Mappings: DOC-REQ-008.
+- **FR-008**: System MUST add browser-facing tests covering latest-run-only steps, delayed `taskRunId` arrival, step-scoped observability attachment, and the Steps-first information hierarchy. Mappings: DOC-REQ-009.
+- **FR-009**: System MUST implement production frontend/runtime code changes plus validation tests in this phase; documentation-only work is insufficient. Mappings: DOC-REQ-003, DOC-REQ-004, DOC-REQ-009.
+
+### Key Entities
+
+- **TaskDetailStepLedger**: Latest/current-run step snapshot loaded from `/api/executions/{workflowId}/steps`.
+- **TaskDetailStepRowView**: UI view model for one step row, combining the frozen API row with local expansion/loading state.
+- **StepObservabilityAttachment**: Lazy row-level fetch state for observability summary, live logs, static logs, and diagnostics keyed by a row `taskRunId`.
+- **StepEvidenceGroups**: Expanded row groups for Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Browser tests prove the Steps section renders above Timeline and Artifacts using latest-run step-ledger data.
+- **SC-002**: Browser tests prove observability requests are row-scoped and are only issued when an expanded row exposes `taskRunId`.
+- **SC-003**: Browser tests prove delayed `taskRunId` attachment updates the expanded row from waiting copy to observability-backed content without requiring whole-page remounts.
+- **SC-004**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` pass.
+
+## Assumptions
+
+- Phase 4 stops at the Mission Control task-detail pivot; folding review verdict production deeper into `checks[]` remains the later review-gate phase.
+- The API and latest-run step-ledger contract from Phase 3 remain authoritative and unchanged in this phase.
+- Generic execution-wide Artifacts and Timeline sections still remain on the page, but they become secondary to the Steps surface.

--- a/specs/141-step-ledger-phase4/speckit_analyze_report.md
+++ b/specs/141-step-ledger-phase4/speckit_analyze_report.md
@@ -1,0 +1,33 @@
+# Speckit Analyze Report: Step Ledger Phase 4
+
+## Findings
+
+### spec.md
+
+- Severity: LOW
+- Location: User Story 2
+- Problem: The observability drilldown requirement could be read as replacing all execution-wide artifact access.
+- Remediation: Clarify that execution-wide Timeline and Artifacts remain secondary surfaces rather than being removed.
+- Rationale: Keeps Phase 4 aligned with the rollout goal of reprioritizing, not deleting, secondary evidence.
+
+### plan.md
+
+- Severity: LOW
+- Location: Complexity Tracking
+- Problem: Polling-state stability was only implied in the summary.
+- Remediation: Explicitly call out logical-step-based expansion state preservation in the plan.
+- Rationale: This is the most likely frontend regression vector during the pivot.
+
+### tasks.md
+
+- Severity: LOW
+- Location: Phase 3 / Phase 4 tasks
+- Problem: Styling work could drift ahead of the semantic UI structure.
+- Remediation: Keep CSS work dependent on the task-detail markup changes and expanded row groups.
+- Rationale: Preserves TDD flow and avoids styling a speculative structure.
+
+## Safe to Implement
+
+- **Safe to Implement**: YES
+- **Blocking Remediations**: None
+- **Determination Rationale**: The Phase 4 spec, plan, and tasks now cover the required runtime UI work, verification commands, and latest-run/observability edge cases without leaving critical ambiguity.

--- a/specs/141-step-ledger-phase4/tasks.md
+++ b/specs/141-step-ledger-phase4/tasks.md
@@ -1,0 +1,99 @@
+# Tasks: Step Ledger Phase 4
+
+**Input**: Design documents from `/specs/141-step-ledger-phase4/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing browser tests before implementing the corresponding task-detail UI behavior.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create or extend the Phase 4 task-detail browser-test target in `frontend/src/entrypoints/task-detail.test.tsx`.
+- [X] T013 Extend `api_service/api/routers/task_dashboard_view_model.py` so Mission Control runtime config exposes task-run route templates needed by row-scoped observability.
+- [X] T014 Add unit coverage in `tests/unit/api/routers/test_task_dashboard_view_model.py` for the task-run runtime-config route templates.
+
+---
+
+## Phase 2: User Story 1 - Steps become the primary task-detail surface (Priority: P1)
+
+**Goal**: Render a Steps-first task-detail page backed by the latest-run step ledger.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering Steps rendering above Timeline and Artifacts, latest-run-only row rendering, and execution-detail-then-steps fetch ordering.
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Update `frontend/src/entrypoints/task-detail.tsx` to fetch `/api/executions/{workflowId}/steps`, render a primary Steps section, and keep Timeline/Artifacts secondary.
+
+---
+
+## Phase 3: User Story 2 - Expanded steps attach observability and evidence lazily (Priority: P1)
+
+**Goal**: Expanded rows own step-scoped observability and evidence drilldown.
+
+### Tests for User Story 2
+
+- [X] T004 [P] [US2] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering lazy row-level observability fetches, no `/api/task-runs/*` requests for collapsed rows or rows without `taskRunId`, and delayed `taskRunId` attachment on a refreshed latest-run ledger.
+- [X] T005 [P] [US2] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering expanded-row groups for Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata.
+
+### Implementation for User Story 2
+
+- [X] T006 [US2] Update `frontend/src/entrypoints/task-detail.tsx` to preserve expanded row state by `logicalStepId`, attach observability only for expanded bound rows, and render stable empty-state / delayed-binding copy for unbound rows.
+
+---
+
+## Phase 4: User Story 3 - Steps remain dense and readable across themes (Priority: P2)
+
+**Goal**: Make the new Steps surface fit the existing Mission Control design system.
+
+### Tests for User Story 3
+
+- [X] T007 [P] [US3] Extend `frontend/src/entrypoints/task-detail.test.tsx` with semantic rendering checks for status chips, check badges, and secondary execution-wide artifacts below Steps.
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] Update `frontend/src/styles/mission-control.css` and any related task-detail markup in `frontend/src/entrypoints/task-detail.tsx` for dense step rows, compact check badges, and readable expanded evidence groups in light/dark themes.
+
+---
+
+## Phase 5: Validation
+
+- [X] T009 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T010 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [X] T011 Run `npm run ui:typecheck`
+- [X] T012 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **User Story 1 (Phase 2)**: Depends on Setup.
+- **User Story 2 (Phase 3)**: Depends on User Story 1 fetch/render foundations.
+- **User Story 3 (Phase 4)**: Depends on the step-row markup from User Story 1 and the expanded groups from User Story 2.
+- **Validation (Phase 5)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- T002 can be written before implementation begins.
+- T004 and T005 can be written in parallel once the basic row structure is understood.
+- T007 can be added while polishing markup/CSS, but before final verification.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing tests for the Steps-first layout and fetch order.
+2. Render the latest-run step ledger above Timeline and Artifacts.
+3. Move observability attachment into expanded step rows.
+4. Polish density/styling and run verification.
+
+### TDD Notes
+
+- Prefer Red → Green for T002 before T003 and T004/T005 before T006.
+- If some styling details are not practical to drive entirely from failing tests, add the closest semantic browser assertions first and then tighten the CSS implementation.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -91,6 +91,7 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
         == "/api/artifacts/{artifactId}/download"
     )
     assert config["sources"]["taskRuns"]["observabilitySummary"] == "/api/task-runs/{taskRunId}/observability-summary"
+    assert config["sources"]["taskRuns"]["observabilityEvents"] == "/api/task-runs/{taskRunId}/observability/events"
     assert config["sources"]["taskRuns"]["logsStream"] == "/api/task-runs/{taskRunId}/logs/stream"
     assert config["sources"]["taskRuns"]["logsStdout"] == "/api/task-runs/{taskRunId}/logs/stdout"
     assert config["sources"]["taskRuns"]["logsStderr"] == "/api/task-runs/{taskRunId}/logs/stderr"

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -90,6 +90,14 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
         config["sources"]["temporal"]["artifactDownload"]
         == "/api/artifacts/{artifactId}/download"
     )
+    assert config["sources"]["taskRuns"]["observabilitySummary"] == "/api/task-runs/{taskRunId}/observability-summary"
+    assert config["sources"]["taskRuns"]["logsStream"] == "/api/task-runs/{taskRunId}/logs/stream"
+    assert config["sources"]["taskRuns"]["logsStdout"] == "/api/task-runs/{taskRunId}/logs/stdout"
+    assert config["sources"]["taskRuns"]["logsStderr"] == "/api/task-runs/{taskRunId}/logs/stderr"
+    assert config["sources"]["taskRuns"]["logsMerged"] == "/api/task-runs/{taskRunId}/logs/merged"
+    assert config["sources"]["taskRuns"]["diagnostics"] == "/api/task-runs/{taskRunId}/diagnostics"
+    assert config["sources"]["taskRuns"]["artifactSession"] == "/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}"
+    assert config["sources"]["taskRuns"]["artifactSessionControl"] == "/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}/control"
     assert "speckit" not in config["sources"]
     assert "orchestrator" not in config["sources"]
     assert "externalRuns" not in config["sources"]


### PR DESCRIPTION
## Summary
- pivot Mission Control task detail to a Steps-first surface backed by the execution step ledger
- attach task-run observability lazily per expanded step and keep execution-wide artifacts secondary
- expose task-run route templates in dashboard runtime config and add the Phase 4 spec package

## Why
Phase 4 requires the frontend to treat step-ledger rows as the primary operator view instead of using task-run observability as the whole-page model.

## Impact
Operators now see latest-run steps above Timeline and Artifacts, with grouped Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata on expansion. Row-scoped observability requests only fire when a bound step is expanded.

## Validation
- `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `npm run ui:typecheck`
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`