### PR TITLE
Lock DooD Phase 0 contract

### DIFF
--- a/docs/ManagedAgents/CodexManagedSessionPlane.md
+++ b/docs/ManagedAgents/CodexManagedSessionPlane.md
@@ -2,7 +2,7 @@
 
 Status: Desired state
 Owners: MoonMind Platform
-Last updated: 2026-04-06
+Last updated: 2026-04-09
 Related:
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
@@ -63,6 +63,8 @@ The managed session plane is the task-scoped Codex runtime environment:
 - continuity reused across steps within the same task only
 
 The session plane is a continuity and performance cache. It is not durable truth.
+
+Managed-session steps may invoke **control-plane tools** that launch separate workload containers as described in [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md). Those workload containers remain outside session identity: they do not become `session_id`, `session_epoch`, `container_id`, `thread_id`, or `active_turn_id`, and they do not replace the task-scoped session container.
 
 ## 3. Protocol
 

--- a/docs/ManagedAgents/DockerOutOfDocker.md
+++ b/docs/ManagedAgents/DockerOutOfDocker.md
@@ -3,7 +3,7 @@
 **Implementation tracking:** [`docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`](../tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md)
 **Status:** Desired state
 **Owners:** MoonMind Platform
-**Last updated:** 2026-04-08
+**Last updated:** 2026-04-09
 
 **Related:**
 - [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
@@ -33,7 +33,7 @@ The goal is to let MoonMind run these workloads **against the task workspace** w
 - the **Temporal control plane** as the owner of launch, policy, cancellation, and observability
 - worker images generic and maintainable
 
-This document replaces the older framing that treated DooD mainly as a sandbox-worker trick for arbitrary heavy commands. The updated model distinguishes **managed agent session containers** from **non-agent workload containers**.
+This document replaces the older framing that treated DooD mainly as a sandbox-worker trick for arbitrary heavy commands. The updated model distinguishes **managed agent session containers** from **non-agent workload containers**. Phase 0 locks that contract here; remaining rollout work belongs in [`docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`](../tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md).
 
 ---
 
@@ -219,7 +219,7 @@ Rules:
 - it must have best-effort termination on step cancel, timeout, or task cancel
 - it must not become a hidden long-lived background service
 
-The initial implementation emphasis should remain **one-shot workload containers**. Bounded helper containers are a valid direction, but they do not change the separation between session-plane identity and workload identity.
+The initial implementation emphasis should remain **one-shot workload containers**. Bounded helper containers remain a later phase. They are a valid direction, but they do not change the separation between session-plane identity and workload identity.
 
 ---
 
@@ -240,6 +240,8 @@ For normal specialized workloads, the preferred model is:
 5. MoonMind publishes artifacts and returns a normal `ToolResult`
 
 This keeps specialized workload containers in the **tool** world rather than pretending they are extra agent sessions.
+
+The initial DooD execution primitive is `tool.type = "skill"`. `tool.type = "agent_runtime"` remains reserved for true long-lived agent runtimes rather than ordinary workload containers.
 
 ### 7.3 Curated activity exception
 

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -3,7 +3,7 @@
 **Implementation tracking:** [`docs/tmp/remaining-work/Temporal-ManagedAndExternalAgentExecutionModel.md`](../tmp/remaining-work/Temporal-ManagedAndExternalAgentExecutionModel.md)
 
 Status: **Implemented** (runtime live; contract hardening in progress)
-Last updated: 2026-04-04
+Last updated: 2026-04-09
 Related:
 - [`docs/Tasks/AgentSkillSystem.md`](../Tasks/AgentSkillSystem.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
@@ -51,6 +51,8 @@ This document does **not** define:
 - source precedence rules across built-in, deployment, repo, and local skills
 - ordinary one-shot LLM activity behavior (`mm.activity.llm`)
 - generic executable tool contracts outside true agent runtime execution
+
+Docker-backed workload tools are ordinary executable tools. They stay on the `tool.type = "skill"` path described by [`docs/Tasks/SkillAndPlanContracts.md`](../Tasks/SkillAndPlanContracts.md) and are not new `MoonMind.AgentRun` instances unless the launched runtime is itself a true managed agent runtime. [`docs/ManagedAgents/DockerOutOfDocker.md`](../ManagedAgents/DockerOutOfDocker.md) defines that workload-container boundary.
 
 MoonMind explicitly separates long-lived, stateful agent execution from plain one-shot model calls. True agent execution is treated as a first-class orchestration concept built around:
 

--- a/docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md
+++ b/docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md
@@ -1,0 +1,31 @@
+# DockerOutOfDocker Remaining Work
+
+Source doc: [`docs/ManagedAgents/DockerOutOfDocker.md`](../../ManagedAgents/DockerOutOfDocker.md)
+Status: Phase 0 complete; Phases 1 through 7 pending
+Last updated: 2026-04-09
+
+## Phase checklist
+
+- [x] Phase 0: Lock the contract and carve the boundary across the canonical DooD, session-plane, and execution-model docs.
+- [ ] Phase 1: Define the control-plane workload contract (`WorkloadRequest`, `WorkloadResult`, `RunnerProfile`, ownership metadata, validation rules).
+- [ ] Phase 2: Build the Docker workload launcher on the existing Docker-capable `agent_runtime` worker fleet.
+- [ ] Phase 3: Expose DooD through executable tools such as `container.run_workload` and `unreal.run_tests`.
+- [ ] Phase 4: Publish durable workload artifacts, live-log linkage, and optional session-association metadata without confusing workload identity with session identity.
+- [ ] Phase 5: Harden security, policy, concurrency control, and orphan cleanup.
+- [ ] Phase 6: Validate the architecture with the Unreal pilot runner profile and representative repository coverage.
+- [ ] Phase 7: Evaluate bounded helper containers only after one-shot workload containers are stable and well observed.
+
+## Phase 0 completion notes
+
+- Canonical glossary locked around `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
+- Session-plane doc now states that managed-session steps may invoke control-plane workload tools whose containers remain outside session identity.
+- Execution-model doc now states that Docker-backed workload tools remain ordinary executable tools unless they launch a true managed agent runtime.
+- A focused unit test guards the tracker reference and the agreed boundary wording.
+
+## Guardrails to preserve during later phases
+
+- Keep `tool.type = "skill"` as the initial execution primitive for Docker-backed workload launches.
+- Keep the current Docker-capable `agent_runtime` fleet as the first workload host.
+- Keep one-shot workload containers as the MVP lifecycle.
+- Keep bounded helper containers as a later phase, not part of the MVP.
+- Keep artifacts and bounded workflow metadata as durable truth.

--- a/docs/tmp/remaining-work/README.md
+++ b/docs/tmp/remaining-work/README.md
@@ -11,6 +11,7 @@ Tracker rules:
 ## Current trackers
 
 - `Api-ExecutionsApiContract.md`
+- `ManagedAgents-DockerOutOfDocker.md`
 - `Tasks-SkillAndPlanContracts.md`
 - `Temporal-ManagedAndExternalAgentExecutionModel.md`
 - `Temporal-RunHistoryAndRerunSemantics.md`

--- a/specs/143-dood-phase0/checklists/requirements.md
+++ b/specs/143-dood-phase0/checklists/requirements.md
@@ -2,7 +2,7 @@
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-04-09
-**Feature**: [spec.md](/mnt/d/code/MoonMind/specs/143-dood-phase0/spec.md)
+**Feature**: [spec.md](../spec.md)
 
 ## Content Quality
 

--- a/specs/143-dood-phase0/checklists/requirements.md
+++ b/specs/143-dood-phase0/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Docker-Out-of-Docker Phase 0 Contract Lock
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-09
+**Feature**: [spec.md](/mnt/d/code/MoonMind/specs/143-dood-phase0/spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Docs-mode feature scoped to Phase 0 deliverables only: canonical documentation alignment, remaining-work tracking, and automated validation.

--- a/specs/143-dood-phase0/contracts/dood-phase0-doc-contract.md
+++ b/specs/143-dood-phase0/contracts/dood-phase0-doc-contract.md
@@ -1,0 +1,46 @@
+# DooD Phase 0 Documentation Contract
+
+## Purpose
+
+Define the exact documentation assertions that Phase 0 must lock before Phase 1 implementation begins.
+
+## Required canonical surfaces
+
+1. `docs/ManagedAgents/DockerOutOfDocker.md`
+2. `docs/ManagedAgents/CodexManagedSessionPlane.md`
+3. `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
+4. `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`
+
+## Required assertions
+
+### Glossary consistency
+
+- The canonical docs must use the terms:
+  - `session container`
+  - `workload container`
+  - `runner profile`
+  - `session-assisted workload`
+
+### Session-plane boundary
+
+- The session-plane doc must say that session-plane steps may invoke control-plane tools that launch separate workload containers.
+- The session-plane doc must say those workload containers are outside session identity.
+
+### Execution-model boundary
+
+- The execution-model doc must say Docker-backed workload launches are ordinary executable tools.
+- The execution-model doc must say those launches are not new `MoonMind.AgentRun` instances unless the launched workload is itself a true managed runtime.
+
+### Lifecycle scope
+
+- The canonical docs must preserve one-shot workload containers as the initial DooD implementation scope.
+- The canonical docs must preserve bounded helper containers as a later phase rather than the MVP.
+
+### Tracker presence
+
+- The canonical DooD doc must link to `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`.
+- `docs/tmp/remaining-work/README.md` must list the same tracker.
+
+## Validation surface
+
+- A focused pytest test reads the required files and fails if any assertion above is no longer true.

--- a/specs/143-dood-phase0/data-model.md
+++ b/specs/143-dood-phase0/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: Docker-Out-of-Docker Phase 0 Contract Lock
+
+## Entities
+
+### SessionContainerTerm
+
+- **Purpose**: Represents the canonical term for the task-scoped managed Codex container used for continuity within one task.
+- **Required attributes**:
+  - `name`: `session container`
+  - `identity_scope`: task-scoped managed session only
+  - `durable_truth_role`: none; continuity cache only
+
+### WorkloadContainerTerm
+
+- **Purpose**: Represents the canonical term for the specialized non-agent container launched by the control plane for a bounded workload.
+- **Required attributes**:
+  - `name`: `workload container`
+  - `launch_path`: ordinary executable tool on the control plane
+  - `identity_scope`: separate from session identity
+  - `default_lifecycle`: one-shot container for Phases 1 through 4
+
+### RunnerProfileTerm
+
+- **Purpose**: Represents the curated MoonMind definition of an allowed workload-container shape.
+- **Required attributes**:
+  - `name`: `runner profile`
+  - `authority`: MoonMind policy / control plane
+  - `shape`: image, mount, environment, resource, network, and cleanup rules
+
+### SessionAssistedWorkloadTerm
+
+- **Purpose**: Represents a managed-session step that requests a specialized workload through the control plane.
+- **Required attributes**:
+  - `name`: `session-assisted workload`
+  - `session_identity_transfer`: forbidden
+  - `docker_authority`: remains with the Docker-capable worker fleet
+
+### DoodRemainingWorkTracker
+
+- **Purpose**: Represents the temporary implementation tracker linked from the canonical DooD doc.
+- **Required attributes**:
+  - `path`: `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`
+  - `role`: phased rollout checklist after Phase 0
+  - `canonical_relationship`: linked from the canonical DooD doc, not duplicated inside it
+
+### DoodPhase0DocContractTest
+
+- **Purpose**: Represents the automated validation surface that guards the Phase 0 boundary.
+- **Required attributes**:
+  - `path`: `tests/unit/docs/test_dood_phase0_contract.py`
+  - `assertions`: glossary consistency, execution primitive wording, tracker presence
+  - `failure_mode`: fail fast if any required phrase or file path disappears

--- a/specs/143-dood-phase0/plan.md
+++ b/specs/143-dood-phase0/plan.md
@@ -9,7 +9,7 @@ Implement Phase 0 of the Docker-out-of-Docker rollout by locking the canonical a
 
 ## Technical Context
 
-**Language/Version**: Markdown documentation plus Python 3.13 for validation tests  
+**Language/Version**: Markdown documentation plus Python 3.12+ for validation tests  
 **Primary Dependencies**: pytest, repository markdown docs, `pathlib`-based file assertions  
 **Storage**: Repository files only  
 **Testing**: Focused pytest unit test followed by `./tools/test_unit.sh`  

--- a/specs/143-dood-phase0/plan.md
+++ b/specs/143-dood-phase0/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Docker-Out-of-Docker Phase 0 Contract Lock
+
+**Branch**: `143-dood-phase0` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/143-dood-phase0/spec.md`
+
+## Summary
+
+Implement Phase 0 of the Docker-out-of-Docker rollout by locking the canonical architecture wording across the DooD, Codex managed-session, and managed-execution docs; adding a DooD remaining-work tracker under `docs/tmp/remaining-work/`; and introducing an automated unit test that fails when the agreed glossary, execution primitive, or tracker reference drifts.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation plus Python 3.13 for validation tests  
+**Primary Dependencies**: pytest, repository markdown docs, `pathlib`-based file assertions  
+**Storage**: Repository files only  
+**Testing**: Focused pytest unit test followed by `./tools/test_unit.sh`  
+**Target Platform**: MoonMind repository documentation and unit-test suite  
+**Project Type**: Documentation contract lock with executable validation  
+**Performance Goals**: Keep the validation test fast and deterministic while covering the Phase 0 contract surface  
+**Constraints**: Phase 0 only; no launcher/runtime/tooling implementation beyond documentation and validation; preserve Constitution Principle XII by keeping rollout tracking under `docs/tmp/remaining-work/`  
+**Scale/Scope**: Three canonical docs, one remaining-work tracker, one focused unit test
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The slice clarifies orchestration boundaries instead of introducing new runtime behavior.
+- **II. One-Click Agent Deployment**: PASS. No deployment changes are introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The wording keeps workload tools as control-plane concepts rather than hardwiring Docker into session identity.
+- **IV. Own Your Data**: PASS. The plan reinforces artifacts and bounded metadata as durable truth.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The execution primitive remains the documented `tool.type = "skill"` tool path.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. This phase hardens contracts and keeps implementation sequencing out of canonical docs.
+- **VII. Powerful Runtime Configurability**: PASS. No runtime configuration behavior changes.
+- **VIII. Modular and Extensible Architecture**: PASS. The slice preserves the session-plane, tool-path, and agent-runtime boundaries.
+- **IX. Resilient by Default**: PASS. Automated validation guards the contract against future documentation drift.
+- **XI. Spec-Driven Development**: PASS. The work is fully driven by spec, plan, and tasks artifacts.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs describe desired-state boundaries; the rollout checklist lives under `docs/tmp/remaining-work/`.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. No compatibility aliases or dual semantic paths are introduced.
+
+## Research
+
+- `docs/ManagedAgents/DockerOutOfDocker.md` already contains the target glossary (`session container`, `workload container`, `runner profile`, `session-assisted workload`) and already states that one-shot workload containers are the initial emphasis.
+- `docs/ManagedAgents/CodexManagedSessionPlane.md` currently links to the DooD doc but does not explicitly say that session-plane steps may invoke control-plane workload tools whose containers remain outside session identity.
+- `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` currently defines `MoonMind.AgentRun` for true agent runtimes and excludes generic executable tools, but it does not yet name Docker-backed workload tools as ordinary executable tools distinct from managed agent runs.
+- `docs/tmp/remaining-work/README.md` lists active trackers but there is no DooD rollout tracker yet, even though `docs/ManagedAgents/DockerOutOfDocker.md` already links to one.
+- The repo does not already contain a documentation-contract unit test for this DooD boundary, so the fastest durable guard is a focused pytest file that asserts the required phrases and tracker path exist.
+
+## Project Structure
+
+- Update `docs/ManagedAgents/DockerOutOfDocker.md` to ensure the tracker link and Phase 0 contract wording stay aligned.
+- Update `docs/ManagedAgents/CodexManagedSessionPlane.md` with a short cross-reference for session-assisted workload tools.
+- Update `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` with a short note that Docker-backed workload tools are ordinary executable tools unless they launch a true managed runtime.
+- Add `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md` as the DooD rollout tracker and list it in `docs/tmp/remaining-work/README.md`.
+- Add `tests/unit/docs/test_dood_phase0_contract.py` for automated validation.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the glossary and validation entities guarded by this phase.
+
+## Contracts
+
+- [contracts/dood-phase0-doc-contract.md](./contracts/dood-phase0-doc-contract.md)
+
+## Implementation Plan
+
+1. Add a failing unit test that asserts the required DooD/session-plane/execution-model wording and the presence of the remaining-work tracker.
+2. Add the DooD tracker under `docs/tmp/remaining-work/` and register it in `docs/tmp/remaining-work/README.md`.
+3. Update the canonical session-plane and execution-model docs with the missing Phase 0 cross-reference and execution-boundary wording.
+4. Tighten the canonical DooD doc wording only where needed to keep the tracker reference and Phase 0 decisions explicit.
+5. Rerun the focused pytest test, then run `./tools/test_unit.sh` for final verification.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `pytest -q tests/unit/docs/test_dood_phase0_contract.py`
+2. `./tools/test_unit.sh`
+
+### Manual Validation
+
+1. Read the three canonical docs together and confirm they share one glossary and one execution-boundary story.
+2. Confirm the remaining-work tracker exists under `docs/tmp/remaining-work/` and is linked from the canonical DooD doc.
+3. Confirm the validation test fails if the required wording or tracker reference is removed.

--- a/specs/143-dood-phase0/quickstart.md
+++ b/specs/143-dood-phase0/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart: Docker-Out-of-Docker Phase 0 Contract Lock
+
+## Verify the canonical docs
+
+1. Read `docs/ManagedAgents/DockerOutOfDocker.md`.
+2. Read `docs/ManagedAgents/CodexManagedSessionPlane.md`.
+3. Read `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+4. Confirm the three docs share the same glossary and preserve the tool-path boundary for Docker-backed workloads.
+
+## Run automated validation
+
+```bash
+pytest -q tests/unit/docs/test_dood_phase0_contract.py
+./tools/test_unit.sh
+```
+
+## Expected result
+
+- The focused test passes.
+- The full unit suite passes.
+- The canonical DooD doc links to `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`.
+- The session-plane and execution-model docs state that workload containers remain outside session identity unless they are true managed runtimes.

--- a/specs/143-dood-phase0/research.md
+++ b/specs/143-dood-phase0/research.md
@@ -1,0 +1,41 @@
+# Research: Docker-Out-of-Docker Phase 0 Contract Lock
+
+## Context
+
+Phase 0 of the DooD rollout is a contract-locking step. The main question is not how to build the launcher yet, but whether the canonical docs already agree on the architecture boundary and what minimal executable validation should guard that agreement.
+
+## Findings
+
+### Decision: Keep `docs/ManagedAgents/DockerOutOfDocker.md` as the canonical desired-state source
+
+- **What was chosen**: Treat `docs/ManagedAgents/DockerOutOfDocker.md` as the canonical desired-state DooD document and adjust nearby docs to align with it.
+- **Rationale**: The DooD doc already defines the glossary, the tool-path default, the one-shot workload-container emphasis, and the separation between session identity and workload identity.
+- **Alternatives considered**: Split the contract across multiple canonical docs equally. Rejected because Phase 0 is meant to lock one boundary source before broader implementation work.
+
+### Decision: Add short cross-reference wording instead of duplicating the full DooD design
+
+- **What was chosen**: Add concise references in `docs/ManagedAgents/CodexManagedSessionPlane.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- **Rationale**: Constitution Principle XII requires canonical docs to stay declarative and avoid duplicating volatile rollout detail. The DooD doc should remain the detailed source while adjacent docs state only the boundary relevant to their scope.
+- **Alternatives considered**: Copy large DooD sections into the session-plane and execution-model docs. Rejected because duplication would make drift more likely.
+
+### Decision: Treat Docker-backed workloads as ordinary executable tools unless they launch a true managed runtime
+
+- **What was chosen**: Preserve `tool.type = "skill"` as the initial execution primitive for DooD-backed workload launches and reserve `tool.type = "agent_runtime"` for true managed runtimes only.
+- **Rationale**: This matches the existing `SkillAndPlanContracts` split and prevents specialized containers from being mislabeled as new `MoonMind.AgentRun` instances.
+- **Alternatives considered**: Model specialized workload containers as child `MoonMind.AgentRun` workflows immediately. Rejected because Phase 0 explicitly locks the boundary on the tool path first.
+
+### Decision: Add a focused unit test for documentation drift
+
+- **What was chosen**: Add a dedicated pytest file that reads the canonical docs and the DooD tracker path and asserts the required phrases and references exist.
+- **Rationale**: The repo does not already have a doc-contract test for this boundary. A small test gives Phase 0 executable validation without inventing production code outside the phase scope.
+- **Alternatives considered**: Rely on manual review only. Rejected because the user asked for TDD and Phase 0 should still leave a durable guard.
+
+## Audit Summary
+
+| Area | Current state | Phase 0 action |
+|------|---------------|----------------|
+| `docs/ManagedAgents/DockerOutOfDocker.md` | Already defines glossary and one-shot workload emphasis | Tighten only where tracker/Phase 0 wording needs to stay explicit |
+| `docs/ManagedAgents/CodexManagedSessionPlane.md` | Links to DooD doc but does not explicitly describe session-assisted workload tools | Add short cross-reference paragraph |
+| `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` | Defines true agent-runtime boundary but does not name Docker-backed workload tools explicitly | Add short execution-model note |
+| `docs/tmp/remaining-work/` | No DooD tracker exists yet | Add tracker and register it in README |
+| `tests/unit/` | No DooD Phase 0 documentation contract test exists | Add focused pytest coverage |

--- a/specs/143-dood-phase0/spec.md
+++ b/specs/143-dood-phase0/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Docker-Out-of-Docker Phase 0 Contract Lock
+
+**Feature Branch**: `143-dood-phase0`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 0 using test-driven development of the DooD plan."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Align the canonical DooD glossary and boundary docs (Priority: P1)
+
+MoonMind engineers need the canonical Docker-out-of-Docker documentation set to state one consistent architectural boundary before Phase 1 code work begins, so later implementation does not split across conflicting terms or lifecycle assumptions.
+
+**Why this priority**: Phase 0 exists specifically to freeze terminology and boundary rules before launcher and tool-path code spreads in multiple directions.
+
+**Independent Test**: Read `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexManagedSessionPlane.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` and confirm they use the same glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the canonical DooD doc defines the workload architecture, **When** engineers review the related session-plane and execution-model docs, **Then** those docs cross-reference the same glossary instead of introducing conflicting container identity terms.
+2. **Given** the DooD strategy distinguishes task-scoped managed sessions from specialized workload containers, **When** the three canonical docs are reviewed together, **Then** each document preserves that separation without implying a workload container is session continuity state.
+
+---
+
+### User Story 2 - Freeze the execution primitive and lifecycle scope (Priority: P1)
+
+MoonMind engineers need the execution model and session-plane docs to state that Docker-backed workload launches enter through ordinary executable tools first, remain outside `MoonMind.AgentRun` identity unless they are true agent runtimes, and focus the MVP on one-shot workload containers.
+
+**Why this priority**: The highest-risk ambiguity in the current plan is whether specialized containers should be modeled as agent sessions, helper services, or tool executions.
+
+**Independent Test**: Read the three canonical docs and confirm they all state that Docker-backed workloads are ordinary executable tools, not new managed sessions, and that Phase 1 through Phase 4 target one-shot workload containers first.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed Codex step requests a specialized toolchain, **When** the execution boundary is documented, **Then** the launch path is described as a control-plane tool invocation using `tool.type = "skill"` rather than a child `MoonMind.AgentRun`.
+2. **Given** bounded helper containers are a later direction, **When** the canonical docs describe current scope, **Then** they explicitly keep helper containers out of the MVP and preserve one-shot workload containers as the first implementation target.
+
+---
+
+### User Story 3 - Leave durable implementation tracking and executable validation (Priority: P2)
+
+MoonMind maintainers need a temporary implementation tracker plus an automated test that guards the new Phase 0 wording so the canonical docs and backlog references do not drift immediately after the contract lock lands.
+
+**Why this priority**: Phase 0 is only useful if the frozen boundary remains checkable and the unfinished rollout work stays linked from the canonical docs.
+
+**Independent Test**: Run the focused unit test suite for the DooD Phase 0 documentation contract and confirm it passes while the remaining-work tracker exists and is referenced from the canonical doc set.
+
+**Acceptance Scenarios**:
+
+1. **Given** the canonical DooD doc points to unfinished implementation work, **When** maintainers inspect `docs/tmp/remaining-work/`, **Then** a Phase 0 tracker exists for the DooD rollout and is referenced from the canonical doc.
+2. **Given** future edits could reintroduce ambiguous language, **When** the new automated validation runs, **Then** it fails if the required cross-reference or execution-boundary wording disappears from the canonical docs.
+
+### Edge Cases
+
+- A future documentation edit keeps the DooD glossary in one file but removes the session-plane or execution-model cross-reference, creating silent terminology drift.
+- A future edit reclassifies Docker-backed workload tools as managed sessions or `MoonMind.AgentRun` instances without an explicit architecture change.
+- The DooD implementation tracker is deleted or renamed while the canonical doc still links to it.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `docs/ManagedAgents/DockerOutOfDocker.md` MUST remain the canonical desired-state document for MoonMind's Docker-backed specialized workload-container architecture.
+- **FR-002**: `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexManagedSessionPlane.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` MUST use one consistent glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
+- **FR-003**: `docs/ManagedAgents/CodexManagedSessionPlane.md` MUST state that the managed session plane may invoke control-plane tools that launch separate workload containers, but those workload containers remain outside session identity.
+- **FR-004**: `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` MUST state that Docker-backed workload launches are ordinary executable tools and MUST NOT be treated as new `MoonMind.AgentRun` instances unless the launched runtime is itself a true managed agent runtime.
+- **FR-005**: The canonical documentation set MUST state that the initial DooD implementation scope for Phases 1 through 4 is one-shot workload containers and that bounded helper containers remain a later phase.
+- **FR-006**: The canonical documentation set MUST state that `tool.type = "skill"` is the initial execution primitive for Docker-backed workload launches and MUST preserve `tool.type = "agent_runtime"` for true long-lived agent runtimes only.
+- **FR-007**: `docs/tmp/remaining-work/` MUST contain a DooD implementation tracker linked from the canonical DooD doc and summarizing the remaining phased rollout work after Phase 0.
+- **FR-008**: The Phase 0 implementation MUST include automated validation that fails when the required DooD/session-plane/execution-model wording or remaining-work tracker reference is missing.
+
+### Key Entities *(include if feature involves data)*
+
+- **Session Container**: The task-scoped managed Codex container that carries session continuity within one task.
+- **Workload Container**: The separate specialized non-agent container launched through the control plane to perform a bounded workload.
+- **Runner Profile**: The curated MoonMind-owned workload-container definition that constrains image, mounts, environment, resources, and policy.
+- **Session-Assisted Workload**: A managed-session step that requests a specialized workload through the control plane without inheriting unrestricted Docker authority.
+- **DooD Remaining-Work Tracker**: The temporary backlog file in `docs/tmp/remaining-work/` that records unfinished rollout phases linked from the canonical DooD doc.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The canonical DooD, session-plane, and execution-model docs can be read together without contradicting each other on container identity, glossary, or execution primitive.
+- **SC-002**: The canonical docs explicitly preserve `tool.type = "skill"` for the initial Docker-backed workload path and reserve `tool.type = "agent_runtime"` for true managed runtimes.
+- **SC-003**: A DooD implementation tracker exists under `docs/tmp/remaining-work/` and is linked from the canonical DooD doc.
+- **SC-004**: Automated unit validation for the Phase 0 documentation contract passes through `./tools/test_unit.sh` using a targeted DooD Phase 0 test file.

--- a/specs/143-dood-phase0/tasks.md
+++ b/specs/143-dood-phase0/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: Docker-Out-of-Docker Phase 0 Contract Lock
+
+**Input**: Design documents from `/specs/143-dood-phase0/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: TDD is required for this feature. Start with the focused documentation-contract test, make it fail, then update docs and tracker files until it passes.
+
+**Organization**: Tasks are grouped by user story to keep the Phase 0 contract lock independently reviewable and executable.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature artifacts and validation surface before editing canonical docs
+
+- [X] T001 Review `specs/143-dood-phase0/spec.md`, `specs/143-dood-phase0/plan.md`, and `specs/143-dood-phase0/contracts/dood-phase0-doc-contract.md` to lock the Phase 0 assertions.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared validation surface and remaining-work tracker before story-specific doc edits
+
+- [X] T002 [P] Add a failing documentation-contract test in `tests/unit/docs/test_dood_phase0_contract.py` covering glossary terms, tool-path wording, and tracker references.
+- [X] T003 Create the DooD remaining-work tracker in `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md` and register it in `docs/tmp/remaining-work/README.md`.
+
+**Checkpoint**: The automated contract guard exists and the rollout tracker path is in place.
+
+---
+
+## Phase 3: User Story 1 - Align the canonical DooD glossary and boundary docs (Priority: P1) 🎯 MVP
+
+**Goal**: Keep the DooD, session-plane, and execution-model docs on one glossary and one container-identity story.
+
+**Independent Test**: Read the three canonical docs and confirm they share `session container`, `workload container`, `runner profile`, and `session-assisted workload` without implying that workload containers are session identity.
+
+### Tests for User Story 1
+
+- [X] T004 [US1] Run the focused glossary/boundary assertions in `tests/unit/docs/test_dood_phase0_contract.py` and confirm the initial failure before doc edits.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Add the session-assisted workload cross-reference and outside-session-identity wording to `docs/ManagedAgents/CodexManagedSessionPlane.md`.
+- [X] T006 [US1] Tighten glossary/tracker wording in `docs/ManagedAgents/DockerOutOfDocker.md` so the canonical doc remains the clear desired-state source for Phase 0.
+
+**Checkpoint**: The session-plane doc and canonical DooD doc tell the same glossary and identity story.
+
+---
+
+## Phase 4: User Story 2 - Freeze the execution primitive and lifecycle scope (Priority: P1)
+
+**Goal**: Preserve the tool-path-first execution boundary and the one-shot workload-container MVP scope.
+
+**Independent Test**: Read the canonical docs and confirm Docker-backed workloads are documented as ordinary executable tools, not new `MoonMind.AgentRun` instances, while one-shot workload containers remain the initial implementation scope.
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Add the Docker-backed executable-tool note to `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`, explicitly distinguishing ordinary workload tools from true managed runtimes.
+- [X] T008 [US2] Tighten `docs/ManagedAgents/DockerOutOfDocker.md` so the `tool.type = "skill"` boundary and one-shot-workload-first scope remain explicit.
+
+**Checkpoint**: The execution-model and DooD docs agree on the execution primitive and MVP lifecycle scope.
+
+---
+
+## Phase 5: User Story 3 - Leave durable implementation tracking and executable validation (Priority: P2)
+
+**Goal**: Leave a durable rollout tracker and green automated validation for the Phase 0 contract.
+
+**Independent Test**: Run the focused doc-contract test and the full unit suite, then confirm the tracker is listed in `docs/tmp/remaining-work/README.md`.
+
+### Tests for User Story 3
+
+- [X] T009 [US3] Run `pytest -q tests/unit/docs/test_dood_phase0_contract.py` using `tests/unit/docs/test_dood_phase0_contract.py` as the targeted validation gate.
+- [X] T010 [US3] Run `./tools/test_unit.sh` and record completion by updating `specs/143-dood-phase0/tasks.md`.
+
+**Checkpoint**: Phase 0 leaves both durable tracking and executable validation behind.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification and artifact consistency
+
+- [X] T011 [P] Verify the commands and expected outcomes in `specs/143-dood-phase0/quickstart.md`.
+- [X] T012 [P] Mark completed work in `specs/143-dood-phase0/tasks.md` and confirm the feature artifacts stay aligned with the final docs/test result.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all story work.
+- **User Story 1 (Phase 3)**: Depends on Phase 2.
+- **User Story 2 (Phase 4)**: Depends on Phase 2 and should follow the same canonical DooD wording updated in Phase 3.
+- **User Story 3 (Phase 5)**: Depends on Phases 3 and 4 because it validates the finished wording.
+- **Polish (Phase 6)**: Depends on all previous phases.
+
+### Parallel Opportunities
+
+- `T002` and `T003` can proceed in parallel after Setup.
+- `T011` and `T012` can proceed in parallel once validation is complete.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Lock the test and tracker path.
+2. Update the session-plane and canonical DooD docs.
+3. Update the execution-model note.
+4. Run targeted validation before the full unit suite.
+
+### TDD Order
+
+1. Write `tests/unit/docs/test_dood_phase0_contract.py`.
+2. Run the focused test and confirm it fails.
+3. Update the canonical docs and tracker files until the focused test passes.
+4. Run `./tools/test_unit.sh` for final regression coverage.

--- a/tests/unit/docs/test_dood_phase0_contract.py
+++ b/tests/unit/docs/test_dood_phase0_contract.py
@@ -24,7 +24,7 @@ def _read(path: Path) -> str:
 def test_canonical_dood_doc_links_phase0_tracker() -> None:
     dood_text = _read(DOOD_DOC)
 
-    assert "ManagedAgents-DockerOutOfDocker.md" in dood_text
+    assert "../tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md" in dood_text
     assert TRACKER.exists()
 
 

--- a/tests/unit/docs/test_dood_phase0_contract.py
+++ b/tests/unit/docs/test_dood_phase0_contract.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOOD_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "DockerOutOfDocker.md"
+SESSION_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "CodexManagedSessionPlane.md"
+EXECUTION_DOC = (
+    REPO_ROOT / "docs" / "Temporal" / "ManagedAndExternalAgentExecutionModel.md"
+)
+TRACKER = (
+    REPO_ROOT
+    / "docs"
+    / "tmp"
+    / "remaining-work"
+    / "ManagedAgents-DockerOutOfDocker.md"
+)
+TRACKER_INDEX = REPO_ROOT / "docs" / "tmp" / "remaining-work" / "README.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_canonical_dood_doc_links_phase0_tracker() -> None:
+    dood_text = _read(DOOD_DOC)
+
+    assert "ManagedAgents-DockerOutOfDocker.md" in dood_text
+    assert TRACKER.exists()
+
+
+def test_session_plane_doc_declares_session_assisted_workloads_outside_identity() -> None:
+    session_text = _read(SESSION_DOC)
+
+    assert "control-plane tools" in session_text
+    assert "workload containers remain outside session identity" in session_text
+
+
+def test_execution_model_doc_keeps_docker_workloads_on_tool_path() -> None:
+    execution_text = _read(EXECUTION_DOC)
+
+    assert "Docker-backed workload tools are ordinary executable tools" in execution_text
+    assert (
+        "not new `MoonMind.AgentRun` instances unless the launched runtime is itself"
+        in execution_text
+    )
+
+
+def test_dood_glossary_and_scope_terms_remain_present() -> None:
+    dood_text = _read(DOOD_DOC)
+    lowered = dood_text.lower()
+
+    for term in (
+        "session container",
+        "workload container",
+        "runner profile",
+        "session-assisted workload",
+        "one-shot workload containers",
+        "bounded helper containers remain a later phase",
+        '`tool.type = "skill"`',
+        '`tool.type = "agent_runtime"`',
+    ):
+        assert term in lowered
+
+
+def test_tracker_is_listed_in_remaining_work_index() -> None:
+    tracker_index_text = _read(TRACKER_INDEX)
+
+    assert "ManagedAgents-DockerOutOfDocker.md" in tracker_index_text


### PR DESCRIPTION
## Summary
- lock the Docker-out-of-Docker Phase 0 contract across the canonical DooD, Codex managed-session, and managed execution docs
- add the DooD remaining-work tracker and full Spec Kit artifacts for feature `143-dood-phase0`
- add a focused unit test that guards the glossary, tool-path boundary, and tracker references

## Remediation outcomes
- aligned the session-plane doc with the DooD boundary so workload containers stay outside session identity
- aligned the execution-model doc so Docker-backed workloads remain ordinary executable tools unless they launch a true managed runtime
- tightened the DooD doc wording so the tracker link, `tool.type = "skill"` boundary, and later-phase helper-container scope stay explicit

## Validation
- `pytest -q tests/unit/docs/test_dood_phase0_contract.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`