### PR TITLE
Implement live logs phase 6 compatibility

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -117,7 +117,7 @@ def _build_default_attachment_policy(config: "dict[str, Any]") -> dict[str, Any]
     }
 
 
-def _build_live_logs_feature_config() -> dict[str, object]:
+def build_live_logs_feature_config() -> dict[str, object]:
     """Build the grouped Live Logs feature flags for dashboard consumers."""
 
     return {
@@ -241,7 +241,7 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "submitEnabled": bool(temporal_dashboard.submit_enabled),
                 "debugFieldsEnabled": bool(temporal_dashboard.debug_fields_enabled),
             },
-            **_build_live_logs_feature_config(),
+            **build_live_logs_feature_config(),
         },
         "system": {
             **system_metadata,
@@ -290,4 +290,9 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
     }
 
 
-__all__ = ["build_runtime_config", "normalize_status", "status_maps"]
+__all__ = [
+    "build_live_logs_feature_config",
+    "build_runtime_config",
+    "normalize_status",
+    "status_maps",
+]

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -2,7 +2,12 @@ import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { renderWithClient } from '../utils/test-utils';
-import { expandRouteTemplate, getSessionProjectionRefetchInterval, TaskDetailPage } from './task-detail';
+import {
+  expandRouteTemplate,
+  getSessionProjectionRefetchInterval,
+  normalizeObservabilityEvent,
+  TaskDetailPage,
+} from './task-detail';
 import { BootPayload } from '../boot/parseBootPayload';
 import { MockInstance } from 'vitest';
 
