### PR TITLE
[codex] Fix managed-session publish PR flow

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3536,6 +3536,65 @@ class TemporalAgentRuntimeActivities:
         support_root = Path(workspace).resolve().parent / ".moonmind"
         support_bin = support_root / "bin"
         support_gitconfig = support_root / "gitconfig"
+        github_token = str(env.get("GITHUB_TOKEN", "")).strip()
+        git_helper_path = support_bin / "git-credential-moonmind"
+        helper_command: str | None = None
+
+        try:
+            support_root.mkdir(parents=True, exist_ok=True)
+            support_bin.mkdir(parents=True, exist_ok=True)
+            if github_token:
+                helper_script = (
+                    "#!/usr/bin/env python3\n"
+                    "import os\n"
+                    "import sys\n"
+                    "\n"
+                    "operation = str(sys.argv[1] if len(sys.argv) > 1 else '').strip().lower()\n"
+                    "if operation not in {'get', 'fill'}:\n"
+                    "    raise SystemExit(0)\n"
+                    "\n"
+                    "request = {}\n"
+                    "for raw_line in sys.stdin:\n"
+                    "    line = raw_line.rstrip('\\n')\n"
+                    "    if not line:\n"
+                    "        break\n"
+                    "    key, _, value = line.partition('=')\n"
+                    "    request[key] = value\n"
+                    "\n"
+                    "host = str(request.get('host') or '').strip().lower()\n"
+                    "protocol = str(request.get('protocol') or '').strip().lower()\n"
+                    "if host != 'github.com' or (protocol and protocol != 'https'):\n"
+                    "    raise SystemExit(0)\n"
+                    "\n"
+                    "token = str(os.environ.get('GITHUB_TOKEN', '')).strip()\n"
+                    "if not token:\n"
+                    "    raise SystemExit(0)\n"
+                    "\n"
+                    "sys.stdout.write('username=x-access-token\\n')\n"
+                    "sys.stdout.write(f'password={token}\\n\\n')\n"
+                    "sys.stdout.flush()\n"
+                )
+                git_helper_path.write_text(helper_script, encoding="utf-8")
+                git_helper_path.chmod(0o700)
+                helper_command = shlex.quote(str(git_helper_path))
+
+            git_config_lines = [
+                "# moonmind-runtime-git-config\n",
+                "[safe]\n",
+                f'\tdirectory = "{Path(workspace).resolve()}"\n',
+            ]
+            if helper_command is not None:
+                git_config_lines.extend(
+                    [
+                        "[credential]\n",
+                        f"\thelper = !{helper_command}\n",
+                    ]
+                )
+            support_gitconfig.write_text("".join(git_config_lines), encoding="utf-8")
+            support_gitconfig.chmod(0o600)
+        except OSError:
+            pass
+
         if support_bin.exists():
             existing_path = str(env.get("PATH") or "").strip()
             env["PATH"] = (

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3593,7 +3593,14 @@ class TemporalAgentRuntimeActivities:
             support_gitconfig.write_text("".join(git_config_lines), encoding="utf-8")
             support_gitconfig.chmod(0o600)
         except OSError:
-            pass
+            logger.warning(
+                "Failed to bootstrap workspace-local git support files for workspace %s "
+                "(support_root=%s, gitconfig=%s)",
+                workspace,
+                support_root,
+                support_gitconfig,
+                exc_info=True,
+            )
 
         if support_bin.exists():
             existing_path = str(env.get("PATH") or "").strip()

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -96,6 +96,9 @@ STREAMING_EXTERNAL_HEARTBEAT_TIMEOUT = timedelta(seconds=120)
 MANAGED_STATUS_ACTIVITY_PATCH_ID = "agent-run-managed-status-activity-v1"
 PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 MANAGED_TASK_WORKFLOW_BINDING_PATCH_ID = "agent-run-managed-task-workflow-binding-v1"
+MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID = (
+    "agent-run-managed-session-fetch-result-activity-v1"
+)
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.Run (run.py:50).
@@ -385,6 +388,108 @@ class MoonMindAgentRun:
     @staticmethod
     def _uses_codex_session_adapter(request: AgentExecutionRequest) -> bool:
         return request.agent_kind == "managed" and request.managed_session is not None
+
+    @staticmethod
+    def _request_workspace_starting_branch(
+        request: AgentExecutionRequest,
+    ) -> str | None:
+        workspace_spec = (
+            request.workspace_spec
+            if isinstance(request.workspace_spec, Mapping)
+            else {}
+        )
+        branch = str(
+            workspace_spec.get("startingBranch")
+            or workspace_spec.get("branch")
+            or ""
+        ).strip()
+        return branch or None
+
+    def _build_managed_fetch_result_activity_input(
+        self,
+        request: AgentExecutionRequest,
+    ) -> dict[str, Any]:
+        params = request.parameters if isinstance(request.parameters, Mapping) else {}
+        raw_publish_mode = params.get("publishMode")
+        publish_mode = (
+            str(raw_publish_mode).strip().lower()
+            if isinstance(raw_publish_mode, str) and raw_publish_mode.strip()
+            else "none"
+        )
+
+        run_id = str(self.run_id or "").strip()
+        if request.managed_session is not None:
+            run_id = str(request.managed_session.task_run_id).strip()
+
+        activity_input: dict[str, Any] = {
+            "run_id": run_id,
+            "agent_id": request.agent_id,
+        }
+        if publish_mode != "none":
+            activity_input["publish_mode"] = publish_mode
+
+        raw_commit_message = params.get("commitMessage")
+        if isinstance(raw_commit_message, str) and raw_commit_message.strip():
+            activity_input["commit_message"] = raw_commit_message.strip()
+
+        target_branch = str(
+            params.get("publishBaseBranch")
+            or self._request_workspace_starting_branch(request)
+            or ""
+        ).strip()
+        if target_branch:
+            activity_input["target_branch"] = target_branch
+
+        if _request_selected_skill(request) == "pr-resolver":
+            activity_input["pr_resolver_expected"] = True
+        return activity_input
+
+    async def _fetch_managed_result(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        adapter: AgentAdapter,
+        uses_codex_session_adapter: bool,
+        use_managed_status_activity: bool,
+    ) -> AgentRunResult:
+        if uses_codex_session_adapter:
+            if workflow.patched(MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID):
+                result_payload = await self._execute_routed_activity(
+                    "agent_runtime.fetch_result",
+                    self._build_managed_fetch_result_activity_input(request),
+                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                )
+                return (
+                    AgentRunResult(**result_payload)
+                    if isinstance(result_payload, dict)
+                    else result_payload
+                )
+
+            return await adapter.fetch_result(
+                self.run_id,
+                pr_resolver_expected=(
+                    _request_selected_skill(request) == "pr-resolver"
+                ),
+            )
+
+        if use_managed_status_activity:
+            result_payload = await self._execute_routed_activity(
+                "agent_runtime.fetch_result",
+                self._build_managed_fetch_result_activity_input(request),
+                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            )
+            return (
+                AgentRunResult(**result_payload)
+                if isinstance(result_payload, dict)
+                else result_payload
+            )
+
+        return await adapter.fetch_result(
+            self.run_id,
+            pr_resolver_expected=(
+                _request_selected_skill(request) == "pr-resolver"
+            ),
+        )
 
     async def _ensure_manager_and_signal(
         self,
@@ -1095,46 +1200,11 @@ class MoonMindAgentRun:
                         uses_codex_session_adapter
                         and handle.status in _TERMINAL_RUN_STATUSES
                     ):
-                        raw_publish_mode = (request.parameters or {}).get("publishMode")
-                        publish_mode = (
-                            str(raw_publish_mode).strip().lower()
-                            if isinstance(raw_publish_mode, str)
-                            and raw_publish_mode.strip()
-                            else "none"
-                        )
-                        params = request.parameters or {}
-                        target_branch = (
-                            params.get("publishBaseBranch") or params.get("startingBranch")
-                        )
-                        activity_input: dict[str, Any] = {
-                            "run_id": self.run_id,
-                            "agent_id": request.agent_id,
-                        }
-                        if publish_mode != "none":
-                            activity_input["publish_mode"] = publish_mode
-                        raw_commit_message = (request.parameters or {}).get(
-                            "commitMessage"
-                        )
-                        if (
-                            isinstance(raw_commit_message, str)
-                            and raw_commit_message.strip()
-                        ):
-                            activity_input["commit_message"] = (
-                                raw_commit_message.strip()
-                            )
-                        if target_branch:
-                            activity_input["target_branch"] = target_branch
-                        if _request_selected_skill(request) == "pr-resolver":
-                            activity_input["pr_resolver_expected"] = True
-                        result_payload = await self._execute_routed_activity(
-                            "agent_runtime.fetch_result",
-                            activity_input,
-                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                        )
-                        self.final_result = (
-                            AgentRunResult(**result_payload)
-                            if isinstance(result_payload, dict)
-                            else result_payload
+                        self.final_result = await self._fetch_managed_result(
+                            request=request,
+                            adapter=adapter,
+                            uses_codex_session_adapter=uses_codex_session_adapter,
+                            use_managed_status_activity=use_managed_status_activity,
                         )
                         skip_poll_and_fetch = True
 
@@ -1388,52 +1458,12 @@ class MoonMindAgentRun:
                         )
                         self.final_result = AgentRunResult(**result_dict) if isinstance(result_dict, dict) else result_dict
                     else:
-                        if uses_codex_session_adapter or use_managed_status_activity:
-                            raw_publish_mode = (request.parameters or {}).get("publishMode")
-                            publish_mode = str(raw_publish_mode).strip().lower() if isinstance(raw_publish_mode, str) and raw_publish_mode.strip() else "none"
-                            params = request.parameters or {}
-                            target_branch = params.get("publishBaseBranch") or params.get("startingBranch")
-
-                            activity_input: dict[str, Any] = {
-                                "run_id": self.run_id,
-                                "agent_id": request.agent_id,
-                            }
-                            if publish_mode != "none":
-                                activity_input["publish_mode"] = publish_mode
-                            raw_commit_message = (request.parameters or {}).get(
-                                "commitMessage"
-                            )
-                            if (
-                                isinstance(raw_commit_message, str)
-                                and raw_commit_message.strip()
-                            ):
-                                activity_input["commit_message"] = (
-                                    raw_commit_message.strip()
-                                )
-                            if target_branch:
-                                activity_input["target_branch"] = target_branch
-                            if _request_selected_skill(request) == "pr-resolver":
-                                activity_input["pr_resolver_expected"] = True
-
-                            result_payload = await self._execute_routed_activity(
-                                "agent_runtime.fetch_result",
-                                activity_input,
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-
-                            )
-                            self.final_result = (
-                                AgentRunResult(**result_payload)
-                                if isinstance(result_payload, dict)
-                                else result_payload
-                            )
-                        else:
-                            # Managed agent legacy path.
-                            self.final_result = await adapter.fetch_result(
-                                self.run_id,
-                                pr_resolver_expected=(
-                                    _request_selected_skill(request) == "pr-resolver"
-                                ),
-                            )
+                        self.final_result = await self._fetch_managed_result(
+                            request=request,
+                            adapter=adapter,
+                            uses_codex_session_adapter=uses_codex_session_adapter,
+                            use_managed_status_activity=use_managed_status_activity,
+                        )
 
                 if (
                     request.agent_kind == "external"

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -1095,7 +1095,47 @@ class MoonMindAgentRun:
                         uses_codex_session_adapter
                         and handle.status in _TERMINAL_RUN_STATUSES
                     ):
-                        self.final_result = await adapter.fetch_result(handle.run_id)
+                        raw_publish_mode = (request.parameters or {}).get("publishMode")
+                        publish_mode = (
+                            str(raw_publish_mode).strip().lower()
+                            if isinstance(raw_publish_mode, str)
+                            and raw_publish_mode.strip()
+                            else "none"
+                        )
+                        params = request.parameters or {}
+                        target_branch = (
+                            params.get("publishBaseBranch") or params.get("startingBranch")
+                        )
+                        activity_input: dict[str, Any] = {
+                            "run_id": self.run_id,
+                            "agent_id": request.agent_id,
+                        }
+                        if publish_mode != "none":
+                            activity_input["publish_mode"] = publish_mode
+                        raw_commit_message = (request.parameters or {}).get(
+                            "commitMessage"
+                        )
+                        if (
+                            isinstance(raw_commit_message, str)
+                            and raw_commit_message.strip()
+                        ):
+                            activity_input["commit_message"] = (
+                                raw_commit_message.strip()
+                            )
+                        if target_branch:
+                            activity_input["target_branch"] = target_branch
+                        if _request_selected_skill(request) == "pr-resolver":
+                            activity_input["pr_resolver_expected"] = True
+                        result_payload = await self._execute_routed_activity(
+                            "agent_runtime.fetch_result",
+                            activity_input,
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        )
+                        self.final_result = (
+                            AgentRunResult(**result_payload)
+                            if isinstance(result_payload, dict)
+                            else result_payload
+                        )
                         skip_poll_and_fetch = True
 
                 elif request.agent_kind == "external":
@@ -1348,9 +1388,7 @@ class MoonMindAgentRun:
                         )
                         self.final_result = AgentRunResult(**result_dict) if isinstance(result_dict, dict) else result_dict
                     else:
