### PR TITLE
[codex] fix publish staging for ignored runtime files

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3581,44 +3581,48 @@ class TemporalAgentRuntimeActivities:
         ]
 
     @staticmethod
-    def _parse_git_status_paths(status_output: str) -> tuple[str, ...]:
-        """Extract changed paths from `git status --porcelain` output."""
+    def _parse_git_status_paths(status_output: bytes) -> tuple[str, ...]:
+        """Extract changed paths from `git status --porcelain=v1 -z` output."""
 
-        def _split_rename_paths(
-            entry: str,
-            *,
-            is_renamed: bool,
-        ) -> tuple[str, ...]:
-            if not is_renamed or " -> " not in entry:
-                return (entry,)
-            try:
-                tokens = tuple(shlex.split(entry))
-            except ValueError:
-                return (entry,)
-            if len(tokens) == 3 and tokens[1] == "->":
-                return (tokens[0], tokens[2])
-            return (entry,)
+        def _decode_path(path_bytes: bytes) -> str:
+            return os.fsdecode(path_bytes)
 
-        def _normalize_path(path_text: str) -> str:
-            text = str(path_text or "").strip()
-            if text.startswith('"') and text.endswith('"') and len(text) >= 2:
-                return text[1:-1]
-            return text
+        raw_output = bytes(status_output or b"")
+        if not raw_output:
+            return ()
 
+        entries = raw_output.split(b"\0")
         paths: list[str] = []
-        for raw_line in str(status_output or "").splitlines():
-            line = raw_line.rstrip()
-            if len(line) < 4:
+        index = 0
+        while index < len(entries):
+            record = entries[index]
+            if not record:
+                index += 1
                 continue
-            status = line[:2]
-            is_renamed = ("R" in status) or ("C" in status)
-            entry = line[3:].strip()
-            if not entry:
-                continue
-            for path in _split_rename_paths(entry, is_renamed=is_renamed):
-                normalized_path = _normalize_path(path)
-                if normalized_path:
-                    paths.append(normalized_path)
+            if len(record) < 4 or record[2:3] != b" ":
+                raise ValueError(f"unexpected git status record: {record!r}")
+
+            status = record[:2].decode("ascii", errors="strict")
+            path_bytes = record[3:]
+            if not path_bytes:
+                raise ValueError(f"missing path in git status record: {record!r}")
+            paths.append(_decode_path(path_bytes))
+
+            if "R" in status or "C" in status:
+                index += 1
+                if index >= len(entries):
+                    raise ValueError(
+                        f"missing original path for git rename/copy record: {record!r}"
+                    )
+                original_path_bytes = entries[index]
+                if not original_path_bytes:
+                    raise ValueError(
+                        f"missing original path for git rename/copy record: {record!r}"
+                    )
+                paths.append(_decode_path(original_path_bytes))
+
+            index += 1
+
         return tuple(dict.fromkeys(paths))
 
     @staticmethod
@@ -3738,7 +3742,11 @@ class TemporalAgentRuntimeActivities:
 
         status_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
-                workspace, "status", "--porcelain", "--untracked-files=all",
+                workspace,
+                "status",
+                "--porcelain=v1",
+                "-z",
+                "--untracked-files=all",
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -3756,15 +3764,20 @@ class TemporalAgentRuntimeActivities:
                 "push_error": f"could not inspect workspace changes: {detail}",
             }
 
-        status_text = status_stdout.decode("utf-8", errors="replace")
-        if not status_text.strip():
+        if not status_stdout:
             return {}
 
-        changed_paths = tuple(
-            path
-            for path in self._parse_git_status_paths(status_text)
-            if not self._should_exclude_publish_path(path)
-        )
+        try:
+            changed_paths = tuple(
+                path
+                for path in self._parse_git_status_paths(status_stdout)
+                if not self._should_exclude_publish_path(path)
+            )
+        except ValueError as exc:
+            return {
+                "push_status": "failed",
+                "push_error": f"could not parse workspace changes: {exc}",
+            }
         if not changed_paths:
             return {}
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -159,10 +159,10 @@ _GEMINI_RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "code: 429",
 )
 _OPERATOR_SUMMARY_TAIL_BYTES = 64 * 1024
-_PUBLISH_GIT_ADD_EXCLUDES: tuple[str, ...] = (
-    ":(exclude)CLAUDE.md",
-    ":(exclude)live_streams.spool",
-    ":(exclude).agents/skills/active",
+_PUBLISH_GIT_EXCLUDED_PATHS: tuple[str, ...] = (
+    "CLAUDE.md",
+    "live_streams.spool",
+    ".agents/skills/active",
 )
 _SESSION_CONTROLLER_HEARTBEAT_INTERVAL_SECONDS = 10.0
 
@@ -3581,6 +3581,58 @@ class TemporalAgentRuntimeActivities:
         ]
 
     @staticmethod
