### PR TITLE
[codex] Implement Live Logs Phase 7 hardening

### DIFF
--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -128,6 +128,9 @@ def build_live_logs_feature_config() -> dict[str, object]:
         "liveLogsSessionTimelineRollout": str(
             settings.feature_flags.live_logs_session_timeline_rollout
         ),
+        "liveLogsStructuredHistoryEnabled": bool(
+            settings.feature_flags.live_logs_structured_history_enabled
+        ),
     }
 
 

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import time
 from collections import deque
 from collections.abc import Iterator
 from datetime import UTC, datetime
@@ -777,7 +778,7 @@ def _load_task_run_observability_events(
     record: object,
     session_record: CodexManagedSessionRecord | None,
     limit: int,
-) -> list[dict[str, object]]:
+) -> tuple[list[dict[str, object]], str]:
     workspace_path = getattr(record, "workspace_path", None)
     started_at = getattr(record, "started_at", None)
 
@@ -795,11 +796,13 @@ def _load_task_run_observability_events(
     )
     if event_journal_path is not None:
         events.extend(_iter_event_journal(event_journal_path, run_id=record_run_id))
+        source = "journal"
     elif _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
         for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
             normalized = _normalize_live_event(payload)
             if normalized is not None:
                 events.append(normalized)
+        source = "spool"
     else:
         events.extend(
             _iter_historical_artifact_events(
@@ -808,7 +811,8 @@ def _load_task_run_observability_events(
                 limit_per_stream=limit,
             )
         )
-    return events
+        source = "artifacts"
+    return events, source
 
 
 def _filter_observability_events(
@@ -929,6 +933,8 @@ async def get_observability_summary(
             detail="Observability record not found for this task run",
         )
     await _require_observability_access(record, _user)
+    metrics = get_metrics_emitter()
+    started = time.perf_counter()
 
     terminal_statuses = {"completed", "failed", "canceled", "cancelled", "timed_out"}
     run_status = getattr(record, "status", None)
@@ -950,6 +956,11 @@ async def get_observability_summary(
     base["supportsLiveStreaming"] = supports_live
     base["liveStreamStatus"] = live_stream_status
     base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
+    metrics.observe(
+        "livelogs.summary.latency",
+        value=time.perf_counter() - started,
+        tags={"stream": "livelogs"},
+    )
     return {"summary": base}
 
 
@@ -1070,14 +1081,20 @@ async def get_task_run_observability_events(
             detail="Observability record not found for this task run",
         )
     await _require_observability_access(record, _user)
+    metrics = get_metrics_emitter()
+    started = time.perf_counter()
 
     session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
-    events = await asyncio.to_thread(
-        _load_task_run_observability_events,
-        record=record,
-        session_record=session_record,
-        limit=limit,
-    )
+    try:
+        events, source = await asyncio.to_thread(
+            _load_task_run_observability_events,
+            record=record,
+            session_record=session_record,
+            limit=limit,
+        )
+    except Exception:
+        metrics.increment("livelogs.history.error", tags={"stream": "livelogs"})
+        raise
     events = _filter_observability_events(
         events,
         since=since,
@@ -1089,6 +1106,14 @@ async def get_task_run_observability_events(
     truncated = len(events) > limit
     if truncated:
         events = events[:limit]
+
+    metric_tags = {"stream": "livelogs", "source": source}
+    metrics.observe(
+        "livelogs.history.latency",
+        value=time.perf_counter() - started,
+        tags=metric_tags,
+    )
+    metrics.increment("livelogs.history.source", tags=metric_tags)
 
     return {
         "events": events,

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -778,6 +778,9 @@ def _load_task_run_observability_events(
     record: object,
     session_record: CodexManagedSessionRecord | None,
     limit: int,
+    since: int | None = None,
+    streams: set[str] | None = None,
+    kinds: set[str] | None = None,
 ) -> tuple[list[dict[str, object]], str]:
     workspace_path = getattr(record, "workspace_path", None)
     started_at = getattr(record, "started_at", None)
@@ -795,13 +798,31 @@ def _load_task_run_observability_events(
         else None
     )
     if event_journal_path is not None:
-        events.extend(_iter_event_journal(event_journal_path, run_id=record_run_id))
+        events.extend(
+            _collect_matching_observability_events(
+                _iter_event_journal(event_journal_path, run_id=record_run_id),
+                limit=limit,
+                since=since,
+                streams=streams,
+                kinds=kinds,
+            )
+        )
         source = "journal"
     elif _spool_contains_renderable_chunks(workspace_path, started_at=started_at):
-        for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at):
-            normalized = _normalize_live_event(payload)
-            if normalized is not None:
-                events.append(normalized)
+        normalized_events = (
+            normalized
+            for payload in _iter_run_spool_chunks(workspace_path, started_at=started_at)
+            if (normalized := _normalize_live_event(payload)) is not None
+        )
+        events.extend(
+            _collect_matching_observability_events(
+                normalized_events,
+                limit=limit,
+                since=since,
+                streams=streams,
+                kinds=kinds,
+            )
+        )
         source = "spool"
     else:
         events.extend(
@@ -815,6 +836,49 @@ def _load_task_run_observability_events(
     return events, source
 
 
+def _event_matches_observability_filters(
+    event: dict[str, object],
+    *,
+    since: int | None = None,
+    streams: set[str] | None = None,
+    kinds: set[str] | None = None,
+) -> bool:
+    sequence = _coerce_sequence(event.get("sequence"))
+    if since is not None and sequence is not None and sequence > 0 and sequence <= since:
+        return False
+    stream = str(event.get("stream") or "").strip()
+    if streams and stream not in streams:
+        return False
+    kind = str(event.get("kind") or "").strip()
+    if kinds and kind not in kinds:
+        return False
+    return True
+
+
+def _collect_matching_observability_events(
+    events: Iterator[dict[str, object]],
+    *,
+    limit: int,
+    since: int | None = None,
+    streams: set[str] | None = None,
+    kinds: set[str] | None = None,
+) -> list[dict[str, object]]:
+    collected: list[dict[str, object]] = []
+    max_events = max(1, limit) + 1
+    for event in events:
+        if not _event_matches_observability_filters(
+            event,
+            since=since,
+            streams=streams,
+            kinds=kinds,
+        ):
+            continue
+        collected.append(event)
+        if len(collected) >= max_events:
+            break
+    return collected
+
+
 def _filter_observability_events(
     events: list[dict[str, object]],
     *,
@@ -824,14 +888,12 @@ def _filter_observability_events(
 ) -> list[dict[str, object]]:
     filtered: list[dict[str, object]] = []
     for event in events:
-        sequence = _coerce_sequence(event.get("sequence"))
-        if since is not None and sequence is not None and sequence > 0 and sequence <= since:
-            continue
-        stream = str(event.get("stream") or "").strip()
-        if streams and stream not in streams:
-            continue
-        kind = str(event.get("kind") or "").strip()
-        if kinds and kind not in kinds:
+        if not _event_matches_observability_filters(
+            event,
+            since=since,
+            streams=streams,
+            kinds=kinds,
+        ):
             continue
         filtered.append(event)
     return filtered
@@ -841,6 +903,30 @@ def _event_sort_key(payload: dict[str, object]) -> tuple[datetime, int]:
     sequence = _coerce_sequence(payload.get("sequence"))
     timestamp = _coerce_utc_datetime(payload.get("timestamp")) or datetime.min.replace(tzinfo=UTC)
     return (timestamp, sequence if sequence is not None and sequence > 0 else 2**31 - 1)
+
+
+def _emit_livelogs_metric_increment(
+    metric: str,
+    *,
+    value: int = 1,
+    tags: dict[str, object] | None = None,
+) -> None:
+    try:
+        get_metrics_emitter().increment(metric, value=value, tags=tags)
+    except Exception:
+        return
+
+
+def _emit_livelogs_metric_observe(
+    metric: str,
+    *,
+    value: float,
+    tags: dict[str, object] | None = None,
+) -> None:
+    try:
+        get_metrics_emitter().observe(metric, value=value, tags=tags)
+    except Exception:
+        return
 
 
 def _iter_artifact_fallback_content(
@@ -933,7 +1019,6 @@ async def get_observability_summary(
             detail="Observability record not found for this task run",
         )
     await _require_observability_access(record, _user)
-    metrics = get_metrics_emitter()
     started = time.perf_counter()
 
     terminal_statuses = {"completed", "failed", "canceled", "cancelled", "timed_out"}
@@ -956,7 +1041,7 @@ async def get_observability_summary(
     base["supportsLiveStreaming"] = supports_live
     base["liveStreamStatus"] = live_stream_status
     base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
-    metrics.observe(
+    _emit_livelogs_metric_observe(
         "livelogs.summary.latency",
         value=time.perf_counter() - started,
         tags={"stream": "livelogs"},
@@ -1081,46 +1166,53 @@ async def get_task_run_observability_events(
             detail="Observability record not found for this task run",
         )
     await _require_observability_access(record, _user)
-    metrics = get_metrics_emitter()
     started = time.perf_counter()
-
-    session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
+    stream_filters = set(stream or [])
+    kind_filters = {item for item in (kind or []) if item}
     try:
+        session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
         events, source = await asyncio.to_thread(
             _load_task_run_observability_events,
             record=record,
             session_record=session_record,
             limit=limit,
+            since=since,
+            streams=stream_filters,
+            kinds=kind_filters,
         )
+        if source == "artifacts":
+            events = _filter_observability_events(
+                events,
+                since=since,
+                streams=stream_filters,
+                kinds=kind_filters,
+            )
+        events.sort(key=_event_sort_key)
+        truncated = len(events) > limit
+        if truncated:
+            events = events[:limit]
+
+        response = {
+            "events": events,
+            "truncated": truncated,
+            "sessionSnapshot": _build_session_snapshot(session_record)
+            or _build_record_session_snapshot(record),
+        }
     except Exception:
-        metrics.increment("livelogs.history.error", tags={"stream": "livelogs"})
+        _emit_livelogs_metric_increment(
+            "livelogs.history.error",
+            tags={"stream": "livelogs"},
+        )
         raise
-    events = _filter_observability_events(
-        events,
-        since=since,
-        streams=set(stream or []),
-        kinds={item for item in (kind or []) if item},
-    )
-
-    events.sort(key=_event_sort_key)
-    truncated = len(events) > limit
-    if truncated:
-        events = events[:limit]
-
     metric_tags = {"stream": "livelogs", "source": source}
-    metrics.observe(
+    _emit_livelogs_metric_observe(
         "livelogs.history.latency",
         value=time.perf_counter() - started,
         tags=metric_tags,
     )
-    metrics.increment("livelogs.history.source", tags=metric_tags)
+    _emit_livelogs_metric_increment("livelogs.history.source", tags=metric_tags)
 
-    return {
-        "events": events,
-        "truncated": truncated,
-        "sessionSnapshot": _build_session_snapshot(session_record)
-        or _build_record_session_snapshot(record),
-    }
+    return response
 
 
 @router.get(
@@ -1163,9 +1255,8 @@ async def stream_task_run_live_logs(
             detail="Live streaming is not supported for this run.",
         )
 
-    metrics = get_metrics_emitter()
     tags = {"stream": "livelogs"}
-    metrics.increment("livelogs.stream.connect", tags=tags)
+    _emit_livelogs_metric_increment("livelogs.stream.connect", tags=tags)
 
     # Use queries parameter 'since'
     since_sequence = since or 0
@@ -1201,11 +1292,11 @@ async def stream_task_run_live_logs(
         except asyncio.CancelledError:
             raise
         except Exception:
-            metrics.increment("livelogs.stream.error", tags=tags)
+            _emit_livelogs_metric_increment("livelogs.stream.error", tags=tags)
             raise
         finally:
             reader.stop()
-            metrics.increment("livelogs.stream.disconnect", tags=tags)
+            _emit_livelogs_metric_increment("livelogs.stream.disconnect", tags=tags)
 
     return StreamingResponse(
         _instrumented_generator(),

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -301,7 +301,7 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByText('Plan work')).toBeTruthy();
       expect(screen.getByText('Apply patch')).toBeTruthy();
       expect(screen.getByText('Verify tests')).toBeTruthy();
-      expect(screen.getByText('Latest run')).toBeTruthy();
+      expect(screen.getByText(/Latest Run/i)).toBeTruthy();
       expect(screen.getAllByText('02-run').length).toBeGreaterThan(0);
     });
 
@@ -2069,6 +2069,19 @@ describe('LiveLogsPanel', () => {
       },
     },
   };
+  const structuredHistoryDisabledPayload: BootPayload = {
+    page: 'task-detail',
+    apiBase: '/api',
+    initialData: {
+      dashboardConfig: {
+        features: {
+          logStreamingEnabled: true,
+          liveLogsSessionTimelineEnabled: true,
+          liveLogsStructuredHistoryEnabled: false,
+        },
+      },
+    },
+  };
 
   const activeSummary = {
     summary: {
@@ -2899,6 +2912,41 @@ describe('LiveLogsPanel', () => {
     await waitFor(() => {
       expect(screen.getByText(/empty history fallback line/)).toBeTruthy();
     });
+  });
+
+  it('skips structured history and loads merged logs when structured history is disabled', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/observability-summary')) {
+        return Promise.resolve({ ok: true, json: async () => noStreamSummary } as Response);
+      }
+      if (url.includes('/observability/events')) {
+        return Promise.resolve({ ok: false, status: 500 } as Response);
+      }
+      if (url.includes('/logs/merged')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => 'rollback merged history\n',
+        } as unknown as Response);
+      }
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({ ok: true, json: async () => ({ artifacts: [] }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => codexExecution } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={structuredHistoryDisabledPayload} />);
+    fireEvent.click(await screen.findByText('Live Logs'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/rollback merged history/)).toBeTruthy();
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/observability/events')),
+    ).toBe(false);
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url).includes('/logs/merged')),
+    ).toBe(true);
   });
 
   it('derives session badges from camelCase historical event metadata', async () => {

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -18,6 +18,7 @@ type DashboardConfig = {
     logStreamingEnabled?: boolean;
     liveLogsSessionTimelineEnabled?: boolean;
     liveLogsSessionTimelineRollout?: string;
+    liveLogsStructuredHistoryEnabled?: boolean;
   };
   sources?: {
     temporal?: Record<string, string>;
@@ -75,6 +76,10 @@ function shouldEnableSessionTimelineViewer({
     return Boolean(String(taskRunId || '').trim());
   }
   return config?.features?.liveLogsSessionTimelineEnabled === true;
+}
+
+function shouldUseStructuredHistory(config: DashboardConfig | undefined): boolean {
+  return config?.features?.liveLogsStructuredHistoryEnabled !== false;
 }
 
 export function getSessionProjectionRefetchInterval(
@@ -1399,12 +1404,14 @@ function StepObservabilityGroup({
   apiBase,
   logStreamingEnabled,
   sessionTimelineEnabled,
+  structuredHistoryEnabled,
   row,
   routes,
 }: {
   apiBase: string;
   logStreamingEnabled: boolean;
   sessionTimelineEnabled: boolean;
+  structuredHistoryEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   routes: TaskRunRouteTemplates;
 }) {
@@ -1436,6 +1443,7 @@ function StepObservabilityGroup({
         autoExpand
         routes={routes}
         sessionTimelineEnabled={sessionTimelineEnabled}
+        structuredHistoryEnabled={structuredHistoryEnabled}
       />
       <StaticLogPanel
         apiBase={apiBase}
@@ -1472,6 +1480,7 @@ function StepLedgerRowCard({
   apiBase,
   logStreamingEnabled,
   sessionTimelineEnabled,
+  structuredHistoryEnabled,
   row,
   runId,
   expanded,
@@ -1482,6 +1491,7 @@ function StepLedgerRowCard({
   apiBase: string;
   logStreamingEnabled: boolean;
   sessionTimelineEnabled: boolean;
+  structuredHistoryEnabled: boolean;
   row: z.infer<typeof StepLedgerRowSchema>;
   runId: string;
   expanded: boolean;
@@ -1554,6 +1564,7 @@ function StepLedgerRowCard({
                 apiBase={apiBase}
                 logStreamingEnabled={logStreamingEnabled}
                 sessionTimelineEnabled={sessionTimelineEnabled}
+                structuredHistoryEnabled={structuredHistoryEnabled}
                 row={row}
                 routes={routes}
               />
@@ -1580,6 +1591,7 @@ function LiveLogsPanel({
   autoExpand = false,
   routes,
   sessionTimelineEnabled,
+  structuredHistoryEnabled,
 }: {
   apiBase: string;
   taskRunId: string;
@@ -1587,6 +1599,7 @@ function LiveLogsPanel({
   autoExpand?: boolean;
   routes: TaskRunRouteTemplates;
   sessionTimelineEnabled: boolean;
+  structuredHistoryEnabled: boolean;
 }) {
   const [logContent, setLogContent] = useState<TimelineRow[]>([]);
   const [viewerState, setViewerState] = useState<LogViewerState>('starting');
@@ -1627,13 +1640,13 @@ function LiveLogsPanel({
   const historyQuery = useQuery({
     queryKey: ['task-run-observability-events', taskRunId],
     queryFn: () => fetchObservabilityEvents(apiBase, taskRunId, routes.observabilityEvents),
-    enabled: !!taskRunId && expanded && summaryQuery.isSuccess,
+    enabled: structuredHistoryEnabled && !!taskRunId && expanded && summaryQuery.isSuccess,
     staleTime: Infinity,
     retry: false,
   });
   const historyRows = useMemo(() => mapEventsToTimelineRows(historyQuery.data), [historyQuery.data]);
-  const historyUnavailable = historyQuery.isError || historyQuery.data === null;
-  const historyEmpty = historyQuery.isSuccess && historyRows.length === 0;
+  const historyUnavailable = !structuredHistoryEnabled || historyQuery.isError || historyQuery.data === null;
+  const historyEmpty = structuredHistoryEnabled && historyQuery.isSuccess && historyRows.length === 0;
 
   // Legacy fallback: keep merged text available for older runs or partial failures.
   const tailQuery = useQuery({
@@ -1643,7 +1656,7 @@ function LiveLogsPanel({
       !!taskRunId &&
       expanded &&
       summaryQuery.isSuccess &&
-      (historyUnavailable || historyEmpty),
+      (!structuredHistoryEnabled || historyUnavailable || historyEmpty),
     staleTime: Infinity,
     retry: false,
   });
@@ -1654,11 +1667,11 @@ function LiveLogsPanel({
       setViewerState('starting');
       return;
     }
-    if (historyQuery.isError && tailQuery.isError) {
+    if ((structuredHistoryEnabled && historyQuery.isError && tailQuery.isError) || (!structuredHistoryEnabled && tailQuery.isError)) {
       setViewerState('error');
     } else if (
       summaryQuery.isSuccess &&
-      (historyQuery.isSuccess || tailQuery.isSuccess)
+      ((structuredHistoryEnabled && historyQuery.isSuccess) || tailQuery.isSuccess)
     ) {
       const summary = summaryQuery.data;
       const runIsTerminal =
@@ -1677,6 +1690,7 @@ function LiveLogsPanel({
     }
   }, [
     expanded,
+    structuredHistoryEnabled,
     historyQuery.data,
     historyQuery.isError,
     historyQuery.isSuccess,
@@ -1695,6 +1709,9 @@ function LiveLogsPanel({
 
   // Sync structured history into the local timeline when history fetch completes.
   useEffect(() => {
+    if (!structuredHistoryEnabled) {
+      return;
+    }
     if (historyQuery.isSuccess) {
       const sequences = historyQuery.data?.events
         .map((event) => event.sequence)
@@ -1714,21 +1731,21 @@ function LiveLogsPanel({
         }
       }
     }
-  }, [historyQuery.data, historyQuery.isSuccess, historyRows]);
+  }, [historyQuery.data, historyQuery.isSuccess, historyRows, structuredHistoryEnabled]);
 
   // Sync legacy merged-text fallback only when structured history is unavailable.
   useEffect(() => {
-    if (tailQuery.isSuccess && tailQuery.data && (historyUnavailable || historyEmpty)) {
+    if (tailQuery.isSuccess && tailQuery.data && (!structuredHistoryEnabled || historyUnavailable || historyEmpty)) {
       if (lastSeqRef.current === null) {
         setLogContent(parseArtifactToRows(tailQuery.data));
       }
     }
-  }, [historyEmpty, historyUnavailable, tailQuery.data, tailQuery.isSuccess]);
+  }, [historyEmpty, historyUnavailable, structuredHistoryEnabled, tailQuery.data, tailQuery.isSuccess]);
 
   // Connect to SSE only after tail succeeds, if streaming is supported and active
   useEffect(() => {
     if (!taskRunId || !expanded || !summaryQuery.isSuccess || !isVisible) return;
-    if (!historyQuery.isSuccess && !tailQuery.isSuccess) return;
+    if ((structuredHistoryEnabled && !historyQuery.isSuccess && !tailQuery.isSuccess) || (!structuredHistoryEnabled && !tailQuery.isSuccess)) return;
 
     const summary = summaryQuery.data;
     const runIsTerminal =
@@ -2472,6 +2489,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
   const actionsOn = Boolean(cfg?.features?.temporalDashboard?.actionsEnabled);
   const debugOn = Boolean(cfg?.features?.temporalDashboard?.debugFieldsEnabled);
   const logStreamingEnabled = cfg?.features?.logStreamingEnabled !== false;
+  const structuredHistoryEnabled = shouldUseStructuredHistory(cfg);
 
   const taskIdMatch = window.location.pathname.match(
     /^\/tasks\/(?:temporal\/|proposals\/|schedules\/|manifests\/)?([^/]+)$/,
@@ -2951,6 +2969,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                       apiBase={payload.apiBase}
                       logStreamingEnabled={logStreamingEnabled}
                       sessionTimelineEnabled={sessionTimelineEnabled}
+                      structuredHistoryEnabled={structuredHistoryEnabled}
                       row={row}
                       runId={latestRunId}
                       expanded={Boolean(expandedSteps[row.logicalStepId])}
@@ -3222,6 +3241,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                       autoExpand={showTaskRunAttachNotice}
                       routes={taskRunRoutes}
                       sessionTimelineEnabled={sessionTimelineEnabled}
+                      structuredHistoryEnabled={structuredHistoryEnabled}
                     />
                     <StaticLogPanel
                       apiBase={payload.apiBase}

--- a/moonmind/config/settings.py
+++ b/moonmind/config/settings.py
@@ -1611,6 +1611,17 @@ class FeatureFlagsSettings(BaseSettings):
             "Allowed values: off, internal, codex_managed, all_managed."
         ),
     )
+    live_logs_structured_history_enabled: bool = Field(
+        True,
+        validation_alias=AliasChoices(
+            "FEATURE_FLAGS__LIVE_LOGS_STRUCTURED_HISTORY_ENABLED",
+            "LIVE_LOGS_STRUCTURED_HISTORY_ENABLED",
+        ),
+        description=(
+            "Enable structured historical Live Logs loading through "
+            "/observability/events. Disable to force merged-tail rollback."
+        ),
+    )
 
     task_template_catalog: bool = Field(
         True,

--- a/specs/145-live-logs-phase7/checklists/requirements.md
+++ b/specs/145-live-logs-phase7/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Live Logs Phase 7 Hardening and Rollback
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent is explicit: deliverables include production code changes plus validation tests.

--- a/specs/145-live-logs-phase7/contracts/live-logs-phase7-hardening.md
+++ b/specs/145-live-logs-phase7/contracts/live-logs-phase7-hardening.md
@@ -1,0 +1,33 @@
+# Contract: Live Logs Phase 7 Hardening and Rollback
+
+## 1. Backend router metrics
+
+### 1.1 `/api/task-runs/{id}/observability-summary`
+
+- MUST emit `livelogs.summary.latency` through the shared metrics emitter when the route reaches summary shaping logic.
+- MUST keep response payload unchanged.
+
+### 1.2 `/api/task-runs/{id}/observability/events`
+
+- MUST emit `livelogs.history.latency` and `livelogs.history.source` on successful history reconstruction.
+- MUST tag successful history metrics with `source=journal`, `source=spool`, or `source=artifacts`.
+- MUST emit `livelogs.history.error` on failures that occur after authorization while loading history.
+- MUST keep the existing response payload unchanged.
+
+### 1.3 `/api/task-runs/{id}/logs/stream`
+
+- MUST preserve `livelogs.stream.connect`, `livelogs.stream.disconnect`, and `livelogs.stream.error`.
+- MUST not let metrics failures change stream semantics.
+
+## 2. Frontend rollback behavior
+
+- Dashboard runtime config exposes `features.liveLogsStructuredHistoryEnabled`.
+- When the flag is `false`, the task-detail page:
+  - still fetches `/observability-summary`,
+  - does not request `/observability/events`,
+  - uses `/logs/merged` as the initial historical surface,
+  - still allows live SSE follow when supported.
+
+## 3. Authorization
+
+- `/api/task-runs/{id}/observability/events` MUST remain protected by the same owner/superuser rules as the other task-run observability routes.

--- a/specs/145-live-logs-phase7/data-model.md
+++ b/specs/145-live-logs-phase7/data-model.md
@@ -1,0 +1,59 @@
+# Data Model: Live Logs Phase 7 Hardening and Rollback
+
+## 1. Router metrics
+
+Phase 7 does not add a new persisted business entity. It adds best-effort operational events around existing router surfaces.
+
+### 1.1 Summary metrics
+
+| Metric | Type | When emitted | Tags |
+| --- | --- | --- | --- |
+| `livelogs.summary.latency` | timing | `/observability-summary` completes route business logic | `stream=livelogs` |
+
+### 1.2 History metrics
+
+| Metric | Type | When emitted | Tags |
+| --- | --- | --- | --- |
+| `livelogs.history.latency` | timing | `/observability/events` completes a successful history reconstruction | `stream=livelogs`, `source=journal\|spool\|artifacts` |
+| `livelogs.history.source` | counter | `/observability/events` serves one history source | `stream=livelogs`, `source=journal\|spool\|artifacts` |
+| `livelogs.history.error` | counter | `/observability/events` fails after authorization while loading history | `stream=livelogs` |
+
+### 1.3 Stream metrics
+
+Phase 7 keeps the existing SSE metrics:
+
+| Metric | Type | Tags |
+| --- | --- | --- |
+| `livelogs.stream.connect` | counter | `stream=livelogs` |
+| `livelogs.stream.disconnect` | counter | `stream=livelogs` |
+| `livelogs.stream.error` | counter | `stream=livelogs` |
+
+## 2. History source classification
+
+`/observability/events` must classify the source used to reconstruct the response:
+
+- `journal`: persisted `observability.events.jsonl`
+- `spool`: shared append-only spool replay
+- `artifacts`: synthesized fallback from stdout/stderr/diagnostics/session artifacts
+
+This source is operational metadata only. It is not returned to the browser in the response body.
+
+## 3. Structured-history rollback flag
+
+| Config field | Dashboard key | Type | Default | Meaning |
+| --- | --- | --- | --- | --- |
+| `live_logs_structured_history_enabled` | `liveLogsStructuredHistoryEnabled` | boolean | `true` | When `false`, the browser skips `/observability/events` and loads merged history directly. |
+
+This flag is independent from:
+
+- `live_logs_session_timeline_rollout`
+- `log_streaming_enabled`
+
+## 4. Frontend behavior
+
+When `liveLogsStructuredHistoryEnabled=false`:
+
+1. Live Logs still fetches summary first.
+2. The history query for `/observability/events` is disabled.
+3. The merged-tail fallback query becomes the primary historical load path.
+4. Active runs may still upgrade to live SSE if the summary says streaming is available.

--- a/specs/145-live-logs-phase7/plan.md
+++ b/specs/145-live-logs-phase7/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Live Logs Phase 7 Hardening and Rollback
+
+**Branch**: `145-live-logs-phase7` | **Date**: 2026-04-09 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/145-live-logs-phase7/spec.md`
+
+## Summary
+
+Implement the remaining high-signal Phase 7 work that is still absent after the prior Live Logs slices: instrument the summary/history/stream router surfaces with operational metrics, add explicit owner-access regression coverage for `/observability/events`, and add a dedicated frontend rollback switch that disables structured-history loading while preserving the rest of the Live Logs panel lifecycle.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript, React 19  
+**Primary Dependencies**: FastAPI task-run routers, MoonMind StatsD emitter, Workflow/feature flag settings, Mission Control task-detail page, Vitest, pytest  
+**Storage**: Existing managed-run store, session store, artifact-backed event journals, shared spool transport, browser query cache  
+**Testing**: `pytest`, `./tools/test_unit.sh`, `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`  
+**Target Platform**: Docker/Compose-hosted MoonMind API service plus Mission Control frontend  
+**Project Type**: backend + frontend hardening slice  
+**Performance Goals**: keep metrics best-effort, keep the current summary -> history/tail -> SSE lifecycle unchanged, and avoid adding extra network round trips when structured-history rollback is disabled  
+**Constraints**: preserve existing route contracts, preserve current Live Logs viewer semantics, do not make metrics authoritative for success, and keep rollback behavior runtime-configurable  
+**Scale/Scope**: Phase 7 operational hardening only; no new route family, no rewrite of the viewer, and no feature-flag removal
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The work instruments MoonMind-owned observability surfaces and preserves normalized router/frontend contracts.
+- **II. One-Click Agent Deployment**: PASS. No new service or deployment dependency is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. Metrics and rollback flags are expressed in MoonMind routes/config, not provider-native transports.
+- **IV. Own Your Data**: PASS. Structured history and merged fallback remain MoonMind artifact-backed surfaces.
+- **VI. Thin Scaffolding, Thick Contracts**: PASS. The slice strengthens existing contracts instead of adding a parallel observability API.
+- **VII. Powerful Runtime Configurability**: PASS. The rollback path is an explicit feature flag instead of a code change.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay bounded to feature flags, task-run routers, task-detail logic, and tests.
+- **IX. Resilient by Default**: PASS. Metrics are best-effort, denied requests are handled explicitly, and the browser can roll back to merged history without losing the panel.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. Phase 7 work is isolated into a dedicated spec/plan/tasks slice.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs remain unchanged; rollout/hardening stays in this feature package.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. The rollback switch reuses the existing merged-tail path rather than adding another legacy viewer.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/145-live-logs-phase7/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── live-logs-phase7-hardening.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+moonmind/config/settings.py                        # MODIFY: structured-history rollback feature flag
+api_service/api/routers/task_dashboard_view_model.py # MODIFY: expose grouped Live Logs rollback config
+api_service/api/routers/task_runs.py              # MODIFY: summary/history metrics and owner-access-safe instrumentation
+frontend/src/entrypoints/task-detail.tsx          # MODIFY: skip structured-history fetch when rollback flag disables it
+tests/unit/config/test_settings.py                # MODIFY: feature-flag coverage
+tests/unit/api/routers/test_task_dashboard_view_model.py # MODIFY: runtime-config coverage
+tests/unit/api/routers/test_task_runs.py          # MODIFY: metrics and ownership regression coverage
+frontend/src/entrypoints/task-detail.test.tsx     # MODIFY: rollback-path browser coverage
+```
+
+**Structure Decision**: Keep the hardening slice on the existing backend router/config and task-detail entrypoint path. The rollout/rollback behavior should remain a config-driven extension of the current Live Logs lifecycle, not a new UI or API surface.
+
+## Research
+
+- The router already emits `livelogs.stream.connect`, `livelogs.stream.disconnect`, and `livelogs.stream.error`, but it does not emit summary latency or structured-history latency/source metrics.
+- `/observability/events` already enforces observability access through `_require_observability_access`, yet explicit owner-based regression tests exist for summary and continuity routes but not for the events route.
+- The frontend already supports `liveLogsSessionTimelineEnabled` and rollout scoping, but it has no dedicated kill switch for the `/observability/events` path once the session-aware timeline is enabled.
+- The merged-tail fallback is already production-safe and stable, so Phase 7 rollback can reuse that path instead of inventing a second compatibility model.
+
+## Data Model
+
+- See [data-model.md](./data-model.md) for the router metric events, history source tags, and structured-history rollback flag behavior.
+
+## Contracts
+
+- [contracts/live-logs-phase7-hardening.md](./contracts/live-logs-phase7-hardening.md)
+
+## Implementation Plan
+
+1. Add failing backend tests for summary/history metrics and `/observability/events` owner access, plus failing frontend/runtime-config tests for the structured-history rollback flag.
+2. Extend feature flag settings and dashboard runtime config to expose `liveLogsStructuredHistoryEnabled`.
+3. Instrument `task_runs.py` so summary and history routes emit best-effort latency/source/error metrics while preserving existing SSE metrics.
+4. Update `task-detail.tsx` so Live Logs skips `/observability/events` and uses merged history directly when the rollback flag is disabled.
+5. Run focused UI/backend verification plus scope validation, then mark all completed tasks in `tasks.md`.
+
+## Verification Plan
+
+### Automated Tests
+
+1. `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+2. `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py`
+3. `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+4. `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+### Manual Validation
+
+1. Disable structured history in runtime config and confirm Live Logs loads merged history without requesting `/observability/events`.
+2. Re-enable structured history and confirm the panel returns to `/observability/events` first.
+3. Observe emitted StatsD traffic or patched test doubles and confirm summary/history/stream router metrics fire on success and error paths.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required for this slice.

--- a/specs/145-live-logs-phase7/quickstart.md
+++ b/specs/145-live-logs-phase7/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Live Logs Phase 7 Hardening and Rollback
+
+## Prerequisites
+
+- Repo dependencies installed
+- Current branch: `145-live-logs-phase7`
+
+## Verification commands
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
+./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py
+SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime
+SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main
+```
+
+## Runtime checks
+
+1. Set `FEATURE_FLAGS__LIVE_LOGS_STRUCTURED_HISTORY_ENABLED=false`.
+2. Open a task detail page and expand `Live Logs`.
+3. Confirm the browser loads merged history without calling `/observability/events`.
+4. Re-enable the flag and confirm `/observability/events` is used again.
+5. Verify summary/history/stream route tests assert the expected metrics behavior.

--- a/specs/145-live-logs-phase7/research.md
+++ b/specs/145-live-logs-phase7/research.md
@@ -1,0 +1,32 @@
+# Research: Live Logs Phase 7 Hardening and Rollback
+
+## Decision 1: Reuse the existing StatsD emitter for router metrics
+
+- **Decision**: Instrument `task_runs.py` with `get_metrics_emitter()` instead of introducing a new observability helper abstraction.
+- **Rationale**: The emitter is already the shared best-effort metrics boundary in MoonMind and the SSE route already depends on it.
+- **Alternatives considered**:
+  - Add logging-only instrumentation. Rejected because Phase 7 explicitly calls for latency/disconnect operational metrics.
+  - Introduce a route-local metrics wrapper. Rejected because it adds indirection without improving the contract.
+
+## Decision 2: Model history-source metrics from the actual reconstruction path
+
+- **Decision**: Teach the history-loading helper to report whether the request used `journal`, `spool`, or `artifacts`, then tag metrics with that source.
+- **Rationale**: Phase 7 needs operational visibility into which fallback path is carrying traffic during rollout.
+- **Alternatives considered**:
+  - Emit latency only. Rejected because it hides which fallback path produced the response.
+  - Infer source in tests only. Rejected because operators need runtime telemetry, not just assertions.
+
+## Decision 3: Add a dedicated structured-history rollback flag
+
+- **Decision**: Add `live_logs_structured_history_enabled` under feature flags, defaulting to `true`, and expose it to the dashboard as `liveLogsStructuredHistoryEnabled`.
+- **Rationale**: The existing timeline flag controls viewer eligibility, not whether the browser should call `/observability/events`. Phase 7 needs a kill switch for that path.
+- **Alternatives considered**:
+  - Reuse `liveLogsSessionTimelineEnabled`. Rejected because it would disable the entire session-aware viewer instead of rolling back only the structured-history fetch path.
+  - Reuse `logStreamingEnabled`. Rejected because that flag controls live SSE transport, not historical loading.
+
+## Decision 4: Add owner-access regression coverage directly on `/observability/events`
+
+- **Decision**: Mirror the owner-versus-cross-owner tests already used for summary and artifact-session routes on the structured-history endpoint.
+- **Rationale**: The endpoint is already protected through shared access helpers, so the highest-value Phase 7 hardening is explicit regression coverage rather than a new auth model.
+- **Alternatives considered**:
+  - Rely on summary-route coverage. Rejected because `/observability/events` is a distinct route added later in the rollout and deserves direct protection.

--- a/specs/145-live-logs-phase7/spec.md
+++ b/specs/145-live-logs-phase7/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Live Logs Phase 7 Hardening and Rollback
+
+**Feature Branch**: `145-live-logs-phase7`  
+**Created**: 2026-04-09  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 7 using test-driven development from the Live Logs Session-Aware Implementation Plan. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Observe Live Logs surface health operationally (Priority: P1)
+
+MoonMind operators need the Live Logs summary, structured-history, and live-stream surfaces to emit their own health metrics so regressions can be detected before the session-aware timeline becomes the default managed-run experience.
+
+**Why this priority**: Phase 7 explicitly calls for operational hardening. Without metrics on the main read surfaces, the team cannot validate latency, disconnect rate, or history-read behavior during rollout.
+
+**Independent Test**: Request `/observability-summary`, `/observability/events`, and `/logs/stream` in automated tests and verify the router emits the expected StatsD metrics for latency, connect/disconnect, and error paths.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task run summary request succeeds, **When** MoonMind serves `/observability-summary`, **Then** it records a summary latency metric tagged for the Live Logs surface.
+2. **Given** structured observability history is loaded from the journal, spool, or artifact fallback, **When** MoonMind serves `/observability/events`, **Then** it records journal/history latency and source metrics for that request.
+3. **Given** an SSE client connects and later disconnects or errors, **When** MoonMind serves `/logs/stream`, **Then** it records connect, disconnect, and error metrics without breaking the stream response contract.
+
+---
+
+### User Story 2 - Protect structured history with the same ownership rules as other observability surfaces (Priority: P1)
+
+Operators need the structured history endpoint to enforce the same owner-based authorization as summary and continuity routes so the new historical timeline surface is safe to expose broadly.
+
+**Why this priority**: Phase 7 requires validating auth and ownership checks for the new observability surfaces. `/observability/events` is the newest Phase 3+ route and needs explicit owner-access regression coverage.
+
+**Independent Test**: Exercise `/api/task-runs/{id}/observability/events` as the owning user and as a different user, then verify the route allows the owner and rejects cross-owner access with `403`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a non-superuser owns the workflow bound to a task run, **When** they request `/observability/events`, **Then** the structured history loads successfully.
+2. **Given** a different non-superuser requests the same run, **When** they request `/observability/events`, **Then** MoonMind rejects access with `403`.
+3. **Given** the structured history request is denied, **When** MoonMind responds, **Then** it does not emit a false success metric for that request.
+
+---
+
+### User Story 3 - Roll back the structured-history timeline path without breaking Live Logs (Priority: P1)
+
+MoonMind operators need a runtime-config switch that disables structured-history loading in the browser and returns Live Logs to the merged-tail path so the team can roll back the new historical timeline path without removing the overall Live Logs panel.
+
+**Why this priority**: Phase 7 requires a defined rollback behavior. The existing timeline flag controls the richer viewer, but it does not provide a dedicated kill switch for the `/observability/events` path once the timeline UI is already enabled.
+
+**Independent Test**: Render the task detail page with the new rollback flag disabled and confirm the browser skips `/observability/events`, loads `/logs/merged`, and keeps the existing Live Logs lifecycle intact.
+
+**Acceptance Scenarios**:
+
+1. **Given** the structured-history rollout switch is disabled, **When** an operator opens Live Logs, **Then** the browser skips `/observability/events` and loads the merged-tail fallback directly.
+2. **Given** the structured-history rollout switch is enabled, **When** an operator opens Live Logs, **Then** the browser still prefers `/observability/events` before `/logs/merged`.
+3. **Given** the structured-history rollback switch is disabled while the session timeline viewer remains enabled, **When** Live Logs renders, **Then** the panel still works with historical merged content and optional live SSE follow for active runs.
+
+### Edge Cases
+
+- A structured-history request may fail before any journal is read; latency/error metrics must still be emitted without assuming a history source.
+- A task run may have no persisted event journal and no spool, causing artifact synthesis to serve `/observability/events`; source-tag metrics must still identify the fallback path truthfully.
+- Owner authorization may fail before summary/history loading; metrics must not label the request as a successful history read.
+- The browser may disable structured history while the session-aware timeline viewer remains eligible; Live Logs must still render merged text and live updates without trying the history endpoint first.
+- Metrics emission itself may fail or be disabled; router behavior must remain best-effort and continue serving responses.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `/api/task-runs/{id}/observability-summary` MUST emit a Live Logs summary latency metric for every completed request path that reaches the router business logic.
+- **FR-002**: `/api/task-runs/{id}/observability/events` MUST emit latency metrics and a history-source metric that distinguishes at least `journal`, `spool`, and `artifacts` when one of those sources is used.
+- **FR-003**: `/api/task-runs/{id}/observability/events` MUST emit an error metric for failed history reads after the request passes authorization and enters the route handler.
+- **FR-004**: `/api/task-runs/{id}/logs/stream` MUST continue to emit connect, disconnect, and error metrics for SSE activity.
+- **FR-005**: `/api/task-runs/{id}/observability/events` MUST enforce the same owner-based access rules as the other task-run observability routes.
+- **FR-006**: The dashboard runtime config MUST expose a dedicated rollback flag for structured-history usage in Live Logs.
+- **FR-007**: The task-detail frontend MUST skip `/observability/events` and use `/logs/merged` directly when the structured-history rollback flag is disabled.
+- **FR-008**: The task-detail frontend MUST preserve the current summary -> history/tail -> SSE lifecycle while honoring the structured-history rollback flag.
+- **FR-009**: The Phase 7 slice MUST ship production runtime/frontend code changes plus automated validation tests; docs-only edits are insufficient.
+
+### Key Entities *(include if feature involves data)*
+
+- **Live Logs Router Metrics**: Best-effort StatsD events emitted for summary latency, history latency/source, and SSE connect/disconnect/error activity.
+- **History Source Tag**: The normalized label describing whether `/observability/events` reconstructed history from the journal, shared spool, or artifact fallback.
+- **Structured History Rollback Flag**: Runtime-config feature data that tells the frontend whether it should request `/observability/events` or fall back to merged history directly.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests prove `/observability-summary` and `/observability/events` emit the expected latency/source/error metrics and do not mislabel denied requests as successful history reads.
+- **SC-002**: Unit tests prove owner access and cross-owner rejection for `/observability/events`.
+- **SC-003**: Browser tests prove disabling structured history skips `/observability/events` and falls back to merged history while preserving Live Logs behavior.
+- **SC-004**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`, `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py`, and scope validation pass.

--- a/specs/145-live-logs-phase7/speckit_analyze_report.md
+++ b/specs/145-live-logs-phase7/speckit_analyze_report.md
@@ -1,0 +1,35 @@
+# Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| C1 | Constitution | LOW | plan.md: Complexity Tracking | No constitution violations remain after artifact cleanup. | Proceed without exception handling. |
+
+## Coverage Summary Table
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --- | --- | --- | --- |
+| summary-latency-metrics | Yes | T002, T003, T011 | Backend tests plus router instrumentation. |
+| history-latency-source-error-metrics | Yes | T002, T003, T011 | Covers journal/spool/artifact metrics and error path. |
+| sse-metrics-preserved | Yes | T003, T011 | Covered through router instrumentation scope. |
+| observability-events-owner-access | Yes | T004, T005, T011 | Owner and cross-owner regression coverage. |
+| structured-history-rollback-flag | Yes | T006, T008, T011 | Settings and dashboard runtime-config coverage. |
+| frontend-skips-events-when-rollback-disabled | Yes | T007, T009, T010 | Browser coverage and implementation. |
+| frontend-preserves-summary-tail-sse-lifecycle | Yes | T007, T009, T010 | Rollback path keeps existing lifecycle. |
+
+**Constitution Alignment Issues:** None.
+
+**Unmapped Tasks:** None.
+
+## Metrics
+
+- Total Requirements: 9
+- Total Tasks: 13
+- Coverage % (requirements with >=1 task): 100%
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Proceed to implementation.
+- Keep the backend metrics best-effort and avoid changing response payloads while instrumenting.

--- a/specs/145-live-logs-phase7/tasks.md
+++ b/specs/145-live-logs-phase7/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: Live Logs Phase 7 Hardening and Rollback
+
+**Input**: Design documents from `/specs/145-live-logs-phase7/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`
+
+**Tests**: TDD is required where feasible. Write failing tests before implementing the corresponding runtime/frontend changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+
+## Phase 1: Setup
+
+- [X] T001 Create the Phase 7 spec artifact set in `specs/145-live-logs-phase7/`.
+
+## Phase 2: User Story 1 - Observe Live Logs surface health operationally (Priority: P1)
+
+**Goal**: Emit best-effort metrics for the summary, structured-history, and stream router surfaces.
+
+### Tests for User Story 1
+
+- [X] T002 [P] [US1] Add failing router metric tests in `tests/unit/api/routers/test_task_runs.py` for summary latency, history latency/source, and history error emission.
+
+### Implementation for User Story 1
+
+- [X] T003 [US1] Update `api_service/api/routers/task_runs.py` to instrument summary/history metrics while preserving existing SSE metrics and route responses.
+
+## Phase 3: User Story 2 - Protect structured history with the same ownership rules as other observability surfaces (Priority: P1)
+
+**Goal**: Add explicit owner-versus-cross-owner regression coverage for `/observability/events`.
+
+### Tests for User Story 2
+
+- [X] T004 [P] [US2] Add failing owner-access and cross-owner rejection tests in `tests/unit/api/routers/test_task_runs.py` for `/api/task-runs/{id}/observability/events`.
+
+### Implementation for User Story 2
+
+- [X] T005 [US2] Update `api_service/api/routers/task_runs.py` as needed so metrics and access control remain correct for authorized and rejected `/observability/events` requests.
+
+## Phase 4: User Story 3 - Roll back the structured-history timeline path without breaking Live Logs (Priority: P1)
+
+**Goal**: Expose and honor a dedicated structured-history rollback flag in dashboard config and the task-detail page.
+
+### Tests for User Story 3
+
+- [X] T006 [P] [US3] Add failing feature-flag tests in `tests/unit/config/test_settings.py` and `tests/unit/api/routers/test_task_dashboard_view_model.py` for `live_logs_structured_history_enabled`.
+- [X] T007 [P] [US3] Add failing browser tests in `frontend/src/entrypoints/task-detail.test.tsx` covering disabled structured-history fetch and merged-tail-first fallback.
+
+### Implementation for User Story 3
+
+- [X] T008 [US3] Update `moonmind/config/settings.py` and `api_service/api/routers/task_dashboard_view_model.py` to expose `liveLogsStructuredHistoryEnabled`.
+- [X] T009 [US3] Update `frontend/src/entrypoints/task-detail.tsx` to skip `/observability/events` and load merged history directly when the rollback flag is disabled.
+
+## Phase 5: Validation
+
+- [X] T010 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+- [X] T011 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py`
+- [X] T012 Run `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
+- [X] T013 Run `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **User Story 1 (Phase 2)**: Depends on Setup.
+- **User Story 2 (Phase 3)**: Can follow the same router test baseline as User Story 1.
+- **User Story 3 (Phase 4)**: Depends on Setup and can proceed in parallel with router work until implementation touches the shared config/frontend files.
+- **Validation (Phase 5)**: Depends on all implementation work.
+
+### Parallel Opportunities
+
+- `T002`, `T004`, `T006`, and `T007` can be written in parallel because they touch different test targets.
+- `T003` and `T008` can proceed independently after the failing tests are in place.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Add the failing router, config, and browser tests.
+2. Land the backend instrumentation and owner-access-safe metrics behavior.
+3. Expose the structured-history rollback flag through config.
+4. Honor the flag in the Live Logs browser lifecycle.
+5. Run focused verification and scope validation.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -375,12 +375,18 @@ def test_build_runtime_config_groups_live_logs_feature_flags(monkeypatch) -> Non
         "live_logs_session_timeline_rollout",
         "internal",
     )
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_structured_history_enabled",
+        False,
+    )
 
     config = build_runtime_config("/tasks")
 
     assert config["features"]["logStreamingEnabled"] is True
     assert config["features"]["liveLogsSessionTimelineEnabled"] is True
     assert config["features"]["liveLogsSessionTimelineRollout"] == "internal"
+    assert config["features"]["liveLogsStructuredHistoryEnabled"] is False
 
 
 def test_build_live_logs_feature_config_exposes_all_managed_rollout(monkeypatch) -> None:
@@ -390,6 +396,11 @@ def test_build_live_logs_feature_config_exposes_all_managed_rollout(monkeypatch)
         "live_logs_session_timeline_rollout",
         "all_managed",
     )
+    monkeypatch.setattr(
+        settings.feature_flags,
+        "live_logs_structured_history_enabled",
+        True,
+    )
 
     feature_config = build_live_logs_feature_config()
 
@@ -397,6 +408,7 @@ def test_build_live_logs_feature_config_exposes_all_managed_rollout(monkeypatch)
         "logStreamingEnabled": True,
         "liveLogsSessionTimelineEnabled": True,
         "liveLogsSessionTimelineRollout": "all_managed",
+        "liveLogsStructuredHistoryEnabled": True,
     }
 
 

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -167,6 +167,26 @@ def test_get_observability_summary_includes_session_snapshot(
     assert snapshot["threadId"] == "thread-2"
 
 
+def test_get_observability_summary_emits_latency_metric(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    metrics = MagicMock()
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch("api_service.api.routers.task_runs.get_metrics_emitter", return_value=metrics):
+            response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    assert metrics.observe.call_args.args[0] == "livelogs.summary.latency"
+    assert metrics.observe.call_args.kwargs["tags"] == {"stream": "livelogs"}
+
+
 def test_get_observability_summary_uses_record_snapshot_when_session_record_missing(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -1229,6 +1249,81 @@ def test_get_task_run_observability_events_uses_record_snapshot_when_session_rec
     assert body["sessionSnapshot"]["activeTurnId"] == "turn-9"
 
 
+def test_get_task_run_observability_events_emits_history_metrics_for_journal(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        json.dumps(
+            {
+                "runId": "run-1",
+                "sequence": 5,
+                "stream": "stdout",
+                "text": "persisted stdout\n",
+                "timestamp": "2026-04-08T00:00:00Z",
+                "kind": "stdout_chunk",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+    metrics = MagicMock()
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            with patch("api_service.api.routers.task_runs.get_metrics_emitter", return_value=metrics):
+                response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    observe_calls = [
+        call for call in metrics.observe.call_args_list if call.args[0] == "livelogs.history.latency"
+    ]
+    assert len(observe_calls) == 1
+    assert observe_calls[0].kwargs["tags"] == {"stream": "livelogs", "source": "journal"}
+    assert any(
+        call.args[0] == "livelogs.history.source"
+        and call.kwargs["tags"] == {"stream": "livelogs", "source": "journal"}
+        for call in metrics.increment.call_args_list
+    )
+
+
+def test_get_task_run_observability_events_emits_error_metric_on_history_failure(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    mock_record = MagicMock()
+    mock_record.workspace_path = "/tmp/workspace"
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    metrics = MagicMock()
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_observability_events",
+            side_effect=RuntimeError("boom"),
+        ):
+            with patch("api_service.api.routers.task_runs.get_metrics_emitter", return_value=metrics):
+                with pytest.raises(RuntimeError, match="boom"):
+                    test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert any(
+        call.args[0] == "livelogs.history.error"
+        and call.kwargs["tags"] == {"stream": "livelogs"}
+        for call in metrics.increment.call_args_list
+    )
+
+
 def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -1262,6 +1357,85 @@ def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
     assert '"sessionId":"sess-1"' in response.text
     assert '"activeTurnId":"turn-3"' in response.text
     assert '"session_id"' not in response.text
+
+
+def test_get_task_run_observability_events_allows_owner_access() -> None:
+    owner_id = uuid4()
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=owner_id,
+        email="owner@example.com",
+        is_superuser=False,
+    )
+
+    mock_record = MagicMock()
+    mock_record.workflow_id = "mm:wf-1"
+    mock_record.workspace_path = "/tmp/workspace"
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    metrics = MagicMock()
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedRunStore.load",
+            return_value=mock_record,
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(owner_id))),
+            ):
+                with patch(
+                    "api_service.api.routers.task_runs.get_metrics_emitter",
+                    return_value=metrics,
+                ):
+                    response = test_client.get(
+                        f"/api/task-runs/{uuid4()}/observability/events"
+                    )
+
+    assert response.status_code == 200
+    assert any(
+        call.args[0] == "livelogs.history.source"
+        for call in metrics.increment.call_args_list
+    )
+
+
+def test_get_task_run_observability_events_forbids_cross_owner_access_without_success_metrics() -> None:
+    owner_id = uuid4()
+    other_id = uuid4()
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=other_id,
+        email="other@example.com",
+        is_superuser=False,
+    )
+
+    mock_record = MagicMock()
+    mock_record.workflow_id = "mm:wf-1"
+    mock_record.workspace_path = "/tmp/workspace"
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    metrics = MagicMock()
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedRunStore.load",
+            return_value=mock_record,
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_execution_owner_binding",
+                new=AsyncMock(return_value=("user", str(owner_id))),
+            ):
+                with patch(
+                    "api_service.api.routers.task_runs.get_metrics_emitter",
+                    return_value=metrics,
+                ):
+                    response = test_client.get(
+                        f"/api/task-runs/{uuid4()}/observability/events"
+                    )
+
+    assert response.status_code == 403
+    assert metrics.observe.call_count == 0
+    assert metrics.increment.call_count == 0
 
 
 def test_load_task_run_session_record_uses_targeted_standard_paths(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -187,6 +187,27 @@ def test_get_observability_summary_emits_latency_metric(
     assert metrics.observe.call_args.kwargs["tags"] == {"stream": "livelogs"}
 
 
+def test_get_observability_summary_ignores_metrics_emitter_failures(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"runId": str(run_id), "status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs.get_metrics_emitter",
+            side_effect=ValueError("bad port"),
+        ):
+            response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["runId"] == str(run_id)
+
+
 def test_get_observability_summary_uses_record_snapshot_when_session_record_missing(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -1324,6 +1345,74 @@ def test_get_task_run_observability_events_emits_error_metric_on_history_failure
     )
 
 
+def test_get_task_run_observability_events_emits_error_metric_when_session_record_load_fails(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    mock_record = MagicMock()
+    mock_record.workspace_path = "/tmp/workspace"
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    metrics = MagicMock()
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_session_record",
+            side_effect=RuntimeError("session boom"),
+        ):
+            with patch("api_service.api.routers.task_runs.get_metrics_emitter", return_value=metrics):
+                with pytest.raises(RuntimeError, match="session boom"):
+                    test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert any(
+        call.args[0] == "livelogs.history.error"
+        and call.kwargs["tags"] == {"stream": "livelogs"}
+        for call in metrics.increment.call_args_list
+    )
+
+
+def test_get_task_run_observability_events_ignores_metrics_emitter_failures(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        json.dumps(
+            {
+                "runId": "run-1",
+                "sequence": 5,
+                "stream": "stdout",
+                "text": "persisted stdout\n",
+                "timestamp": "2026-04-08T00:00:00Z",
+                "kind": "stdout_chunk",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            with patch(
+                "api_service.api.routers.task_runs.get_metrics_emitter",
+                side_effect=ValueError("bad port"),
+            ):
+                response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events")
+
+    assert response.status_code == 200
+    assert [event["sequence"] for event in response.json()["events"]] == [5]
+
+
 def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
     client: tuple[TestClient, AsyncMock],
 ) -> None:
@@ -1359,6 +1448,38 @@ def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
     assert '"session_id"' not in response.text
 
 
+def test_stream_task_run_live_logs_ignores_metrics_emitter_failures(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    mock_record = MagicMock()
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.workspace_path = "/tmp/workspace"
+
+    async def _follow(*args, **kwargs):
+        yield RunObservabilityEvent(
+            runId="run-1",
+            sequence=11,
+            stream="stdout",
+            text="hello\n",
+            timestamp="2026-04-08T00:00:01Z",
+            kind="stdout_chunk",
+        )
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs.get_metrics_emitter",
+            side_effect=ValueError("bad port"),
+        ):
+            with patch("api_service.api.routers.task_runs.SpoolLogReader.follow", new=_follow):
+                response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stream?since=10")
+
+    assert response.status_code == 200
+    assert '"text":"hello\\n"' in response.text
+
+
 def test_get_task_run_observability_events_allows_owner_access() -> None:
     owner_id = uuid4()
     app = FastAPI()
@@ -1373,6 +1494,7 @@ def test_get_task_run_observability_events_allows_owner_access() -> None:
     mock_record.workflow_id = "mm:wf-1"
     mock_record.workspace_path = "/tmp/workspace"
     mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = None
     metrics = MagicMock()
 
     with TestClient(app) as test_client:
@@ -1388,9 +1510,17 @@ def test_get_task_run_observability_events_allows_owner_access() -> None:
                     "api_service.api.routers.task_runs.get_metrics_emitter",
                     return_value=metrics,
                 ):
-                    response = test_client.get(
-                        f"/api/task-runs/{uuid4()}/observability/events"
-                    )
+                    with patch(
+                        "api_service.api.routers.task_runs._load_task_run_session_record",
+                        return_value=None,
+                    ):
+                        with patch(
+                            "api_service.api.routers.task_runs._load_task_run_observability_events",
+                            return_value=([], "artifacts"),
+                        ):
+                            response = test_client.get(
+                                f"/api/task-runs/{uuid4()}/observability/events"
+                            )
 
     assert response.status_code == 200
     assert any(
@@ -1414,6 +1544,7 @@ def test_get_task_run_observability_events_forbids_cross_owner_access_without_su
     mock_record.workflow_id = "mm:wf-1"
     mock_record.workspace_path = "/tmp/workspace"
     mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = None
     metrics = MagicMock()
 
     with TestClient(app) as test_client:

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -265,6 +265,28 @@ class TestFeatureFlagsSettings:
         with pytest.raises(ValidationError):
             FeatureFlagsSettings(_env_file=None)
 
+    def test_live_logs_structured_history_enabled_defaults_true(self, monkeypatch):
+        monkeypatch.delenv(
+            "FEATURE_FLAGS__LIVE_LOGS_STRUCTURED_HISTORY_ENABLED", raising=False
+        )
+        monkeypatch.delenv("LIVE_LOGS_STRUCTURED_HISTORY_ENABLED", raising=False)
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.live_logs_structured_history_enabled is True
+
+    def test_live_logs_structured_history_enabled_accepts_unprefixed_env(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv(
+            "FEATURE_FLAGS__LIVE_LOGS_STRUCTURED_HISTORY_ENABLED", raising=False
+        )
+        monkeypatch.setenv("LIVE_LOGS_STRUCTURED_HISTORY_ENABLED", "false")
+
+        settings = FeatureFlagsSettings(_env_file=None)
+
+        assert settings.live_logs_structured_history_enabled is False
+
 
 class TestWorkflowSettings:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- add Phase 7 Live Logs hardening metrics for observability summary and structured-history loading
- cover `/observability/events` with explicit owner and cross-owner regression tests
- add a structured-history rollback flag and fall back to merged log history in the task detail UI when it is disabled

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py`
- `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`