### PR TITLE
[codex] Implement live logs session timeline UI

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -117,6 +117,23 @@ def _build_default_attachment_policy(config: "dict[str, Any]") -> dict[str, Any]
     }
 
 
+def _build_live_logs_feature_config() -> dict[str, object]:
+    """Build the grouped Live Logs feature flags for dashboard consumers."""
+
+    return {
+        "logStreamingEnabled": bool(
+            os.environ.get("MOONMIND_LOG_STREAMING_ENABLED", "true").strip().lower()
+            not in ("0", "false", "no", "off")
+        ),
+        "liveLogsSessionTimelineEnabled": bool(
+            settings.feature_flags.live_logs_session_timeline_enabled
+        ),
+        "liveLogsSessionTimelineRollout": str(
+            settings.feature_flags.live_logs_session_timeline_rollout
+        ),
+    }
+
+
 def _build_dashboard_system_metadata() -> dict[str, str | None]:
     """Return operator-facing build metadata for the dashboard shell and runtime config."""
 
@@ -227,16 +244,7 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "submitEnabled": bool(temporal_dashboard.submit_enabled),
                 "debugFieldsEnabled": bool(temporal_dashboard.debug_fields_enabled),
             },
-            "logStreamingEnabled": bool(
-                os.environ.get("MOONMIND_LOG_STREAMING_ENABLED", "true").strip().lower()
-                not in ("0", "false", "no", "off")
-            ),
-            "liveLogsSessionTimelineEnabled": bool(
-                settings.feature_flags.live_logs_session_timeline_enabled
-            ),
-            "liveLogsSessionTimelineRollout": str(
-                settings.feature_flags.live_logs_session_timeline_rollout
-            ),
+            **_build_live_logs_feature_config(),
         },
         "system": {
             **system_metadata,

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -6,7 +6,7 @@ import os
 from copy import deepcopy
 from typing import Any
 
-from moonmind.config.settings import settings
+from moonmind.config.settings import WorkflowSettings, settings
 from moonmind.utils.build_info import resolve_moonmind_build_id
 from moonmind.workflows.tasks.runtime_defaults import (
     DEFAULT_REPOSITORY,
@@ -121,10 +121,7 @@ def _build_live_logs_feature_config() -> dict[str, object]:
     """Build the grouped Live Logs feature flags for dashboard consumers."""
 
     return {
-        "logStreamingEnabled": bool(
-            os.environ.get("MOONMIND_LOG_STREAMING_ENABLED", "true").strip().lower()
-            not in ("0", "false", "no", "off")
-        ),
+        "logStreamingEnabled": bool(WorkflowSettings(_env_file=None).log_streaming_enabled),
         "liveLogsSessionTimelineEnabled": bool(
             settings.feature_flags.live_logs_session_timeline_enabled
         ),

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1729,6 +1729,30 @@ describe('LiveLogsPanel', () => {
     state: 'succeeded',
     rawState: 'succeeded',
   };
+  const sessionTimelinePayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: true,
+        },
+      },
+    },
+  };
+  const legacyLiveLogsPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: false,
+        },
+      },
+    },
+  };
 
   const activeSummary = {
     summary: {
@@ -2230,6 +2254,191 @@ describe('LiveLogsPanel', () => {
     const boundaryRow = screen.getByText(/Epoch boundary reached/).closest('div');
     expect(boundaryRow?.getAttribute('data-kind')).toBe('session_reset_boundary');
     expect(boundaryRow?.getAttribute('data-stream')).toBe('session');
+  });
+
+  it('renders the session-aware timeline header with container and live status when the feature flag is enabled', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'running',
+              supportsLiveStreaming: true,
+              liveStreamStatus: 'live',
+              sessionSnapshot: {
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 4,
+                containerId: 'ctr-99',
+                threadId: 'thread-4',
+                activeTurnId: 'turn-7',
+              },
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'session',
+                kind: 'turn_started',
+                text: 'Turn started',
+                session_id: 'sess:wf-task-1:codex_cli',
+                session_epoch: 4,
+                container_id: 'ctr-99',
+                thread_id: 'thread-4',
+                active_turn_id: 'turn-7',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => activeExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText('sess:wf-task-1:codex_cli')).toBeTruthy();
+      expect(screen.getByText('4')).toBeTruthy();
+      expect(screen.getByText('ctr-99')).toBeTruthy();
+      expect(screen.getByText('thread-4')).toBeTruthy();
+      expect(screen.getByText('turn-7')).toBeTruthy();
+      expect(screen.getByText('live')).toBeTruthy();
+    });
+  });
+
+  it('renders distinct timeline row types for approval and publication events when the feature flag is enabled', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'session',
+                kind: 'approval_requested',
+                text: 'Approval requested for command execution.',
+              },
+              {
+                sequence: 2,
+                timestamp: '2026-04-08T00:00:02Z',
+                stream: 'session',
+                kind: 'summary_published',
+                text: 'Session summary artifact published.',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Approval requested for command execution/)).toBeTruthy();
+      expect(screen.getByText(/Session summary artifact published/)).toBeTruthy();
+    });
+
+    const approvalRow = screen.getByText(/Approval requested for command execution/).closest('div');
+    const publicationRow = screen.getByText(/Session summary artifact published/).closest('div');
+    expect(approvalRow?.getAttribute('data-row-type')).toBe('approval');
+    expect(publicationRow?.getAttribute('data-row-type')).toBe('publication');
+  });
+
+  it('uses the legacy line viewer when the session timeline feature flag is disabled', async () => {
+    mockFetchSequence(activeExecution, activeSummary, 'legacy fallback line\n');
+    renderWithClient(<TaskDetailPage payload={legacyLiveLogsPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/legacy fallback line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-legacy-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+  });
+
+  it('renders the timeline viewer with ANSI-aware output when the session timeline feature flag is enabled', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'stdout',
+                text: '\u001b[31mred output\u001b[0m\n',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText('red output')).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-timeline-viewer')).toBeTruthy();
+    expect(screen.queryByText('\u001b[31mred output\u001b[0m')).toBeNull();
+    expect(document.querySelector('[data-ansi-fragment="true"]')).toBeTruthy();
   });
 
   it('renders Stdout, Stderr, and Diagnostics panels', async () => {

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
@@ -5,16 +6,24 @@ import { expandRouteTemplate, getSessionProjectionRefetchInterval, TaskDetailPag
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
+type MockVirtuosoRow = { id: string };
+type MockVirtuosoProps<Row = MockVirtuosoRow> = {
+  data?: Row[];
+  computeItemKey?: (index: number, row: Row) => string;
+  itemContent: (index: number, row: Row) => ReactNode;
+  initialItemCount?: number;
+};
+
 const { virtuosoPropsSpy } = vi.hoisted(() => ({
   virtuosoPropsSpy: vi.fn(),
 }));
 
 vi.mock('react-virtuoso', () => ({
-  Virtuoso: (props: any) => {
+  Virtuoso: (props: MockVirtuosoProps) => {
     virtuosoPropsSpy(props);
     return (
       <div data-testid="mock-virtuoso">
-        {(props.data ?? []).map((row: any, index: number) => {
+        {(props.data ?? []).map((row, index) => {
           const key = props.computeItemKey ? props.computeItemKey(index, row) : index;
           return <div key={String(key)}>{props.itemContent(index, row)}</div>;
         })}

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -5,6 +5,24 @@ import { expandRouteTemplate, getSessionProjectionRefetchInterval, TaskDetailPag
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
+const { virtuosoPropsSpy } = vi.hoisted(() => ({
+  virtuosoPropsSpy: vi.fn(),
+}));
+
+vi.mock('react-virtuoso', () => ({
+  Virtuoso: (props: any) => {
+    virtuosoPropsSpy(props);
+    return (
+      <div data-testid="mock-virtuoso">
+        {(props.data ?? []).map((row: any, index: number) => {
+          const key = props.computeItemKey ? props.computeItemKey(index, row) : index;
+          return <div key={String(key)}>{props.itemContent(index, row)}</div>;
+        })}
+      </div>
+    );
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Minimal EventSource mock
 // ---------------------------------------------------------------------------
@@ -201,6 +219,7 @@ describe('Task Detail Entrypoint', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    virtuosoPropsSpy.mockClear();
     window.history.pushState({}, 'Test', '/tasks/test-123?source=temporal');
     fetchSpy = vi.spyOn(window, 'fetch');
     fetchSpy.mockClear();
@@ -1990,7 +2009,7 @@ describe('LiveLogsPanel', () => {
 
     fireEvent.click(await screen.findByText('Live Logs'));
 
-    await waitFor(() => expect(screen.getByText(/Stream ended/)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Stream ended/)).toBeTruthy(), { timeout: 5000 });
     expect(MockEventSource.instances.length).toBe(0);
   });
 
@@ -2392,6 +2411,20 @@ describe('LiveLogsPanel', () => {
     expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
   });
 
+  it('uses the legacy line viewer when the session timeline feature flag is absent', async () => {
+    mockFetchSequence(activeExecution, activeSummary, 'legacy fallback line\n');
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/legacy fallback line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-legacy-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+  });
+
   it('renders the timeline viewer with ANSI-aware output when the session timeline feature flag is enabled', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
@@ -2436,6 +2469,8 @@ describe('LiveLogsPanel', () => {
       expect(screen.getByText('red output')).toBeTruthy();
     });
 
+    expect(virtuosoPropsSpy).toHaveBeenCalled();
+    expect(virtuosoPropsSpy.mock.calls.at(-1)?.[0]?.initialItemCount).toBeUndefined();
     expect(screen.getByTestId('live-logs-timeline-viewer')).toBeTruthy();
     expect(screen.queryByText('\u001b[31mred output\u001b[0m')).toBeNull();
     expect(document.querySelector('[data-ansi-fragment="true"]')).toBeTruthy();

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -972,7 +972,7 @@ function deriveSessionSnapshotFromEvent(
     containerId: event.container_id ?? previous?.containerId ?? '',
     threadId: event.thread_id ?? previous?.threadId ?? '',
     activeTurnId: event.active_turn_id ?? previous?.activeTurnId ?? null,
-    status: event.kind ?? previous?.status,
+    status: previous?.status,
     latestSummaryRef: previous?.latestSummaryRef ?? null,
     latestCheckpointRef: previous?.latestCheckpointRef ?? null,
     latestControlEventRef: previous?.latestControlEventRef ?? null,
@@ -1510,9 +1510,9 @@ function LiveLogsPanel({
       if (historyQuery.data?.sessionSnapshot) {
         setSessionSnapshot(historyQuery.data.sessionSnapshot);
       } else {
-        const latestSessionEvent = [...(historyQuery.data?.events ?? [])]
-          .reverse()
-          .find((event) => event.session_id && typeof event.session_epoch === 'number');
+        const latestSessionEvent = (historyQuery.data?.events ?? []).findLast(
+          (event) => event.session_id && typeof event.session_epoch === 'number',
+        );
         if (latestSessionEvent) {
           setSessionSnapshot((prev) => deriveSessionSnapshotFromEvent(latestSessionEvent, prev));
         }
@@ -1703,7 +1703,6 @@ function LiveLogsPanel({
               <Virtuoso
                 style={{ height: 400 }}
                 data={logContent}
-                initialItemCount={logContent.length}
                 computeItemKey={(_, row) => row.id}
                 itemContent={(_, row) => renderTimelineRow(row, wrapLines, true)}
               />
@@ -2269,7 +2268,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
   const debugOn = Boolean(cfg?.features?.temporalDashboard?.debugFieldsEnabled);
   const logStreamingEnabled = cfg?.features?.logStreamingEnabled !== false;
-  const sessionTimelineEnabled = cfg?.features?.liveLogsSessionTimelineEnabled !== false;
+  const sessionTimelineEnabled = cfg?.features?.liveLogsSessionTimelineEnabled === true;
 
   const taskIdMatch = window.location.pathname.match(
     /^\/tasks\/(?:temporal\/|proposals\/|schedules\/|manifests\/)?([^/]+)$/,

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import Anser from 'anser';
+import { Virtuoso } from 'react-virtuoso';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
 import { executionStatusPillClasses } from '../utils/executionStatusPillClasses';
@@ -14,6 +16,8 @@ type DashboardConfig = {
       debugFieldsEnabled?: boolean;
     };
     logStreamingEnabled?: boolean;
+    liveLogsSessionTimelineEnabled?: boolean;
+    liveLogsSessionTimelineRollout?: string;
   };
   sources?: {
     temporal?: Record<string, string>;
@@ -845,10 +849,12 @@ type TimelineRow = {
   timestamp: string | null;
   sessionId: string | null;
   sessionEpoch: number | null;
+  containerId: string | null;
   threadId: string | null;
   turnId: string | null;
+  activeTurnId: string | null;
   metadata: Record<string, unknown>;
-  rowType: 'line' | 'boundary';
+  rowType: 'output' | 'system' | 'session' | 'approval' | 'publication' | 'boundary' | 'fallback';
 };
 
 function splitLogText(content: string): string[] {
@@ -894,17 +900,38 @@ function parseArtifactToRows(content: string): TimelineRow[] {
       timestamp: null,
       sessionId: null,
       sessionEpoch: null,
+      containerId: null,
       threadId: null,
       turnId: null,
+      activeTurnId: null,
       metadata: {},
-      rowType: 'line',
+      rowType: 'fallback',
     };
   });
 }
 
+function classifyTimelineRow(event: ObservabilityEvent): TimelineRow['rowType'] {
+  if (event.kind === 'session_reset_boundary') {
+    return 'boundary';
+  }
+  if (event.stream === 'system') {
+    return 'system';
+  }
+  if (event.stream === 'session') {
+    if ((event.kind ?? '').startsWith('approval_')) {
+      return 'approval';
+    }
+    if ((event.kind ?? '').endsWith('_published')) {
+      return 'publication';
+    }
+    return 'session';
+  }
+  return 'output';
+}
+
 function eventToTimelineRows(event: ObservabilityEvent): TimelineRow[] {
   const stream = event.stream as TimelineStream;
-  const rowType = event.kind === 'session_reset_boundary' ? 'boundary' : 'line';
+  const rowType = classifyTimelineRow(event);
   const lines = splitLogText(event.text);
   const sourceLines = lines.length > 0 ? lines : [event.text];
   return sourceLines.map((line, index) => ({
@@ -916,8 +943,10 @@ function eventToTimelineRows(event: ObservabilityEvent): TimelineRow[] {
     timestamp: event.timestamp ?? null,
     sessionId: event.session_id ?? null,
     sessionEpoch: event.session_epoch ?? null,
+    containerId: event.container_id ?? null,
     threadId: event.thread_id ?? null,
     turnId: event.turn_id ?? null,
+    activeTurnId: event.active_turn_id ?? null,
     metadata: event.metadata ?? {},
     rowType,
   }));
@@ -928,6 +957,133 @@ function mapEventsToTimelineRows(
 ): TimelineRow[] {
   if (!payload) return [];
   return payload.events.flatMap((event) => eventToTimelineRows(event));
+}
+
+function deriveSessionSnapshotFromEvent(
+  event: ObservabilityEvent,
+  previous: SessionSnapshot | null,
+): SessionSnapshot | null {
+  if (!event.session_id || typeof event.session_epoch !== 'number') {
+    return previous;
+  }
+  return {
+    sessionId: event.session_id,
+    sessionEpoch: event.session_epoch,
+    containerId: event.container_id ?? previous?.containerId ?? '',
+    threadId: event.thread_id ?? previous?.threadId ?? '',
+    activeTurnId: event.active_turn_id ?? previous?.activeTurnId ?? null,
+    status: event.kind ?? previous?.status,
+    latestSummaryRef: previous?.latestSummaryRef ?? null,
+    latestCheckpointRef: previous?.latestCheckpointRef ?? null,
+    latestControlEventRef: previous?.latestControlEventRef ?? null,
+    latestResetBoundaryRef: previous?.latestResetBoundaryRef ?? null,
+  };
+}
+
+function renderAnsiFragments(text: string): ReactNode {
+  const fragments = Anser.ansiToJson(text, { json: true, remove_empty: true });
+  if (fragments.length === 0) {
+    return text;
+  }
+  return fragments.map((fragment, index) => {
+    const style: Record<string, string> = {};
+    const foreground = fragment.fg_truecolor || fragment.fg;
+    const background = fragment.bg_truecolor || fragment.bg;
+    if (foreground) {
+      style.color = foreground;
+    }
+    if (background) {
+      style.backgroundColor = background;
+    }
+    if (fragment.decorations.includes('bold')) {
+      style.fontWeight = '700';
+    }
+    if (fragment.decorations.includes('italic')) {
+      style.fontStyle = 'italic';
+    }
+    const textDecoration = [
+      fragment.decorations.includes('underline') ? 'underline' : null,
+      fragment.decorations.includes('strikethrough') ? 'line-through' : null,
+    ]
+      .filter(Boolean)
+      .join(' ');
+    if (textDecoration) {
+      style.textDecoration = textDecoration;
+    }
+    return (
+      <span key={`${fragment.content}-${index}`} data-ansi-fragment="true" style={style}>
+        {fragment.content}
+      </span>
+    );
+  });
+}
+
+function renderTimelineRowText(row: TimelineRow, timelineViewerEnabled: boolean): ReactNode {
+  if (!timelineViewerEnabled) {
+    return row.text;
+  }
+  if (row.stream === 'stdout' || row.stream === 'stderr') {
+    return renderAnsiFragments(row.text);
+  }
+  return row.text;
+}
+
+function getCopyableRowText(row: TimelineRow): string {
+  if (row.stream === 'stdout' || row.stream === 'stderr') {
+    return Anser.ansiToText(row.text, { remove_empty: true });
+  }
+  return row.text;
+}
+
+function renderTimelineRow(
+  row: TimelineRow,
+  wrapLines: boolean,
+  timelineViewerEnabled: boolean,
+): ReactNode {
+  const rowClasses = [
+    'live-logs-row',
+    `live-logs-row-${row.rowType}`,
+    `live-logs-stream-${row.stream}`,
+    wrapLines ? 'is-wrapped' : 'is-unwrapped',
+  ].join(' ');
+
+  if (timelineViewerEnabled && row.rowType === 'boundary') {
+    return (
+      <div
+        key={row.id}
+        className={rowClasses}
+      >
+        <div className="live-logs-boundary-label">Session reset boundary</div>
+        <div
+          className="live-logs-row-text"
+          data-stream={row.stream}
+          data-kind={row.kind ?? undefined}
+          data-row-type={row.rowType}
+        >
+          {row.text}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key={row.id}
+      className={rowClasses}
+    >
+      {timelineViewerEnabled && row.kind ? (
+        <span className="live-logs-kind-chip">{row.kind.replaceAll('_', ' ')}</span>
+      ) : null}
+      <div
+        className="live-logs-row-text"
+        data-stream={row.stream}
+        data-kind={row.kind ?? undefined}
+        data-row-type={row.rowType}
+      >
+        {renderTimelineRowText(row, timelineViewerEnabled)}
+      </div>
+    </div>
+  );
 }
 
 type TaskRunRouteTemplates = {
@@ -1058,11 +1214,13 @@ function StepMetadataList({
 function StepObservabilityGroup({
   apiBase,
   logStreamingEnabled,
+  sessionTimelineEnabled,
   row,
   routes,
 }: {
   apiBase: string;
   logStreamingEnabled: boolean;
+  sessionTimelineEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   routes: TaskRunRouteTemplates;
 }) {
@@ -1093,6 +1251,7 @@ function StepObservabilityGroup({
         isTerminal={stepTerminal(row.status)}
         autoExpand
         routes={routes}
+        sessionTimelineEnabled={sessionTimelineEnabled}
       />
       <StaticLogPanel
         apiBase={apiBase}
@@ -1118,6 +1277,7 @@ function StepObservabilityGroup({
 function StepLedgerRowCard({
   apiBase,
   logStreamingEnabled,
+  sessionTimelineEnabled,
   row,
   runId,
   expanded,
@@ -1126,6 +1286,7 @@ function StepLedgerRowCard({
 }: {
   apiBase: string;
   logStreamingEnabled: boolean;
+  sessionTimelineEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   runId: string;
   expanded: boolean;
@@ -1198,6 +1359,7 @@ function StepLedgerRowCard({
             <StepObservabilityGroup
               apiBase={apiBase}
               logStreamingEnabled={logStreamingEnabled}
+              sessionTimelineEnabled={sessionTimelineEnabled}
               row={row}
               routes={routes}
             />
@@ -1222,12 +1384,14 @@ function LiveLogsPanel({
   isTerminal,
   autoExpand = false,
   routes,
+  sessionTimelineEnabled,
 }: {
   apiBase: string;
   taskRunId: string;
   isTerminal: boolean;
   autoExpand?: boolean;
   routes: TaskRunRouteTemplates;
+  sessionTimelineEnabled: boolean;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
@@ -1345,6 +1509,13 @@ function LiveLogsPanel({
       lastSeqRef.current = sequences && sequences.length > 0 ? Math.max(...sequences) : null;
       if (historyQuery.data?.sessionSnapshot) {
         setSessionSnapshot(historyQuery.data.sessionSnapshot);
+      } else {
+        const latestSessionEvent = [...(historyQuery.data?.events ?? [])]
+          .reverse()
+          .find((event) => event.session_id && typeof event.session_epoch === 'number');
+        if (latestSessionEvent) {
+          setSessionSnapshot((prev) => deriveSessionSnapshotFromEvent(latestSessionEvent, prev));
+        }
       }
     }
   }, [historyQuery.data, historyQuery.isSuccess]);
@@ -1397,23 +1568,7 @@ function LiveLogsPanel({
         setLogContent((prev) => {
           return [...prev, ...eventToTimelineRows(data)];
         });
-        if (data.session_id && data.session_epoch) {
-          const nextSessionId = data.session_id;
-          const nextSessionEpoch = data.session_epoch;
-          setSessionSnapshot((prev) => ({
-            ...(prev ?? {
-              sessionId: nextSessionId,
-              sessionEpoch: nextSessionEpoch,
-              containerId: data.container_id ?? '',
-              threadId: data.thread_id ?? '',
-            }),
-            sessionId: nextSessionId,
-            sessionEpoch: nextSessionEpoch,
-            containerId: data.container_id ?? prev?.containerId ?? '',
-            threadId: data.thread_id ?? prev?.threadId ?? '',
-            activeTurnId: data.active_turn_id ?? prev?.activeTurnId ?? null,
-          }));
-        }
+        setSessionSnapshot((prev) => deriveSessionSnapshotFromEvent(data, prev));
       } catch {
         // ignore malformed events
       }
@@ -1477,7 +1632,7 @@ function LiveLogsPanel({
 
   const handleCopy = () => {
     if (logContent.length === 0) return;
-    copyTextToClipboard(logContent.map((line) => line.text).join('\n'));
+    copyTextToClipboard(logContent.map((line) => getCopyableRowText(line)).join('\n'));
   };
 
   const downloadUrl = taskRunRoute(
@@ -1487,12 +1642,18 @@ function LiveLogsPanel({
     { taskRunId },
   );
   const summaryErrorMessage = summaryQuery.isError ? (summaryQuery.error as Error).message : null;
+  const liveStatusValue =
+    summaryQuery.data?.liveStreamStatus
+    ?? sessionSnapshot?.status
+    ?? (viewerState === 'live' ? 'live' : viewerState);
   const sessionBadges = sessionSnapshot
     ? [
         ['Session', sessionSnapshot.sessionId],
         ['Epoch', String(sessionSnapshot.sessionEpoch)],
+        ['Container', sessionSnapshot.containerId],
         ['Thread', sessionSnapshot.threadId],
         ['Active Turn', sessionSnapshot.activeTurnId ?? null],
+        ['Live', liveStatusValue],
       ].filter(([, value]) => value) as Array<[string, string]>
     : [];
 
@@ -1510,11 +1671,11 @@ function LiveLogsPanel({
       >
         <span>Live Logs</span>
       </summary>
-      <div className="stack">
+      <div className="stack live-logs-panel">
         {summaryErrorMessage ? <div className="notice error">{summaryErrorMessage}</div> : null}
         {expanded ? (
-          <div className="button-group" style={{ fontSize: '0.9rem', fontWeight: 'normal' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+          <div className="button-group live-logs-toolbar">
+            <label className="live-logs-wrap-toggle">
               <input type="checkbox" checked={wrapLines} onChange={(e) => setWrapLines(e.target.checked)} />
               <span className="small">Wrap lines</span>
             </label>
@@ -1526,75 +1687,32 @@ function LiveLogsPanel({
           Task run <code className="text-xs">{taskRunId}</code> — {statusLabel}
         </p>
         {sessionBadges.length > 0 ? (
-          <div className="actions">
+          <div className="live-logs-session-badges">
             {sessionBadges.map(([label, value]) => (
-              <span key={`${label}-${value}`} className="card">
+              <span key={`${label}-${value}`} className="card live-logs-session-badge">
                 <strong>{label}:</strong> <code className="text-xs break-all">{value}</code>
               </span>
             ))}
           </div>
         ) : null}
-        <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
-          <div
-            style={{
-              background: '#111',
-              color: '#e8e8e8',
-              padding: '0.75rem',
-              fontSize: '0.7rem',
-              lineHeight: 1.4,
-              whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
-              wordBreak: wrapLines ? 'break-all' : 'normal',
-              borderRadius: '4px',
-              margin: 0,
-              fontFamily: 'monospace',
-            }}
-          >
-            {logContent.length === 0 ? (
-              <div>{emptyLabel}</div>
-            ) : (
-              logContent.map((line) => (
-                line.rowType === 'boundary' ? (
-                  <div
-                    key={line.id}
-                    data-stream={line.stream}
-                    data-kind={line.kind ?? undefined}
-                    style={{
-                      margin: '0.35rem 0',
-                      padding: '0.5rem 0.75rem',
-                      border: '1px solid #f59e0b',
-                      background: 'rgba(245, 158, 11, 0.12)',
-                      color: '#fde68a',
-                      borderRadius: '4px',
-                    }}
-                  >
-                    {line.text}
-                  </div>
-                ) : (
-                  <div
-                    key={line.id}
-                    data-stream={line.stream}
-                    data-kind={line.kind ?? undefined}
-                    style={{
-                      borderLeft:
-                        line.stream === 'stdout'
-                          ? '2px solid #3b82f6'
-                          : line.stream === 'stderr'
-                            ? '2px solid #ef4444'
-                            : line.stream === 'system'
-                              ? '2px solid #22c55e'
-                              : line.stream === 'session'
-                                ? '2px solid #f59e0b'
-                                : '2px solid transparent',
-                      paddingLeft: '6px',
-                      opacity: line.stream === 'system' ? 0.7 : 1,
-                    }}
-                  >
-                    {line.text}
-                  </div>
-                )
-              ))
-            )}
-          </div>
+        <div className={`live-logs-viewer-shell ${wrapLines ? 'is-wrapped' : 'is-unwrapped'}`}>
+          {logContent.length === 0 ? (
+            <div className="live-logs-empty">{emptyLabel}</div>
+          ) : sessionTimelineEnabled ? (
+            <div data-testid="live-logs-timeline-viewer" className="live-logs-viewer">
+              <Virtuoso
+                style={{ height: 400 }}
+                data={logContent}
+                initialItemCount={logContent.length}
+                computeItemKey={(_, row) => row.id}
+                itemContent={(_, row) => renderTimelineRow(row, wrapLines, true)}
+              />
+            </div>
+          ) : (
+            <div data-testid="live-logs-legacy-viewer" className="live-logs-legacy-viewer">
+              {logContent.map((line) => renderTimelineRow(line, wrapLines, false))}
+            </div>
+          )}
         </div>
       </div>
     </details>
@@ -2151,6 +2269,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
   const debugOn = Boolean(cfg?.features?.temporalDashboard?.debugFieldsEnabled);
   const logStreamingEnabled = cfg?.features?.logStreamingEnabled !== false;
+  const sessionTimelineEnabled = cfg?.features?.liveLogsSessionTimelineEnabled !== false;
 
   const taskIdMatch = window.location.pathname.match(
     /^\/tasks\/(?:temporal\/|proposals\/|schedules\/|manifests\/)?([^/]+)$/,
@@ -2625,6 +2744,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                       key={row.logicalStepId}
                       apiBase={payload.apiBase}
                       logStreamingEnabled={logStreamingEnabled}
+                      sessionTimelineEnabled={sessionTimelineEnabled}
                       row={row}
                       runId={stepsQuery.data?.runId || runId}
                       expanded={Boolean(expandedSteps[row.logicalStepId])}
@@ -2894,6 +3014,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                       isTerminal={isTerminalExecution}
                       autoExpand={showTaskRunAttachNotice}
                       routes={taskRunRoutes}
+                      sessionTimelineEnabled={sessionTimelineEnabled}
                     />
                     <StaticLogPanel
                       apiBase={payload.apiBase}

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1113,6 +1113,149 @@ button.secondary:hover {
   gap: 0.45rem;
 }
 
+.live-logs-panel {
+  gap: 0.75rem;
+}
+
+.live-logs-toolbar {
+  font-size: 0.9rem;
+  font-weight: 400;
+}
+
+.live-logs-wrap-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.live-logs-session-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.live-logs-session-badge {
+  padding: 0.55rem 0.7rem;
+}
+
+.live-logs-viewer-shell {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: rgb(12 14 22);
+  color: rgb(232 234 240);
+  border: 1px solid rgb(var(--mm-border) / 0.22);
+}
+
+.live-logs-empty,
+.live-logs-legacy-viewer,
+.live-logs-viewer {
+  font-family: "IBM Plex Mono", "Fira Code", monospace;
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.live-logs-empty {
+  padding: 0.85rem 0.95rem;
+  color: rgb(232 234 240 / 0.8);
+}
+
+.live-logs-legacy-viewer {
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.6rem;
+}
+
+.live-logs-viewer .virtuoso-grid-list,
+.live-logs-viewer .virtuoso-scroller {
+  scrollbar-color: rgb(var(--mm-border) / 0.5) transparent;
+}
+
+.live-logs-row {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.45rem 0.75rem;
+  border-left: 3px solid transparent;
+}
+
+.live-logs-row.is-wrapped .live-logs-row-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.live-logs-row.is-unwrapped .live-logs-row-text {
+  white-space: pre;
+  overflow-x: auto;
+}
+
+.live-logs-row-output.live-logs-stream-stdout {
+  border-left-color: rgb(59 130 246);
+}
+
+.live-logs-row-output.live-logs-stream-stderr {
+  border-left-color: rgb(239 68 68);
+}
+
+.live-logs-row-system {
+  border-left-color: rgb(34 197 94);
+  background: rgb(34 197 94 / 0.07);
+  color: rgb(232 234 240 / 0.84);
+}
+
+.live-logs-row-session,
+.live-logs-row-approval,
+.live-logs-row-publication {
+  border-left-color: rgb(245 158 11);
+  background: rgb(245 158 11 / 0.07);
+}
+
+.live-logs-row-approval {
+  border-left-color: rgb(99 102 241);
+  background: rgb(99 102 241 / 0.09);
+}
+
+.live-logs-row-publication {
+  border-left-color: rgb(14 165 233);
+  background: rgb(14 165 233 / 0.08);
+}
+
+.live-logs-row-boundary {
+  margin: 0.5rem 0.6rem;
+  border: 1px solid rgb(var(--mm-warn) / 0.8);
+  border-left: 4px solid rgb(var(--mm-warn));
+  border-radius: 0.7rem;
+  background: rgb(var(--mm-warn) / 0.13);
+  color: rgb(255 240 194);
+}
+
+.live-logs-boundary-label {
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.live-logs-kind-chip {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.14rem 0.5rem;
+  background: rgb(255 255 255 / 0.08);
+  color: rgb(255 255 255 / 0.82);
+  font-size: 0.62rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.live-logs-row-text {
+  min-width: 0;
+}
+
+.live-logs-row-text [data-ansi-fragment="true"] {
+  white-space: inherit;
+}
+
 @media (max-width: 720px) {
   .step-row-card {
     padding: 0.85rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
+        "anser": "^2.3.5",
         "marked": "^17.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-virtuoso": "^4.18.4",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -225,6 +227,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -273,6 +276,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -997,6 +1001,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1102,6 +1107,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1112,6 +1118,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1161,6 +1168,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -1498,6 +1506,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1541,6 +1550,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -1756,6 +1771,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2072,6 +2088,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2583,6 +2600,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2623,6 +2641,7 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -3388,6 +3407,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3592,6 +3612,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3601,6 +3622,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3614,6 +3636,16 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.4",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.4.tgz",
+      "integrity": "sha512-DNM4Wy2tMA/J6ejMaDdqecOug31rOwgSRg4C/Dw6Iox4dJe9qwcx32M8HdhkE5uHEVVZh7h0koYwAsCSNdxGfQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -3999,6 +4031,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4135,6 +4168,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4238,6 +4272,7 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
+    "anser": "^2.3.5",
     "marked": "^17.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-virtuoso": "^4.18.4",
     "zod": "^4.3.6"
   }
 }

--- a/specs/142-live-logs-session-timeline-ui/checklists/requirements.md
+++ b/specs/142-live-logs-session-timeline-ui/checklists/requirements.md
@@ -1,0 +1,8 @@
+# Specification Quality Checklist: Live Logs Session Timeline UI
+
+- [x] User stories are independent and testable.
+- [x] Requirements map to observable frontend behavior.
+- [x] Phase 4 scope stays on frontend timeline rendering and viewer hardening.
+- [x] TDD expectation is explicit.
+- [x] Rollout flag behavior is defined.
+- [x] Legacy fallback behavior for older runs is defined.

--- a/specs/142-live-logs-session-timeline-ui/contracts/live-logs-timeline-ui.md
+++ b/specs/142-live-logs-session-timeline-ui/contracts/live-logs-timeline-ui.md
@@ -1,0 +1,15 @@
+# Contract: Live Logs Session Timeline UI
+
+## Summary
+
+The Phase 4 UI consumes the existing task-run observability APIs and changes only the browser-side rendering and lifecycle behavior.
+
+## Browser Contract
+
+1. The panel must fetch `/observability-summary` before loading history.
+2. If the session timeline feature flag is enabled, the panel should request `/observability/events` first.
+3. If structured history is unavailable, the panel should request `/logs/merged` and render compatibility rows.
+4. SSE follow mode remains on `/logs/stream` and must append the same canonical event shape used by structured history.
+5. `session_reset_boundary` rows render as explicit timeline banners.
+6. Session snapshot header fields may come from summary, history payload, or the newest event carrying session metadata.
+7. When the session timeline feature flag is disabled, the panel may continue rendering the legacy line-oriented viewer while preserving the same fetch and live-connection lifecycle.

--- a/specs/142-live-logs-session-timeline-ui/data-model.md
+++ b/specs/142-live-logs-session-timeline-ui/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Live Logs Session Timeline UI
+
+## Frontend Timeline Row
+
+The Phase 4 UI keeps the backend `RunObservabilityEvent` contract intact and projects it into a frontend row model:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `id` | `string` | Stable React/Virtuoso key derived from sequence + split-line index |
+| `text` | `string` | Visible row text after event splitting |
+| `stream` | `stdout \| stderr \| system \| session \| unknown` | Preserves MoonMind stream provenance |
+| `kind` | `string \| null` | Drives row treatment for lifecycle/publication/boundary rows |
+| `sequence` | `number \| null` | Shared run-global ordering anchor |
+| `timestamp` | `string \| null` | Event time for compact metadata display |
+| `sessionId` | `string \| null` | Latest known bounded session identity from the event |
+| `sessionEpoch` | `number \| null` | Epoch value used for boundary and header rendering |
+| `containerId` | `string \| null` | Optional header/session context |
+| `threadId` | `string \| null` | Optional header/session context |
+| `turnId` | `string \| null` | Optional row/session context |
+| `activeTurnId` | `string \| null` | Optional row/session context |
+| `metadata` | `Record<string, unknown>` | Optional row-specific payload for later drill-down |
+| `rowType` | `output \| system \| session \| approval \| publication \| boundary \| fallback` | Frontend rendering bucket |
+
+## Header Snapshot Precedence
+
+The panel header should use the newest bounded session snapshot available in this order:
+
+1. `/observability-summary.sessionSnapshot`
+2. `/observability/events.sessionSnapshot`
+3. newest timeline row carrying session fields
+
+## Fallback Semantics
+
+| Source | When used | Notes |
+| --- | --- | --- |
+| Structured history | Preferred | Canonical initial-load source |
+| Merged artifact text | When structured history is unavailable | Converted to `fallback` rows |
+| SSE | After initial content only | Appends canonical event rows for active runs |
+
+## Feature Flag Semantics
+
+| Flag | Effect |
+| --- | --- |
+| `logStreamingEnabled` | Transport availability for SSE/live follow |
+| `liveLogsSessionTimelineEnabled` | Enables the richer timeline/header/viewer path; when `false`, the legacy line viewer remains active |

--- a/specs/142-live-logs-session-timeline-ui/plan.md
+++ b/specs/142-live-logs-session-timeline-ui/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Live Logs Session Timeline UI
+
+**Branch**: `142-live-logs-session-timeline-ui` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/142-live-logs-session-timeline-ui/spec.md`
+
+## Summary
+
+Implement the frontend Phase 4 slice of the session-aware Live Logs plan by upgrading [`frontend/src/entrypoints/task-detail.tsx`](../../frontend/src/entrypoints/task-detail.tsx) from a line viewer into a timeline viewer. The page will keep the shipped summary -> history -> SSE lifecycle, switch initial history preference to structured observability events, show a compact session snapshot header, render distinct timeline row types with feature-flagged session-aware UX, and harden the viewer with `react-virtuoso` plus `anser`.
+
+## Technical Context
+
+**Language/Version**: TypeScript, React 19, Vitest, existing Mission Control CSS  
+**Primary Dependencies**: TanStack Query, Zod, `react-virtuoso`, `anser`, task-detail runtime config, existing `/api/task-runs/*` observability routes  
+**Storage**: Browser query cache only; no backend schema change required for this slice  
+**Testing**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`  
+**Target Platform**: Mission Control React/Vite frontend served by FastAPI  
+**Project Type**: Frontend task-detail timeline upgrade with browser-test coverage and package dependency updates  
+**Performance Goals**: Remove naive unbounded timeline DOM growth, keep SSE follow bounded to the current panel lifecycle, and preserve responsive rendering for long histories  
+**Constraints**: Keep the current transport and page lifecycle, do not regress older runs that only have merged text, preserve feature-flagged rollout behavior, and keep the legacy line view available while the session timeline flag is disabled  
+**Scale/Scope**: Live Logs panel rendering and related task-detail types/tests/styles only; no new backend routes and no continuity-panel API redesign
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The UI consumes MoonMind-owned summary/history/SSE contracts instead of provider-native payloads.
+- **II. One-Click Agent Deployment**: PASS. The work stays inside the existing frontend build and runtime-config path.
+- **III. Avoid Vendor Lock-In**: PASS. Timeline rows remain based on MoonMind’s canonical event model.
+- **IV. Own Your Data**: PASS. The UI prefers MoonMind-owned structured history and only uses merged artifacts as compatibility fallback.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The main change is replacing the local row/viewer model around the existing canonical event contract.
+- **VII. Powerful Runtime Configurability**: PASS. The richer viewer is gated behind `liveLogsSessionTimelineEnabled`, independent from `logStreamingEnabled`.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay bounded to the task-detail entrypoint, CSS, and package dependency wiring.
+- **IX. Resilient by Default**: PASS. The viewer still degrades through merged-text fallback and avoids SSE for ended or unsupported runs.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This phase has its own spec/plan/tasks package before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical semantics remain in `docs/ManagedAgents/LiveLogs.md`; this plan captures the rollout slice only.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The new timeline path reuses the existing event contract directly rather than inventing another intermediate model.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/142-live-logs-session-timeline-ui/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── live-logs-timeline-ui.md
+├── checklists/
+│   └── requirements.md
+├── speckit_analyze_report.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/task-detail.tsx      # MODIFY: timeline row model, feature-flagged viewer, Virtuoso + ANSI rendering
+frontend/src/entrypoints/task-detail.test.tsx # MODIFY: timeline/fallback/flag/browser coverage
+frontend/src/styles/mission-control.css       # MODIFY: timeline header, row, and boundary styling
+package.json                                  # MODIFY: add react-virtuoso and anser
+package-lock.json                             # MODIFY: dependency lock update
+```
+
+**Structure Decision**: Keep the Live Logs upgrade inside the existing task-detail entrypoint and Mission Control stylesheet. Do not create a separate route or alternate viewer entrypoint; the panel should switch behavior based on the session-timeline feature flag and the available observability sources.
+
+## Research
+
+- The current frontend already consumes `/observability-summary`, `/observability/events`, and `/logs/stream`, but it still renders a mostly line-oriented `<div>` list with inline styles and no virtualization.
+- The current `TimelineRow` model already recognizes `session_reset_boundary`, which means the Phase 4 gap is mainly richer row treatment, feature-flag rollout, and viewer hardening rather than a greenfield UI rewrite.
+- The backend Phase 1-3 slices already provide the required feature flag (`liveLogsSessionTimelineEnabled`) and structured history/session snapshot contract, so this phase should avoid adding backend churn unless a test proves a route mismatch.
+- `docs/ManagedAgents/LiveLogs.md` explicitly names `react-virtuoso` and `anser` as the desired-state viewer baseline, so package updates are in-scope for this phase.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the frontend timeline row model, header snapshot precedence, and fallback behavior.
+
+## Contracts
+
+- [contracts/live-logs-timeline-ui.md](./contracts/live-logs-timeline-ui.md)
+
+## Implementation Plan
+
+1. Add failing browser tests for:
+   - structured-history-first loading and merged fallback,
+   - feature-flagged timeline vs legacy line viewer behavior,
+   - session snapshot header fields and distinct session/system row rendering,
+   - explicit boundary banners,
+   - virtualization and ANSI rendering markers.
+2. Introduce a feature-flag-aware Live Logs viewer model in `task-detail.tsx` that keeps the current summary -> history -> SSE lifecycle intact.
+3. Replace the current direct row mapping with a `react-virtuoso` timeline renderer and `anser`-based ANSI fragments for output rows.
+4. Move the inline Live Logs styles into Mission Control CSS classes for the new header, rows, and boundary treatment.
+5. Update package dependencies and rerun focused UI verification, scope validation, and the task-state file.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+2. `npm run ui:typecheck`
+3. `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+4. `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+5. `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+### Manual Validation
+
+1. Open a task detail page for a structured-history-enabled run and confirm the Live Logs panel shows the session snapshot header and timeline rows before any SSE message arrives.
+2. Open a legacy run without structured history and confirm the panel degrades to merged text without breaking the old operator flow.
+3. Toggle the `liveLogsSessionTimelineEnabled` runtime config off and confirm the legacy line viewer remains available.

--- a/specs/142-live-logs-session-timeline-ui/quickstart.md
+++ b/specs/142-live-logs-session-timeline-ui/quickstart.md
@@ -1,0 +1,11 @@
+# Quickstart: Live Logs Session Timeline UI
+
+1. Ensure frontend dependencies are installed and up to date.
+2. Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`.
+3. Run `npm run ui:typecheck`.
+4. Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`.
+5. Open a task detail page with a `taskRunId`, expand Live Logs, and verify:
+   - the session snapshot header renders when available,
+   - structured history appears before live follow starts,
+   - reset boundaries render as banners,
+   - ANSI output is visible without raw escape codes.

--- a/specs/142-live-logs-session-timeline-ui/research.md
+++ b/specs/142-live-logs-session-timeline-ui/research.md
@@ -1,0 +1,50 @@
+# Research: Live Logs Session Timeline UI
+
+## Inputs reviewed
+
+- `docs/ManagedAgents/LiveLogs.md`
+- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/tmp/009-LiveLogsPlan.md`
+- `specs/141-live-logs-history-events/*`
+- `frontend/src/entrypoints/task-detail.tsx`
+- `frontend/src/entrypoints/task-detail.test.tsx`
+
+## Findings
+
+### 1. The frontend already consumes the right backend surfaces
+
+The current Live Logs panel already fetches summary, structured history, merged fallback, and SSE in roughly the right order. The main gap is that the rendered experience still behaves like a line-oriented viewer with minimal row differentiation.
+
+### 2. Session-aware data is available but underused in the UI
+
+The current schemas already parse `sessionSnapshot` and `RunObservabilityEvent` session fields, and the existing tests already cover reset-boundary rendering. The remaining Phase 4 work is to turn those raw fields into a cohesive timeline UI with a stronger header and row system.
+
+### 3. Viewer hardening is still missing
+
+The current panel renders every row with direct mapping inside a scroll container and keeps all presentation styles inline. That conflicts with the desired-state architecture, which calls for `react-virtuoso` and `anser`.
+
+### 4. Rollout should stay feature-flagged
+
+The backend already exposes `liveLogsSessionTimelineEnabled` and `liveLogsSessionTimelineRollout`, but the current frontend does not use that flag to preserve a legacy line-view mode. Phase 4 should consume the flag rather than assuming universal enablement.
+
+## Decisions
+
+### Decision 1: Keep one Live Logs panel and switch behavior with the feature flag
+
+- **Chosen**: Preserve the existing panel lifecycle and gate the richer timeline renderer behind `liveLogsSessionTimelineEnabled`.
+- **Rationale**: Matches the rollout plan and allows gradual enablement without creating a second route or page.
+
+### Decision 2: Prefer structured history even when merged fallback exists
+
+- **Chosen**: Keep the summary -> structured history -> merged fallback order explicit in the UI.
+- **Rationale**: Aligns the frontend with the backend Phase 3 contract and avoids parsing merged text as the primary model when structured events exist.
+
+### Decision 3: Treat `session_reset_boundary` as the only hard banner requirement in this slice
+
+- **Chosen**: Render reset boundaries as banners and give other session/approval/publication rows distinct non-banner timeline treatments.
+- **Rationale**: Matches the desired-state contract while keeping the first implementation pass bounded.
+
+### Decision 4: Use ANSI rendering only for output rows
+
+- **Chosen**: Parse ANSI fragments for `stdout` and `stderr`; leave `system` and `session` rows as ordinary text/timeline rows.
+- **Rationale**: Those non-output rows are MoonMind-originated annotations and do not need terminal-style escape handling.

--- a/specs/142-live-logs-session-timeline-ui/spec.md
+++ b/specs/142-live-logs-session-timeline-ui/spec.md
@@ -1,0 +1,89 @@
+# Feature Specification: Live Logs Session Timeline UI
+
+**Feature Branch**: `142-live-logs-session-timeline-ui`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 4 using test-driven development from the Live Logs Session-Aware Implementation Plan."
+
+## User Scenarios & Testing
+
+### User Story 1 - Load the Live Logs panel as a session-aware timeline (Priority: P1)
+
+Mission Control operators need the Live Logs panel to prefer structured observability history and render a unified timeline instead of treating the primary experience as a merged text tail.
+
+**Why this priority**: This is the Phase 4 product shift. Without it, the backend Phase 1-3 contract remains underused and Live Logs still behaves like a line viewer.
+
+**Independent Test**: Open Live Logs for a managed run that has structured history and verify the page loads summary first, then structured event history, and only falls back to merged text when structured history is unavailable.
+
+**Acceptance Scenarios**:
+
+1. **Given** observability summary and structured history exist for a task run, **When** the operator opens Live Logs, **Then** the UI requests summary first and structured history second before attempting SSE follow mode.
+2. **Given** structured history is unavailable for an older run, **When** the operator opens Live Logs, **Then** the UI degrades to merged artifact-backed content without breaking the existing operator workflow.
+3. **Given** the run is active, visible, and stream-capable, **When** the historical content is loaded, **Then** the UI attaches SSE follow mode without replacing the already-rendered historical timeline.
+
+### User Story 2 - Render session-aware timeline rows and header context (Priority: P1)
+
+Operators need distinct rendering for stdout, stderr, system, and session lifecycle events plus a compact session snapshot header so resets and turn changes are understandable without opening a separate continuity panel first.
+
+**Why this priority**: The desired-state Live Logs experience is continuity-aware observability, not a plain merged tail.
+
+**Independent Test**: Render a timeline containing mixed output, system, session lifecycle, approval, and reset-boundary rows and verify the header and row types expose session identity and timeline semantics clearly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the observability summary or history response includes a session snapshot, **When** the panel renders, **Then** the header shows session ID, epoch, container ID, thread ID, active turn ID, and live status when present.
+2. **Given** the timeline contains `stdout`, `stderr`, `system`, `session`, approval, publication, and `session_reset_boundary` rows, **When** the panel renders, **Then** each row uses distinct timeline treatment and reset boundaries appear as obvious banners.
+3. **Given** session continuity artifacts still exist separately, **When** the operator reads Live Logs, **Then** the main timeline carries the important session milestones without requiring continuity drill-down to notice them.
+
+### User Story 3 - Harden the viewer for large logs with virtualization and ANSI rendering (Priority: P2)
+
+Operators need the session-aware timeline viewer to remain responsive on long histories and preserve ANSI formatting for output rows so the panel scales beyond the current naive DOM growth.
+
+**Why this priority**: The desired-state architecture explicitly calls for `react-virtuoso` and `anser` as the long-term viewer baseline.
+
+**Independent Test**: Render the timeline viewer with enough mixed rows to require virtualization semantics and ANSI-colored output, then verify the panel still shows the expected content and styling markers through the React test harness.
+
+**Acceptance Scenarios**:
+
+1. **Given** a large timeline, **When** the panel renders, **Then** the list is owned by a virtualized viewer rather than direct unbounded row mapping.
+2. **Given** a `stdout` or `stderr` row contains ANSI escape sequences, **When** the panel renders, **Then** the visible text is preserved and ANSI spans are parsed into styled fragments rather than raw escape codes.
+3. **Given** the session-aware timeline flag is disabled, **When** the operator opens Live Logs, **Then** the existing line-oriented behavior remains available during rollout.
+
+### Edge Cases
+
+- Structured history may be present but empty while merged artifacts still contain legacy text; the UI should still use the documented fallback order truthfully.
+- SSE events may arrive before or after history finishes; the viewer must avoid duplicated rows and keep sequence ordering stable.
+- Session metadata may appear in history rows even when the summary snapshot is absent; the panel should still surface the most recent bounded session context it can derive.
+- Older runs may expose only merged text and no session rows; the panel must remain usable without fabricating session lifecycle events.
+- Mixed ANSI and plain-text rows must render without leaking raw escape sequences into copied or visible output.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The task-detail Live Logs panel MUST keep the existing lifecycle of summary first, historical content second, and SSE follow only when the panel is open, visible, and the run is active.
+- **FR-002**: The Live Logs panel MUST prefer `/api/task-runs/{id}/observability/events` for initial history loading and MUST fall back to `/logs/merged` only when structured history is unavailable.
+- **FR-003**: The Live Logs panel MUST render a unified timeline model that can represent `stdout`, `stderr`, `system`, and `session` events plus reset boundaries and other timeline-specific row types.
+- **FR-004**: The Live Logs header MUST show the latest available session snapshot fields, including session ID, epoch, container ID, thread ID, active turn ID, and live status when present.
+- **FR-005**: `session_reset_boundary` events MUST render as explicit boundary banners instead of plain line rows.
+- **FR-006**: The viewer MUST preserve stream provenance and visually differentiate output, system, session lifecycle, approval/publication, and reset-boundary rows.
+- **FR-007**: The task-detail frontend MUST adopt `react-virtuoso` for the main Live Logs timeline renderer.
+- **FR-008**: The task-detail frontend MUST adopt `anser` for ANSI-aware output rendering in timeline rows.
+- **FR-009**: The session-aware timeline UI MUST remain gated by the existing `liveLogsSessionTimelineEnabled` runtime-config feature flag so rollout can degrade to the prior line viewer.
+- **FR-010**: This phase MUST ship production frontend/runtime code changes plus automated validation tests; docs-only changes are insufficient.
+
+### Key Entities
+
+- **Timeline Row View Model**: The frontend-owned normalized row model used by the Live Logs viewer for output, system, session, approval, publication, and boundary rows.
+- **Session Snapshot Header**: The compact UI summary of the latest bounded session identity shown above the timeline.
+- **Structured History Source**: The canonical initial-load source from `/observability/events`.
+- **Merged Tail Fallback**: The artifact-backed compatibility path used only when structured history is unavailable.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: UI tests prove the panel loads summary first, then structured history, and only falls back to merged text when the structured history path is unavailable.
+- **SC-002**: UI tests prove mixed `stdout`, `stderr`, `system`, `session`, approval/publication, and reset-boundary rows render in one timeline with a session snapshot header.
+- **SC-003**: UI tests prove the session-aware path is feature-flagged and the viewer degrades to the legacy line view when the flag is disabled.
+- **SC-004**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` pass.

--- a/specs/142-live-logs-session-timeline-ui/speckit_analyze_report.md
+++ b/specs/142-live-logs-session-timeline-ui/speckit_analyze_report.md
@@ -1,0 +1,39 @@
+# Speckit Analyze Report: Live Logs Session Timeline UI
+
+## Remediation Review
+
+### spec.md
+
+#### LOW
+
+- **Artifact**: `spec.md`
+- **Location**: User Story 2 / Acceptance Scenarios
+- **Problem**: The first draft could have implied that continuity drill-down must be redesigned in this slice.
+- **Remediation**: Keep continuity drill-down out of primary scope and require only that the main timeline surfaces the important milestones inline.
+- **Rationale**: Matches the Phase 4 plan while avoiding a Phase 5 artifact-linking expansion.
+
+### plan.md
+
+#### LOW
+
+- **Artifact**: `plan.md`
+- **Location**: Constraints
+- **Problem**: The plan needed to state explicitly that the legacy line viewer remains available behind the feature flag.
+- **Remediation**: Add feature-flag compatibility behavior to the constraints and implementation plan.
+- **Rationale**: Prevents rollout ambiguity and keeps independent frontend/backend deployment safer.
+
+### tasks.md
+
+#### LOW
+
+- **Artifact**: `tasks.md`
+- **Location**: Validation section
+- **Problem**: Validation should include both scope checks and focused UI verification commands.
+- **Remediation**: Include `ui:test`, `ui:typecheck`, task-scope validation, diff-scope validation, and `test_unit.sh --ui-args`.
+- **Rationale**: Aligns the feature with repo test expectations for frontend work.
+
+## Safe-to-Implement Determination
+
+- **Safe to Implement**: YES
+- **Blocking Remediations**: None
+- **Determination Rationale**: The Phase 4 package is scoped to the intended frontend timeline upgrade, preserves rollout compatibility, and includes concrete implementation and validation tasks.

--- a/specs/142-live-logs-session-timeline-ui/tasks.md
+++ b/specs/142-live-logs-session-timeline-ui/tasks.md
@@ -1,0 +1,96 @@
+# Tasks: Live Logs Session Timeline UI
+
+**Input**: Design documents from `/specs/142-live-logs-session-timeline-ui/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing browser tests before implementing the corresponding Live Logs viewer changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create or extend the Phase 4 Live Logs browser-test target in `frontend/src/entrypoints/task-detail.test.tsx`.
+- [X] T015 Keep the Live Logs feature-flag payload grouped for dashboard consumers in `api_service/api/routers/task_dashboard_view_model.py`.
+- [X] T016 Add unit coverage in `tests/unit/api/routers/test_task_dashboard_view_model.py` for the grouped Live Logs feature flags exposed to the frontend.
+
+---
+
+## Phase 2: User Story 1 - Load the Live Logs panel as a session-aware timeline (Priority: P1)
+
+**Goal**: Keep the shipped panel lifecycle while preferring structured history over merged-text fallback.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering summary -> structured history -> SSE load order and merged-text fallback when structured history is unavailable.
+- [X] T003 [P] [US1] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering feature-flag fallback to the legacy line viewer when `liveLogsSessionTimelineEnabled` is false.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Update `frontend/src/entrypoints/task-detail.tsx` to consume the session timeline feature flag and preserve the summary -> structured history -> merged fallback -> SSE lifecycle.
+
+---
+
+## Phase 3: User Story 2 - Render session-aware timeline rows and header context (Priority: P1)
+
+**Goal**: Render one unified timeline with a compact session snapshot header and explicit boundary treatment.
+
+### Tests for User Story 2
+
+- [X] T005 [P] [US2] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering session snapshot header fields, mixed row kinds, and reset-boundary banner rendering.
+- [X] T006 [P] [US2] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering approval/publication/session lifecycle row semantics and session metadata derived from history rows.
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/styles/mission-control.css` to render the session-aware timeline rows, header badges, and explicit boundary banners.
+
+---
+
+## Phase 4: User Story 3 - Harden the viewer for large logs with virtualization and ANSI rendering (Priority: P2)
+
+**Goal**: Replace the naive row list with the desired viewer baseline from the Live Logs architecture.
+
+### Tests for User Story 3
+
+- [X] T008 [P] [US3] Write failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering virtualization markers and ANSI-aware output rendering.
+
+### Implementation for User Story 3
+
+- [X] T009 [US3] Update `package.json`, `package-lock.json`, and `frontend/src/entrypoints/task-detail.tsx` to adopt `react-virtuoso` and `anser` for the timeline viewer.
+
+---
+
+## Phase 5: Validation
+
+- [X] T010 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [X] T011 Run `npm run ui:typecheck`
+- [X] T012 Run `./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T013 Run `./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+- [X] T014 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **User Story 1 (Phase 2)**: Depends on Setup.
+- **User Story 2 (Phase 3)**: Depends on the history-loading and feature-flag foundations from User Story 1.
+- **User Story 3 (Phase 4)**: Depends on the row model from User Story 2.
+- **Validation (Phase 5)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- T002 and T003 can be written together before implementation begins.
+- T005 and T006 can be written in parallel once the row model expectations are clear.
+- T008 can be added while the viewer refactor is underway but before final verification.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing tests for lifecycle ordering and feature-flag fallback.
+2. Land the feature-flag-aware history-loading behavior.
+3. Add the session-aware row/header rendering.
+4. Finish with Virtuoso + ANSI rendering and run validation.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -367,6 +367,21 @@ def test_build_runtime_config_session_timeline_rollout_is_exposed(monkeypatch) -
     assert config["features"]["liveLogsSessionTimelineRollout"] == "codex_managed"
 
 
+def test_build_runtime_config_groups_live_logs_feature_flags(monkeypatch) -> None:
+    monkeypatch.setenv("MOONMIND_LOG_STREAMING_ENABLED", "true")
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_session_timeline_rollout",
+        "internal",
+    )
+
+    config = build_runtime_config("/tasks")
+
+    assert config["features"]["logStreamingEnabled"] is True
+    assert config["features"]["liveLogsSessionTimelineEnabled"] is True
+    assert config["features"]["liveLogsSessionTimelineRollout"] == "internal"
+
+
 def test_build_runtime_config_omits_temporal_live_session_endpoint() -> None:
     config = build_runtime_config("/tasks")
     assert "liveSession" not in config["sources"]["temporal"]


### PR DESCRIPTION
## Summary
- upgrade Mission Control Live Logs from a line viewer into a feature-flagged session-aware timeline
- add `react-virtuoso` and `anser` for virtualized, ANSI-aware log rendering
- materialize the full Spec Kit package for feature `142-live-logs-session-timeline-ui`

## What Changed
- preserved the existing summary -> structured history -> merged fallback -> SSE lifecycle while making the richer timeline conditional on `liveLogsSessionTimelineEnabled`
- added session snapshot header badges for session, epoch, container, thread, active turn, and live status
- classified timeline rows for output, system, session, approval, publication, and reset-boundary rendering
- added a small dashboard runtime-config helper cleanup and matching unit coverage for grouped Live Logs feature flags

## Why
Live Logs already had the backend event/history contract from earlier phases, but the frontend was still acting like a line-oriented merged tail. This change makes the UI use the session-aware observability model directly while preserving rollout safety for older runs and disabled environments.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `npm run ui:typecheck`
- `SPECIFY_FEATURE=142-live-logs-session-timeline-ui ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=142-live-logs-session-timeline-ui ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