+    def _parse_git_status_paths(status_output: str) -> tuple[str, ...]:
+        """Extract changed paths from `git status --porcelain` output."""
+
+        def _split_rename_paths(
+            entry: str,
+            *,
+            is_renamed: bool,
+        ) -> tuple[str, ...]:
+            if not is_renamed or " -> " not in entry:
+                return (entry,)
+            try:
+                tokens = tuple(shlex.split(entry))
+            except ValueError:
+                return (entry,)
+            if len(tokens) == 3 and tokens[1] == "->":
+                return (tokens[0], tokens[2])
+            return (entry,)
+
+        def _normalize_path(path_text: str) -> str:
+            text = str(path_text or "").strip()
+            if text.startswith('"') and text.endswith('"') and len(text) >= 2:
+                return text[1:-1]
+            return text
+
+        paths: list[str] = []
+        for raw_line in str(status_output or "").splitlines():
+            line = raw_line.rstrip()
+            if len(line) < 4:
+                continue
+            status = line[:2]
+            is_renamed = ("R" in status) or ("C" in status)
+            entry = line[3:].strip()
+            if not entry:
+                continue
+            for path in _split_rename_paths(entry, is_renamed=is_renamed):
+                normalized_path = _normalize_path(path)
+                if normalized_path:
+                    paths.append(normalized_path)
+        return tuple(dict.fromkeys(paths))
+
+    @staticmethod
+    def _should_exclude_publish_path(path_text: str) -> bool:
+        """Skip runtime scaffolding paths that should never be published."""
+        normalized = str(path_text or "").strip().rstrip("/")
+        if not normalized:
+            return True
+        for excluded in _PUBLISH_GIT_EXCLUDED_PATHS:
+            if normalized == excluded or normalized.startswith(f"{excluded}/"):
+                return True
+        return False
+
+    @staticmethod
     def _workspace_command_env(workspace: str) -> dict[str, str]:
         """Build a subprocess env that exposes workspace-local command shims."""
         env = dict(os.environ)
@@ -3704,12 +3756,21 @@ class TemporalAgentRuntimeActivities:
                 "push_error": f"could not inspect workspace changes: {detail}",
             }
 
