### PR TITLE
[codex] Harden Codex managed session cancellation

### DIFF
--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -58,6 +58,7 @@ from moonmind.workflows.temporal.manifest_ingest import (
 )
 from moonmind.workflows.temporal.runtime.managed_session_store import (
     ManagedSessionStore,
+    TERMINAL_MANAGED_SESSION_STATUSES,
 )
 from moonmind.schemas.managed_session_models import canonical_codex_managed_runtime_id
 
@@ -1722,25 +1723,49 @@ class TemporalExecutionService:
         reason: str,
     ) -> None:
         store = ManagedSessionStore(_get_managed_session_store_root())
+        canonical_runtime_id = "codex_cli"
+        default_session_id = f"sess:{workflow_id}:{canonical_runtime_id}"
         try:
-            session_records = await asyncio.to_thread(store.list_active)
+            session_record = store.load(default_session_id)
         except Exception:
             logger.warning(
-                "Failed to read managed session store before cancel for workflow %s",
+                "Failed to load managed session record %s before cancel for workflow %s",
+                default_session_id,
                 workflow_id,
                 exc_info=True,
             )
-            return
+            session_record = None
+        else:
+            if (
+                session_record is None
+                or session_record.task_run_id != workflow_id
+                or canonical_codex_managed_runtime_id(session_record.runtime_id)
+                != canonical_runtime_id
+                or session_record.status in TERMINAL_MANAGED_SESSION_STATUSES
+            ):
+                session_record = None
 
-        session_record = next(
-            (
-                record
-                for record in session_records
-                if record.task_run_id == workflow_id
-                and canonical_codex_managed_runtime_id(record.runtime_id) == "codex_cli"
-            ),
-            None,
-        )
+        if session_record is None:
+            try:
+                session_records = await asyncio.to_thread(store.list_active)
+            except Exception:
+                logger.warning(
+                    "Failed to read managed session store before cancel for workflow %s",
+                    workflow_id,
+                    exc_info=True,
+                )
+                return
+
+            session_record = next(
+                (
+                    record
+                    for record in session_records
+                    if record.task_run_id == workflow_id
+                    and canonical_codex_managed_runtime_id(record.runtime_id)
+                    == canonical_runtime_id
+                ),
+                None,
+            )
         if session_record is None:
             return
 

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -56,6 +56,10 @@ from moonmind.workflows.temporal.manifest_ingest import (
     initialize_manifest_projection,
     list_manifest_nodes,
 )
+from moonmind.workflows.temporal.runtime.managed_session_store import (
+    ManagedSessionStore,
+)
+from moonmind.schemas.managed_session_models import canonical_codex_managed_runtime_id
 
 TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.COMPLETED,
@@ -66,6 +70,15 @@ TERMINAL_STATES: set[MoonMindWorkflowState] = {
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _get_managed_session_store_root() -> str:
+    import os
+
+    return os.path.join(
+        os.environ.get("MOONMIND_AGENT_RUNTIME_STORE", "/work/agent_jobs"),
+        "managed_sessions",
+    )
 
 NON_TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.SCHEDULED,
@@ -1469,6 +1482,15 @@ class TemporalExecutionService:
         )
         reason_text = (reason or default_reason).strip() or default_reason
 
+        if (
+            record.workflow_type is TemporalWorkflowType.RUN
+            and record.state not in TERMINAL_STATES
+        ):
+            await self._best_effort_terminate_task_scoped_codex_session(
+                workflow_id=record.workflow_id,
+                reason=reason_text,
+            )
+
         try:
             if graceful:
                 await self._client_adapter.cancel_workflow(record.workflow_id)
@@ -1692,6 +1714,50 @@ class TemporalExecutionService:
         await self._session.commit()
         await self._session.refresh(record)
         return record
