### PR TITLE
[codex] Harden live logs phase 7

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -1011,42 +1011,44 @@ async def get_observability_summary(
 ) -> dict:
     """Fetch the observability summary for a task run from the shared agent jobs volume."""
     store = ManagedRunStore(_get_agent_runtime_store_root())
-    
-    record = await asyncio.to_thread(store.load, str(id))
-    if not record:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Observability record not found for this task run",
-        )
-    await _require_observability_access(record, _user)
     started = time.perf_counter()
 
-    terminal_statuses = {"completed", "failed", "canceled", "cancelled", "timed_out"}
-    run_status = getattr(record, "status", None)
-    is_terminal = run_status in terminal_statuses
+    try:
+        record = await asyncio.to_thread(store.load, str(id))
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Observability record not found for this task run",
+            )
+        await _require_observability_access(record, _user)
 
-    raw_live_stream_capable = getattr(record, "live_stream_capable", None)
-    if is_terminal:
-        supports_live = False
-        live_stream_status = "ended"
-    elif raw_live_stream_capable is True:
-        supports_live = True
-        live_stream_status = "available"
-    else:  # Catches False and None
-        supports_live = False
-        live_stream_status = "unavailable"
+        terminal_statuses = {"completed", "failed", "canceled", "cancelled", "timed_out"}
+        run_status = getattr(record, "status", None)
+        is_terminal = run_status in terminal_statuses
 
-    base = record.model_dump(by_alias=True)
-    session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
-    base["supportsLiveStreaming"] = supports_live
-    base["liveStreamStatus"] = live_stream_status
-    base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
-    _emit_livelogs_metric_observe(
-        "livelogs.summary.latency",
-        value=time.perf_counter() - started,
-        tags={"stream": "livelogs"},
-    )
-    return {"summary": base}
+        raw_live_stream_capable = getattr(record, "live_stream_capable", None)
+        if is_terminal:
+            supports_live = False
+            live_stream_status = "ended"
+        elif raw_live_stream_capable is True:
+            supports_live = True
+            live_stream_status = "available"
+        else:  # Catches False and None
+            supports_live = False
+            live_stream_status = "unavailable"
+
+        base = record.model_dump(by_alias=True)
+        session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
+        base["supportsLiveStreaming"] = supports_live
+        base["liveStreamStatus"] = live_stream_status
+        base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)
+        return {"summary": base}
+    finally:
+        _emit_livelogs_metric_observe(
+            "livelogs.summary.latency",
+            value=time.perf_counter() - started,
+            tags={"stream": "livelogs"},
+        )
 
 
 @router.get(

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -46,6 +46,9 @@ from moonmind.observability.transport import SpoolLogReader
 router = APIRouter(prefix="/task-runs", tags=["task_runs"])
 
 _HISTORICAL_EVENT_CHUNK_SIZE = 65536
+_OBSERVABILITY_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "canceled", "cancelled", "timed_out"}
+)
 
 
 # Live Session legacy endpoints removed in Phase 6. Use /observability-summary and /logs/stream.
@@ -1022,9 +1025,8 @@ async def get_observability_summary(
             )
         await _require_observability_access(record, _user)
 
-        terminal_statuses = {"completed", "failed", "canceled", "cancelled", "timed_out"}
         run_status = getattr(record, "status", None)
-        is_terminal = run_status in terminal_statuses
+        is_terminal = run_status in _OBSERVABILITY_TERMINAL_STATUSES
 
         raw_live_stream_capable = getattr(record, "live_stream_capable", None)
         if is_terminal:
@@ -1243,14 +1245,13 @@ async def stream_task_run_live_logs(
     await _require_observability_access(record, _user)
 
     # Check if run ended => artifact fallback
-    terminal_statuses = ["completed", "failed", "canceled", "cancelled", "timed_out"]
-    if getattr(record, "status", None) in terminal_statuses:
+    if getattr(record, "status", None) in _OBSERVABILITY_TERMINAL_STATUSES:
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
             detail="Run is no longer active. Use artifact retrieval APIs.",
         )
-        
-    # Check capabilities 
+
+    # Check capabilities
     if not getattr(record, "live_stream_capable", False):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -3403,8 +3403,16 @@ describe('LiveLogsPanel', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/do not have permission to view observability for this run/i),
-      ).toBeTruthy();
-    });
+        fetchSpy.mock.calls.some(([url]) => String(url).includes('/observability-summary')),
+      ).toBe(true);
+    }, { timeout: 5000 });
+
+    expect(
+      await screen.findByText(
+        /do not have permission to view observability for this run/i,
+        {},
+        { timeout: 5000 },
+      ),
+    ).toBeTruthy();
   });
 });

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -73,6 +73,21 @@ def test_get_observability_summary_returns_404_when_missing(
     assert "not found" in response.json()["detail"].lower()
 
 
+def test_get_observability_summary_emits_latency_metric_for_404(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    metrics = MagicMock()
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=None):
+        with patch("api_service.api.routers.task_runs.get_metrics_emitter", return_value=metrics):
+            response = test_client.get(f"/api/task-runs/{uuid4()}/observability-summary")
+
+    assert response.status_code == 404
+    assert metrics.observe.call_args.args[0] == "livelogs.summary.latency"
+    assert metrics.observe.call_args.kwargs["tags"] == {"stream": "livelogs"}
+
+
 def test_get_observability_summary_returns_200(
     client: tuple[TestClient, AsyncMock],
 ) -> None:


### PR DESCRIPTION
## Summary
- emit `livelogs.summary.latency` for all completed `/observability-summary` handler paths, including 404 responses
- add router regression coverage for the summary 404 metric path
- stabilize the Live Logs 403 authorization UI test so the full unit script passes reliably

## Why
Phase 7 hardening requires operational coverage on the Live Logs surfaces and a validated test path for the rollback-ready UI. The backend change makes summary latency metrics reflect real completed requests, and the frontend test change removes a timing-sensitive failure in the required unit run.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py`
- `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `SPECIFY_FEATURE=145-live-logs-phase7 ./.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