-        if not status_stdout.decode("utf-8", errors="replace").strip():
+        status_text = status_stdout.decode("utf-8", errors="replace")
+        if not status_text.strip():
+            return {}
+
+        changed_paths = tuple(
+            path
+            for path in self._parse_git_status_paths(status_text)
+            if not self._should_exclude_publish_path(path)
+        )
+        if not changed_paths:
             return {}
 
         add_proc = await asyncio.create_subprocess_exec(
             *self._workspace_git_command(
-                workspace, "add", "-A", "--", ".", *_PUBLISH_GIT_ADD_EXCLUDES,
+                workspace, "add", "-A", "--", *changed_paths,
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -88,6 +88,28 @@ def test_detect_pr_url_uses_workspace_command_shims(tmp_path):
     assert gh_env["PATH"].startswith(str(workspace.parent / ".moonmind" / "bin"))
 
 
+def test_parse_git_status_paths_handles_nul_delimited_non_ascii_and_renames() -> None:
+    status_output = (
+        b'M  "quoted-looking.txt"\0'
+        b'?? na\xc3\xafve.txt\0'
+        b"R  renamed path.txt\0old path.txt\0"
+    )
+
+    paths = TemporalAgentRuntimeActivities._parse_git_status_paths(status_output)
+
+    assert paths == (
+        '"quoted-looking.txt"',
+        "naïve.txt",
+        "renamed path.txt",
+        "old path.txt",
+    )
+
+
+def test_parse_git_status_paths_rejects_truncated_rename_record() -> None:
+    with pytest.raises(ValueError, match="missing original path"):
+        TemporalAgentRuntimeActivities._parse_git_status_paths(b"R  renamed path.txt\0")
+
+
 # ---------------------------------------------------------------------------
 # _push_workspace_branch
 # ---------------------------------------------------------------------------
@@ -453,7 +475,7 @@ class TestPushWorkspaceBranch:
                 proc.returncode = 0
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(
-                    return_value=(b" M api_service/main.py\n?? tests/new_test.py\n", b"")
+                    return_value=(b" M api_service/main.py\0?? tests/new_test.py\0", b"")
                 )
                 proc.returncode = 0
             elif call_count == 3:  # git add -A with runtime exclusions
@@ -509,7 +531,7 @@ class TestPushWorkspaceBranch:
                 proc.communicate = AsyncMock(return_value=(b"auto-dirty123\n", b""))
                 proc.returncode = 0
             elif call_count == 2:  # status --porcelain
-                proc.communicate = AsyncMock(return_value=(b" M api_service/main.py\n", b""))
+                proc.communicate = AsyncMock(return_value=(b" M api_service/main.py\0", b""))
                 proc.returncode = 0
             elif call_count == 3:  # git add -A
                 proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -547,7 +569,7 @@ class TestPushWorkspaceBranch:
                 proc.communicate = AsyncMock(return_value=(b"auto-claude123\n", b""))
                 proc.returncode = 0
             elif call_count == 2:  # status --porcelain
-                proc.communicate = AsyncMock(return_value=(b"?? CLAUDE.md\n", b""))
+                proc.communicate = AsyncMock(return_value=(b"?? CLAUDE.md\0", b""))
                 proc.returncode = 0
             elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
@@ -582,7 +604,10 @@ class TestPushWorkspaceBranch:
                 proc.returncode = 0
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(
-                    return_value=(b" M moonmind/workflows/temporal/activity_runtime.py\n", b"")
+                    return_value=(
+                        b" M moonmind/workflows/temporal/activity_runtime.py\0",
+                        b"",
+                    )
                 )
                 proc.returncode = 0
             elif call_count == 3:  # git add -A for changed paths only

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -486,12 +486,10 @@ class TestPushWorkspaceBranch:
         assert result["push_commit_count"] == 1
         assert result["push_commit_message"] == "Ship dirty workspace"
         add_call = recorded_calls[2]
-        assert list(add_call[-5:]) == [
+        assert list(add_call[-3:]) == [
             "--",
-            ".",
-            ":(exclude)CLAUDE.md",
-            ":(exclude)live_streams.spool",
-            ":(exclude).agents/skills/active",
+            "api_service/main.py",
+            "tests/new_test.py",
         ]
         commit_call = next(call for call in recorded_calls if "commit" in call)
         assert list(commit_call[-3:]) == ["commit", "-m", "Ship dirty workspace"]
@@ -538,10 +536,12 @@ class TestPushWorkspaceBranch:
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)
         call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
 
         async def _mock_exec(*args, **kwargs):
             nonlocal call_count
             call_count += 1
+            recorded_calls.append(args)
             proc = AsyncMock()
             if call_count == 1:  # rev-parse
                 proc.communicate = AsyncMock(return_value=(b"auto-claude123\n", b""))
@@ -549,13 +549,7 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"?? CLAUDE.md\n", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # git add -A with exclusions
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count == 4:  # staged diff check
-                proc.communicate = AsyncMock(return_value=(b"", b""))
-                proc.returncode = 0
-            elif call_count == 5:  # push
+            elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -569,6 +563,58 @@ class TestPushWorkspaceBranch:
         assert result["push_status"] == "no_commits"
         assert result["push_branch"] == "auto-claude123"
         assert result["push_commit_count"] == 0
+        assert all("add" not in call for call in recorded_calls)
+
+    @pytest.mark.asyncio
+    async def test_push_stages_only_porcelain_reported_paths(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        call_count = 0
+        recorded_calls: list[tuple[object, ...]] = []
+
+        async def _mock_exec(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            recorded_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:  # rev-parse
+                proc.communicate = AsyncMock(return_value=(b"auto-dirty123\n", b""))
+                proc.returncode = 0
+            elif call_count == 2:  # status --porcelain
+                proc.communicate = AsyncMock(
+                    return_value=(b" M moonmind/workflows/temporal/activity_runtime.py\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 3:  # git add -A for changed paths only
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # staged diff check
+                proc.communicate = AsyncMock(
+                    return_value=(b"moonmind/workflows/temporal/activity_runtime.py\n", b"")
+                )
+                proc.returncode = 0
+            elif call_count == 5:  # commit
+                proc.communicate = AsyncMock(return_value=(b"[auto-dirty123 abc123] msg\n", b""))
+                proc.returncode = 0
+            elif call_count == 6:  # push
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            else:  # rev-list --count
+                proc.communicate = AsyncMock(return_value=(b"1\n", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._push_workspace_branch("run-1")
+
+        assert result["push_status"] == "pushed"
+        add_call = recorded_calls[2]
+        assert "." not in add_call
+        assert "live_streams.spool" not in add_call
+        assert list(add_call[-2:]) == [
+            "--",
+            "moonmind/workflows/temporal/activity_runtime.py",
+        ]
 
     def test_workspace_command_env_includes_support_gitconfig_and_git_identity(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,


### PR DESCRIPTION
## What changed
This updates the publish/finalization git staging logic for managed runtime workspaces so it stages only the paths reported by `git status --porcelain` instead of running `git add -A -- .` with pathspec exclusions.

It also adds regression coverage for:
- dirty workspaces with real repo changes
- runtime-scaffolding-only changes that should not be staged
- targeted staging that excludes `live_streams.spool` and other runtime-only paths

## Why
The workflow `mm:c47d9e35-18ce-4b14-b15f-36cec0f70f3a` completed its execution steps but failed in the final publish phase.

Root cause: `git add -A -- . ':(exclude)live_streams.spool'` still exits nonzero when an ignored top-level `live_streams.spool` file exists, so the run was marked failed even though the actual work had succeeded.

## Impact
Managed runtime runs no longer fail the publish stage just because the live log spool file exists in the workspace. Real repo changes are still committed and pushed, while runtime-only scaffolding stays out of the publish commit.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py`
- `./tools/test_unit.sh`
- Restarted `temporal-worker-agent-runtime` locally and verified it returned healthy
