### PR TITLE
[codex] Fix managed Codex workflow replay

### DIFF
--- a/moonmind/rag/embedding.py
+++ b/moonmind/rag/embedding.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Iterable, List, Optional
+from typing import Any, Iterable, List, Optional
 
-import google.generativeai as genai
 from openai import OpenAI
 
 logger = logging.getLogger(__name__)
@@ -42,11 +41,19 @@ class EmbeddingClient:
         self._config = config
         self._provider = config.provider.lower()
         self._cached_dimension: Optional[int] = None
+        self._google_genai: Any | None = None
         if self._provider == "google":
             api_key = config.google_api_key
             if not api_key:
                 raise EmbeddingError("GOOGLE_API_KEY is required for google embeddings")
+            try:
+                import google.generativeai as genai
+            except Exception as exc:  # pragma: no cover - import/runtime edge
+                raise EmbeddingError(
+                    f"google.generativeai import failed: {exc}"
+                ) from exc
             genai.configure(api_key=api_key)
+            self._google_genai = genai
         elif self._provider == "openai":
             api_key = config.openai_api_key
             if not api_key:
@@ -67,7 +74,10 @@ class EmbeddingClient:
             raise EmbeddingError("Query text cannot be empty")
         if self._provider == "google":
             try:
-                response = genai.embed_content(model=self._config.model, content=text)
+                response = self._google_genai.embed_content(
+                    model=self._config.model,
+                    content=text,
+                )
             except Exception as exc:  # pragma: no cover - network failure
                 raise EmbeddingError(f"Google embedding failed: {exc}") from exc
             result = response.get("embedding") if isinstance(response, dict) else None

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -48,7 +48,6 @@ from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
 )
 
-
 SessionSnapshotLoader = Callable[
     [str], Awaitable[CodexManagedSessionSnapshot | Mapping[str, Any]]
 ]