-                        if uses_codex_session_adapter:
-                            self.final_result = await adapter.fetch_result(self.run_id)
-                        elif use_managed_status_activity:
+                        if uses_codex_session_adapter or use_managed_status_activity:
                             raw_publish_mode = (request.parameters or {}).get("publishMode")
                             publish_mode = str(raw_publish_mode).strip().lower() if isinstance(raw_publish_mode, str) and raw_publish_mode.strip() else "none"
                             params = request.parameters or {}

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -573,6 +573,25 @@ class TestPushWorkspaceBranch:
         assert "git-credential-moonmind" in gitconfig_text
         assert str(workspace.resolve()) in gitconfig_text
 
+    def test_workspace_command_env_logs_bootstrap_failures(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "run-1" / "repo"
+        monkeypatch.setenv("PATH", "/usr/bin")
+
+        with patch(
+            "pathlib.Path.mkdir",
+            side_effect=OSError("read-only filesystem"),
+        ), patch(
+            "moonmind.workflows.temporal.activity_runtime.logger.warning"
+        ) as warning_mock:
+            env = TemporalAgentRuntimeActivities._workspace_command_env(str(workspace))
+
+        assert env["PATH"] == "/usr/bin"
+        assert "GIT_CONFIG_GLOBAL" not in env
+        warning_mock.assert_called_once()
+        assert warning_mock.call_args.args[1] == str(workspace)
+
     @pytest.mark.asyncio
     async def test_push_revlist_failure_falls_through(self):
         """When rev-list --count raises, we fall through to 'pushed' (safe default)."""

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -541,6 +541,38 @@ class TestPushWorkspaceBranch:
         assert env["GIT_AUTHOR_EMAIL"] == "moonmind@example.com"
         assert env["GIT_COMMITTER_EMAIL"] == "moonmind@example.com"
 
+    def test_workspace_command_env_bootstraps_git_helper_without_writing_token(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "run-1" / "repo"
+        support_root = workspace.parent / ".moonmind"
+        support_bin = support_root / "bin"
+        gitconfig = support_root / "gitconfig"
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test_token_value")
+        monkeypatch.setattr(settings.workflow, "git_user_name", "MoonMind Bot")
+        monkeypatch.setattr(
+            settings.workflow, "git_user_email", "moonmind@example.com"
+        )
+
+        env = TemporalAgentRuntimeActivities._workspace_command_env(str(workspace))
+
+        helper_path = support_bin / "git-credential-moonmind"
+        assert support_bin.is_dir()
+        assert gitconfig.is_file()
+        assert helper_path.is_file()
+        assert env["PATH"].startswith(str(support_bin))
+        assert env["GIT_CONFIG_GLOBAL"] == str(gitconfig)
+
+        helper_text = helper_path.read_text(encoding="utf-8")
+        gitconfig_text = gitconfig.read_text(encoding="utf-8")
+        assert "ghp_test_token_value" not in helper_text
+        assert "ghp_test_token_value" not in gitconfig_text
+        assert "os.environ.get('GITHUB_TOKEN'" in helper_text
+        assert "password={token}" in helper_text
+        assert "git-credential-moonmind" in gitconfig_text
+        assert str(workspace.resolve()) in gitconfig_text
+
     @pytest.mark.asyncio
     async def test_push_revlist_failure_falls_through(self):
         """When rev-list --count raises, we fall through to 'pushed' (safe default)."""

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -110,9 +110,9 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
             )
 
         async def fetch_result(self, run_id: str) -> AgentRunResult:
-            return AgentRunResult(
-                summary="Session-backed Codex step completed.",
-                metadata={"resultSource": "codex-session-adapter"},
+            raise AssertionError(
+                "Terminal managed-session runs should fetch results through "
+                "agent_runtime.fetch_result"
             )
 
         async def cancel(self, run_id: str) -> AgentRunStatus:
@@ -175,6 +175,11 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
                 "activeTurnId": None,
                 "terminationRequested": False,
             }
+        if activity_name == "agent_runtime.fetch_result":
+            return {
+                "summary": "Session-backed Codex step completed.",
+                "metadata": {"resultSource": "agent-runtime-fetch-result"},
+            }
         if activity_name == "agent_runtime.publish_artifacts":
             return payload
         raise AssertionError(f"Unexpected routed activity: {activity_name}")
@@ -214,17 +219,22 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     ]
     assert run.run_id == "managed-session-run-1"
     assert result.summary == "Session-backed Codex step completed."
