### PR TITLE
Activate live logs for active Codex session runs

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -190,6 +190,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         started_at = _current_time()
         original_instruction_ref = str(request.instruction_ref or "").strip() or None
         original_skillset_ref = str(request.resolved_skillset_ref or "").strip() or None
+        workspace_path = self._workspace_path_for_request(
+            binding=binding,
+            request=request,
+        )
         if request.input_refs:
             raise ValueError(
                 "CodexSessionAdapter does not support inputRefs for managed session turns"
@@ -208,21 +212,70 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             session_state=session_handle.session_state,
             runtime_epoch=session_handle.session_state.session_epoch,
         )
+        initial_result = AgentRunResult(
+            outputRefs=[],
+            summary=None,
+            metadata={
+                "instructionRef": original_instruction_ref,
+                "resolvedSkillsetRef": original_skillset_ref,
+            },
+        )
+        self._save_run_state(
+            run_id=run_id,
+            agent_id=request.agent_id,
+            managed_run_id=binding.task_run_id,
+            binding=binding,
+            workspace_path=workspace_path,
+            locator=locator.model_dump(mode="json", by_alias=True),
+            active_turn_id=session_handle.session_state.active_turn_id,
+            result=initial_result.model_dump(mode="json", by_alias=True),
+            status="running",
+            started_at=started_at,
+            finished_at=None,
+            profile_id=launch_context.profile_id or None,
+        )
         instructions = await self._instructions_for_request(
             binding=binding,
             request=request,
         )
-        turn_response = await self._coerce_turn_response(
-            self._send_turn(
-                SendCodexManagedSessionTurnRequest(
-                    sessionId=locator.session_id,
-                    sessionEpoch=locator.session_epoch,
-                    containerId=locator.container_id,
-                    threadId=locator.thread_id,
-                    instructions=instructions,
+        try:
+            turn_response = await self._coerce_turn_response(
+                self._send_turn(
+                    SendCodexManagedSessionTurnRequest(
+                        sessionId=locator.session_id,
+                        sessionEpoch=locator.session_epoch,
+                        containerId=locator.container_id,
+                        threadId=locator.thread_id,
+                        instructions=instructions,
+                    )
                 )
             )
-        )
+        except Exception as exc:
+            finished_at = _current_time()
+            failure_result = AgentRunResult(
+                outputRefs=[],
+                summary=str(exc).strip() or "Codex managed-session turn failed",
+                failureClass="execution_error",
+                metadata={
+                    "instructionRef": original_instruction_ref,
+                    "resolvedSkillsetRef": original_skillset_ref,
+                },
+            )
+            self._save_run_state(
+                run_id=run_id,
+                agent_id=request.agent_id,
+                managed_run_id=binding.task_run_id,
+                binding=binding,
+                workspace_path=workspace_path,
+                locator=locator.model_dump(mode="json", by_alias=True),
+                active_turn_id=session_handle.session_state.active_turn_id,
+                result=failure_result.model_dump(mode="json", by_alias=True),
+                status="failed",
+                started_at=started_at,
+                finished_at=finished_at,
+                profile_id=launch_context.profile_id or None,
+            )
+            raise
         if turn_response.status != "completed":
             reason = str(turn_response.metadata.get("reason") or "").strip()
             if not reason:
@@ -230,6 +283,31 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     "Codex managed-session turn failed"
                     f" with status '{turn_response.status}'"
                 )
+            finished_at = _current_time()
+            failure_result = AgentRunResult(
+                outputRefs=list(turn_response.output_refs),
+                summary=reason,
+                failureClass="execution_error",
+                metadata={
+                    "instructionRef": original_instruction_ref,
+                    "resolvedSkillsetRef": original_skillset_ref,
+                    "turnId": turn_response.turn_id,
+                },
+            )
+            self._save_run_state(
+                run_id=run_id,
+                agent_id=request.agent_id,
+                managed_run_id=binding.task_run_id,
+                binding=binding,
+                workspace_path=workspace_path,
+                locator=locator.model_dump(mode="json", by_alias=True),
+                active_turn_id=turn_response.session_state.active_turn_id,
+                result=failure_result.model_dump(mode="json", by_alias=True),
+                status="failed",
+                started_at=started_at,
+                finished_at=finished_at,
+                profile_id=launch_context.profile_id or None,
+            )
             raise RuntimeError(reason)
         await self._signal_control_action(
             action="send_turn",
@@ -282,10 +360,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             agent_id=request.agent_id,
             managed_run_id=binding.task_run_id,
             binding=binding,
-            workspace_path=self._workspace_path_for_request(
-                binding=binding,
-                request=request,
-            ),
+            workspace_path=workspace_path,
             locator=current_locator.model_dump(mode="json", by_alias=True),
             active_turn_id=None,
             result=result.model_dump(mode="json", by_alias=True),
@@ -897,6 +972,16 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             if binding is not None
             else (existing.workspace_path if existing is not None else None)
         )
+        live_stream_capable = (
+            bool(resolved_workspace_path)
+            if resolved_workspace_path is not None
+            else (existing.live_stream_capable if existing is not None else None)
+        )
+        session_id = str(locator.get("sessionId") or "").strip() or None
+        session_epoch_value = locator.get("sessionEpoch")
+        session_epoch = (
+            session_epoch_value if isinstance(session_epoch_value, int) else None
+        )
         container_id = str(locator.get("containerId") or "").strip() or None
         thread_id = str(locator.get("threadId") or "").strip() or None
         record = ManagedRunRecord(
@@ -945,9 +1030,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             errorMessage=summary if status != "completed" else None,
             failureClass=result.get("failureClass"),
             providerErrorCode=_artifact_ref(result.get("providerErrorCode")),
-            liveStreamCapable=False,
-            sessionId=binding.session_id if binding is not None else None,
-            sessionEpoch=binding.session_epoch if binding is not None else None,
+            liveStreamCapable=live_stream_capable,
+            sessionId=session_id or (binding.session_id if binding is not None else None),
+            sessionEpoch=session_epoch or (binding.session_epoch if binding is not None else None),
             containerId=container_id or (existing.container_id if existing is not None else None),
             threadId=thread_id or (existing.thread_id if existing is not None else None),
             activeTurnId=active_turn_id or (existing.active_turn_id if existing is not None else None),

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -91,6 +91,16 @@ PublishArtifactsFunc = Callable[
     Awaitable[CodexManagedSessionArtifactsPublication | Mapping[str, Any]],
 ]
 
+_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS = 4096
+
+
+def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
+    normalized = str(summary or "").strip() or default
+    if len(normalized) <= _MAX_AGENT_RUN_RESULT_SUMMARY_CHARS:
+        return normalized
+    truncated = normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS].rstrip()
+    return truncated or normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS]
+
 
 class CodexSessionExecutionState(BaseModel):
     """Persisted step-scoped execution state for one session-backed managed run."""
