### PR TITLE
[codex] Step ledger phase 6 hardening

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -743,7 +743,7 @@ async def _load_execution_progress(
     *,
     temporal_client: Client,
     workflow_id: str,
-) -> ExecutionProgressModel | None:
+) -> tuple[ExecutionProgressModel | None, str | None]:
     try:
         payload = await query_workflow(temporal_client, workflow_id, "get_progress")
     except Exception as exc:
@@ -753,13 +753,21 @@ async def _load_execution_progress(
             exc,
             exc_info=True,
         )
-        return None
+        return None, None
 
     if payload is None:
-        return None
+        return None, None
+
+    queried_run_id = None
+    if isinstance(payload, Mapping):
+        queried_run_id = (
+            _coerce_temporal_scalar(payload.get("runId"))
+            or _coerce_temporal_scalar(payload.get("run_id"))
+            or None
+        )
 
     try:
-        return ExecutionProgressModel.model_validate(payload)
+        return ExecutionProgressModel.model_validate(payload), queried_run_id
     except ValidationError as exc:
         logger.warning(
             "Invalid execution progress payload for %s: %s",
@@ -767,7 +775,7 @@ async def _load_execution_progress(
             exc,
             exc_info=True,
         )
-        return None
+        return None, None
 
 
 async def _load_execution_step_ledger(
@@ -2164,11 +2172,15 @@ async def describe_execution(
     execution = await _enrich_execution_dependencies(execution, service=service)
     execution = await _hydrate_provider_profile_metadata(execution, session)
     if execution.workflow_type == "MoonMind.Run":
-        progress = await _load_execution_progress(
+        progress, queried_run_id = await _load_execution_progress(
             temporal_client=temporal_client,
             workflow_id=canonical_workflow_id,
         )
-        execution = execution.model_copy(update={"progress": progress})
+        update: dict[str, object] = {"progress": progress}
+        if queried_run_id:
+            update["run_id"] = queried_run_id
+            update["temporal_run_id"] = queried_run_id
+        execution = execution.model_copy(update=update)
     if not execution.task_run_id:
         task_run_id = await asyncio.to_thread(
             _resolve_task_run_id_from_managed_store,

--- a/docs/tmp/remaining-work/Api-ExecutionsApiContract.md
+++ b/docs/tmp/remaining-work/Api-ExecutionsApiContract.md
@@ -4,7 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Implement `GET /api/executions/{workflowId}/steps` backed by a workflow query for latest/current run step state.
-- Add `progress` to the real execution-detail payload and keep `GET /api/executions/{workflowId}` cheap enough for normal polling.
-- Return step-scoped refs (`childWorkflowId`, `childRunId`, `taskRunId`) and grouped artifact refs without forcing clients to parse generic artifacts.
-- Add workflow-boundary and API contract tests covering step status vocabulary, attempt identity, and latest-run behavior across Continue-As-New.
+No remaining step-ledger rollout work.

--- a/docs/tmp/remaining-work/Temporal-RunHistoryAndRerunSemantics.md
+++ b/docs/tmp/remaining-work/Temporal-RunHistoryAndRerunSemantics.md
@@ -4,6 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Keep default task detail and default step detail anchored to the latest/current run only.
-- Add explicit follow-on design if historical run step views or cross-run attempt history become product requirements.
-- Verify rerun and Continue-As-New flows preserve `workflowId` identity while rotating `runId` and step-attempt scope correctly.
+No remaining step-ledger rollout work.

--- a/docs/tmp/remaining-work/Temporal-TemporalArchitecture.md
+++ b/docs/tmp/remaining-work/Temporal-TemporalArchitecture.md
@@ -4,6 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Implement the workflow-owned step ledger in `MoonMind.Run` and expose it through query/update-safe deterministic state.
-- Keep Visibility and Memo bounded while surfacing step truth through query/detail APIs.
-- Add workflow-boundary coverage for meaningful step transitions, check/review transitions, and latest-run query behavior.
+No remaining step-ledger rollout work.

--- a/docs/tmp/remaining-work/Temporal-WorkflowArtifactSystemDesign.md
+++ b/docs/tmp/remaining-work/Temporal-WorkflowArtifactSystemDesign.md
@@ -4,6 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Standardize step-scoped artifact link metadata (`step_id`, `attempt`, optional `scope`) in artifact creation and linkage flows.
-- Add server-side grouping for step evidence so Mission Control does not derive latest step output client-side.
-- Verify managed-run and provider result artifacts populate the semantic step artifact slots used by the step ledger.
+No remaining step-ledger rollout work.

--- a/docs/tmp/remaining-work/Temporal-WorkflowTypeCatalogAndLifecycle.md
+++ b/docs/tmp/remaining-work/Temporal-WorkflowTypeCatalogAndLifecycle.md
@@ -4,6 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Ensure `MoonMind.Run` owns compact step truth and progress while `MoonMind.AgentRun` remains the true runtime lifecycle boundary.
-- Keep Memo/Search Attribute updates compact and user-visible rather than log- or heartbeat-driven.
-- Add lifecycle tests for plan resolved, step ready, step started, step reviewing, step succeeded, step failed, and step canceled transitions.
+No remaining step-ledger rollout work.

--- a/docs/tmp/remaining-work/UI-MissionControlArchitecture.md
+++ b/docs/tmp/remaining-work/UI-MissionControlArchitecture.md
@@ -4,7 +4,4 @@ Updated: 2026-04-04
 
 ## Step-ledger rollout
 
-- Implement the Steps section on task detail above Timeline and generic Artifacts.
-- Fetch `/api/executions/{workflowId}/steps` after execution detail and before execution-wide artifact browsing.
-- Support expanded step rows with Summary, Checks, Logs & Diagnostics, Artifacts, and Metadata groups.
-- Add browser-facing tests for latest-run-only steps, delayed `taskRunId` arrival, and step-scoped observability attachment.
+No remaining step-ledger rollout work.

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -322,6 +322,76 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('loads execution-wide artifacts against the latest run exposed by the step ledger', async () => {
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      stepsHref: '/api/executions/test-123/steps',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      title: 'Run rotation task',
+      summary: 'Execution summary',
+      status: 'running',
+      state: 'executing',
+      rawState: 'executing',
+      temporalStatus: 'running',
+      createdAt: '2026-04-09T00:00:00Z',
+      updatedAt: '2026-04-09T00:00:04Z',
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/executions/test-123/steps')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...latestStepsSnapshot,
+            runId: '02-run',
+          }),
+        } as Response);
+      }
+      if (url.includes('/executions/default/test-123/02-run/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      if (url.includes('/executions/default/test-123/01-run/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={stepsPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy();
+    });
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([url]) =>
+          String(url).includes('/executions/default/test-123/02-run/artifacts'),
+        ),
+      ).toBe(true);
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).includes('/executions/default/test-123/01-run/artifacts'),
+      ),
+    ).toBe(false);
+  });
+
   it('expands a bound step into grouped step details and lazily attaches row-scoped observability', async () => {
     const mockExecution = {
       taskId: 'test-123',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -2354,11 +2354,12 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     enabled: Boolean(execution?.stepsHref),
     refetchInterval: liveUpdates && execution?.stepsHref ? detailPoll : false,
   });
+  const latestRunId = stepsQuery.data?.runId || runId;
 
   const artifactsQuery = useQuery({
-    queryKey: ['task-detail-artifacts', namespace, workflowId, runId],
+    queryKey: ['task-detail-artifacts', namespace, workflowId, latestRunId],
     queryFn: async () => {
-      const path = `${payload.apiBase}/executions/${encodeURIComponent(namespace)}/${encodeURIComponent(workflowId)}/${encodeURIComponent(runId)}/artifacts`;
+      const path = `${payload.apiBase}/executions/${encodeURIComponent(namespace)}/${encodeURIComponent(workflowId)}/${encodeURIComponent(latestRunId)}/artifacts`;
       const response = await fetch(path);
       if (!response.ok) {
         throw new Error(`Artifacts: ${response.statusText}`);
@@ -2366,9 +2367,9 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       return ArtifactListSchema.parse(await response.json());
     },
     enabled:
-      Boolean(namespace && workflowId && runId)
+      Boolean(namespace && workflowId && latestRunId)
       && (!execution?.stepsHref || stepsQuery.isSuccess || stepsQuery.isError),
-    refetchInterval: liveUpdates && namespace && workflowId && runId ? detailPoll : false,
+    refetchInterval: liveUpdates && namespace && workflowId && latestRunId ? detailPoll : false,
   });
 
   const runSummaryQuery = useQuery({
@@ -2417,7 +2418,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const invalidate = () => {
     void queryClient.invalidateQueries({ queryKey: ['task-detail', encodedTaskId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-steps', workflowId] });
-    void queryClient.invalidateQueries({ queryKey: ['task-detail-artifacts', namespace, workflowId, runId] });
+    void queryClient.invalidateQueries({ queryKey: ['task-detail-artifacts', namespace, workflowId, latestRunId] });
     void queryClient.invalidateQueries({ queryKey: ['task-detail-run-summary', summaryArtifactRef] });
   };
 
@@ -2653,7 +2654,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             {execution.scheduledFor ? <Card label="Scheduled For">{formatWhen(execution.scheduledFor)}</Card> : null}
             <Card label="Created">{formatWhen(execution.createdAt)}</Card>
             <Card label="Latest Run">
-              <code className="text-xs break-all">{runId || '—'}</code>
+              <code className="text-xs break-all">{latestRunId || '—'}</code>
             </Card>
             {resolvedTaskRunId ? (
               <Card label="Task Run">
@@ -2741,7 +2742,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                 <div>
                   <h3>Steps</h3>
                   <p className="small">
-                    Latest run <code className="text-xs break-all">{stepsQuery.data?.runId || runId || '—'}</code>
+                    Latest run <code className="text-xs break-all">{latestRunId || '—'}</code>
                   </p>
                 </div>
                 {stepsQuery.data ? (
@@ -2763,7 +2764,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                       logStreamingEnabled={logStreamingEnabled}
                       sessionTimelineEnabled={sessionTimelineEnabled}
                       row={row}
-                      runId={stepsQuery.data?.runId || runId}
+                      runId={latestRunId}
                       expanded={Boolean(expandedSteps[row.logicalStepId])}
                       onToggle={() => toggleStep(row.logicalStepId)}
                       routes={taskRunRoutes}

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -4093,10 +4093,12 @@ class MoonMindRunWorkflow:
 
     @workflow.query
     def get_progress(self) -> dict[str, Any]:
-        return ExecutionProgressModel.model_validate(self._progress_snapshot).model_dump(
+        payload = ExecutionProgressModel.model_validate(self._progress_snapshot).model_dump(
             by_alias=True,
             mode="json",
         )
+        payload["runId"] = workflow.info().run_id
+        return payload
 
     @workflow.query
     def get_step_ledger(self) -> dict[str, Any]:

--- a/specs/143-step-ledger-phase6/checklists/requirements.md
+++ b/specs/143-step-ledger-phase6/checklists/requirements.md
@@ -1,0 +1,5 @@
+- [X] Latest-run-only semantics stay anchored to `workflowId`
+- [X] `runId` rotation across rerun / Continue-As-New is covered explicitly
+- [X] Projection/degraded-read truthfulness is covered explicitly
+- [X] Task-detail secondary evidence alignment is covered explicitly
+- [X] Runtime code changes plus validation tests are required

--- a/specs/143-step-ledger-phase6/contracts/latest-run-hardening-contract.md
+++ b/specs/143-step-ledger-phase6/contracts/latest-run-hardening-contract.md
@@ -1,0 +1,14 @@
+# Latest-Run Hardening Contract
+
+## Scope
+
+This phase hardens the default latest-run read path for `MoonMind.Run` task detail.
+
+## Contract Rules
+
+1. `workflowId` remains the durable task/detail identifier.
+2. `/api/executions/{workflowId}` may begin from a projection-backed row, but when bounded workflow query data exposes a newer current run, the response must adopt that latest `runId`.
+3. `/api/executions/{workflowId}/steps` remains the authoritative latest-run step surface.
+4. The public `progress` object remains the documented bounded `ExecutionProgress` contract.
+5. Mission Control generic artifact browsing must use the latest/current run once it is known from the Steps surface.
+6. Degraded reads may omit `progress`, but they must not invent a new `runId`.

--- a/specs/143-step-ledger-phase6/contracts/requirements-traceability.md
+++ b/specs/143-step-ledger-phase6/contracts/requirements-traceability.md
@@ -1,0 +1,10 @@
+# Requirements Traceability: Step Ledger Phase 6
+
+| Source Requirement | Spec Mapping | Planned Implementation | Validation Strategy |
+| --- | --- | --- | --- |
+| DOC-REQ-001 | FR-001, FR-002, FR-004 | Reconcile execution detail and task-detail latest-run reads to the current workflow run while preserving latest-run-only semantics | Router, contract, and browser tests assert latest-run identity and latest-run-scoped artifact reads |
+| DOC-REQ-002 | FR-001, FR-003, FR-004 | Keep `workflowId` stable while rerun / Continue-As-New rotates `runId` and the default detail view follows the current run | Contract and service coverage assert rerun / Continue-As-New latest-run behavior |
+| DOC-REQ-003 | FR-001, FR-003 | Prefer workflow query truth over stale projection `runId` values without fabricating degraded-read state | Router and contract tests assert queried latest-run reconciliation and honest degradation |
+| DOC-REQ-004 | FR-002 | Keep execution-wide artifact browsing aligned to the latest resolved run rather than a stale detail snapshot | Targeted browser test asserts artifact fetches switch to the latest run from the step ledger |
+| DOC-REQ-005 | FR-002, FR-004 | Preserve the Steps-first Mission Control model while keeping secondary evidence panels truthful | Task-detail tests assert latest-run Steps remain primary and artifacts stay aligned |
+| DOC-REQ-006 | FR-005 | Remove completed step-ledger rollout bullets from tmp tracker files once Phase 6 lands | Tracker-file diff plus spec-package validation confirm the rollout bullets are retired |

--- a/specs/143-step-ledger-phase6/data-model.md
+++ b/specs/143-step-ledger-phase6/data-model.md
@@ -1,0 +1,46 @@
+# Data Model: Step Ledger Phase 6
+
+## LatestRunExecutionRead
+
+Represents the task-detail execution model after latest-run reconciliation.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `workflowId` | string | Stable logical execution identifier |
+| `runId` | string | Latest/current Temporal run used by the task detail |
+| `temporalRunId` | string | Alias of the latest/current run for debug compatibility |
+| `progress` | `ExecutionProgress \| null` | Bounded latest-run summary, unchanged externally |
+
+Rules:
+
+- `runId` remains stable for one Temporal run and rotates on rerun / Continue-As-New.
+- The public `progress` object does not expose extra reconciliation fields.
+
+## InternalProgressQueryEnvelope
+
+Internal workflow-to-router query payload used to keep detail reads truthful.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `runId` | string | Latest/current workflow run id for reconciliation |
+| `total` ... `updatedAt` | `ExecutionProgress` fields | Existing bounded progress fields |
+
+Rules:
+
+- The router may read `runId` from the raw query payload.
+- Public API responses continue validating and returning only the documented `ExecutionProgress` shape.
+
+## RunScopedArtifactRead
+
+Represents generic execution-wide artifact browsing on task detail.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `namespace` | string | Temporal namespace |
+| `workflowId` | string | Stable logical execution id |
+| `runId` | string | Latest/current run whose artifacts are being browsed |
+
+Rules:
+
+- Default task detail remains latest-run-only.
+- Artifact reads must not silently mix rows from two run ids in one default panel.

--- a/specs/143-step-ledger-phase6/plan.md
+++ b/specs/143-step-ledger-phase6/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Step Ledger Phase 6
+
+**Branch**: `143-step-ledger-phase6` | **Date**: 2026-04-09 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/143-step-ledger-phase6/spec.md`
+
+## Summary
+
+Harden latest-run semantics for the step-ledger rollout. The backend will reconcile execution-detail run identity to workflow query truth during projection lag, Mission Control will keep secondary artifact reads aligned to the latest step-ledger run, and the completed step-ledger rollout trackers will be retired from `docs/tmp/remaining-work`.
+
+## Technical Context
+
+**Language/Version**: Python 3.11, TypeScript + React 18  
+**Primary Dependencies**: Temporal Python SDK query contract, FastAPI execution router, TanStack Query task-detail page  
+**Storage**: Temporal workflow query state, existing projection tables, artifact APIs only  
+**Testing**: `pytest tests/unit/api/routers/test_executions.py -q`, `pytest tests/contract/test_temporal_execution_api.py -q`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py`  
+**Target Platform**: `/api/executions` read path and Mission Control task-detail UI  
+**Project Type**: Backend read-path hardening, frontend read alignment, doc tracker cleanup  
+**Performance Goals**: Keep detail polling bounded; avoid fetching the full step ledger just to build `progress`; keep latest-run artifact reads correct without introducing cross-run mixing  
+**Constraints**: Preserve public `ExecutionProgress` shape, keep `workflowId` as durable identity, avoid hidden compatibility wrappers, and keep degradation truthful when Temporal queries fail  
+**Scale/Scope**: `MoonMind.Run` progress query contract, execution router detail hydration, task-detail artifact query keying, and tmp tracker retirement
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The workflow query remains the owner of latest-run truth; the router and UI only consume it.
+- **IV. Own Your Data**: PASS. Artifact reads stay artifact-backed and run-scoped; no logs or step history move into workflow state.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The external `progress` contract stays stable while internal query reconciliation is tightened.
+- **IX. Resilient by Default**: PASS. The work targets projection lag, degraded reads, and Continue-As-New correctness with automated coverage.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Phase 6 gets its own feature package and task list.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. The implementation removes finished tmp rollout bullets instead of leaving stale backlog text.
+- **XIII. Pre-Release Delete, Don't Deprecate**: PASS. The cleanup retires completed rollout notes rather than preserving stale migration checklists.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/143-step-ledger-phase6/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── requirements-traceability.md
+│   └── latest-run-hardening-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/workflows/run.py            # MODIFY: expose latest queried run id on bounded progress payload
+api_service/api/routers/executions.py                  # MODIFY: reconcile execution-detail run identity from progress-query truth
+tests/unit/api/routers/test_executions.py              # MODIFY: latest-run reconciliation coverage
+tests/contract/test_temporal_execution_api.py          # MODIFY: public-contract latest-run reconciliation coverage
+frontend/src/entrypoints/task-detail.tsx               # MODIFY: keep execution-wide artifact reads aligned to the latest step-ledger run
+frontend/src/entrypoints/task-detail.test.tsx          # MODIFY: browser coverage for latest-run artifact alignment
+docs/tmp/remaining-work/*.md                           # MODIFY: retire completed step-ledger rollout tracker bullets
+```
+
+**Structure Decision**: Keep run reconciliation at the workflow-query and router boundary instead of building another projection or compatibility layer. The frontend only consumes the resulting latest-run identity.
+
+## Complexity Tracking
+
+The main risk is accidentally changing the public `progress` contract while trying to carry enough latest-run metadata to reconcile stale projections. Mitigation: keep the extra latest-run signal internal to the workflow/router exchange, validate the public `ExecutionProgressModel` unchanged, and add contract tests that assert `progress` stays bounded while `runId` is corrected.

--- a/specs/143-step-ledger-phase6/quickstart.md
+++ b/specs/143-step-ledger-phase6/quickstart.md
@@ -1,0 +1,39 @@
+# Quickstart: Step Ledger Phase 6
+
+## 1. Verify latest-run reconciliation in the execution router
+
+```bash
+pytest tests/unit/api/routers/test_executions.py -q
+```
+
+Focus:
+
+- execution detail adopts the queried latest `runId`
+- `progress` remains bounded and public-shape compatible
+
+## 2. Verify public contract behavior
+
+```bash
+pytest tests/contract/test_temporal_execution_api.py -q
+```
+
+Focus:
+
+- latest-run-only detail and steps semantics remain intact across mocked query lag
+- degraded/read-repair flows still pass
+
+## 3. Verify Mission Control latest-run artifact alignment
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
+```
+
+Focus:
+
+- generic Artifacts reads switch to the latest run once the step ledger resolves
+
+## 4. Run final unit verification
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py
+```

--- a/specs/143-step-ledger-phase6/research.md
+++ b/specs/143-step-ledger-phase6/research.md
@@ -1,0 +1,21 @@
+# Research: Step Ledger Phase 6
+
+## Decision 1: Reconcile detail `runId` from the existing progress query instead of issuing a second latest-run query
+
+- **Decision**: Reuse the already-required `get_progress` query to carry an internal latest-run identifier for router reconciliation, while keeping the external `ExecutionProgress` API shape unchanged.
+- **Rationale**: Detail reads already pay for the bounded progress query. Reusing that query keeps detail polling cheap and avoids adding a second workflow roundtrip solely to repair stale projection `runId` values.
+- **Alternatives considered**:
+  - Query the full step ledger on every detail read. Rejected because it duplicates the later `/steps` fetch and inflates the detail read path.
+  - Trust the projection row until it refreshes. Rejected because it leaves detail and step-ledger run identity inconsistent during Continue-As-New lag.
+
+## Decision 2: Keep generic execution-wide artifacts keyed to the latest run once the Steps query resolves
+
+- **Decision**: Mission Control should use the latest run exposed by the step ledger for generic execution-wide artifact reads whenever that latest-run data is available.
+- **Rationale**: The page is explicitly latest-run-only. If the step ledger has already moved to the new run, the secondary Artifacts panel must not keep reading the old run's artifact namespace.
+- **Alternatives considered**:
+  - Keep using the initial execution-detail `runId`. Rejected because it can lag behind the workflow query during Continue-As-New rollover.
+
+## Decision 3: Retire completed tmp rollout bullets rather than rewriting canonical docs
+
+- **Decision**: Remove the step-ledger rollout bullets from the relevant `docs/tmp/remaining-work` files once Phase 6 tests pass.
+- **Rationale**: Constitution Principle XII says completed migration/backlog notes should be removed rather than left behind after the work is done.

--- a/specs/143-step-ledger-phase6/spec.md
+++ b/specs/143-step-ledger-phase6/spec.md
@@ -1,0 +1,101 @@
+# Feature Specification: Step Ledger Phase 6
+
+**Feature Branch**: `143-step-ledger-phase6`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 6 using test-driven development of the step-ledger rollout plan. Harden latest-run semantics, degraded reads, Continue-As-New behavior, and rollout cleanup so task detail remains truthful and bounded across reruns and projection drift."
+
+## Source Document Requirements
+
+Source: `docs/Temporal/StepLedgerAndProgressModel.md`, `docs/Temporal/RunHistoryAndRerunSemantics.md`, `docs/Temporal/SourceOfTruthAndProjectionModel.md`, `docs/Temporal/WorkflowArtifactSystemDesign.md`, `docs/UI/MissionControlArchitecture.md`, `docs/tmp/remaining-work/*step-ledger rollout trackers`
+
+| ID | Source Section | Requirement Summary |
+| --- | --- | --- |
+| DOC-REQ-001 | `StepLedgerAndProgressModel` §4-§10 | Default task detail and `/api/executions/{workflowId}/steps` must stay latest-run-only, with attempt identity scoped by `(workflowId, runId, logicalStepId, attempt)`. |
+| DOC-REQ-002 | `RunHistoryAndRerunSemantics` §5-§8 | `workflowId` stays stable across rerun and Continue-As-New while `runId` rotates, and task-oriented detail should continue following the same logical execution. |
+| DOC-REQ-003 | `SourceOfTruthAndProjectionModel` §5-§9 | Temporal remains authoritative for latest `runId`; projection-backed reads may degrade or repair, but must not invent stale latest-run truth. |
+| DOC-REQ-004 | `WorkflowArtifactSystemDesign` §1, §5.2 | Generic artifact browsing must remain run-scoped and artifact-backed, not reconstructed from workflow state or mixed across run boundaries. |
+| DOC-REQ-005 | `MissionControlArchitecture` §9.2 | Task detail should keep the Steps surface primary while secondary evidence panels still follow the latest/current run. |
+| DOC-REQ-006 | `tmp/remaining-work` step-ledger trackers | API, workflow, artifact, UI, architecture, and run-history rollout trackers should be retired once implementation and verification land. |
+
+## User Scenarios & Testing
+
+### User Story 1 - Execution detail follows the workflow's latest run during projection lag (Priority: P1)
+
+An operator opens a task detail page during Continue-As-New or rerun churn and expects the visible run identity to match the workflow's latest run, not a stale projection row.
+
+**Why this priority**: If detail reads show an old `runId` while the step ledger is already on the new run, the page becomes internally inconsistent.
+
+**Independent Test**: Simulate a stale projection-backed execution detail record plus a workflow progress query that reports a newer `runId`, then assert the execution detail response and task-detail page follow the queried latest run.
+
+**Acceptance Scenarios**:
+
+1. **Given** execution detail is loaded from a stale projection row, **When** the progress query reports a newer latest run, **Then** the response uses the queried `runId` while keeping the bounded `progress` payload unchanged.
+2. **Given** the Steps query reports a newer latest run than the initial detail payload, **When** Mission Control loads secondary run-scoped artifacts, **Then** those reads use the latest run rather than the stale run.
+
+---
+
+### User Story 2 - Latest-run semantics remain truthful through degraded reads and repair (Priority: P1)
+
+An operator or API caller hits degraded-mode execution reads and expects truthful latest-run behavior rather than fabricated or mixed historical state.
+
+**Why this priority**: Phase 6 exists to harden the system around failure modes after the earlier feature phases shipped.
+
+**Independent Test**: Exercise public and unit-level reads with projection fallback, orphaned-row repair, and rerun/Continue-As-New transitions, then assert latest-run-only behavior and honest degraded responses remain intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** Temporal sync fails but a projection fallback exists, **When** execution detail is requested, **Then** the API degrades honestly and still keeps `workflowId` anchored to one logical execution.
+2. **Given** an orphaned projection row is repaired from canonical state, **When** the task detail is read again, **Then** only the latest run is surfaced and old run identities are not mixed into the default view.
+
+---
+
+### User Story 3 - Step-ledger rollout trackers are retired after hardening lands (Priority: P2)
+
+An engineer reading canonical docs should no longer see already-finished step-ledger rollout work lingering in `docs/tmp/remaining-work`.
+
+**Why this priority**: Constitution Principle XII requires finishing migration work by deleting or retiring completed rollout notes.
+
+**Independent Test**: Review the owning tmp tracker files after implementation and confirm the step-ledger rollout bullets covered by Phases 1-6 are removed.
+
+**Acceptance Scenarios**:
+
+1. **Given** Phase 6 verification is complete, **When** the tmp tracker files are inspected, **Then** the step-ledger rollout bullets for API, workflow, artifact, UI, architecture, and run-history hardening are gone.
+
+### Edge Cases
+
+- What happens when the progress query is unavailable? Detail reads remain honest, keep `progress` as `null`, and do not fabricate a newer `runId`.
+- What happens when the Steps query returns a newer run after the initial detail fetch? The task-detail page should align secondary latest-run evidence with the step-ledger run.
+- What happens when the projection row is stale but still authoritative enough to authorize ownership? The router may use it for access checks, but latest-run display state should prefer workflow query truth when available.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST reconcile execution-detail `runId` to the workflow's latest queried run when bounded latest-run query data is available, without exposing extra non-contract fields in `progress`. Mappings: DOC-REQ-001, DOC-REQ-002, DOC-REQ-003.
+- **FR-002**: System MUST keep secondary task-detail evidence reads aligned to the latest/current run once the step ledger is loaded. Mappings: DOC-REQ-001, DOC-REQ-004, DOC-REQ-005.
+- **FR-003**: System MUST preserve honest degraded-read behavior for projection fallback and repair flows, keeping `workflowId` stable and latest-run-only semantics intact. Mappings: DOC-REQ-002, DOC-REQ-003.
+- **FR-004**: System MUST add automated coverage for rerun / Continue-As-New latest-run semantics at the workflow-boundary, router/contract, and Mission Control levels where applicable. Mappings: DOC-REQ-001, DOC-REQ-002, DOC-REQ-003, DOC-REQ-005.
+- **FR-005**: System MUST retire the completed step-ledger rollout bullets from the tmp tracking docs once the hardening work is verified. Mappings: DOC-REQ-006.
+- **FR-006**: System MUST implement production runtime code changes plus validation tests in this phase; docs-only cleanup is insufficient. Mappings: DOC-REQ-001 through DOC-REQ-005.
+
+### Key Entities
+
+- **LatestRunExecutionRead**: The execution-detail payload after reconciling bounded progress-query latest-run truth with the projection-backed base record.
+- **RunScopedArtifactRead**: Task-detail artifact fetch behavior keyed to the latest/current run rather than a stale detail snapshot.
+- **ProjectionRepairReadMode**: Truthful degraded/read-repair behavior for detail reads when Temporal sync or projection state drifts.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Unit and contract tests prove execution detail prefers the queried latest `runId` during projection lag while keeping `progress` bounded.
+- **SC-002**: Browser tests prove secondary artifact reads on task detail follow the latest run exposed by the step ledger.
+- **SC-003**: Existing repair/degraded-read tests continue passing with no mixed-run regressions.
+- **SC-004**: `pytest tests/unit/api/routers/test_executions.py -q`, `pytest tests/contract/test_temporal_execution_api.py -q`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py` pass.
+
+## Assumptions
+
+- Phase 6 hardens the latest-run read path and rollout cleanup; it does not introduce a new historical-runs UI.
+- Projection repair behavior already exists and is being tightened, not redesigned.
+- The bounded `progress` API contract remains unchanged externally even if the workflow/router exchange carries extra internal reconciliation metadata.

--- a/specs/143-step-ledger-phase6/speckit_analyze_report.md
+++ b/specs/143-step-ledger-phase6/speckit_analyze_report.md
@@ -1,0 +1,16 @@
+# Speckit Analyze Report: Step Ledger Phase 6
+
+## Result
+
+Safe to Implement: YES
+
+## Findings
+
+- No spec/plan/tasks consistency blockers found for the Phase 6 scope.
+- Runtime scope is satisfied because the task list requires backend and frontend production code changes plus validation tests.
+- Source-traceability requirements are mapped through `contracts/requirements-traceability.md`.
+
+## Residual Risks
+
+- Latest-run reconciliation must not leak extra internal fields through the public `progress` API contract.
+- Browser coverage must confirm the generic Artifacts panel follows the latest run once the Steps query resolves.

--- a/specs/143-step-ledger-phase6/tasks.md
+++ b/specs/143-step-ledger-phase6/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: Step Ledger Phase 6
+
+**Input**: Design documents from `/specs/143-step-ledger-phase6/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing router/contract/browser tests before implementing the corresponding behavior.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create the Phase 6 feature package and traceability artifacts under `specs/143-step-ledger-phase6/`.
+
+---
+
+## Phase 2: User Story 1 - Execution detail follows the workflow's latest run during projection lag (Priority: P1)
+
+**Goal**: Backend detail reads and task-detail latest-run state remain internally consistent through Continue-As-New lag.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Write failing router tests in `tests/unit/api/routers/test_executions.py` covering latest-run `runId` reconciliation from the bounded progress query.
+- [X] T003 [P] [US1] Write failing public-contract coverage in `tests/contract/test_temporal_execution_api.py` proving execution detail follows the queried latest run without changing the public `progress` shape.
+- [X] T004 [P] [US1] Write failing workflow-query coverage in `tests/unit/workflows/temporal/workflows/test_run_step_ledger.py` for latest-run metadata carried on the bounded progress query payload.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update `moonmind/workflows/temporal/workflows/run.py` so the bounded progress query carries internal latest-run metadata.
+- [X] T006 [US1] Update `api_service/api/routers/executions.py` so execution detail adopts the queried latest `runId` while returning the same public `progress` contract.
+
+---
+
+## Phase 3: User Story 2 - Latest-run semantics remain truthful through degraded reads and repair (Priority: P1)
+
+**Goal**: Secondary task-detail evidence and repair/degraded reads stay latest-run-only.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Write failing browser coverage in `frontend/src/entrypoints/task-detail.test.tsx` proving generic artifact reads switch to the latest run exposed by the step ledger.
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Update `frontend/src/entrypoints/task-detail.tsx` so execution-wide artifact reads use the latest resolved run id rather than a stale detail snapshot.
+
+---
+
+## Phase 4: User Story 3 - Step-ledger rollout trackers are retired (Priority: P2)
+
+**Goal**: Remove completed step-ledger rollout backlog bullets from tmp trackers.
+
+### Implementation for User Story 3
+
+- [X] T009 [US3] Retire completed step-ledger rollout bullets from the relevant `docs/tmp/remaining-work/*.md` tracker files.
+
+---
+
+## Phase 5: Validation
+
+- [ ] T010 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T011 Run `pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`
+- [X] T012 Run `pytest tests/unit/api/routers/test_executions.py -q`
+- [X] T013 Run `pytest tests/contract/test_temporal_execution_api.py -q`
+- [ ] T014 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [ ] T015 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **User Story 1 (Phase 2)**: Depends on Setup.
+- **User Story 2 (Phase 3)**: Depends on the latest-run identity work from User Story 1.
+- **User Story 3 (Phase 4)**: Depends on verification that the hardening work is implemented.
+- **Validation (Phase 5)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- T002, T003, and T004 can be written in parallel before backend implementation.
+- T007 can be written in parallel with the backend work once the latest-run contract is fixed.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add failing backend tests for queried latest-run reconciliation.
+2. Reconcile execution detail `runId` from workflow query truth without changing the public `progress` contract.
+3. Align the task-detail generic artifact panel to the latest run.
+4. Retire completed tmp trackers and run final verification.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -151,6 +151,7 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             assert describe_body["artifactRefs"] == ["artifact://input/123"]
             query_state[workflow_id] = {
                 "get_progress": {
+                    "runId": "run-query-latest",
                     "total": 2,
                     "pending": 1,
                     "ready": 0,
@@ -166,7 +167,7 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
                 },
                 "get_step_ledger": {
                     "workflowId": workflow_id,
-                    "runId": describe_body["runId"],
+                    "runId": "run-query-latest",
                     "runScope": "latest",
                     "steps": [
                         {
@@ -209,8 +210,11 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             describe_response = await client.get(f"/api/executions/{workflow_id}")
             assert describe_response.status_code == 200
             describe_body = describe_response.json()
+            assert describe_body["runId"] == "run-query-latest"
+            assert describe_body["temporalRunId"] == "run-query-latest"
             assert describe_body["progress"]["running"] == 1
             assert describe_body["progress"]["currentStepTitle"] == "Run tests"
+            assert "runId" not in describe_body["progress"]
             assert describe_body["stepsHref"] == f"/api/executions/{workflow_id}/steps"
             original_temporal_run_id = describe_response.json()["temporalRunId"]
 
@@ -218,6 +222,7 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             assert steps_response.status_code == 200
             steps_body = steps_response.json()
             assert steps_body["workflowId"] == workflow_id
+            assert steps_body["runId"] == "run-query-latest"
             assert steps_body["runScope"] == "latest"
             assert steps_body["steps"][0]["refs"]["taskRunId"] == "task-run-123"
 
@@ -277,6 +282,9 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             assert rerun_response.status_code == 200
             assert rerun_response.json()["accepted"] is True
             assert rerun_response.json()["applied"] == "continue_as_new"
+            latest_rerun_run_id = rerun_response.json()["execution"]["runId"]
+            query_state[workflow_id]["get_progress"]["runId"] = latest_rerun_run_id
+            query_state[workflow_id]["get_step_ledger"]["runId"] = latest_rerun_run_id
 
             rerun_detail = await client.get(f"/api/executions/{workflow_id}")
             assert rerun_detail.status_code == 200
@@ -285,6 +293,7 @@ async def test_execution_lifecycle_endpoints_contract(tmp_path, query_state):
             assert rerun_execution["workflowId"] == workflow_id
             assert rerun_execution["detailHref"] == f"/tasks/{workflow_id}"
             assert rerun_execution["temporalRunId"] != original_temporal_run_id
+            assert rerun_execution["temporalRunId"] == latest_rerun_run_id
 
             pause_response = await client.post(
                 f"/api/executions/{workflow_id}/signal",

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1324,6 +1324,56 @@ def test_describe_execution_includes_latest_run_progress() -> None:
     }
 
 
+def test_describe_execution_prefers_progress_query_run_id_when_newer_latest_run() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        progress={
+            "runId": "run-99",
+            "total": 3,
+            "pending": 0,
+            "ready": 1,
+            "running": 1,
+            "awaitingExternal": 0,
+            "reviewing": 0,
+            "succeeded": 1,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": "Run tests",
+            "updatedAt": "2026-04-08T12:00:00Z",
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["runId"] == "run-99"
+    assert payload["temporalRunId"] == "run-99"
+    assert payload["progress"] == {
+        "total": 3,
+        "pending": 0,
+        "ready": 1,
+        "running": 1,
+        "awaitingExternal": 0,
+        "reviewing": 0,
+        "succeeded": 1,
+        "failed": 0,
+        "skipped": 0,
+        "canceled": 0,
+        "currentStepTitle": "Run tests",
+        "updatedAt": "2026-04-08T12:00:00Z",
+    }
+    assert "runId" not in payload["progress"]
+
+
 def test_describe_execution_leaves_progress_null_when_query_fails() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_step_ledger.py
@@ -155,6 +155,25 @@ def test_run_initializes_latest_run_step_ledger(monkeypatch: pytest.MonkeyPatch)
     assert progress["pending"] == 1
 
 
+def test_run_progress_query_exposes_current_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindRunWorkflow()
+    now = datetime(2026, 4, 7, 12, 0, tzinfo=UTC)
+
+    workflow._initialize_step_ledger(
+        ordered_nodes=_ordered_nodes(),
+        dependency_map=_dependency_map(),
+        updated_at=now,
+    )
+
+    progress = workflow.get_progress()
+
+    assert progress["runId"] == "run-1"
+    assert progress["total"] == 2
+
+
 def test_run_tracks_status_transitions_and_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure_workflow_runtime(monkeypatch)
     workflow = MoonMindRunWorkflow()


### PR DESCRIPTION
## Summary
This finishes Step Ledger Phase 6 hardening.

- reconcile execution detail `runId` / `temporalRunId` from workflow latest-run query truth during projection lag
- keep Mission Control execution-wide artifact reads aligned to the latest run exposed by the step ledger
- add Phase 6 spec artifacts and coverage for latest-run reconciliation
- retire completed step-ledger rollout bullets from the tmp tracking docs

## Why
During Continue-As-New or rerun churn, execution detail could show a stale projection-backed run id while `/api/executions/{workflowId}/steps` was already on the newer run. That left the task-detail page internally inconsistent and could point generic artifact browsing at the wrong run.

## Validation
Passed:
- `.venv/bin/python -m pytest tests/unit/workflows/temporal/workflows/test_run_step_ledger.py -q`
- `.venv/bin/python -m pytest tests/unit/api/routers/test_executions.py -q`
- `.venv/bin/python -m pytest tests/contract/test_temporal_execution_api.py -q`
- `.venv/bin/python -m pytest tests/unit/specs/test_doc_req_traceability.py -q`
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx -t "loads execution-wide artifacts against the latest run exposed by the step ledger"`

Known existing failure not introduced by this change:
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py tests/unit/workflows/temporal/workflows/test_run_step_ledger.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`

Both stop on a pre-existing `LiveLogsPanel` EventSource test failure in `frontend/src/entrypoints/task-detail.test.tsx`.

## Impact
Task detail now stays latest-run-only and internally consistent across reruns / Continue-As-New, including the secondary Artifacts panel.