### PR TITLE
[codex] Fix Codex managed-session publish workspace persistence

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -778,8 +778,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
 
         runtime_id = self._runtime_id or "codex_cli"
         summary = str(result.get("summary") or "").strip() or None
-        workspace_path = (
-            str(workspace_path or "").strip()
+        resolved_workspace_path = (
+            (str(workspace_path or "").strip() or None)
             if binding is not None
             else (existing.workspace_path if existing is not None else None)
         )
@@ -793,7 +793,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             status=status,
             startedAt=started_at,
             finishedAt=finished_at,
-            workspacePath=workspace_path,
+            workspacePath=resolved_workspace_path,
             stdoutArtifactRef=_artifact_ref(
                 session_artifact_metadata.get("stdoutArtifactRef"),
                 fallback=_infer_runtime_artifact_ref(

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -261,6 +261,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             agent_id=request.agent_id,
             managed_run_id=binding.task_run_id,
             binding=binding,
+            workspace_path=self._workspace_path_for_request(
+                binding=binding,
+                request=request,
+            ),
             locator=current_locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
             result=result.model_dump(mode="json", by_alias=True),
@@ -387,6 +391,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             agent_id=state.agent_id,
             managed_run_id=state.managed_run_id,
             binding=None,
+            workspace_path=None,
             locator=state.locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
             result=canceled_result.model_dump(mode="json", by_alias=True),
@@ -674,6 +679,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         agent_id: str,
         managed_run_id: str | None = None,
         binding: CodexManagedSessionBinding | None = None,
+        workspace_path: str | None = None,
         locator: Mapping[str, Any],
         active_turn_id: str | None,
         result: Mapping[str, Any],
@@ -701,6 +707,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             agent_id=agent_id,
             managed_run_id=managed_run_id,
             binding=binding,
+            workspace_path=workspace_path,
             locator=locator,
             active_turn_id=active_turn_id,
             result=result,
@@ -716,6 +723,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         agent_id: str,
         managed_run_id: str | None,
         binding: CodexManagedSessionBinding | None,
+        workspace_path: str | None,
         locator: Mapping[str, Any],
         active_turn_id: str | None,
         result: Mapping[str, Any],
@@ -771,7 +779,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         runtime_id = self._runtime_id or "codex_cli"
         summary = str(result.get("summary") or "").strip() or None
         workspace_path = (
-            str(self._session_root(binding))
+            str(workspace_path or "").strip()
             if binding is not None
             else (existing.workspace_path if existing is not None else None)
         )

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -297,6 +297,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert persisted_record.workflow_id == "wf-agent-run-1"
     assert persisted_record.runtime_id == "codex_cli"
     assert persisted_record.status == "completed"
+    assert persisted_record.workspace_path == str(workspace_path)
     assert persisted_record.stdout_artifact_ref == "artifact:stdout"
     assert persisted_record.stderr_artifact_ref == "artifact:stderr"
     assert persisted_record.diagnostics_ref == "artifact:diagnostics"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -697,6 +697,64 @@ async def test_cancel_interrupts_active_turn_and_marks_run_canceled(
     assert result.summary == "Canceled Codex managed-session turn."
 
 
+async def test_save_run_state_persists_blank_workspace_path_as_none(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=AsyncMock(),
+        launch_session=AsyncMock(),
+        session_status=AsyncMock(),
+        send_turn=AsyncMock(),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=AsyncMock(),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=binding.task_run_id,
+        agent_id="codex",
+        managed_run_id=binding.task_run_id,
+        binding=binding,
+        workspace_path="   ",
+        locator={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Completed",
+            "metadata": {},
+        },
+        status="completed",
+        started_at=datetime.now(tz=UTC),
+        finished_at=datetime.now(tz=UTC),
+    )
+
+    persisted_record = run_store.load(binding.task_run_id)
+
+    assert persisted_record is not None
+    assert persisted_record.workspace_path is None
+
+
 async def test_terminate_session_uses_remote_session_control_surface(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed
This fixes Codex managed-session run persistence so the managed-run record stores the actual repo workspace path used by the session, not the parent session root.

## Why
Workflow `mm:e1c914cc-a1e1-4e41-9c00-8f393d615851` failed during finalization because publish ran `git rev-parse --abbrev-ref HEAD` in `/work/agent_jobs/mm:e1c914cc-a1e1-4e41-9c00-8f393d615851`, while the real checkout was `/work/agent_jobs/mm:e1c914cc-a1e1-4e41-9c00-8f393d615851/repo`.

The adapter was persisting the session root into `ManagedRunRecord.workspacePath`, and later publish logic trusted that path for branch detection.

## Impact
New managed Codex session runs persist the repo workspace consistently, so post-run push and PR creation operate on the git checkout instead of a non-repo parent directory.

## Validation
- `.venv/bin/pytest -q tests/unit/workflows/adapters/test_codex_session_adapter.py`
- `.venv/bin/pytest -q tests/unit/services/temporal/test_fetch_result_push.py`

## Notes
`./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py` also surfaced an unrelated existing frontend failure in `entrypoints/task-detail.test.tsx`, so this PR scopes only the managed-session publish fix.