### PR TITLE
[codex] Fix agent runtime worker bootstrap

### DIFF
--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -301,7 +301,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByText('Plan work')).toBeTruthy();
       expect(screen.getByText('Apply patch')).toBeTruthy();
       expect(screen.getByText('Verify tests')).toBeTruthy();
-      expect(screen.getByText('Latest run')).toBeTruthy();
+      expect(screen.getByText(/Latest Run/i)).toBeTruthy();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
     });
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -1188,16 +1188,33 @@ class DockerCodexManagedSessionController:
             return []
         reconciled: list[CodexManagedSessionRecord] = []
         for record in self._session_store.list_active():
-            if await self._container_exists(record.container_id):
+            try:
+                container_exists = await self._container_exists(record.container_id)
+                if not container_exists:
+                    updated = await self._session_store.update(
+                        record.session_id,
+                        status="degraded",
+                        error_message=(
+                            "managed session container is missing during reconcile"
+                        ),
+                        updated_at=datetime.now(tz=UTC),
+                    )
+                    reconciled.append(updated)
+                    continue
                 if self._session_supervisor is not None:
                     await self._session_supervisor.start(record)
                 reconciled.append(record)
-                continue
-            updated = await self._session_store.update(
-                record.session_id,
-                status="degraded",
-                error_message="managed session container is missing during reconcile",
-                updated_at=datetime.now(tz=UTC),
-            )
-            reconciled.append(updated)
+            except Exception as exc:
+                logger.warning(
+                    "Managed session reconcile degraded session %s after reattach failure",
+                    record.session_id,
+                    exc_info=True,
+                )
+                updated = await self._session_store.update(
+                    record.session_id,
+                    status="degraded",
+                    error_message=str(exc),
+                    updated_at=datetime.now(tz=UTC),
+                )
+                reconciled.append(updated)
         return reconciled

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -611,24 +611,38 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
 
         dispatcher = SkillActivityDispatcher()
 