-    assert result.metadata["resultSource"] == "codex-session-adapter"
+    assert result.metadata["resultSource"] == "agent-runtime-fetch-result"
     assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
     assert result.metadata["childRunId"] == "run-1"
     assert result.metadata["taskRunId"] == "wf-task-1"
     assert result.metadata["managedSession"]["sessionId"] == "sess:wf-task-1:codex_cli"
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.load_session_snapshot",
+        "agent_runtime.fetch_result",
         "agent_runtime.publish_artifacts",
     ]
     assert routed_calls[0][1]["workflowId"] == "wf-task-1:session:override"
     assert routed_calls[0][1]["taskRunId"] == "wf-task-1"
+    assert routed_calls[1][1] == {
+        "run_id": "managed-session-run-1",
+        "agent_id": "codex",
+    }
 
 
 async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -19,6 +19,10 @@ from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 pytestmark = [pytest.mark.asyncio]
 
 
+def _patch_all_enabled(_patch_id: str) -> bool:
+    return True
+
+
 def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     workflow_info = type(
         "WorkflowInfo",
@@ -38,7 +42,7 @@ def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(agent_run_module.workflow, "info", workflow_info)
     monkeypatch.setattr(agent_run_module.workflow, "logger", logger)
-    monkeypatch.setattr(agent_run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(agent_run_module.workflow, "patched", _patch_all_enabled)
     monkeypatch.setattr(
         agent_run_module.workflow,
         "now",
@@ -232,7 +236,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     assert routed_calls[0][1]["workflowId"] == "wf-task-1:session:override"
     assert routed_calls[0][1]["taskRunId"] == "wf-task-1"
     assert routed_calls[1][1] == {
-        "run_id": "managed-session-run-1",
+        "run_id": "wf-task-1",
         "agent_id": "codex",
     }
 
@@ -326,5 +330,105 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
     assert result.metadata["taskRunId"] == "managed-run-1"
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.fetch_result",
+        "agent_runtime.publish_artifacts",
+    ]
+
+
+async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    def _patched(patch_id: str) -> bool:
+        return (
+            patch_id
+            != agent_run_module.MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID
+        )
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-session-run-legacy",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+        async def fetch_result(
+            self,
+            run_id: str,
+            *,
+            pr_resolver_expected: bool = False,
+        ) -> AgentRunResult:
+            assert run_id == "managed-session-run-legacy"
+            assert pr_resolver_expected is False
+            return AgentRunResult(summary="Legacy managed-session fetch path.")
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "patched", _patched)
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_managed_session_request())
+
+    assert result.summary == "Legacy managed-session fetch path."
+    assert [name for name, _payload in routed_calls] == [
         "agent_runtime.publish_artifacts",
     ]

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -271,6 +271,7 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
 
     _configure_workflow_runtime(monkeypatch)
 
