### PR TITLE
[codex] fix managed Codex detached-HEAD publish failure

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3141,6 +3141,10 @@ class TemporalAgentRuntimeActivities:
             or request.get("publish_base_branch")
             or request.get("publishBaseBranch")
         ) if isinstance(request, Mapping) else None
+        head_branch = (
+            request.get("head_branch")
+            or request.get("headBranch")
+        ) if isinstance(request, Mapping) else None
 
         async def _unused_profile_fetcher(**_kwargs: Any) -> dict[str, Any]:
             return {"profiles": []}
@@ -3213,6 +3217,8 @@ class TemporalAgentRuntimeActivities:
                 push_kwargs: dict[str, Any] = {
                     "target_branch": target_branch,
                 }
+                if isinstance(head_branch, str) and head_branch.strip():
+                    push_kwargs["head_branch"] = head_branch.strip()
                 if (
                     isinstance(raw_commit_message, str)
                     and raw_commit_message.strip()
@@ -3806,6 +3812,7 @@ class TemporalAgentRuntimeActivities:
         run_id: str,
         *,
         target_branch: str | None = None,
+        head_branch: str | None = None,
         commit_message: str | None = None,
     ) -> dict[str, Any]:
         """Push the workspace branch to origin.
@@ -3848,6 +3855,41 @@ class TemporalAgentRuntimeActivities:
             protected = {"main", "master", "HEAD"}
             if target_branch:
                 protected.add(target_branch)
+            if (
+                current_branch == "HEAD"
+                and head_branch
+                and head_branch not in protected
+            ):
+                repair_proc = await asyncio.create_subprocess_exec(
+                    *self._workspace_git_command(
+                        workspace, "checkout", "-B", head_branch,
+                    ),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=command_env,
+                )
+                repair_stdout, repair_stderr = await asyncio.wait_for(
+                    repair_proc.communicate(), timeout=30,
+                )
+                if repair_proc.returncode != 0:
+                    repair_detail = (
+                        repair_stderr.decode("utf-8", errors="replace").strip()
+                        or repair_stdout.decode("utf-8", errors="replace").strip()
+                    )
+                    return {
+                        "push_status": "failed",
+                        "push_error": (
+                            "could not recover detached HEAD onto "
+                            f"'{head_branch}': {repair_detail}"
+                        ),
+                        "push_branch": "HEAD",
+                    }
+                logger.info(
+                    "Recovered detached HEAD for run %s onto branch '%s' before push",
+                    run_id,
+                    head_branch,
+                )
+                current_branch = head_branch
             if not current_branch or current_branch in protected:
                 logger.warning(
                     "Post-agent git push skipped for run %s: "

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3868,9 +3868,18 @@ class TemporalAgentRuntimeActivities:
                     stderr=asyncio.subprocess.PIPE,
                     env=command_env,
                 )
-                repair_stdout, repair_stderr = await asyncio.wait_for(
-                    repair_proc.communicate(), timeout=30,
-                )
+                try:
+                    repair_stdout, repair_stderr = await asyncio.wait_for(
+                        repair_proc.communicate(), timeout=30,
+                    )
+                except asyncio.TimeoutError:
+                    repair_proc.kill()
+                    await repair_proc.wait()
+                    return {
+                        "push_status": "failed",
+                        "push_error": "detached HEAD recovery timed out after 30s",
+                        "push_branch": "HEAD",
+                    }
                 if repair_proc.returncode != 0:
                     repair_detail = (
                         repair_stderr.decode("utf-8", errors="replace").strip()

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -419,7 +419,6 @@ class MoonMindAgentRun:
         )
         branch = str(
             workspace_spec.get("targetBranch")
-            or workspace_spec.get("branch")
             or ""
         ).strip()
         return branch or None

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -408,6 +408,22 @@ class MoonMindAgentRun:
         ).strip()
         return branch or None
 
+    @staticmethod
+    def _request_workspace_target_branch(
+        request: AgentExecutionRequest,
+    ) -> str | None:
+        workspace_spec = (
+            request.workspace_spec
+            if isinstance(request.workspace_spec, Mapping)
+            else {}
+        )
+        branch = str(
+            workspace_spec.get("targetBranch")
+            or workspace_spec.get("branch")
+            or ""
+        ).strip()
+        return branch or None
+
     def _build_managed_fetch_result_activity_input(
         self,
         request: AgentExecutionRequest,
@@ -442,6 +458,14 @@ class MoonMindAgentRun:
         ).strip()
         if target_branch:
             activity_input["target_branch"] = target_branch
+
+        head_branch = str(
+            params.get("targetBranch")
+            or self._request_workspace_target_branch(request)
+            or ""
+        ).strip()
+        if head_branch:
+            activity_input["head_branch"] = head_branch
 
         if _request_selected_skill(request) == "pr-resolver":
             activity_input["pr_resolver_expected"] = True

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -157,6 +157,51 @@ class TestPushWorkspaceBranch:
         assert result["push_status"] == "protected_branch"
 
     @pytest.mark.asyncio
+    async def test_push_recovers_detached_head_to_explicit_head_branch(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        captured_checkout_args = None
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count, captured_checkout_args
+            call_count += 1
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # checkout -B feature branch
+                captured_checkout_args = args
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 3:  # status --porcelain
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="main",
+                head_branch="feature/recover-detached-head",
+            )
+
+        assert result["push_status"] == "pushed"
+        assert result["push_branch"] == "feature/recover-detached-head"
+        assert captured_checkout_args is not None
+        assert captured_checkout_args[-3:] == (
+            "checkout",
+            "-B",
+            "feature/recover-detached-head",
+        )
+
+    @pytest.mark.asyncio
     async def test_push_protected_target_branch(self):
         """target_branch is included in the protected set."""
         store = _make_mock_store()

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
@@ -200,6 +201,41 @@ class TestPushWorkspaceBranch:
             "-B",
             "feature/recover-detached-head",
         )
+
+    @pytest.mark.asyncio
+    async def test_push_detached_head_recovery_timeout_kills_checkout(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        repair_proc = MagicMock()
+        repair_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        repair_proc.wait = AsyncMock(return_value=0)
+        repair_proc.kill = MagicMock()
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:  # rev-parse
+                proc = MagicMock()
+                proc.communicate = AsyncMock(return_value=(b"HEAD\n", b""))
+                proc.returncode = 0
+                return proc
+            if call_count == 2:  # checkout -B feature branch
+                return repair_proc
+            raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch(
+                "run-1",
+                target_branch="main",
+                head_branch="feature/recover-detached-head",
+            )
+
+        assert result["push_status"] == "failed"
+        assert result["push_branch"] == "HEAD"
+        assert result["push_error"] == "detached HEAD recovery timed out after 30s"
+        repair_proc.kill.assert_called_once_with()
+        repair_proc.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_push_protected_target_branch(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -70,9 +70,29 @@ def _managed_session_request(
             "runtimeId": "codex_cli",
             "executionProfileRef": "codex-default",
         },
-        parameters=parameters or {"publishMode": "none"},
-        workspaceSpec=workspace_spec or {},
+        parameters=parameters if parameters is not None else {"publishMode": "none"},
+        workspaceSpec=workspace_spec if workspace_spec is not None else {},
     )
+
+
+async def test_managed_session_request_preserves_explicit_empty_inputs() -> None:
+    request = _managed_session_request(parameters={}, workspace_spec={})
+
+    assert request.parameters == {}
+    assert request.workspace_spec == {}
+
+
+async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_head_branch() -> None:
+    run = MoonMindAgentRun()
+    request = _managed_session_request(
+        parameters={"publishMode": "pr"},
+        workspace_spec={"branch": "main", "startingBranch": "main"},
+    )
+
+    activity_input = run._build_managed_fetch_result_activity_input(request)
+
+    assert activity_input["target_branch"] == "main"
+    assert "head_branch" not in activity_input
 
 
 async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -50,7 +50,11 @@ def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _managed_session_request() -> AgentExecutionRequest:
+def _managed_session_request(
+    *,
+    parameters: dict[str, Any] | None = None,
+    workspace_spec: dict[str, Any] | None = None,
+) -> AgentExecutionRequest:
     return AgentExecutionRequest(
         agentKind="managed",
         agentId="codex",
@@ -66,7 +70,8 @@ def _managed_session_request() -> AgentExecutionRequest:
             "runtimeId": "codex_cli",
             "executionProfileRef": "codex-default",
         },
-        parameters={"publishMode": "none"},
+        parameters=parameters or {"publishMode": "none"},
+        workspaceSpec=workspace_spec or {},
     )
 
 
@@ -347,6 +352,150 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
         "agent_runtime.fetch_result",
         "agent_runtime.publish_artifacts",
     ]
+
+
+async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId="managed-session-run-publish",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+        async def status(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="completed",
+            )
+
+        async def fetch_result(self, run_id: str) -> AgentRunResult:
+            raise AssertionError(
+                "Terminal managed-session runs should fetch results through "
+                "agent_runtime.fetch_result"
+            )
+
+        async def cancel(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="canceled",
+            )
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        run.completion_event.set()
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.fetch_result":
+            return {"summary": "Managed publish success", "metadata": {}}
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": _managed_session_request().managed_session.model_dump(
+                    mode="json",
+                    by_alias=True,
+                ),
+                "status": "active",
+                "containerId": None,
+                "threadId": None,
+                "activeTurnId": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.prepare_turn_instructions":
+            return "Prepared publish instructions"
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "CodexSessionAdapter",
+        _FakeCodexSessionAdapter,
+    )
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(
+        _managed_session_request(
+            parameters={"publishMode": "pr"},
+            workspace_spec={
+                "startingBranch": "main",
+                "targetBranch": "feature/recover-detached-head",
+            },
+        )
+    )
+
+    assert result.summary == "Managed publish success"
+    fetch_payload = next(
+        payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
+    )
+    assert fetch_payload["publish_mode"] == "pr"
+    assert fetch_payload["target_branch"] == "main"
+    assert fetch_payload["head_branch"] == "feature/recover-detached-head"
 
 
 async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(


### PR DESCRIPTION
## Summary
This change fixes managed Codex publish failures when the agent step succeeds but the workspace ends the run on detached `HEAD`.

## What Changed
- Passed both the publish base branch and intended work branch through the managed fetch-result activity input.
- Updated the publish activity to recover detached `HEAD` onto the known work branch before attempting `git push`.
- Added unit coverage for detached-`HEAD` recovery in the publish activity.
- Added workflow-boundary coverage to ensure managed Codex session runs pass the publish branch context through to the activity.

## Root Cause
The failing workflow completed its single managed Codex step successfully, but the managed session left the repository on detached `HEAD`. The publish stage treated that state as a protected branch failure and marked the entire workflow failed even though the code change itself had succeeded.

## Impact
Managed Codex runs that finish with detached `HEAD` now recover onto the intended work branch and continue publishing instead of failing at finalization.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
- `./tools/test_unit.sh`