### PR TITLE
[codex] Implement step ledger phase 5 review checks

### DIFF
--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -475,6 +475,74 @@ describe('Task Detail Entrypoint', () => {
     ).toBe(true);
   });
 
+  it('renders retry counts and review artifact refs inside the Checks section', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '02-run',
+      runId: '02-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Review detail task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...latestStepsSnapshot,
+            steps: latestStepsSnapshot.steps.map((step) =>
+              step.logicalStepId === 'apply'
+                ? {
+                    ...step,
+                    status: 'reviewing',
+                    checks: [
+                      {
+                        kind: 'approval_policy',
+                        status: 'failed',
+                        summary: 'Reviewer requested another retry',
+                        retryCount: 2,
+                        artifactRef: 'art-review-2',
+                      },
+                    ],
+                  }
+                : step,
+            ),
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => mockExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show details for Apply patch' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Retry count: 2')).toBeTruthy();
+      expect(screen.getByText('art-review-2')).toBeTruthy();
+      expect(screen.getAllByText('approval policy: failed')[0]).toBeTruthy();
+    });
+  });
+
   it('resolves step-level task-run routes against apiBase', async () => {
     const apiBasePayload: BootPayload = {
       ...stepsPayload,

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1002,6 +1002,23 @@ function StepCheckBadge({ check }: { check: z.infer<typeof StepLedgerCheckSchema
   );
 }
 
+function StepCheckDetails({ check }: { check: z.infer<typeof StepLedgerCheckSchema> }) {
+  return (
+    <div className="step-check-details">
+      {typeof check.retryCount === 'number' ? (
+        <span className="small">Retry count: {check.retryCount}</span>
+      ) : null}
+      {check.artifactRef ? (
+        <span className="small">
+          Review artifact: <code className="text-xs break-all">{check.artifactRef}</code>
+        </span>
+      ) : (
+        <span className="small">No review artifact linked yet.</span>
+      )}
+    </div>
+  );
+}
+
 function StepArtifactsList({
   artifacts,
 }: {
@@ -1186,6 +1203,7 @@ function StepLedgerRowCard({
                   <li key={`${check.kind}-${check.status}-${index}`}>
                     <StepCheckBadge check={check} />
                     {check.summary ? <span className="small"> {check.summary}</span> : null}
+                    <StepCheckDetails check={check} />
                   </li>
                 ))}
               </ul>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1113,6 +1113,13 @@ button.secondary:hover {
   gap: 0.45rem;
 }
 
+.step-check-details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 0.3rem;
+}
+
 @media (max-width: 720px) {
   .step-row-card {
     padding: 0.85rem;

--- a/moonmind/workflows/temporal/step_ledger.py
+++ b/moonmind/workflows/temporal/step_ledger.py
@@ -190,6 +190,40 @@ def update_step_row(
     raise KeyError(f"Unknown logical step id: {logical_step_id}")
 
 
+def upsert_step_check(
+    rows: list[dict[str, Any]],
+    logical_step_id: str,
+    *,
+    kind: str,
+    status: str,
+    summary: str | None = None,
+    retry_count: int = 0,
+    artifact_ref: str | None = None,
+) -> dict[str, Any]:
+    for row in rows:
+        if row.get("logicalStepId") != logical_step_id:
+            continue
+        checks = row.get("checks")
+        if not isinstance(checks, list):
+            checks = []
+        check_payload = {
+            "kind": kind,
+            "status": status,
+            "summary": summary,
+            "retryCount": retry_count,
+            "artifactRef": artifact_ref,
+        }
+        for index, existing in enumerate(checks):
+            if isinstance(existing, Mapping) and existing.get("kind") == kind:
+                checks[index] = check_payload
+                row["checks"] = checks
+                return check_payload
+        checks.append(check_payload)
+        row["checks"] = checks
+        return check_payload
+    raise KeyError(f"Unknown logical step id: {logical_step_id}")
+
+
 def refresh_ready_steps(rows: list[dict[str, Any]], *, updated_at: datetime) -> None:
     statuses = {
         str(row.get("logicalStepId")): str(row.get("status") or "")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -789,7 +789,8 @@ class MoonMindRunWorkflow:
         if normalized == "INCONCLUSIVE":
             return "Review inconclusive; accepted execution"
         if retry_count > 0:
-            return f"Approved after {retry_count} retry"
+            retry_label = "retry" if retry_count == 1 else "retries"
+            return f"Approved after {retry_count} {retry_label}"
         return "Approved by structured review"
 
     def _review_gate_active(
@@ -797,6 +798,7 @@ class MoonMindRunWorkflow:
         *,
         approval_policy: Any,
         tool_type: str,
+        tool_name: str,
     ) -> bool:
         if approval_policy is None or not getattr(approval_policy, "enabled", False):
             return False
@@ -805,7 +807,12 @@ class MoonMindRunWorkflow:
             for value in getattr(approval_policy, "skip_tool_types", ())
             if str(value).strip()
         }
-        return tool_type not in skip_tool_types
+        normalized_tool_type = str(tool_type or "").strip().lower()
+        normalized_tool_name = str(tool_name or "").strip().lower()
+        return (
+            normalized_tool_type not in skip_tool_types
+            and normalized_tool_name not in skip_tool_types
+        )
 
     def _inject_review_feedback_into_inputs(
         self,
@@ -823,7 +830,13 @@ class MoonMindRunWorkflow:
             issues,
         )
         if tool_type == "agent_runtime":
-            for key in ("instruction", "instructionsText", "instructions_text"):
+            for key in (
+                "instructions",
+                "instructionRef",
+                "instruction",
+                "instructionsText",
+                "instructions_text",
+            ):
                 instruction = merged_inputs.get(key)
                 if isinstance(instruction, str) and instruction.strip():
                     merged_inputs[key] = build_feedback_instruction(
@@ -1632,6 +1645,7 @@ class MoonMindRunWorkflow:
             review_gate_active = self._review_gate_active(
                 approval_policy=approval_policy,
                 tool_type=tool_type,
+                tool_name=tool_name,
             )
             max_review_attempts = (
                 int(getattr(approval_policy, "max_review_attempts", 0))
@@ -1922,14 +1936,15 @@ class MoonMindRunWorkflow:
                         **self._execute_kwargs_for_route(review_route),
                     )
                 )
+                step_attempt = self._step_attempt_for(node_id) or 0
                 review_artifact_ref = await self._write_json_artifact(
                     name=(
                         "reports/review_"
-                        f"{node_id}_attempt_{self._step_attempt_for(node_id) or 0}.json"
+                        f"{node_id}_attempt_{step_attempt}.json"
                     ),
                     payload={
                         "logicalStepId": node_id,
-                        "attempt": self._step_attempt_for(node_id),
+                        "attempt": step_attempt,
                         "reviewAttempt": current_review_attempt,
                         "request": review_request.to_payload(),
                         "verdict": review_verdict.to_payload(),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -45,12 +45,19 @@ with workflow.unsafe.imports_passed_through():
     )
 
 from moonmind.workflows.skills.skill_plan_contracts import parse_plan_definition
+from moonmind.workflows.skills.approval_policy import (
+    ReviewRequest,
+    build_feedback_input,
+    build_feedback_instruction,
+    parse_review_verdict,
+)
 from moonmind.workflows.skills.skill_registry import parse_skill_registry
 from moonmind.workflows.temporal.step_ledger import (
     build_initial_step_rows,
     build_progress_summary,
     build_step_ledger_snapshot,
     refresh_ready_steps,
+    upsert_step_check,
     update_step_row,
 )
 from moonmind.workflows.temporal.activity_catalog import (
@@ -631,6 +638,38 @@ class MoonMindRunWorkflow:
             return
         self._sync_progress_snapshot(updated_at=updated_at)
 
+    def _upsert_step_check(
+        self,
+        logical_step_id: str,
+        *,
+        kind: str,
+        status: str,
+        summary: str | None = None,
+        retry_count: int = 0,
+        artifact_ref: str | None = None,
+    ) -> bool:
+        try:
+            upsert_step_check(
+                self._step_ledger_rows,
+                logical_step_id,
+                kind=kind,
+                status=status,
+                summary=summary,
+                retry_count=retry_count,
+                artifact_ref=artifact_ref,
+            )
+        except KeyError:
+            self._get_logger().warning(
+                "Skipping step-check update for unknown logical step id %s",
+                logical_step_id,
+                extra={
+                    "event": "step_check_unknown_step",
+                    "logical_step_id": logical_step_id,
+                },
+            )
+            return False
+        return True
+
     def _step_attempt_for(self, logical_step_id: str) -> int | None:
         for row in self._step_ledger_rows:
             if row.get("logicalStepId") == logical_step_id:
@@ -730,6 +769,70 @@ class MoonMindRunWorkflow:
     def _refresh_step_readiness(self, *, updated_at: datetime) -> None:
         refresh_ready_steps(self._step_ledger_rows, updated_at=updated_at)
         self._sync_progress_snapshot(updated_at=updated_at)
+
+    def _bounded_review_summary(self, value: Any, *, fallback: str) -> str:
+        summary = self._coerce_text(value, max_chars=240)
+        if summary:
+            return summary
+        return fallback
+
+    def _check_status_for_review_verdict(self, verdict: str) -> str:
+        normalized = str(verdict or "").strip().upper()
+        if normalized == "PASS":
+            return "passed"
+        if normalized == "FAIL":
+            return "failed"
+        return "inconclusive"
+
+    def _accepted_review_summary(self, verdict: str, *, retry_count: int) -> str:
+        normalized = str(verdict or "").strip().upper()
+        if normalized == "INCONCLUSIVE":
+            return "Review inconclusive; accepted execution"
+        if retry_count > 0:
+            return f"Approved after {retry_count} retry"
+        return "Approved by structured review"
+
+    def _review_gate_active(
+        self,
+        *,
+        approval_policy: Any,
+        tool_type: str,
+    ) -> bool:
+        if approval_policy is None or not getattr(approval_policy, "enabled", False):
+            return False
+        skip_tool_types = {
+            str(value).strip().lower()
+            for value in getattr(approval_policy, "skip_tool_types", ())
+            if str(value).strip()
+        }
+        return tool_type not in skip_tool_types
+
+    def _inject_review_feedback_into_inputs(
+        self,
+        *,
+        tool_type: str,
+        original_inputs: Mapping[str, Any],
+        attempt: int,
+        feedback: str,
+        issues: tuple[Mapping[str, Any], ...],
+    ) -> dict[str, Any]:
+        merged_inputs = build_feedback_input(
+            original_inputs,
+            attempt,
+            feedback,
+            issues,
+        )
+        if tool_type == "agent_runtime":
+            for key in ("instruction", "instructionsText", "instructions_text"):
+                instruction = merged_inputs.get(key)
+                if isinstance(instruction, str) and instruction.strip():
+                    merged_inputs[key] = build_feedback_instruction(
+                        instruction,
+                        attempt,
+                        feedback,
+                    )
+                    break
+        return merged_inputs
 
     def _dependency_ids_from_parameters(self, parameters: Mapping[str, Any]) -> list[str]:
         task_payload = parameters.get("task")
@@ -1524,175 +1627,222 @@ class MoonMindRunWorkflow:
             ).strip()
             tool_version = str(selected_node.get("version") or "").strip()
             node_id = str(node.get("id") or "unknown")
-            node_inputs = dict(node.get("inputs", {}))
-
-            self._step_count = index
-            self._summary = (
-                f"Executing plan step {index}/{len(ordered_nodes)}: {tool_name}"
+            original_node_inputs = dict(node.get("inputs", {}))
+            approval_policy = plan_definition.policy.approval_policy
+            review_gate_active = self._review_gate_active(
+                approval_policy=approval_policy,
+                tool_type=tool_type,
             )
-            self._update_memo()
-            self._refresh_step_readiness(updated_at=workflow.now())
-            self._mark_step_running(
-                node_id,
-                updated_at=workflow.now(),
-                summary=self._summary,
+            max_review_attempts = (
+                int(getattr(approval_policy, "max_review_attempts", 0))
+                if review_gate_active
+                else 0
             )
+            review_retry_count = 0
+            previous_review_feedback: str | None = None
+            previous_review_issues: tuple[Mapping[str, Any], ...] = ()
+            result_status: str | None = None
+            execution_result: Any = None
+            accepted_execution = False
+            current_review_attempt = 1
 
-            system_retries = 0
-            while system_retries <= 3:
-                if tool_type == "agent_runtime":
-                    # --- Agent dispatch: child workflow ---
-                    try:
-                        request = self._build_agent_execution_request(
-                            node_inputs=node_inputs,
-                            node_id=node_id,
-                            tool_name=tool_name,
-                            resolved_skillset_ref=registry_snapshot_ref,
-                        )
-                        request = await self._maybe_bind_task_scoped_session(request)
-                        child_workflow_id = (
-                            f"{workflow.info().workflow_id}:agent:{node_id}"
-                        )
-                        if system_retries > 0:
-                            child_workflow_id = (
-                                f"{child_workflow_id}:retry{system_retries}"
-                            )
-                        self._active_agent_child_workflow_id = child_workflow_id
-                        self._active_agent_id = request.agent_id
-                        self._mark_step_waiting(
-                            node_id,
-                            status="awaiting_external",
-                            updated_at=workflow.now(),
-                            waiting_reason="Awaiting child workflow progress",
-                            summary=f"Awaiting child workflow for {tool_name}",
-                            refs={"childWorkflowId": child_workflow_id},
-                        )
-                        try:
-                            child_result = await workflow.execute_child_workflow(
-                                "MoonMind.AgentRun",
-                                request,
-                                id=child_workflow_id,
-                                task_queue=WORKFLOW_TASK_QUEUE,
-                            )
-                        finally:
-                            self._active_agent_child_workflow_id = None
-                            self._active_agent_id = None
-                        execution_result = self._map_agent_run_result(child_result)
-                    except Exception:
-                        self._mark_step_terminal(
-                            node_id,
-                            status="failed",
-                            updated_at=workflow.now(),
-                            summary=f"{tool_name} failed",
-                            last_error="execution_error",
-                        )
-                        if failure_mode == "FAIL_FAST":
-                            raise
-                        result_status = "FAILED"
-                        break
-
-                elif tool_type == "skill":
-                    # --- Activity dispatch: existing skill path ---
-                    if not tool_name or not tool_version:
-                        raise ValueError("plan node tool name/version is required")
-                    invocation_payload = {
-                        "id": node_id,
-                        "tool": {
-                            "type": "skill",
-                            "name": tool_name,
-                            "version": tool_version,
-                        },
-                        "skill": {"name": tool_name, "version": tool_version},
-                        "inputs": node_inputs,
-                        "options": node.get("options", {}),
-                    }
-                    route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                        "mm.skill.execute"
-                    )
-                    if skill_definitions_by_key:
-                        skill_key = (tool_name, tool_version)
-                        if skill_key not in skill_definitions_by_key:
-                            raise ValueError(
-                                "Tool "
-                                f"'{tool_name}:{tool_version}' was not found in pinned "
-                                "registry snapshot"
-                            )
-                        route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(
-                            skill_definitions_by_key[skill_key]
-                        )
-                    if route.activity_type not in {
-                        "mm.skill.execute",
-                        "mm.tool.execute",
-                    }:
-                        raise ValueError(
-                            "plan node tool executor "
-                            f"'{route.activity_type}' is unsupported by MoonMind.Run; "
-                            "expected mm.tool.execute or mm.skill.execute"
-                        )
-
-                    try:
-                        execute_payload = {
-                            "invocation_payload": invocation_payload,
-                            "principal": self._principal(),
-                            "registry_snapshot_ref": registry_snapshot_ref,
-                            "context": {
-                                "workflow_id": workflow.info().workflow_id,
-                                "run_id": workflow.info().run_id,
-                                "node_id": node_id,
-                            },
-                        }
-                        if workflow.patched("idempotency_key_phase3"):
-                            execute_payload["idempotency_key"] = (
-                                f"{workflow.info().workflow_id}_{node_id}_execute"
-                            )
-
-                        execution_result = await workflow.execute_activity(
-                            route.activity_type,
-                            execute_payload,
-                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                            **self._execute_kwargs_for_route(route),
-                        )
-                    except Exception:
-                        self._mark_step_terminal(
-                            node_id,
-                            status="failed",
-                            updated_at=workflow.now(),
-                            summary=f"{tool_name} failed",
-                            last_error="execution_error",
-                        )
-                        if failure_mode == "FAIL_FAST":
-                            raise
-                        result_status = "FAILED"
-                        break
-
-                else:
-                    raise ValueError(
-                        f"unsupported plan node tool.type: '{tool_type}'; "
-                        "expected 'skill' or 'agent_runtime'"
+            while current_review_attempt <= (max_review_attempts + 1):
+                node_inputs = dict(original_node_inputs)
+                if previous_review_feedback:
+                    node_inputs = self._inject_review_feedback_into_inputs(
+                        tool_type=tool_type,
+                        original_inputs=node_inputs,
+                        attempt=review_retry_count,
+                        feedback=previous_review_feedback,
+                        issues=previous_review_issues,
                     )
 
-                result_status = self._activity_result_status(execution_result)
-                if result_status is None:
-                    if failure_mode == "FAIL_FAST":
-                        raise ValueError(
-                            "plan node execution result is missing required status field"
-                        )
-                    break
-                self._record_step_result_evidence(
-                    node_id,
-                    execution_result=execution_result,
-                    updated_at=workflow.now(),
+                self._step_count = index
+                self._summary = (
+                    f"Executing plan step {index}/{len(ordered_nodes)}: {tool_name}"
                 )
-                if result_status != "COMPLETED":
-                    failure_message = self._activity_result_failure_message(
-                        execution_result
-                    )
+                self._update_memo()
+                self._refresh_step_readiness(updated_at=workflow.now())
+                self._mark_step_running(
+                    node_id,
+                    updated_at=workflow.now(),
+                    summary=self._summary,
+                )
 
-                    retryable = failure_message == "system_error" or (
-                        failure_message == "execution_error"
-                        and tool_type == "agent_runtime"
+                system_retries = 0
+                while system_retries <= 3:
+                    if tool_type == "agent_runtime":
+                        # --- Agent dispatch: child workflow ---
+                        try:
+                            request = self._build_agent_execution_request(
+                                node_inputs=node_inputs,
+                                node_id=node_id,
+                                tool_name=tool_name,
+                                resolved_skillset_ref=registry_snapshot_ref,
+                            )
+                            request = await self._maybe_bind_task_scoped_session(request)
+                            child_workflow_id = (
+                                f"{workflow.info().workflow_id}:agent:{node_id}"
+                            )
+                            if system_retries > 0:
+                                child_workflow_id = (
+                                    f"{child_workflow_id}:retry{system_retries}"
+                                )
+                            self._active_agent_child_workflow_id = child_workflow_id
+                            self._active_agent_id = request.agent_id
+                            self._mark_step_waiting(
+                                node_id,
+                                status="awaiting_external",
+                                updated_at=workflow.now(),
+                                waiting_reason="Awaiting child workflow progress",
+                                summary=f"Awaiting child workflow for {tool_name}",
+                                refs={"childWorkflowId": child_workflow_id},
+                            )
+                            try:
+                                child_result = await workflow.execute_child_workflow(
+                                    "MoonMind.AgentRun",
+                                    request,
+                                    id=child_workflow_id,
+                                    task_queue=WORKFLOW_TASK_QUEUE,
+                                )
+                            finally:
+                                self._active_agent_child_workflow_id = None
+                                self._active_agent_id = None
+                            execution_result = self._map_agent_run_result(child_result)
+                        except Exception:
+                            self._mark_step_terminal(
+                                node_id,
+                                status="failed",
+                                updated_at=workflow.now(),
+                                summary=f"{tool_name} failed",
+                                last_error="execution_error",
+                            )
+                            if failure_mode == "FAIL_FAST":
+                                raise
+                            result_status = "FAILED"
+                            break
+
+                    elif tool_type == "skill":
+                        # --- Activity dispatch: existing skill path ---
+                        if not tool_name or not tool_version:
+                            raise ValueError("plan node tool name/version is required")
+                        invocation_payload = {
+                            "id": node_id,
+                            "tool": {
+                                "type": "skill",
+                                "name": tool_name,
+                                "version": tool_version,
+                            },
+                            "skill": {"name": tool_name, "version": tool_version},
+                            "inputs": node_inputs,
+                            "options": node.get("options", {}),
+                        }
+                        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                            "mm.skill.execute"
+                        )
+                        if skill_definitions_by_key:
+                            skill_key = (tool_name, tool_version)
+                            if skill_key not in skill_definitions_by_key:
+                                raise ValueError(
+                                    "Tool "
+                                    f"'{tool_name}:{tool_version}' was not found in pinned "
+                                    "registry snapshot"
+                                )
+                            route = DEFAULT_ACTIVITY_CATALOG.resolve_skill(
+                                skill_definitions_by_key[skill_key]
+                            )
+                        if route.activity_type not in {
+                            "mm.skill.execute",
+                            "mm.tool.execute",
+                        }:
+                            raise ValueError(
+                                "plan node tool executor "
+                                f"'{route.activity_type}' is unsupported by MoonMind.Run; "
+                                "expected mm.tool.execute or mm.skill.execute"
+                            )
+
+                        try:
+                            execute_payload = {
+                                "invocation_payload": invocation_payload,
+                                "principal": self._principal(),
+                                "registry_snapshot_ref": registry_snapshot_ref,
+                                "context": {
+                                    "workflow_id": workflow.info().workflow_id,
+                                    "run_id": workflow.info().run_id,
+                                    "node_id": node_id,
+                                },
+                            }
+                            if workflow.patched("idempotency_key_phase3"):
+                                execute_payload["idempotency_key"] = (
+                                    f"{workflow.info().workflow_id}_{node_id}_execute"
+                                )
+
+                            execution_result = await workflow.execute_activity(
+                                route.activity_type,
+                                execute_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                **self._execute_kwargs_for_route(route),
+                            )
+                        except Exception:
+                            self._mark_step_terminal(
+                                node_id,
+                                status="failed",
+                                updated_at=workflow.now(),
+                                summary=f"{tool_name} failed",
+                                last_error="execution_error",
+                            )
+                            if failure_mode == "FAIL_FAST":
+                                raise
+                            result_status = "FAILED"
+                            break
+
+                    else:
+                        raise ValueError(
+                            f"unsupported plan node tool.type: '{tool_type}'; "
+                            "expected 'skill' or 'agent_runtime'"
+                        )
+
+                    result_status = self._activity_result_status(execution_result)
+                    if result_status is None:
+                        if failure_mode == "FAIL_FAST":
+                            raise ValueError(
+                                "plan node execution result is missing required status field"
+                            )
+                        break
+                    self._record_step_result_evidence(
+                        node_id,
+                        execution_result=execution_result,
+                        updated_at=workflow.now(),
                     )
-                    if retryable and system_retries < 3:
+                    if result_status != "COMPLETED":
+                        failure_message = self._activity_result_failure_message(
+                            execution_result
+                        )
+
+                        retryable = failure_message == "system_error" or (
+                            failure_message == "execution_error"
+                            and tool_type == "agent_runtime"
+                        )
+                        if retryable and system_retries < 3:
+                            self._mark_step_terminal(
+                                node_id,
+                                status="failed",
+                                updated_at=workflow.now(),
+                                summary=f"{tool_name} failed",
+                                last_error=failure_message,
+                            )
+                            system_retries += 1
+                            self._get_logger().info(
+                                f"Retrying plan node {node_id} after {failure_message} "
+                                f"(attempt {system_retries} of 3)"
+                            )
+                            self._mark_step_running(
+                                node_id,
+                                updated_at=workflow.now(),
+                                summary=self._summary,
+                            )
+                            continue
+
                         self._mark_step_terminal(
                             node_id,
                             status="failed",
@@ -1700,39 +1850,145 @@ class MoonMindRunWorkflow:
                             summary=f"{tool_name} failed",
                             last_error=failure_message,
                         )
-                        system_retries += 1
-                        self._get_logger().info(
-                            f"Retrying plan node {node_id} after {failure_message} "
-                            f"(attempt {system_retries} of 3)"
-                        )
-                        self._mark_step_running(
-                            node_id,
-                            updated_at=workflow.now(),
-                            summary=self._summary,
-                        )
-                        continue
+                        if failure_mode == "FAIL_FAST":
+                            detail = (
+                                f" with error '{failure_message}'"
+                                if failure_message
+                                else ""
+                            )
+                            raise ValueError(
+                                f"plan node execution returned status {result_status}{detail}"
+                            )
+                        break
 
+                    break
+
+                if result_status is None or result_status != "COMPLETED":
+                    break
+
+                if not review_gate_active:
+                    accepted_execution = True
+                    break
+
+                self._mark_step_waiting(
+                    node_id,
+                    status="reviewing",
+                    updated_at=workflow.now(),
+                    waiting_reason="Awaiting structured review result",
+                    summary="Structured review in progress",
+                )
+                self._upsert_step_check(
+                    node_id,
+                    kind="approval_policy",
+                    status="pending",
+                    summary="Structured review in progress",
+                    retry_count=review_retry_count,
+                    artifact_ref=None,
+                )
+
+                review_request = ReviewRequest(
+                    node_id=node_id,
+                    step_index=index,
+                    total_steps=len(ordered_nodes),
+                    review_attempt=current_review_attempt,
+                    tool_name=tool_name,
+                    tool_version=tool_version,
+                    tool_type=tool_type,
+                    inputs=node_inputs,
+                    execution_result=(
+                        execution_result
+                        if isinstance(execution_result, Mapping)
+                        else {}
+                    ),
+                    workflow_context={
+                        "workflow_id": workflow.info().workflow_id,
+                        "run_id": workflow.info().run_id,
+                        "plan_title": plan_definition.metadata.title,
+                    },
+                    reviewer_model=str(
+                        getattr(approval_policy, "reviewer_model", "default")
+                    ),
+                    review_timeout_seconds=int(
+                        getattr(approval_policy, "review_timeout_seconds", 120)
+                    ),
+                    previous_feedback=previous_review_feedback,
+                )
+                review_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("step.review")
+                review_verdict = parse_review_verdict(
+                    await workflow.execute_activity(
+                        "step.review",
+                        review_request.to_payload(),
+                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        **self._execute_kwargs_for_route(review_route),
+                    )
+                )
+                review_artifact_ref = await self._write_json_artifact(
+                    name=(
+                        "reports/review_"
+                        f"{node_id}_attempt_{self._step_attempt_for(node_id) or 0}.json"
+                    ),
+                    payload={
+                        "logicalStepId": node_id,
+                        "attempt": self._step_attempt_for(node_id),
+                        "reviewAttempt": current_review_attempt,
+                        "request": review_request.to_payload(),
+                        "verdict": review_verdict.to_payload(),
+                    },
+                )
+                review_check_status = self._check_status_for_review_verdict(
+                    review_verdict.verdict
+                )
+
+                if review_verdict.verdict == "FAIL":
+                    review_retry_count += 1
+                    failed_review_summary = self._bounded_review_summary(
+                        review_verdict.feedback,
+                        fallback="Review failed; retrying step",
+                    )
+                    self._upsert_step_check(
+                        node_id,
+                        kind="approval_policy",
+                        status=review_check_status,
+                        summary=failed_review_summary,
+                        retry_count=review_retry_count,
+                        artifact_ref=review_artifact_ref,
+                    )
+                    if review_retry_count <= max_review_attempts:
+                        previous_review_feedback = (
+                            review_verdict.feedback
+                            or "Structured review requested another retry."
+                        )
+                        previous_review_issues = tuple(review_verdict.issues)
+                        current_review_attempt += 1
+                        continue
                     self._mark_step_terminal(
                         node_id,
                         status="failed",
                         updated_at=workflow.now(),
-                        summary=f"{tool_name} failed",
-                        last_error=failure_message,
+                        summary=failed_review_summary,
+                        last_error="review_failed",
                     )
                     if failure_mode == "FAIL_FAST":
-                        detail = (
-                            f" with error '{failure_message}'"
-                            if failure_message
-                            else ""
-                        )
                         raise ValueError(
-                            f"plan node execution returned status {result_status}{detail}"
+                            f"plan node review failed after {review_retry_count} retry"
                         )
                     break
 
+                self._upsert_step_check(
+                    node_id,
+                    kind="approval_policy",
+                    status=review_check_status,
+                    summary=self._accepted_review_summary(
+                        review_verdict.verdict,
+                        retry_count=review_retry_count,
+                    ),
+                    retry_count=review_retry_count,
+                    artifact_ref=review_artifact_ref,
+                )
+                accepted_execution = True
                 break
 
-            if result_status is None or result_status != "COMPLETED":
+            if not accepted_execution:
                 continue
 
             self._mark_step_terminal(

--- a/specs/142-step-ledger-phase5/checklists/requirements.md
+++ b/specs/142-step-ledger-phase5/checklists/requirements.md
@@ -1,0 +1,8 @@
+# Specification Quality Checklist: Step Ledger Phase 5
+
+- [x] Runtime scope includes production workflow code changes.
+- [x] Validation tasks include workflow-boundary and UI verification.
+- [x] Source requirements map to functional requirements and planned implementation.
+- [x] Review evidence is explicitly artifact-backed rather than workflow-state-backed.
+- [x] `reviewing` lifecycle behavior and `checks[]` semantics are explicit.
+- [x] The existing Steps UI remains the primary review/check surface.

--- a/specs/142-step-ledger-phase5/contracts/requirements-traceability.md
+++ b/specs/142-step-ledger-phase5/contracts/requirements-traceability.md
@@ -1,0 +1,12 @@
+# Requirements Traceability: Step Ledger Phase 5
+
+| Source Requirement | Spec Mapping | Planned Implementation | Validation Strategy |
+| --- | --- | --- | --- |
+| DOC-REQ-001 | FR-001, FR-004 | Mutate the workflow-owned step row to `reviewing` during approval-policy work and preserve attempt semantics across retries | Workflow-boundary tests assert live `reviewing` transitions and final attempt counts |
+| DOC-REQ-002 | FR-002 | Populate `checks[]` with `approval_policy` verdict state, bounded summaries, retry counts, and artifact refs | Workflow-boundary tests assert check-row shape; UI tests assert rendering |
+| DOC-REQ-003 | FR-003 | Write full review request/verdict/issue payloads to artifacts and store only bounded summaries in workflow state | Workflow-boundary tests assert `artifactRef` linkage and bounded row content |
+| DOC-REQ-004 | FR-001, FR-004, FR-005 | Execute review after eligible steps, retry failed reviews with feedback injection, and accept `INCONCLUSIVE` results | Workflow-boundary tests cover PASS, FAIL→retry→PASS, and INCONCLUSIVE |
+| DOC-REQ-005 | FR-002, FR-005, FR-006 | Surface operator-visible review state, verdicts, and retry progress on the step row and in Mission Control | Workflow-boundary tests plus targeted task-detail UI tests |
+| DOC-REQ-006 | FR-006 | Extend the existing Checks section rather than inventing a new detail surface | Task-detail tests assert review metadata appears inside Checks |
+| DOC-REQ-007 | FR-006 | Keep compact badge/readability patterns consistent with Mission Control semantic styling | UI rendering checks plus targeted frontend verification |
+| DOC-REQ-008 | FR-001, FR-007 | Add workflow-boundary coverage for `reviewing` lifecycle transitions and replay-safe step-ledger mutation | `pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q` |

--- a/specs/142-step-ledger-phase5/contracts/review-check-ledger-contract.md
+++ b/specs/142-step-ledger-phase5/contracts/review-check-ledger-contract.md
@@ -1,0 +1,32 @@
+# Review Check Ledger Contract
+
+## Workflow behavior
+
+1. Execute the plan step normally.
+2. If approval policy is enabled for the step and the execution completed successfully:
+   - mark the step `reviewing`
+   - upsert a pending `approval_policy` check row
+   - execute `step.review`
+   - write review evidence to an artifact
+   - update the same check row with final verdict summary, retry count, and `artifactRef`
+3. If the verdict is `FAIL` and retries remain:
+   - inject feedback into the rerun
+   - rerun the same logical step
+4. If the verdict is `PASS` or `INCONCLUSIVE`:
+   - finish the step normally
+
+## Step row invariants
+
+- `logicalStepId` remains stable across review retries.
+- `attempt` increments for each rerun of the logical step.
+- `checks[]` remains bounded and display-safe.
+- `artifactRef` points to review evidence, never inline review bodies.
+
+## UI contract
+
+The Checks section must render, per check row:
+
+1. verdict badge
+2. bounded summary
+3. `Retry count: N`
+4. `Review artifact: <artifactRef>` or explicit “No review artifact linked yet.”

--- a/specs/142-step-ledger-phase5/data-model.md
+++ b/specs/142-step-ledger-phase5/data-model.md
@@ -1,0 +1,63 @@
+# Data Model: Step Ledger Phase 5
+
+## ApprovalPolicyStepCheck
+
+Phase 5 makes approval policy the first concrete `checks[]` producer.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `kind` | `"approval_policy"` | Stable check kind for review-gate output |
+| `status` | `pending \| passed \| failed \| inconclusive` | Current/final review verdict state shown in the UI |
+| `summary` | string \| null | Bounded operator-facing summary of the latest review state |
+| `retryCount` | integer | Number of failed reviews that triggered a retry for the logical step |
+| `artifactRef` | string \| null | Artifact containing full review request/verdict/issues payload |
+
+## Review lifecycle on one logical step row
+
+1. Step execution begins: row status becomes `running`, `attempt` increments.
+2. Eligible completed execution enters review: row status becomes `reviewing`; `checks[]` contains a pending `approval_policy` row.
+3. Review verdict is stored:
+   - `PASS`: check becomes `passed`, row later becomes `succeeded`
+   - `FAIL` with retries remaining: check becomes `failed`, `retryCount` increments, feedback is injected into the rerun, and the same logical step reruns
+   - `INCONCLUSIVE`: check becomes `inconclusive`, but the workflow accepts the execution
+4. Full request/verdict/issue detail is stored in a JSON artifact referenced by `artifactRef`
+
+## ReviewEvidenceArtifact
+
+Suggested JSON payload shape written by the workflow:
+
+```json
+{
+  "logicalStepId": "apply-patch",
+  "attempt": 2,
+  "reviewAttempt": 2,
+  "request": { "...": "bounded copy of review request payload" },
+  "verdict": {
+    "verdict": "FAIL",
+    "confidence": 0.82,
+    "feedback": "Tests still fail because imports are missing.",
+    "issues": [
+      {
+        "severity": "error",
+        "description": "Missing import",
+        "evidence": "stderr tail"
+      }
+    ]
+  }
+}
+```
+
+The workflow row stores only:
+
+- latest bounded summary
+- `retryCount`
+- latest `artifactRef`
+
+## UI rendering additions
+
+The existing Checks group adds two small pieces of structured metadata per check row:
+
+1. `Retry count: N`
+2. `Review artifact: <artifactRef>` or explicit empty-state copy
+
+The rest of the expanded step surface remains unchanged from Phase 4.

--- a/specs/142-step-ledger-phase5/plan.md
+++ b/specs/142-step-ledger-phase5/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Step Ledger Phase 5
+
+**Branch**: `142-step-ledger-phase5` | **Date**: 2026-04-08 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/142-step-ledger-phase5/spec.md`
+
+## Summary
+
+Reconcile approval-policy review state into the workflow-owned step ledger. `MoonMind.Run` will execute structured review for eligible steps, mutate `checks[]` and `reviewing` status as the authoritative live state, offload full review evidence to artifacts, and expose retry counts plus review evidence in the existing Mission Control Checks section.
+
+## Technical Context
+
+**Language/Version**: Python 3.11 for workflow/runtime code, TypeScript + React 18 for Mission Control  
+**Primary Dependencies**: Temporal Python SDK, existing artifact activities, existing `step.review` activity route, React/Vitest task-detail surface  
+**Storage**: Compact workflow state for step status/check summaries; JSON artifacts for full review request/verdict payloads; existing browser query cache only  
+**Testing**: `pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`  
+**Target Platform**: `MoonMind.Run` workflow and Mission Control task-detail UI  
+**Project Type**: Backend workflow/state integration with small frontend evidence rendering updates  
+**Performance Goals**: Keep review payloads out of workflow state; do not add whole-page observability reads; keep execution-detail polling bounded  
+**Constraints**: Preserve latest-run-only semantics, keep review evidence artifact-backed, avoid workflow-state bloat, and keep workflow mutations deterministic and replay-safe  
+**Scale/Scope**: `MoonMind.Run` review/check integration, step-ledger helpers, step-detail check rendering/tests, no new page routes or compatibility layers
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. `MoonMind.Run` remains the owner of operator-facing review/check state instead of introducing a second review status system outside the workflow.
+- **IV. Own Your Data**: PASS. Full review feedback and issue payloads remain in MoonMind artifacts, not in logs or external-only stores.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The work reuses the existing `step.review` route, `checks[]` schema, and Steps UI contract instead of inventing new read paths.
+- **IX. Resilient by Default**: PASS. Review state remains deterministic, artifact-backed, and covered by workflow-boundary tests for reviewing/retry transitions.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Phase 5 gets a dedicated feature package with source traceability and explicit validation tasks.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical semantics stay in the step-ledger/review docs; this plan captures rollout work only.
+- **XIII. Pre-Release Delete, Don't Deprecate**: PASS. The implementation extends the canonical step ledger rather than preserving a parallel observability-only review story.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/142-step-ledger-phase5/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── requirements-traceability.md
+│   └── review-check-ledger-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/step_ledger.py                    # MODIFY: structured check helpers for bounded step-check mutation
+moonmind/workflows/temporal/workflows/run.py                 # MODIFY: approval-policy review loop, retry/check mutation, review evidence artifacts
+tests/unit/workflows/temporal/test_step_ledger.py            # MODIFY: helper/model coverage for structured checks
+tests/unit/workflows/temporal/workflows/test_run_step_ledger.py  # MODIFY: workflow-boundary review/check transition coverage
+frontend/src/entrypoints/task-detail.tsx                     # MODIFY: show retry counts and review artifact refs in Checks section
+frontend/src/entrypoints/task-detail.test.tsx                # MODIFY: verify review/check rendering in the existing Steps panel
+frontend/src/styles/mission-control.css                      # MODIFY: small styling refinements for review metadata in the Checks section
+```
+
+**Structure Decision**: Keep review/check production inside `MoonMind.Run` because the step ledger is workflow-owned state. The UI change remains a narrow extension of the Phase 4 Steps panel rather than a new review-specific surface.
+
+## Complexity Tracking
+
+The main implementation risk is mixing review retry logic with existing execution and system retry behavior in a way that obscures the current attempt or bloats workflow state. Mitigation: keep review evidence artifact-backed, isolate check mutation into small step-ledger helpers, and add workflow-boundary tests that assert the final row shape rather than only unit-testing helpers in isolation.

--- a/specs/142-step-ledger-phase5/quickstart.md
+++ b/specs/142-step-ledger-phase5/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Step Ledger Phase 5
+
+## 1. Run the workflow-boundary review/check tests
+
+```bash
+pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q
+```
+
+## 2. Run the targeted Mission Control step-detail tests
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
+```
+
+## 3. Run the Spec Kit task-scope gate
+
+```bash
+.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+```
+
+## 4. Run the required final verification path
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+```
+
+## Expected verification
+
+- Eligible steps enter `reviewing` during approval-policy review.
+- Final step rows expose structured `approval_policy` checks with retry counts and artifact refs.
+- Full review request/verdict bodies stay artifact-backed rather than inflating workflow state.
+- Mission Control renders verdict badges, retry counts, and review artifact refs inside the Checks section.

--- a/specs/142-step-ledger-phase5/research.md
+++ b/specs/142-step-ledger-phase5/research.md
@@ -1,0 +1,30 @@
+# Research: Step Ledger Phase 5
+
+## Decision 1: Reuse the existing step row as the only review state surface
+
+- **Decision**: Approval-policy review mutates the existing step row through `status`, `attempt`, and `checks[]` rather than creating a separate review projection or a workflow-summary-only status.
+- **Rationale**: The canonical step-ledger doc already assigns `reviewing` and `checks[]` to the workflow-owned row. Phase 5 should make that contract real.
+- **Alternatives considered**:
+  - **Store review state only in workflow summary or memo**: rejected because it bypasses the canonical step-ledger contract and is too lossy for the Steps UI.
+  - **Create a separate review table/projection first**: rejected because the rollout explicitly says approval policy should be the first concrete producer of `checks[]`, not a parallel state machine.
+
+## Decision 2: Persist full review payloads in JSON artifacts, not workflow state
+
+- **Decision**: After each review verdict, write a compact JSON artifact containing the request, verdict, and issues, then link it from `checks[].artifactRef`.
+- **Rationale**: The step-ledger doc explicitly keeps large review bodies out of workflow state and Search Attributes, while still requiring durable evidence.
+- **Alternatives considered**:
+  - **Inline full feedback/issues into `checks[]`**: rejected because it bloats workflow state and breaks the bounded row contract.
+
+## Decision 3: Keep UI scope narrow and build on the Phase 4 Checks section
+
+- **Decision**: Extend the existing Checks section to show retry counts and review artifact refs instead of adding a dedicated review panel.
+- **Rationale**: Phase 4 already established the expanded Steps panel as the primary detail surface with a stable Checks group.
+- **Alternatives considered**:
+  - **Add a new “Review” section under each step**: rejected because it duplicates the purpose of `checks[]` and dilutes the existing information hierarchy.
+
+## Decision 4: Treat review retries as step-attempt retries on the same logical step
+
+- **Decision**: A failed review reruns the same logical step, increments the step attempt, and accumulates `retryCount` on the approval-policy check row.
+- **Rationale**: The canonical step-ledger model makes attempts run-scoped per logical step and expects retries to stay attached to that row.
+- **Alternatives considered**:
+  - **Record review retries separately from step attempts**: rejected because it makes the row harder to reason about and conflicts with the existing attempt model.

--- a/specs/142-step-ledger-phase5/spec.md
+++ b/specs/142-step-ledger-phase5/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Step Ledger Phase 5
+
+**Feature Branch**: `142-step-ledger-phase5`  
+**Created**: 2026-04-08  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 5 using test-driven development of the step-ledger rollout plan. Reconcile review/checks into the workflow-owned step ledger so approval-policy review state, verdicts, retry counts, and review evidence appear inside the Steps UI without parsing logs."
+
+## Source Document Requirements
+
+Source: `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Tasks/StepReviewGateSystem.md`, `docs/UI/MissionControlArchitecture.md`, `docs/UI/MissionControlStyleGuide.md`, `docs/tmp/remaining-work/Temporal-WorkflowTypeCatalogAndLifecycle.md`
+
+| ID | Source Section | Requirement Summary |
+| --- | --- | --- |
+| DOC-REQ-001 | `StepLedgerAndProgressModel` §8-§10 | `MoonMind.Run` step rows must use `reviewing` as a first-class status during structured review/check work and preserve run-scoped attempt semantics. |
+| DOC-REQ-002 | `StepLedgerAndProgressModel` §9 | `checks[]` is the canonical structured location for review/check verdicts, retry counts, summaries, and bounded artifact refs. |
+| DOC-REQ-003 | `StepLedgerAndProgressModel` §3.3, §9 | Large review payloads and feedback must remain out of workflow state and be linked through artifact refs instead. |
+| DOC-REQ-004 | `StepReviewGateSystem` §1, §5.1, §5.2 | Approval policy should wrap eligible step execution with review, retry failed reviews with feedback, and treat `INCONCLUSIVE` as accepted execution. |
+| DOC-REQ-005 | `StepReviewGateSystem` §2, §8 | Mission Control must expose review verdicts, retry progress, and review state as operator-visible step evidence rather than log conventions. |
+| DOC-REQ-006 | `MissionControlArchitecture` §9.2 | Task detail pages are the correct surface for step evidence, checks, managed-run observability, and review results. |
+| DOC-REQ-007 | `MissionControlStyleGuide` §5 | Review/check badges and summaries must remain compact, readable, and consistent with existing Mission Control semantic classes. |
+| DOC-REQ-008 | `remaining-work/Temporal-WorkflowTypeCatalogAndLifecycle` | Workflow lifecycle coverage must include `step reviewing` transitions and remain replay-safe at the workflow boundary. |
+
+## User Scenarios & Testing
+
+### User Story 1 - Approval policy becomes the first real `checks[]` producer (Priority: P1)
+
+An operator enables approval-policy review for a plan and expects the step ledger to show live review state and final verdicts directly on the step row.
+
+**Why this priority**: Phase 5 exists to prevent the review system from creating a parallel state machine outside the step ledger.
+
+**Independent Test**: Execute the workflow boundary with an approval-policy-enabled plan and assert the step row transitions through `reviewing`, emits a structured `approval_policy` check, and ends with a bounded final verdict plus retry count.
+
+**Acceptance Scenarios**:
+
+1. **Given** an eligible step completes execution and approval policy is enabled, **When** the review activity starts, **Then** the step row enters `reviewing` and `checks[]` contains a pending `approval_policy` row.
+2. **Given** the review verdict is `PASS`, **When** review finishes, **Then** the step completes successfully and the final `approval_policy` check shows a passed verdict, bounded summary, retry count, and review evidence artifact ref.
+3. **Given** the review verdict is `INCONCLUSIVE`, **When** review finishes, **Then** the workflow accepts the step execution without introducing a second hidden state machine, while still surfacing the review outcome in `checks[]`.
+
+---
+
+### User Story 2 - Failed reviews retry with feedback while staying inside one step row (Priority: P1)
+
+An operator needs approval-policy failures to retry the same logical step and expose retry counts and latest review evidence without reading raw logs.
+
+**Why this priority**: The main product risk is splitting retry/review state across workflow summaries, logs, and the UI. The step row must remain authoritative.
+
+**Independent Test**: Drive a FAIL then PASS sequence through the workflow boundary and assert the same logical step row increments attempt, records retry count, stores only bounded summary state, and writes full review payloads to artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the first review verdict is `FAIL` and retries remain, **When** the workflow prepares the retry, **Then** the step row records the failed review in `checks[]`, keeps review details bounded, and reruns the same logical step with injected feedback.
+2. **Given** a later review verdict passes after one or more failed reviews, **When** the step completes, **Then** the final step row shows the terminal verdict, accumulated retry count, and latest review evidence artifact ref.
+3. **Given** review feedback contains long text or issues, **When** the workflow stores review evidence, **Then** the step row stores only a bounded summary and artifact ref, not the full review body.
+
+---
+
+### User Story 3 - Mission Control exposes review verdicts inside the expanded step panel (Priority: P2)
+
+An operator opens the Steps panel and expects review status, retry counts, and linked review evidence to be visible in the existing Checks section without leaving the step row.
+
+**Why this priority**: Phase 4 already made Steps the primary detail surface; Phase 5 must finish that surface for review/check work.
+
+**Independent Test**: Render a step row with approval-policy check data and assert the expanded Checks section shows verdict badges, retry counts, and artifact refs with no dependency on task-run logs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a step row has approval-policy check data, **When** the operator expands the row, **Then** the Checks section shows the verdict badge, summary, retry count, and linked review artifact ref.
+2. **Given** the step is still under review, **When** the row renders, **Then** the Steps surface shows `reviewing` state and pending-review copy without waiting for execution-wide logs.
+3. **Given** a row has no review evidence artifact, **When** the row renders, **Then** the Checks section remains stable and explicitly shows that no review artifact is linked yet.
+
+### Edge Cases
+
+- What happens when approval policy is absent or disabled? The execution path remains unchanged and `checks[]` stays empty unless another producer populates it.
+- What happens when a tool type is exempt from review? The step should not enter `reviewing` and no approval-policy check row should be created.
+- What happens when the review activity fails transiently? Temporal activity retry handles the activity failure; the step row should not fabricate a final verdict.
+- What happens when a step already failed execution before review could run? The workflow records the execution failure as before and does not create a fake passed review row.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST invoke structured approval-policy review from `MoonMind.Run` for eligible completed step executions and represent that work with step status `reviewing`. Mappings: DOC-REQ-001, DOC-REQ-004, DOC-REQ-008.
+- **FR-002**: System MUST populate `checks[]` with an `approval_policy` row carrying verdict state, bounded summary, `retryCount`, and optional `artifactRef`, instead of requiring log parsing. Mappings: DOC-REQ-002, DOC-REQ-005.
+- **FR-003**: System MUST keep full review feedback/issues outside workflow state by writing review evidence to artifacts and linking that artifact through `checks[].artifactRef`. Mappings: DOC-REQ-003.
+- **FR-004**: System MUST retry eligible steps after failed reviews by injecting review feedback into the rerun while keeping the latest/current attempt state on the same logical step row. Mappings: DOC-REQ-001, DOC-REQ-004.
+- **FR-005**: System MUST treat `INCONCLUSIVE` review outcomes as accepted execution while still surfacing the actual review result in step evidence. Mappings: DOC-REQ-004, DOC-REQ-005.
+- **FR-006**: System MUST render approval-policy check data in the existing Mission Control Steps surface with compact badges, retry count copy, and review artifact refs in the Checks section. Mappings: DOC-REQ-005, DOC-REQ-006, DOC-REQ-007.
+- **FR-007**: System MUST add workflow-boundary tests for `reviewing` transitions, final verdict/check state, retry count behavior, and bounded artifact-backed review evidence. Mappings: DOC-REQ-008.
+- **FR-008**: System MUST implement production runtime code changes plus validation tests in this phase; documentation-only work is insufficient. Mappings: DOC-REQ-001 through DOC-REQ-008.
+
+### Key Entities
+
+- **ApprovalPolicyStepCheck**: The `checks[]` row for approval-policy review, carrying verdict state, bounded summary, retry count, and optional evidence artifact ref.
+- **ReviewEvidenceArtifact**: The durable JSON artifact containing full review request/verdict/issue payloads that stay outside workflow state.
+- **ReviewRetryState**: Workflow-owned state that tracks current review feedback and retry count for one logical step attempt sequence.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Workflow-boundary tests prove eligible steps transition through `reviewing` and end with structured `approval_policy` check rows.
+- **SC-002**: Workflow-boundary tests prove a FAIL→PASS review sequence increments step attempt, exposes retry count, and stores full review evidence in an artifact instead of workflow state.
+- **SC-003**: UI tests prove the expanded Checks section shows verdict badges, retry counts, and review artifact refs without requiring task-run observability fetches.
+- **SC-004**: `pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` pass.
+
+## Assumptions
+
+- Phase 5 focuses on reconciling review/check state into the existing ledger and UI, not on building a richer cross-run review history surface.
+- The placeholder `step.review` activity may continue using mocked/pass-through behavior in isolated activity tests, while workflow-boundary tests stub verdicts directly.
+- The Phase 3/4 execution and task-detail contracts remain authoritative; this phase extends them rather than redefining step identity or latest-run semantics.

--- a/specs/142-step-ledger-phase5/speckit_analyze_report.md
+++ b/specs/142-step-ledger-phase5/speckit_analyze_report.md
@@ -1,0 +1,33 @@
+# Speckit Analyze Report: Step Ledger Phase 5
+
+## Findings
+
+### spec.md
+
+- Severity: LOW
+- Location: User Story 1 / User Story 2
+- Problem: Review verdict storage could drift into workflow state if the artifact boundary is not explicit.
+- Remediation: Keep `artifactRef` mandatory when full review evidence exists and describe the bounded workflow-state posture directly in the requirements.
+- Rationale: This preserves Temporal history safety and keeps the step ledger display-safe.
+
+### plan.md
+
+- Severity: LOW
+- Location: Summary / Complexity Tracking
+- Problem: The workflow/system retry interaction could be easy to misread.
+- Remediation: Call out the review-vs-system-retry risk and keep the implementation centered on small step-ledger helpers plus workflow-boundary tests.
+- Rationale: This is the highest-risk integration seam in Phase 5.
+
+### tasks.md
+
+- Severity: LOW
+- Location: Phase 2 / Phase 3
+- Problem: UI work could race ahead of the final check-row shape.
+- Remediation: Keep UI implementation dependent on the finalized `checks[]` contract from workflow work.
+- Rationale: Prevents frontend polish from encoding speculative review-state semantics.
+
+## Safe to Implement
+
+- **Safe to Implement**: YES
+- **Blocking Remediations**: None
+- **Determination Rationale**: The Phase 5 artifacts now tie the review/check rollout directly to the existing step-ledger contract, keep evidence artifact-backed, and define workflow-boundary plus UI validation for the highest-risk behavior.

--- a/specs/142-step-ledger-phase5/tasks.md
+++ b/specs/142-step-ledger-phase5/tasks.md
@@ -1,0 +1,94 @@
+# Tasks: Step Ledger Phase 5
+
+**Input**: Design documents from `/specs/142-step-ledger-phase5/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing workflow-boundary/UI tests before implementing the corresponding behavior.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create or extend the Phase 5 workflow-boundary test target in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`.
+- [X] T002 Create or extend the Phase 5 UI test target in `frontend/src/entrypoints/task-detail.test.tsx`.
+
+---
+
+## Phase 2: User Story 1 - Approval policy becomes the first real `checks[]` producer (Priority: P1)
+
+**Goal**: `MoonMind.Run` owns live review/check state in the step ledger.
+
+### Tests for User Story 1
+
+- [X] T003 [P] [US1] Write failing workflow-boundary tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` covering `reviewing` transitions, pending approval-policy checks, PASS verdicts, and `INCONCLUSIVE` acceptance.
+- [X] T004 [P] [US1] Extend `tests/unit/workflows/temporal/test_step_ledger.py` with failing helper/model assertions for structured approval-policy check mutation and bounded artifact refs.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update `moonmind/workflows/temporal/step_ledger.py` with deterministic helpers for upserting structured step checks.
+- [X] T006 [US1] Update `moonmind/workflows/temporal/workflows/run.py` to invoke `step.review` for eligible completed steps, mark rows `reviewing`, persist review evidence artifacts, and finalize approval-policy check rows.
+
+---
+
+## Phase 3: User Story 2 - Failed reviews retry with feedback on the same logical step (Priority: P1)
+
+**Goal**: Approval-policy failures retry the same logical step while keeping the row authoritative.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Write failing workflow-boundary tests in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` covering FAIL→retry→PASS, retry count accumulation, feedback injection, and bounded artifact-backed review evidence.
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Update `moonmind/workflows/temporal/workflows/run.py` to inject review feedback into reruns, increment retry counts on the approval-policy check row, and keep full feedback out of workflow state.
+
+---
+
+## Phase 4: User Story 3 - Mission Control exposes review verdicts inside Checks (Priority: P2)
+
+**Goal**: The existing Steps UI clearly shows review verdicts, retry counts, and evidence refs.
+
+### Tests for User Story 3
+
+- [X] T009 [P] [US3] Write failing UI tests in `frontend/src/entrypoints/task-detail.test.tsx` covering verdict badges, retry-count copy, and review artifact refs in the expanded Checks section.
+
+### Implementation for User Story 3
+
+- [X] T010 [US3] Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/styles/mission-control.css` so the Checks section renders retry counts and review artifact refs with compact Mission Control styling.
+
+---
+
+## Phase 5: Validation
+
+- [X] T011 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T012 Run `pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`
+- [ ] T013 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [ ] T014 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **User Story 1 (Phase 2)**: Depends on Setup.
+- **User Story 2 (Phase 3)**: Depends on the approval-policy check production from User Story 1.
+- **User Story 3 (Phase 4)**: Depends on the finalized `checks[]` shape from User Story 1/2.
+- **Validation (Phase 5)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- T003 and T004 can be written in parallel before implementation begins.
+- T009 can be written in parallel with backend work once the final check-row contract is agreed.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing workflow tests for live review/check state.
+2. Implement workflow-owned approval-policy checks and review artifacts.
+3. Add retry-with-feedback coverage.
+4. Extend the existing Checks UI with retry counts and review evidence refs.
+5. Run final verification.

--- a/tests/unit/workflows/temporal/test_step_ledger.py
+++ b/tests/unit/workflows/temporal/test_step_ledger.py
@@ -13,6 +13,7 @@ from moonmind.schemas.temporal_models import (
 from moonmind.workflows.temporal.step_ledger import (
     build_initial_step_rows,
     build_progress_summary,
+    upsert_step_check,
     update_step_row,
 )
 
@@ -338,6 +339,50 @@ def test_update_step_row_allows_explicit_last_error_clear() -> None:
     )
 
     assert rows[0]["status"] == "succeeded"
+
+
+def test_upsert_step_check_updates_existing_review_state() -> None:
+    updated_at = datetime(2026, 4, 7, 12, 15, tzinfo=UTC)
+    rows = build_initial_step_rows(
+        ordered_nodes=[
+            {
+                "id": "review-patch",
+                "tool": {"type": "skill", "name": "repo.review_patch", "version": "1"},
+                "inputs": {"title": "Review patch"},
+            }
+        ],
+        dependency_map={"review-patch": []},
+        updated_at=updated_at,
+    )
+
+    upsert_step_check(
+        rows,
+        "review-patch",
+        kind="approval_policy",
+        status="pending",
+        summary="Structured review in progress",
+        retry_count=0,
+        artifact_ref=None,
+    )
+    upsert_step_check(
+        rows,
+        "review-patch",
+        kind="approval_policy",
+        status="failed",
+        summary="Reviewer requested another retry",
+        retry_count=1,
+        artifact_ref="art_review_1",
+    )
+
+    assert rows[0]["checks"] == [
+        {
+            "kind": "approval_policy",
+            "status": "failed",
+            "summary": "Reviewer requested another retry",
+            "retryCount": 1,
+            "artifactRef": "art_review_1",
+        }
+    ]
     assert rows[0]["lastError"] is None
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -4,6 +4,7 @@ Pure unit tests — no Temporal test server needed.
 """
 
 import unittest
+from types import SimpleNamespace
 
 import pytest
 
@@ -365,6 +366,46 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         moonmind = metadata.get("moonmind") or {}
         self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")
 
+    def test_build_agent_execution_request_preserves_retry_feedback_in_instructions_fields(
+        self,
+    ) -> None:
+        from unittest.mock import patch
+
+        wf = MoonMindRunWorkflow()
+
+        class MockInfo:
+            workflow_id = "test-wf-id"
+            run_id = "test-run-id"
+
+        for instruction_key in ("instructions", "instructionRef"):
+            with self.subTest(instruction_key=instruction_key):
+                retried_inputs = wf._inject_review_feedback_into_inputs(
+                    tool_type="agent_runtime",
+                    original_inputs={
+                        instruction_key: "Implement the requested change.",
+                        "targetRuntime": "jules",
+                    },
+                    attempt=1,
+                    feedback="Fix the missing import before retrying.",
+                    issues=(),
+                )
+
+                with patch(
+                    "moonmind.workflows.temporal.workflows.run.workflow.info",
+                    return_value=MockInfo(),
+                ):
+                    request = wf._build_agent_execution_request(
+                        node_inputs=retried_inputs,
+                        node_id="node-review-retry",
+                        tool_name="jules",
+                    )
+
+                self.assertIn("REVIEW FEEDBACK (attempt 1)", request.instruction_ref)
+                self.assertIn(
+                    "Fix the missing import before retrying.",
+                    request.instruction_ref,
+                )
+
     def test_build_agent_execution_request_overrides_stale_selected_skill(self) -> None:
         from unittest.mock import patch
 
@@ -395,6 +436,46 @@ class TestBuildAgentExecutionRequest(unittest.TestCase):
         metadata = request.parameters.get("metadata") or {}
         moonmind = metadata.get("moonmind") or {}
         self.assertEqual(moonmind.get("selectedSkill"), "pr-resolver")
+
+
+class TestReviewGateHelpers(unittest.TestCase):
+    def test_review_gate_skips_matching_tool_identifier(self) -> None:
+        wf = MoonMindRunWorkflow()
+        approval_policy = SimpleNamespace(
+            enabled=True,
+            skip_tool_types=("repo.publish",),
+        )
+
+        is_active = wf._review_gate_active(
+            approval_policy=approval_policy,
+            tool_type="skill",
+            tool_name="repo.publish",
+        )
+
+        self.assertFalse(is_active)
+
+    def test_review_gate_still_skips_matching_tool_type(self) -> None:
+        wf = MoonMindRunWorkflow()
+        approval_policy = SimpleNamespace(
+            enabled=True,
+            skip_tool_types=("agent_runtime",),
+        )
+
+        is_active = wf._review_gate_active(
+            approval_policy=approval_policy,
+            tool_type="agent_runtime",
+            tool_name="jules",
+        )
+
+        self.assertFalse(is_active)
+
+    def test_accepted_review_summary_pluralizes_retries(self) -> None:
+        wf = MoonMindRunWorkflow()
+
+        self.assertEqual(
+            wf._accepted_review_summary("PASS", retry_count=2),
+            "Approved after 2 retries",
+        )
 
 
 class TestFetchProfileSnapshots(unittest.TestCase):

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -59,6 +61,70 @@ def _ordered_nodes() -> list[dict]:
 
 def _dependency_map() -> dict[str, list[str]]:
     return {"prepare": [], "run-tests": ["prepare"]}
+
+
+def _approval_policy_plan_payload() -> dict[str, Any]:
+    return {
+        "plan_version": "1.0",
+        "metadata": {
+            "title": "Approval policy plan",
+            "created_at": "2026-04-08T00:00:00Z",
+            "registry_snapshot": {
+                "digest": "reg:sha256:" + ("a" * 64),
+                "artifact_ref": "artifact://registry/1",
+            },
+        },
+        "policy": {
+            "failure_mode": "FAIL_FAST",
+            "max_concurrency": 1,
+            "approval_policy": {
+                "enabled": True,
+                "max_review_attempts": 1,
+                "reviewer_model": "default",
+                "review_timeout_seconds": 120,
+                "skip_tool_types": [],
+            },
+        },
+        "nodes": [
+            {
+                "id": "apply-patch",
+                "tool": {
+                    "type": "skill",
+                    "name": "repo.apply_patch",
+                    "version": "1.0.0",
+                },
+                "inputs": {"instruction": "Apply the patch"},
+                "options": {},
+            }
+        ],
+        "edges": [],
+    }
+
+
+def _registry_payload() -> dict[str, Any]:
+    return {
+        "skills": [
+            {
+                "name": "repo.apply_patch",
+                "version": "1.0.0",
+                "description": "Apply patch",
+                "inputs": {"schema": {"type": "object"}},
+                "outputs": {"schema": {"type": "object"}},
+                "executor": {
+                    "activity_type": "mm.skill.execute",
+                    "selector": {"mode": "by_capability"},
+                },
+                "requirements": {"capabilities": ["sandbox"]},
+                "policies": {
+                    "timeouts": {
+                        "start_to_close_seconds": 1800,
+                        "schedule_to_close_seconds": 3600,
+                    },
+                    "retries": {"max_attempts": 1},
+                },
+            }
+        ]
+    }
 
 
 def test_run_initializes_latest_run_step_ledger(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -496,3 +562,242 @@ def test_run_accepts_tuple_output_refs_and_ignores_string_values(
 
     assert step["artifacts"]["outputPrimary"] == "art_primary_1"
     assert step["artifacts"]["runtimeStdout"] == "art_stdout_1"
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_marks_step_reviewing_and_records_passed_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    review_snapshots: list[dict[str, Any]] = []
+    written_review_payloads: list[dict[str, Any]] = []
+    review_artifact_ids = iter(("art_review_1",))
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
+        if activity_type == "artifact.create":
+            return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
+        if activity_type == "mm.skill.execute":
+            return {
+                "status": "COMPLETED",
+                "summary": "Patch applied cleanly",
+                "outputs": {"outputSummaryRef": "art_summary_1"},
+            }
+        if activity_type == "step.review":
+            step = workflow.get_step_ledger()["steps"][0]
+            review_snapshots.append(step)
+            return {
+                "verdict": "PASS",
+                "confidence": 0.91,
+                "feedback": None,
+                "issues": [],
+            }
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            artifact_ref = getattr(payload, "artifact_ref", None)
+            if artifact_ref == "art_plan_1":
+                return json.dumps(_approval_policy_plan_payload()).encode("utf-8")
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(_registry_payload()).encode("utf-8")
+        if activity_type == "artifact.write_complete":
+            written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
+            return {"ok": True}
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-run-review-1",
+        run_id="run-review-1",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["owner-1"]},
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    assert review_snapshots
+    assert review_snapshots[0]["status"] == "reviewing"
+    assert review_snapshots[0]["checks"] == [
+        {
+            "kind": "approval_policy",
+            "status": "pending",
+            "summary": "Structured review in progress",
+            "retryCount": 0,
+            "artifactRef": None,
+        }
+    ]
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["status"] == "succeeded"
+    assert step["checks"] == [
+        {
+            "kind": "approval_policy",
+            "status": "passed",
+            "summary": "Approved by structured review",
+            "retryCount": 0,
+            "artifactRef": "art_review_1",
+        }
+    ]
+    assert written_review_payloads[0]["verdict"]["verdict"] == "PASS"
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retry_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    written_review_payloads: list[dict[str, Any]] = []
+    skill_inputs: list[dict[str, Any]] = []
+    review_artifact_ids = iter(("art_review_1", "art_review_2"))
+    review_verdicts = iter(
+        (
+            {
+                "verdict": "FAIL",
+                "confidence": 0.84,
+                "feedback": "Tests still fail because the import is missing.",
+                "issues": [
+                    {
+                        "severity": "error",
+                        "description": "Missing import",
+                        "evidence": "stderr tail",
+                    }
+                ],
+            },
+            {
+                "verdict": "PASS",
+                "confidence": 0.93,
+                "feedback": None,
+                "issues": [],
+            },
+        )
+    )
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
+        if activity_type == "artifact.create":
+            return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
+        if activity_type == "mm.skill.execute":
+            invocation_payload = payload["invocation_payload"]
+            skill_inputs.append(dict(invocation_payload["inputs"]))
+            return {
+                "status": "COMPLETED",
+                "summary": "Patch applied cleanly",
+                "outputs": {"outputSummaryRef": f"art_summary_{len(skill_inputs)}"},
+            }
+        if activity_type == "step.review":
+            return next(review_verdicts)
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            artifact_ref = getattr(payload, "artifact_ref", None)
+            if artifact_ref == "art_plan_1":
+                return json.dumps(_approval_policy_plan_payload()).encode("utf-8")
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(_registry_payload()).encode("utf-8")
+        if activity_type == "artifact.write_complete":
+            written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
+            return {"ok": True}
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-run-review-2",
+        run_id="run-review-2",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["owner-1"]},
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    assert len(skill_inputs) == 2
+    assert "_review_feedback" not in skill_inputs[0]
+    assert skill_inputs[1]["_review_feedback"] == {
+        "attempt": 1,
+        "feedback": "Tests still fail because the import is missing.",
+        "issues": [
+            {
+                "severity": "error",
+                "description": "Missing import",
+                "evidence": "stderr tail",
+            }
+        ],
+    }
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["attempt"] == 2
+    assert step["status"] == "succeeded"
+    assert step["checks"] == [
+        {
+            "kind": "approval_policy",
+            "status": "passed",
+            "summary": "Approved after 1 retry",
+            "retryCount": 1,
+            "artifactRef": "art_review_2",
+        }
+    ]
+    assert written_review_payloads[0]["verdict"]["verdict"] == "FAIL"
+    assert written_review_payloads[1]["verdict"]["verdict"] == "PASS"

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -801,3 +801,142 @@ async def test_run_execution_stage_retries_failed_reviews_with_feedback_and_retr
     ]
     assert written_review_payloads[0]["verdict"]["verdict"] == "FAIL"
     assert written_review_payloads[1]["verdict"]["verdict"] == "PASS"
+
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_retries_agent_runtime_reviews_with_feedback_in_instruction_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    written_review_payloads: list[dict[str, Any]] = []
+    child_requests: list[Any] = []
+    review_artifact_ids = iter(("art_review_1", "art_review_2"))
+    review_verdicts = iter(
+        (
+            {
+                "verdict": "FAIL",
+                "confidence": 0.84,
+                "feedback": "Add the missing validation before retrying.",
+                "issues": [],
+            },
+            {
+                "verdict": "PASS",
+                "confidence": 0.93,
+                "feedback": None,
+                "issues": [],
+            },
+        )
+    )
+
+    plan_payload = _approval_policy_plan_payload()
+    plan_payload["nodes"] = [
+        {
+            "id": "delegate-agent",
+            "tool": {"type": "agent_runtime", "name": "jules", "version": ""},
+            "inputs": {
+                "targetRuntime": "jules",
+                "instructions": "Implement the requested change.",
+            },
+            "options": {},
+        }
+    ]
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "provider_profile.list":
+            return {"profiles": []}
+        if activity_type == "artifact.create":
+            return ({"artifact_id": next(review_artifact_ids)}, {"upload_url": "unused"})
+        if activity_type == "step.review":
+            return next(review_verdicts)
+        raise AssertionError(f"unexpected activity: {activity_type}")
+
+    async def fake_execute_typed_activity(
+        activity_type: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_type == "artifact.read":
+            artifact_ref = getattr(payload, "artifact_ref", None)
+            if artifact_ref == "art_plan_1":
+                return json.dumps(plan_payload).encode("utf-8")
+        if activity_type == "artifact.write_complete":
+            written_review_payloads.append(json.loads(payload.payload.decode("utf-8")))
+            return {"ok": True}
+        raise AssertionError(f"unexpected typed activity: {activity_type}")
+
+    async def fake_execute_child_workflow(
+        workflow_name: str,
+        request: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        assert workflow_name == "MoonMind.AgentRun"
+        child_requests.append(request)
+        return {
+            "summary": "Agent run completed",
+            "output_refs": ["art_output_1"],
+            "failure_class": None,
+        }
+
+    workflow_info = SimpleNamespace(
+        namespace="default",
+        workflow_id="wf-run-review-agent-1",
+        run_id="run-review-agent-1",
+        task_queue="mm.workflow",
+        search_attributes={"mm_owner_type": ["user"], "mm_owner_id": ["owner-1"]},
+    )
+    monkeypatch.setattr(run_module.workflow, "info", lambda: workflow_info)
+    monkeypatch.setattr(run_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        run_module,
+        "execute_typed_activity",
+        fake_execute_typed_activity,
+    )
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind"},
+        plan_ref="art_plan_1",
+    )
+
+    assert len(child_requests) == 2
+    assert child_requests[0].instruction_ref == "Implement the requested change."
+    assert "REVIEW FEEDBACK (attempt 1)" in child_requests[1].instruction_ref
+    assert (
+        "Add the missing validation before retrying."
+        in child_requests[1].instruction_ref
+    )
+    step = workflow.get_step_ledger()["steps"][0]
+    assert step["attempt"] == 2
+    assert step["status"] == "succeeded"
+    assert step["checks"] == [
+        {
+            "kind": "approval_policy",
+            "status": "passed",
+            "summary": "Approved after 1 retry",
+            "retryCount": 1,
+            "artifactRef": "art_review_2",
+        }
+    ]
+    assert written_review_payloads[0]["attempt"] == 1
+    assert written_review_payloads[1]["attempt"] == 2


### PR DESCRIPTION
## What changed
- add workflow-owned approval-policy review reconciliation to `MoonMind.Run`
- mark eligible steps as `reviewing`, write structured `checks[]`, and persist review evidence as artifacts
- retry failed reviews on the same logical step with injected review feedback and incremented retry counts
- extend Mission Control step details to show retry count and review artifact references inside the Checks section
- add the Phase 5 Spec Kit artifact set under `specs/142-step-ledger-phase5`

## Why
Phase 5 makes approval policy the first concrete producer of step-ledger `checks[]` so review state is visible from the ledger itself instead of being inferred from logs. This keeps the workflow row authoritative while storing full review evidence outside workflow state.

## Impact
- operators can see live `reviewing` state, final review verdicts, retry count, and linked review evidence directly in the step panel
- workflow retries preserve logical step identity while feeding structured review feedback back into reruns
- review evidence stays artifact-backed rather than expanding workflow history

## Validation
- `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/workflows/temporal/test_step_ledger.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py`
- `./tools/test_unit.sh --dashboard-only --no-xdist --ui-args frontend/src/entrypoints/task-detail.test.tsx -t "renders retry counts and review artifact refs inside the Checks section"`
- `npm run ui:typecheck`

## Known issue
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` still has a pre-existing flaky `LiveLogsPanel` failure when the whole file runs together. The focused Phase 5 UI assertion passes, but the full-file run is not stable yet.
- the diff-scope validator could not run in this environment because the script uses `mapfile` and the machine only has `/bin/bash` 3.2.
