### PR TITLE
Align task-scoped Codex termination with typed workflow updates

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -16,8 +16,6 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
-        CodexManagedSessionSnapshot,
-        TerminateCodexManagedSessionRequest,
         CodexManagedSessionWorkflowInput,
         canonical_codex_managed_runtime_id,
     )
@@ -2307,48 +2305,26 @@ class MoonMindRunWorkflow:
             if handle is not None and binding is not None:
                 if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH):
                     try:
-                        snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                            "agent_runtime.load_session_snapshot"
+                        await handle.execute_update(
+                            "TerminateSession",
+                            {
+                                "reason": reason,
+                            },
                         )
-                        snapshot_payload = await workflow.execute_activity(
-                            snapshot_route.activity_type,
-                            binding.model_dump(mode="json", by_alias=True),
-                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                            **self._execute_kwargs_for_route(snapshot_route),
-                        )
-                        snapshot = CodexManagedSessionSnapshot.model_validate(
-                            snapshot_payload
-                        )
-                        if snapshot.container_id and snapshot.thread_id:
-                            terminate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
-                                "agent_runtime.terminate_session"
-                            )
-                            await workflow.execute_activity(
-                                terminate_route.activity_type,
-                                TerminateCodexManagedSessionRequest(
-                                    sessionId=snapshot.binding.session_id,
-                                    sessionEpoch=snapshot.binding.session_epoch,
-                                    containerId=snapshot.container_id,
-                                    threadId=snapshot.thread_id,
-                                    reason=reason,
-                                ).model_dump(mode="json", by_alias=True),
-                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-                                **self._execute_kwargs_for_route(terminate_route),
-                            )
                     except Exception as exc:
                         self._get_logger().warning(
-                            "Task-scoped Codex terminate activity failed for %s; "
-                            "falling back to session signal: %s",
+                            "Task-scoped Codex terminate update failed for %s: %s",
                             binding.session_id,
                             exc,
                         )
-                await handle.signal(
-                    "control_action",
-                    {
-                        "action": "terminate_session",
-                        "reason": reason,
-                    },
-                )
+                else:
+                    await handle.signal(
+                        "control_action",
+                        {
+                            "action": "terminate_session",
+                            "reason": reason,
+                        },
+                    )
         finally:
             self._codex_session_handle = None
             self._codex_session_binding = None

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -16,7 +16,9 @@ with workflow.unsafe.imports_passed_through():
     )
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
+        CodexManagedSessionSnapshot,
         CodexManagedSessionWorkflowInput,