@@ -251,17 +261,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 )
             )
         except Exception as exc:
-            finished_at = _current_time()
-            failure_result = AgentRunResult(
-                outputRefs=[],
-                summary=str(exc).strip() or "Codex managed-session turn failed",
-                failureClass="execution_error",
-                metadata={
-                    "instructionRef": original_instruction_ref,
-                    "resolvedSkillsetRef": original_skillset_ref,
-                },
-            )
-            self._save_run_state(
+            self._persist_failed_run_state(
                 run_id=run_id,
                 agent_id=request.agent_id,
                 managed_run_id=binding.task_run_id,
@@ -269,92 +269,115 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 workspace_path=workspace_path,
                 locator=locator.model_dump(mode="json", by_alias=True),
                 active_turn_id=session_handle.session_state.active_turn_id,
-                result=failure_result.model_dump(mode="json", by_alias=True),
-                status="failed",
+                summary=exc,
+                default_summary="Codex managed-session turn failed",
                 started_at=started_at,
-                finished_at=finished_at,
+                finished_at=_current_time(),
+                instruction_ref=original_instruction_ref,
+                resolved_skillset_ref=original_skillset_ref,
                 profile_id=launch_context.profile_id or None,
             )
             raise
+        current_locator = self._locator_from_state(
+            session_state=turn_response.session_state,
+            runtime_epoch=turn_response.session_state.session_epoch,
+        )
         if turn_response.status != "completed":
-            reason = str(turn_response.metadata.get("reason") or "").strip()
-            if not reason:
-                reason = (
+            reason = _clamp_agent_run_result_summary(
+                turn_response.metadata.get("reason"),
+                default=(
                     "Codex managed-session turn failed"
                     f" with status '{turn_response.status}'"
-                )
-            finished_at = _current_time()
-            failure_result = AgentRunResult(
-                outputRefs=list(turn_response.output_refs),
-                summary=reason,
-                failureClass="execution_error",
-                metadata={
-                    "instructionRef": original_instruction_ref,
-                    "resolvedSkillsetRef": original_skillset_ref,
-                    "turnId": turn_response.turn_id,
-                },
+                ),
             )
-            self._save_run_state(
+            self._persist_failed_run_state(
                 run_id=run_id,
                 agent_id=request.agent_id,
                 managed_run_id=binding.task_run_id,
                 binding=binding,
                 workspace_path=workspace_path,
-                locator=locator.model_dump(mode="json", by_alias=True),
+                locator=current_locator.model_dump(mode="json", by_alias=True),
                 active_turn_id=turn_response.session_state.active_turn_id,
-                result=failure_result.model_dump(mode="json", by_alias=True),
-                status="failed",
+                summary=reason,
+                default_summary=reason,
+                output_refs=turn_response.output_refs,
                 started_at=started_at,
-                finished_at=finished_at,
+                finished_at=_current_time(),
+                instruction_ref=original_instruction_ref,
+                resolved_skillset_ref=original_skillset_ref,
+                turn_id=turn_response.turn_id,
                 profile_id=launch_context.profile_id or None,
             )
             raise RuntimeError(reason)
-        await self._signal_control_action(
-            action="send_turn",
-            reason=None,
-            container_id=turn_response.session_state.container_id,
-            thread_id=turn_response.session_state.thread_id,
-        )
 
-        current_locator = self._locator_from_state(
-            session_state=turn_response.session_state,
-            runtime_epoch=turn_response.session_state.session_epoch,
-        )
-        summary = await self.fetch_session_summary(binding=binding, locator=current_locator)
-        publication = await self._coerce_publication(
-            self._publish_remote_artifacts(
-                PublishCodexManagedSessionArtifactsRequest(
-                    sessionId=current_locator.session_id,
-                    sessionEpoch=current_locator.session_epoch,
-                    containerId=current_locator.container_id,
-                    threadId=current_locator.thread_id,
-                    taskRunId=binding.task_run_id,
-                    metadata={"runId": run_id, "workflowId": self._workflow_id},
+        publication: CodexManagedSessionArtifactsPublication | None = None
+        try:
+            await self._signal_control_action(
+                action="send_turn",
+                reason=None,
+                container_id=turn_response.session_state.container_id,
+                thread_id=turn_response.session_state.thread_id,
+            )
+            summary = await self.fetch_session_summary(
+                binding=binding,
+                locator=current_locator,
+            )
+            publication = await self._coerce_publication(
+                self._publish_remote_artifacts(
+                    PublishCodexManagedSessionArtifactsRequest(
+                        sessionId=current_locator.session_id,
+                        sessionEpoch=current_locator.session_epoch,
+                        containerId=current_locator.container_id,
+                        threadId=current_locator.thread_id,
+                        taskRunId=binding.task_run_id,
+                        metadata={"runId": run_id, "workflowId": self._workflow_id},
+                    )
                 )
             )
-        )
 
-        assistant_text = str(
-            turn_response.metadata.get("assistantText")
-            or summary.metadata.get("lastAssistantText")
-            or ""
-        ).strip() or "Codex managed-session turn completed."
-        output_refs = self._merge_output_refs(
-            turn_response.output_refs,
-            publication.published_artifact_refs,
-        )
-        result = AgentRunResult(
-            outputRefs=output_refs,
-            summary=assistant_text,
-            metadata={
-                "instructionRef": original_instruction_ref,
-                "resolvedSkillsetRef": original_skillset_ref,
-                "sessionSummary": summary.model_dump(mode="json", by_alias=True),
-                "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
-                "turnId": turn_response.turn_id,
-            },
-        )
-        finished_at = _current_time()
+            assistant_text = _clamp_agent_run_result_summary(
+                turn_response.metadata.get("assistantText")
+                or summary.metadata.get("lastAssistantText"),
+                default="Codex managed-session turn completed.",
+            )
+            output_refs = self._merge_output_refs(
+                turn_response.output_refs,
+                publication.published_artifact_refs,
+            )
+            result = AgentRunResult(
+                outputRefs=output_refs,
+                summary=assistant_text,
+                metadata={
+                    "instructionRef": original_instruction_ref,
+                    "resolvedSkillsetRef": original_skillset_ref,
+                    "sessionSummary": summary.model_dump(mode="json", by_alias=True),
+                    "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
+                    "turnId": turn_response.turn_id,
+                },
+            )
+        except Exception as exc:
+            self._persist_failed_run_state(
+                run_id=run_id,
+                agent_id=request.agent_id,
+                managed_run_id=binding.task_run_id,
+                binding=binding,
+                workspace_path=workspace_path,
+                locator=current_locator.model_dump(mode="json", by_alias=True),
+                active_turn_id=turn_response.session_state.active_turn_id,
+                summary=exc,
+                default_summary="Codex managed-session turn failed",
+                output_refs=self._merge_output_refs(
+                    turn_response.output_refs,
+                    publication.published_artifact_refs if publication is not None else (),
+                ),
+                started_at=started_at,
+                finished_at=_current_time(),
+                instruction_ref=original_instruction_ref,
+                resolved_skillset_ref=original_skillset_ref,
+                turn_id=turn_response.turn_id,
+                profile_id=launch_context.profile_id or None,
+            )
+            raise
         self._save_run_state(
             run_id=run_id,
             agent_id=request.agent_id,
@@ -366,7 +389,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             result=result.model_dump(mode="json", by_alias=True),
             status="completed",
             started_at=started_at,
-            finished_at=finished_at,
+            finished_at=_current_time(),
             profile_id=launch_context.profile_id or None,
         )
         return AgentRunHandle(
@@ -1035,9 +1058,59 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             sessionEpoch=session_epoch or (binding.session_epoch if binding is not None else None),
             containerId=container_id or (existing.container_id if existing is not None else None),
             threadId=thread_id or (existing.thread_id if existing is not None else None),
-            activeTurnId=active_turn_id or (existing.active_turn_id if existing is not None else None),
+            activeTurnId=active_turn_id,
         )
         self._run_store.save(record)
+
+    def _persist_failed_run_state(
+        self,
+        *,
+        run_id: str,
+        agent_id: str,
+        managed_run_id: str | None,
+        binding: CodexManagedSessionBinding | None,
+        workspace_path: str | None,
+        locator: Mapping[str, Any],
+        active_turn_id: str | None,
+        summary: Any,
+        default_summary: str,
+        started_at: datetime,
+        finished_at: datetime,
+        instruction_ref: str | None,
+        resolved_skillset_ref: str | None,
+        profile_id: str | None,
+        output_refs: tuple[str, ...] | list[str] = (),
+        turn_id: str | None = None,
+    ) -> None:
+        metadata: dict[str, Any] = {
+            "instructionRef": instruction_ref,
+            "resolvedSkillsetRef": resolved_skillset_ref,
+        }
+        if turn_id:
+            metadata["turnId"] = turn_id
+        failure_result = AgentRunResult(
+            outputRefs=list(output_refs),
+            summary=_clamp_agent_run_result_summary(
+                summary,
+                default=default_summary,
+            ),
+            failureClass="execution_error",
+            metadata=metadata,
+        )
+        self._save_run_state(
+            run_id=run_id,
+            agent_id=agent_id,
+            managed_run_id=managed_run_id,
+            binding=binding,
+            workspace_path=workspace_path,
+            locator=locator,
+            active_turn_id=active_turn_id,
+            result=failure_result.model_dump(mode="json", by_alias=True),
+            status="failed",
+            started_at=started_at,
+            finished_at=finished_at,
+            profile_id=profile_id,
+        )
 
     def _merge_output_refs(self, *groups: Any) -> list[str]:
         seen: list[str] = []

--- a/specs/147-live-logs-phase1-activation/plan.md
+++ b/specs/147-live-logs-phase1-activation/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Live Logs Phase 1 Activation
+
+**Branch**: `147-live-logs-phase1-activation` | **Date**: 2026-04-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/147-live-logs-phase1-activation/spec.md`
+
+## Summary
+
+The local repo already ships the session-aware event schema, the task-run observability router, spool-based live transport, and the managed-session controller/supervisor event publisher. The remaining Phase 1 gap is the Codex adapter path: `CodexSessionAdapter.start()` persists the task-run record only after `send_turn`, summary fetch, and artifact publication complete, and it hardcodes `liveStreamCapable=False`. This slice will activate the existing Live Logs path by persisting an early `running` record with live capability enabled, preserving bounded session snapshot fields, and updating failure/completion paths so Mission Control can attach to an active Codex turn without a frontend rewrite.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI, Pydantic, pytest, Temporal-adjacent runtime adapters already in `moonmind/`  
+**Storage**: JSON file-backed managed run/session stores plus workspace-backed spool files and artifact-backed JSONL history  
+**Testing**: `pytest` via `./tools/test_unit.sh`  
+**Target Platform**: Linux containers and local dev environments backing managed-agent execution  
+**Project Type**: backend/runtime observability slice  
+**Performance Goals**: Preserve current live attachment behavior with no extra blocking round-trips before Mission Control can attach  
+**Constraints**: No docs-only solution; keep provider behavior MoonMind-normalized; do not regress active/terminal observability truthfulness; preserve in-flight runtime control even when observability publication fails  
+**Scale/Scope**: Narrow Phase 1 backend activation slice across the Codex adapter, managed-run persistence, and regression tests
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. This slice activates the existing MoonMind observability path rather than building a provider-native browser integration.
+- **II. One-Click Agent Deployment**: PASS. No new operator setup or external infrastructure is required.
+- **III. Avoid Vendor Lock-In**: PASS. The implementation stays inside MoonMind’s normalized task-run observability contract even though the immediate producer is Codex managed sessions.
+- **IV. Own Your Data**: PASS. Live and historical observability remain workspace/artifact-backed and MoonMind-owned.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No agent-skill storage or runtime materialization changes are introduced.
+- **VI. Design for Deletion / Tests as Anchor**: PASS. The change is a thin adapter/runtime fix guarded by boundary tests.
+- **VII. Powerful Runtime Configurability**: PASS. Existing runtime config and observability routing stay intact.
+- **VIII. Modular and Extensible Architecture**: PASS. The work stays within adapter and observability boundaries already defined by the runtime model.
+- **IX. Resilient by Default**: PASS. The plan adds explicit failure-path cleanup for the new early-persistence window and keeps observability failures non-fatal to runtime control.
+- **X. Facilitate Continuous Improvement**: PASS. The slice improves live operator diagnosis without changing run-summary semantics.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. The implementation is driven by this spec/plan/tasks slice.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs remain unchanged; this execution slice lives under `specs/`.
+- **XIII. Pre-Release, Remove Old Patterns Entirely**: PASS. No compatibility aliases or translation layers are added; the adapter’s incorrect late-only persistence behavior is replaced directly.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/147-live-logs-phase1-activation/
+├── plan.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── workflows/adapters/codex_session_adapter.py
+├── workflows/temporal/runtime/managed_session_controller.py
+└── schemas/agent_runtime_models.py
+
+api_service/
+└── api/routers/task_runs.py
+
+tests/
+├── unit/workflows/adapters/test_codex_session_adapter.py
+├── unit/services/temporal/runtime/test_managed_session_controller.py
+└── unit/api/routers/test_task_runs.py
+```
+
+**Structure Decision**: Keep the implementation inside the existing adapter/controller/router seams. No new frontend or documentation work is required for this slice because the current observability consumers already exist.
+
+## Implementation Strategy
+
+### Baseline facts from current code
+
+- `CodexSessionAdapter.start()` persists the task-run `ManagedRunRecord` only after `send_turn`, summary fetch, and artifact publication, so the UI cannot attach to an active Codex managed-session run.
+- The same adapter currently writes `liveStreamCapable=False`, which causes `/observability-summary` and `/logs/stream` to report the run as unavailable for live follow.
+- The managed-session controller and supervisor already emit normalized session events (`session_started`, `turn_started`, `turn_completed`, publication rows, reset-boundary rows) into the task-run spool and durable observability journal.
+- The task-run router already prefers structured history, degrades through spool/merged artifacts, and truthfully reports live state when the run record exists and advertises capability.
+
+### Planned changes
+
+1. Update `CodexSessionAdapter.start()` to persist a `running` managed-run record immediately after the managed session is ensured and the bounded locator is known.
+2. Teach `_persist_managed_run_record()` to advertise live capability for active Codex managed-session runs and to preserve workspace/session fields through running, failed, and completed updates.
+3. Add failure-path persistence so a turn failure after the early save moves the managed-run record to a terminal failure state instead of leaving it stale.
+4. Confirm controller-emitted session events remain visible through the task-run observability stream during active execution and that final artifact publication still writes durable refs back onto the record.
+
+### Test-first approach
+
+- Start with adapter tests that assert the store contains a `running` live-capable record before the `send_turn` await completes.
+- Add or update failure-path adapter tests so failed turns rewrite the early record to a terminal state.
+- Add a controller or router regression test only where needed to prove active-session event rows still reach the task-run stream and summary remains truthful.
+
+## Complexity Tracking
+
+No constitution violations are expected for this slice.

--- a/specs/147-live-logs-phase1-activation/spec.md
+++ b/specs/147-live-logs-phase1-activation/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Live Logs Phase 1 Activation
+
+**Feature Branch**: `147-live-logs-phase1-activation`  
+**Created**: 2026-04-10  
+**Status**: Draft  
+**Input**: User description: "$speckit-orchestrate Implement Phase 1 using test-driven development from the Live Logs plan: make Codex managed-session runs produce an active observability record early, publish live events while the turn is still in flight, and keep the existing summary + merged-tail + SSE viewer working. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Mission Control attaches before the Codex turn finishes (Priority: P1)
+
+Mission Control operators need a real managed-run observability record as soon as a Codex managed session is ready so the existing Live Logs summary, history, and SSE routes can attach while the turn is still executing.
+
+**Why this priority**: The router and frontend already know how to read an active capable record. The main blocker is that the Codex adapter does not persist one until after the turn, summary fetch, and artifact publication are already done.
+
+**Independent Test**: Start a Codex managed-session run with a `send_turn` stub that pauses before completion and confirm the managed-run store already contains a `running` record with workspace and session metadata plus `liveStreamCapable: true`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task-scoped Codex managed session has been resolved and the adapter is about to send a turn, **When** the adapter persists the initial managed-run record, **Then** the record is already visible in `running` state with `workspacePath`, `sessionId`, `sessionEpoch`, `containerId`, `threadId`, and `liveStreamCapable: true`.
+2. **Given** that active record exists before the turn finishes, **When** Mission Control requests `/api/task-runs/{id}/observability-summary`, **Then** the summary reports live streaming as available instead of waiting for terminal artifact publication.
+3. **Given** the run is still active, **When** Mission Control attaches to `/api/task-runs/{id}/logs/stream`, **Then** the route does not reject the run for missing live-stream capability.
+
+---
+
+### User Story 2 - Active Codex turns publish observable session events (Priority: P1)
+
+Mission Control operators need live session-plane events to appear in the same task-run observability stream while the Codex turn is in flight so the existing Live Logs viewer shows visible activity before completion.
+
+**Why this priority**: Early record persistence is not enough if the active run still produces no observable rows until the final summary and artifact snapshot are published.
+
+**Independent Test**: Execute a managed-session run through the real controller/supervisor path or adapter test doubles, emit `session_started`, `turn_started`, and `turn_completed`, and confirm the task-run spool or durable publication path preserves those rows in sequence order.
+
+**Acceptance Scenarios**:
+
+1. **Given** the managed-session controller already emits normalized session events through the session supervisor, **When** a Codex turn starts and completes, **Then** the task-run observability stream contains at least `session_started`, `turn_started`, and `turn_completed` rows in one run-global sequence.
+2. **Given** the run later publishes summary and checkpoint artifacts, **When** the final managed-run record is updated, **Then** it retains the durable `observabilityEventsRef` and runtime artifact refs without dropping the earlier live capability or session snapshot fields.
+3. **Given** event publication fails for one session row, **When** runtime control still succeeds, **Then** the run continues and artifact publication is not blocked by the observability failure.
+
+---
+
+### User Story 3 - Failure paths stay truthful for in-flight observability (Priority: P2)
+
+Operators need failed or aborted turns to leave behind an accurate managed-run record instead of a stale `running` entry once the adapter encounters a send-turn failure.
+
+**Why this priority**: Persisting the record earlier introduces a new failure window. That window must end in a truthful terminal state rather than leaving Mission Control attached to a run that already failed.
+
+**Independent Test**: Force `send_turn` to return a failed status after the early record has been written and confirm the managed-run store moves the record to a terminal failure state with the same workspace and session metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** the adapter persisted a `running` record before `_send_turn(...)`, **When** the managed turn later fails, **Then** the managed-run record is updated to a terminal non-success state instead of remaining `running`.
+2. **Given** the failed run already advertised live capability, **When** the run becomes terminal, **Then** observability summary truthfully reports live streaming as ended.
+
+### Edge Cases
+
+- A Codex turn returns a failed status before any summary or artifact publication; the early record must still be cleaned up into a truthful terminal state.
+- Session events may exist in the task-run spool before a durable observability journal exists; active history retrieval must keep degrading through spool-based reads.
+- A run may have session metadata in the managed-session store but not yet in final task-run artifact metadata; summary and stream routes must still have enough bounded context to operate.
+- Observability publication failures must remain non-fatal for runtime control and artifact publication.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `CodexSessionAdapter.start()` MUST persist a managed-run record in `running` state before awaiting the managed `send_turn` completion path.
+- **FR-002**: The early managed-run record MUST set `liveStreamCapable` to `true` for Codex managed-session runs with a writable workspace-backed spool path.
+- **FR-003**: The early managed-run record MUST include `workspacePath`, `sessionId`, `sessionEpoch`, `containerId`, `threadId`, and `activeTurnId` when available from the bounded session snapshot.
+- **FR-004**: Codex managed-session lifecycle events emitted during launch and turn execution MUST remain visible in the task-run observability stream while the run is active.
+- **FR-005**: The final managed-run record MUST retain durable runtime artifact refs and `observabilityEventsRef` after artifact publication without regressing the live-stream capability contract for active runs.
+- **FR-006**: If the Codex managed turn fails after the early record is written, the adapter MUST update the managed-run record to a truthful terminal failure state.
+- **FR-007**: This phase MUST ship production runtime code changes under `moonmind/` and automated validation tests under `tests/`; docs-only edits are insufficient.
+
+### Key Entities *(include if feature involves data)*
+
+- **Early Managed Run Record**: The first persisted `ManagedRunRecord` for a Codex managed-session turn, written before turn completion so Mission Control can attach.
+- **Task-Run Observability Stream**: The workspace-backed spool and durable event history used by summary, structured history, merged fallback, and SSE routes.
+- **Session Snapshot Fields**: The bounded `sessionId`, `sessionEpoch`, `containerId`, `threadId`, and `activeTurnId` values mirrored onto task-run observability records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Adapter tests prove a `running` managed-run record exists before `send_turn` completes and that the record advertises `liveStreamCapable: true`.
+- **SC-002**: Adapter or controller boundary tests prove `session_started`, `turn_started`, and `turn_completed` are published into the task-run observability stream for Codex managed-session runs.
+- **SC-003**: Router-facing tests continue to show active capable runs report `supportsLiveStreaming: true` and terminal runs report live streaming as ended.
+- **SC-004**: `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` passes for the final implementation.

--- a/specs/147-live-logs-phase1-activation/tasks.md
+++ b/specs/147-live-logs-phase1-activation/tasks.md
@@ -1,0 +1,118 @@
+# Tasks: Live Logs Phase 1 Activation
+
+**Input**: Design documents from `/specs/147-live-logs-phase1-activation/`
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: Tests are required for this slice because the user explicitly requested test-driven development.
+
+**Organization**: Tasks are grouped by user story so the active-record path and truthful failure handling can be verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story the task traces to (`US1`, `US2`, `US3`)
+
+## Phase 1: Foundational Contract Alignment
+
+**Purpose**: Lock the Phase 1 slice onto the actual local code seams before implementation.
+
+- [X] T001 Review the current Codex adapter, managed-session controller/supervisor, and task-run router contracts in `moonmind/workflows/adapters/codex_session_adapter.py`, `moonmind/workflows/temporal/runtime/managed_session_controller.py`, `moonmind/workflows/temporal/runtime/managed_session_supervisor.py`, and `api_service/api/routers/task_runs.py`.
+- [X] T002 Validate task scope in runtime mode with `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+
+---
+
+## Phase 2: User Story 1 - Mission Control attaches before the Codex turn finishes (Priority: P1) 🎯 MVP
+
+**Goal**: Persist an active live-capable task-run record before `send_turn` completes so the existing Live Logs summary/history/SSE path can attach to an in-flight Codex managed-session run.
+
+**Independent Test**: Pause `send_turn` inside the adapter test and confirm the managed-run store already contains a `running` record with session metadata and `liveStreamCapable: true`.
+
+### Tests for User Story 1
+
+- [X] T003 [P] [US1] Add failing adapter coverage in `tests/unit/workflows/adapters/test_codex_session_adapter.py` proving `CodexSessionAdapter.start()` writes a `running` managed-run record before `_send_turn(...)` completes and advertises `liveStreamCapable=True`.
+- [X] T004 [P] [US1] Add or tighten router assertions in `tests/unit/api/routers/test_task_runs.py` covering active capable summary/stream truthfulness for Codex managed-session runs.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update early persistence flow in `moonmind/workflows/adapters/codex_session_adapter.py` so a `running` `ManagedRunRecord` is saved immediately after session resolution and locator creation.
+- [X] T006 [US1] Update task-run record persistence in `moonmind/workflows/adapters/codex_session_adapter.py` so active Codex managed-session runs preserve workspace/session snapshot fields and advertise `liveStreamCapable=True`.
+
+**Checkpoint**: Mission Control can discover an active Codex managed-session run before the turn finishes.
+
+---
+
+## Phase 3: User Story 2 - Active Codex turns publish observable session events (Priority: P1)
+
+**Goal**: Ensure controller/supervisor session-plane events remain visible through the task-run observability stream during the active turn and that final artifact publication preserves the durable refs on the task-run record.
+
+**Independent Test**: Emit `session_started`, `turn_started`, and `turn_completed` through the managed-session controller/supervisor path and confirm task-run observability still exposes them while the run is active and after publication completes.
+
+### Tests for User Story 2
+
+- [X] T007 [P] [US2] Add or tighten boundary coverage in `tests/unit/services/temporal/runtime/test_managed_session_controller.py` proving the existing session event publication path still emits normalized timeline rows for `send_turn`.
+- [X] T008 [P] [US2] Add adapter assertions in `tests/unit/workflows/adapters/test_codex_session_adapter.py` proving the final task-run record retains `observabilityEventsRef` and artifact refs after publication.
+
+### Implementation for User Story 2
+
+- [X] T009 [US2] Adjust `moonmind/workflows/adapters/codex_session_adapter.py` and any required runtime helper seams so completion updates preserve the active-record session metadata while keeping controller/supervisor-published event rows usable through the task-run observability path.
+
+**Checkpoint**: The active run shows session lifecycle activity before completion and preserves durable refs afterward.
+
+---
+
+## Phase 4: User Story 3 - Failure paths stay truthful for in-flight observability (Priority: P2)
+
+**Goal**: Guarantee the early-persisted run record does not remain stale when a managed turn fails.
+
+**Independent Test**: Force a failed `send_turn` response and confirm the task-run record transitions from the early `running` state to a terminal failure state with the same workspace/session metadata.
+
+### Tests for User Story 3
+
+- [X] T010 [P] [US3] Add failing adapter coverage in `tests/unit/workflows/adapters/test_codex_session_adapter.py` proving a failed turn rewrites the early live-capable record to a terminal failure state.
+
+### Implementation for User Story 3
+
+- [X] T011 [US3] Update failure handling in `moonmind/workflows/adapters/codex_session_adapter.py` so turn failures finalize the previously persisted task-run record truthfully instead of leaving it `running`.
+
+**Checkpoint**: Early-persisted records stay truthful across send-turn failures.
+
+---
+
+## Phase 5: Validation and Closeout
+
+**Purpose**: Run the required validation and finish the spec workflow cleanly.
+
+- [X] T012 Run `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`.
+- [X] T013 Mark completed tasks as `[X]` in `specs/147-live-logs-phase1-activation/tasks.md`.
+- [X] T014 Run `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`.
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 establishes the exact implementation scope and validation guardrail.
+- Phase 2 is the MVP and blocks everything else because the active record must exist before the other observability surfaces matter.
+- Phase 3 depends on Phase 2 because the task-run record must exist before active event publication is useful to Mission Control.
+- Phase 4 depends on Phase 2 because it updates the new early-persistence window.
+- Phase 5 runs after all implementation work is complete.
+
+### Within Each User Story
+
+- Write the tests first and confirm they fail for the targeted gap.
+- Implement the runtime changes only after the relevant failing tests exist.
+- Re-run the focused tests before moving to the next story.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1.
+2. Complete Phase 2 and verify the early live-capable record path.
+3. Re-run the targeted adapter/router tests.
+4. Continue with session-event preservation and failure cleanup.
+
+### Notes
+
+- Keep the change inside existing adapter/controller/router boundaries.
+- Do not add compatibility wrappers for old task-run persistence behavior.
+- Preserve non-fatal observability publication semantics.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1463,6 +1463,40 @@ def test_stream_task_run_live_logs_serializes_canonical_event_aliases(
     assert '"session_id"' not in response.text
 
 
+def test_stream_task_run_live_logs_rejects_non_live_capable_active_run(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    mock_record = MagicMock()
+    mock_record.status = "running"
+    mock_record.live_stream_capable = False
+    mock_record.workspace_path = "/tmp/workspace"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stream")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Live streaming is not supported for this run."
+
+
+def test_stream_task_run_live_logs_returns_gone_for_terminal_run(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    mock_record = MagicMock()
+    mock_record.status = "completed"
+    mock_record.live_stream_capable = True
+    mock_record.workspace_path = "/tmp/workspace"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stream")
+
+    assert response.status_code == 410
+    assert response.json()["detail"] == "Run is no longer active. Use artifact retrieval APIs."
+
+
 def test_stream_task_run_live_logs_ignores_metrics_emitter_failures(
     client: tuple[TestClient, AsyncMock],
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1325,6 +1325,11 @@ async def test_controller_send_turn_emits_follow_up_reason_in_session_events(
         call.kwargs.get("metadata")
         for call in session_supervisor.emit_session_event.call_args_list
     ]
+    emitted_kinds = [
+        call.kwargs.get("kind")
+        for call in session_supervisor.emit_session_event.call_args_list
+    ]
+    assert emitted_kinds == ["turn_started", "turn_completed"]
     assert emitted_metadata == [
         {"action": "send_turn", "reason": "Operator follow-up"},
         {

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -342,7 +343,7 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
         persisted_record.observability_events_ref
         == "artifact:observability.events.jsonl"
     )
-    assert persisted_record.live_stream_capable is False
+    assert persisted_record.live_stream_capable is True
     assert status.status == "completed"
     assert result.summary == "Implemented through the session container."
     assert result.output_refs == [
@@ -369,11 +370,112 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["threadId"] == "thread-1"
 
 
+async def test_start_persists_running_live_capable_record_before_send_turn_completes(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    send_turn_started = asyncio.Event()
+    release_send_turn = asyncio.Event()
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        raise AssertionError("session_status should not be used before launch")
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        send_turn_started.set()
+        await release_send_turn.wait()
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    start_task = asyncio.create_task(
+        adapter.start(_request(binding, workspace_path=str(workspace_path)))
+    )
+    await asyncio.wait_for(send_turn_started.wait(), timeout=1)
+
+    persisted_running = run_store.load(binding.task_run_id)
+    assert persisted_running is not None
+    assert persisted_running.status == "running"
+    assert persisted_running.finished_at is None
+    assert persisted_running.workspace_path == str(workspace_path)
+    assert persisted_running.live_stream_capable is True
+    assert persisted_running.session_id == binding.session_id
+    assert persisted_running.session_epoch == binding.session_epoch
+    assert persisted_running.container_id == "container-1"
+    assert persisted_running.thread_id == "thread-1"
+    assert persisted_running.active_turn_id is None
+    assert persisted_running.observability_events_ref is None
+
+    release_send_turn.set()
+    await start_task
+
+    persisted_completed = run_store.load(binding.task_run_id)
+    assert persisted_completed is not None
+    assert persisted_completed.status == "completed"
+    assert persisted_completed.live_stream_capable is True
+
+
 async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path) -> None:
     binding = _binding()
     workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
     summary_calls: list[Any] = []
     publication_calls: list[Any] = []
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(binding=binding)
@@ -429,7 +531,7 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
         cooldown_reporter=_async_noop,
         workflow_id="wf-agent-run-1",
         runtime_id="codex_cli",
-        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        run_store=run_store,
         load_session_snapshot=_load_snapshot,
         launch_session=_launch_session,
         session_status=_session_status,
@@ -451,6 +553,17 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
 
     assert summary_calls == []
     assert publication_calls == []
+    persisted_record = run_store.load(binding.task_run_id)
+    assert persisted_record is not None
+    assert persisted_record.status == "failed"
+    assert persisted_record.workspace_path == str(workspace_path)
+    assert persisted_record.live_stream_capable is True
+    assert persisted_record.error_message == "empty managed-session turn"
+    assert persisted_record.session_id == binding.session_id
+    assert persisted_record.session_epoch == binding.session_epoch
+    assert persisted_record.container_id == "container-1"
+    assert persisted_record.thread_id == "thread-1"
+
 
 
 async def test_start_passes_profile_materialization_payload_to_launch_session(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -476,6 +476,8 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
     summary_calls: list[Any] = []
     publication_calls: list[Any] = []
     run_store = ManagedRunStore(tmp_path / "managed_runs")
+    oversized_reason = "turn failed: " + ("x" * 5000)
+    expected_reason = oversized_reason[:4096]
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(binding=binding)
@@ -494,12 +496,12 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
     async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
         return _turn_response(
             session_id=binding.session_id,
-            session_epoch=binding.session_epoch,
-            container_id="container-1",
-            thread_id="thread-1",
+            session_epoch=binding.session_epoch + 1,
+            container_id="container-2",
+            thread_id="thread-2",
             status="failed",
             assistant_text="",
-        ).model_copy(update={"metadata": {"reason": "empty managed-session turn"}})
+        ).model_copy(update={"metadata": {"reason": oversized_reason}})
 
     async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
         summary_calls.append(_request)
@@ -548,9 +550,10 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
     )
 
-    with pytest.raises(RuntimeError, match="empty managed-session turn"):
+    with pytest.raises(RuntimeError) as excinfo:
         await adapter.start(_request(binding, workspace_path=str(workspace_path)))
 
+    assert str(excinfo.value) == expected_reason
     assert summary_calls == []
     assert publication_calls == []
     persisted_record = run_store.load(binding.task_run_id)
@@ -558,12 +561,92 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
     assert persisted_record.status == "failed"
     assert persisted_record.workspace_path == str(workspace_path)
     assert persisted_record.live_stream_capable is True
-    assert persisted_record.error_message == "empty managed-session turn"
+    assert persisted_record.error_message == expected_reason
     assert persisted_record.session_id == binding.session_id
-    assert persisted_record.session_epoch == binding.session_epoch
-    assert persisted_record.container_id == "container-1"
-    assert persisted_record.thread_id == "thread-1"
+    assert persisted_record.session_epoch == binding.session_epoch + 1
+    assert persisted_record.container_id == "container-2"
+    assert persisted_record.thread_id == "thread-2"
 
+
+async def test_start_marks_run_failed_when_post_turn_follow_up_raises(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    signal_calls: list[Any] = []
+    summary_error = "summary fetch failed after send_turn"
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_request: Any) -> CodexManagedSessionHandle:
+        raise AssertionError("session_status should not be used before launch")
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch + 1,
+            container_id="container-2",
+            thread_id="thread-2",
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        raise RuntimeError(summary_error)
+
+    async def _signal_action(payload: dict[str, Any]) -> None:
+        signal_calls.append(payload)
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=AsyncMock(),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_signal_action,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(RuntimeError, match=summary_error):
+        await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    assert signal_calls[-1] == {
+        "action": "send_turn",
+        "containerId": "container-2",
+        "threadId": "thread-2",
+    }
+    persisted_record = run_store.load(binding.task_run_id)
+    assert persisted_record is not None
+    assert persisted_record.status == "failed"
+    assert persisted_record.error_message == summary_error
+    assert persisted_record.live_stream_capable is True
+    assert persisted_record.session_epoch == binding.session_epoch + 1
+    assert persisted_record.container_id == "container-2"
+    assert persisted_record.thread_id == "thread-2"
 
 
 async def test_start_passes_profile_materialization_payload_to_launch_session(
@@ -1391,6 +1474,87 @@ async def test_save_run_state_persists_blank_workspace_path_as_none(
 
     assert persisted_record is not None
     assert persisted_record.workspace_path is None
+
+
+async def test_save_run_state_clears_active_turn_id_when_explicitly_none(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = str(tmp_path / "agent_jobs" / binding.task_run_id / "repo")
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "secret_ref"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=AsyncMock(),
+        launch_session=AsyncMock(),
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=AsyncMock(),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    adapter._save_run_state(
+        run_id=binding.task_run_id,
+        agent_id="codex",
+        managed_run_id=binding.task_run_id,
+        binding=binding,
+        workspace_path=workspace_path,
+        locator={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id="turn-active",
+        result={
+            "summary": "Still running",
+            "metadata": {},
+        },
+        status="running",
+        started_at=datetime.now(tz=UTC),
+    )
+
+    adapter._save_run_state(
+        run_id=binding.task_run_id,
+        agent_id="codex",
+        managed_run_id=binding.task_run_id,
+        binding=binding,
+        workspace_path=workspace_path,
+        locator={
+            "sessionId": binding.session_id,
+            "sessionEpoch": binding.session_epoch,
+            "containerId": "container-1",
+            "threadId": "thread-1",
+        },
+        active_turn_id=None,
+        result={
+            "summary": "Completed",
+            "metadata": {},
+        },
+        status="completed",
+        started_at=datetime.now(tz=UTC),
+        finished_at=datetime.now(tz=UTC),
+    )
+
+    persisted_record = run_store.load(binding.task_run_id)
+
+    assert persisted_record is not None
+    assert persisted_record.active_turn_id is None
 
 
 async def test_terminate_session_uses_remote_session_control_surface(


### PR DESCRIPTION
## Summary
- persist a Codex managed-session task-run record in `running` state before `_send_turn(...)` completes
- advertise `liveStreamCapable` from the real workspace-backed observability path instead of hardcoding `false`
- finalize the early task-run record truthfully on send-turn failure and tighten router/controller/adapter regression coverage

## Remediation
- aligned the Phase 1 scope to the actual local codebase gap instead of the older line-centric plan
- kept the change inside existing adapter/controller/router seams without a frontend rewrite

## Testing
- `./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`