@@ -300,7 +301,10 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
             )
 
         async def fetch_result(self, run_id: str) -> AgentRunResult:
-            return AgentRunResult(summary="Managed success", metadata={})
+            raise AssertionError(
+                "Terminal managed-session runs should fetch results through "
+                "agent_runtime.fetch_result"
+            )
 
     async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
         run.completion_event.set()
@@ -354,6 +358,9 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         payload: Any,
         **_kwargs: Any,
     ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Managed success", "metadata": {}}
         if activity_name == "agent_runtime.publish_artifacts":
             return payload
         raise AssertionError(f"Unexpected routed activity: {activity_name}")
@@ -403,6 +410,13 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         )
     )
 
+    fetch_payload = next(
+        payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
+    )
+    assert fetch_payload == {
+        "run_id": "managed-session-run-2",
+        "agent_id": "codex_cli",
+    }
     assert result.metadata["managedSession"] == {
         "workflowId": "wf-run-1:session:codex_cli",
         "taskRunId": "wf-run-1",

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -265,6 +265,7 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
     )
     assert fetch_payload["publish_mode"] == "pr"
     assert fetch_payload["commit_message"] == "Use producer commit text"
+    assert fetch_payload["target_branch"] == "main"
 
 
 async def test_agent_run_managed_preserves_task_scoped_session_metadata(
@@ -414,7 +415,7 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
         payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
     )
     assert fetch_payload == {
-        "run_id": "managed-session-run-2",
+        "run_id": "wf-run-1",
         "agent_id": "codex_cli",
     }
     assert result.metadata["managedSession"] == {


### PR DESCRIPTION
## Summary
- route terminal managed Codex session runs through `agent_runtime.fetch_result` so publish-aware branch push logic always runs before PR creation
- bootstrap workspace-local git credential helper and gitconfig on demand so publish pushes can authenticate even when support files were not preseeded
- update managed-session and publish-push unit coverage for the new fetch path and git bootstrap behavior

## Root cause
The failing workflow completed its local code change, but the managed Codex session path bypassed `agent_runtime.fetch_result` and read the result directly from `CodexSessionAdapter.fetch_result`. That skipped the post-run branch push step, left the branch local-only, and caused native GitHub PR creation to fail with HTTP 422 because the remote head branch did not exist.

## Impact
Managed-session publish flows now use the same fetch-and-push path as the standard managed runtime, so successful runs can push their branch before PR creation. Fresh workspaces also synthesize the git support files needed for non-interactive authenticated pushes.

## Validation
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py tests/unit/services/temporal/test_fetch_result_push.py`
- `./tools/test_unit.sh`