+
+    async def _best_effort_terminate_task_scoped_codex_session(
+        self,
+        *,
+        workflow_id: str,
+        reason: str,
+    ) -> None:
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        try:
+            session_records = await asyncio.to_thread(store.list_active)
+        except Exception:
+            logger.warning(
+                "Failed to read managed session store before cancel for workflow %s",
+                workflow_id,
+                exc_info=True,
+            )
+            return
+
+        session_record = next(
+            (
+                record
+                for record in session_records
+                if record.task_run_id == workflow_id
+                and canonical_codex_managed_runtime_id(record.runtime_id) == "codex_cli"
+            ),
+            None,
+        )
+        if session_record is None:
+            return
+
+        session_workflow_id = f"{workflow_id}:session:{session_record.runtime_id}"
+        try:
+            await self._client_adapter.update_workflow(
+                session_workflow_id,
+                "TerminateSession",
+                {"reason": reason},
+            )
+        except Exception:
+            logger.warning(
+                "Best-effort session termination dispatch failed for workflow %s session %s",
+                workflow_id,
+                session_record.session_id,
+                exc_info=True,
+            )
 
     async def mark_projection_repair_pending(
         self,

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -528,29 +528,37 @@ class MoonMindAgentSessionWorkflow:
         self, payload: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         request = CodexManagedSessionWorkflowControlRequest.model_validate(payload or {})
-        if self._container_id and self._thread_id:
-            locator = self._require_locator()
-            handle = CodexManagedSessionHandle.model_validate(
-                await self._execute_routed_activity(
-                    "agent_runtime.terminate_session",
-                    TerminateCodexManagedSessionRequest(
-                        sessionId=locator.session_id,
-                        sessionEpoch=locator.session_epoch,
-                        containerId=locator.container_id,
-                        threadId=locator.thread_id,
-                        reason=request.reason,
-                    ).model_dump(by_alias=True),
-                )
-            )
-            self._apply_runtime_snapshot(
-                handle.session_state.model_dump(mode="json", by_alias=True),
-                last_control_action="terminate_session",
-                last_control_reason=request.reason,
-            )
         self._status = AGENT_SESSION_STATUS_TERMINATING
         self._termination_requested = True
         self._last_control_action = "terminate_session"
         self._last_control_reason = request.reason
+        if self._container_id and self._thread_id:
+            locator = self._require_locator()
+            try:
+                handle = CodexManagedSessionHandle.model_validate(
+                    await self._execute_routed_activity(
+                        "agent_runtime.terminate_session",
+                        TerminateCodexManagedSessionRequest(
+                            sessionId=locator.session_id,
+                            sessionEpoch=locator.session_epoch,
+                            containerId=locator.container_id,
+                            threadId=locator.thread_id,
+                            reason=request.reason,
+                        ).model_dump(by_alias=True),
+                    )
+                )
+            except Exception as exc:
+                workflow.logger.warning(
+                    "Managed session terminate activity failed for %s: %s",
+                    self._binding.session_id,
+                    exc,
+                )
+            else:
+                self._apply_runtime_snapshot(
+                    handle.session_state.model_dump(mode="json", by_alias=True),
+                    last_control_action="terminate_session",
+                    last_control_reason=request.reason,
+                )
         return self.get_status()
 
     @terminate_session_update.validator

--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -27,6 +27,7 @@ with workflow.unsafe.imports_passed_through():
         CodexManagedSessionWorkflowInput,
         FetchCodexManagedSessionSummaryRequest,
         InterruptCodexManagedSessionTurnRequest,
+        TerminateCodexManagedSessionRequest,
         PublishCodexManagedSessionArtifactsRequest,
         SendCodexManagedSessionTurnRequest,
         SteerCodexManagedSessionTurnRequest,
@@ -527,6 +528,25 @@ class MoonMindAgentSessionWorkflow:
         self, payload: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         request = CodexManagedSessionWorkflowControlRequest.model_validate(payload or {})
+        if self._container_id and self._thread_id:
+            locator = self._require_locator()
+            handle = CodexManagedSessionHandle.model_validate(
+                await self._execute_routed_activity(
+                    "agent_runtime.terminate_session",
+                    TerminateCodexManagedSessionRequest(
+                        sessionId=locator.session_id,
+                        sessionEpoch=locator.session_epoch,
+                        containerId=locator.container_id,
+                        threadId=locator.thread_id,
+                        reason=request.reason,
+                    ).model_dump(by_alias=True),
+                )
+            )
+            self._apply_runtime_snapshot(
+                handle.session_state.model_dump(mode="json", by_alias=True),
+                last_control_action="terminate_session",
+                last_control_reason=request.reason,
+            )
         self._status = AGENT_SESSION_STATUS_TERMINATING
         self._termination_requested = True
         self._last_control_action = "terminate_session"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -145,6 +145,8 @@ _GITHUB_PR_URL_PATTERN = re.compile(
 INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 # Replay-stable patch id for parent-initiated defensive slot release on child terminal state.
 RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release-1"
+# Replay-stable patch id for task-scoped Codex terminate activities during finalization.
+RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
@@ -2303,32 +2305,43 @@ class MoonMindRunWorkflow:
         binding = self._codex_session_binding
         try:
             if handle is not None and binding is not None:
-                snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                    "agent_runtime.load_session_snapshot"
-                )
-                snapshot_payload = await workflow.execute_activity(
-                    snapshot_route.activity_type,
-                    binding.model_dump(mode="json", by_alias=True),
-                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                    **self._execute_kwargs_for_route(snapshot_route),
-                )
-                snapshot = CodexManagedSessionSnapshot.model_validate(snapshot_payload)
-                if snapshot.container_id and snapshot.thread_id:
-                    terminate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                        "agent_runtime.terminate_session"
-                    )
-                    await workflow.execute_activity(
-                        terminate_route.activity_type,
-                        TerminateCodexManagedSessionRequest(
-                            sessionId=snapshot.binding.session_id,
-                            sessionEpoch=snapshot.binding.session_epoch,
-                            containerId=snapshot.container_id,
-                            threadId=snapshot.thread_id,
-                            reason=reason,
-                        ).model_dump(mode="json", by_alias=True),
-                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                        **self._execute_kwargs_for_route(terminate_route),
-                    )
+                if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH):
+                    try:
+                        snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                            "agent_runtime.load_session_snapshot"
+                        )
+                        snapshot_payload = await workflow.execute_activity(
+                            snapshot_route.activity_type,
+                            binding.model_dump(mode="json", by_alias=True),
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            **self._execute_kwargs_for_route(snapshot_route),
+                        )
+                        snapshot = CodexManagedSessionSnapshot.model_validate(
+                            snapshot_payload
+                        )
+                        if snapshot.container_id and snapshot.thread_id:
+                            terminate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                                "agent_runtime.terminate_session"
+                            )
+                            await workflow.execute_activity(
+                                terminate_route.activity_type,
+                                TerminateCodexManagedSessionRequest(
+                                    sessionId=snapshot.binding.session_id,
+                                    sessionEpoch=snapshot.binding.session_epoch,
+                                    containerId=snapshot.container_id,
+                                    threadId=snapshot.thread_id,
+                                    reason=reason,
+                                ).model_dump(mode="json", by_alias=True),
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                **self._execute_kwargs_for_route(terminate_route),
+                            )
+                    except Exception as exc:
+                        self._get_logger().warning(
+                            "Task-scoped Codex terminate activity failed for %s; "
+                            "falling back to session signal: %s",
+                            binding.session_id,
+                            exc,
+                        )
                 await handle.signal(
                     "control_action",
                     {

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -16,6 +16,8 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
+        CodexManagedSessionSnapshot,
+        TerminateCodexManagedSessionRequest,
         CodexManagedSessionWorkflowInput,
         canonical_codex_managed_runtime_id,
     )
@@ -2301,6 +2303,32 @@ class MoonMindRunWorkflow:
         binding = self._codex_session_binding
         try:
             if handle is not None and binding is not None:
+                snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                    "agent_runtime.load_session_snapshot"
+                )
+                snapshot_payload = await workflow.execute_activity(
+                    snapshot_route.activity_type,
+                    binding.model_dump(mode="json", by_alias=True),
+                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                    **self._execute_kwargs_for_route(snapshot_route),
+                )
+                snapshot = CodexManagedSessionSnapshot.model_validate(snapshot_payload)
+                if snapshot.container_id and snapshot.thread_id:
+                    terminate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                        "agent_runtime.terminate_session"
+                    )
+                    await workflow.execute_activity(
+                        terminate_route.activity_type,
+                        TerminateCodexManagedSessionRequest(
+                            sessionId=snapshot.binding.session_id,
+                            sessionEpoch=snapshot.binding.session_epoch,
+                            containerId=snapshot.container_id,
+                            threadId=snapshot.thread_id,
+                            reason=reason,
+                        ).model_dump(mode="json", by_alias=True),
+                        cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                        **self._execute_kwargs_for_route(terminate_route),
+                    )
                 await handle.signal(
                     "control_action",
                     {

--- a/specs/144-codex-managed-session-cancel-hardening/plan.md
+++ b/specs/144-codex-managed-session-cancel-hardening/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: codex-managed-session-cancel-hardening
+
+**Branch**: `144-codex-managed-session-cancel-hardening` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/144-codex-managed-session-cancel-hardening/spec.md`
+
+## Summary
+
+Harden Codex managed-session cancellation by wiring the API/service cancel path to best-effort invoke `TerminateSession` on the task-scoped session workflow and by making the session workflow’s `TerminateSession` update execute the real `agent_runtime.terminate_session` activity when runtime handles still exist.
+
+## Technical Context
+
+**Language/Version**: Python 3.13  
+**Primary Dependencies**: Temporal Python SDK, `TemporalExecutionService`, `ManagedSessionStore`, `MoonMind.AgentSession`, `TemporalClientAdapter`, `agent_runtime.terminate_session`  
+**Storage**: Temporal workflow state plus file-backed `ManagedSessionStore` records under `/work/agent_jobs/managed_sessions`  
+**Testing**: pytest unit tests plus final verification via `./tools/test_unit.sh`  
+**Target Platform**: Docker/Compose-hosted MoonMind API and Temporal workers  
+**Constraints**: keep cleanup in the workflow/activity plane because the API container does not own Docker access; preserve task-scoped session identity and avoid new compatibility aliases
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Cleanup remains routed through Temporal workflow/activity boundaries.
+- **II. One-Click Agent Deployment**: PASS. No new operator dependency is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The change stays inside the existing Codex-specific managed-session boundary.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The hardening strengthens existing cancel/terminate contracts instead of adding sidecar cleanup scripts.
+- **IX. Resilient by Default**: PASS. Best-effort session teardown closes an orphaned-runtime failure mode; tests cover the boundary.
+- **XI. Spec-Driven Development**: PASS. This hardening slice adds dedicated spec artifacts before implementation.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The change updates the active cancel path directly without compatibility shims.
+
+## Implementation Plan
+
+1. Add failing workflow tests for `TerminateSession` executing the managed-session terminate activity when runtime handles exist.
+2. Add failing service tests for best-effort session-workflow teardown dispatch during execution cancellation.
+3. Refactor `MoonMind.AgentSession.terminate_session_update()` to invoke `agent_runtime.terminate_session` using the current locator when handles are available.
+4. Add a best-effort Codex session teardown helper in `TemporalExecutionService.cancel_execution()` using `ManagedSessionStore` and `TemporalClientAdapter.update_workflow("TerminateSession")`.
+5. Run focused tests, then final verification via `./tools/test_unit.sh`.

--- a/specs/144-codex-managed-session-cancel-hardening/spec.md
+++ b/specs/144-codex-managed-session-cancel-hardening/spec.md
@@ -1,0 +1,47 @@
+# Feature Specification: Codex Managed Session Cancel Hardening
+
+**Feature Branch**: `144-codex-managed-session-cancel-hardening`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Harden cancel flow for Codex managed session workflows so UI-triggered task cancellation still tears down the managed session when workflow replay is stuck or the parent does not reach finalization promptly."
+
+## User Scenarios & Testing
+
+### User Story 1 - Canceling a Codex task tears down its managed session (Priority: P1)
+
+Operators need task cancellation to stop the task-scoped Codex managed session, not just record a cancel request on the parent workflow.
+
+**Why this priority**: A canceled task that leaves its managed session container running leaks runtime resources and makes the UI appear stuck.
+
+**Independent Test**: Trigger cancellation for a Codex managed-session task and verify the service best-effort targets the session workflow while the workflow-owned terminate path invokes the managed-session terminate activity when runtime handles exist.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `MoonMind.Run` has an active Codex task-scoped session, **When** an operator cancels the task, **Then** MoonMind best-effort invokes `TerminateSession` on the session workflow in addition to the normal parent cancel path.
+2. **Given** the session workflow still has runtime handles for the active container and thread, **When** `TerminateSession` runs, **Then** it calls the existing `agent_runtime.terminate_session` activity and marks the session as terminating.
+3. **Given** runtime handles are already missing or the session is already terminating, **When** `TerminateSession` runs, **Then** the workflow fails fast or degrades safely without leaving a competing control path.
+
+### Edge Cases
+
+- The managed-session store has no record for the task run.
+- The stored session record belongs to a different task run.
+- The session workflow is already closed or already terminating when the cancel service attempts `TerminateSession`.
+- The parent workflow later reaches finalization and attempts a second termination.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `TemporalExecutionService.cancel_execution` MUST best-effort target the task-scoped Codex session workflow with `TerminateSession` before or alongside the normal parent cancel/terminate call when a live managed-session record exists for that run.
+- **FR-002**: The best-effort session teardown path MUST use existing task-scoped session identity derived from `ManagedSessionStore`; it MUST NOT introduce a second non-Temporal control plane.
+- **FR-003**: `MoonMind.AgentSession.TerminateSession` MUST invoke `agent_runtime.terminate_session` when the workflow snapshot still contains `containerId` and `threadId`.
+- **FR-004**: The workflow-owned terminate path MUST remain idempotent enough for duplicate invocations from service-level cancel and parent finalization.
+- **FR-005**: The slice MUST include automated tests covering service-level session teardown dispatch and workflow-level terminate activity execution.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests verify canceling a `MoonMind.Run` with a live Codex managed-session record dispatches `TerminateSession` to the session workflow before the existing parent cancel call.
+- **SC-002**: Unit tests verify `TerminateSession` executes `agent_runtime.terminate_session` when runtime handles are available.
+- **SC-003**: Unit tests verify duplicate or degraded terminate paths do not crash the cancel service.

--- a/specs/144-codex-managed-session-cancel-hardening/tasks.md
+++ b/specs/144-codex-managed-session-cancel-hardening/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Codex Managed Session Cancel Hardening
+
+**Input**: Design documents from `/specs/144-codex-managed-session-cancel-hardening/`  
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: Add or update failing tests before implementation changes.
+
+## Phase 1: Failing Coverage First
+
+- [X] T001 Add workflow-unit coverage for `TerminateSession` invoking `agent_runtime.terminate_session` when runtime handles exist in `tests/unit/workflows/temporal/workflows/test_agent_session.py`
+- [X] T002 Add service-unit coverage for best-effort session-workflow teardown dispatch in `tests/unit/workflows/temporal/test_temporal_service.py`
+
+## Phase 2: Runtime Hardening
+
+- [X] T003 Update `moonmind/workflows/temporal/workflows/agent_session.py` so `TerminateSession` executes the existing managed-session terminate activity when handles are available
+- [X] T004 Update `moonmind/workflows/temporal/service.py` so cancel requests best-effort invoke `TerminateSession` on the task-scoped Codex session workflow when a live managed-session record exists
+
+## Phase 3: Verification
+
+- [X] T005 Run focused verification for the updated workflow and service tests
+- [X] T006 Run `./tools/test_unit.sh`

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -32,7 +32,10 @@ from moonmind.workflows.temporal.service import (
     TemporalExecutionNotFoundError,
     TemporalExecutionService,
     TemporalExecutionValidationError,
+    _get_managed_session_store_root,
 )
+from moonmind.schemas.managed_session_models import CodexManagedSessionRecord
+from moonmind.workflows.temporal.runtime.managed_session_store import ManagedSessionStore
 
 
 @pytest.fixture
@@ -1508,6 +1511,115 @@ async def test_cancel_execution_records_reject_audit_action(
         )
         assert canceled.closed_at is not None
         assert canceled.search_attributes["mm_state"] == "canceled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_best_effort_terminates_task_scoped_codex_session(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent_jobs"))
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        store.save(
+            CodexManagedSessionRecord(
+                sessionId=f"sess:{created.workflow_id}:codex_cli",
+                sessionEpoch=1,
+                taskRunId=created.workflow_id,
+                containerId="container-1",
+                threadId="thread-1",
+                runtimeId="codex_cli",
+                imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+                controlUrl="docker-exec://container-1",
+                status="ready",
+                workspacePath=f"/work/agent_jobs/{created.workflow_id}/repo",
+                sessionWorkspacePath=f"/work/agent_jobs/{created.workflow_id}/session",
+                artifactSpoolPath=f"/work/agent_jobs/{created.workflow_id}/artifacts",
+                startedAt=datetime.now(tz=UTC),
+            )
+        )
+
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="stop",
+            graceful=True,
+        )
+
+        mock_client_adapter.assert_has_calls(
+            [
+                call.update_workflow(
+                    f"{created.workflow_id}:session:codex_cli",
+                    "TerminateSession",
+                    {"reason": "stop"},
+                ),
+                call.cancel_workflow(created.workflow_id),
+            ],
+            any_order=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_ignores_best_effort_session_terminate_failure(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent_jobs"))
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+        mock_client_adapter.update_workflow.side_effect = RuntimeError("session closed")
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        store.save(
+            CodexManagedSessionRecord(
+                sessionId=f"sess:{created.workflow_id}:codex_cli",
+                sessionEpoch=1,
+                taskRunId=created.workflow_id,
+                containerId="container-1",
+                threadId="thread-1",
+                runtimeId="codex_cli",
+                imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+                controlUrl="docker-exec://container-1",
+                status="ready",
+                workspacePath=f"/work/agent_jobs/{created.workflow_id}/repo",
+                sessionWorkspacePath=f"/work/agent_jobs/{created.workflow_id}/session",
+                artifactSpoolPath=f"/work/agent_jobs/{created.workflow_id}/artifacts",
+                startedAt=datetime.now(tz=UTC),
+            )
+        )
+
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="stop",
+            graceful=True,
+        )
+
+        mock_client_adapter.cancel_workflow.assert_called_once_with(created.workflow_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1573,6 +1573,72 @@ async def test_cancel_execution_best_effort_terminates_task_scoped_codex_session
 
 
 @pytest.mark.asyncio
+async def test_cancel_execution_prefers_direct_session_record_load_for_codex_task_session(
+    tmp_path, mock_client_adapter, monkeypatch
+):
+    async with temporal_db(tmp_path) as session:
+        monkeypatch.setenv("MOONMIND_AGENT_RUNTIME_STORE", str(tmp_path / "agent_jobs"))
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        store = ManagedSessionStore(_get_managed_session_store_root())
+        store.save(
+            CodexManagedSessionRecord(
+                sessionId=f"sess:{created.workflow_id}:codex_cli",
+                sessionEpoch=1,
+                taskRunId=created.workflow_id,
+                containerId="container-1",
+                threadId="thread-1",
+                runtimeId="codex_cli",
+                imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+                controlUrl="docker-exec://container-1",
+                status="ready",
+                workspacePath=f"/work/agent_jobs/{created.workflow_id}/repo",
+                sessionWorkspacePath=f"/work/agent_jobs/{created.workflow_id}/session",
+                artifactSpoolPath=f"/work/agent_jobs/{created.workflow_id}/artifacts",
+                startedAt=datetime.now(tz=UTC),
+            )
+        )
+        monkeypatch.setattr(
+            ManagedSessionStore,
+            "list_active",
+            lambda self: (_ for _ in ()).throw(
+                AssertionError("list_active should not run for canonical Codex session IDs")
+            ),
+        )
+
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="stop",
+            graceful=True,
+        )
+
+        mock_client_adapter.assert_has_calls(
+            [
+                call.update_workflow(
+                    f"{created.workflow_id}:session:codex_cli",
+                    "TerminateSession",
+                    {"reason": "stop"},
+                ),
+                call.cancel_workflow(created.workflow_id),
+            ],
+            any_order=False,
+        )
+
+
+@pytest.mark.asyncio
 async def test_cancel_execution_ignores_best_effort_session_terminate_failure(
     tmp_path, mock_client_adapter, monkeypatch
 ):

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -195,6 +195,71 @@ async def test_agent_session_terminate_update_executes_remote_terminate_when_han
 
 
 @pytest.mark.asyncio
+async def test_agent_session_terminate_update_keeps_terminating_when_remote_terminate_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {
+            "namespace": "default",
+            "workflow_id": "wf-run-1:session:codex_cli",
+            "run_id": "run-session-1",
+            "task_queue": "mm.workflow",
+        },
+    )
+    logger = type(
+        "Logger",
+        (),
+        {
+            "info": lambda *a, **k: None,
+            "warning": lambda _self, message, *args: warnings.append(message % args),
+        },
+    )()
+    monkeypatch.setattr(agent_session_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(agent_session_module.workflow, "logger", logger)
+
+    workflow = MoonMindAgentSessionWorkflow(_workflow_input())
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+            "activeTurnId": "turn-1",
+        }
+    )
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        del payload, kwargs
+        if activity_name == "agent_runtime.terminate_session":
+            raise RuntimeError("terminate failed")
+        raise AssertionError(f"unexpected activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_session_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    status = await workflow.terminate_session_update({"reason": "done"})
+
+    assert status["status"] == AGENT_SESSION_STATUS_TERMINATING
+    assert status["terminationRequested"] is True
+    assert status["lastControlAction"] == "terminate_session"
+    assert status["lastControlReason"] == "done"
+    assert status["activeTurnId"] == "turn-1"
+    assert warnings == [
+        "Managed session terminate activity failed for sess:wf-run-1:codex_cli: "
+        "terminate failed"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_agent_session_send_follow_up_update_executes_session_activity_surface(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -141,6 +141,60 @@ async def test_agent_session_terminate_update_marks_termination_requested(
 
 
 @pytest.mark.asyncio
+async def test_agent_session_terminate_update_executes_remote_terminate_when_handles_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    workflow = MoonMindAgentSessionWorkflow(_workflow_input())
+    workflow.attach_runtime_handles(
+        {
+            "containerId": "container-1",
+            "threadId": "thread-1",
+            "activeTurnId": "turn-1",
+        }
+    )
+
+    captured: list[tuple[str, dict[str, object], dict[str, object]]] = []
+
+    async def _execute_activity(
+        activity_name: str,
+        payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        captured.append((activity_name, payload, kwargs))
+        if activity_name == "agent_runtime.terminate_session":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "terminated",
+                "imageRef": "moonmind:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_session_module.workflow,
+        "execute_activity",
+        _execute_activity,
+    )
+
+    status = await workflow.terminate_session_update({"reason": "done"})
+
+    assert [name for name, _, _ in captured] == ["agent_runtime.terminate_session"]
+    assert captured[0][1]["containerId"] == "container-1"
+    assert captured[0][1]["threadId"] == "thread-1"
+    assert status["status"] == AGENT_SESSION_STATUS_TERMINATING
+    assert status["terminationRequested"] is True
+    assert status["activeTurnId"] is None
+
+
+@pytest.mark.asyncio
 async def test_agent_session_send_follow_up_update_executes_session_activity_surface(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -568,6 +622,20 @@ async def test_agent_session_clear_session_update_preserves_concurrent_terminati
         payload: dict[str, object],
         **_kwargs: object,
     ) -> dict[str, object]:
+        if activity_name == "agent_runtime.terminate_session":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "terminated",
+                "imageRef": "moonmind:latest",
+                "controlUrl": "http://session-control",
+                "metadata": {},
+            }
         if activity_name == "agent_runtime.clear_session":
             await workflow.terminate_session_update({"reason": "Shutdown now"})
             return {

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -7,7 +7,10 @@ import pytest
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import (
+    RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    MoonMindRunWorkflow,
+)
 
 
 def _configure_workflow_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -124,6 +127,11 @@ async def test_run_terminates_active_task_scoped_codex_session(
     _configure_workflow_runtime(monkeypatch)
     signal_calls: list[tuple[str, Any]] = []
     activity_calls: list[tuple[str, Any]] = []
+    patch_calls: list[str] = []
+
+    def fake_patched(patch_id: str) -> bool:
+        patch_calls.append(patch_id)
+        return True
 
     class _FakeHandle:
         async def signal(self, signal_name: str, payload: Any = None) -> None:
@@ -174,6 +182,7 @@ async def test_run_terminates_active_task_scoped_codex_session(
         "execute_activity",
         fake_execute_activity,
     )
+    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
     workflow._codex_session_handle = _FakeHandle()
     workflow._codex_session_binding = CodexManagedSessionBinding(
@@ -200,6 +209,7 @@ async def test_run_terminates_active_task_scoped_codex_session(
             },
         )
     ]
+    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
 
@@ -212,6 +222,7 @@ async def test_run_termination_falls_back_to_session_signal_without_runtime_hand
     _configure_workflow_runtime(monkeypatch)
     signal_calls: list[tuple[str, Any]] = []
     activity_calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
 
     class _FakeHandle:
         async def signal(self, signal_name: str, payload: Any = None) -> None:
@@ -273,3 +284,123 @@ async def test_run_termination_falls_back_to_session_signal_without_runtime_hand
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("execute_activity should not run for legacy histories")
+
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
+async def test_run_termination_signals_session_when_terminate_activity_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    warnings: list[str] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    class _FakeLogger:
+        def warning(self, message: str, *args: Any) -> None:
+            warnings.append(message % args)
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.terminate_session":
+            raise RuntimeError("terminate failed")
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
+    assert warnings == [
+        "Task-scoped Codex terminate activity failed for sess:wf-run-1:codex_cli; "
+        "falling back to session signal: terminate failed"
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -123,10 +123,57 @@ async def test_run_terminates_active_task_scoped_codex_session(
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
     signal_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
 
     class _FakeHandle:
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.terminate_session":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "terminated",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
 
     workflow._codex_session_handle = _FakeHandle()
     workflow._codex_session_binding = CodexManagedSessionBinding(
@@ -140,6 +187,10 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.terminate_session",
+    ]
     assert signal_calls == [
         (
             "control_action",
@@ -151,3 +202,74 @@ async def test_run_terminates_active_task_scoped_codex_session(
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
+async def test_run_termination_falls_back_to_session_signal_without_runtime_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "terminating",
+                "containerId": None,
+                "threadId": None,
+                "activeTurnId": None,
+                "lastControlAction": "terminate_session",
+                "lastControlReason": "success",
+                "terminationRequested": True,
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+    ]
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary

This hardens cancellation for Codex managed-session task runs so canceling a task tears down the task-scoped session even when the parent workflow does not reach finalization promptly.

## What changed

- updated `MoonMind.Run` finalization to load the live session snapshot and call `agent_runtime.terminate_session` before signaling the session workflow
- updated `MoonMind.AgentSession.TerminateSession` to execute the real managed-session terminate activity when runtime handles are still present
- updated `TemporalExecutionService.cancel_execution()` to best-effort invoke `TerminateSession` on the task-scoped Codex session workflow before the normal parent cancel/terminate path
- added spec artifacts for the cancel hardening slice under `specs/144-codex-managed-session-cancel-hardening/`
- added workflow and service unit coverage for the new cancel and terminate behavior

## Why

A recent stuck cancellation showed two related problems:

1. the UI and API were successfully sending cancel requests to Temporal, but a replay-broken `MoonMind.AgentRun` child could prevent graceful cancel completion
2. even when the parent workflow was force-terminated, the Codex managed session container could remain orphaned because teardown depended too heavily on workflow-close side effects instead of the explicit terminate activity path

This change closes the managed-session teardown gap by driving termination through the session workflow and its existing activity boundary.

## Impact

- Codex managed-session tasks should clean up their session containers more reliably during cancel and terminate flows
- stuck or degraded cancel paths still get a best-effort session teardown request from the execution service
- duplicate termination remains safe because the service path and parent finalization both target the same workflow-owned control surface

## Validation

- `./.venv/bin/pytest -q tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/test_temporal_service.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