-        # Build agent_runtime dependencies (store + supervisor + launcher + session controller)
-        (
-            run_store,
-            run_supervisor,
-            run_launcher,
-            session_controller,
-        ) = _build_agent_runtime_deps()
-        reconciled = await run_supervisor.reconcile()
-        if reconciled:
-            logger.info(
-                "Reconciled %d stale managed run records during startup",
-                len(reconciled),
-            )
-        session_reconciled = await session_controller.reconcile()
-        if session_reconciled:
-            logger.info(
-                "Reconciled %d managed session records during startup",
-                len(session_reconciled),
+        run_store = None
+        run_supervisor = None
+        run_launcher = None
+        session_controller = None
+        agent_runtime_activities = None
+        if topology.fleet == AGENT_RUNTIME_FLEET:
+            # Docker-backed managed-session reconciliation only belongs on the
+            # agent_runtime fleet, which owns the required privileges.
+            (
+                run_store,
+                run_supervisor,
+                run_launcher,
+                session_controller,
+            ) = _build_agent_runtime_deps()
+            reconciled = await run_supervisor.reconcile()
+            if reconciled:
+                logger.info(
+                    "Reconciled %d stale managed run records during startup",
+                    len(reconciled),
+                )
+            session_reconciled = await session_controller.reconcile()
+            if session_reconciled:
+                logger.info(
+                    "Reconciled %d managed session records during startup",
+                    len(session_reconciled),
+                )
+            agent_runtime_activities = TemporalAgentRuntimeActivities(
+                artifact_service=artifact_service,
+                run_store=run_store,
+                run_supervisor=run_supervisor,
+                run_launcher=run_launcher,
+                session_controller=session_controller,
             )
 
         bindings = build_worker_activity_bindings(
@@ -646,13 +660,7 @@ async def _build_runtime_activities(topology) -> tuple[AsyncExitStack, list[obje
             integration_activities=TemporalIntegrationActivities(
                 artifact_service=artifact_service
             ),
-            agent_runtime_activities=TemporalAgentRuntimeActivities(
-                artifact_service=artifact_service,
-                run_store=run_store,
-                run_supervisor=run_supervisor,
-                run_launcher=run_launcher,
-                session_controller=session_controller,
-            ),
+            agent_runtime_activities=agent_runtime_activities,
             proposal_activities=TemporalProposalActivities(
                 artifact_service=artifact_service,
                 proposal_service_factory=_build_proposal_service_factory(),

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1654,7 +1654,7 @@ async def test_controller_reconcile_reattaches_or_degrades_active_sessions(
 
 
 @pytest.mark.asyncio
-async def test_controller_reconcile_surfaces_transient_inspect_failures(
+async def test_controller_reconcile_degrades_when_container_inspect_fails(
     tmp_path: Path,
 ) -> None:
     store = ManagedSessionStore(tmp_path / "session-store")
@@ -1695,8 +1695,16 @@ async def test_controller_reconcile_surfaces_transient_inspect_failures(
         command_runner=_fake_runner,
     )
 
-    with pytest.raises(RuntimeError, match="failed to inspect managed session container ctr-ok"):
-        await controller.reconcile()
+    reconciled = await controller.reconcile()
+
+    assert [record.session_id for record in reconciled] == ["sess-ok"]
+    degraded = store.load("sess-ok")
+    assert degraded is not None
+    assert degraded.status == "degraded"
+    assert degraded.error_message == (
+        "failed to inspect managed session container ctr-ok: "
+        "docker daemon unavailable"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -720,15 +720,10 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     mock_jules_activities_cls.assert_called_once_with(
         artifact_service=ANY
     )
-    mock_agent_runtime_activities_cls.assert_called_once_with(
-        artifact_service=ANY,
-        run_store=ANY,
-        run_supervisor=ANY,
-        run_launcher=ANY,
-        session_controller=session_controller,
-    )
-    run_supervisor.reconcile.assert_awaited_once()
-    session_controller.reconcile.assert_awaited_once()
+    mock_agent_runtime_activities_cls.assert_not_called()
+    mock_build_deps.assert_not_called()
+    run_supervisor.reconcile.assert_not_awaited()
+    session_controller.reconcile.assert_not_awaited()
     mock_dispatcher_cls.assert_called_once_with()
     mock_skill_activities_cls.assert_called_once_with(
         dispatcher=mock_dispatcher_cls.return_value,
@@ -741,7 +736,7 @@ async def test_build_runtime_activities_injects_concrete_handlers(
         skill_activities=mock_skill_activities_cls.return_value,
         sandbox_activities=mock_sandbox_activities_cls.return_value,
         integration_activities=mock_jules_activities_cls.return_value,
-        agent_runtime_activities=mock_agent_runtime_activities_cls.return_value,
+        agent_runtime_activities=None,
         proposal_activities=mock_proposal_activities_cls.return_value,
         review_activities=ANY,
         agent_skills_activities=ANY,
@@ -756,4 +751,93 @@ async def test_build_runtime_activities_injects_concrete_handlers(
     assert callable(proposal_service_factory)
     import typing
     assert isinstance(proposal_service_factory(), typing.AsyncContextManager)
+    await resources.aclose()
+
+
+@pytest.mark.asyncio
+@patch("moonmind.workflows.temporal.worker_runtime._build_agent_runtime_deps")
+@patch("moonmind.workflows.temporal.worker_runtime.build_worker_activity_bindings")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalAgentRuntimeActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalIntegrationActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalSandboxActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalSkillActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.SkillActivityDispatcher")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalPlanActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalArtifactActivities")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalArtifactService")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalArtifactRepository")
+@patch("moonmind.workflows.temporal.worker_runtime.TemporalProposalActivities")
+async def test_build_runtime_activities_reconciles_managed_sessions_only_on_agent_runtime_fleet(
+    mock_proposal_activities_cls,
+    mock_repository_cls,
+    mock_service_cls,
+    mock_artifact_activities_cls,
+    mock_plan_activities_cls,
+    mock_dispatcher_cls,
+    mock_skill_activities_cls,
+    mock_sandbox_activities_cls,
+    mock_jules_activities_cls,
+    mock_agent_runtime_activities_cls,
+    mock_build_bindings,
+    mock_build_deps,
+):
+    run_store = MagicMock()
+    run_supervisor = MagicMock()
+    run_supervisor.reconcile = AsyncMock(return_value=[])
+    run_launcher = MagicMock()
+    session_controller = MagicMock()
+    session_controller.reconcile = AsyncMock(return_value=[])
+    mock_build_deps.return_value = (
+        run_store,
+        run_supervisor,
+        run_launcher,
+        session_controller,
+    )
+
+    @asynccontextmanager
+    async def _fake_session_context():
+        yield "session"
+
+    topology = MagicMock()
+    topology.fleet = AGENT_RUNTIME_FLEET
+
+    mock_binding = MagicMock()
+    mock_binding.handler = "agent_runtime_handler"
+    mock_build_bindings.return_value = [mock_binding]
+
+    with patch(
+        "moonmind.workflows.temporal.worker_runtime.get_async_session_context",
+        side_effect=_fake_session_context,
+    ):
+        resources, handlers = await _build_runtime_activities(topology)
+
+    assert handlers == [
+        "agent_runtime_handler",
+        resolve_adapter_metadata,
+        get_activity_route,
+        resolve_external_adapter,
+        external_adapter_execution_style,
+    ]
+    mock_build_deps.assert_called_once_with()
+    run_supervisor.reconcile.assert_awaited_once()
+    session_controller.reconcile.assert_awaited_once()
+    mock_agent_runtime_activities_cls.assert_called_once_with(
+        artifact_service=ANY,
+        run_store=run_store,
+        run_supervisor=run_supervisor,
+        run_launcher=run_launcher,
+        session_controller=session_controller,
+    )
+    mock_build_bindings.assert_called_once_with(
+        fleet=AGENT_RUNTIME_FLEET,
+        artifact_activities=mock_artifact_activities_cls.return_value,
+        plan_activities=mock_plan_activities_cls.return_value,
+        skill_activities=mock_skill_activities_cls.return_value,
+        sandbox_activities=mock_sandbox_activities_cls.return_value,
+        integration_activities=mock_jules_activities_cls.return_value,
+        agent_runtime_activities=mock_agent_runtime_activities_cls.return_value,
+        proposal_activities=mock_proposal_activities_cls.return_value,
+        review_activities=ANY,
+        agent_skills_activities=ANY,
+    )
     await resources.aclose()


### PR DESCRIPTION
## Summary
- prevent managed-session reconciliation failures from crashing the agent-runtime worker during startup
- run Docker-backed managed-session bootstrap only on the `agent_runtime` fleet so sandbox workers do not touch agent-runtime session state
- extend unit coverage for both reconcile degradation and fleet-scoped bootstrap behavior

## Root Cause
The failed workflow timed out waiting on `agent_runtime.build_launch_context` because `mm.activity.agent_runtime` had no pollers. The agent-runtime worker was crash-looping during startup reconciliation when stale managed-session container inspection failed, and the sandbox worker was incorrectly executing the same Docker-backed reconciliation path.

## Validation
- `.venv/bin/pytest tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`
- restarted `temporal-worker-agent-runtime` and `temporal-worker-sandbox`
- verified both workers became healthy and Temporal showed pollers on `mm.activity.agent_runtime` and `mm.activity.sandbox`

## Notes
- `./tools/test_unit.sh` still hits an existing unrelated frontend failure in `entrypoints/task-detail.test.tsx` around the "Latest run" assertion.
