### PR TITLE
[codex] Fix Codex managed-session turn completion detection

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -804,7 +804,7 @@ def build_default_activity_catalog(
             capability_class="agent_runtime",
             task_queue=cfg.activity_agent_runtime_task_queue,
             fleet=AGENT_RUNTIME_FLEET,
-            timeouts=TemporalActivityTimeouts(360, 600, heartbeat_timeout_seconds=30),
+            timeouts=TemporalActivityTimeouts(3600, 3900, heartbeat_timeout_seconds=30),
             retries=_activity_retries(max_attempts=1, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -38,7 +38,9 @@ from moonmind.schemas.managed_session_models import (
 
 _STATE_FILENAME = ".moonmind-codex-session-state.json"
 _READY_LOOP_SECONDS = 3600.0
-_DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = 300.0
+# Reserve a minute for the activity to return cleanly before Temporal's
+# start-to-close timeout fires.
+_DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = 3540.0
 _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
@@ -238,7 +240,7 @@ class CodexAppServerRpcClient:
 
     def wait_for_notification(
         self,
-        method: str,
+        method: str | None,
         *,
         predicate: Callable[[Mapping[str, Any]], bool] | None = None,
         timeout_seconds: float | None = None,
@@ -253,7 +255,7 @@ class CodexAppServerRpcClient:
             deadline = time.monotonic() + effective_timeout
         while True:
             for index, notification in enumerate(self._notifications):
-                if notification.get("method") != method:
+                if method is not None and notification.get("method") != method:
                     continue
                 if predicate is not None and not predicate(notification):
                     continue
@@ -263,11 +265,12 @@ class CodexAppServerRpcClient:
             if deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
+                    wait_label = "notification" if method is None else f"notification {method}"
                     raise TimeoutError(
-                        f"timed out waiting for codex app-server notification {method}"
+                        f"timed out waiting for codex app-server {wait_label}"
                     )
             message = self._read_message(timeout_seconds=remaining)
-            if message.get("method") == method and (
+            if (method is None or message.get("method") == method) and (
                 predicate is None or predicate(message)
             ):
                 return message
@@ -478,6 +481,68 @@ class CodexManagedSessionRuntime:
                     return text.strip()
         return ""
 
+    @staticmethod
+    def _find_turn_payload(
+        thread_payload: Mapping[str, Any],
+        *,
+        vendor_turn_id: str,
+    ) -> Mapping[str, Any] | None:
+        thread = thread_payload.get("thread")
+        if not isinstance(thread, Mapping):
+            return None
+        turns = thread.get("turns")
+        if not isinstance(turns, list):
+            return None
+        for turn in reversed(turns):
+            if not isinstance(turn, Mapping):
+                continue
+            if str(turn.get("id") or "").strip() != vendor_turn_id:
+                continue
+            return turn
+        return None
+
+    def _wait_for_turn_completion(
+        self,
+        *,
+        client: CodexAppServerRpcClient,
+        vendor_thread_id: str,
+        vendor_turn_id: str,
+    ) -> Mapping[str, Any]:
+        deadline = time.monotonic() + self._turn_completion_timeout_seconds
+        while True:
+            thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
+            turn_payload = self._find_turn_payload(
+                thread_payload,
+                vendor_turn_id=vendor_turn_id,
+            )
+            if isinstance(turn_payload, Mapping):
+                status = str(turn_payload.get("status") or "").strip().lower()
+                if status == "completed":
+                    return thread_payload
+                if status in {"failed", "error", "interrupted", "canceled", "cancelled"}:
+                    raise RuntimeError(
+                        f"codex app-server turn {vendor_turn_id} ended with status {status}"
+                    )
+                if turn_payload.get("error") not in (None, ""):
+                    raise RuntimeError(
+                        f"codex app-server turn {vendor_turn_id} ended with an error"
+                    )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(
+                    "timed out waiting for codex app-server turn completion "
+                    f"after {self._turn_completion_timeout_seconds} seconds"
+                )
+
+            try:
+                client.wait_for_notification(
+                    None,
+                    timeout_seconds=min(1.0, remaining),
+                )
+            except TimeoutError:
+                continue
+
     def _find_vendor_thread_path(self, vendor_thread_id: str) -> str | None:
         sessions_root = self._codex_home_path / "sessions"
         if not sessions_root.is_dir():
@@ -623,21 +688,11 @@ class CodexManagedSessionRuntime:
         self._save_state(state)
         self._append_spool("stdout", f"turn started: {vendor_turn_id}\n")
 
-        try:
-            client.wait_for_notification(
-                "turn/completed",
-                predicate=lambda message: (
-                    isinstance(message.get("params"), Mapping)
-                    and message["params"].get("threadId") == vendor_thread_id
-                ),
-                timeout_seconds=self._turn_completion_timeout_seconds,
-            )
-        except TimeoutError as exc:
-            raise RuntimeError(
-                "timed out waiting for codex app-server turn/completed notification "
-                f"after {self._turn_completion_timeout_seconds} seconds"
-            ) from exc
-        thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
+        thread_payload = self._wait_for_turn_completion(
+            client=client,
+            vendor_thread_id=vendor_thread_id,
+            vendor_turn_id=vendor_turn_id,
+        )
         assistant_text = self._extract_assistant_text(thread_payload)
 
         state.active_turn_id = None

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -405,6 +405,42 @@ def test_runtime_send_turn_accepts_item_completed_notification_contract(
     assert response.metadata["assistantText"] == "OK"
 
 
+def test_runtime_send_turn_completes_via_thread_read_without_notification(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "OK"
+
+
 def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -21,7 +21,8 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
 def _write_fake_app_server(
     tmp_path: Path,
     *,
-    emit_completion: bool = True,
+    completion_notification_method: str | None = "turn/completed",
+    complete_turn_on_read: bool = True,
     fail_thread_resume: bool = False,
     resume_requires_existing_rollout_path: bool = False,
     start_thread_id: str = "vendor-thread-1",
@@ -31,15 +32,16 @@ def _write_fake_app_server(
 ) -> Path:
     script = tmp_path / "fake_app_server.py"
     completion_block = """
+        turn_completed = True
         sys.stdout.write(json.dumps({
-            "method": "turn/completed",
+            "method": COMPLETION_NOTIFICATION_METHOD,
             "params": {
                 "threadId": thread_id,
                 "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
             },
         }) + "\\n")
 """.rstrip()
-    if not emit_completion:
+    if not completion_notification_method:
         completion_block = ""
     script_template = """
 import json
@@ -52,6 +54,9 @@ FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
 RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
 START_THREAD_ID = __START_THREAD_ID__
 START_THREAD_PATH = __START_THREAD_PATH__
+COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
+COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
+turn_completed = False
 
 for line in sys.stdin:
     message = json.loads(line)
@@ -177,6 +182,7 @@ for line in sys.stdin:
         assert isinstance(input_items, list)
         assert input_items[0]["type"] == "text"
         assert input_items[0]["text"] == "Reply with exactly the word OK"
+        turn_completed = COMPLETE_TURN_ON_READ and not COMPLETION_NOTIFICATION_METHOD
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
@@ -194,6 +200,12 @@ __COMPLETION_BLOCK__
         sys.stdout.flush()
     elif method == "thread/read":
         thread_id = message["params"]["threadId"]
+        turn_status = "completed" if turn_completed else "inProgress"
+        turn_items = []
+        if turn_completed:
+            turn_items = [
+                {"type": "agentMessage", "id": "msg-1", "text": "OK", "phase": "final_answer", "memoryCitation": None}
+            ]
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {
@@ -216,11 +228,9 @@ __COMPLETION_BLOCK__
                     "turns": [
                         {
                             "id": "vendor-turn-1",
-                            "status": "completed",
+                            "status": turn_status,
                             "error": None,
-                            "items": [
-                                {"type": "agentMessage", "id": "msg-1", "text": "OK", "phase": "final_answer", "memoryCitation": None}
-                            ],
+                            "items": turn_items,
                         }
                     ],
                 }
@@ -244,6 +254,14 @@ __COMPLETION_BLOCK__
         .replace(
             "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
             "True" if resume_requires_existing_rollout_path else "False",
+        )
+        .replace(
+            "__COMPLETION_NOTIFICATION_METHOD__",
+            repr(completion_notification_method),
+        )
+        .replace(
+            "__COMPLETE_TURN_ON_READ__",
+            "True" if complete_turn_on_read else "False",
         )
         .replace("__START_THREAD_ID__", repr(start_thread_id))
         .replace("__START_THREAD_PATH__", repr(start_thread_path))
@@ -349,6 +367,41 @@ def test_runtime_send_turn_returns_completed_response_with_assistant_text(
     assert response.status == "completed"
     assert response.turn_id == "vendor-turn-1"
     assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "OK"
+
+
+def test_runtime_send_turn_accepts_item_completed_notification_contract(
+    tmp_path: Path,
+) -> None:
+    script = _write_fake_app_server(
+        tmp_path,
+        completion_notification_method="item/completed",
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
     assert response.metadata["assistantText"] == "OK"
 
 
@@ -553,7 +606,11 @@ def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) 
 def test_runtime_send_turn_times_out_without_completion_notification(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path, emit_completion=False)
+    script = _write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+    )
     request = _launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
@@ -568,7 +625,7 @@ def test_runtime_send_turn_times_out_without_completion_notification(
     )
     runtime.launch_session(request)
 
-    with pytest.raises(RuntimeError, match="timed out waiting for codex app-server"):
+    with pytest.raises(RuntimeError, match="timed out waiting for codex app-server turn completion"):
         runtime.send_turn(
             SendCodexManagedSessionTurnRequest(
                 sessionId="sess-1",

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -1313,6 +1313,6 @@ async def test_agent_runtime_send_turn_disables_catalog_retries(
             send_turn = catalog.resolve_activity("agent_runtime.send_turn")
 
             assert send_turn.retries.max_attempts == 1
-            assert send_turn.timeouts.start_to_close_seconds == 360
-            assert send_turn.timeouts.schedule_to_close_seconds == 600
+            assert send_turn.timeouts.start_to_close_seconds == 3600
+            assert send_turn.timeouts.schedule_to_close_seconds == 3900
             assert send_turn.timeouts.heartbeat_timeout_seconds == 30


### PR DESCRIPTION
## Summary
- stop treating `turn/completed` as the only managed-session completion signal and instead wait for the started turn to reach a completed state in `thread/read`
- keep a larger `agent_runtime.send_turn` timeout budget so real repo-sized Codex turns have enough time to finish and return cleanly
- add runtime boundary coverage for the `item/completed` notification contract observed in the failed run

## Root Cause
The failed workflow `mm:5a0e4f82-23c1-4573-a0ed-59fb7c7b9443` was not just a slow turn. The preserved Codex session reached `response.completed`, but MoonMind's in-container managed-session runtime was blocked waiting for a `turn/completed` notification that this app-server build did not emit. The app-server trace showed `item/completed` and the turn reached a completed state in `thread/read`, so the workflow was misclassified as a timeout.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/workflows/temporal/test_activity_runtime.py`
- result: `45 passed, 1 warning`
- restarted `temporal-worker-workflow` and `temporal-worker-agent-runtime` after the change