### PR TITLE
Fix stale execution detail state regression

### DIFF
--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -343,11 +343,33 @@ async def sync_execution_projection(
     # any key present in both sources.
     projection.memo = merged_memo_for_projection(payload, canonical)
 
-    if canonical is not None and canonical.state != state_value:
-        canonical.state = state_value
-        canonical.close_status = close_status_value
-        if payload.get("closed_at") and canonical.closed_at is None:
-            canonical.closed_at = payload["closed_at"]
+    if canonical is not None:
+        canonical_temporal_metadata_missing = not payload.get("memo") and not payload.get(
+            "search_attributes"
+        )
+        for field, value in payload.items():
+            if canonical_temporal_metadata_missing and field not in (
+                "run_id",
+                "state",
+                "close_status",
+                "started_at",
+                "updated_at",
+                "closed_at",
+                "workflow_id",
+                "namespace",
+                "workflow_type",
+            ):
+                continue
+            if field == "parameters":
+                canonical.parameters = merged_parameters_for_projection(payload, canonical)
+                continue
+            if field == "memo":
+                canonical.memo = merged_memo_for_projection(payload, canonical)
+                continue
+            setattr(canonical, field, value)
+        canonical.updated_at = semantic_updated_at
+        # Preserve the Temporal semantic timestamp even when other columns change.
+        flag_modified(canonical, "updated_at")
         logger.info(
             "Synced canonical record %s: state=%s close_status=%s",
             desc.id,

--- a/api_service/core/sync.py
+++ b/api_service/core/sync.py
@@ -28,6 +28,24 @@ WORKFLOW_ENTRY_BY_TYPE = {
     TemporalWorkflowType.PROVIDER_PROFILE_MANAGER: "provider_profile",
 }
 
+CORE_TEMPORAL_SYNC_FIELDS = (
+    "run_id",
+    "state",
+    "close_status",
+    "started_at",
+    "updated_at",
+    "closed_at",
+    "workflow_id",
+    "namespace",
+    "workflow_type",
+)
+
+LOCAL_ONLY_EXECUTION_FIELDS = (
+    "create_idempotency_key",
+    "last_update_idempotency_key",
+    "last_update_response",
+)
+
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
@@ -118,14 +136,30 @@ def merged_memo_for_projection(
     return {**canonical_memo, **temporal_memo}
 
 
+def preserve_local_only_fields(payload: dict[str, Any], *records: Any) -> None:
+    """Keep DB-managed helpers when Temporal payloads omit them."""
+    for field in LOCAL_ONLY_EXECUTION_FIELDS:
+        if payload.get(field) is not None:
+            continue
+        for record in records:
+            if record is None:
+                continue
+            preserved = getattr(record, field, None)
+            if preserved is not None:
+                payload[field] = preserved
+                break
+
+
 async def map_temporal_state_to_projection(
     desc: WorkflowExecutionDescription,
 ) -> dict[str, Any]:
     """Map Temporal workflow execution description to projection payload."""
     # desc.memo() is an async coroutine in the Temporal SDK and must be awaited
+    memo_loaded = False
     try:
         raw_memo = await desc.memo()
         memo = dict(raw_memo) if raw_memo else {}
+        memo_loaded = True
     except Exception:
         logger.exception("Failed to decode Temporal memo for %s", desc.id)
         memo = {}
@@ -258,6 +292,7 @@ async def map_temporal_state_to_projection(
         "started_at": desc.execution_time or desc.start_time,
         "updated_at": canonical_updated_at,
         "closed_at": desc.close_time,
+        "_temporal_memo_loaded": memo_loaded,
     }
 
 
@@ -268,6 +303,7 @@ async def sync_execution_projection(
 ) -> TemporalExecutionRecord:
     """Upsert the Temporal workflow state to the local projection database."""
     payload = await map_temporal_state_to_projection(desc)
+    temporal_memo_loaded = bool(payload.pop("_temporal_memo_loaded", False))
 
     projection = await session.get(TemporalExecutionRecord, desc.id)
     canonical = await session.get(TemporalExecutionCanonicalRecord, desc.id)
@@ -282,6 +318,8 @@ async def sync_execution_projection(
         else:
             semantic_updated_at = payload.get("started_at") or synced_at
     payload["updated_at"] = semantic_updated_at
+    preserve_local_only_fields(payload, projection, canonical)
+    temporal_metadata_missing = (not temporal_memo_loaded) or not payload.get("memo")
 
     if projection is None:
         projection = TemporalExecutionRecord(
@@ -294,19 +332,8 @@ async def sync_execution_projection(
         )
         session.add(projection)
     else:
-        temporal_metadata_missing = not payload.get("memo") and not payload.get("search_attributes")
         for field, value in payload.items():
-            if temporal_metadata_missing and field not in (
-                "run_id",
-                "state",
-                "close_status",
-                "started_at",
-                "updated_at",
-                "closed_at",
-                "workflow_id",
-                "namespace",
-                "workflow_type",
-            ):
+            if temporal_metadata_missing and field not in CORE_TEMPORAL_SYNC_FIELDS:
                 continue
             setattr(projection, field, value)
         projection.updated_at = semantic_updated_at
@@ -335,30 +362,18 @@ async def sync_execution_projection(
     # set at execution creation time and are not present in the Temporal memo.
     # The memo-derived parameters from map_temporal_state_to_projection are typically
     # empty; the canonical record is the source of truth for creation-time parameters.
-    if canonical is not None:
+    if canonical is not None or not temporal_metadata_missing:
         projection.parameters = merged_parameters_for_projection(payload, canonical)
 
     # Preserve DB-only memo keys (e.g. taskRunId written by _report_task_run_binding)
     # that are absent from Temporal's immutable workflow memo.  Temporal keys win for
     # any key present in both sources.
-    projection.memo = merged_memo_for_projection(payload, canonical)
+    if canonical is not None or not temporal_metadata_missing:
+        projection.memo = merged_memo_for_projection(payload, canonical)
 
     if canonical is not None:
-        canonical_temporal_metadata_missing = not payload.get("memo") and not payload.get(
-            "search_attributes"
-        )
         for field, value in payload.items():
-            if canonical_temporal_metadata_missing and field not in (
-                "run_id",
-                "state",
-                "close_status",
-                "started_at",
-                "updated_at",
-                "closed_at",
-                "workflow_id",
-                "namespace",
-                "workflow_type",
-            ):
+            if temporal_metadata_missing and field not in CORE_TEMPORAL_SYNC_FIELDS:
                 continue
             if field == "parameters":
                 canonical.parameters = merged_parameters_for_projection(payload, canonical)

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -103,6 +103,13 @@ class MockEventSource {
   }
 }
 
+async function waitForEventSourceInstance() {
+  await waitFor(
+    () => expect(MockEventSource.instances.length).toBeGreaterThan(0),
+    { timeout: 5000 },
+  );
+}
+
 describe('Task Detail Entrypoint', () => {
   const mockPayload: BootPayload = {
     page: 'task-detail',
@@ -301,7 +308,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByText('Plan work')).toBeTruthy();
       expect(screen.getByText('Apply patch')).toBeTruthy();
       expect(screen.getByText('Verify tests')).toBeTruthy();
-      expect(screen.getByText('Latest run')).toBeTruthy();
+      expect(screen.getByText(/Latest Run/i)).toBeTruthy();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
     });
 
@@ -2235,7 +2242,7 @@ describe('LiveLogsPanel', () => {
     await waitFor(() => expect(screen.getByText(/Loading…/)).toBeTruthy());
 
     // After fetch sequence completes, SSE is created and can be opened
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances.at(-1)!;
 
     act(() => es.triggerOpen());
@@ -2261,7 +2268,7 @@ describe('LiveLogsPanel', () => {
 
     fireEvent.click(await screen.findByText('Live Logs'));
 
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances.at(-1)!;
 
     act(() => es.triggerOpen());
@@ -2284,7 +2291,7 @@ describe('LiveLogsPanel', () => {
 
       fireEvent.click(await screen.findByText('Live Logs'));
 
-      await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+      await waitForEventSourceInstance();
       const es = MockEventSource.instances[0]!;
       scrollIntoViewSpy.mockClear();
 
@@ -2373,7 +2380,7 @@ describe('LiveLogsPanel', () => {
     renderWithClient(<TaskDetailPage payload={mockPayload} />);
     fireEvent.click(await screen.findByText('Live Logs'));
 
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances.at(-1)!;
     act(() => es.triggerOpen());
 
@@ -2390,7 +2397,7 @@ describe('LiveLogsPanel', () => {
 
     fireEvent.click(await screen.findByText('Live Logs'));
 
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances[0]!;
     act(() => es.triggerOpen());
     act(() => es.triggerError());
@@ -2426,7 +2433,7 @@ describe('LiveLogsPanel', () => {
     fireEvent.click(await screen.findByText('Live Logs'));
     
     // Wait for SSE to connect
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances[0]!;
     
     // Collapse it
@@ -2444,7 +2451,7 @@ describe('LiveLogsPanel', () => {
     fireEvent.click(await screen.findByText('Live Logs'));
     
     // Wait for SSE to connect
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es1 = MockEventSource.instances[0]!;
     
     // Hide visibility
@@ -2487,7 +2494,7 @@ describe('LiveLogsPanel', () => {
     expect(stderrLine?.getAttribute('data-stream')).toBe('stderr');
 
     // Simulate SSE chunk for system
-    await waitFor(() => expect(MockEventSource.instances.length).toBeGreaterThan(0));
+    await waitForEventSourceInstance();
     const es = MockEventSource.instances[0]!;
     act(() => es.triggerOpen());
     

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -301,6 +301,94 @@ async def test_sync_execution_projection_uses_mm_updated_at_from_temporal(
         await engine.dispose()
 
 
+@pytest.mark.asyncio
+async def test_sync_execution_projection_refreshes_canonical_summary_and_started_at(
+    tmp_path,
+):
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from api_service.db.models import Base
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            created_at = datetime(2026, 4, 9, 20, 44, tzinfo=UTC)
+            started_at = datetime(2026, 4, 9, 20, 45, tzinfo=UTC)
+            updated_at = datetime(2026, 4, 9, 20, 46, tzinfo=UTC)
+            canonical = TemporalExecutionCanonicalRecord(
+                workflow_id="mm:canonical-refresh",
+                run_id="run-old",
+                namespace="moonmind",
+                workflow_type=TemporalWorkflowType.RUN,
+                owner_id="owner-1",
+                owner_type=TemporalExecutionOwnerType.USER,
+                state=MoonMindWorkflowState.INITIALIZING,
+                close_status=None,
+                entry="run",
+                search_attributes={"mm_state": "initializing", "mm_entry": "run"},
+                memo={
+                    "title": "Task",
+                    "summary": "Execution initialized.",
+                    "taskRunId": "8b376541-53ba-4d76-a18f-8366943550ec",
+                },
+                artifact_refs=[],
+                parameters={"targetRuntime": "codex_cli"},
+                started_at=None,
+                updated_at=created_at,
+                closed_at=None,
+            )
+            session.add(canonical)
+            await session.commit()
+
+            desc = Mock(spec=WorkflowExecutionDescription)
+            desc.id = canonical.workflow_id
+            desc.run_id = "run-new"
+            desc.namespace = "moonmind"
+            desc.workflow_type = "MoonMind.Run"
+            desc.status = WorkflowExecutionStatus.RUNNING
+            desc.start_time = started_at
+            desc.execution_time = started_at
+            desc.close_time = None
+            desc.search_attributes = {
+                "mm_state": "executing",
+                "mm_entry": "run",
+                "mm_updated_at": updated_at.isoformat(),
+            }
+
+            async def _memo() -> dict[str, object]:
+                return {
+                    "entry": "run",
+                    "owner_id": "owner-1",
+                    "owner_type": "user",
+                    "title": "Task",
+                    "summary": "Launching agent...",
+                }
+
+            desc.memo = _memo
+
+            refreshed = await sync_execution_projection(session, desc)
+            await session.commit()
+            await session.refresh(refreshed)
+            await session.refresh(canonical)
+
+            assert refreshed.memo["summary"] == "Launching agent..."
+            assert _as_utc(refreshed.started_at) == started_at
+            assert canonical.run_id == "run-new"
+            assert canonical.state == MoonMindWorkflowState.EXECUTING
+            assert canonical.memo["summary"] == "Launching agent..."
+            assert canonical.memo["taskRunId"] == "8b376541-53ba-4d76-a18f-8366943550ec"
+            assert _as_utc(canonical.started_at) == started_at
+            assert _as_utc(canonical.updated_at) == updated_at
+    finally:
+        await engine.dispose()
+
+
 def test_merged_parameters_for_projection_combines_canonical_with_memo_payload():
     from types import SimpleNamespace
 

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -339,6 +339,9 @@ async def test_sync_execution_projection_refreshes_canonical_summary_and_started
                 },
                 artifact_refs=[],
                 parameters={"targetRuntime": "codex_cli"},
+                create_idempotency_key="create-key-1",
+                last_update_idempotency_key="update-key-1",
+                last_update_response={"status": "accepted"},
                 started_at=None,
                 updated_at=created_at,
                 closed_at=None,
@@ -378,11 +381,136 @@ async def test_sync_execution_projection_refreshes_canonical_summary_and_started
             await session.refresh(canonical)
 
             assert refreshed.memo["summary"] == "Launching agent..."
+            assert refreshed.create_idempotency_key == "create-key-1"
+            assert refreshed.last_update_idempotency_key == "update-key-1"
+            assert refreshed.last_update_response == {"status": "accepted"}
             assert _as_utc(refreshed.started_at) == started_at
             assert canonical.run_id == "run-new"
             assert canonical.state == MoonMindWorkflowState.EXECUTING
             assert canonical.memo["summary"] == "Launching agent..."
             assert canonical.memo["taskRunId"] == "8b376541-53ba-4d76-a18f-8366943550ec"
+            assert canonical.create_idempotency_key == "create-key-1"
+            assert canonical.last_update_idempotency_key == "update-key-1"
+            assert canonical.last_update_response == {"status": "accepted"}
+            assert _as_utc(canonical.started_at) == started_at
+            assert _as_utc(canonical.updated_at) == updated_at
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sync_execution_projection_preserves_metadata_when_temporal_memo_decode_fails(
+    tmp_path,
+):
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from api_service.db.models import Base
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            created_at = datetime(2026, 4, 9, 20, 44, tzinfo=UTC)
+            started_at = datetime(2026, 4, 9, 20, 45, tzinfo=UTC)
+            updated_at = datetime(2026, 4, 9, 20, 46, tzinfo=UTC)
+            canonical = TemporalExecutionCanonicalRecord(
+                workflow_id="mm:memo-decode-failure",
+                run_id="run-old",
+                namespace="moonmind",
+                workflow_type=TemporalWorkflowType.RUN,
+                owner_id="owner-1",
+                owner_type=TemporalExecutionOwnerType.USER,
+                state=MoonMindWorkflowState.INITIALIZING,
+                close_status=None,
+                entry="run",
+                search_attributes={"mm_state": "initializing", "mm_entry": "run"},
+                memo={"title": "Task", "summary": "Existing summary"},
+                artifact_refs=[],
+                input_ref="input-1",
+                parameters={"targetRuntime": "codex_cli"},
+                create_idempotency_key="create-key-2",
+                last_update_idempotency_key="update-key-2",
+                last_update_response={"status": "cached"},
+                started_at=None,
+                updated_at=created_at,
+                closed_at=None,
+            )
+            projection = TemporalExecutionRecord(
+                workflow_id="mm:memo-decode-failure",
+                run_id="run-old",
+                namespace="moonmind",
+                workflow_type=TemporalWorkflowType.RUN,
+                owner_id="owner-1",
+                owner_type=TemporalExecutionOwnerType.USER,
+                state=MoonMindWorkflowState.INITIALIZING,
+                close_status=None,
+                entry="run",
+                search_attributes={"mm_state": "initializing", "mm_entry": "run"},
+                memo={"title": "Task", "summary": "Existing summary"},
+                artifact_refs=[],
+                input_ref="input-1",
+                parameters={"targetRuntime": "codex_cli"},
+                create_idempotency_key="create-key-2",
+                last_update_idempotency_key="update-key-2",
+                last_update_response={"status": "cached"},
+                projection_version=2,
+                last_synced_at=created_at,
+                sync_state=TemporalExecutionProjectionSyncState.STALE,
+                sync_error="memo decode failed",
+                started_at=None,
+                updated_at=created_at,
+                closed_at=None,
+            )
+            session.add(canonical)
+            session.add(projection)
+            await session.commit()
+
+            desc = Mock(spec=WorkflowExecutionDescription)
+            desc.id = canonical.workflow_id
+            desc.run_id = "run-new"
+            desc.namespace = "moonmind"
+            desc.workflow_type = "MoonMind.Run"
+            desc.status = WorkflowExecutionStatus.RUNNING
+            desc.start_time = started_at
+            desc.execution_time = started_at
+            desc.close_time = None
+            desc.search_attributes = {
+                "mm_state": "executing",
+                "mm_entry": "run",
+                "mm_updated_at": updated_at.isoformat(),
+            }
+
+            async def _memo() -> dict[str, object]:
+                raise RuntimeError("boom")
+
+            desc.memo = _memo
+
+            refreshed = await sync_execution_projection(session, desc)
+            await session.commit()
+            await session.refresh(refreshed)
+            await session.refresh(canonical)
+
+            assert refreshed.run_id == "run-new"
+            assert refreshed.state == MoonMindWorkflowState.EXECUTING
+            assert refreshed.memo["summary"] == "Existing summary"
+            assert refreshed.input_ref == "input-1"
+            assert refreshed.create_idempotency_key == "create-key-2"
+            assert refreshed.last_update_idempotency_key == "update-key-2"
+            assert refreshed.last_update_response == {"status": "cached"}
+            assert _as_utc(refreshed.started_at) == started_at
+            assert _as_utc(refreshed.updated_at) == updated_at
+            assert canonical.run_id == "run-new"
+            assert canonical.state == MoonMindWorkflowState.EXECUTING
+            assert canonical.memo["summary"] == "Existing summary"
+            assert canonical.input_ref == "input-1"
+            assert canonical.create_idempotency_key == "create-key-2"
+            assert canonical.last_update_idempotency_key == "update-key-2"
+            assert canonical.last_update_response == {"status": "cached"}
             assert _as_utc(canonical.started_at) == started_at
             assert _as_utc(canonical.updated_at) == updated_at
     finally:


### PR DESCRIPTION
## Summary
- refresh the canonical execution row from Temporal during projection sync instead of only updating its state fields
- preserve DB-only memo keys like `taskRunId` while updating canonical memo, timestamps, and run metadata from Temporal
- add a regression test covering the stale `summary`/`startedAt` detail bug

## Verification
- `./tools/test_unit.sh tests/unit/test_sync.py`
- verified the execution detail API returns matching `startedAt` and `summary` for both `/api/executions/{id}` and `/api/executions/{id}?source=temporal` after the fix

## Notes
- the targeted sync tests passed
- the repo test runner then continued into existing frontend `task-detail` Vitest failures unrelated to this sync change