### PR TITLE
[codex] Fix managed-session turn response errors

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -690,7 +690,50 @@ class DockerCodexManagedSessionController:
             command,
             input_text=json.dumps(payload),
         )
-        return json.loads(stdout.strip() or "{}")
+        session_id = str(payload.get("sessionId") or "").strip()
+        target_label = (
+            f"managed-session action {action} for session {session_id} "
+            f"in container {container_id}"
+            if session_id
+            else f"managed-session action {action} in container {container_id}"
+        )
+
+        response_text = stdout.strip()
+        if not response_text:
+            rendered_command, _rendered_detail = self._scrub_command_failure(
+                command,
+                "stdout was blank",
+                extra_env=extra_env,
+            )
+            raise RuntimeError(
+                f"{target_label} returned no JSON output: {rendered_command}"
+            )
+
+        try:
+            response_payload = json.loads(response_text)
+        except json.JSONDecodeError as exc:
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                command,
+                f"stdout={response_text}",
+                extra_env=extra_env,
+            )
+            raise RuntimeError(
+                f"{target_label} returned invalid JSON via {rendered_command}: "
+                f"{rendered_detail}"
+            ) from exc
+
+        if not isinstance(response_payload, dict):
+            rendered_command, rendered_detail = self._scrub_command_failure(
+                command,
+                f"stdout={response_text}",
+                extra_env=extra_env,
+            )
+            raise RuntimeError(
+                f"{target_label} returned a non-object JSON payload via {rendered_command}: "
+                f"{rendered_detail}"
+            )
+
+        return response_payload
 
     async def _wait_ready(self, *, container_id: str) -> None:
         command = (

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -699,38 +699,43 @@ class DockerCodexManagedSessionController:
         )
 
         response_text = stdout.strip()
-        if not response_text:
-            rendered_command, _rendered_detail = self._scrub_command_failure(
+        def _raise_invalid_json_response(
+            reason: str,
+            detail: str,
+            *,
+            from_exc: Exception | None = None,
+        ) -> None:
+            rendered_command, rendered_detail = self._scrub_command_failure(
                 command,
-                "stdout was blank",
+                detail,
                 extra_env=extra_env,
             )
-            raise RuntimeError(
-                f"{target_label} returned no JSON output: {rendered_command}"
+            message = (
+                f"{target_label} {reason} via {rendered_command}: {rendered_detail}"
+            )
+            if from_exc is not None:
+                raise RuntimeError(message) from from_exc
+            raise RuntimeError(message)
+
+        if not response_text:
+            _raise_invalid_json_response(
+                "returned no JSON output",
+                "stdout was blank",
             )
 
         try:
             response_payload = json.loads(response_text)
         except json.JSONDecodeError as exc:
-            rendered_command, rendered_detail = self._scrub_command_failure(
-                command,
+            _raise_invalid_json_response(
+                "returned invalid JSON",
                 f"stdout={response_text}",
-                extra_env=extra_env,
+                from_exc=exc,
             )
-            raise RuntimeError(
-                f"{target_label} returned invalid JSON via {rendered_command}: "
-                f"{rendered_detail}"
-            ) from exc
 
         if not isinstance(response_payload, dict):
-            rendered_command, rendered_detail = self._scrub_command_failure(
-                command,
+            _raise_invalid_json_response(
+                "returned a non-object JSON payload",
                 f"stdout={response_text}",
-                extra_env=extra_env,
-            )
-            raise RuntimeError(
-                f"{target_label} returned a non-object JSON payload via {rendered_command}: "
-                f"{rendered_detail}"
             )
 
         return response_payload

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -840,6 +840,78 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_controller_send_turn_rejects_blank_runtime_stdout() -> None:
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            return 0, "", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(RuntimeError, match="managed-session action send_turn") as exc_info:
+        await controller.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "session sess-1" in message
+    assert "container ctr-1" in message
+    assert "returned no JSON output" in message
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_rejects_invalid_runtime_json() -> None:
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            return 0, "not-json", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(RuntimeError, match="returned invalid JSON") as exc_info:
+        await controller.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "managed-session action send_turn" in message
+    assert "session sess-1" in message
+    assert "stdout=not-json" in message
+
+
+@pytest.mark.asyncio
 async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -912,6 +912,44 @@ async def test_controller_send_turn_rejects_invalid_runtime_json() -> None:
 
 
 @pytest.mark.asyncio
+async def test_controller_send_turn_rejects_non_object_runtime_json() -> None:
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "invoke" in command:
+            return 0, "[]", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(
+        RuntimeError, match="returned a non-object JSON payload"
+    ) as exc_info:
+        await controller.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
+
+    message = str(exc_info.value)
+    assert "managed-session action send_turn" in message
+    assert "session sess-1" in message
+    assert "stdout=[]" in message
+
+
+@pytest.mark.asyncio
 async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
This change hardens the managed Codex session controller when a container-side `invoke` call returns malformed output.

## What changed
- reject blank stdout from managed-session `invoke` calls instead of treating it as `{}`
- reject invalid or non-object JSON payloads with an explicit runtime error that includes the action plus session/container context
- add controller regression tests for blank stdout and malformed JSON during `send_turn`

## Root cause
The failed workflow `mm:f1c9200a-1f39-4447-845b-4357835f7a51` hit `agent_runtime.send_turn`, where `docker exec ... invoke send_turn` returned exit code `0` with no JSON on stdout. The controller previously converted that blank output into `{}`, which then failed later as a misleading Pydantic validation error for missing `sessionState`, `turnId`, and `status`.

## Impact
Workflow failures at this boundary now surface as direct managed-session runtime errors instead of opaque schema-validation noise, which makes diagnosis and remediation much faster.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py`