### PR TITLE
[codex] Fix managed-session docker proxy timeouts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -658,6 +658,7 @@ services:
       VOLUMES: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./docker/docker-proxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
     networks:
       - docker-proxy-network
     restart: unless-stopped

--- a/docker/docker-proxy/haproxy.cfg
+++ b/docker/docker-proxy/haproxy.cfg
@@ -1,10 +1,10 @@
 global
-    log stdout format raw daemon "${LOG_LEVEL}"
+    log stdout format raw daemon info
 
     pidfile /run/haproxy.pid
     maxconn 4000
 
-    # Turn on stats unix socket
+    # Persist server state across reloads
     server-state-file /var/lib/haproxy/server-state
 
 defaults

--- a/docker/docker-proxy/haproxy.cfg
+++ b/docker/docker-proxy/haproxy.cfg
@@ -1,0 +1,74 @@
+global
+    log stdout format raw daemon "${LOG_LEVEL}"
+
+    pidfile /run/haproxy.pid
+    maxconn 4000
+
+    # Turn on stats unix socket
+    server-state-file /var/lib/haproxy/server-state
+
+defaults
+    mode http
+    log global
+    option httplog
+    option dontlognull
+    option http-server-close
+    option redispatch
+    retries 3
+    timeout http-request 10s
+    timeout queue 1m
+    timeout connect 10s
+    # Managed-session docker exec calls can stay open for up to 65 minutes
+    # (`agent_runtime.send_turn` schedule-to-close). Keep the proxy above that
+    # budget so long Codex turns do not get severed at HAProxy's stock 10m
+    # client/server timeout boundary.
+    timeout client 75m
+    timeout server 75m
+    timeout tunnel 75m
+    timeout http-keep-alive 10s
+    timeout check 10s
+    maxconn 3000
+
+    # Allow seamless reloads
+    load-server-state-from-file global
+
+    # Use provided example error pages
+    errorfile 400 /usr/local/etc/haproxy/errors/400.http
+    errorfile 403 /usr/local/etc/haproxy/errors/403.http
+    errorfile 408 /usr/local/etc/haproxy/errors/408.http
+    errorfile 500 /usr/local/etc/haproxy/errors/500.http
+    errorfile 502 /usr/local/etc/haproxy/errors/502.http
+    errorfile 503 /usr/local/etc/haproxy/errors/503.http
+    errorfile 504 /usr/local/etc/haproxy/errors/504.http
+
+backend dockerbackend
+    server dockersocket /var/run/docker.sock
+
+frontend dockerfrontend
+    bind :2375
+    http-request deny unless METH_GET || { env(POST) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers/[a-zA-Z0-9_.-]+/((stop)|(restart)|(kill)) } { env(ALLOW_RESTARTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/auth } { env(AUTH) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/build } { env(BUILD) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/commit } { env(COMMIT) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/configs } { env(CONFIGS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/containers } { env(CONTAINERS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/distribution } { env(DISTRIBUTION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/events } { env(EVENTS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/exec } { env(EXEC) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/images } { env(IMAGES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/info } { env(INFO) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/networks } { env(NETWORKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/nodes } { env(NODES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/_ping } { env(PING) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/plugins } { env(PLUGINS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/secrets } { env(SECRETS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/services } { env(SERVICES) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/session } { env(SESSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/swarm } { env(SWARM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/system } { env(SYSTEM) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/tasks } { env(TASKS) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/version } { env(VERSION) -m bool }
+    http-request allow if { path,url_dec -m reg -i ^(/v[\d\.]+)?/volumes } { env(VOLUMES) -m bool }
+    http-request deny
+    default_backend dockerbackend


### PR DESCRIPTION
## What changed
- mount a repo-owned HAProxy config into `docker-proxy`
- raise the proxy `client`, `server`, and `tunnel` timeouts from the stock 10 minutes to 75 minutes
- keep the rest of the docker-socket-proxy access policy unchanged

## Why
A managed Codex session failed during `agent_runtime.send_turn` because the long-lived `docker exec` transport crossed the proxy's default 10-minute timeout boundary. The failing workflow hit `send_turn` at `2026-04-10 00:57:14Z` and failed at `2026-04-10 01:07:14Z`, matching the HAProxy timeout exactly.

## Impact
- long-running managed-session turns are no longer severed by the Docker socket proxy at 10 minutes
- the fix stays in deployment config and does not change workflow or adapter contracts
- future stacks get the safer timeout behavior directly from the repo instead of the proxy image defaults

## Validation
- `docker compose config`
- recreated `moonmind-docker-proxy-1`
- verified the live proxy config reports `timeout client 75m`, `timeout server 75m`, and `timeout tunnel 75m`
- reran the failed workflow as `mm:b9f3a70e-d353-4457-99d3-2cf0597637db` after the proxy change