@@ -69,7 +74,7 @@ class MockEventSource {
   }
 
   triggerLogChunk(
-    data: { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
+    data: Record<string, unknown> & { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
   ) {
     const event = new MessageEvent('log_chunk', {
       data: JSON.stringify({
@@ -81,7 +86,7 @@ class MockEventSource {
   }
 
   triggerMessage(
-    data: { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
+    data: Record<string, unknown> & { sequence: number; stream: string; text: string; timestamp?: string; kind?: string },
   ) {
     this.onmessage?.(
       new MessageEvent('message', {
@@ -1993,6 +1998,14 @@ describe('LiveLogsPanel', () => {
     state: 'succeeded',
     rawState: 'succeeded',
   };
+  const codexExecution = {
+    ...activeExecution,
+    targetRuntime: 'codex_cli',
+  };
+  const geminiExecution = {
+    ...activeExecution,
+    targetRuntime: 'gemini_cli',
+  };
   const sessionTimelinePayload: BootPayload = {
     page: 'task-detail',
     apiBase: '/api',
@@ -2001,6 +2014,45 @@ describe('LiveLogsPanel', () => {
         features: {
           logStreamingEnabled: true,
           liveLogsSessionTimelineEnabled: true,
+        },
+      },
+    },
+  };
+  const codexManagedRolloutPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: true,
+          liveLogsSessionTimelineRollout: 'codex_managed',
+        },
+      },
+    },
+  };
+  const allManagedRolloutPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: true,
+          liveLogsSessionTimelineRollout: 'all_managed',
+        },
+      },
+    },
+  };
+  const rolloutOffPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: true,
+          liveLogsSessionTimelineRollout: 'off',
         },
       },
     },
@@ -2184,7 +2236,7 @@ describe('LiveLogsPanel', () => {
 
     // After fetch sequence completes, SSE is created and can be opened
     await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-    const es = MockEventSource.instances[0]!;
+    const es = MockEventSource.instances.at(-1)!;
 
     act(() => es.triggerOpen());
     await waitFor(() => expect(screen.getByText(/Connected/)).toBeTruthy());
@@ -2210,7 +2262,7 @@ describe('LiveLogsPanel', () => {
     fireEvent.click(await screen.findByText('Live Logs'));
 
     await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-    const es = MockEventSource.instances[0]!;
+    const es = MockEventSource.instances.at(-1)!;
 
     act(() => es.triggerOpen());
     act(() => es.triggerLogChunk({ sequence: 0, stream: 'stdout', text: 'live line\n' }));
@@ -2322,7 +2374,7 @@ describe('LiveLogsPanel', () => {
     fireEvent.click(await screen.findByText('Live Logs'));
 
     await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
-    const es = MockEventSource.instances[0]!;
+    const es = MockEventSource.instances.at(-1)!;
     act(() => es.triggerOpen());
 
     // Transition to terminal state on next poll
@@ -2759,6 +2811,171 @@ describe('LiveLogsPanel', () => {
 
     expect(screen.getByTestId('live-logs-legacy-viewer')).toBeTruthy();
     expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+  });
+
+  it('enables the session timeline for codex managed runs when rollout is codex_managed', async () => {
+    mockFetchSequence(codexExecution, activeSummary, 'codex rollout line\n');
+    renderWithClient(<TaskDetailPage payload={codexManagedRolloutPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/codex rollout line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-timeline-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-legacy-viewer')).toBeNull();
+  });
+
+  it('keeps non-codex runs on the legacy viewer when rollout is codex_managed', async () => {
+    mockFetchSequence(geminiExecution, activeSummary, 'gemini rollout line\n');
+    renderWithClient(<TaskDetailPage payload={codexManagedRolloutPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/gemini rollout line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-legacy-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+  });
+
+  it('enables the session timeline for managed runs when rollout is all_managed', async () => {
+    mockFetchSequence(geminiExecution, activeSummary, 'all managed line\n');
+    renderWithClient(<TaskDetailPage payload={allManagedRolloutPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/all managed line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-timeline-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-legacy-viewer')).toBeNull();
+  });
+
+  it('prefers the legacy viewer when rollout is off even if the boolean flag is true', async () => {
+    mockFetchSequence(codexExecution, activeSummary, 'rollout off line\n');
+    renderWithClient(<TaskDetailPage payload={rolloutOffPayload} />);
+
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/rollout off line/)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('live-logs-legacy-viewer')).toBeTruthy();
+    expect(screen.queryByTestId('live-logs-timeline-viewer')).toBeNull();
+  });
+
+  it('falls back to merged logs when structured history succeeds with zero events', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({ ok: true, json: async () => endedSummary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ events: [], truncated: false }),
+        } as Response);
+      }
+      if (url.includes('/logs/merged')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => 'empty history fallback line\n',
+        } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => terminalExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/empty history fallback line/)).toBeTruthy();
+    });
+  });
+
+  it('derives session badges from camelCase historical event metadata', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            summary: {
+              status: 'completed',
+              supportsLiveStreaming: false,
+              liveStreamStatus: 'ended',
+            },
+          }),
+        } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                sequence: 1,
+                timestamp: '2026-04-08T00:00:01Z',
+                stream: 'session',
+                kind: 'turn_started',
+                text: 'Camel case turn started',
+                sessionId: 'sess:wf-task-1:codex_cli',
+                sessionEpoch: 5,
+                containerId: 'ctr-camel',
+                threadId: 'thread-camel',
+                activeTurnId: 'turn-camel',
+              },
+            ],
+            truncated: false,
+          }),
+        } as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => codexExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={sessionTimelinePayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText('sess:wf-task-1:codex_cli')).toBeTruthy();
+      expect(screen.getByText('ctr-camel')).toBeTruthy();
+      expect(screen.getByText('thread-camel')).toBeTruthy();
+      expect(screen.getByText('turn-camel')).toBeTruthy();
+    });
+  });
+
+  it('normalizes camelCase observability event metadata into the canonical session fields', () => {
+    expect(
+      normalizeObservabilityEvent({
+        sequence: 11,
+        timestamp: '2026-04-08T00:00:11Z',
+        stream: 'session',
+        text: 'Camel case SSE turn started',
+        kind: 'turn_started',
+        sessionId: 'sess:wf-task-1:codex_cli',
+        sessionEpoch: 6,
+        containerId: 'ctr-live-camel',
+        threadId: 'thread-live-camel',
+        activeTurnId: 'turn-live-camel',
+      }),
+    ).toMatchObject({
+      session_id: 'sess:wf-task-1:codex_cli',
+      session_epoch: 6,
+      container_id: 'ctr-live-camel',
+      thread_id: 'thread-live-camel',
+      active_turn_id: 'turn-live-camel',
+    });
   });
 
   it('renders the timeline viewer with ANSI-aware output when the session timeline feature flag is enabled', async () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1036,12 +1036,6 @@ function mapEventsToTimelineRows(
   return payload.events.flatMap((event) => eventToTimelineRows(event));
 }
 
-function hasRenderableObservabilityHistory(
-  payload: z.infer<typeof ObservabilityEventsResponseSchema> | null | undefined,
-): boolean {
-  return mapEventsToTimelineRows(payload).length > 0;
-}
-
 function deriveSessionSnapshotFromEvent(
   event: ObservabilityEvent,
   previous: SessionSnapshot | null,
@@ -1629,7 +1623,7 @@ function LiveLogsPanel({
   });
   const historyRows = useMemo(() => mapEventsToTimelineRows(historyQuery.data), [historyQuery.data]);
   const historyUnavailable = historyQuery.isError || historyQuery.data === null;
-  const historyEmpty = historyQuery.isSuccess && !hasRenderableObservabilityHistory(historyQuery.data);
+  const historyEmpty = historyQuery.isSuccess && historyRows.length === 0;
 
   // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -25,8 +25,57 @@ type DashboardConfig = {
   };
 };
 
+type LiveLogsSessionTimelineRollout = 'off' | 'internal' | 'codex_managed' | 'all_managed';
+
 const GITHUB_PULL_REQUEST_PATH_PATTERN = /^\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+$/i;
 const SESSION_PROJECTION_POLL_MS = 5000;
+
+function normalizeLiveLogsSessionTimelineRollout(
+  value: string | null | undefined,
+): LiveLogsSessionTimelineRollout | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (
+    normalized === 'off'
+    || normalized === 'internal'
+    || normalized === 'codex_managed'
+    || normalized === 'all_managed'
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function isCodexManagedRuntime(runtimeId: string | null | undefined): boolean {
+  const normalized = String(runtimeId || '').trim().toLowerCase();
+  return normalized === 'codex' || normalized === 'codex_cli';
+}
+
+function shouldEnableSessionTimelineViewer({
+  config,
+  targetRuntime,
+  taskRunId,
+}: {
+  config: DashboardConfig | undefined;
+  targetRuntime: string | null | undefined;
+  taskRunId: string | null | undefined;
+}): boolean {
+  const rollout = normalizeLiveLogsSessionTimelineRollout(
+    config?.features?.liveLogsSessionTimelineRollout,
+  );
+  if (rollout === 'off') {
+    return false;
+  }
+  if (rollout === 'internal') {
+    return true;
+  }
+  if (rollout === 'codex_managed') {
+    return isCodexManagedRuntime(targetRuntime);
+  }
+  if (rollout === 'all_managed') {
+    return Boolean(String(taskRunId || '').trim());
+  }
+  return config?.features?.liveLogsSessionTimelineEnabled === true;
+}
 
 export function getSessionProjectionRefetchInterval(
   isTerminal: boolean,
@@ -258,7 +307,7 @@ const ObservabilitySummarySchema = z.object({
   sessionSnapshot: SessionSnapshotSchema.nullable().optional(),
 });
 
-const ObservabilityEventSchema = z
+const RawObservabilityEventSchema = z
   .object({
     sequence: z.number(),
     timestamp: z.string(),
@@ -266,15 +315,43 @@ const ObservabilityEventSchema = z
     text: z.string(),
     offset: z.number().nullable().optional(),
     kind: z.string().nullable().optional(),
+    sessionId: z.string().nullable().optional(),
     session_id: z.string().nullable().optional(),
+    sessionEpoch: z.number().nullable().optional(),
     session_epoch: z.number().nullable().optional(),
+    containerId: z.string().nullable().optional(),
     container_id: z.string().nullable().optional(),
+    threadId: z.string().nullable().optional(),
     thread_id: z.string().nullable().optional(),
+    turnId: z.string().nullable().optional(),
     turn_id: z.string().nullable().optional(),
+    activeTurnId: z.string().nullable().optional(),
     active_turn_id: z.string().nullable().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();
+
+export function normalizeObservabilityEvent(event: z.infer<typeof RawObservabilityEventSchema>) {
+  return {
+    sequence: event.sequence,
+    timestamp: event.timestamp,
+    stream: event.stream,
+    text: event.text,
+    offset: event.offset ?? null,
+    kind: event.kind ?? null,
+    session_id: event.session_id ?? event.sessionId ?? null,
+    session_epoch: event.session_epoch ?? event.sessionEpoch ?? null,
+    container_id: event.container_id ?? event.containerId ?? null,
+    thread_id: event.thread_id ?? event.threadId ?? null,
+    turn_id: event.turn_id ?? event.turnId ?? null,
+    active_turn_id: event.active_turn_id ?? event.activeTurnId ?? null,
+    metadata: event.metadata ?? {},
+  };
+}
+
+const ObservabilityEventSchema = RawObservabilityEventSchema.transform((event) =>
+  normalizeObservabilityEvent(event),
+);
 
 const ObservabilityEventsResponseSchema = z.object({
   events: z.array(ObservabilityEventSchema).default([]),
@@ -959,6 +1036,12 @@ function mapEventsToTimelineRows(
   return payload.events.flatMap((event) => eventToTimelineRows(event));
 }
 
+function hasRenderableObservabilityHistory(
+  payload: z.infer<typeof ObservabilityEventsResponseSchema> | null | undefined,
+): boolean {
+  return mapEventsToTimelineRows(payload).length > 0;
+}
+
 function deriveSessionSnapshotFromEvent(
   event: ObservabilityEvent,
   previous: SessionSnapshot | null,
@@ -1544,7 +1627,9 @@ function LiveLogsPanel({
     staleTime: Infinity,
     retry: false,
   });
+  const historyRows = useMemo(() => mapEventsToTimelineRows(historyQuery.data), [historyQuery.data]);
   const historyUnavailable = historyQuery.isError || historyQuery.data === null;
+  const historyEmpty = historyQuery.isSuccess && !hasRenderableObservabilityHistory(historyQuery.data);
 
   // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({
@@ -1554,7 +1639,7 @@ function LiveLogsPanel({
       !!taskRunId &&
       expanded &&
       summaryQuery.isSuccess &&
-      historyUnavailable,
+      (historyUnavailable || historyEmpty),
     staleTime: Infinity,
     retry: false,
   });
@@ -1578,7 +1663,7 @@ function LiveLogsPanel({
 
       if (!supportsStreaming) {
         setViewerState(
-          (historyQuery.data?.events.length ?? 0) > 0 || Boolean(tailQuery.data)
+          historyRows.length > 0 || Boolean(tailQuery.data)
             ? 'ended'
             : 'not_available',
         );
@@ -1607,12 +1692,11 @@ function LiveLogsPanel({
   // Sync structured history into the local timeline when history fetch completes.
   useEffect(() => {
     if (historyQuery.isSuccess) {
-      const rows = mapEventsToTimelineRows(historyQuery.data);
       const sequences = historyQuery.data?.events
         .map((event) => event.sequence)
         .filter((sequence) => Number.isFinite(sequence));
-      if (lastSeqRef.current === null) {
-        setLogContent(rows);
+      if (lastSeqRef.current === null && historyRows.length > 0) {
+        setLogContent(historyRows);
       }
       lastSeqRef.current = sequences && sequences.length > 0 ? Math.max(...sequences) : null;
       if (historyQuery.data?.sessionSnapshot) {
@@ -1626,16 +1710,16 @@ function LiveLogsPanel({
         }
       }
     }
-  }, [historyQuery.data, historyQuery.isSuccess]);
+  }, [historyQuery.data, historyQuery.isSuccess, historyRows]);
 
   // Sync legacy merged-text fallback only when structured history is unavailable.
   useEffect(() => {
-    if (tailQuery.isSuccess && tailQuery.data && historyUnavailable) {
+    if (tailQuery.isSuccess && tailQuery.data && (historyUnavailable || historyEmpty)) {
       if (lastSeqRef.current === null) {
         setLogContent(parseArtifactToRows(tailQuery.data));
       }
     }
-  }, [historyUnavailable, tailQuery.data, tailQuery.isSuccess]);
+  }, [historyEmpty, historyUnavailable, tailQuery.data, tailQuery.isSuccess]);
 
   // Connect to SSE only after tail succeeds, if streaming is supported and active
   useEffect(() => {
@@ -2384,7 +2468,6 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
   const debugOn = Boolean(cfg?.features?.temporalDashboard?.debugFieldsEnabled);
   const logStreamingEnabled = cfg?.features?.logStreamingEnabled !== false;
-  const sessionTimelineEnabled = cfg?.features?.liveLogsSessionTimelineEnabled === true;
 
   const taskIdMatch = window.location.pathname.match(
     /^\/tasks\/(?:temporal\/|proposals\/|schedules\/|manifests\/)?([^/]+)$/,
@@ -2420,6 +2503,11 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const summaryArtifactRef = execution?.summaryArtifactRef || execution?.summary_artifact_ref || '';
   const explicitTaskRunId = execution?.taskRunId || execution?.task_run_id || '';
   const resolvedTaskRunId = explicitTaskRunId;
+  const sessionTimelineEnabled = shouldEnableSessionTimelineViewer({
+    config: cfg,
+    targetRuntime: execution?.targetRuntime,
+    taskRunId: resolvedTaskRunId,
+  });
   const previousTaskRunIdRef = useRef(resolvedTaskRunId);
   const [showTaskRunAttachNotice, setShowTaskRunAttachNotice] = useState(false);
 

--- a/specs/144-live-logs-phase6/checklists/requirements.md
+++ b/specs/144-live-logs-phase6/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Live Logs Phase 6 Compatibility and Cleanup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-09  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent is explicit: this slice requires production frontend/runtime changes plus automated validation tests.

--- a/specs/144-live-logs-phase6/contracts/live-logs-phase6-compatibility.md
+++ b/specs/144-live-logs-phase6/contracts/live-logs-phase6-compatibility.md
@@ -1,0 +1,38 @@
+# Contract: Live Logs Phase 6 Compatibility
+
+## Runtime Config Contract
+
+Dashboard config continues to expose:
+
+- `features.logStreamingEnabled`
+- `features.liveLogsSessionTimelineEnabled`
+- `features.liveLogsSessionTimelineRollout`
+
+Frontend compatibility rules:
+
+1. If rollout is missing, fall back to the boolean gate.
+2. If rollout is present, it becomes the primary eligibility input.
+3. Missing or false boolean values must not crash older or newer payload combinations.
+
+## Observability Event Compatibility Contract
+
+Frontend event normalization must accept:
+
+- canonical camelCase session fields from task-run history and SSE
+- legacy snake_case session fields used by existing browser tests and older compatibility paths
+- minimal events that contain only:
+  - `sequence`
+  - `timestamp`
+  - `stream`
+  - `text`
+
+The normalized frontend event model is the single input to timeline-row mapping and session-snapshot derivation.
+
+## Fallback Ordering Contract
+
+Initial Live Logs content is resolved in this order:
+
+1. `observability-summary`
+2. `observability/events`
+3. `logs/merged` when structured history is unavailable or empty
+4. optional SSE live follow when the run is active and stream-capable

--- a/specs/144-live-logs-phase6/data-model.md
+++ b/specs/144-live-logs-phase6/data-model.md
@@ -1,0 +1,61 @@
+# Data Model: Live Logs Phase 6 Compatibility and Cleanup
+
+## Timeline Eligibility
+
+Determines whether the task-detail page renders:
+
+- the session-aware timeline viewer, or
+- the legacy line viewer
+
+Inputs:
+
+- `liveLogsSessionTimelineEnabled`
+- `liveLogsSessionTimelineRollout`
+- current run `targetRuntime`
+- presence of a task-run-backed observability surface
+
+Rules:
+
+1. Missing or disabled rollout config degrades to the legacy line viewer.
+2. `codex_managed` enables the timeline only for Codex managed runs.
+3. `all_managed` enables the timeline for any managed run with task-run observability.
+4. Older boot payloads that expose only the boolean remain readable through safe fallback logic.
+
+## Compatibility-Normalized Observability Event
+
+Frontend-owned normalized shape used before mapping into `TimelineRow`.
+
+Fields:
+
+- `sequence`
+- `timestamp`
+- `stream`
+- `text`
+- `kind`
+- `offset`
+- `sessionId`
+- `sessionEpoch`
+- `containerId`
+- `threadId`
+- `turnId`
+- `activeTurnId`
+- `metadata`
+
+Accepted source aliases:
+
+- camelCase: `sessionId`, `sessionEpoch`, `containerId`, `threadId`, `turnId`, `activeTurnId`
+- snake_case: `session_id`, `session_epoch`, `container_id`, `thread_id`, `turn_id`, `active_turn_id`
+
+Compatibility rule:
+
+- Older minimal payloads may omit all session fields and `kind`.
+- Those payloads still normalize successfully if `sequence`, `timestamp`, `stream`, and `text` exist.
+
+## Merged Fallback Trigger
+
+The frontend requests `/logs/merged` when either condition is true:
+
+1. `/observability/events` is unavailable or errors, or
+2. `/observability/events` succeeds but returns zero normalized rows
+
+The merged fallback remains compatibility-only and does not replace structured history when structured rows exist.

--- a/specs/144-live-logs-phase6/plan.md
+++ b/specs/144-live-logs-phase6/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Live Logs Phase 6 Compatibility and Cleanup
+
+**Branch**: `144-live-logs-phase6` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/144-live-logs-phase6/spec.md`
+
+## Summary
+
+Implement the Phase 6 rollout and compatibility slice of the Live Logs session-aware migration by tightening the boundary between dashboard config, frontend viewer eligibility, and frontend observability-event normalization. This slice will 1) respect `liveLogsSessionTimelineRollout` when enabling the session-aware viewer, 2) fall back to merged logs when structured history is present but empty, and 3) normalize observability events from both history and SSE across camelCase, snake_case, and older minimal payload shapes so frontend and backend slices can roll independently for a short migration window.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript, React 19, Vitest  
+**Primary Dependencies**: task dashboard runtime config helpers, task-detail Live Logs viewer, Zod schemas, existing `/api/task-runs/*` observability routes  
+**Storage**: Browser query cache only; no new persistent store required  
+**Testing**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`, `pytest` unit coverage for dashboard config helpers  
+**Target Platform**: Mission Control React frontend served by FastAPI task dashboard boot payload  
+**Project Type**: frontend compatibility hardening plus dashboard runtime-config support  
+**Performance Goals**: preserve the current summary -> history -> SSE lifecycle without extra round trips or duplicate timeline rows  
+**Constraints**: keep `/logs/merged` stable, keep `/logs/stream` stable, avoid backend compatibility wrappers for event aliases, preserve older runs, keep rollout safety behind feature flags  
+**Scale/Scope**: Phase 6 only; no new backend observability route family and no feature-flag removal
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The UI continues to consume MoonMind-owned observability contracts and normalizes only MoonMind payload aliases, not provider-native events.
+- **II. One-Click Agent Deployment**: PASS. No new service, dependency, or deployment prerequisite is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. Rollout gating is expressed in MoonMind runtime config and normalized event shapes, not vendor-specific UI branches.
+- **IV. Own Your Data**: PASS. Historical fallback remains artifact-backed through existing MoonMind routes.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The main work is contract hardening around the existing viewer and route payloads, not a new transport.
+- **VII. Powerful Runtime Configurability**: PASS. The session-aware viewer now respects rollout scope instead of a coarse boolean only.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay bounded to runtime-config helpers, frontend normalization helpers, and tests.
+- **IX. Resilient by Default**: PASS. Empty-history fallback and alias-tolerant parsing improve deployment safety for historical runs and mixed-version windows.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This rollout slice has dedicated spec/plan/tasks artifacts before implementation.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical Live Logs docs remain declarative; this plan covers the Phase 6 rollout slice only.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The cleanup consolidates the viewer onto one compatibility-aware normalization path instead of adding another long-lived model.
+
+## Research
+
+- The backend already exposes `liveLogsSessionTimelineRollout` and `liveLogsSessionTimelineEnabled` in the dashboard boot payload, but the frontend currently uses only the boolean and ignores rollout scope.
+- The backend task-runs router normalizes observability events with Pydantic `by_alias=True`, so event payloads come back with camelCase session fields such as `sessionId`, while the frontend currently reads only snake_case keys such as `session_id`.
+- The frontend already degrades to `/logs/merged` when `/observability/events` is missing or errors, but it does not fall back when the structured-history route succeeds with zero events and merged compatibility text still exists.
+- The current Live Logs viewer already keeps the correct lifecycle order and already supports legacy line-view mode, which means Phase 6 is a compatibility hardening slice rather than a renderer rewrite.
+- The runtime scope validation script requires at least one production change under `api_service/` or `moonmind/`, so the plan must include a concrete runtime-config helper change in addition to frontend/test work.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/144-live-logs-phase6/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── live-logs-phase6-compatibility.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/task_dashboard_view_model.py  # MODIFY: centralize Live Logs feature config helpers used by dashboard consumers
+tests/unit/api/routers/test_task_dashboard_view_model.py # MODIFY: rollout config coverage
+frontend/src/entrypoints/task-detail.tsx             # MODIFY: rollout-aware eligibility, event alias normalization, empty-history fallback
+frontend/src/entrypoints/task-detail.test.tsx        # MODIFY: TDD coverage for rollout scope, alias compatibility, empty-history fallback
+```
+
+**Structure Decision**: Keep Phase 6 bounded to the dashboard runtime config helper and the existing task-detail entrypoint. Do not add new routes or a second viewer entrypoint.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the rollout eligibility inputs, compatibility-normalized event shape, and merged-fallback trigger rules.
+
+## Contracts
+
+- [contracts/live-logs-phase6-compatibility.md](./contracts/live-logs-phase6-compatibility.md)
+
+## Implementation Plan
+
+1. Add failing tests for the Phase 6 compatibility seam:
+   - rollout scope eligibility in dashboard config and task-detail rendering,
+   - empty structured-history fallback to merged logs,
+   - camelCase and snake_case event alias handling in history and SSE,
+   - graceful rendering of older minimal SSE payloads.
+2. Refactor the dashboard runtime-config helper so grouped Live Logs feature flags stay centralized and testable for rollout-aware frontend consumption.
+3. Introduce a compatibility-aware frontend normalization path in `task-detail.tsx` that:
+   - computes timeline eligibility from rollout scope plus run context,
+   - accepts both camelCase and snake_case event aliases,
+   - treats empty structured history as fallback-eligible when merged content exists.
+4. Keep the existing summary -> history -> SSE lifecycle intact while routing eligible runs to the timeline viewer and ineligible runs to the legacy line viewer.
+5. Run focused UI/runtime-config verification, scope validation, and final UI regression commands, then mark completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+2. `npm run ui:typecheck`
+3. `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+4. `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+5. `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+6. `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+### Manual Validation
+
+1. Open Live Logs for a Codex managed run with rollout `codex_managed` and confirm the session-aware timeline renders.
+2. Open Live Logs for a non-Codex managed run with rollout `codex_managed` and confirm the legacy line viewer remains active.
+3. Open a historical run where `/observability/events` returns an empty list but `/logs/merged` still has content and confirm the merged compatibility text is shown.
+4. Stream one live event carrying camelCase session metadata and one carrying snake_case metadata and confirm the session snapshot header updates in both cases.

--- a/specs/144-live-logs-phase6/quickstart.md
+++ b/specs/144-live-logs-phase6/quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart: Live Logs Phase 6 Compatibility and Cleanup
+
+## Goal
+
+Verify rollout-aware viewer eligibility and mixed-payload compatibility for Live Logs.
+
+## Steps
+
+1. Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`.
+2. Run `npm run ui:typecheck`.
+3. Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`.
+4. Run `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+5. Run `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+
+## Manual Spot Checks
+
+1. With rollout `codex_managed`, open a Codex managed run and confirm the timeline viewer appears.
+2. With rollout `codex_managed`, open a non-Codex managed run and confirm the legacy line viewer appears.
+3. Open a run where structured history is empty but merged logs are available and confirm merged compatibility text is shown.
+4. Confirm session header state updates for both camelCase and snake_case live event payloads.

--- a/specs/144-live-logs-phase6/research.md
+++ b/specs/144-live-logs-phase6/research.md
@@ -1,0 +1,25 @@
+# Research: Live Logs Phase 6 Compatibility and Cleanup
+
+## Decision 1: Frontend should normalize event aliases instead of adding backend compatibility duplicates
+
+- **Decision**: Accept both camelCase and snake_case observability event aliases in the frontend normalization path.
+- **Rationale**: The backend already emits canonical camelCase aliases from `RunObservabilityEvent`. Adding duplicate snake_case fields on the backend would create a longer-lived compatibility contract that the pre-release compatibility policy discourages.
+- **Alternatives considered**:
+  - Add snake_case aliases to backend responses: rejected because it expands the API surface during a rollout slice.
+  - Keep frontend snake_case-only parsing: rejected because it fails the mixed-deploy compatibility requirement.
+
+## Decision 2: Empty structured history should trigger merged fallback
+
+- **Decision**: Treat a successful `/observability/events` response with zero rows as fallback-eligible when `/logs/merged` still has compatibility content.
+- **Rationale**: Historical runs may have no structured event journal even though the endpoint exists. Showing a blank timeline would hide real artifact-backed observability during rollout.
+- **Alternatives considered**:
+  - Treat any successful history response as authoritative, even when empty: rejected because it strands older runs.
+  - Add backend flags for fallback intent: rejected because the frontend can infer the condition without widening the API contract.
+
+## Decision 3: Rollout eligibility should use both rollout scope and run context
+
+- **Decision**: Compute viewer eligibility from `liveLogsSessionTimelineRollout` plus run context, while using `liveLogsSessionTimelineEnabled` and missing config as safe fallbacks for older boot payloads.
+- **Rationale**: Phase 6 requires codex-only versus all-managed rollout control. The current boolean-only gate cannot express that distinction.
+- **Alternatives considered**:
+  - Continue using the boolean only: rejected because it ignores rollout scope.
+  - Move per-run eligibility to the backend: rejected for this slice because the task-detail page already has enough run context and the boot payload already carries rollout scope.

--- a/specs/144-live-logs-phase6/spec.md
+++ b/specs/144-live-logs-phase6/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Live Logs Phase 6 Compatibility and Cleanup
+
+**Feature Branch**: `144-live-logs-phase6`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 6 using test-driven development from the Live Logs Session-Aware Implementation Plan. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Respect rollout scope when enabling the session timeline (Priority: P1)
+
+Mission Control operators need the Live Logs session-aware timeline to turn on only for runs that are inside the configured Phase 6 rollout scope so the new viewer can be deployed gradually without forcing every managed run onto the new path at once.
+
+**Why this priority**: Phase 6 is explicitly about staged rollout safety. Without rollout-aware eligibility, `liveLogsSessionTimelineEnabled` behaves like a global on/off switch and skips the codex-only versus all-managed migration boundary described in the plan.
+
+**Independent Test**: Render the task detail page with different `liveLogsSessionTimelineRollout` values and run types, then confirm the session timeline activates only for eligible runs while ineligible runs stay on the legacy line viewer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the rollout scope is `codex_managed`, **When** an operator opens Live Logs for a Codex managed run, **Then** the session-aware timeline is enabled.
+2. **Given** the rollout scope is `codex_managed`, **When** an operator opens Live Logs for a non-Codex managed run, **Then** the legacy line viewer remains active.
+3. **Given** the rollout scope is `all_managed`, **When** an operator opens Live Logs for any managed run with a task-run-backed observability surface, **Then** the session-aware timeline is enabled.
+4. **Given** the rollout scope is absent or `off`, **When** the frontend is deployed against older or disabled config, **Then** Live Logs degrades to the legacy line viewer without crashing.
+
+---
+
+### User Story 2 - Degrade cleanly across mixed observability payloads and empty history (Priority: P1)
+
+Operators need Live Logs to stay readable while frontend and backend slices roll independently, including historical runs that only expose merged text and active runs whose live events still arrive in older minimal payload shapes.
+
+**Why this priority**: Phase 6 requires a short deployment window where the frontend and backend can move independently. The UI must therefore tolerate both canonical and legacy-shaped observability payloads while keeping historical runs observable.
+
+**Independent Test**: Load Live Logs with empty structured history plus merged fallback content, then stream live events using both camelCase and snake_case session metadata fields and confirm the panel renders and updates session context correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** `/observability/events` returns success with no rows but `/logs/merged` still has compatibility content, **When** the operator opens Live Logs, **Then** the UI falls back to merged text instead of showing a false empty timeline.
+2. **Given** a live or historical observability event carries session metadata with camelCase field names, **When** the frontend parses that event, **Then** the timeline row and session snapshot still update correctly.
+3. **Given** a live or historical observability event carries session metadata with snake_case field names, **When** the frontend parses that event, **Then** the same timeline row and session snapshot render correctly.
+4. **Given** the SSE stream emits an older minimal event payload without session metadata or event kind, **When** the frontend receives it, **Then** the output row still renders in sequence order without breaking the panel.
+
+---
+
+### User Story 3 - Remove remaining legacy-only assumptions from the Live Logs viewer path (Priority: P2)
+
+MoonMind engineers need the task-detail observability code to use one compatibility-aware timeline normalization path instead of scattered assumptions about which payload shape or viewer mode is authoritative.
+
+**Why this priority**: Phase 6 ends with cleanup after rollout safety is in place. If the viewer still depends on hardcoded boolean gating or one exact payload alias set, future cleanup and flag removal will stay brittle.
+
+**Independent Test**: Inspect and exercise the Live Logs viewer helpers through automated tests that cover rollout eligibility, event normalization, and fallback ordering without depending on duplicate legacy-only branches.
+
+**Acceptance Scenarios**:
+
+1. **Given** the session timeline feature flag and rollout scope are both present, **When** the task-detail page computes Live Logs behavior, **Then** one helper decides whether the timeline viewer is enabled for the current run.
+2. **Given** observability events arrive from history or SSE, **When** the frontend normalizes them, **Then** one shared compatibility path handles field aliases and older minimal payloads.
+3. **Given** the compatibility path determines the run is not eligible for the session-aware timeline, **When** the operator opens Live Logs, **Then** the legacy line viewer still works without duplicating fetch or stream lifecycle logic.
+
+### Edge Cases
+
+- Structured history exists but contains zero events while merged artifacts still contain historical text; the viewer must show the merged fallback instead of a blank timeline.
+- SSE rows may arrive with camelCase session metadata while historical rows use snake_case aliases, or vice versa; both must normalize into the same frontend row model.
+- The boot payload may expose `liveLogsSessionTimelineEnabled` without `liveLogsSessionTimelineRollout`, or the reverse, during an independent deploy window; the viewer must choose a safe fallback.
+- A non-Codex managed run may have `session` rows in the future; `all_managed` must enable the session-aware viewer without special-casing only Codex.
+- Older minimal SSE rows may omit `kind` and session metadata entirely; they must still render as output/system rows without throwing.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The task-detail frontend MUST enable the session-aware Live Logs timeline only when the current run is eligible for the configured rollout scope.
+- **FR-002**: Rollout scope `codex_managed` MUST enable the session-aware Live Logs timeline for Codex managed runs and MUST keep non-Codex managed runs on the legacy line viewer.
+- **FR-003**: Rollout scope `all_managed` MUST enable the session-aware Live Logs timeline for any managed run that exposes task-run observability.
+- **FR-004**: Rollout scope `off` or missing rollout metadata MUST degrade to the legacy line viewer without breaking Live Logs.
+- **FR-005**: The Live Logs viewer MUST fall back to `/logs/merged` when structured history is unavailable or when structured history returns zero rows and merged compatibility content exists.
+- **FR-006**: The Live Logs viewer MUST normalize observability events from both historical retrieval and SSE through one compatibility path that accepts camelCase and snake_case session metadata aliases.
+- **FR-007**: The Live Logs viewer MUST continue to render older minimal observability events that only provide sequence, stream, text, and timestamp.
+- **FR-008**: The session snapshot header MUST update from compatible live or historical event metadata regardless of whether the source uses camelCase or snake_case field names.
+- **FR-009**: The Phase 6 slice MUST ship production frontend/runtime code changes plus automated validation tests; docs-only changes are insufficient.
+
+### Key Entities *(include if feature involves data)*
+
+- **Timeline Eligibility**: The frontend decision that determines whether the session-aware Live Logs viewer or the legacy line viewer should render for the current run.
+- **Compatibility-Normalized Observability Event**: A frontend-owned normalized event shape that accepts both canonical and legacy field aliases before mapping rows into the timeline.
+- **Merged Fallback Trigger**: The condition that tells the viewer to use `/logs/merged` because structured history is missing or empty for a historical compatibility run.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Browser tests prove `codex_managed`, `all_managed`, and disabled rollout modes enable the correct Live Logs viewer for eligible and ineligible runs.
+- **SC-002**: Browser tests prove empty structured history falls back to merged content instead of leaving the panel blank.
+- **SC-003**: Browser tests prove the Live Logs viewer accepts both camelCase and snake_case session metadata from historical responses and SSE payloads.
+- **SC-004**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `npm run ui:typecheck`, `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`, and `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` pass.

--- a/specs/144-live-logs-phase6/tasks.md
+++ b/specs/144-live-logs-phase6/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Live Logs Phase 6 Compatibility and Cleanup
+
+**Input**: Design documents from `/specs/144-live-logs-phase6/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing tests before implementing the corresponding runtime/frontend changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [x] T001 [P] Add failing rollout-scope runtime-config coverage in `tests/unit/api/routers/test_task_dashboard_view_model.py`
+- [x] T002 [P] [US1] Add failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` for `codex_managed`, `all_managed`, and disabled rollout eligibility
+- [x] T003 [P] [US2] Add failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` for empty structured-history fallback to `/logs/merged`
+- [x] T004 [P] [US2] Add failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` for camelCase, snake_case, and minimal SSE/history observability payload compatibility
+
+## Phase 2: Foundational
+
+- [x] T005 Implement centralized Live Logs rollout feature helpers in `api_service/api/routers/task_dashboard_view_model.py`
+- [x] T006 Implement compatibility-aware timeline eligibility and observability-event normalization helpers in `frontend/src/entrypoints/task-detail.tsx`
+
+## Phase 3: User Story 1 - Respect rollout scope when enabling the session timeline (Priority: P1)
+
+**Goal**: Turn on the session-aware viewer only for runs that are inside the configured rollout boundary.
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Update `frontend/src/entrypoints/task-detail.tsx` to select the session-aware or legacy Live Logs viewer from rollout scope plus run context
+
+## Phase 4: User Story 2 - Degrade cleanly across mixed observability payloads and empty history (Priority: P1)
+
+**Goal**: Keep Live Logs readable for historical runs and mixed frontend/backend deploy windows.
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Update `frontend/src/entrypoints/task-detail.tsx` to fall back to `/logs/merged` when structured history is unavailable or empty
+- [x] T009 [US2] Update `frontend/src/entrypoints/task-detail.tsx` to normalize camelCase, snake_case, and minimal observability payloads for both history and SSE
+
+## Phase 5: User Story 3 - Remove remaining legacy-only assumptions from the Live Logs viewer path (Priority: P2)
+
+**Goal**: Consolidate the compatibility logic into one maintainable viewer path instead of scattered legacy assumptions.
+
+### Implementation for User Story 3
+
+- [x] T010 [US3] Refactor `frontend/src/entrypoints/task-detail.tsx` so rollout eligibility, event normalization, and fallback intent flow through one compatibility-aware helper path
+
+## Phase 6: Validation
+
+- [x] T011 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [x] T012 Run `npm run ui:typecheck`
+- [x] T013 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+- [x] T014 Run `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [x] T015 Run `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+- [x] T016 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on the failing tests from Phase 1.
+- **User Story 1 (Phase 3)**: Depends on Phase 2.
+- **User Story 2 (Phase 4)**: Depends on Phase 2.
+- **User Story 3 (Phase 5)**: Depends on Phase 3 and Phase 4.
+- **Validation (Phase 6)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- `T001` through `T004` can be written in parallel because they touch separate test targets or separate test cases.
+- `T007` and `T008` can be staged sequentially on the same frontend file once the shared helpers from `T006` exist.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add the failing runtime-config and browser tests.
+2. Land the shared rollout/helper changes.
+3. Enable rollout-aware viewer selection.
+4. Finish empty-history fallback and payload alias compatibility.
+5. Consolidate the compatibility path and run validation.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from api_service.api.routers.task_dashboard_view_model import (
+    build_live_logs_feature_config,
     build_runtime_config,
     normalize_status,
     status_maps,
@@ -380,6 +381,23 @@ def test_build_runtime_config_groups_live_logs_feature_flags(monkeypatch) -> Non
     assert config["features"]["logStreamingEnabled"] is True
     assert config["features"]["liveLogsSessionTimelineEnabled"] is True
     assert config["features"]["liveLogsSessionTimelineRollout"] == "internal"
+
+
+def test_build_live_logs_feature_config_exposes_all_managed_rollout(monkeypatch) -> None:
+    monkeypatch.setenv("MOONMIND_LOG_STREAMING_ENABLED", "true")
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_session_timeline_rollout",
+        "all_managed",
+    )
+
+    feature_config = build_live_logs_feature_config()
+
+    assert feature_config == {
+        "logStreamingEnabled": True,
+        "liveLogsSessionTimelineEnabled": True,
+        "liveLogsSessionTimelineRollout": "all_managed",
+    }
 
 
 def test_build_runtime_config_omits_temporal_live_session_endpoint() -> None:


### PR DESCRIPTION
## Summary
- add rollout-scope aware Live Logs feature config and viewer gating for `off`, `codex_managed`, and `all_managed`
- normalize observability event payload aliases so the timeline can read camelCase and snake_case session metadata during mixed deploy windows
- fall back to merged logs when structured history is empty and record the Phase 6 spec/tasks artifacts for the implementation

## Why
Phase 6 of the Live Logs session-aware plan is about independent frontend/backend rollout safety. The viewer needed to degrade cleanly for older runs, empty structured histories, and mixed payload shapes while preserving the new timeline path for in-scope managed runs.

## Impact
- Codex-managed and all-managed rollout scopes now behave as configured in the dashboard boot payload
- historical or partially migrated runs remain observable through `/logs/merged` when structured timeline history is unavailable or empty
- observability payload compatibility is centralized in one frontend helper instead of scattered legacy-only assumptions

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `npm run ui:typecheck`
- `pytest tests/unit/api/routers/test_task_dashboard_view_model.py -q`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py --ui-args frontend/src/entrypoints/task-detail.test.tsx`
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx`
- `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=144-live-logs-phase6 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`