### PR TITLE
[codex] Fix managed session turn recovery and provider defaults

### DIFF
--- a/api_service/api/routers/provider_profiles.py
+++ b/api_service/api/routers/provider_profiles.py
@@ -71,6 +71,7 @@ class ProviderProfileCreate(BaseModel):
     cooldown_after_429_seconds: int = Field(default=900, ge=0)
     rate_limit_policy: str = Field(default="backoff", pattern="^(backoff|queue|fail_fast)$")
     enabled: bool = True
+    is_default: bool = False
     max_lease_duration_seconds: int = Field(default=7200, ge=60)
 
     @field_validator("env_template", mode="before")
@@ -131,6 +132,7 @@ class ProviderProfileUpdate(BaseModel):
         default=None, pattern="^(backoff|queue|fail_fast)$"
     )
     enabled: Optional[bool] = None
+    is_default: Optional[bool] = None
     max_lease_duration_seconds: Optional[int] = Field(default=None, ge=60)
 
     @field_validator("secret_refs", mode="after")
@@ -166,6 +168,7 @@ class ProviderProfileResponse(BaseModel):
     cooldown_after_429_seconds: int
     rate_limit_policy: str
     enabled: bool
+    is_default: bool
     max_lease_duration_seconds: int
     created_at: Optional[str]
     updated_at: Optional[str]
@@ -201,6 +204,11 @@ async def list_profiles(
         stmt = stmt.where(ManagedAgentProviderProfile.runtime_id == runtime_id)
     if enabled_only:
         stmt = stmt.where(ManagedAgentProviderProfile.enabled.is_(True))
+    stmt = stmt.order_by(
+        ManagedAgentProviderProfile.is_default.desc(),
+        ManagedAgentProviderProfile.priority.desc(),
+        ManagedAgentProviderProfile.profile_id.asc(),
+    )
 
     result = await session.execute(stmt)
     rows = result.scalars().all()
@@ -251,9 +259,16 @@ async def create_profile(
         cooldown_after_429_seconds=body.cooldown_after_429_seconds,
         rate_limit_policy=ManagedAgentRateLimitPolicy(body.rate_limit_policy),
         enabled=body.enabled,
+        is_default=False,
         max_lease_duration_seconds=body.max_lease_duration_seconds,
     )
     session.add(profile)
+    await session.flush()
+    await normalize_runtime_default_profile(
+        session=session,
+        runtime_id=body.runtime_id,
+        preferred_profile_id=profile.profile_id if body.is_default else None,
+    )
     await session.commit()
     await session.refresh(profile)
 
@@ -273,6 +288,7 @@ async def update_profile(
         raise HTTPException(status_code=404, detail="Profile not found")
 
     update_data = body.model_dump(exclude_unset=True)
+    requested_is_default = update_data.pop("is_default", None)
     for key, value in update_data.items():
         if key == "rate_limit_policy" and value is not None:
             value = ManagedAgentRateLimitPolicy(value)
@@ -282,6 +298,15 @@ async def update_profile(
             value = RuntimeMaterializationMode(value)
         setattr(profile, key, value)
 
+    if requested_is_default is False:
+        profile.is_default = False
+
+    await session.flush()
+    await normalize_runtime_default_profile(
+        session=session,
+        runtime_id=profile.runtime_id,
+        preferred_profile_id=profile.profile_id if requested_is_default else None,
+    )
     await session.commit()
     await session.refresh(profile)
     await sync_provider_profile_manager(session=session, runtime_id=profile.runtime_id)
@@ -298,6 +323,8 @@ async def delete_profile(
         raise HTTPException(status_code=404, detail="Profile not found")
     runtime_id = profile.runtime_id
     await session.delete(profile)
+    await session.flush()
+    await normalize_runtime_default_profile(session=session, runtime_id=runtime_id)
     await session.commit()
     await sync_provider_profile_manager(session=session, runtime_id=runtime_id)
 
@@ -334,10 +361,14 @@ def _row_to_dict(row: ManagedAgentProviderProfile) -> dict[str, Any]:
             row.rate_limit_policy.value if row.rate_limit_policy else None
         ),
         "enabled": row.enabled,
+        "is_default": row.is_default,
         "max_lease_duration_seconds": row.max_lease_duration_seconds,
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
     }
 
 
-from api_service.services.provider_profile_service import sync_provider_profile_manager
+from api_service.services.provider_profile_service import (
+    normalize_runtime_default_profile,
+    sync_provider_profile_manager,
+)

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1841,6 +1841,13 @@ class ManagedAgentProviderProfile(Base):
         Index("ix_provider_profiles_runtime", "runtime_id"),
         Index("ix_provider_profiles_provider", "provider_id"),
         Index("ix_provider_profiles_enabled", "enabled"),
+        Index(
+            "ux_provider_profiles_runtime_default",
+            "runtime_id",
+            unique=True,
+            sqlite_where=text("is_default = 1"),
+            postgresql_where=text("is_default = true"),
+        ),
     )
 
     profile_id: Mapped[str] = mapped_column(String(128), primary_key=True)
@@ -1879,7 +1886,10 @@ class ManagedAgentProviderProfile(Base):
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
     )
-    
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
     tags: Mapped[Optional[list[str]]] = mapped_column(JSON, nullable=True)
     priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100, server_default=text("100"))
 

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -542,6 +542,9 @@ async def _auto_seed_provider_profiles() -> list[str]:
         RuntimeMaterializationMode,
         ManagedAgentRateLimitPolicy,
     )
+    from api_service.services.provider_profile_service import (
+        normalize_runtime_default_profile,
+    )
 
     if os.environ.get("MOONMIND_SKIP_PROVIDER_PROFILE_SEED", "").lower() in ("1", "true", "yes"):
         logger.info("Provider profile auto-seeding disabled via MOONMIND_SKIP_PROVIDER_PROFILE_SEED.")