@@ -60,6 +59,7 @@ LaunchSessionFunc = Callable[
 SessionStatusFunc = Callable[
     [CodexManagedSessionLocator], Awaitable[CodexManagedSessionHandle | Mapping[str, Any]]
 ]
+PrepareTurnInstructionsFunc = Callable[[dict[str, Any]], Awaitable[str | Mapping[str, Any]]]
 SendTurnFunc = Callable[
     [SendCodexManagedSessionTurnRequest],
     Awaitable[CodexManagedSessionTurnResponse | Mapping[str, Any]],
@@ -114,6 +114,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         load_session_snapshot: SessionSnapshotLoader,
         launch_session: LaunchSessionFunc,
         session_status: SessionStatusFunc,
+        prepare_turn_instructions: PrepareTurnInstructionsFunc | None,
         send_turn: SendTurnFunc,
         interrupt_turn: InterruptTurnFunc,
         clear_remote_session: ClearSessionFunc,
@@ -130,6 +131,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         self._load_session_snapshot = load_session_snapshot
         self._launch_session = launch_session
         self._session_status = session_status
+        self._prepare_turn_instructions = prepare_turn_instructions
         self._send_turn = send_turn
         self._interrupt_turn = interrupt_turn
         self._clear_remote_session = clear_remote_session
@@ -516,6 +518,35 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         return handle
 
     async def _instructions_for_request(
+        self,
+        *,
+        binding: CodexManagedSessionBinding,
+        request: AgentExecutionRequest,
+    ) -> str:
+        if self._prepare_turn_instructions is None:
+            return await self._legacy_instructions_for_request(
+                binding=binding,
+                request=request,
+            )
+        prepared = await self._prepare_turn_instructions(
+            {
+                "request": request.model_dump(by_alias=True, exclude_none=True),
+                "workspacePath": self._workspace_path_for_request(
+                    binding=binding,
+                    request=request,
+                ),
+            }
+        )
+        if isinstance(prepared, Mapping):
+            prepared = prepared.get("instructions")
+        instructions = str(prepared or "").strip()
+        if instructions:
+            return instructions
+        raise ValueError(
+            "CodexSessionAdapter requires prepare_turn_instructions to return non-empty text"
+        )
+
+    async def _legacy_instructions_for_request(
         self,
         *,
         binding: CodexManagedSessionBinding,

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -790,6 +790,15 @@ def build_default_activity_catalog(
             heartbeat_required=True,
         ),
         TemporalActivityDefinition(
+            activity_type="agent_runtime.prepare_turn_instructions",
+            family="agent_runtime",
+            capability_class="agent_runtime",
+            task_queue=cfg.activity_agent_runtime_task_queue,
+            fleet=AGENT_RUNTIME_FLEET,
+            timeouts=TemporalActivityTimeouts(60, 180),
+            retries=_activity_retries(max_attempts=2, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="agent_runtime.send_turn",
             family="agent_runtime",
             capability_class="agent_runtime",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2824,7 +2824,7 @@ class TemporalAgentRuntimeActivities:
         if instruction_ref:
             if not workspace_path_raw:
                 raise TemporalActivityRuntimeError(
-                    "payload.workspacePath is required when request.instructionRef is set"
+                    "payload.workspace_path or payload.workspacePath is required when request.instructionRef is set"
                 )
             from moonmind.rag.context_injection import ContextInjectionService
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -102,6 +102,9 @@ from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
     shape_launch_github_auth_environment,
 )
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
+from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
+    append_managed_codex_runtime_note,
+)
 
 
 
@@ -382,6 +385,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "agent_runtime.session_status": (
         "agent_runtime",
         "agent_runtime_session_status",
+    ),
+    "agent_runtime.prepare_turn_instructions": (
+        "agent_runtime",
+        "agent_runtime_prepare_turn_instructions",
     ),
     "agent_runtime.send_turn": ("agent_runtime", "agent_runtime_send_turn"),
     "agent_runtime.steer_turn": ("agent_runtime", "agent_runtime_steer_turn"),
@@ -2797,6 +2804,44 @@ class TemporalAgentRuntimeActivities:
             response,
             activity_type="agent_runtime.session_status",
             model_type=CodexManagedSessionHandle,
+        )
+
+    async def agent_runtime_prepare_turn_instructions(
+        self,
+        payload: Mapping[str, Any],
+        /,
+    ) -> str:
+        request_raw = payload.get("request")
+        if not isinstance(request_raw, Mapping):
+            raise TemporalActivityRuntimeError(
+                "payload.request is required for agent_runtime.prepare_turn_instructions"
+            )
+        request = AgentExecutionRequest.model_validate(dict(request_raw))
+        workspace_path_raw = str(
+            payload.get("workspace_path") or payload.get("workspacePath") or ""
+        ).strip()
+        instruction_ref = str(request.instruction_ref or "").strip()
+        if instruction_ref:
+            if not workspace_path_raw:
+                raise TemporalActivityRuntimeError(
+                    "payload.workspacePath is required when request.instructionRef is set"
+                )
+            from moonmind.rag.context_injection import ContextInjectionService
+
+            service = ContextInjectionService()
+            await service.inject_context(
+                request=request,
+                workspace_path=Path(workspace_path_raw),
+            )
+            instruction_ref = str(request.instruction_ref or "").strip()
+            if instruction_ref:
+                return append_managed_codex_runtime_note(instruction_ref)
+        parameters = request.parameters if isinstance(request.parameters, dict) else {}
+        instructions = str(parameters.get("instructions") or "").strip()
+        if instructions:
+            return append_managed_codex_runtime_note(instructions)
+        raise TemporalActivityRuntimeError(
+            "request.instructionRef or request.parameters.instructions is required"
         )
 
     async def agent_runtime_send_turn(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -99,6 +99,9 @@ MANAGED_TASK_WORKFLOW_BINDING_PATCH_ID = "agent-run-managed-task-workflow-bindin
 MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-fetch-result-activity-v1"
 )
+MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID = (
+    "agent-run-managed-session-prepare-turn-instructions-activity-v1"
+)
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.Run (run.py:50).
@@ -1063,6 +1066,9 @@ class MoonMindAgentRun:
                     run_store = ManagedRunStore(_MANAGED_RUN_STORE_ROOT)
 
                     if uses_codex_session_adapter:
+                        use_prepare_turn_instructions_activity = workflow.patched(
+                            MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID
+                        )
                         if request.managed_session is None:
                             raise ApplicationError(
                                 "managedSession is required for Codex session-backed runs",
@@ -1120,6 +1126,13 @@ class MoonMindAgentRun:
                                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
                             )
 
+                        async def _prepare_turn_instructions(request_payload: Any) -> Any:
+                            return await self._execute_routed_activity(
+                                "agent_runtime.prepare_turn_instructions",
+                                request_payload,
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            )
+
                         async def _send_turn(request_payload: Any) -> Any:
                             return await self._execute_routed_activity(
                                 "agent_runtime.send_turn",
@@ -1173,6 +1186,11 @@ class MoonMindAgentRun:
                             load_session_snapshot=_load_session_snapshot,
                             launch_session=_launch_session,
                             session_status=_session_status,
+                            prepare_turn_instructions=(
+                                _prepare_turn_instructions
+                                if use_prepare_turn_instructions_activity
+                                else None
+                            ),
                             send_turn=_send_turn,
                             interrupt_turn=_interrupt_turn,
                             clear_remote_session=_clear_session,

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -34,6 +34,21 @@ async def _async_noop(*_args: Any, **_kwargs: Any) -> None:
     return None
 
 
+async def _prepare_turn_instructions(payload: dict[str, Any]) -> str:
+    request = payload.get("request") if isinstance(payload, dict) else {}
+    instruction_ref = ""
+    if isinstance(request, dict):
+        instruction_ref = str(
+            request.get("instructionRef") or request.get("instruction_ref") or ""
+        ).strip()
+        parameters = request.get("parameters")
+        if not instruction_ref and isinstance(parameters, dict):
+            inline = str(parameters.get("instructions") or "").strip()
+            if inline:
+                return f"{inline}\n\nManaged Codex CLI note:"
+    return f"{instruction_ref}\n\nManaged Codex CLI note:"
+
+
 def _binding() -> CodexManagedSessionBinding:
     return CodexManagedSessionBinding(
         workflowId="wf-task-1:session:codex_cli",
@@ -260,6 +275,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
         load_session_snapshot=_load_snapshot,
         launch_session=_launch_session,
         session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_send_turn,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -332,28 +348,19 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["threadId"] == "thread-1"
 
 
-async def test_start_restores_context_injection_before_sending_turn(
+async def test_start_delegates_turn_instruction_preparation_before_sending_turn(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     binding = _binding()
     expected_workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
     send_turn_calls: list[Any] = []
+    prepared_payloads: list[dict[str, Any]] = []
 
-    class _FakeContextInjectionService:
-        async def inject_context(
-            self,
-            *,
-            request: AgentExecutionRequest,
-            workspace_path: Path,
-        ) -> None:
-            assert workspace_path == expected_workspace_path
-            request.instruction_ref = "Injected context instruction"
-
-    monkeypatch.setattr(
-        "moonmind.rag.context_injection.ContextInjectionService",
-        _FakeContextInjectionService,
-    )
+    async def _custom_prepare_turn_instructions(payload: dict[str, Any]) -> str:
+        prepared_payloads.append(payload)
+        assert payload["workspacePath"] == str(expected_workspace_path)
+        assert payload["request"]["instructionRef"] == "artifact:instructions"
+        return "Injected context instruction\n\nManaged Codex CLI note:"
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(binding=binding)
@@ -388,6 +395,7 @@ async def test_start_restores_context_injection_before_sending_turn(
         load_session_snapshot=_load_snapshot,
         launch_session=_launch_session,
         session_status=AsyncMock(),
+        prepare_turn_instructions=_custom_prepare_turn_instructions,
         send_turn=_send_turn,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -416,6 +424,7 @@ async def test_start_restores_context_injection_before_sending_turn(
 
     await adapter.start(_request(binding, workspace_path=str(expected_workspace_path)))
 
+    assert prepared_payloads
     assert send_turn_calls
     assert send_turn_calls[0].instructions.startswith("Injected context instruction")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
@@ -438,6 +447,7 @@ async def test_start_rejects_non_text_input_refs_for_session_turns(
         load_session_snapshot=AsyncMock(),
         launch_session=AsyncMock(),
         session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=AsyncMock(),
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -524,6 +534,7 @@ async def test_start_reuses_existing_task_scoped_session_without_launching(
         load_session_snapshot=_load_snapshot,
         launch_session=_launch_session,
         session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_send_turn,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -591,6 +602,7 @@ async def test_clear_session_rotates_epoch_and_signals_session_workflow(
         load_session_snapshot=_load_snapshot,
         launch_session=_async_noop,
         session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_async_noop,
         interrupt_turn=_async_noop,
         clear_remote_session=_clear_remote_session,
@@ -657,6 +669,7 @@ async def test_cancel_interrupts_active_turn_and_marks_run_canceled(
         load_session_snapshot=_load_snapshot,
         launch_session=_async_noop,
         session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_async_noop,
         interrupt_turn=_interrupt_turn,
         clear_remote_session=_async_noop,
@@ -715,6 +728,7 @@ async def test_save_run_state_persists_blank_workspace_path_as_none(
         load_session_snapshot=AsyncMock(),
         launch_session=AsyncMock(),
         session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=AsyncMock(),
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -795,6 +809,7 @@ async def test_terminate_session_uses_remote_session_control_surface(
         load_session_snapshot=_load_snapshot,
         launch_session=_async_noop,
         session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_async_noop,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -857,6 +872,7 @@ async def test_fetch_result_maps_failed_pr_resolver_artifact_for_completed_run(
         load_session_snapshot=_async_noop,
         launch_session=_async_noop,
         session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_async_noop,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,
@@ -938,6 +954,7 @@ async def test_fetch_result_maps_blocked_pr_resolver_artifact_for_completed_run(
         load_session_snapshot=_async_noop,
         launch_session=_async_noop,
         session_status=_async_noop,
+        prepare_turn_instructions=_prepare_turn_instructions,
         send_turn=_async_noop,
         interrupt_turn=_async_noop,
         clear_remote_session=_async_noop,

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1287,6 +1287,7 @@ async def test_build_activity_bindings_resolves_agent_runtime_fleet(
             assert "agent_runtime.launch_session" in bound_types
             assert "agent_runtime.publish_artifacts" in bound_types
             assert "agent_runtime.session_status" in bound_types
+            assert "agent_runtime.prepare_turn_instructions" in bound_types
             assert "agent_runtime.send_turn" in bound_types
             assert "agent_runtime.steer_turn" in bound_types
             assert "agent_runtime.interrupt_turn" in bound_types

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1330,6 +1330,17 @@ class AgentRuntimeSendTurnBoundaryTest:
         )
 
 
+@workflow.defn(name="AgentRuntimePrepareTurnInstructionsBoundaryTest")
+class AgentRuntimePrepareTurnInstructionsBoundaryTest:
+    @workflow.run
+    async def run(self, input_dict: dict) -> str:
+        return await workflow.execute_activity(
+            "agent_runtime.prepare_turn_instructions",
+            input_dict,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+
+
 @pytest.mark.asyncio
 async def test_agent_runtime_launch_session_temporal_boundary(
     monkeypatch: pytest.MonkeyPatch,
@@ -1444,3 +1455,100 @@ async def test_agent_runtime_send_turn_temporal_boundary() -> None:
 
             assert isinstance(result, CodexManagedSessionTurnResponse)
             assert result.turn_id == "turn-1"
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_injects_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _FakeContextInjectionService:
+        async def inject_context(
+            self,
+            *,
+            request: Any,
+            workspace_path: Path,
+        ) -> None:
+            assert workspace_path == tmp_path
+            request.instruction_ref = "Injected context instruction"
+
+    monkeypatch.setattr(
+        "moonmind.rag.context_injection.ContextInjectionService",
+        _FakeContextInjectionService,
+    )
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "instructionRef": "artifact:instructions",
+                "parameters": {"publishMode": "none"},
+            },
+            "workspacePath": str(tmp_path),
+        }
+    )
+
+    assert result.startswith("Injected context instruction")
+    assert "Managed Codex CLI note:" in result
+
+
+@pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_temporal_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from temporalio import activity
+
+    class _FakeContextInjectionService:
+        async def inject_context(
+            self,
+            *,
+            request: Any,
+            workspace_path: Path,
+        ) -> None:
+            assert workspace_path == tmp_path
+            request.instruction_ref = "Injected context instruction"
+
+    monkeypatch.setattr(
+        "moonmind.rag.context_injection.ContextInjectionService",
+        _FakeContextInjectionService,
+    )
+    activities_impl = TemporalAgentRuntimeActivities()
+
+    @activity.defn(name="agent_runtime.prepare_turn_instructions")
+    async def _agent_runtime_prepare_turn_instructions_wrapper(
+        request: dict,
+    ) -> str:
+        return await activities_impl.agent_runtime_prepare_turn_instructions(request)
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="boundary-test-queue-prepare-turn-instructions",
+            workflows=[AgentRuntimePrepareTurnInstructionsBoundaryTest],
+            activities=[_agent_runtime_prepare_turn_instructions_wrapper],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                AgentRuntimePrepareTurnInstructionsBoundaryTest.run,
+                {
+                    "request": {
+                        "agentKind": "managed",
+                        "agentId": "codex",
+                        "correlationId": "corr-1",
+                        "idempotencyKey": "idem-1",
+                        "instructionRef": "artifact:instructions",
+                        "parameters": {"publishMode": "none"},
+                    },
+                    "workspacePath": str(tmp_path),
+                },
+                id="boundary-test-prepare-turn-instructions",
+                task_queue="boundary-test-queue-prepare-turn-instructions",
+            )
+
+            assert result.startswith("Injected context instruction")
+            assert "Managed Codex CLI note:" in result

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1497,6 +1497,31 @@ async def test_agent_runtime_prepare_turn_instructions_injects_context(
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_requires_workspace_for_instruction_ref() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match=(
+            "payload.workspace_path or payload.workspacePath is required "
+            "when request.instructionRef is set"
+        ),
+    ):
+        await activities.agent_runtime_prepare_turn_instructions(
+            {
+                "request": {
+                    "agentKind": "managed",
+                    "agentId": "codex",
+                    "correlationId": "corr-1",
+                    "idempotencyKey": "idem-1",
+                    "instructionRef": "artifact:instructions",
+                    "parameters": {"publishMode": "none"},
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_temporal_boundary(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -78,6 +78,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     session_adapter_requests: list[AgentExecutionRequest] = []
     loaded_snapshots: list[dict[str, Any]] = []
     requested_snapshot_workflow_ids: list[str] = []
+    prepared_instruction_results: list[str] = []
 
     _configure_workflow_runtime(monkeypatch)
 
@@ -88,6 +89,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     class _FakeCodexSessionAdapter:
         def __init__(self, **kwargs: Any) -> None:
             self._load_session_snapshot = kwargs["load_session_snapshot"]
+            self._prepare_turn_instructions = kwargs["prepare_turn_instructions"]
 
         async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
             session_adapter_requests.append(request)
@@ -95,6 +97,14 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
             requested_snapshot_workflow_ids.append(snapshot_workflow_id)
             loaded_snapshots.append(
                 await self._load_session_snapshot(snapshot_workflow_id)
+            )
+            prepared_instruction_results.append(
+                await self._prepare_turn_instructions(
+                    {
+                        "request": request.model_dump(by_alias=True, exclude_none=True),
+                        "workspacePath": "/work/task/repo",
+                    }
+                )
             )
             return AgentRunHandle(
                 runId="managed-session-run-1",
@@ -184,6 +194,8 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
                 "summary": "Session-backed Codex step completed.",
                 "metadata": {"resultSource": "agent-runtime-fetch-result"},
             }
+        if activity_name == "agent_runtime.prepare_turn_instructions":
+            return "Prepared session instructions"
         if activity_name == "agent_runtime.publish_artifacts":
             return payload
         raise AssertionError(f"Unexpected routed activity: {activity_name}")
@@ -221,6 +233,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
             "terminationRequested": False,
         }
     ]
+    assert prepared_instruction_results == ["Prepared session instructions"]
     assert run.run_id == "managed-session-run-1"
     assert result.summary == "Session-backed Codex step completed."
     assert result.metadata["resultSource"] == "agent-runtime-fetch-result"
@@ -230,12 +243,14 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     assert result.metadata["managedSession"]["sessionId"] == "sess:wf-task-1:codex_cli"
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.load_session_snapshot",
+        "agent_runtime.prepare_turn_instructions",
         "agent_runtime.fetch_result",
         "agent_runtime.publish_artifacts",
     ]
     assert routed_calls[0][1]["workflowId"] == "wf-task-1:session:override"
     assert routed_calls[0][1]["taskRunId"] == "wf-task-1"
-    assert routed_calls[1][1] == {
+    assert routed_calls[1][1]["workspacePath"] == "/work/task/repo"
+    assert routed_calls[2][1] == {
         "run_id": "wf-task-1",
         "agent_id": "codex",
     }
@@ -432,3 +447,99 @@ async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
     assert [name for name, _payload in routed_calls] == [
         "agent_runtime.publish_artifacts",
     ]
+
+
+async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_histories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    _configure_workflow_runtime(monkeypatch)
+
+    def _patched(patch_id: str) -> bool:
+        return (
+            patch_id
+            != agent_run_module.MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID
+        )
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **kwargs: Any) -> None:
+            assert kwargs["prepare_turn_instructions"] is None
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-session-run-legacy-prepare",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+        async def fetch_result(
+            self,
+            run_id: str,
+            *,
+            pr_resolver_expected: bool = False,
+        ) -> AgentRunResult:
+            assert run_id == "managed-session-run-legacy-prepare"
+            assert pr_resolver_expected is False
+            return AgentRunResult(summary="Legacy instruction preparation path.")
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Legacy instruction preparation path.", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "patched", _patched)
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_managed_session_request())
+
+    assert result.summary == "Legacy instruction preparation path."


### PR DESCRIPTION
## Summary
This PR fixes a managed Codex workflow replay failure that left `MoonMind.AgentRun` stuck on workflow-task replays instead of progressing execution.

## What Changed
- moved managed Codex turn-instruction preparation behind a replay-safe Temporal activity boundary
- gated the new activity path with a workflow patch so existing histories keep their original replay shape
- retained a legacy path for pre-patch runs while removing eager Google embedding imports that were failing during replay
- added unit and workflow-boundary coverage for the new and legacy execution paths

## Root Cause
The managed Codex session adapter was preparing instructions inside workflow execution, which imported RAG/provider code during replay. That violated the workflow/activity boundary and caused workflow-task failures and deadlocked execution for the affected run.

## Impact
Managed Codex task-scoped session runs now preserve replay safety for old histories while using an activity-side instruction-preparation path for new histories.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/test_activity_runtime.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py tests/unit/rag/test_context_injection.py tests/unit/moonmind/rag/test_service.py`
- `ui:test` (via `./tools/test_unit.sh`)

## Operational Recovery
During verification, I restarted the relevant Temporal workers, terminated the stale child workflows for the stuck execution, and reset the parent workflow so the task could resume on the fixed code path.