+        TerminateCodexManagedSessionRequest,
         canonical_codex_managed_runtime_id,
     )
     from moonmind.schemas.temporal_activity_models import (
@@ -143,8 +145,10 @@ _GITHUB_PR_URL_PATTERN = re.compile(
 INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 # Replay-stable patch id for parent-initiated defensive slot release on child terminal state.
 RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release-1"
-# Replay-stable patch id for task-scoped Codex terminate activities during finalization.
+# Replay-stable patch id for task-scoped Codex terminate activity+signal finalization.
 RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
+# Replay-stable patch id for task-scoped Codex terminate child-workflow updates.
+RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH = "run-task-scoped-session-termination-v2"
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
@@ -2303,7 +2307,7 @@ class MoonMindRunWorkflow:
         binding = self._codex_session_binding
         try:
             if handle is not None and binding is not None:
-                if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH):
+                if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
                     try:
                         await handle.execute_update(
                             "TerminateSession",
@@ -2317,6 +2321,57 @@ class MoonMindRunWorkflow:
                             binding.session_id,
                             exc,
                         )
+                        await handle.signal(
+                            "control_action",
+                            {
+                                "action": "terminate_session",
+                                "reason": reason,
+                            },
+                        )
+                elif workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH):
+                    try:
+                        snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                            "agent_runtime.load_session_snapshot"
+                        )
+                        snapshot_payload = await workflow.execute_activity(
+                            snapshot_route.activity_type,
+                            binding.model_dump(mode="json", by_alias=True),
+                            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                            **self._execute_kwargs_for_route(snapshot_route),
+                        )
+                        snapshot = CodexManagedSessionSnapshot.model_validate(
+                            snapshot_payload
+                        )
+                        if snapshot.container_id and snapshot.thread_id:
+                            terminate_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
+                                "agent_runtime.terminate_session"
+                            )
+                            await workflow.execute_activity(
+                                terminate_route.activity_type,
+                                TerminateCodexManagedSessionRequest(
+                                    sessionId=snapshot.binding.session_id,
+                                    sessionEpoch=snapshot.binding.session_epoch,
+                                    containerId=snapshot.container_id,
+                                    threadId=snapshot.thread_id,
+                                    reason=reason,
+                                ).model_dump(mode="json", by_alias=True),
+                                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                                **self._execute_kwargs_for_route(terminate_route),
+                            )
+                    except Exception as exc:
+                        self._get_logger().warning(
+                            "Task-scoped Codex terminate activity failed for %s; "
+                            "falling back to session signal: %s",
+                            binding.session_id,
+                            exc,
+                        )
+                    await handle.signal(
+                        "control_action",
+                        {
+                            "action": "terminate_session",
+                            "reason": reason,
+                        },
+                    )
                 else:
                     await handle.signal(
                         "control_action",

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -125,8 +125,8 @@ async def test_run_terminates_active_task_scoped_codex_session(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
-    activity_calls: list[tuple[str, Any]] = []
     patch_calls: list[str] = []
 
     def fake_patched(patch_id: str) -> bool:
@@ -134,54 +134,11 @@ async def test_run_terminates_active_task_scoped_codex_session(
         return True
 
     class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
-
-    async def fake_execute_activity(
-        activity_name: str,
-        payload: Any,
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        activity_calls.append((activity_name, payload))
-        if activity_name == "agent_runtime.load_session_snapshot":
-            return {
-                "binding": {
-                    "workflowId": "wf-run-1:session:codex_cli",
-                    "taskRunId": "wf-run-1",
-                    "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 1,
-                    "runtimeId": "codex_cli",
-                    "executionProfileRef": "codex-default",
-                },
-                "status": "active",
-                "containerId": "container-1",
-                "threadId": "thread-1",
-                "activeTurnId": None,
-                "lastControlAction": None,
-                "lastControlReason": None,
-                "terminationRequested": False,
-            }
-        if activity_name == "agent_runtime.terminate_session":
-            return {
-                "sessionState": {
-                    "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 1,
-                    "containerId": "container-1",
-                    "threadId": "thread-1",
-                    "activeTurnId": None,
-                },
-                "status": "terminated",
-                "imageRef": "codex:latest",
-                "controlUrl": "docker-exec://container-1",
-                "metadata": {},
-            }
-        raise AssertionError(f"unexpected activity {activity_name}")
-
-    monkeypatch.setattr(
-        run_module.workflow,
-        "execute_activity",
-        fake_execute_activity,
-    )
     monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
     workflow._codex_session_handle = _FakeHandle()
@@ -196,69 +153,36 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert [name for name, _ in activity_calls] == [
-        "agent_runtime.load_session_snapshot",
-        "agent_runtime.terminate_session",
-    ]
-    assert signal_calls == [
+    assert update_calls == [
         (
-            "control_action",
+            "TerminateSession",
             {
-                "action": "terminate_session",
                 "reason": "success",
             },
         )
     ]
+    assert signal_calls == []
     assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
 
 
 @pytest.mark.asyncio
-async def test_run_termination_falls_back_to_session_signal_without_runtime_handles(
+async def test_run_termination_uses_typed_update_without_runtime_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
-    activity_calls: list[tuple[str, Any]] = []
     monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
 
     class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
-
-    async def fake_execute_activity(
-        activity_name: str,
-        payload: Any,
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        activity_calls.append((activity_name, payload))
-        if activity_name == "agent_runtime.load_session_snapshot":
-            return {
-                "binding": {
-                    "workflowId": "wf-run-1:session:codex_cli",
-                    "taskRunId": "wf-run-1",
-                    "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 1,
-                    "runtimeId": "codex_cli",
-                    "executionProfileRef": "codex-default",
-                },
-                "status": "terminating",
-                "containerId": None,
-                "threadId": None,
-                "activeTurnId": None,
-                "lastControlAction": "terminate_session",
-                "lastControlReason": "success",
-                "terminationRequested": True,
-            }
-        raise AssertionError(f"unexpected activity {activity_name}")
-
-    monkeypatch.setattr(
-        run_module.workflow,
-        "execute_activity",
-        fake_execute_activity,
-    )
 
     workflow._codex_session_handle = _FakeHandle()
     workflow._codex_session_binding = CodexManagedSessionBinding(
@@ -272,18 +196,15 @@ async def test_run_termination_falls_back_to_session_signal_without_runtime_hand
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert [name for name, _ in activity_calls] == [
-        "agent_runtime.load_session_snapshot",
-    ]
-    assert signal_calls == [
+    assert update_calls == [
         (
-            "control_action",
+            "TerminateSession",
             {
-                "action": "terminate_session",
                 "reason": "success",
             },
         )
     ]
+    assert signal_calls == []
 
 
 @pytest.mark.asyncio
@@ -292,9 +213,13 @@ async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
 
     class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
 
@@ -316,6 +241,7 @@ async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
+    assert update_calls == []
     assert signal_calls == [
         (
             "control_action",
@@ -330,15 +256,20 @@ async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
 
 
 @pytest.mark.asyncio
-async def test_run_termination_signals_session_when_terminate_activity_fails(
+async def test_run_termination_logs_when_terminate_update_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
     warnings: list[str] = []
 
     class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+            raise RuntimeError("terminate update failed")
+
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
 
@@ -346,35 +277,7 @@ async def test_run_termination_signals_session_when_terminate_activity_fails(
         def warning(self, message: str, *args: Any) -> None:
             warnings.append(message % args)
 
-    async def fake_execute_activity(
-        activity_name: str,
-        payload: Any,
-        **_kwargs: Any,
-    ) -> dict[str, Any]:
-        if activity_name == "agent_runtime.load_session_snapshot":
-            return {
-                "binding": {
-                    "workflowId": "wf-run-1:session:codex_cli",
-                    "taskRunId": "wf-run-1",
-                    "sessionId": "sess:wf-run-1:codex_cli",
-                    "sessionEpoch": 1,
-                    "runtimeId": "codex_cli",
-                    "executionProfileRef": "codex-default",
-                },
-                "status": "active",
-                "containerId": "container-1",
-                "threadId": "thread-1",
-                "activeTurnId": None,
-                "lastControlAction": None,
-                "lastControlReason": None,
-                "terminationRequested": False,
-            }
-        if activity_name == "agent_runtime.terminate_session":
-            raise RuntimeError("terminate failed")
-        raise AssertionError(f"unexpected activity {activity_name}")
-
     monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
-    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
 
     workflow._codex_session_handle = _FakeHandle()
@@ -389,18 +292,18 @@ async def test_run_termination_signals_session_when_terminate_activity_fails(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert signal_calls == [
+    assert update_calls == [
         (
-            "control_action",
+            "TerminateSession",
             {
-                "action": "terminate_session",
                 "reason": "success",
             },
         )
     ]
+    assert signal_calls == []
     assert warnings == [
-        "Task-scoped Codex terminate activity failed for sess:wf-run-1:codex_cli; "
-        "falling back to session signal: terminate failed"
+        "Task-scoped Codex terminate update failed for sess:wf-run-1:codex_cli: "
+        "terminate update failed"
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -9,6 +9,7 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
     MoonMindRunWorkflow,
 )
 
@@ -131,7 +132,7 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     def fake_patched(patch_id: str) -> bool:
         patch_calls.append(patch_id)
-        return True
+        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH
 
     class _FakeHandle:
         async def execute_update(self, update_name: str, payload: Any = None) -> None:
@@ -139,6 +140,7 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
+
     monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
     workflow._codex_session_handle = _FakeHandle()
@@ -162,27 +164,75 @@ async def test_run_terminates_active_task_scoped_codex_session(
         )
     ]
     assert signal_calls == []
-    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH]
+    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
 
 
 @pytest.mark.asyncio
-async def test_run_termination_uses_typed_update_without_runtime_handles(
+async def test_run_termination_uses_v1_patch_history_for_inflight_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
-    update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
-    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    activity_calls: list[tuple[str, Any]] = []
+    patch_calls: list[str] = []
+
+    def fake_patched(patch_id: str) -> bool:
+        patch_calls.append(patch_id)
+        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH
 
     class _FakeHandle:
-        async def execute_update(self, update_name: str, payload: Any = None) -> None:
-            update_calls.append((update_name, payload))
-
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.terminate_session":
+            return {
+                "sessionState": {
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "containerId": "container-1",
+                    "threadId": "thread-1",
+                    "activeTurnId": None,
+                },
+                "status": "terminated",
+                "imageRef": "codex:latest",
+                "controlUrl": "docker-exec://container-1",
+                "metadata": {},
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
     workflow._codex_session_handle = _FakeHandle()
     workflow._codex_session_binding = CodexManagedSessionBinding(
@@ -196,15 +246,101 @@ async def test_run_termination_uses_typed_update_without_runtime_handles(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert update_calls == [
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+        "agent_runtime.terminate_session",
+    ]
+    assert signal_calls == [
         (
-            "TerminateSession",
+            "control_action",
             {
+                "action": "terminate_session",
                 "reason": "success",
             },
         )
     ]
-    assert signal_calls == []
+    assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
+        RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
+async def test_run_termination_uses_v1_signal_fallback_without_runtime_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    activity_calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    )
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        activity_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "terminating",
+                "containerId": None,
+                "threadId": None,
+                "activeTurnId": None,
+                "lastControlAction": "terminate_session",
+                "lastControlReason": "success",
+                "terminationRequested": True,
+            }
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert [name for name, _ in activity_calls] == [
+        "agent_runtime.load_session_snapshot",
+    ]
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -277,7 +413,11 @@ async def test_run_termination_logs_when_terminate_update_fails(
         def warning(self, message: str, *args: Any) -> None:
             warnings.append(message % args)
 
-    monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: True)
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
+    )
     monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
 
     workflow._codex_session_handle = _FakeHandle()
@@ -300,10 +440,99 @@ async def test_run_termination_logs_when_terminate_update_fails(
             },
         )
     ]
-    assert signal_calls == []
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
     assert warnings == [
         "Task-scoped Codex terminate update failed for sess:wf-run-1:codex_cli: "
         "terminate update failed"
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
+async def test_run_termination_signals_session_when_v1_terminate_activity_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    signal_calls: list[tuple[str, Any]] = []
+    warnings: list[str] = []
+
+    class _FakeHandle:
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    class _FakeLogger:
+        def warning(self, message: str, *args: Any) -> None:
+            warnings.append(message % args)
+
+    async def fake_execute_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        if activity_name == "agent_runtime.load_session_snapshot":
+            return {
+                "binding": {
+                    "workflowId": "wf-run-1:session:codex_cli",
+                    "taskRunId": "wf-run-1",
+                    "sessionId": "sess:wf-run-1:codex_cli",
+                    "sessionEpoch": 1,
+                    "runtimeId": "codex_cli",
+                    "executionProfileRef": "codex-default",
+                },
+                "status": "active",
+                "containerId": "container-1",
+                "threadId": "thread-1",
+                "activeTurnId": None,
+                "lastControlAction": None,
+                "lastControlReason": None,
+                "terminationRequested": False,
+            }
+        if activity_name == "agent_runtime.terminate_session":
+            raise RuntimeError("terminate failed")
+        raise AssertionError(f"unexpected activity {activity_name}")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    )
+    monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
+
+    workflow._codex_session_handle = _FakeHandle()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert signal_calls == [
+        (
+            "control_action",
+            {
+                "action": "terminate_session",
+                "reason": "success",
+            },
+        )
+    ]
+    assert warnings == [
+        "Task-scoped Codex terminate activity failed for sess:wf-run-1:codex_cli; "
+        "falling back to session signal: terminate failed"
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None


### PR DESCRIPTION
## Summary
- route patched task-scoped Codex session termination through the `TerminateSession` workflow update instead of the legacy `control_action` signal
- keep the legacy signal path only for unpatched histories guarded by `RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH`
- update unit coverage to assert typed-update behavior for patched histories and legacy-signal behavior only for the compatibility path

## Verification
- `./.venv/bin/pytest -q tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/api/routers/test_task_runs.py`
- `./tools/test_unit.sh`