@@ -552,6 +555,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
         {
             "profile_id": "gemini_default",
             "runtime_id": "gemini_cli",
+            "is_default": True,
             "provider_id": "google",
             "provider_label": "Google",
             "default_model": None,  # inherits runtime default: gemini-3.1-pro-preview
@@ -564,6 +568,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
         {
             "profile_id": "codex_default",
             "runtime_id": "codex_cli",
+            "is_default": True,
             "provider_id": "moonladder",
             "provider_label": "MoonLadder",
             "default_model": None,  # inherits runtime default: gpt-5.4
@@ -576,6 +581,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
         {
             "profile_id": "claude_anthropic",
             "runtime_id": "claude_code",
+            "is_default": True,
             "provider_id": "anthropic",
             "provider_label": "Anthropic",
             "default_model": None,  # inherits runtime default: Sonnet 4.6
@@ -594,6 +600,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
         _DEFAULT_PROFILES.append({
             "profile_id": "claude_minimax",
             "runtime_id": "claude_code",
+            "is_default": False,
             "provider_id": "minimax",
             "provider_label": "MiniMax",
             "default_model": "MiniMax-M2.7",
@@ -625,6 +632,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
         _DEFAULT_PROFILES.append({
             "profile_id": "codex_openrouter_qwen36_plus",
             "runtime_id": "codex_cli",
+            "is_default": False,
             "provider_id": "openrouter",
             "provider_label": "OpenRouter",
             "default_model": "qwen/qwen3.6-plus:free",
@@ -729,6 +737,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 len(to_insert),
             )
 
+            touched_runtime_ids: set[str] = set()
             for profile_def in to_insert:
                 profile = ManagedAgentProviderProfile(
                     profile_id=profile_def["profile_id"],
@@ -756,12 +765,22 @@ async def _auto_seed_provider_profiles() -> list[str]:
                         ManagedAgentRateLimitPolicy.BACKOFF,
                     ),
                     enabled=True,
+                    is_default=bool(profile_def.get("is_default", False)),
                     max_lease_duration_seconds=profile_def.get(
                         "max_lease_duration_seconds", 7200
                     ),
                 )
                 session.add(profile)
-                seeded.append(profile_def["runtime_id"])
+                runtime_id = profile_def["runtime_id"]
+                touched_runtime_ids.add(runtime_id)
+                seeded.append(runtime_id)
+
+            await session.flush()
+            for runtime_id in touched_runtime_ids:
+                await normalize_runtime_default_profile(
+                    session=session,
+                    runtime_id=runtime_id,
+                )
 
             await session.commit()
             logger.info(

--- a/api_service/migrations/versions/e6f7a8b9c0d1_add_provider_profile_runtime_defaults.py
+++ b/api_service/migrations/versions/e6f7a8b9c0d1_add_provider_profile_runtime_defaults.py
@@ -1,0 +1,94 @@
+"""add provider profile runtime defaults
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5c6f7a8b9c0
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
+
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: Union[str, None] = "d5c6f7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+
+profiles_table = table(
+    "managed_agent_provider_profiles",
+    column("profile_id", sa.String),
+    column("runtime_id", sa.String),
+    column("enabled", sa.Boolean),
+    column("priority", sa.Integer),
+    column("is_default", sa.Boolean),
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "managed_agent_provider_profiles",
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    bind = op.get_bind()
+    rows = list(
+        bind.execute(
+            sa.select(
+                profiles_table.c.profile_id,
+                profiles_table.c.runtime_id,
+                profiles_table.c.enabled,
+                profiles_table.c.priority,
+            )
+        )
+    )
+
+    runtime_rows: dict[str, list[sa.Row]] = {}
+    for row in rows:
+        runtime_rows.setdefault(str(row.runtime_id), []).append(row)
+
+    for runtime_id, runtime_profiles in runtime_rows.items():
+        runtime_profiles.sort(
+            key=lambda row: (
+                1 if row.enabled else 0,
+                row.priority if row.priority is not None else 100,
+                str(row.profile_id),
+            ),
+            reverse=True,
+        )
+        default_profile_id = runtime_profiles[0].profile_id
+        bind.execute(
+            profiles_table.update()
+            .where(profiles_table.c.runtime_id == runtime_id)
+            .values(is_default=False)
+        )
+        bind.execute(
+            profiles_table.update()
+            .where(profiles_table.c.profile_id == default_profile_id)
+            .values(is_default=True)
+        )
+
+    op.create_index(
+        "ux_provider_profiles_runtime_default",
+        "managed_agent_provider_profiles",
+        ["runtime_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default = true"),
+        sqlite_where=sa.text("is_default = 1"),
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("One-way migration: provider profile runtime defaults")

--- a/api_service/migrations/versions/e6f7a8b9c0d1_add_provider_profile_runtime_defaults.py
+++ b/api_service/migrations/versions/e6f7a8b9c0d1_add_provider_profile_runtime_defaults.py
@@ -62,11 +62,10 @@ def upgrade() -> None:
     for runtime_id, runtime_profiles in runtime_rows.items():
         runtime_profiles.sort(
             key=lambda row: (
-                1 if row.enabled else 0,
-                row.priority if row.priority is not None else 100,
+                0 if row.enabled else 1,
+                -(row.priority if row.priority is not None else 100),
                 str(row.profile_id),
             ),
-            reverse=True,
         )
         default_profile_id = runtime_profiles[0].profile_id
         bind.execute(
@@ -91,4 +90,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    raise NotImplementedError("One-way migration: provider profile runtime defaults")
+    op.drop_index(
+        "ux_provider_profiles_runtime_default",
+        table_name="managed_agent_provider_profiles",
+    )
+    op.drop_column("managed_agent_provider_profiles", "is_default")

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -1,15 +1,74 @@
 import logging
+from typing import Any
+
+from sqlalchemy import case
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
-from typing import Any
 
 from api_service.db.models import ManagedAgentProviderProfile
 
 logger = logging.getLogger(__name__)
 
+
+async def normalize_runtime_default_profile(
+    *,
+    session: AsyncSession,
+    runtime_id: str,
+    preferred_profile_id: str | None = None,
+) -> str | None:
+    """Ensure exactly one provider profile is marked default for a runtime."""
+
+    normalized_runtime_id = str(runtime_id or "").strip()
+    if not normalized_runtime_id:
+        raise ValueError("runtime_id is required")
+
+    stmt = (
+        select(ManagedAgentProviderProfile)
+        .where(ManagedAgentProviderProfile.runtime_id == normalized_runtime_id)
+        .order_by(
+            case((ManagedAgentProviderProfile.enabled.is_(True), 1), else_=0).desc(),
+            case((ManagedAgentProviderProfile.is_default.is_(True), 1), else_=0).desc(),
+            ManagedAgentProviderProfile.priority.desc(),
+            ManagedAgentProviderProfile.profile_id.asc(),
+        )
+    )
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    if not rows:
+        return None
+
+    enabled_rows = [row for row in rows if row.enabled]
+    candidates = enabled_rows or rows
+
+    selected = None
+    if preferred_profile_id:
+        selected = next(
+            (row for row in candidates if row.profile_id == preferred_profile_id),
+            None,
+        )
+    if selected is None:
+        selected = next((row for row in candidates if row.is_default), None)
+    if selected is None:
+        selected = candidates[0]
+
+    selected_id = selected.profile_id
+    changed = False
+    for row in rows:
+        should_be_default = row.profile_id == selected_id
+        if row.is_default != should_be_default:
+            row.is_default = should_be_default
+            changed = True
+
+    if changed:
+        await session.flush()
+
+    return selected_id
+
+
 def _manager_profile_payload(row: ManagedAgentProviderProfile) -> dict[str, Any]:
     return {
         "profile_id": row.profile_id,
+        "is_default": row.is_default,
         "runtime_id": row.runtime_id,
         "provider_id": row.provider_id,
         "provider_label": row.provider_label,
@@ -43,9 +102,17 @@ async def sync_provider_profile_manager(
     runtime_id: str,
 ) -> None:
     """Ensure runtime manager exists and push the latest enabled profiles."""
-    stmt = select(ManagedAgentProviderProfile).where(
-        ManagedAgentProviderProfile.runtime_id == runtime_id,
-        ManagedAgentProviderProfile.enabled.is_(True),
+    stmt = (
+        select(ManagedAgentProviderProfile)
+        .where(
+            ManagedAgentProviderProfile.runtime_id == runtime_id,
+            ManagedAgentProviderProfile.enabled.is_(True),
+        )
+        .order_by(
+            ManagedAgentProviderProfile.is_default.desc(),
+            ManagedAgentProviderProfile.priority.desc(),
+            ManagedAgentProviderProfile.profile_id.asc(),
+        )
     )
     result = await session.execute(stmt)
     rows = result.scalars().all()

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import type { ProviderProfile } from './ProviderProfilesManager';
-import { defaultFormState, toFormState, parseCommandBehavior, parseTags, parsePriority, parseClearEnvKeys } from './ProviderProfilesManager';
+import {
+  defaultFormState,
+  toFormState,
+  parseCommandBehavior,
+  parseTags,
+  parsePriority,
+  parseClearEnvKeys,
+} from './ProviderProfilesManager';
 
 describe('defaultFormState', () => {
   it('includes advanced fields with correct defaults', () => {
@@ -11,6 +18,7 @@ describe('defaultFormState', () => {
     expect(state.priority).toBe('');
     expect(state.clearEnvKeysText).toBe('');
     expect(state.accountLabel).toBe('');
+    expect(state.isDefault).toBe(false);
   });
 
   it('includes all legacy fields', () => {
@@ -22,6 +30,7 @@ describe('defaultFormState', () => {
     expect(state.credentialSource).toBe('secret_ref');
     expect(state.rateLimitPolicy).toBe('backoff');
     expect(state.enabled).toBe(true);
+    expect(state.isDefault).toBe(false);
   });
 });
 
@@ -37,6 +46,7 @@ describe('toFormState', () => {
     cooldown_after_429_seconds: 300,
     rate_limit_policy: 'backoff',
     enabled: true,
+    is_default: false,
   };
 
   const fullProfile: ProviderProfile = {
@@ -51,6 +61,7 @@ describe('toFormState', () => {
     priority: 200,
     clear_env_keys: ['OPENAI_API_KEY', 'OPENAI_BASE_URL'],
     account_label: 'team-prod',
+    is_default: true,
   };
 
   it('maps a minimal profile with null advanced fields', () => {
@@ -61,6 +72,7 @@ describe('toFormState', () => {
     expect(state.priority).toBe('');
     expect(state.clearEnvKeysText).toBe('');
     expect(state.accountLabel).toBe('');
+    expect(state.isDefault).toBe(false);
   });
 
   it('maps a full profile with advanced fields', () => {
@@ -73,6 +85,7 @@ describe('toFormState', () => {
     expect(state.priority).toBe('200');
     expect(state.clearEnvKeysText).toBe('OPENAI_API_KEY\nOPENAI_BASE_URL');
     expect(state.accountLabel).toBe('team-prod');
+    expect(state.isDefault).toBe(true);
   });
 
   it('maps legacy fields correctly', () => {
@@ -90,6 +103,7 @@ describe('toFormState', () => {
     expect(state.cooldownAfter429Seconds).toBe('300');
     expect(state.rateLimitPolicy).toBe('backoff');
     expect(state.enabled).toBe(true);
+    expect(state.isDefault).toBe(true);
   });
 
   it('handles null/undefined optional string fields', () => {

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -16,6 +16,7 @@ export interface ProviderProfile {
   cooldown_after_429_seconds: number;
   rate_limit_policy: string;
   enabled: boolean;
+  is_default?: boolean;
   command_behavior?: Record<string, unknown> | null;
   tags?: string[] | null;
   priority?: number | null;
@@ -52,6 +53,7 @@ interface ProviderProfileFormState {
   cooldownAfter429Seconds: string;
   rateLimitPolicy: string;
   enabled: boolean;
+  isDefault: boolean;
   commandBehavior: string;
   tagsText: string;
   priority: string;
@@ -77,6 +79,7 @@ export function defaultFormState(): ProviderProfileFormState {
     cooldownAfter429Seconds: '300',
     rateLimitPolicy: 'backoff',
     enabled: true,
+    isDefault: false,
     commandBehavior: '{}',
     tagsText: '',
     priority: '',
@@ -101,6 +104,7 @@ export function toFormState(profile: ProviderProfile): ProviderProfileFormState 
     cooldownAfter429Seconds: String(profile.cooldown_after_429_seconds ?? 300),
     rateLimitPolicy: profile.rate_limit_policy ?? 'backoff',
     enabled: Boolean(profile.enabled),
+    isDefault: Boolean(profile.is_default),
     commandBehavior: profile.command_behavior ? JSON.stringify(profile.command_behavior, null, 2) : '{}',
     tagsText: (profile.tags ?? []).join(', '),
     priority: profile.priority != null ? String(profile.priority) : '',
@@ -201,6 +205,7 @@ export function ProviderProfilesManager({
         cooldown_after_429_seconds: Number(form.cooldownAfter429Seconds),
         rate_limit_policy: form.rateLimitPolicy,
         enabled: form.enabled,
+        is_default: form.isDefault,
         command_behavior: parseCommandBehavior(form.commandBehavior),
         tags: parseTags(form.tagsText),
         priority: parsePriority(form.priority),
@@ -373,6 +378,11 @@ export function ProviderProfilesManager({
                 <tr key={profile.profile_id}>
                   <td className="px-3 py-4">
                     <div className="font-medium text-slate-900 dark:text-white">{profile.profile_id}</div>
+                    {profile.is_default ? (
+                      <div className="text-xs font-medium text-emerald-700 dark:text-emerald-400">
+                        Runtime default
+                      </div>
+                    ) : null}
                     {profile.default_model ? (
                       <div className="text-xs text-slate-500 dark:text-slate-400">
                         Model: {profile.default_model}
@@ -598,6 +608,16 @@ export function ProviderProfilesManager({
               }
             />
             Enabled
+          </label>
+          <label className="flex items-center gap-3 rounded-2xl border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={form.isDefault}
+              onChange={(event) =>
+                setForm((current) => ({ ...current, isDefault: event.target.checked }))
+              }
+            />
+            Runtime default
           </label>
         </div>
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -241,6 +241,7 @@ describe("Task Create Entrypoint", () => {
                   {
                     profile_id: "profile:gemini-default",
                     account_label: "Gemini Default",
+                    is_default: true,
                   },
                 ]
               : runtimeId === "claude_code"
@@ -248,16 +249,19 @@ describe("Task Create Entrypoint", () => {
                     {
                       profile_id: "profile:claude-default",
                       account_label: "Claude Default",
+                      is_default: true,
                     },
                   ]
                 : [
                     {
                       profile_id: "profile:codex-default",
                       account_label: "Codex Default",
+                      is_default: true,
                     },
                     {
                       profile_id: "profile:codex-secondary",
                       account_label: "Codex Secondary",
+                      is_default: false,
                     },
                   ];
           return Promise.resolve({
@@ -585,10 +589,12 @@ describe("Task Create Entrypoint", () => {
         (providerSelect as HTMLSelectElement).options,
       ).map((option) => option.text);
       expect(labels).toEqual([
-        "Default (system chooses)",
-        "Codex Default",
+        "Codex Default (Default)",
         "Codex Secondary",
       ]);
+      expect((providerSelect as HTMLSelectElement).value).toBe(
+        "profile:codex-default",
+      );
     });
 
     fireEvent.change(screen.getByLabelText("Runtime"), {
@@ -599,7 +605,10 @@ describe("Task Create Entrypoint", () => {
       const labels = Array.from(
         (providerSelect as HTMLSelectElement).options,
       ).map((option) => option.text);
-      expect(labels).toEqual(["Default (system chooses)", "Gemini Default"]);
+      expect(labels).toEqual(["Gemini Default (Default)"]);
+      expect((providerSelect as HTMLSelectElement).value).toBe(
+        "profile:gemini-default",
+      );
     });
   });
 
@@ -656,10 +665,15 @@ describe("Task Create Entrypoint", () => {
 
   it("uploads task input to the returned single-put URL and finalizes the artifact before task creation", async () => {
     const providerProfileItems = [
-      { profile_id: "profile:codex-default", account_label: "Codex Default" },
+      {
+        profile_id: "profile:codex-default",
+        account_label: "Codex Default",
+        is_default: true,
+      },
       {
         profile_id: "profile:codex-secondary",
         account_label: "Codex Secondary",
+        is_default: false,
       },
     ];
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -91,6 +91,20 @@ interface ProviderProfile {
   profile_id: string;
   account_label?: string | null;
   default_model?: string | null;
+  is_default?: boolean;
+}
+
+function resolveDefaultProviderProfileId(
+  profiles: ProviderProfile[],
+): string {
+  const explicitDefault = profiles.find((profile) => profile.is_default);
+  if (explicitDefault) {
+    return explicitDefault.profile_id;
+  }
+  if (profiles.length === 1) {
+    return profiles[0].profile_id;
+  }
+  return profiles[0]?.profile_id || "";
 }
 
 interface SkillsResponse {
@@ -1085,6 +1099,28 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   });
 
   useEffect(() => {
+    const profiles = providerProfilesQuery.data || [];
+    if (profiles.length === 0) {
+      if (providerProfile) {
+        setProviderProfile("");
+      }
+      return;
+    }
+
+    const stillValid = profiles.some(
+      (profile) => profile.profile_id === providerProfile,
+    );
+    if (stillValid) {
+      return;
+    }
+
+    const defaultProfileId = resolveDefaultProviderProfileId(profiles);
+    if (defaultProfileId && providerProfile !== defaultProfileId) {
+      setProviderProfile(defaultProfileId);
+    }
+  }, [providerProfile, providerProfilesQuery.data]);
+
+  useEffect(() => {
     const runtimeChanged = prevRuntimeRef.current !== runtime;
     const profileChanged = prevProviderProfileRef.current !== providerProfile;
 
@@ -1306,10 +1342,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setDependencyMessage(null);
   }
 
-  const providerOptions = (providerProfilesQuery.data || []).map((profile) => ({
-    id: profile.profile_id,
-    label: profile.account_label || profile.profile_id,
-  }));
+  const providerOptions = [...(providerProfilesQuery.data || [])]
+    .sort((left, right) => {
+      const leftDefault = Boolean(left.is_default);
+      const rightDefault = Boolean(right.is_default);
+      if (leftDefault !== rightDefault) {
+        return leftDefault ? -1 : 1;
+      }
+      return (left.account_label || left.profile_id).localeCompare(
+        right.account_label || right.profile_id,
+      );
+    })
+    .map((profile) => ({
+      id: profile.profile_id,
+      label: profile.account_label || profile.profile_id,
+      isDefault: Boolean(profile.is_default),
+    }));
 
   const attachmentValidation = useMemo(
     () => validateAttachmentFiles(selectedAttachmentFiles, attachmentPolicy),
@@ -2622,10 +2670,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               value={providerProfile}
               onChange={(event) => setProviderProfile(event.target.value)}
             >
-              <option value="">Default (system chooses)</option>
               {providerOptions.map((option) => (
                 <option key={option.id} value={option.id}>
-                  {option.label}
+                  {option.isDefault ? `${option.label} (Default)` : option.label}
                 </option>
               ))}
             </select>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -101,8 +101,9 @@ function resolveDefaultProviderProfileId(
   if (explicitDefault) {
     return explicitDefault.profile_id;
   }
-  if (profiles.length === 1) {
-    return profiles[0].profile_id;
+  const onlyProfile = profiles[0];
+  if (profiles.length === 1 && onlyProfile) {
+    return onlyProfile.profile_id;
   }
   return profiles[0]?.profile_id || "";
 }

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4110,6 +4110,11 @@ export interface components {
              */
             enabled: boolean;
             /**
+             * Is Default
+             * @default false
+             */
+            is_default: boolean;
+            /**
              * Max Lease Duration Seconds
              * @default 7200
              */
@@ -4178,6 +4183,8 @@ export interface components {
             rate_limit_policy: string;
             /** Enabled */
             enabled: boolean;
+            /** Is Default */
+            is_default: boolean;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds: number;
             /** Created At */
@@ -4241,6 +4248,8 @@ export interface components {
             rate_limit_policy?: string | null;
             /** Enabled */
             enabled?: boolean | null;
+            /** Is Default */
+            is_default?: boolean | null;
             /** Max Lease Duration Seconds */
             max_lease_duration_seconds?: number | null;
         };

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -643,6 +643,20 @@ class ManagedAgentAdapter:
             result: dict[str, Any] = await fetch_res
         profiles: list[dict[str, Any]] = result.get("profiles", [])
 
+        normalized_selector: dict[str, Any] | None = None
+        if profile_selector:
+            selector_payload: dict[str, Any] = {}
+            for key, value in profile_selector.items():
+                if value is None:
+                    continue
+                if isinstance(value, str) and not value.strip():
+                    continue
+                if isinstance(value, list) and not value:
+                    continue
+                selector_payload[key] = value
+            if selector_payload:
+                normalized_selector = selector_payload
+
         if not profiles:
             raise ProfileResolutionError(
                 f"No enabled provider profiles found for runtime_id='{runtime_id}'"
@@ -665,18 +679,18 @@ class ManagedAgentAdapter:
         for profile in profiles:
             if not profile.get("enabled", True):
                 continue
-            if profile_selector:
-                if profile_selector.get("providerId") and profile.get("provider_id") != profile_selector.get("providerId"):
+            if normalized_selector:
+                if normalized_selector.get("providerId") and profile.get("provider_id") != normalized_selector.get("providerId"):
                     continue
-                if profile_selector.get("runtimeMaterializationMode") and profile.get("runtime_materialization_mode") != profile_selector.get("runtimeMaterializationMode"):
+                if normalized_selector.get("runtimeMaterializationMode") and profile.get("runtime_materialization_mode") != normalized_selector.get("runtimeMaterializationMode"):
                     continue
-                
-                tags_any = profile_selector.get("tagsAny", [])
+
+                tags_any = normalized_selector.get("tagsAny", [])
                 profile_tags = set(profile.get("tags") or [])
                 if tags_any and not set(tags_any).intersection(profile_tags):
                     continue
-                    
-                tags_all = profile_selector.get("tagsAll", [])
+
+                tags_all = normalized_selector.get("tagsAll", [])
                 if tags_all and not set(tags_all).issubset(profile_tags):
                     continue
 
@@ -685,6 +699,18 @@ class ManagedAgentAdapter:
         if not eligible_profiles:
             raise ProfileResolutionError(
                 f"No eligible provider profiles found for runtime_id='{runtime_id}' matching selector constraints."
+            )
+
+        if not normalized_selector:
+            default_profiles = [
+                profile for profile in eligible_profiles if profile.get("is_default")
+            ]
+            if len(eligible_profiles) == 1:
+                return eligible_profiles[0]
+            if len(default_profiles) == 1:
+                return default_profiles[0]
+            raise ProfileResolutionError(
+                f"No default provider profile configured for runtime_id='{runtime_id}'"
             )
 
         eligible_profiles.sort(

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2251,6 +2251,10 @@ class TemporalArtifactActivities:
             stmt = select(ManagedAgentProviderProfile).where(
                 ManagedAgentProviderProfile.runtime_id == runtime_id,
                 ManagedAgentProviderProfile.enabled.is_(True),
+            ).order_by(
+                ManagedAgentProviderProfile.is_default.desc(),
+                ManagedAgentProviderProfile.priority.desc(),
+                ManagedAgentProviderProfile.profile_id.asc(),
             )
             result = await session.execute(stmt)
             rows = result.scalars().all()
@@ -2261,6 +2265,7 @@ class TemporalArtifactActivities:
                 {
                     "profile_id": row.profile_id,
                     "runtime_id": row.runtime_id,
+                    "is_default": row.is_default,
                     "provider_id": row.provider_id,
                     "provider_label": row.provider_label,
                     "tags": row.tags or [],

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -65,6 +65,9 @@ class CodexSessionRuntimeState(BaseModel):
     last_control_action: str | None = Field(None, alias="lastControlAction")
     last_control_at: float | None = Field(None, alias="lastControlAt")
     last_assistant_text: str | None = Field(None, alias="lastAssistantText")
+    last_turn_id: str | None = Field(None, alias="lastTurnId")
+    last_turn_status: str | None = Field(None, alias="lastTurnStatus")
+    last_turn_error: str | None = Field(None, alias="lastTurnError")
 
 
 class CodexAppServerRpcClient:
@@ -440,6 +443,12 @@ class CodexManagedSessionRuntime:
         }
         if state.last_assistant_text:
             merged.setdefault("lastAssistantText", state.last_assistant_text)
+        if state.last_turn_id:
+            merged.setdefault("lastTurnId", state.last_turn_id)
+        if state.last_turn_status:
+            merged.setdefault("lastTurnStatus", state.last_turn_status)
+        if state.last_turn_error:
+            merged.setdefault("lastTurnError", state.last_turn_error)
         return CodexManagedSessionHandle(
             sessionState=self._session_state(state),
             status=status,
@@ -572,6 +581,7 @@ class CodexManagedSessionRuntime:
         *,
         client: CodexAppServerRpcClient,
         state: CodexSessionRuntimeState,
+        allow_fallback_start: bool = True,
     ) -> str:
         thread_path = self._existing_thread_path(
             state.vendor_thread_path
@@ -585,6 +595,8 @@ class CodexManagedSessionRuntime:
         except RuntimeError as exc:
             message = str(exc)
             if "no rollout found" not in message and "thread not found" not in message:
+                raise
+            if not allow_fallback_start:
                 raise
             started = client.request("thread/start", {"cwd": str(self._workspace_path)})
             thread_payload = started.get("thread")
@@ -605,6 +617,109 @@ class CodexManagedSessionRuntime:
             thread_payload.get("path") or recovered_thread_path
         )
         return vendor_thread_id
+
+    @staticmethod
+    def _terminal_turn_outcome(
+        turn_payload: Mapping[str, Any],
+    ) -> tuple[str, str | None] | None:
+        raw_status = str(turn_payload.get("status") or "").strip().lower()
+        error_value = turn_payload.get("error")
+        error_text = str(error_value).strip() if error_value not in (None, "") else None
+        if raw_status == "completed":
+            return "completed", None
+        if raw_status in {"failed", "error"}:
+            return "failed", error_text
+        if raw_status in {"interrupted", "canceled", "cancelled"}:
+            return "interrupted", error_text or raw_status
+        if error_text:
+            return "failed", error_text
+        return None
+
+    def _finalize_turn(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        turn_id: str,
+        status: str,
+        assistant_text: str | None = None,
+        error_text: str | None = None,
+    ) -> None:
+        previous_status = state.last_turn_status
+        state.active_turn_id = None
+        state.last_turn_id = turn_id
+        state.last_turn_status = status
+        state.last_turn_error = error_text
+        if status == "completed":
+            state.last_assistant_text = assistant_text or None
+        self._save_state(state)
+        if status == "completed" and assistant_text and previous_status != "completed":
+            self._append_spool("stdout", f"assistant: {assistant_text}\n")
+        if status in {"failed", "interrupted"} and error_text and previous_status != status:
+            self._append_spool("stderr", f"turn {status}: {error_text}\n")
+
+    def _refresh_turn_state(
+        self,
+        state: CodexSessionRuntimeState,
+    ) -> CodexSessionRuntimeState:
+        active_turn_id = str(state.active_turn_id or "").strip()
+        if not active_turn_id:
+            return state
+
+        client = self._app_server_client()
+        client.initialize()
+        try:
+            thread_payload = client.request(
+                "thread/read",
+                {"threadId": state.vendor_thread_id},
+            )
+        except RuntimeError as exc:
+            try:
+                vendor_thread_id = self._resume_thread(
+                    client=client,
+                    state=state,
+                    allow_fallback_start=False,
+                )
+                thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
+            except RuntimeError as inner_exc:
+                self._finalize_turn(
+                    state=state,
+                    turn_id=active_turn_id,
+                    status="failed",
+                    error_text=str(inner_exc),
+                )
+                return state
+
+        turn_payload = self._find_turn_payload(
+            thread_payload,
+            vendor_turn_id=active_turn_id,
+        )
+        if not isinstance(turn_payload, Mapping):
+            return state
+
+        outcome = self._terminal_turn_outcome(turn_payload)
+        if outcome is None:
+            return state
+
+        status, error_text = outcome
+        assistant_text = self._extract_assistant_text(thread_payload)
+        self._finalize_turn(
+            state=state,
+            turn_id=active_turn_id,
+            status=status,
+            assistant_text=assistant_text,
+            error_text=error_text,
+        )
+        return state
+
+    @staticmethod
+    def _handle_status_for_state(state: CodexSessionRuntimeState) -> str:
+        if state.active_turn_id:
+            return "busy"
+        if state.last_turn_status == "failed":
+            return "failed"
+        if state.last_turn_status == "interrupted":
+            return "interrupted"
+        return "ready"
 
     def launch_session(
         self,
@@ -654,7 +769,8 @@ class CodexManagedSessionRuntime:
         request: CodexManagedSessionLocator,
     ) -> CodexManagedSessionHandle:
         state = self._validate_locator(request)
-        status = "busy" if state.active_turn_id else "ready"
+        state = self._refresh_turn_state(state)
+        status = self._handle_status_for_state(state)
         return self._handle(state, status=status)
 
     def send_turn(
@@ -686,28 +802,18 @@ class CodexManagedSessionRuntime:
             raise RuntimeError("codex app-server turn/start returned a blank turn id")
 
         state.active_turn_id = vendor_turn_id
+        state.last_turn_id = vendor_turn_id
+        state.last_turn_status = "running"
+        state.last_turn_error = None
         state.last_control_action = "send_turn"
         state.last_control_at = time.time()
         self._save_state(state)
         self._append_spool("stdout", f"turn started: {vendor_turn_id}\n")
-
-        thread_payload = self._wait_for_turn_completion(
-            client=client,
-            vendor_thread_id=vendor_thread_id,
-            vendor_turn_id=vendor_turn_id,
-        )
-        assistant_text = self._extract_assistant_text(thread_payload)
-
-        state.active_turn_id = None
-        state.last_assistant_text = assistant_text or None
-        self._save_state(state)
-        if assistant_text:
-            self._append_spool("stdout", f"assistant: {assistant_text}\n")
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),
             turnId=vendor_turn_id,
-            status="completed",
-            metadata={"assistantText": assistant_text},
+            status="running",
+            metadata={},
         )
 
     def steer_turn(
@@ -754,6 +860,9 @@ class CodexManagedSessionRuntime:
             interrupt_params["reason"] = request.reason
         client.request("turn/interrupt", interrupt_params)
         state.active_turn_id = None
+        state.last_turn_id = request.turn_id
+        state.last_turn_status = "interrupted"
+        state.last_turn_error = request.reason or "interrupt requested"
         state.last_control_action = "interrupt_turn"
         state.last_control_at = time.time()
         self._save_state(state)
@@ -812,12 +921,18 @@ class CodexManagedSessionRuntime:
         request: FetchCodexManagedSessionSummaryRequest,
     ) -> CodexManagedSessionSummary:
         state = self._validate_locator(request)
+        state = self._refresh_turn_state(state)
         return CodexManagedSessionSummary(
             sessionState=self._session_state(state),
             latestSummaryRef=None,
             latestCheckpointRef=None,
             latestControlEventRef=None,
-            metadata={"lastAssistantText": state.last_assistant_text},
+            metadata={
+                "lastAssistantText": state.last_assistant_text,
+                "lastTurnId": state.last_turn_id,
+                "lastTurnStatus": state.last_turn_status,
+                "lastTurnError": state.last_turn_error,
+            },
         )
 
     def publish_session_artifacts(

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -48,6 +48,7 @@ _SENSITIVE_ENV_KEY_PATTERN = re.compile(
     r"(?i)(?:token|secret|password|key|credential|auth)"
 )
 _GIT_COMMAND_LOCALE = {"LC_ALL": "C", "LANG": "C"}
+_SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 logger = logging.getLogger(__name__)
 
 
@@ -111,6 +112,7 @@ class DockerCodexManagedSessionController:
         docker_host: str | None = None,
         ready_poll_interval_seconds: float = 1.0,
         ready_poll_attempts: int = 30,
+        turn_poll_interval_seconds: float = 1.0,
         command_runner: CommandRunner = _default_command_runner,
     ) -> None:
         self._workspace_volume_name = workspace_volume_name
@@ -122,6 +124,7 @@ class DockerCodexManagedSessionController:
         self._docker_host = docker_host
         self._ready_poll_interval_seconds = ready_poll_interval_seconds
         self._ready_poll_attempts = ready_poll_attempts
+        self._turn_poll_interval_seconds = turn_poll_interval_seconds
         self._command_runner = command_runner
 
     def _docker_env(self) -> dict[str, str]:
@@ -731,12 +734,58 @@ class DockerCodexManagedSessionController:
                 action,
             ]
         )
-        stdout, stderr = await self._run(
-            command,
+        env = self._docker_env()
+        if extra_env:
+            env.update({str(key): str(value) for key, value in extra_env.items()})
+        returncode, stdout, stderr = await self._command_runner(
+            tuple(command),
             input_text=json.dumps(payload),
+            env=env,
         )
         session_id = str(payload.get("sessionId") or "").strip() or None
         stdout_text = stdout.strip()
+        if returncode != 0:
+            if stdout_text:
+                try:
+                    response_payload = json.loads(stdout_text)
+                except json.JSONDecodeError as exc:
+                    self._raise_transport_failure(
+                        command,
+                        action=action,
+                        container_id=container_id,
+                        session_id=session_id,
+                        reason=f"failed with exit code {returncode} and returned invalid JSON",
+                        stdout=stdout_text,
+                        stderr=stderr,
+                        extra_env=extra_env,
+                        cause=exc,
+                    )
+                if isinstance(response_payload, dict):
+                    error_payload = response_payload.get("error")
+                    if isinstance(error_payload, str) and error_payload.strip():
+                        raise RuntimeError(error_payload.strip())
+                    if error_payload not in (None, ""):
+                        raise RuntimeError(str(error_payload))
+                self._raise_transport_failure(
+                    command,
+                    action=action,
+                    container_id=container_id,
+                    session_id=session_id,
+                    reason=f"failed with exit code {returncode}",
+                    stdout=stdout_text,
+                    stderr=stderr,
+                    extra_env=extra_env,
+                )
+            self._raise_transport_failure(
+                command,
+                action=action,
+                container_id=container_id,
+                session_id=session_id,
+                reason=f"failed with exit code {returncode}",
+                stdout=None,
+                stderr=stderr,
+                extra_env=extra_env,
+            )
         if not stdout_text:
             self._raise_transport_failure(
                 command,
@@ -777,6 +826,135 @@ class DockerCodexManagedSessionController:
                 extra_env=extra_env,
             )
         return response_payload
+
+    def _load_runtime_state_payload(
+        self,
+        *,
+        session_workspace_path: str,
+    ) -> dict[str, Any] | None:
+        state_path = Path(session_workspace_path) / _SESSION_STATE_FILENAME
+        if not state_path.is_file():
+            return None
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _recover_send_turn_response(
+        self,
+        request: SendCodexManagedSessionTurnRequest,
+    ) -> CodexManagedSessionTurnResponse | None:
+        if self._session_store is None:
+            return None
+        record = self._session_store.load(request.session_id)
+        if record is None:
+            return None
+        try:
+            self._matches_locator(record, request)
+        except RuntimeError:
+            return None
+        state_payload = self._load_runtime_state_payload(
+            session_workspace_path=record.session_workspace_path,
+        )
+        if state_payload is None:
+            return None
+        if str(state_payload.get("sessionId") or "").strip() != request.session_id:
+            return None
+        if int(state_payload.get("sessionEpoch") or 0) != request.session_epoch:
+            return None
+        if str(state_payload.get("containerId") or "").strip() != request.container_id:
+            return None
+        if str(state_payload.get("logicalThreadId") or "").strip() != request.thread_id:
+            return None
+
+        turn_id = str(
+            state_payload.get("lastTurnId") or state_payload.get("activeTurnId") or ""
+        ).strip()
+        if not turn_id:
+            return None
+        status = str(state_payload.get("lastTurnStatus") or "").strip().lower()
+        active_turn_id = str(state_payload.get("activeTurnId") or "").strip() or None
+        if not status:
+            status = "running" if active_turn_id else ""
+        if status not in {"accepted", "running", "completed", "interrupted", "failed"}:
+            return None
+
+        metadata: dict[str, Any] = {}
+        assistant_text = str(state_payload.get("lastAssistantText") or "").strip()
+        if assistant_text:
+            metadata["assistantText"] = assistant_text
+        error_text = str(state_payload.get("lastTurnError") or "").strip()
+        if error_text:
+            metadata["reason"] = error_text
+
+        return CodexManagedSessionTurnResponse(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": request.container_id,
+                "threadId": request.thread_id,
+                "activeTurnId": active_turn_id,
+            },
+            turnId=turn_id,
+            status=status,
+            metadata=metadata,
+        )
+
+    async def _wait_for_terminal_turn_response(
+        self,
+        *,
+        request: SendCodexManagedSessionTurnRequest,
+        initial_response: CodexManagedSessionTurnResponse,
+    ) -> CodexManagedSessionTurnResponse:
+        turn_id = initial_response.turn_id
+        while True:
+            payload = await self._invoke_json(
+                container_id=request.container_id,
+                action="session_status",
+                payload=request.model_dump(by_alias=True),
+            )
+            handle = CodexManagedSessionHandle.model_validate(payload)
+            metadata = dict(handle.metadata)
+            turn_id = str(metadata.get("lastTurnId") or turn_id).strip() or turn_id
+            last_turn_status = str(metadata.get("lastTurnStatus") or "").strip().lower()
+            assistant_text = str(metadata.get("lastAssistantText") or "").strip()
+            reason = str(metadata.get("lastTurnError") or "").strip()
+
+            if handle.status == "busy" and handle.session_state.active_turn_id:
+                if self._turn_poll_interval_seconds > 0:
+                    await asyncio.sleep(self._turn_poll_interval_seconds)
+                continue
+
+            if handle.status == "failed" or last_turn_status == "failed":
+                metadata = {"reason": reason or "turn execution failed"}
+                return CodexManagedSessionTurnResponse(
+                    sessionState=handle.session_state,
+                    turnId=turn_id,
+                    status="failed",
+                    metadata=metadata,
+                )
+
+            if handle.status == "interrupted" or last_turn_status == "interrupted":
+                metadata = {"reason": reason or "interrupt requested"}
+                return CodexManagedSessionTurnResponse(
+                    sessionState=handle.session_state,
+                    turnId=turn_id,
+                    status="interrupted",
+                    metadata=metadata,
+                )
+
+            if handle.status == "ready" and not handle.session_state.active_turn_id:
+                metadata = {"assistantText": assistant_text} if assistant_text else {}
+                return CodexManagedSessionTurnResponse(
+                    sessionState=handle.session_state,
+                    turnId=turn_id,
+                    status="completed",
+                    metadata=metadata,
+                )
+
+            if self._turn_poll_interval_seconds > 0:
+                await asyncio.sleep(self._turn_poll_interval_seconds)
 
     async def _wait_ready(self, *, container_id: str) -> None:
         command = (
@@ -1000,24 +1178,38 @@ class DockerCodexManagedSessionController:
         self,
         request: SendCodexManagedSessionTurnRequest,
     ) -> CodexManagedSessionTurnResponse:
-        payload = await self._invoke_json(
-            container_id=request.container_id,
-            action="send_turn",
-            payload=request.model_dump(by_alias=True),
-        )
-        response = CodexManagedSessionTurnResponse.model_validate(payload)
+        try:
+            payload = await self._invoke_json(
+                container_id=request.container_id,
+                action="send_turn",
+                payload=request.model_dump(by_alias=True),
+            )
+            response = CodexManagedSessionTurnResponse.model_validate(payload)
+        except RuntimeError:
+            recovered = self._recover_send_turn_response(request)
+            if recovered is None:
+                raise
+            response = recovered
+
+        terminal_response = response
+        if response.status in {"accepted", "running"}:
+            terminal_response = await self._wait_for_terminal_turn_response(
+                request=request,
+                initial_response=response,
+            )
+
         if self._session_store is not None:
             record = self._session_store.load(request.session_id)
             if record is not None:
                 updated_record = await self._session_store.update(
                     request.session_id,
-                    session_epoch=response.session_state.session_epoch,
-                    container_id=response.session_state.container_id,
-                thread_id=response.session_state.thread_id,
-                active_turn_id=response.session_state.active_turn_id,
-                status=self._record_status_from_turn_status(response.status),
-                updated_at=datetime.now(tz=UTC),
-                error_message=self._turn_error_message(response),
+                    session_epoch=terminal_response.session_state.session_epoch,
+                    container_id=terminal_response.session_state.container_id,
+                    thread_id=terminal_response.session_state.thread_id,
+                    active_turn_id=terminal_response.session_state.active_turn_id,
+                    status=self._record_status_from_turn_status(terminal_response.status),
+                    updated_at=datetime.now(tz=UTC),
+                    error_message=self._turn_error_message(terminal_response),
                 )
                 if self._session_supervisor is not None:
                     await self._emit_session_event(
@@ -1031,20 +1223,20 @@ class DockerCodexManagedSessionController:
                             "reason": request.reason,
                         },
                     )
-                    if response.status == "completed":
+                    if terminal_response.status == "completed":
                         await self._emit_session_event(
                             record=updated_record,
                             kind="turn_completed",
-                            text=f"Turn completed: {response.turn_id}.",
-                            turn_id=response.turn_id,
+                            text=f"Turn completed: {terminal_response.turn_id}.",
+                            turn_id=terminal_response.turn_id,
                             active_turn_id=updated_record.active_turn_id,
                             metadata={
                                 "action": "send_turn",
-                                "assistantText": response.metadata.get("assistantText"),
+                                "assistantText": terminal_response.metadata.get("assistantText"),
                                 "reason": request.reason,
                             },
                         )
-        return response
+        return terminal_response
 
     async def steer_turn(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -9,6 +9,7 @@ import os
 import posixpath
 import re
 import shutil
+import time
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
@@ -29,6 +30,9 @@ from moonmind.schemas.managed_session_models import (
     SendCodexManagedSessionTurnRequest,
     SteerCodexManagedSessionTurnRequest,
     TerminateCodexManagedSessionRequest,
+)
+from moonmind.workflows.codex_session_timeouts import (
+    DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 
@@ -113,6 +117,9 @@ class DockerCodexManagedSessionController:
         ready_poll_interval_seconds: float = 1.0,
         ready_poll_attempts: int = 30,
         turn_poll_interval_seconds: float = 1.0,
+        turn_poll_timeout_seconds: float = (
+            DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS
+        ),
         command_runner: CommandRunner = _default_command_runner,
     ) -> None:
         self._workspace_volume_name = workspace_volume_name
@@ -125,6 +132,7 @@ class DockerCodexManagedSessionController:
         self._ready_poll_interval_seconds = ready_poll_interval_seconds
         self._ready_poll_attempts = ready_poll_attempts
         self._turn_poll_interval_seconds = turn_poll_interval_seconds
+        self._turn_poll_timeout_seconds = turn_poll_timeout_seconds
         self._command_runner = command_runner
 
     def _docker_env(self) -> dict[str, str]:
@@ -868,16 +876,14 @@ class DockerCodexManagedSessionController:
         if str(state_payload.get("logicalThreadId") or "").strip() != request.thread_id:
             return None
 
-        turn_id = str(
-            state_payload.get("lastTurnId") or state_payload.get("activeTurnId") or ""
-        ).strip()
-        if not turn_id:
-            return None
-        status = str(state_payload.get("lastTurnStatus") or "").strip().lower()
         active_turn_id = str(state_payload.get("activeTurnId") or "").strip() or None
+        if not active_turn_id:
+            return None
+        turn_id = active_turn_id
+        status = str(state_payload.get("lastTurnStatus") or "").strip().lower()
         if not status:
             status = "running" if active_turn_id else ""
-        if status not in {"accepted", "running", "completed", "interrupted", "failed"}:
+        if status not in {"accepted", "running"}:
             return None
 
         metadata: dict[str, Any] = {}
@@ -908,11 +914,15 @@ class DockerCodexManagedSessionController:
         initial_response: CodexManagedSessionTurnResponse,
     ) -> CodexManagedSessionTurnResponse:
         turn_id = initial_response.turn_id
+        locator_payload = self._locator_from_session_state(
+            initial_response.session_state
+        ).model_dump(by_alias=True)
+        deadline = time.monotonic() + self._turn_poll_timeout_seconds
         while True:
             payload = await self._invoke_json(
                 container_id=request.container_id,
                 action="session_status",
-                payload=request.model_dump(by_alias=True),
+                payload=locator_payload,
             )
             handle = CodexManagedSessionHandle.model_validate(payload)
             metadata = dict(handle.metadata)
@@ -922,8 +932,12 @@ class DockerCodexManagedSessionController:
             reason = str(metadata.get("lastTurnError") or "").strip()
 
             if handle.status == "busy" and handle.session_state.active_turn_id:
-                if self._turn_poll_interval_seconds > 0:
-                    await asyncio.sleep(self._turn_poll_interval_seconds)
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        "timed out waiting for terminal managed-session turn status "
+                        f"after {self._turn_poll_timeout_seconds} seconds"
+                    )
+                await asyncio.sleep(self._turn_poll_interval_seconds)
                 continue
 
             if handle.status == "failed" or last_turn_status == "failed":
@@ -953,8 +967,12 @@ class DockerCodexManagedSessionController:
                     metadata=metadata,
                 )
 
-            if self._turn_poll_interval_seconds > 0:
-                await asyncio.sleep(self._turn_poll_interval_seconds)
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "timed out waiting for terminal managed-session turn status "
+                    f"after {self._turn_poll_timeout_seconds} seconds"
+                )
+            await asyncio.sleep(self._turn_poll_interval_seconds)
 
     async def _wait_ready(self, *, container_id: str) -> None:
         command = (

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -119,6 +119,7 @@ class ProfileSlotState:
     cooldown_after_429_seconds: int
     rate_limit_policy: str
     enabled: bool
+    is_default: bool = False
     max_lease_duration_seconds: int = _MAX_LEASE_DURATION_SECONDS
     current_leases: list[str] = field(default_factory=list)
     lease_granted_at: dict[str, str] = field(default_factory=dict)  # wf_id -> ISO ts
@@ -186,6 +187,7 @@ class ProfileSlotState:
             "cooldown_after_429_seconds": self.cooldown_after_429_seconds,
             "rate_limit_policy": self.rate_limit_policy,
             "enabled": self.enabled,
+            "is_default": self.is_default,
             "max_lease_duration_seconds": self.max_lease_duration_seconds,
             "current_leases": list(self.current_leases),
             "lease_granted_at": dict(self.lease_granted_at),
@@ -444,6 +446,7 @@ class MoonMindProviderProfileManagerWorkflow:
                 cooldown_after_429_seconds=p.get("cooldown_after_429_seconds", 900),
                 rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                 enabled=p.get("enabled", True),
+                is_default=p.get("is_default", False),
                 max_lease_duration_seconds=p.get(
                     "max_lease_duration_seconds", _MAX_LEASE_DURATION_SECONDS
                 ),
@@ -476,6 +479,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     "rate_limit_policy", existing.rate_limit_policy
                 )
                 existing.enabled = p.get("enabled", existing.enabled)
+                existing.is_default = p.get("is_default", existing.is_default)
                 existing.max_lease_duration_seconds = p.get(
                     "max_lease_duration_seconds", existing.max_lease_duration_seconds
                 )
@@ -494,6 +498,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     ),
                     rate_limit_policy=p.get("rate_limit_policy", "backoff"),
                     enabled=p.get("enabled", True),
+                    is_default=p.get("is_default", False),
                     max_lease_duration_seconds=p.get(
                         "max_lease_duration_seconds", _MAX_LEASE_DURATION_SECONDS
                     ),
@@ -597,17 +602,17 @@ class MoonMindProviderProfileManagerWorkflow:
         for profile in self._profiles.values():
             if not profile.is_available():
                 continue
-                
+
             if selector:
                 if selector.get("providerId") and profile.provider_id != selector.get("providerId"):
                     continue
                 if selector.get("runtimeMaterializationMode") and profile.runtime_materialization_mode != selector.get("runtimeMaterializationMode"):
                     continue
-                
+
                 tags_any = selector.get("tagsAny", [])
                 if tags_any and not set(tags_any).intersection(set(profile.tags)):
                     continue
-                    
+
                 tags_all = selector.get("tagsAll", [])
                 if tags_all and not set(tags_all).issubset(set(profile.tags)):
                     continue
@@ -616,7 +621,17 @@ class MoonMindProviderProfileManagerWorkflow:
 
         if not eligible_profiles:
             return None
-            
+
+        if not selector:
+            default_profiles = [
+                profile for profile in eligible_profiles if profile.is_default
+            ]
+            if len(eligible_profiles) == 1:
+                return eligible_profiles[0]
+            if len(default_profiles) == 1:
+                return default_profiles[0]
+            return None
+
         # Sort descending by priority, then by available slots
         eligible_profiles.sort(key=lambda p: (p.priority, p.available_slots), reverse=True)
         return eligible_profiles[0]
@@ -727,6 +742,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     "cooldown_after_429_seconds": state.cooldown_after_429_seconds,
                     "rate_limit_policy": state.rate_limit_policy,
                     "enabled": state.enabled,
+                    "is_default": state.is_default,
                     "max_lease_duration_seconds": state.max_lease_duration_seconds,
                     "provider_id": state.provider_id,
                     "tags": list(state.tags),

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -567,12 +567,30 @@ class MoonMindProviderProfileManagerWorkflow:
         if leases_changed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
             await self._sync_leases_to_db()
 
+    @staticmethod
+    def _normalize_selector(
+        selector: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        if not selector:
+            return None
+        normalized: dict[str, Any] = {}
+        for key, value in selector.items():
+            if value is None:
+                continue
+            if isinstance(value, str) and not value.strip():
+                continue
+            if isinstance(value, list) and not value:
+                continue
+            normalized[key] = value
+        return normalized or None
+
     def _find_available_profile(
         self,
         selector: Optional[dict[str, Any]] = None,
         execution_profile_ref: str | None = None,
     ) -> Optional[ProfileSlotState]:
         """Find the best available profile matching the selector."""
+        selector = self._normalize_selector(selector)
         exact_profile_id = str(execution_profile_ref or "").strip()
         if exact_profile_id:
             exact_profile = self._profiles.get(exact_profile_id)
@@ -630,6 +648,14 @@ class MoonMindProviderProfileManagerWorkflow:
                 return eligible_profiles[0]
             if len(default_profiles) == 1:
                 return default_profiles[0]
+            if not default_profiles:
+                # Preserve lease assignment for in-flight manager state restored
+                # from payloads created before is_default existed.
+                eligible_profiles.sort(
+                    key=lambda p: (p.priority, p.available_slots),
+                    reverse=True,
+                )
+                return eligible_profiles[0]
             return None
 
         # Sort descending by priority, then by available slots

--- a/tests/e2e/test_task_create_submit_browser.py
+++ b/tests/e2e/test_task_create_submit_browser.py
@@ -170,10 +170,12 @@ def _route_handlers(
                 {
                     "profile_id": "profile:codex-default",
                     "account_label": "Codex Default",
+                    "is_default": True,
                 },
                 {
                     "profile_id": "profile:codex-secondary",
                     "account_label": "Codex Secondary",
+                    "is_default": False,
                 },
             ]
         elif runtime_id == "gemini_cli":
@@ -181,6 +183,7 @@ def _route_handlers(
                 {
                     "profile_id": "profile:gemini-default",
                     "account_label": "Gemini Default",
+                    "is_default": True,
                 }
             ]
         elif runtime_id == "claude_code":
@@ -188,6 +191,7 @@ def _route_handlers(
                 {
                     "profile_id": "profile:claude-default",
                     "account_label": "Claude Default",
+                    "is_default": True,
                 }
             ]
         route.fulfill(
@@ -447,17 +451,16 @@ def test_create_page_shows_provider_profiles_for_selected_runtime(server):
                     !wrap.hidden &&
                     !wrap.classList.contains("hidden") &&
                     select &&
-                    select.options.length >= 3
+                    select.options.length >= 2
                 );
             }
             """
         )
         assert provider_wrap.is_visible()
-        assert provider_select.input_value() == ""
+        assert provider_select.input_value() == "profile:codex-default"
         option_labels = provider_select.locator("option").all_text_contents()
         assert option_labels == [
-            "Default (system chooses)",
-            "Codex Default",
+            "Codex Default (Default)",
             "Codex Secondary",
         ]
 
@@ -470,14 +473,13 @@ def test_create_page_shows_provider_profiles_for_selected_runtime(server):
                     return false;
                 }
                 const labels = Array.from(select.options).map((option) => option.textContent?.trim() || "");
-                return labels.length === 2 && labels[1] === "Gemini Default";
+                return labels.length === 1 && labels[0] === "Gemini Default (Default)";
             }
             """
         )
         option_labels = provider_select.locator("option").all_text_contents()
         assert option_labels == [
-            "Default (system chooses)",
-            "Gemini Default",
+            "Gemini Default (Default)",
         ]
 
         page.select_option('select[name="runtime"]', "claude_code")
@@ -489,14 +491,13 @@ def test_create_page_shows_provider_profiles_for_selected_runtime(server):
                     return false;
                 }
                 const labels = Array.from(select.options).map((option) => option.textContent?.trim() || "");
-                return labels.length === 2 && labels[1] === "Claude Default";
+                return labels.length === 1 && labels[0] === "Claude Default (Default)";
             }
             """
         )
         option_labels = provider_select.locator("option").all_text_contents()
         assert option_labels == [
-            "Default (system chooses)",
-            "Claude Default",
+            "Claude Default (Default)",
         ]
         browser.close()
 

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -62,6 +62,7 @@ async def get_or_create_sample_profile() -> ManagedAgentProviderProfile:
             cooldown_after_429_seconds=120,
             rate_limit_policy=ManagedAgentRateLimitPolicy.BACKOFF,
             enabled=True,
+            is_default=True,
         )
         session.add(profile)
         await session.commit()
@@ -96,6 +97,47 @@ async def test_create_provider_profile(client_app: AsyncClient, _module_db):
     assert data["rate_limit_policy"] == "queue"
     assert data["default_model"] == "test-model-v2"
     assert data["model_overrides"] == {"smart": "test-model-v3"}
+    assert data["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_second_profile_can_become_runtime_default(
+    client_app: AsyncClient,
+    _module_db,
+):
+    """Creating a second profile with is_default should move the runtime default."""
+    first_payload = {
+        "profile_id": "runtime_default_first",
+        "runtime_id": "codex_cli",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://first_secret"},
+        "enabled": True,
+    }
+    second_payload = {
+        "profile_id": "runtime_default_second",
+        "runtime_id": "codex_cli",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://second_secret"},
+        "enabled": True,
+        "is_default": True,
+    }
+
+    async with client_app as client:
+        first_response = await client.post("/api/v1/provider-profiles", json=first_payload)
+        second_response = await client.post("/api/v1/provider-profiles", json=second_payload)
+        listed = await client.get("/api/v1/provider-profiles", params={"runtime_id": "codex_cli"})
+
+    assert first_response.status_code == 201
+    assert first_response.json()["is_default"] is True
+    assert second_response.status_code == 201
+    assert second_response.json()["is_default"] is True
+    assert listed.status_code == 200
+
+    profiles = {profile["profile_id"]: profile for profile in listed.json()}
+    assert profiles["runtime_default_first"]["is_default"] is False
+    assert profiles["runtime_default_second"]["is_default"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -64,6 +64,10 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert defaults["gemini_default"] is None
     assert defaults["codex_default"] is None
     assert defaults["claude_anthropic"] is None
+    runtime_defaults = {p.profile_id: p.is_default for p in profiles}
+    assert runtime_defaults["gemini_default"] is True
+    assert runtime_defaults["codex_default"] is True
+    assert runtime_defaults["claude_anthropic"] is True
 
 
 
@@ -136,6 +140,10 @@ async def test_auto_seed_includes_minimax_when_env_set(_module_db, monkeypatch):
     assert mm_profile.default_model == "MiniMax-M2.7"
     assert mm_profile.volume_ref is None
     assert mm_profile.volume_mount_path is None
+    assert mm_profile.is_default is False
+
+    anthropic_profile = next(p for p in profiles if p.profile_id == "claude_anthropic")
+    assert anthropic_profile.is_default is True
 
 
 @pytest.mark.asyncio
@@ -238,6 +246,7 @@ async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
     profile = next(p for p in profiles if p.profile_id == "codex_openrouter_qwen36_plus")
     assert profile.runtime_id == "codex_cli"
     assert profile.provider_id == "openrouter"
+    assert profile.is_default is False
     assert profile.default_model == "qwen/qwen3.6-plus:free"
     assert profile.secret_refs == {"provider_api_key": "env://OPENROUTER_API_KEY"}
     assert profile.env_template == {
@@ -275,3 +284,6 @@ async def test_auto_seed_includes_openrouter_codex_profile_when_env_set(
     assert profile.command_behavior == {"suppress_default_model_flag": True}
     assert profile.max_parallel_runs == 4
     assert profile.cooldown_after_429_seconds == 300
+
+    codex_default = next(p for p in profiles if p.profile_id == "codex_default")
+    assert codex_default.is_default is True

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -7,6 +7,7 @@ import pytest
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
+    CodexManagedSessionLocator,
     InterruptCodexManagedSessionTurnRequest,
     LaunchCodexManagedSessionRequest,
     SendCodexManagedSessionTurnRequest,
@@ -337,7 +338,7 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
     assert "vendorThreadPath" not in state_payload
 
 
-def test_runtime_send_turn_returns_completed_response_with_assistant_text(
+def test_runtime_send_turn_returns_running_response_then_session_status_completes_turn(
     tmp_path: Path,
 ) -> None:
     script = _write_fake_app_server(tmp_path)
@@ -364,10 +365,21 @@ def test_runtime_send_turn_returns_completed_response_with_assistant_text(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
     assert response.turn_id == "vendor-turn-1"
-    assert response.session_state.active_turn_id is None
-    assert response.metadata["assistantText"] == "OK"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastAssistantText"] == "OK"
 
 
 def test_runtime_send_turn_accepts_item_completed_notification_contract(
@@ -400,9 +412,18 @@ def test_runtime_send_turn_accepts_item_completed_notification_contract(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
     assert response.turn_id == "vendor-turn-1"
-    assert response.metadata["assistantText"] == "OK"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == "OK"
 
 
 def test_runtime_send_turn_completes_via_thread_read_without_notification(
@@ -435,10 +456,20 @@ def test_runtime_send_turn_completes_via_thread_read_without_notification(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
     assert response.turn_id == "vendor-turn-1"
-    assert response.session_state.active_turn_id is None
-    assert response.metadata["assistantText"] == "OK"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastAssistantText"] == "OK"
 
 
 def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
@@ -484,7 +515,16 @@ def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
     updated_state = json.loads(state_path.read_text(encoding="utf-8"))
     assert updated_state["vendorThreadPath"] == str(recovered_path)
 
@@ -516,7 +556,16 @@ def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
     updated_state = json.loads(
         (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
             encoding="utf-8"
@@ -557,7 +606,16 @@ def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_n
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
     updated_state = json.loads(
         (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(
             encoding="utf-8"
@@ -602,7 +660,16 @@ def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(
         )
     )
 
-    assert response.status == "completed"
+    assert response.status == "running"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
     updated_state = json.loads(state_path.read_text(encoding="utf-8"))
     assert updated_state["vendorThreadId"] == "vendor-thread-1"
     assert updated_state["vendorThreadPath"] == "/tmp/vendor-thread-1.jsonl"
@@ -639,7 +706,7 @@ def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) 
     assert handle.metadata["vendorThreadId"] == "vendor-thread-1"
 
 
-def test_runtime_send_turn_times_out_without_completion_notification(
+def test_runtime_session_status_remains_busy_without_completion_notification(
     tmp_path: Path,
 ) -> None:
     script = _write_fake_app_server(
@@ -661,16 +728,26 @@ def test_runtime_send_turn_times_out_without_completion_notification(
     )
     runtime.launch_session(request)
 
-    with pytest.raises(RuntimeError, match="timed out waiting for codex app-server turn completion"):
-        runtime.send_turn(
-            SendCodexManagedSessionTurnRequest(
-                sessionId="sess-1",
-                sessionEpoch=1,
-                containerId="ctr-1",
-                threadId="logical-thread-1",
-                instructions="Reply with exactly the word OK",
-            )
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
         )
+    )
+    assert response.status == "running"
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "busy"
 
     state_payload = json.loads(
         (Path(request.session_workspace_path) / ".moonmind-codex-session-state.json").read_text(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -847,6 +847,7 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
 async def test_controller_send_turn_polls_session_status_until_completed() -> None:
     commands: list[tuple[str, ...]] = []
     session_status_calls = 0
+    session_status_payloads: list[dict[str, object]] = []
 
     async def _fake_runner(
         command: tuple[str, ...],
@@ -871,6 +872,7 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
             }
             return 0, json.dumps(payload), ""
         if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            session_status_payloads.append(json.loads(input_text or "{}"))
             session_status_calls += 1
             if session_status_calls == 1:
                 payload = {
@@ -927,6 +929,14 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
     assert response.status == "completed"
     assert response.turn_id == "vendor-turn-1"
     assert response.metadata["assistantText"] == "OK"
+    assert len(session_status_payloads) == 2
+    for payload in session_status_payloads:
+        assert payload["sessionId"] == "sess-1"
+        assert payload["sessionEpoch"] == 1
+        assert payload["containerId"] == "ctr-1"
+        assert payload["threadId"] == "logical-thread-1"
+        assert "instructions" not in payload
+        assert "reason" not in payload
     assert any(command[-2:] == ("invoke", "send_turn") for command in commands)
     assert any(command[-2:] == ("invoke", "session_status") for command in commands)
 
@@ -1022,6 +1032,144 @@ async def test_controller_send_turn_recovers_from_blank_output_using_runtime_sta
     assert response.status == "completed"
     assert response.turn_id == "vendor-turn-1"
     assert response.metadata["assistantText"] == "Recovered OK"
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_does_not_recover_stale_completed_turn_state(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    session_workspace = tmp_path / "work" / "session"
+    session_workspace.mkdir(parents=True, exist_ok=True)
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath=str(session_workspace),
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    (session_workspace / ".moonmind-codex-session-state.json").write_text(
+        json.dumps(
+            {
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "logicalThreadId": "logical-thread-1",
+                "vendorThreadId": "vendor-thread-1",
+                "containerId": "ctr-1",
+                "activeTurnId": None,
+                "lastControlAction": "send_turn",
+                "lastTurnId": "vendor-turn-prior",
+                "lastTurnStatus": "completed",
+                "lastAssistantText": "stale output",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "send_turn" in command:
+            return 0, "   \n", ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+    )
+
+    with pytest.raises(RuntimeError, match="returned no JSON output"):
+        await controller.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_times_out_when_session_never_reaches_terminal_state(
+) -> None:
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": "vendor-turn-1",
+                },
+                "turnId": "vendor-turn-1",
+                "status": "running",
+                "metadata": {},
+            }
+            return 0, json.dumps(payload), ""
+        if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": "vendor-turn-1",
+                },
+                "status": "busy",
+                "metadata": {
+                    "lastTurnId": "vendor-turn-1",
+                    "lastTurnStatus": "running",
+                },
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        turn_poll_interval_seconds=0,
+        turn_poll_timeout_seconds=0,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="timed out waiting for terminal managed-session turn status",
+    ):
+        await controller.send_turn(
+            SendCodexManagedSessionTurnRequest(
+                sessionId="sess-1",
+                sessionEpoch=1,
+                containerId="ctr-1",
+                threadId="logical-thread-1",
+                instructions="Reply with exactly the word OK",
+            )
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -844,6 +844,187 @@ async def test_controller_send_turn_executes_inside_container(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_controller_send_turn_polls_session_status_until_completed() -> None:
+    commands: list[tuple[str, ...]] = []
+    session_status_calls = 0
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        nonlocal session_status_calls
+        commands.append(command)
+        if command[:3] == ("docker", "exec", "-i") and "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": "vendor-turn-1",
+                },
+                "turnId": "vendor-turn-1",
+                "status": "running",
+                "metadata": {},
+            }
+            return 0, json.dumps(payload), ""
+        if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            session_status_calls += 1
+            if session_status_calls == 1:
+                payload = {
+                    "sessionState": {
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 1,
+                        "containerId": "ctr-1",
+                        "threadId": "logical-thread-1",
+                        "activeTurnId": "vendor-turn-1",
+                    },
+                    "status": "busy",
+                    "metadata": {
+                        "lastTurnId": "vendor-turn-1",
+                        "lastTurnStatus": "running",
+                    },
+                }
+                return 0, json.dumps(payload), ""
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "ready",
+                "metadata": {
+                    "lastTurnId": "vendor-turn-1",
+                    "lastTurnStatus": "completed",
+                    "lastAssistantText": "OK",
+                },
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        turn_poll_interval_seconds=0,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.metadata["assistantText"] == "OK"
+    assert any(command[-2:] == ("invoke", "send_turn") for command in commands)
+    assert any(command[-2:] == ("invoke", "session_status") for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_controller_send_turn_recovers_from_blank_output_using_runtime_state(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "session-store")
+    session_workspace = tmp_path / "work" / "session"
+    session_workspace.mkdir(parents=True, exist_ok=True)
+    store.save(
+        CodexManagedSessionRecord(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            taskRunId="task-1",
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            runtimeId="codex_cli",
+            imageRef="img",
+            controlUrl="docker-exec://ctr-1",
+            status="ready",
+            workspacePath="/work/repo",
+            sessionWorkspacePath=str(session_workspace),
+            artifactSpoolPath="/work/artifacts",
+            startedAt="2026-04-06T12:00:00Z",
+        )
+    )
+    (session_workspace / ".moonmind-codex-session-state.json").write_text(
+        json.dumps(
+            {
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "logicalThreadId": "logical-thread-1",
+                "vendorThreadId": "vendor-thread-1",
+                "containerId": "ctr-1",
+                "activeTurnId": "vendor-turn-1",
+                "lastControlAction": "send_turn",
+                "lastTurnId": "vendor-turn-1",
+                "lastTurnStatus": "running",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "exec", "-i") and "send_turn" in command:
+            return 0, "   \n", ""
+        if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "ready",
+                "metadata": {
+                    "lastTurnId": "vendor-turn-1",
+                    "lastTurnStatus": "completed",
+                    "lastAssistantText": "Recovered OK",
+                },
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        session_store=store,
+        command_runner=_fake_runner,
+        turn_poll_interval_seconds=0,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.metadata["assistantText"] == "Recovered OK"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     (
         "stdout",

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -187,10 +187,18 @@ async def test_resolve_profile_by_id():
     assert ("slot_request", "wf-123", "gemini_cli") not in calls
 
 
-async def test_resolve_profile_auto_picks_first():
+async def test_resolve_profile_auto_picks_runtime_default():
     profiles = [
-        {"profile_id": "first", "credential_source": "secret_ref"},
-        {"profile_id": "second", "credential_source": "oauth_volume"},
+        {
+            "profile_id": "first",
+            "credential_source": "secret_ref",
+            "is_default": False,
+        },
+        {
+            "profile_id": "second",
+            "credential_source": "oauth_volume",
+            "is_default": True,
+        },
     ]
 
     adapter = ManagedAgentAdapter(
@@ -211,7 +219,7 @@ async def test_resolve_profile_auto_picks_first():
         idempotencyKey="idem-auto",
     )
     handle = await adapter.start(request)
-    assert handle.metadata["profile_id"] == "first"
+    assert handle.metadata["profile_id"] == "second"
 
 
 async def test_resolve_profile_selector_filters():

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -254,6 +254,29 @@ class TestProviderProfileManagerHelpers:
         assert best is not None
         assert best.profile_id == "p2"
 
+    def test_find_available_profile_prefers_runtime_default(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=3,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=False,
+        )
+        wf._profiles["p2"] = ProfileSlotState(
+            profile_id="p2",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+
+        best = wf._find_available_profile()
+        assert best is not None
+        assert best.profile_id == "p2"
+
     def test_find_available_profile_none_available(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(
@@ -353,7 +376,7 @@ class TestProviderProfileManagerHelpers:
             rate_limit_policy="backoff", enabled=True, provider_id="anthropic", priority=200
         )
         
-        best = wf._find_available_profile()
+        best = wf._find_available_profile({"providerId": "anthropic"})
         assert best is not None
         assert best.profile_id == "p3"
 

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -277,6 +277,56 @@ class TestProviderProfileManagerHelpers:
         assert best is not None
         assert best.profile_id == "p2"
 
+    def test_find_available_profile_treats_empty_selector_as_no_selector(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=3,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=False,
+            priority=500,
+        )
+        wf._profiles["p2"] = ProfileSlotState(
+            profile_id="p2",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            priority=100,
+        )
+
+        best = wf._find_available_profile({"tagsAny": [], "tagsAll": []})
+        assert best is not None
+        assert best.profile_id == "p2"
+
+    def test_find_available_profile_falls_back_to_priority_when_no_default_exists(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=2,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=False,
+            priority=100,
+        )
+        wf._profiles["p2"] = ProfileSlotState(
+            profile_id="p2",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=False,
+            priority=300,
+        )
+
+        best = wf._find_available_profile()
+        assert best is not None
+        assert best.profile_id == "p2"
+
     def test_find_available_profile_none_available(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(


### PR DESCRIPTION
## What changed

This PR combines two related fixes that were developed while recovering a failed workflow run:

- adds runtime-default provider profile support across the API, workflow manager, migration, and UI
- fixes Codex managed-session turn transport so a started turn is no longer lost when the initial `send_turn` transport returns blank output

## Why it changed

A workflow failed because the managed-session controller expected one long-lived `send_turn` transport call to both start and finish the turn. In the failing run, the turn had already started and persisted state, but the transport returned no JSON and the workflow failed anyway.

Separately, the recovered workspace changes introduced provider-profile runtime defaults, but that work needed to be completed, normalized, and verified across backend, workflow, and UI boundaries.

## Impact

- managed Codex sessions now acknowledge a started turn quickly, persist turn state, and reconcile completion through `session_status`
- blank or non-zero transport failures can now recover from durable runtime state instead of immediately failing the workflow when the turn is already active
- provider profile resolution now supports one runtime default per runtime and uses it consistently in API responses, workflow selection, and the task creation UI

## Root cause

The managed-session controller treated `agent_runtime.send_turn` as a single fragile blocking transport. If that process exited without JSON, the controller hard-failed even when the runtime had already written `activeTurnId` and related turn state to disk.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- targeted managed-session runtime/controller suites
- targeted Codex session adapter and Temporal activity boundary suites

## Notes

The branch includes the recovered provider-default changes plus the separate runtime-side transport fix, because both were part of resolving the original failed workflow end to end.