### PR TITLE
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -174,6 +174,10 @@ h1 {
   line-height: 1;
 }
 
+.masthead h1 {
+  font-size: clamp(1.55rem, 2.35vw, 2.15rem);
+}
+
 .masthead-meta {
   margin: 0.25rem 0 0;
   display: flex;


### PR DESCRIPTION
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps