### PR TITLE
[codex] Fix Codex session OpenRouter materialization

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -16,6 +16,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunState,
     AgentRunStatus,
     ManagedRunRecord,
+    ManagedRuntimeProfile,
 )
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -44,6 +45,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     build_managed_profile_launch_context,
     default_credential_source_for_runtime,
 )
+from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
 )
@@ -54,7 +56,8 @@ SessionSnapshotLoader = Callable[
 SessionHandleSignaler = Callable[[dict[str, Any]], Awaitable[None]]
 SessionControlSignaler = Callable[[dict[str, Any]], Awaitable[None]]
 LaunchSessionFunc = Callable[
-    [LaunchCodexManagedSessionRequest], Awaitable[CodexManagedSessionHandle | Mapping[str, Any]]
+    [Mapping[str, Any] | LaunchCodexManagedSessionRequest],
+    Awaitable[CodexManagedSessionHandle | Mapping[str, Any]],
 ]
 SessionStatusFunc = Callable[
     [CodexManagedSessionLocator], Awaitable[CodexManagedSessionHandle | Mapping[str, Any]]
@@ -192,6 +195,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             binding=binding,
             request=request,
             environment=launch_context.delta_env_overrides,
+            profile=self._profile_for_launch(
+                runtime_id=runtime_id,
+                profile=profile,
+                launch_context=launch_context,
+            ),
         )
         locator = self._locator_from_state(
             session_state=session_handle.session_state,
@@ -585,6 +593,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         binding: CodexManagedSessionBinding,
         request: AgentExecutionRequest,
         environment: dict[str, str],
+        profile: ManagedRuntimeProfile,
     ) -> CodexManagedSessionHandle:
         snapshot = await self._load_snapshot(binding.workflow_id)
         if snapshot.container_id and snapshot.thread_id:
@@ -626,7 +635,11 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 else {}
             ),
         )
-        handle = await self._coerce_handle(self._launch_session(launch_request))
+        launch_payload = {
+            "request": launch_request.model_dump(mode="json", by_alias=True),
+            "profile": profile.model_dump(mode="json", by_alias=True),
+        }
+        handle = await self._coerce_handle(self._launch_session(launch_payload))
         await self._attach_runtime_handles(
             {
                 "containerId": handle.session_state.container_id,
@@ -641,6 +654,38 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             active_turn_id=handle.session_state.active_turn_id,
         )
         return handle
+
+    def _profile_for_launch(
+        self,
+        *,
+        runtime_id: str,
+        profile: Mapping[str, Any],
+        launch_context: ManagedProfileLaunchContext,
+    ) -> ManagedRuntimeProfile:
+        runtime_default_model, runtime_default_effort = resolve_runtime_defaults(
+            runtime_id
+        )
+        return ManagedRuntimeProfile(
+            profileId=launch_context.profile_id,
+            runtimeId=runtime_id,
+            providerId=profile.get("provider_id"),
+            providerLabel=profile.get("provider_label"),
+            authMode=profile.get("auth_mode"),
+            credentialSource=launch_context.credential_source,
+            runtimeMaterializationMode=profile.get("runtime_materialization_mode"),
+            commandBehavior=profile.get("command_behavior") or {},
+            commandTemplate=profile.get("command_template") or [],
+            defaultModel=profile.get("default_model") or runtime_default_model,
+            modelOverrides=profile.get("model_overrides") or {},
+            defaultEffort=profile.get("default_effort") or runtime_default_effort,
+            envOverrides=launch_context.delta_env_overrides,
+            envTemplate=profile.get("env_template") or {},
+            fileTemplates=profile.get("file_templates") or [],
+            homePathOverrides=profile.get("home_path_overrides") or {},
+            passthroughEnvKeys=launch_context.passthrough_env_keys,
+            clearEnvKeys=profile.get("clear_env_keys") or [],
+            secretRefs=profile.get("secret_refs") or {},
+        )
 
     async def _current_locator(
         self, binding: CodexManagedSessionBinding

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -99,6 +99,7 @@ from moonmind.workflows.temporal.manifest_ingest import (
     plan_nodes_to_runtime_nodes,
 )
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_managed_api_key_reference,
     shape_launch_github_auth_environment,
 )
 from moonmind.workflows.temporal.runtime.paths import managed_runtime_artifact_root
@@ -2730,13 +2731,85 @@ class TemporalAgentRuntimeActivities:
             ) from exc
 
     @staticmethod
+    def _coerce_launch_session_request_payload(
+        request: Mapping[str, Any] | LaunchCodexManagedSessionRequest | None,
+    ) -> tuple[LaunchCodexManagedSessionRequest, ManagedRuntimeProfile | None]:
+        if isinstance(request, LaunchCodexManagedSessionRequest):
+            return request, None
+
+        payload = _coerce_activity_request(
+            request,
+            activity_type="agent_runtime.launch_session",
+        )
+        request_payload = payload.get("request")
+        if isinstance(request_payload, Mapping):
+            profile_payload = payload.get("profile")
+            profile = (
+                ManagedRuntimeProfile.model_validate(profile_payload)
+                if profile_payload is not None
+                else None
+            )
+            return (
+                LaunchCodexManagedSessionRequest.model_validate(request_payload),
+                profile,
+            )
+        return LaunchCodexManagedSessionRequest.model_validate(payload), None
+
+    @staticmethod
+    async def _materialize_launch_session_environment(
+        *,
+        request: LaunchCodexManagedSessionRequest,
+        profile: ManagedRuntimeProfile,
+    ) -> dict[str, str]:
+        from moonmind.workflows.adapters.materializer import (
+            ProviderProfileMaterializer,
+        )
+        from moonmind.workflows.adapters.secret_boundary import (
+            SecretResolverBoundary,
+        )
+
+        class _ActivitySecretResolver(SecretResolverBoundary):
+            async def resolve_secrets(
+                self,
+                secret_refs: dict[str, str],
+            ) -> dict[str, str]:
+                resolved: dict[str, str] = {}
+                for key, ref in secret_refs.items():
+                    resolved[key] = await resolve_managed_api_key_reference(str(ref))
+                return resolved
+
+        materializer = ProviderProfileMaterializer(
+            base_env=dict(request.environment),
+            secret_resolver=_ActivitySecretResolver(),
+        )
+        runtime_support_dir = str(
+            Path(request.codex_home_path).expanduser().resolve().parent
+        )
+        materialized_environment, _command = await materializer.materialize(
+            profile,
+            workspace_path=request.workspace_path,
+            runtime_support_dir=runtime_support_dir,
+        )
+        return materialized_environment
+
+    @staticmethod
     async def _shape_launch_session_request(
         request: LaunchCodexManagedSessionRequest,
+        *,
+        profile: ManagedRuntimeProfile | None = None,
     ) -> LaunchCodexManagedSessionRequest:
         """Resolve runtime-only auth immediately before remote session launch."""
 
+        environment = dict(request.environment)
+        if profile is not None:
+            environment = (
+                await TemporalAgentRuntimeActivities._materialize_launch_session_environment(
+                    request=request,
+                    profile=profile,
+                )
+            )
         environment = await shape_launch_github_auth_environment(
-            request.environment,
+            environment,
             ambient_github_token=os.environ.get("GITHUB_TOKEN"),
         )
         return request.model_copy(update={"environment": environment})
@@ -2749,12 +2822,13 @@ class TemporalAgentRuntimeActivities:
         controller = self._require_session_controller(
             activity_type="agent_runtime.launch_session"
         )
-        validated = self._validate_session_request(
-            request,
-            activity_type="agent_runtime.launch_session",
-            model_type=LaunchCodexManagedSessionRequest,
+        validated, profile = self._coerce_launch_session_request_payload(
+            request
         )
-        validated = await self._shape_launch_session_request(validated)
+        validated = await self._shape_launch_session_request(
+            validated,
+            profile=profile,
+        )
         try:
             response = await controller.launch_session(validated)
         except Exception as exc:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -2775,7 +2775,10 @@ class TemporalAgentRuntimeActivities:
             ) -> dict[str, str]:
                 resolved: dict[str, str] = {}
                 for key, ref in secret_refs.items():
-                    resolved[key] = await resolve_managed_api_key_reference(str(ref))
+                    resolved[key] = await resolve_managed_api_key_reference(
+                        ref,
+                        field_name=f"profile.secretRefs.{key}",
+                    )
                 return resolved
 
         materializer = ProviderProfileMaterializer(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -40,6 +40,8 @@ _STATE_FILENAME = ".moonmind-codex-session-state.json"
 _READY_LOOP_SECONDS = 3600.0
 _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = 300.0
 _STDOUT_EOF = object()
+_AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
+_AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -305,6 +307,7 @@ class CodexManagedSessionRuntime:
         session_workspace_path: str,
         artifact_spool_path: str,
         codex_home_path: str,
+        auth_volume_path: str | None = None,
         image_ref: str,
         control_url: str,
         container_id: str,
@@ -315,6 +318,9 @@ class CodexManagedSessionRuntime:
         self._session_workspace_path = Path(session_workspace_path)
         self._artifact_spool_path = Path(artifact_spool_path)
         self._codex_home_path = Path(codex_home_path)
+        self._auth_volume_path = (
+            Path(auth_volume_path) if str(auth_volume_path or "").strip() else None
+        )
         self._image_ref = image_ref
         self._control_url = control_url
         self._container_id = container_id
@@ -331,6 +337,39 @@ class CodexManagedSessionRuntime:
         self._session_workspace_path.mkdir(parents=True, exist_ok=True)
         self._artifact_spool_path.mkdir(parents=True, exist_ok=True)
         self._codex_home_path.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _should_seed_auth_entry(path: Path) -> bool:
+        name = path.name
+        if name in _AUTH_SEED_EXCLUDED_NAMES:
+            return False
+        return not any(name.startswith(prefix) for prefix in _AUTH_SEED_EXCLUDED_PREFIXES)
+
+    def _seed_codex_home_from_auth_volume(self) -> None:
+        if self._auth_volume_path is None:
+            return
+        source_root = self._auth_volume_path
+        if not source_root.exists():
+            raise RuntimeError(
+                f"MANAGED_AUTH_VOLUME_PATH does not exist: {source_root}"
+            )
+        if not source_root.is_dir():
+            raise RuntimeError(
+                f"MANAGED_AUTH_VOLUME_PATH must be a directory: {source_root}"
+            )
+
+        self._ensure_directories()
+        for source_path in sorted(source_root.iterdir()):
+            if not self._should_seed_auth_entry(source_path):
+                continue
+            destination = self._codex_home_path / source_path.name
+            if source_path.is_symlink():
+                continue
+            if source_path.is_dir():
+                shutil.copytree(source_path, destination, dirs_exist_ok=True)
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, destination)
 
     def _append_spool(self, stream_name: str, text: str) -> None:
         if stream_name not in {"stdout", "stderr"}:
@@ -504,6 +543,7 @@ class CodexManagedSessionRuntime:
         request: LaunchCodexManagedSessionRequest,
     ) -> CodexManagedSessionHandle:
         self._ensure_directories()
+        self._seed_codex_home_from_auth_volume()
         client = self._app_server_client()
         client.initialize()
         started = client.request("thread/start", {"cwd": str(self._workspace_path)})
@@ -826,11 +866,13 @@ def _runtime_from_environment() -> CodexManagedSessionRuntime:
             str(_DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS),
         )
     )
+    auth_volume_path = str(os.environ.get("MANAGED_AUTH_VOLUME_PATH") or "").strip() or None
     return CodexManagedSessionRuntime(
         workspace_path=workspace_path,
         session_workspace_path=session_workspace_path,
         artifact_spool_path=artifact_spool_path,
         codex_home_path=codex_home_path,
+        auth_volume_path=auth_volume_path,
         image_ref=image_ref,
         control_url=control_url,
         container_id=container_id,

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import Mapping
+from typing import Any, Mapping
 
 from sqlalchemy import select
 
@@ -27,6 +27,22 @@ _MANAGED_GITHUB_TOKEN_SLUGS: tuple[str, ...] = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_secret_ref_input(
+    ref: str | Mapping[str, Any],
+    *,
+    field_name: str = "MANAGED_API_KEY_REF",
+) -> str:
+    if not isinstance(ref, str):
+        raise ValueError(
+            f"{field_name} must be a string secret reference, got {type(ref).__name__}"
+        )
+
+    stripped = ref.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} is empty")
+    return stripped
 
 
 async def resolve_managed_github_token_from_store() -> str | None:
@@ -122,12 +138,14 @@ async def shape_launch_github_auth_environment(
     return shaped_environment
 
 
-async def resolve_managed_api_key_reference(ref: str) -> str:
+async def resolve_managed_api_key_reference(
+    ref: str | Mapping[str, Any],
+    *,
+    field_name: str = "MANAGED_API_KEY_REF",
+) -> str:
     """Resolve a profile api_key_ref or secret_ref into the credential string using RootSecretResolver."""
 
-    stripped = ref.strip()
-    if not stripped:
-        raise ValueError("MANAGED_API_KEY_REF is empty")
+    stripped = _normalize_secret_ref_input(ref, field_name=field_name)
         
     if "://" not in stripped:
         stripped = f"env://{stripped}"

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -173,6 +173,22 @@ class DockerCodexManagedSessionController:
                 "launch_session environment cannot override reserved session keys: "
                 + ", ".join(reserved_keys)
             )
+        auth_volume_path = str(
+            request.environment.get("MANAGED_AUTH_VOLUME_PATH") or ""
+        ).strip()
+        if auth_volume_path:
+            normalized_auth_volume_path = _normalize_absolute_posix_path(
+                auth_volume_path,
+                field_name="environment.MANAGED_AUTH_VOLUME_PATH",
+            )
+            normalized_codex_home_path = _normalize_absolute_posix_path(
+                request.codex_home_path,
+                field_name="codexHomePath",
+            )
+            if normalized_auth_volume_path == normalized_codex_home_path:
+                raise RuntimeError(
+                    "environment.MANAGED_AUTH_VOLUME_PATH must not equal codexHomePath"
+                )
 
     @staticmethod
     def _volume_mount(volume_name: str, target_path: str) -> str:
@@ -753,8 +769,6 @@ class DockerCodexManagedSessionController:
             _MANAGED_SESSION_CONTAINER_USER,
             "--mount",
             self._volume_mount(self._workspace_volume_name, self._workspace_root),
-            "--mount",
-            self._volume_mount(self._codex_volume_name, request.codex_home_path),
             "-e",
             f"MOONMIND_SESSION_WORKSPACE_PATH={request.workspace_path}",
             "-e",
@@ -768,6 +782,16 @@ class DockerCodexManagedSessionController:
             "-e",
             f"MOONMIND_SESSION_CONTROL_URL=docker-exec://{container_name}",
         ]
+        auth_volume_path = str(
+            request.environment.get("MANAGED_AUTH_VOLUME_PATH") or ""
+        ).strip()
+        if auth_volume_path:
+            run_command.extend(
+                [
+                    "--mount",
+                    self._volume_mount(self._codex_volume_name, auth_volume_path),
+                ]
+            )
         for key, value in sorted(request.environment.items()):
             run_command.extend(["-e", f"{key}={value}"])
         run_command.extend(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -149,6 +149,15 @@ class DockerCodexManagedSessionController:
                 f"{field_name} must stay within workspace_root {workspace_root}: {candidate}"
             ) from exc
 
+    def _is_within_workspace_root(self, path: Path) -> bool:
+        workspace_root = Path(self._workspace_root).expanduser().resolve()
+        candidate = path.expanduser().resolve()
+        try:
+            candidate.relative_to(workspace_root)
+        except ValueError:
+            return False
+        return True
+
     def _validate_launch_request(self, request: LaunchCodexManagedSessionRequest) -> None:
         self._validate_workspace_path(request.workspace_path, field_name="workspacePath")
         self._validate_workspace_path(
@@ -498,6 +507,10 @@ class DockerCodexManagedSessionController:
             or ""
         ).strip()
         if workspace_path.exists():
+            self._collect_managed_support_paths(
+                request=request,
+                owned_paths=created_paths,
+            )
             if repository:
                 if not await self._workspace_is_git_repository(workspace_path=workspace_path):
                     await self._clone_workspace(
@@ -516,6 +529,10 @@ class DockerCodexManagedSessionController:
             workspace_path.parent.mkdir(parents=True, exist_ok=True)
             workspace_path.mkdir(parents=True, exist_ok=True)
             created_paths.append(workspace_path)
+            self._collect_managed_support_paths(
+                request=request,
+                owned_paths=created_paths,
+            )
             self._normalize_container_path_ownership(created_paths)
             return
 
@@ -528,7 +545,30 @@ class DockerCodexManagedSessionController:
             workspace_path=workspace_path,
             request=request,
         )
+        self._collect_managed_support_paths(
+            request=request,
+            owned_paths=created_paths,
+        )
         self._normalize_container_path_ownership(created_paths)
+
+    def _collect_managed_support_paths(
+        self,
+        *,
+        request: LaunchCodexManagedSessionRequest,
+        owned_paths: list[Path],
+    ) -> None:
+        codex_home_path = Path(request.codex_home_path)
+        if not self._is_within_workspace_root(codex_home_path):
+            return
+
+        runtime_support_path = codex_home_path.parent
+        if not runtime_support_path.exists():
+            runtime_support_path.mkdir(parents=True, exist_ok=True)
+        owned_paths.append(runtime_support_path)
+
+        if not codex_home_path.exists():
+            codex_home_path.mkdir(parents=True, exist_ok=True)
+        owned_paths.append(codex_home_path)
 
     async def _ensure_target_branch(
         self,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -656,6 +656,42 @@ def test_runtime_launch_session_exports_codex_home(tmp_path: Path) -> None:
     )
 
 
+def test_runtime_launch_session_seeds_auth_volume_without_overwriting_materialized_config(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(tmp_path)
+    request = _launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    (auth_volume_path / "auth.json").write_text('{"token":"oauth"}', encoding="utf-8")
+    (auth_volume_path / "config.toml").write_text("model = 'gpt-5.4'\n", encoding="utf-8")
+    (auth_volume_path / "logs_1.sqlite").write_text("log", encoding="utf-8")
+    Path(request.codex_home_path, "config.toml").write_text(
+        "model = 'qwen/qwen3.6-plus:free'\n",
+        encoding="utf-8",
+    )
+
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    runtime.launch_session(request)
+
+    assert Path(request.codex_home_path, "auth.json").is_file()
+    assert Path(request.codex_home_path, "config.toml").read_text(encoding="utf-8") == (
+        "model = 'qwen/qwen3.6-plus:free'\n"
+    )
+    assert not Path(request.codex_home_path, "logs_1.sqlite").exists()
+
+
 def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     workspace_path = tmp_path / "repo"
     workspace_path.mkdir()

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2072,7 +2072,9 @@ async def test_controller_launch_uses_mount_syntax_for_colon_scoped_paths(
     assert "--user" in run_command
     assert "1000:1000" in run_command
     assert "--mount" in run_command
-    assert "type=volume,src=codex_auth_volume," not in run_command
+    assert not any(
+        "type=volume,src=codex_auth_volume," in arg for arg in run_command
+    )
 
 
 @pytest.mark.asyncio
@@ -2137,6 +2139,92 @@ async def test_controller_launch_mounts_auth_volume_at_separate_managed_auth_pat
         f"type=volume,src=codex_auth_volume,dst={request.codex_home_path}"
         not in run_command
     )
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_normalizes_materialized_codex_home_for_container_user(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    codex_home_path = workspace_root / "task-1" / ".moonmind" / "codex-home"
+    codex_home_path.mkdir(parents=True, exist_ok=True)
+    config_path = codex_home_path / "config.toml"
+    config_path.write_text("model = 'qwen/qwen3.6-plus:free'\n", encoding="utf-8")
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath=str(codex_home_path),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    chown_calls: list[tuple[Path, int, int, bool]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        _fake_chown,
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del input_text, env
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    chowned_paths = {path for path, _uid, _gid, _follow_symlinks in chown_calls}
+    assert codex_home_path.parent in chowned_paths
+    assert codex_home_path in chowned_paths
+    assert config_path in chowned_paths
+    assert all(uid == 1000 and gid == 1000 for _path, uid, gid, _follow in chown_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -2072,10 +2072,70 @@ async def test_controller_launch_uses_mount_syntax_for_colon_scoped_paths(
     assert "--user" in run_command
     assert "1000:1000" in run_command
     assert "--mount" in run_command
+    assert "type=volume,src=codex_auth_volume," not in run_command
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_mounts_auth_volume_at_separate_managed_auth_path() -> None:
+    workspace_root = Path("/tmp/agent_jobs")
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath=str(workspace_root / "task-1" / ".moonmind" / "codex-home"),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth"},
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    run_command = commands[1]
     assert (
-        "type=volume,src=codex_auth_volume,"
-        f"dst={request.codex_home_path}"
-        in run_command
+        "type=volume,src=codex_auth_volume,dst=/home/app/.codex-auth" in run_command
+    )
+    assert (
+        f"type=volume,src=codex_auth_volume,dst={request.codex_home_path}"
+        not in run_command
     )
 
 

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, ManagedRunRecord
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    ManagedRunRecord,
+)
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionBinding,
@@ -294,14 +297,18 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     persisted_record = run_store.load(binding.task_run_id)
 
     assert len(launch_calls) == 1
-    launch_request = launch_calls[0]
-    assert launch_request.session_id == binding.session_id
-    assert launch_request.workspace_path == str(workspace_path)
-    assert launch_request.session_workspace_path.endswith(f"{binding.task_run_id}/session")
-    assert launch_request.artifact_spool_path.endswith(f"{binding.task_run_id}/artifacts")
-    assert launch_request.codex_home_path.endswith(f"{binding.task_run_id}/.moonmind/codex-home")
-    assert launch_request.image_ref == "ghcr.io/moonladderstudios/moonmind:latest"
-    assert launch_request.workspace_spec == {"workspacePath": str(workspace_path)}
+    launch_payload = launch_calls[0]
+    assert isinstance(launch_payload, dict)
+    assert launch_payload["profile"]["runtimeId"] == "codex_cli"
+    assert launch_payload["profile"]["profileId"] == "codex-default"
+    launch_request = launch_payload["request"]
+    assert launch_request["sessionId"] == binding.session_id
+    assert launch_request["workspacePath"] == str(workspace_path)
+    assert launch_request["sessionWorkspacePath"].endswith(f"{binding.task_run_id}/session")
+    assert launch_request["artifactSpoolPath"].endswith(f"{binding.task_run_id}/artifacts")
+    assert launch_request["codexHomePath"].endswith(f"{binding.task_run_id}/.moonmind/codex-home")
+    assert launch_request["imageRef"] == "ghcr.io/moonladderstudios/moonmind:latest"
+    assert launch_request["workspaceSpec"] == {"workspacePath": str(workspace_path)}
     assert send_turn_calls[0].instructions.startswith("artifact:instructions")
     assert "Managed Codex CLI note:" in send_turn_calls[0].instructions
 
@@ -346,6 +353,106 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["action"] == "send_turn"
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
+
+
+async def test_start_passes_profile_materialization_payload_to_launch_session(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    launch_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(request: Any) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [
+                {
+                    "profile_id": "codex_openrouter_qwen36_plus",
+                    "provider_id": "openrouter",
+                    "credential_source": "secret_ref",
+                    "default_model": "qwen/qwen3.6-plus:free",
+                    "secret_refs": {"provider_api_key": "env://OPENROUTER_API_KEY"},
+                    "home_path_overrides": {
+                        "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+                    },
+                    "env_template": {"OPENAI_BASE_URL": "https://openrouter.ai/api/v1"},
+                    "file_templates": [
+                        {
+                            "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                            "contentTemplate": "model = 'qwen/qwen3.6-plus:free'",
+                        }
+                    ],
+                }
+            ]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(
+            return_value=_turn_response(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    request = _request(binding).model_copy(
+        update={"execution_profile_ref": "codex_openrouter_qwen36_plus"}
+    )
+    await adapter.start(request)
+
+    assert len(launch_calls) == 1
+    launch_payload = launch_calls[0]
+    profile = launch_payload["profile"]
+    assert profile["profileId"] == "codex_openrouter_qwen36_plus"
+    assert profile["credentialSource"] == "secret_ref"
+    assert profile["defaultModel"] == "qwen/qwen3.6-plus:free"
+    assert profile["secretRefs"] == {"provider_api_key": "env://OPENROUTER_API_KEY"}
+    assert profile["homePathOverrides"] == {
+        "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+    }
 
 
 async def test_start_delegates_turn_instruction_preparation_before_sending_turn(

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -28,6 +28,14 @@ async def test_resolve_empty_raises() -> None:
         await resolve_managed_api_key_reference("  ")
 
 
+async def test_resolve_rejects_structured_secret_ref_values() -> None:
+    with pytest.raises(
+        ValueError,
+        match="MANAGED_API_KEY_REF must be a string secret reference",
+    ):
+        await resolve_managed_api_key_reference({"ref": "env://MY_TEST_SECRET_KEY"})
+
+
 async def test_resolve_unknown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NOT_SET_XYZ", raising=False)
     with pytest.raises(ValueError, match="Unable to resolve"):

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -521,10 +521,13 @@ async def test_launch_session_materializes_profile_into_request_environment(
                 "providerId": "openrouter",
                 "credentialSource": "secret_ref",
                 "envTemplate": {
-                    "OPENAI_BASE_URL": "https://openrouter.ai/api/v1"
+                    "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
+                    "OPENROUTER_API_KEY": {
+                        "from_secret_ref": "provider_api_key"
+                    },
                 },
                 "secretRefs": {
-                    "OPENROUTER_API_KEY": "env://OPENROUTER_API_KEY"
+                    "provider_api_key": "env://OPENROUTER_API_KEY"
                 },
                 "homePathOverrides": {
                     "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
@@ -549,6 +552,50 @@ async def test_launch_session_materializes_profile_into_request_environment(
     assert "qwen/qwen3.6-plus:free" in (codex_home_path / "config.toml").read_text(
         encoding="utf-8"
     )
+
+
+async def test_launch_session_rejects_structured_secret_ref_values(
+    tmp_path: Path,
+) -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock()
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    with pytest.raises(
+        ValueError,
+        match="profile.secretRefs.provider_api_key must be a string secret reference",
+    ):
+        await activities.agent_runtime_launch_session(
+            {
+                "request": {
+                    "taskRunId": "task-1",
+                    "sessionId": "sess-1",
+                    "threadId": "thread-1",
+                    "workspacePath": str(tmp_path / "task-1" / "repo"),
+                    "sessionWorkspacePath": str(tmp_path / "task-1" / "session"),
+                    "artifactSpoolPath": str(tmp_path / "task-1" / "artifacts"),
+                    "codexHomePath": str(
+                        tmp_path / "task-1" / ".moonmind" / "codex-home"
+                    ),
+                    "imageRef": "moonmind:latest",
+                },
+                "profile": {
+                    "runtimeId": "codex_cli",
+                    "envTemplate": {
+                        "OPENROUTER_API_KEY": {
+                            "from_secret_ref": "provider_api_key"
+                        }
+                    },
+                    "secretRefs": {
+                        "provider_api_key": {
+                            "ref": "env://OPENROUTER_API_KEY"
+                        }
+                    },
+                },
+            }
+        )
+
+    controller.launch_session.assert_not_awaited()
 
 
 async def test_load_session_snapshot_queries_session_workflow_via_client_boundary(

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -481,6 +481,76 @@ async def test_launch_session_redacts_github_token_in_failure_details() -> None:
     assert "[REDACTED]" in message
 
 
+async def test_launch_session_materializes_profile_into_request_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-123")
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+    codex_home_path = tmp_path / "task-1" / ".moonmind" / "codex-home"
+
+    await activities.agent_runtime_launch_session(
+        {
+            "request": {
+                "taskRunId": "task-1",
+                "sessionId": "sess-1",
+                "threadId": "thread-1",
+                "workspacePath": str(tmp_path / "task-1" / "repo"),
+                "sessionWorkspacePath": str(tmp_path / "task-1" / "session"),
+                "artifactSpoolPath": str(tmp_path / "task-1" / "artifacts"),
+                "codexHomePath": str(codex_home_path),
+                "imageRef": "moonmind:latest",
+                "environment": {"MANAGED_ACCOUNT_LABEL": "Codex CLI via OpenRouter"},
+            },
+            "profile": {
+                "runtimeId": "codex_cli",
+                "profileId": "codex_openrouter_qwen36_plus",
+                "providerId": "openrouter",
+                "credentialSource": "secret_ref",
+                "envTemplate": {
+                    "OPENAI_BASE_URL": "https://openrouter.ai/api/v1"
+                },
+                "secretRefs": {
+                    "OPENROUTER_API_KEY": "env://OPENROUTER_API_KEY"
+                },
+                "homePathOverrides": {
+                    "CODEX_HOME": "{{runtime_support_dir}}/codex-home"
+                },
+                "fileTemplates": [
+                    {
+                        "path": "{{runtime_support_dir}}/codex-home/config.toml",
+                        "contentTemplate": {"model": "qwen/qwen3.6-plus:free"},
+                        "format": "toml",
+                    }
+                ],
+            },
+        }
+    )
+
+    launched_request = controller.launch_session.await_args.args[0]
+    assert launched_request.environment["OPENROUTER_API_KEY"] == "sk-or-123"
+    assert launched_request.environment["OPENAI_BASE_URL"] == "https://openrouter.ai/api/v1"
+    assert launched_request.environment["CODEX_HOME"] == str(codex_home_path)
+    assert launched_request.environment["MANAGED_ACCOUNT_LABEL"] == "Codex CLI via OpenRouter"
+    assert (codex_home_path / "config.toml").is_file()
+    assert "qwen/qwen3.6-plus:free" in (codex_home_path / "config.toml").read_text(
+        encoding="utf-8"
+    )
+
+
 async def test_load_session_snapshot_queries_session_workflow_via_client_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

This fixes the managed Codex session path so session-backed OpenRouter profiles are actually materialized at launch instead of silently falling back to the shared OpenAI-flavored Codex home.

## Root Cause

The normal managed launcher materialized provider profiles, but the managed-session path only forwarded launch-context env deltas. That meant:

- `secret_refs` were never resolved for session-backed launches
- `env_template`, `file_templates`, and `home_path_overrides` were never applied
- the controller mounted `codex_auth_volume` directly over active `CODEX_HOME`
- the session runtime started against shared auth-volume state, which let OpenAI config bleed into runs that requested OpenRouter/Qwen

## What Changed

- pass a full `ManagedRuntimeProfile` envelope from the session adapter into `agent_runtime.launch_session`
- materialize session launch environment at the activity boundary using `ProviderProfileMaterializer`
- resolve provider secrets immediately before session launch without storing them in workflow history
- keep active per-run `CODEX_HOME` isolated from the shared auth volume
- mount the auth volume only at `MANAGED_AUTH_VOLUME_PATH` when needed
- seed auth artifacts into per-run `CODEX_HOME` while excluding shared config and sqlite state that can override provider selection
- add regression coverage for adapter, activity, controller, and container runtime boundaries

## Impact

Session-backed Codex runs that request `codex_openrouter_qwen36_plus` now get the intended OpenRouter materialization path instead of booting as `model_provider=openai` / `model=gpt-5.4` from shared state.

## Validation

- `./tools/test_unit.sh`
