### PR TITLE
[codex] unify live logs continuity artifacts

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -709,7 +709,12 @@ def _iter_historical_artifact_events(
                 ),
                 timestamp=str(control_payload.get("recordedAt") or ""),
                 session_record=session_record,
-                metadata={**control_payload, "artifactRef": session_record.latest_control_event_ref},
+                metadata={
+                    **control_payload,
+                    "artifactRef": session_record.latest_control_event_ref,
+                    "controlEventRef": session_record.latest_control_event_ref,
+                    "resetBoundaryRef": session_record.latest_reset_boundary_ref,
+                },
             )
 
     boundary_payload = _read_json_payload(
@@ -724,12 +729,27 @@ def _iter_historical_artifact_events(
             ),
             timestamp=str(boundary_payload.get("recordedAt") or ""),
             session_record=session_record,
-            metadata={**boundary_payload, "artifactRef": session_record.latest_reset_boundary_ref},
+            metadata={
+                **boundary_payload,
+                "artifactRef": session_record.latest_reset_boundary_ref,
+                "controlEventRef": session_record.latest_control_event_ref,
+                "resetBoundaryRef": session_record.latest_reset_boundary_ref,
+            },
         )
 
-    for kind, ref_attr, label in (
-        ("summary_published", session_record.latest_summary_ref, "Session summary published."),
-        ("checkpoint_published", session_record.latest_checkpoint_ref, "Session checkpoint published."),
+    for kind, ref_attr, label, ref_key in (
+        (
+            "summary_published",
+            session_record.latest_summary_ref,
+            "Session summary published.",
+            "summaryRef",
+        ),
+        (
+            "checkpoint_published",
+            session_record.latest_checkpoint_ref,
+            "Session checkpoint published.",
+            "checkpointRef",
+        ),
     ):
         artifact_path = _resolve_safe_artifact_path(ref_attr, artifacts_root)
         if artifact_path is None:
@@ -739,7 +759,7 @@ def _iter_historical_artifact_events(
             text=label,
             timestamp=(session_record.updated_at or session_record.started_at).isoformat(),
             session_record=session_record,
-            metadata={"artifactRef": ref_attr},
+            metadata={"artifactRef": ref_attr, ref_key: ref_attr},
         )
 
 

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -694,12 +694,26 @@ def _iter_historical_artifact_events(
         metadata={"status": session_record.status},
     )
 
-    control_payload = _read_json_payload(
-        _resolve_safe_artifact_path(session_record.latest_control_event_ref, artifacts_root)
+    control_artifact_path = _resolve_safe_artifact_path(
+        session_record.latest_control_event_ref,
+        artifacts_root,
     )
+    reset_boundary_artifact_path = _resolve_safe_artifact_path(
+        session_record.latest_reset_boundary_ref,
+        artifacts_root,
+    )
+
+    control_payload = _read_json_payload(control_artifact_path)
     if control_payload is not None:
         action = str(control_payload.get("action") or "").strip().lower()
         if action == "clear_session":
+            control_metadata = {
+                **control_payload,
+                "artifactRef": session_record.latest_control_event_ref,
+                "controlEventRef": session_record.latest_control_event_ref,
+            }
+            if reset_boundary_artifact_path is not None:
+                control_metadata["resetBoundaryRef"] = session_record.latest_reset_boundary_ref
             yield _build_session_artifact_event(
                 kind="session_cleared",
                 text=(
@@ -709,18 +723,18 @@ def _iter_historical_artifact_events(
                 ),
                 timestamp=str(control_payload.get("recordedAt") or ""),
                 session_record=session_record,
-                metadata={
-                    **control_payload,
-                    "artifactRef": session_record.latest_control_event_ref,
-                    "controlEventRef": session_record.latest_control_event_ref,
-                    "resetBoundaryRef": session_record.latest_reset_boundary_ref,
-                },
+                metadata=control_metadata,
             )
 
-    boundary_payload = _read_json_payload(
-        _resolve_safe_artifact_path(session_record.latest_reset_boundary_ref, artifacts_root)
-    )
+    boundary_payload = _read_json_payload(reset_boundary_artifact_path)
     if boundary_payload is not None:
+        boundary_metadata = {
+            **boundary_payload,
+            "artifactRef": session_record.latest_reset_boundary_ref,
+            "resetBoundaryRef": session_record.latest_reset_boundary_ref,
+        }
+        if control_artifact_path is not None:
+            boundary_metadata["controlEventRef"] = session_record.latest_control_event_ref
         yield _build_session_artifact_event(
             kind="session_reset_boundary",
             text=(
@@ -729,12 +743,7 @@ def _iter_historical_artifact_events(
             ),
             timestamp=str(boundary_payload.get("recordedAt") or ""),
             session_record=session_record,
-            metadata={
-                **boundary_payload,
-                "artifactRef": session_record.latest_reset_boundary_ref,
-                "controlEventRef": session_record.latest_control_event_ref,
-                "resetBoundaryRef": session_record.latest_reset_boundary_ref,
-            },
+            metadata=boundary_metadata,
         )
 
     for kind, ref_attr, label, ref_key in (

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1573,6 +1573,104 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('explains Live Logs as timeline history and Session Continuity as durable drill-down evidence', async () => {
+    const codexPayload: BootPayload = {
+      ...mockPayload,
+      initialData: {
+        dashboardConfig: {
+          features: {
+            logStreamingEnabled: true,
+            liveLogsSessionTimelineEnabled: true,
+          },
+        },
+      },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Codex session task',
+      summary: 'Session-backed work',
+      status: 'completed',
+      state: 'succeeded',
+      rawState: 'succeeded',
+      targetRuntime: 'codex_cli',
+      taskRunId: 'wf-task-1',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: {
+        canCancel: true,
+      },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifact-sessions/sess%3Awf-task-1%3Acodex_cli')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            task_run_id: 'wf-task-1',
+            session_id: 'sess:wf-task-1:codex_cli',
+            session_epoch: 2,
+            grouped_artifacts: [
+              {
+                group_key: 'continuity',
+                title: 'Continuity',
+                artifacts: [{ artifact_id: 'art-summary', status: 'complete' }],
+              },
+            ],
+            latest_summary_ref: { artifact_id: 'art-summary' },
+            latest_checkpoint_ref: null,
+            latest_control_event_ref: null,
+            latest_reset_boundary_ref: null,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={codexPayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/timeline shows what happened/i)).toBeTruthy();
+      expect(screen.getByText(/durable evidence and drill-down/i)).toBeTruthy();
+    });
+  });
+
   it('routes Session Continuity follow-up and reset controls through the task-run session control API', async () => {
     const codexPayload: BootPayload = {
       ...mockPayload,
@@ -2472,6 +2570,97 @@ describe('LiveLogsPanel', () => {
     const publicationRow = screen.getByText(/Session summary artifact published/).closest('div');
     expect(approvalRow?.getAttribute('data-row-type')).toBe('approval');
     expect(publicationRow?.getAttribute('data-row-type')).toBe('publication');
+  });
+
+  it('renders inline artifact links for publication and clear-reset timeline rows', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'session',
+                kind: 'summary_published',
+                text: 'Session summary artifact published.',
+                metadata: {
+                  summaryRef: 'art-summary',
+                },
+              },
+              {
+                sequence: 2,
+                timestamp: '2026-04-08T00:00:02Z',
+                stream: 'session',
+                kind: 'checkpoint_published',
+                text: 'Session checkpoint artifact published.',
+                metadata: {
+                  checkpointRef: 'art-checkpoint',
+                },
+              },
+              {
+                sequence: 3,
+                timestamp: '2026-04-08T00:00:03Z',
+                stream: 'session',
+                kind: 'session_cleared',
+                text: 'Session cleared.',
+                metadata: {
+                  controlEventRef: 'art-control',
+                  resetBoundaryRef: 'art-reset',
+                },
+              },
+              {
+                sequence: 4,
+                timestamp: '2026-04-08T00:00:04Z',
+                stream: 'session',
+                kind: 'session_reset_boundary',
+                text: 'Epoch boundary reached.',
+                metadata: {
+                  controlEventRef: 'art-control',
+                  resetBoundaryRef: 'art-reset',
+                },
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /open summary artifact/i })).toBeTruthy();
+      expect(screen.getByRole('link', { name: /open checkpoint artifact/i })).toBeTruthy();
+      expect(screen.getAllByRole('link', { name: /open control event artifact/i }).length).toBeGreaterThan(0);
+      expect(screen.getAllByRole('link', { name: /open reset boundary artifact/i }).length).toBeGreaterThan(0);
+    });
+
+    expect(
+      screen.getByRole('link', { name: /open summary artifact/i }).getAttribute('href'),
+    ).toBe('/api/artifacts/art-summary/download');
+    expect(
+      screen.getByRole('link', { name: /open checkpoint artifact/i }).getAttribute('href'),
+    ).toBe('/api/artifacts/art-checkpoint/download');
   });
 
   it('uses the legacy line viewer when the session timeline feature flag is disabled', async () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1035,10 +1035,74 @@ function getCopyableRowText(row: TimelineRow): string {
   return row.text;
 }
 
+type TimelineArtifactLink = {
+  key: string;
+  label: string;
+  href: string;
+};
+
+function coerceArtifactRef(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized || null;
+  }
+  if (value && typeof value === 'object') {
+    const candidate = (value as { artifactRef?: unknown; artifact_id?: unknown; artifactId?: unknown }).artifactRef
+      ?? (value as { artifactRef?: unknown; artifact_id?: unknown; artifactId?: unknown }).artifact_id
+      ?? (value as { artifactRef?: unknown; artifact_id?: unknown; artifactId?: unknown }).artifactId;
+    if (typeof candidate === 'string') {
+      const normalized = candidate.trim();
+      return normalized || null;
+    }
+  }
+  return null;
+}
+
+function buildArtifactDownloadHref(apiBase: string, artifactId: string): string {
+  return joinApiBasePath(apiBase, `/artifacts/${encodeURIComponent(artifactId)}/download`);
+}
+
+function buildTimelineArtifactLinks(row: TimelineRow, apiBase: string): TimelineArtifactLink[] {
+  const links: TimelineArtifactLink[] = [];
+  const seen = new Set<string>();
+  const addLink = (label: string, value: unknown) => {
+    const artifactId = coerceArtifactRef(value);
+    if (!artifactId) return;
+    const key = `${label}:${artifactId}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    links.push({
+      key,
+      label,
+      href: buildArtifactDownloadHref(apiBase, artifactId),
+    });
+  };
+
+  if (row.kind === 'summary_published') {
+    addLink('Open summary artifact', row.metadata.summaryRef ?? row.metadata.artifactRef);
+  }
+  if (row.kind === 'checkpoint_published') {
+    addLink('Open checkpoint artifact', row.metadata.checkpointRef ?? row.metadata.artifactRef);
+  }
+  if (row.kind === 'session_cleared' || row.kind === 'session_reset_boundary') {
+    addLink(
+      'Open control event artifact',
+      row.metadata.controlEventRef ?? (row.kind === 'session_cleared' ? row.metadata.artifactRef : null),
+    );
+    addLink(
+      'Open reset boundary artifact',
+      row.metadata.resetBoundaryRef ?? (row.kind === 'session_reset_boundary' ? row.metadata.artifactRef : null),
+    );
+  }
+
+  return links;
+}
+
 function renderTimelineRow(
   row: TimelineRow,
   wrapLines: boolean,
   timelineViewerEnabled: boolean,
+  apiBase: string,
 ): ReactNode {
   const rowClasses = [
     'live-logs-row',
@@ -1046,6 +1110,7 @@ function renderTimelineRow(
     `live-logs-stream-${row.stream}`,
     wrapLines ? 'is-wrapped' : 'is-unwrapped',
   ].join(' ');
+  const artifactLinks = timelineViewerEnabled ? buildTimelineArtifactLinks(row, apiBase) : [];
 
   if (timelineViewerEnabled && row.rowType === 'boundary') {
     return (
@@ -1062,6 +1127,22 @@ function renderTimelineRow(
         >
           {row.text}
         </div>
+        {artifactLinks.length > 0 ? (
+          <div className="live-logs-artifact-links">
+            {artifactLinks.map((link) => (
+              <a
+                key={link.key}
+                className="live-logs-artifact-link"
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={link.label}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -1082,6 +1163,22 @@ function renderTimelineRow(
       >
         {renderTimelineRowText(row, timelineViewerEnabled)}
       </div>
+      {artifactLinks.length > 0 ? (
+        <div className="live-logs-artifact-links">
+          {artifactLinks.map((link) => (
+            <a
+              key={link.key}
+              className="live-logs-artifact-link"
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={link.label}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -1704,6 +1801,11 @@ function LiveLogsPanel({
         <p className="small">
           Task run <code className="text-xs">{taskRunId}</code> — {statusLabel}
         </p>
+        {sessionTimelineEnabled ? (
+          <p className="small">
+            Timeline shows what happened. Continuity artifacts remain the durable drill-down evidence.
+          </p>
+        ) : null}
         {sessionBadges.length > 0 ? (
           <div className="live-logs-session-badges">
             {sessionBadges.map(([label, value]) => (
@@ -1722,12 +1824,12 @@ function LiveLogsPanel({
                 style={{ height: 400 }}
                 data={logContent}
                 computeItemKey={(_, row) => row.id}
-                itemContent={(_, row) => renderTimelineRow(row, wrapLines, true)}
+                itemContent={(_, row) => renderTimelineRow(row, wrapLines, true, apiBase)}
               />
             </div>
           ) : (
             <div data-testid="live-logs-legacy-viewer" className="live-logs-legacy-viewer">
-              {logContent.map((line) => renderTimelineRow(line, wrapLines, false))}
+              {logContent.map((line) => renderTimelineRow(line, wrapLines, false, apiBase))}
             </div>
           )}
         </div>
@@ -2158,6 +2260,9 @@ function SessionContinuityPanel({
     <section className="stack">
       <div>
         <h3>Session Continuity</h3>
+        <p className="small">
+          Continuity artifacts are durable evidence and drill-down for this session.
+        </p>
         <p className="small">
           Session <code>{projection.session_id}</code> — Epoch {projection.session_epoch}
         </p>

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1041,6 +1041,29 @@ type TimelineArtifactLink = {
   href: string;
 };
 
+function TimelineArtifactLinks({ links }: { links: TimelineArtifactLink[] }): ReactNode {
+  if (links.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="live-logs-artifact-links">
+      {links.map((link) => (
+        <a
+          key={link.key}
+          className="live-logs-artifact-link"
+          href={link.href}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={link.label}
+        >
+          {link.label}
+        </a>
+      ))}
+    </div>
+  );
+}
+
 function coerceArtifactRef(value: unknown): string | null {
   if (typeof value === 'string') {
     const normalized = value.trim();
@@ -1127,22 +1150,7 @@ function renderTimelineRow(
         >
           {row.text}
         </div>
-        {artifactLinks.length > 0 ? (
-          <div className="live-logs-artifact-links">
-            {artifactLinks.map((link) => (
-              <a
-                key={link.key}
-                className="live-logs-artifact-link"
-                href={link.href}
-                target="_blank"
-                rel="noreferrer"
-                aria-label={link.label}
-              >
-                {link.label}
-              </a>
-            ))}
-          </div>
-        ) : null}
+        <TimelineArtifactLinks links={artifactLinks} />
       </div>
     );
   }
@@ -1163,22 +1171,7 @@ function renderTimelineRow(
       >
         {renderTimelineRowText(row, timelineViewerEnabled)}
       </div>
-      {artifactLinks.length > 0 ? (
-        <div className="live-logs-artifact-links">
-          {artifactLinks.map((link) => (
-            <a
-              key={link.key}
-              className="live-logs-artifact-link"
-              href={link.href}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={link.label}
-            >
-              {link.label}
-            </a>
-          ))}
-        </div>
-      ) : null}
+      <TimelineArtifactLinks links={artifactLinks} />
     </div>
   );
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1256,6 +1256,30 @@ button.secondary:hover {
   white-space: inherit;
 }
 
+.live-logs-artifact-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.live-logs-artifact-link {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  border: 1px solid rgb(255 255 255 / 0.16);
+  background: rgb(255 255 255 / 0.05);
+  color: rgb(232 234 240 / 0.92);
+  font-size: 0.66rem;
+  text-decoration: none;
+}
+
+.live-logs-artifact-link:hover,
+.live-logs-artifact-link:focus-visible {
+  background: rgb(255 255 255 / 0.12);
+  border-color: rgb(255 255 255 / 0.28);
+}
+
 .step-check-details {
   display: flex;
   flex-wrap: wrap;

--- a/specs/143-live-logs-continuity-unification/checklists/requirements.md
+++ b/specs/143-live-logs-continuity-unification/checklists/requirements.md
@@ -1,0 +1,6 @@
+# Specification Quality Checklist: Live Logs Continuity Unification
+
+- [x] Requirements focus on observable behavior rather than implementation detail.
+- [x] Acceptance scenarios cover publication rows, clear/reset rows, and explanatory copy.
+- [x] Edge cases cover migrated and synthesized historical events.
+- [x] Validation includes production code changes and automated tests.

--- a/specs/143-live-logs-continuity-unification/contracts/live-logs-continuity-unification.md
+++ b/specs/143-live-logs-continuity-unification/contracts/live-logs-continuity-unification.md
@@ -1,0 +1,18 @@
+# Contract: Live Logs Continuity Unification
+
+## Observability Event Metadata
+
+The Phase 5 UI depends on these metadata keys when present on session timeline rows:
+
+- `summaryRef`
+- `checkpointRef`
+- `controlEventRef`
+- `resetBoundaryRef`
+- `artifactRef` as a generic fallback
+
+Historical synthesis must preserve the specific ref keys for publication and clear/reset rows so the same frontend rendering works for journal-backed and synthesized histories.
+
+## UI Contract
+
+- Live Logs rows may render zero or more inline artifact links beneath the main row text.
+- Session Continuity remains the grouped artifact drill-down surface and does not become the source of main timeline row content.

--- a/specs/143-live-logs-continuity-unification/data-model.md
+++ b/specs/143-live-logs-continuity-unification/data-model.md
@@ -1,0 +1,29 @@
+# Data Model: Live Logs Continuity Unification
+
+## Timeline Artifact Link Ref Precedence
+
+For one timeline row, the UI resolves artifact refs in this order:
+
+1. specific ref keys in event metadata:
+   - `summaryRef`
+   - `checkpointRef`
+   - `controlEventRef`
+   - `resetBoundaryRef`
+2. generic `artifactRef` when only one durable artifact is attached
+3. no link when the event metadata contains no durable artifact ref
+
+## Row-to-Link Mapping
+
+- `summary_published` → summary artifact link
+- `checkpoint_published` → checkpoint artifact link
+- `session_cleared` → control-event link and reset-boundary link when present
+- `session_reset_boundary` → reset-boundary link and control-event link when present
+
+## Copy Semantics
+
+- **Live Logs** explains the timeline as chronological event history.
+- **Session Continuity** explains grouped artifacts as durable evidence and drill-down.
+- The continuity panel remains grouped by:
+  - `runtime`
+  - `continuity`
+  - `control`

--- a/specs/143-live-logs-continuity-unification/plan.md
+++ b/specs/143-live-logs-continuity-unification/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: Live Logs Continuity Unification
+
+**Branch**: `143-live-logs-continuity-unification` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/143-live-logs-continuity-unification/spec.md`
+
+## Summary
+
+Implement Phase 5 of the Live Logs session-aware plan by tightening the seam between timeline rows and continuity artifacts. The implementation will keep the current Live Logs timeline and Session Continuity panel, preserve the projection as the artifact drill-down source, add inline artifact links for session publication/reset events, and update task-detail copy so operators understand the difference between the timeline and durable evidence.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript, React 19, Vitest  
+**Primary Dependencies**: existing task-run observability router, existing task-detail timeline viewer, existing session projection endpoint  
+**Storage**: no new persistent store; reuse observability event metadata and grouped session projection metadata  
+**Testing**: `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`  
+**Target Platform**: FastAPI task-run APIs and Mission Control task detail page  
+**Project Type**: backend/frontend observability UX refinement  
+**Constraints**: keep the current Session Continuity control flow intact, avoid adding a new route unless event metadata is insufficient, and preserve legacy fallback behavior for older observability events
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The UI continues to consume MoonMind-owned observability and artifact contracts.
+- **II. One-Click Agent Deployment**: PASS. No deployment or runtime prerequisites change.
+- **III. Avoid Vendor Lock-In**: PASS. Artifact links remain tied to MoonMind artifact refs rather than provider-native session state.
+- **IV. Own Your Data**: PASS. The timeline links directly into durable MoonMind artifacts.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The change tightens existing metadata contracts instead of introducing a second continuity transport.
+- **VII. Powerful Runtime Configurability**: PASS. The richer timeline behavior remains behind the existing session-timeline frontend path.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay bounded to `task_runs.py`, task-detail rendering, and tests.
+- **IX. Resilient by Default**: PASS. Older runs still degrade through generic `artifactRef` metadata or existing continuity drill-down.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This slice gets a dedicated spec/plan/tasks package before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. This implementation plan references the canonical docs and applies only the Phase 5 rollout slice.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The work reuses the current timeline and projection surfaces without adding compatibility wrappers.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/143-live-logs-continuity-unification/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── live-logs-continuity-unification.md
+├── checklists/
+│   └── requirements.md
+├── speckit_analyze_report.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/task_runs.py          # MODIFY: preserve specific artifact-ref metadata for synthesized session rows
+tests/unit/api/routers/test_task_runs.py      # MODIFY: regression coverage for historical event ref metadata
+frontend/src/entrypoints/task-detail.tsx      # MODIFY: inline timeline artifact links and copy/label updates
+frontend/src/entrypoints/task-detail.test.tsx # MODIFY: TDD coverage for artifact links and explanatory copy
+frontend/src/styles/mission-control.css       # MODIFY: timeline artifact-link styling
+```
+
+## Research
+
+- The Live Logs timeline already renders distinct session/publication/boundary row types and parses arbitrary event metadata, so Phase 5 can stay additive.
+- The managed-session supervisor already writes specific metadata keys such as `summaryRef`, `checkpointRef`, `controlEventRef`, and `resetBoundaryRef` into persisted observability events.
+- Historical fallback synthesis in `api_service/api/routers/task_runs.py` currently preserves only generic `artifactRef` values for publication/reset events, so backend normalization is the main contract gap for older runs.
+- The Session Continuity panel already exposes grouped artifacts and latest refs, but it does not yet explain its drill-down role relative to Live Logs.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the timeline-link ref precedence and continuity copy semantics.
+
+## Contracts
+
+- [contracts/live-logs-continuity-unification.md](./contracts/live-logs-continuity-unification.md)
+
+## Implementation Plan
+
+1. Add failing backend tests for synthesized publication/reset event metadata and failing frontend tests for timeline artifact links plus operator-facing copy.
+2. Normalize synthesized historical event metadata in `task_runs.py` so the UI can read specific ref keys for summary/checkpoint/control/reset rows.
+3. Update `task-detail.tsx` to derive inline artifact links from event metadata with a generic `artifactRef` fallback.
+4. Update the Live Logs and Session Continuity panel copy to distinguish event history from durable drill-down evidence.
+5. Add the minimal CSS needed for inline artifact-link presentation and rerun focused verification plus scope validation.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+2. `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+3. `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+4. `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+### Manual Validation
+
+1. Open a managed Codex run with summary/checkpoint publications and confirm the timeline rows expose direct artifact links.
+2. Trigger a clear/reset and confirm the clear/boundary rows expose both control-event and reset-boundary links.
+3. Confirm the Live Logs panel explains timeline semantics while the continuity panel explains artifact drill-down semantics.

--- a/specs/143-live-logs-continuity-unification/quickstart.md
+++ b/specs/143-live-logs-continuity-unification/quickstart.md
@@ -1,0 +1,8 @@
+# Quickstart: Live Logs Continuity Unification
+
+1. Open a managed Codex task detail page with the session timeline flag enabled.
+2. Expand `Live Logs` and verify publication/reset rows expose direct artifact links.
+3. Read the panel copy:
+   - Live Logs should explain the timeline as what happened.
+   - Session Continuity should explain artifacts as durable evidence or drill-down.
+4. Open the linked artifacts and confirm the continuity panel still shows the grouped runtime, continuity, and control artifacts.

--- a/specs/143-live-logs-continuity-unification/research.md
+++ b/specs/143-live-logs-continuity-unification/research.md
@@ -1,0 +1,10 @@
+# Research: Live Logs Continuity Unification
+
+- The Phase 4 timeline viewer already consumes structured observability events and classifies publication and boundary rows separately, so Phase 5 can stay focused on row affordances instead of changing the viewer model again.
+- The managed-session supervisor emits specific event metadata keys:
+  - `summaryRef`
+  - `checkpointRef`
+  - `controlEventRef`
+  - `resetBoundaryRef`
+- Historical synthesis in `api_service/api/routers/task_runs.py` currently falls back to generic `artifactRef` metadata for older runs; aligning that path keeps UI behavior truthful across migrated and non-migrated histories.
+- The current `Session Continuity` panel already exposes grouped runtime/continuity/control artifacts and latest refs, so Phase 5 only needs copy/label clarification rather than a new drill-down API.

--- a/specs/143-live-logs-continuity-unification/spec.md
+++ b/specs/143-live-logs-continuity-unification/spec.md
@@ -1,0 +1,69 @@
+# Feature Specification: Live Logs Continuity Unification
+
+**Feature Branch**: `143-live-logs-continuity-unification`
+**Created**: 2026-04-09
+**Status**: Draft
+**Input**: User description: "Implement Phase 5 using test-driven development from the Live Logs Session-Aware Implementation Plan."
+
+## User Scenarios & Testing
+
+### User Story 1 - Open continuity artifacts directly from timeline events (Priority: P1)
+
+Mission Control operators need the session-aware Live Logs timeline to expose direct links to the related continuity artifacts so they can move from "what happened" to durable evidence without leaving the observability flow.
+
+**Why this priority**: Phase 5 exists to make the timeline and continuity artifacts feel like one observability model instead of two disconnected surfaces.
+
+**Independent Test**: Render the Live Logs panel for a managed run with `summary_published`, `checkpoint_published`, `session_cleared`, and `session_reset_boundary` rows and verify each row exposes the expected artifact links.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `summary_published` timeline row includes a durable summary artifact ref, **When** the operator opens Live Logs, **Then** the row exposes a direct summary artifact link.
+2. **Given** a `checkpoint_published` timeline row includes a durable checkpoint artifact ref, **When** the operator opens Live Logs, **Then** the row exposes a direct checkpoint artifact link.
+3. **Given** a clear/reset pair exists for the latest session epoch, **When** the operator reads the `session_cleared` or `session_reset_boundary` row, **Then** the row exposes direct links to both the control-event artifact and the reset-boundary artifact.
+
+### User Story 2 - Explain timeline vs continuity drill-down clearly (Priority: P1)
+
+Operators need the Live Logs panel and the continuity panel to explain their different jobs so the page reads as one observability workflow instead of duplicate features.
+
+**Why this priority**: The product goal for Phase 5 is to reduce the split-brain feeling between logs and continuity without removing durable artifact drill-down.
+
+**Independent Test**: Render the task detail page for a managed session run and verify the Live Logs panel copy describes the timeline as event history while the continuity panel copy describes artifacts as durable drill-down evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** the session timeline feature flag is enabled, **When** Live Logs renders, **Then** the panel includes operator-facing copy that states the timeline shows what happened.
+2. **Given** a session continuity projection is present, **When** the continuity panel renders, **Then** the panel includes operator-facing copy that states continuity artifacts are durable evidence or drill-down.
+3. **Given** the continuity projection still groups runtime, continuity, and control artifacts, **When** the panel renders, **Then** the grouped artifacts remain available without becoming the primary timeline model.
+
+### Edge Cases
+
+- Structured history rows may come from the persisted observability journal or from historical artifact synthesis; artifact-link rendering must work for both sources.
+- Older runs may have timeline rows with only a generic `artifactRef`; the UI must still render a useful link when a specific ref key is absent.
+- A clear/reset pair may expose one artifact but not the other; the row should show only the refs that exist and must not fabricate missing links.
+- The continuity panel may still be polling while the timeline has already loaded; direct timeline links must not depend on the continuity panel request succeeding first.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The session-aware Live Logs timeline MUST render direct artifact links for `summary_published` and `checkpoint_published` rows when artifact refs are present in event metadata.
+- **FR-002**: The session-aware Live Logs timeline MUST render direct artifact links for clear/reset events so operators can open the control-event artifact and reset-boundary artifact from the relevant timeline rows when those refs exist.
+- **FR-003**: Historical event synthesis for session publication and reset rows MUST preserve artifact-ref metadata needed by the Phase 5 UI.
+- **FR-004**: The task detail page MUST include operator-facing copy that distinguishes the Live Logs timeline ("what happened") from continuity artifacts ("durable evidence / drill-down").
+- **FR-005**: The Session Continuity panel MUST remain the durable artifact drill-down surface and MUST continue to show grouped runtime, continuity, and control artifacts.
+- **FR-006**: The Phase 5 implementation MUST ship production runtime/frontend code changes plus automated validation tests; docs-only edits are insufficient.
+
+### Key Entities
+
+- **Timeline Artifact Link**: A direct artifact affordance rendered inline with one timeline row and resolved from event metadata.
+- **Continuity Drill-Down Copy**: Operator-facing text that explains continuity artifacts as durable evidence instead of duplicated log history.
+- **Historical Event Ref Metadata**: The artifact-ref fields attached to publication and boundary observability rows for both journal-backed and synthesized history.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests prove `summary_published`, `checkpoint_published`, `session_cleared`, and `session_reset_boundary` rows expose the expected artifact links.
+- **SC-002**: Backend tests prove synthesized historical session publication/boundary events preserve the artifact-ref metadata needed by the UI.
+- **SC-003**: Frontend tests prove the task detail copy explains `Live Logs` as event history and continuity artifacts as durable drill-down evidence.
+- **SC-004**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`, and scope validation pass.

--- a/specs/143-live-logs-continuity-unification/speckit_analyze_report.md
+++ b/specs/143-live-logs-continuity-unification/speckit_analyze_report.md
@@ -1,0 +1,29 @@
+# Speckit Analyze Report: Live Logs Continuity Unification
+
+## Remediation Review
+
+### spec.md
+
+#### LOW
+
+- **Artifact**: `spec.md`
+- **Location**: Edge Cases
+- **Problem**: The first draft needed to be explicit about generic `artifactRef` fallback for older histories.
+- **Remediation**: Require the UI to handle both specific ref keys and the generic fallback without fabricating links.
+- **Rationale**: Keeps the Phase 5 slice compatible with partially migrated runs.
+
+### plan.md
+
+#### LOW
+
+- **Artifact**: `plan.md`
+- **Location**: Constraints / Research
+- **Problem**: The implementation plan needed to state clearly that the Session Continuity panel stays the drill-down source instead of becoming another timeline.
+- **Remediation**: Keep the projection panel intact and scope the new work to inline timeline links plus copy alignment.
+- **Rationale**: Matches the Phase 5 goal while avoiding unnecessary control-surface churn.
+
+## Safe-to-Implement Determination
+
+- **Safe to Implement**: YES
+- **Blocking Remediations**: None
+- **Determination Rationale**: The slice is small, contract-driven, and testable, and it closes the main Phase 5 UX gap without requiring a new observability transport.

--- a/specs/143-live-logs-continuity-unification/tasks.md
+++ b/specs/143-live-logs-continuity-unification/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Live Logs Continuity Unification
+
+**Input**: Design documents from `/specs/143-live-logs-continuity-unification/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing tests before implementing the corresponding backend/frontend changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`)
+
+## Phase 1: Setup
+
+- [X] T001 Create the Phase 5 spec artifact set for `143-live-logs-continuity-unification`.
+
+## Phase 2: User Story 1 - Open continuity artifacts directly from timeline events (Priority: P1)
+
+**Goal**: Let operators move from a timeline row to the related continuity artifact without leaving the Live Logs flow.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Add failing backend tests in `tests/unit/api/routers/test_task_runs.py` for synthesized `summary_published`, `checkpoint_published`, `session_cleared`, and `session_reset_boundary` metadata.
+- [X] T003 [P] [US1] Add failing frontend tests in `frontend/src/entrypoints/task-detail.test.tsx` covering inline artifact links for publication and clear/reset rows.
+
+### Implementation for User Story 1
+
+- [X] T004 [US1] Update `api_service/api/routers/task_runs.py` to preserve specific artifact-ref metadata for synthesized historical session events.
+- [X] T005 [US1] Update `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/styles/mission-control.css` to render inline artifact links in session/publication/boundary timeline rows.
+
+## Phase 3: User Story 2 - Explain timeline vs continuity drill-down clearly (Priority: P1)
+
+**Goal**: Make the task detail page read as one observability model with different surfaces for event history and durable evidence.
+
+### Tests for User Story 2
+
+- [X] T006 [P] [US2] Add failing frontend tests in `frontend/src/entrypoints/task-detail.test.tsx` covering the new Live Logs and Session Continuity explanatory copy.
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Update `frontend/src/entrypoints/task-detail.tsx` to add the operator-facing copy for timeline history vs continuity drill-down.
+
+## Phase 4: Validation
+
+- [X] T008 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [X] T009 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- [X] T010 Run `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T011 Run `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1451,6 +1451,89 @@ def test_iter_historical_artifact_events_preserves_specific_session_artifact_ref
     assert events_by_kind["session_reset_boundary"]["metadata"]["resetBoundaryRef"] == "art_reset"
 
 
+def test_iter_historical_artifact_events_omits_missing_reset_boundary_ref(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+
+    (artifacts_root / "art_control").write_text(
+        json.dumps(
+            {
+                "action": "clear_session",
+                "previousSessionEpoch": 1,
+                "newSessionEpoch": 2,
+                "previousThreadId": "thread-1",
+                "newThreadId": "thread-2",
+                "recordedAt": "2026-04-08T00:00:01Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record = SimpleNamespace(
+        diagnostics_ref=None,
+        stdout_artifact_ref=None,
+        stderr_artifact_ref=None,
+        started_at=datetime(2026, 4, 8, 0, 0, tzinfo=UTC),
+    )
+    session_record = _build_session_record()
+
+    events = list(
+        task_runs_router._iter_historical_artifact_events(
+            record,
+            session_record,
+            limit_per_stream=20,
+        )
+    )
+    events_by_kind = {event["kind"]: event for event in events}
+
+    assert events_by_kind["session_cleared"]["metadata"]["controlEventRef"] == "art_control"
+    assert "resetBoundaryRef" not in events_by_kind["session_cleared"]["metadata"]
+
+
+def test_iter_historical_artifact_events_omits_missing_control_event_ref(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+
+    (artifacts_root / "art_reset").write_text(
+        json.dumps(
+            {
+                "sessionEpoch": 2,
+                "threadId": "thread-2",
+                "recordedAt": "2026-04-08T00:00:02Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    record = SimpleNamespace(
+        diagnostics_ref=None,
+        stdout_artifact_ref=None,
+        stderr_artifact_ref=None,
+        started_at=datetime(2026, 4, 8, 0, 0, tzinfo=UTC),
+    )
+    session_record = _build_session_record()
+
+    events = list(
+        task_runs_router._iter_historical_artifact_events(
+            record,
+            session_record,
+            limit_per_stream=20,
+        )
+    )
+    events_by_kind = {event["kind"]: event for event in events}
+
+    assert events_by_kind["session_reset_boundary"]["metadata"]["resetBoundaryRef"] == "art_reset"
+    assert "controlEventRef" not in events_by_kind["session_reset_boundary"]["metadata"]
+
+
 def _build_session_record() -> CodexManagedSessionRecord:
     now = datetime.now(UTC)
     return CodexManagedSessionRecord(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1390,6 +1390,67 @@ def test_iter_historical_artifact_events_chunks_large_logs_and_keeps_tail(
     assert events[1]["text"] == "C" * 65536
 
 
+def test_iter_historical_artifact_events_preserves_specific_session_artifact_refs(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts_root = tmp_path / "artifacts"
+    artifacts_root.mkdir()
+    monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_ARTIFACTS", str(artifacts_root))
+
+    (artifacts_root / "art_control").write_text(
+        json.dumps(
+            {
+                "action": "clear_session",
+                "previousSessionEpoch": 1,
+                "newSessionEpoch": 2,
+                "previousThreadId": "thread-1",
+                "newThreadId": "thread-2",
+                "recordedAt": "2026-04-08T00:00:01Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifacts_root / "art_reset").write_text(
+        json.dumps(
+            {
+                "sessionEpoch": 2,
+                "threadId": "thread-2",
+                "recordedAt": "2026-04-08T00:00:02Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifacts_root / "art_summary").write_text("summary", encoding="utf-8")
+    (artifacts_root / "art_checkpoint").write_text("checkpoint", encoding="utf-8")
+
+    record = SimpleNamespace(
+        diagnostics_ref=None,
+        stdout_artifact_ref=None,
+        stderr_artifact_ref=None,
+        started_at=datetime(2026, 4, 8, 0, 0, tzinfo=UTC),
+    )
+    session_record = _build_session_record()
+
+    events = list(
+        task_runs_router._iter_historical_artifact_events(
+            record,
+            session_record,
+            limit_per_stream=20,
+        )
+    )
+    events_by_kind = {event["kind"]: event for event in events}
+
+    assert events_by_kind["summary_published"]["metadata"]["summaryRef"] == "art_summary"
+    assert events_by_kind["summary_published"]["metadata"]["artifactRef"] == "art_summary"
+    assert events_by_kind["checkpoint_published"]["metadata"]["checkpointRef"] == "art_checkpoint"
+    assert events_by_kind["checkpoint_published"]["metadata"]["artifactRef"] == "art_checkpoint"
+    assert events_by_kind["session_cleared"]["metadata"]["controlEventRef"] == "art_control"
+    assert events_by_kind["session_cleared"]["metadata"]["resetBoundaryRef"] == "art_reset"
+    assert events_by_kind["session_reset_boundary"]["metadata"]["controlEventRef"] == "art_control"
+    assert events_by_kind["session_reset_boundary"]["metadata"]["resetBoundaryRef"] == "art_reset"
+
+
 def _build_session_record() -> CodexManagedSessionRecord:
     now = datetime.now(UTC)
     return CodexManagedSessionRecord(


### PR DESCRIPTION
## What changed
- added the Phase 5 spec package for `143-live-logs-continuity-unification`
- preserved specific continuity artifact refs on synthesized historical session observability rows
- rendered inline artifact links for publication and clear/reset timeline rows in Live Logs
- updated task-detail copy so Live Logs reads as the event timeline and Session Continuity reads as durable evidence/drill-down
- added backend and frontend regression coverage for the new metadata and UI behavior

## Why it changed
Phase 4 delivered the session-aware timeline, but the page still felt split between timeline history and continuity artifacts. Phase 5 closes that gap by letting operators open the relevant continuity artifacts directly from timeline rows while keeping the continuity panel as the artifact drill-down surface.

## Impact
Operators can now move from `summary_published`, `checkpoint_published`, `session_cleared`, and `session_reset_boundary` rows straight to the corresponding durable artifacts without leaving Live Logs. Historical fallback rows and journal-backed rows use the same metadata shape, so the link behavior stays consistent across migrated and synthesized histories.

## Root cause
The timeline already carried the session lifecycle events, but synthesized historical rows only exposed generic artifact metadata and the UI had no inline artifact affordance or copy to explain how timeline history differs from continuity evidence.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
- `npm run ui:typecheck`
- `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=143-live-logs-continuity-unification ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`