### PR TITLE
[codex] Fix codex managed-session turn completion detection

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -47,6 +47,7 @@ _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = (
 _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
+_ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -470,27 +471,47 @@ class CodexManagedSessionRuntime:
         return state
 
     @staticmethod
-    def _extract_assistant_text(thread_payload: Mapping[str, Any]) -> str:
+    def _assistant_text_from_turn_payload(turn_payload: Mapping[str, Any]) -> str:
+        items = turn_payload.get("items")
+        if not isinstance(items, list):
+            return ""
+        for item in reversed(items):
+            if not isinstance(item, Mapping):
+                continue
+            if item.get("type") != "agentMessage":
+                continue
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+        return ""
+
+    @classmethod
+    def _extract_assistant_text(
+        cls,
+        thread_payload: Mapping[str, Any],
+        *,
+        vendor_turn_id: str | None = None,
+    ) -> str:
         thread = thread_payload.get("thread")
         if not isinstance(thread, Mapping):
             return ""
         turns = thread.get("turns")
         if not isinstance(turns, list):
             return ""
+        if vendor_turn_id:
+            turn_payload = cls._find_turn_payload(
+                thread_payload,
+                vendor_turn_id=vendor_turn_id,
+            )
+            if isinstance(turn_payload, Mapping):
+                return cls._assistant_text_from_turn_payload(turn_payload)
+            return ""
         for turn in reversed(turns):
             if not isinstance(turn, Mapping):
                 continue
-            items = turn.get("items")
-            if not isinstance(items, list):
-                continue
-            for item in reversed(items):
-                if not isinstance(item, Mapping):
-                    continue
-                if item.get("type") != "agentMessage":
-                    continue
-                text = item.get("text")
-                if isinstance(text, str) and text.strip():
-                    return text.strip()
+            text = cls._assistant_text_from_turn_payload(turn)
+            if text:
+                return text
         return ""
 
     @staticmethod
@@ -528,20 +549,70 @@ class CodexManagedSessionRuntime:
             if not isinstance(item, Mapping):
                 continue
             item_type = str(item.get("type") or "").strip().lower()
-            if item_type not in {"output_text", "input_text", "text"}:
+            if item_type not in {"output_text", "text"}:
                 continue
             text = item.get("text")
             if isinstance(text, str) and text.strip():
                 parts.append(text.strip())
         return "\n".join(parts).strip()
 
-    def _extract_assistant_text_from_rollout(self, vendor_thread_path: str | None) -> str:
-        rollout_path = self._existing_thread_path(vendor_thread_path)
+    @staticmethod
+    def _payload_references_turn(payload: Any, vendor_turn_id: str) -> bool:
+        if not vendor_turn_id:
+            return False
+        if isinstance(payload, Mapping):
+            direct_turn_id = str(
+                payload.get("turnId") or payload.get("turn_id") or ""
+            ).strip()
+            if direct_turn_id == vendor_turn_id:
+                return True
+            turn_payload = payload.get("turn")
+            if isinstance(turn_payload, Mapping):
+                turn_id = str(turn_payload.get("id") or "").strip()
+                if turn_id == vendor_turn_id:
+                    return True
+            for nested_key in ("payload", "data", "delta", "item", "event"):
+                if CodexManagedSessionRuntime._payload_references_turn(
+                    payload.get(nested_key),
+                    vendor_turn_id,
+                ):
+                    return True
+            return False
+        if isinstance(payload, list):
+            return any(
+                CodexManagedSessionRuntime._payload_references_turn(item, vendor_turn_id)
+                for item in payload
+            )
+        return False
+
+    def _allowed_rollout_path(self, path_value: str | None) -> str | None:
+        normalized = self._normalized_thread_path(path_value)
+        if normalized is None:
+            return None
+        candidate = Path(normalized)
+        try:
+            resolved = candidate.resolve()
+            sessions_root = (self._codex_home_path / "sessions").resolve()
+            resolved.relative_to(sessions_root)
+        except (OSError, RuntimeError, ValueError):
+            return None
+        return str(resolved) if resolved.is_file() else None
+
+    def _extract_assistant_text_from_rollout(
+        self,
+        vendor_thread_path: str | None,
+        *,
+        vendor_turn_id: str,
+    ) -> str:
+        rollout_path = self._allowed_rollout_path(vendor_thread_path)
         if rollout_path is None:
             return ""
         last_text = ""
         try:
-            with Path(rollout_path).open(encoding="utf-8") as handle:
+            rollout_file = Path(rollout_path)
+            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
+                return ""
+            with rollout_file.open(encoding="utf-8") as handle:
                 for raw_line in handle:
                     stripped = raw_line.strip()
                     if not stripped:
@@ -551,6 +622,8 @@ class CodexManagedSessionRuntime:
                     except json.JSONDecodeError:
                         continue
                     if not isinstance(payload, Mapping):
+                        continue
+                    if not self._payload_references_turn(payload, vendor_turn_id):
                         continue
                     entry_type = str(payload.get("type") or "").strip().lower()
                     if entry_type == "response_item":
@@ -583,7 +656,7 @@ class CodexManagedSessionRuntime:
             return ""
         return last_text
 
-    def _resolved_vendor_thread_path(
+    def _resolved_rollout_path(
         self,
         *,
         state: CodexSessionRuntimeState,
@@ -593,13 +666,13 @@ class CodexManagedSessionRuntime:
         runtime_path = None
         if isinstance(thread, Mapping):
             runtime_path = self._normalized_thread_path(thread.get("path"))
-        existing_runtime_path = self._existing_thread_path(runtime_path)
-        if existing_runtime_path is not None:
-            state.vendor_thread_path = existing_runtime_path
-            return existing_runtime_path
-        existing_state_path = self._existing_thread_path(state.vendor_thread_path)
-        if existing_state_path is not None:
-            return existing_state_path
+        allowed_runtime_path = self._allowed_rollout_path(runtime_path)
+        if allowed_runtime_path is not None:
+            state.vendor_thread_path = allowed_runtime_path
+            return allowed_runtime_path
+        allowed_state_path = self._allowed_rollout_path(state.vendor_thread_path)
+        if allowed_state_path is not None:
+            return allowed_state_path
         recovered_path = self._find_vendor_thread_path(state.vendor_thread_id)
         if recovered_path is not None:
             state.vendor_thread_path = recovered_path
@@ -610,15 +683,22 @@ class CodexManagedSessionRuntime:
         *,
         state: CodexSessionRuntimeState,
         thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
     ) -> str:
-        assistant_text = self._extract_assistant_text(thread_payload)
+        assistant_text = self._extract_assistant_text(
+            thread_payload,
+            vendor_turn_id=vendor_turn_id,
+        )
         if assistant_text:
             return assistant_text
-        vendor_thread_path = self._resolved_vendor_thread_path(
+        vendor_thread_path = self._resolved_rollout_path(
             state=state,
             thread_payload=thread_payload,
         )
-        return self._extract_assistant_text_from_rollout(vendor_thread_path)
+        return self._extract_assistant_text_from_rollout(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+        )
 
     @staticmethod
     def _find_turn_payload(
@@ -658,8 +738,10 @@ class CodexManagedSessionRuntime:
                 outcome = self._terminal_turn_outcome(turn_payload)
                 if outcome is not None:
                     return thread_payload, outcome
-            elif self._thread_status_type(thread_payload) == "idle":
-                return thread_payload, ("completed", None)
+            else:
+                thread_outcome = self._terminal_thread_outcome(thread_payload)
+                if thread_outcome is not None:
+                    return thread_payload, thread_outcome
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -756,6 +838,23 @@ class CodexManagedSessionRuntime:
             return "failed", error_text
         return None
 
+    @classmethod
+    def _terminal_thread_outcome(
+        cls,
+        thread_payload: Mapping[str, Any],
+    ) -> tuple[str, str | None] | None:
+        status_type = cls._thread_status_type(thread_payload)
+        if status_type == "idle":
+            return "completed", None
+        if status_type in {"failed", "error"}:
+            return "failed", cls._thread_status_reason(thread_payload)
+        if status_type in {"interrupted", "cancelled", "canceled"}:
+            return (
+                "interrupted",
+                cls._thread_status_reason(thread_payload) or status_type,
+            )
+        return None
+
     def _finalize_turn(
         self,
         *,
@@ -820,24 +919,18 @@ class CodexManagedSessionRuntime:
             if outcome is None:
                 return state
         else:
-            status_type = self._thread_status_type(thread_payload)
-            if status_type == "idle":
-                outcome = ("completed", None)
-            elif status_type in {"failed", "error"}:
-                outcome = ("failed", self._thread_status_reason(thread_payload))
-            elif status_type in {"interrupted", "cancelled", "canceled"}:
-                outcome = (
-                    "interrupted",
-                    self._thread_status_reason(thread_payload) or status_type,
-                )
-            else:
+            outcome = self._terminal_thread_outcome(thread_payload)
+            if outcome is None:
                 return state
 
         status, error_text = outcome
-        assistant_text = self._assistant_text_for_completed_turn(
-            state=state,
-            thread_payload=thread_payload,
-        )
+        assistant_text = ""
+        if status == "completed":
+            assistant_text = self._assistant_text_for_completed_turn(
+                state=state,
+                thread_payload=thread_payload,
+                vendor_turn_id=active_turn_id,
+            )
         if status == "completed" and not assistant_text:
             error_text = "codex app-server turn/completed produced no assistant output"
             self._append_spool(
@@ -985,23 +1078,26 @@ class CodexManagedSessionRuntime:
                 metadata={"reason": message},
             )
 
-        assistant_text = self._assistant_text_for_completed_turn(
-            state=state,
-            thread_payload=thread_payload,
-        )
+        assistant_text = ""
         metadata: dict[str, Any] = {}
-        if status == "completed" and not assistant_text:
-            error_text = "codex app-server turn/completed produced no assistant output"
-            self._append_spool(
-                "stderr",
-                (
-                    "codex app-server turn completed without assistant output: "
-                    f"{vendor_turn_id}\n"
-                ),
+        if status == "completed":
+            assistant_text = self._assistant_text_for_completed_turn(
+                state=state,
+                thread_payload=thread_payload,
+                vendor_turn_id=vendor_turn_id,
             )
-            status = "failed"
-        if assistant_text:
-            metadata["assistantText"] = assistant_text
+            if not assistant_text:
+                error_text = "codex app-server turn/completed produced no assistant output"
+                self._append_spool(
+                    "stderr",
+                    (
+                        "codex app-server turn completed without assistant output: "
+                        f"{vendor_turn_id}\n"
+                    ),
+                )
+                status = "failed"
+            else:
+                metadata["assistantText"] = assistant_text
         if error_text:
             metadata["reason"] = error_text
         self._finalize_turn(

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -494,6 +494,133 @@ class CodexManagedSessionRuntime:
         return ""
 
     @staticmethod
+    def _thread_status_type(thread_payload: Mapping[str, Any]) -> str:
+        thread = thread_payload.get("thread")
+        if not isinstance(thread, Mapping):
+            return ""
+        status = thread.get("status")
+        if not isinstance(status, Mapping):
+            return ""
+        return str(status.get("type") or "").strip().lower()
+
+    @staticmethod
+    def _thread_status_reason(thread_payload: Mapping[str, Any]) -> str | None:
+        thread = thread_payload.get("thread")
+        if not isinstance(thread, Mapping):
+            return None
+        status = thread.get("status")
+        if not isinstance(status, Mapping):
+            return None
+        for field_name in ("reason", "message", "error"):
+            value = status.get(field_name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    @staticmethod
+    def _content_text(content: Any) -> str:
+        if isinstance(content, str):
+            return content.strip()
+        if not isinstance(content, list):
+            return ""
+        parts: list[str] = []
+        for item in content:
+            if not isinstance(item, Mapping):
+                continue
+            item_type = str(item.get("type") or "").strip().lower()
+            if item_type not in {"output_text", "input_text", "text"}:
+                continue
+            text = item.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+        return "\n".join(parts).strip()
+
+    def _extract_assistant_text_from_rollout(self, vendor_thread_path: str | None) -> str:
+        rollout_path = self._existing_thread_path(vendor_thread_path)
+        if rollout_path is None:
+            return ""
+        last_text = ""
+        try:
+            with Path(rollout_path).open(encoding="utf-8") as handle:
+                for raw_line in handle:
+                    stripped = raw_line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        payload = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(payload, Mapping):
+                        continue
+                    entry_type = str(payload.get("type") or "").strip().lower()
+                    if entry_type == "response_item":
+                        response_payload = payload.get("payload")
+                        if not isinstance(response_payload, Mapping):
+                            continue
+                        if (
+                            str(response_payload.get("type") or "").strip().lower()
+                            != "message"
+                            or str(response_payload.get("role") or "").strip().lower()
+                            != "assistant"
+                        ):
+                            continue
+                        text = self._content_text(response_payload.get("content"))
+                        if text:
+                            last_text = text
+                    elif entry_type == "event_msg":
+                        event_payload = payload.get("payload")
+                        if not isinstance(event_payload, Mapping):
+                            continue
+                        if (
+                            str(event_payload.get("type") or "").strip().lower()
+                            != "agent_message"
+                        ):
+                            continue
+                        text = str(event_payload.get("message") or "").strip()
+                        if text:
+                            last_text = text
+        except OSError:
+            return ""
+        return last_text
+
+    def _resolved_vendor_thread_path(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+    ) -> str | None:
+        thread = thread_payload.get("thread")
+        runtime_path = None
+        if isinstance(thread, Mapping):
+            runtime_path = self._normalized_thread_path(thread.get("path"))
+        existing_runtime_path = self._existing_thread_path(runtime_path)
+        if existing_runtime_path is not None:
+            state.vendor_thread_path = existing_runtime_path
+            return existing_runtime_path
+        existing_state_path = self._existing_thread_path(state.vendor_thread_path)
+        if existing_state_path is not None:
+            return existing_state_path
+        recovered_path = self._find_vendor_thread_path(state.vendor_thread_id)
+        if recovered_path is not None:
+            state.vendor_thread_path = recovered_path
+        return recovered_path
+
+    def _assistant_text_for_completed_turn(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+    ) -> str:
+        assistant_text = self._extract_assistant_text(thread_payload)
+        if assistant_text:
+            return assistant_text
+        vendor_thread_path = self._resolved_vendor_thread_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        return self._extract_assistant_text_from_rollout(vendor_thread_path)
+
+    @staticmethod
     def _find_turn_payload(
         thread_payload: Mapping[str, Any],
         *,
@@ -531,6 +658,8 @@ class CodexManagedSessionRuntime:
                 outcome = self._terminal_turn_outcome(turn_payload)
                 if outcome is not None:
                     return thread_payload, outcome
+            elif self._thread_status_type(thread_payload) == "idle":
+                return thread_payload, ("completed", None)
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -685,15 +814,30 @@ class CodexManagedSessionRuntime:
             thread_payload,
             vendor_turn_id=active_turn_id,
         )
-        if not isinstance(turn_payload, Mapping):
-            return state
-
-        outcome = self._terminal_turn_outcome(turn_payload)
-        if outcome is None:
-            return state
+        outcome = None
+        if isinstance(turn_payload, Mapping):
+            outcome = self._terminal_turn_outcome(turn_payload)
+            if outcome is None:
+                return state
+        else:
+            status_type = self._thread_status_type(thread_payload)
+            if status_type == "idle":
+                outcome = ("completed", None)
+            elif status_type in {"failed", "error"}:
+                outcome = ("failed", self._thread_status_reason(thread_payload))
+            elif status_type in {"interrupted", "cancelled", "canceled"}:
+                outcome = (
+                    "interrupted",
+                    self._thread_status_reason(thread_payload) or status_type,
+                )
+            else:
+                return state
 
         status, error_text = outcome
-        assistant_text = self._extract_assistant_text(thread_payload)
+        assistant_text = self._assistant_text_for_completed_turn(
+            state=state,
+            thread_payload=thread_payload,
+        )
         if status == "completed" and not assistant_text:
             error_text = "codex app-server turn/completed produced no assistant output"
             self._append_spool(
@@ -841,7 +985,10 @@ class CodexManagedSessionRuntime:
                 metadata={"reason": message},
             )
 
-        assistant_text = self._extract_assistant_text(thread_payload)
+        assistant_text = self._assistant_text_for_completed_turn(
+            state=state,
+            thread_payload=thread_payload,
+        )
         metadata: dict[str, Any] = {}
         if status == "completed" and not assistant_text:
             error_text = "codex app-server turn/completed produced no assistant output"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -25,7 +25,10 @@ def _write_fake_app_server(
     completion_notification_method: str | None = "turn/completed",
     complete_turn_on_read: bool = True,
     omit_turns_on_read: bool = False,
+    omit_turns_when_incomplete: bool = False,
     assistant_text: str = "OK",
+    thread_status_type: str = "idle",
+    thread_status_reason: str | None = None,
     fail_thread_resume: bool = False,
     resume_requires_existing_rollout_path: bool = False,
     start_thread_id: str = "vendor-thread-1",
@@ -60,7 +63,10 @@ START_THREAD_PATH = __START_THREAD_PATH__
 COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
 COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
 OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
+OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
+THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
+THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
 turn_completed = False
 
 for line in sys.stdin:
@@ -211,9 +217,10 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
+        should_omit_turns = OMIT_TURNS_ON_READ and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
         turns = []
         preview = ""
-        if not OMIT_TURNS_ON_READ or not turn_completed:
+        if not should_omit_turns:
             turns = [
                 {
                     "id": "vendor-turn-1",
@@ -223,6 +230,9 @@ __COMPLETION_BLOCK__
                 }
             ]
             preview = ASSISTANT_TEXT
+        status_payload = {"type": THREAD_STATUS_TYPE}
+        if THREAD_STATUS_REASON:
+            status_payload["reason"] = THREAD_STATUS_REASON
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {
@@ -233,7 +243,7 @@ __COMPLETION_BLOCK__
                     "modelProvider": "openai",
                     "createdAt": 1,
                     "updatedAt": 2,
-                    "status": {"type": "idle"},
+                    "status": status_payload,
                     "path": f"/tmp/{thread_id}.jsonl",
                     "cwd": "/work/repo",
                     "cliVersion": "0.118.0",
@@ -274,9 +284,15 @@ __COMPLETION_BLOCK__
             "True" if complete_turn_on_read else "False",
         )
         .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
+        .replace(
+            "__OMIT_TURNS_WHEN_INCOMPLETE__",
+            "True" if omit_turns_when_incomplete else "False",
+        )
         .replace("__START_THREAD_ID__", repr(start_thread_id))
         .replace("__START_THREAD_PATH__", repr(start_thread_path))
         .replace("__ASSISTANT_TEXT__", repr(assistant_text))
+        .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
+        .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
         .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )
@@ -542,16 +558,30 @@ def test_runtime_send_turn_completes_via_thread_read_without_notification(
 def test_runtime_send_turn_completes_when_thread_read_omits_turns(
     tmp_path: Path,
 ) -> None:
-    transcript_path = tmp_path / "vendor-thread-1.jsonl"
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
     transcript_path.write_text(
         json.dumps(
             {
                 "timestamp": "2026-04-10T07:21:32.088Z",
                 "type": "response_item",
+                "turnId": "vendor-turn-1",
                 "payload": {
                     "type": "message",
                     "role": "assistant",
                     "content": [
+                        {
+                            "type": "input_text",
+                            "text": "Ignore this echoed user input",
+                        },
                         {
                             "type": "output_text",
                             "text": "Recovered from rollout transcript",
@@ -569,7 +599,6 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
     )
-    request = _launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -606,6 +635,197 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
     )
     assert handle.status == "ready"
     assert handle.metadata["lastAssistantText"] == "Recovered from rollout transcript"
+
+
+def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.088Z",
+                "type": "response_item",
+                "turnId": "vendor-turn-0",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Stale text from a previous turn",
+                        }
+                    ],
+                    "phase": "final",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert (
+        response.metadata["reason"]
+        == "codex app-server turn/completed produced no assistant output"
+    )
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "failed"
+    assert handle.metadata["lastTurnStatus"] == "failed"
+
+
+def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = tmp_path / "vendor-thread-1.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.088Z",
+                "type": "response_item",
+                "turnId": "vendor-turn-1",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Do not read arbitrary rollout files",
+                        }
+                    ],
+                    "phase": "final",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert (
+        response.metadata["reason"]
+        == "codex app-server turn/completed produced no assistant output"
+    )
+
+
+@pytest.mark.parametrize(
+    ("thread_status_type", "thread_status_reason", "expected_status", "expected_reason"),
+    [
+        ("failed", "thread failure", "failed", "thread failure"),
+        ("interrupted", "operator stopped", "interrupted", "operator stopped"),
+        ("cancelled", None, "interrupted", "cancelled"),
+    ],
+)
+def test_runtime_send_turn_uses_terminal_thread_status_when_turn_missing(
+    tmp_path: Path,
+    thread_status_type: str,
+    thread_status_reason: str | None,
+    expected_status: str,
+    expected_reason: str,
+) -> None:
+    script = _write_fake_app_server(
+        tmp_path,
+        completion_notification_method=None,
+        complete_turn_on_read=False,
+        omit_turns_on_read=True,
+        omit_turns_when_incomplete=True,
+        thread_status_type=thread_status_type,
+        thread_status_reason=thread_status_reason,
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == expected_status
+    assert response.metadata["reason"] == expected_reason
 
 
 def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -24,6 +24,7 @@ def _write_fake_app_server(
     *,
     completion_notification_method: str | None = "turn/completed",
     complete_turn_on_read: bool = True,
+    omit_turns_on_read: bool = False,
     assistant_text: str = "OK",
     fail_thread_resume: bool = False,
     resume_requires_existing_rollout_path: bool = False,
@@ -58,6 +59,7 @@ START_THREAD_ID = __START_THREAD_ID__
 START_THREAD_PATH = __START_THREAD_PATH__
 COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
 COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
+OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
 turn_completed = False
 
@@ -209,12 +211,24 @@ __COMPLETION_BLOCK__
             turn_items = [
                 {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
             ]
+        turns = []
+        preview = ""
+        if not OMIT_TURNS_ON_READ or not turn_completed:
+            turns = [
+                {
+                    "id": "vendor-turn-1",
+                    "status": turn_status,
+                    "error": None,
+                    "items": turn_items,
+                }
+            ]
+            preview = ASSISTANT_TEXT
         sys.stdout.write(json.dumps({
             "id": msg_id,
             "result": {
                 "thread": {
                     "id": thread_id,
-                    "preview": ASSISTANT_TEXT,
+                    "preview": preview,
                     "ephemeral": False,
                     "modelProvider": "openai",
                     "createdAt": 1,
@@ -228,14 +242,7 @@ __COMPLETION_BLOCK__
                     "agentRole": None,
                     "gitInfo": None,
                     "name": None,
-                    "turns": [
-                        {
-                            "id": "vendor-turn-1",
-                            "status": turn_status,
-                            "error": None,
-                            "items": turn_items,
-                        }
-                    ],
+                    "turns": turns,
                 }
             },
         }) + "\\n")
@@ -266,6 +273,7 @@ __COMPLETION_BLOCK__
             "__COMPLETE_TURN_ON_READ__",
             "True" if complete_turn_on_read else "False",
         )
+        .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
         .replace("__START_THREAD_ID__", repr(start_thread_id))
         .replace("__START_THREAD_PATH__", repr(start_thread_path))
         .replace("__ASSISTANT_TEXT__", repr(assistant_text))
@@ -529,6 +537,75 @@ def test_runtime_send_turn_completes_via_thread_read_without_notification(
     assert handle.status == "ready"
     assert handle.session_state.active_turn_id is None
     assert handle.metadata["lastAssistantText"] == "OK"
+
+
+def test_runtime_send_turn_completes_when_thread_read_omits_turns(
+    tmp_path: Path,
+) -> None:
+    transcript_path = tmp_path / "vendor-thread-1.jsonl"
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.088Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Recovered from rollout transcript",
+                        }
+                    ],
+                    "phase": "final",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "Recovered from rollout transcript"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == "Recovered from rollout transcript"
 
 
 def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(


### PR DESCRIPTION
## What changed
- updated the Codex managed-session runtime to treat `thread.status.type == "idle"` as terminal when `thread/read` omits the completed turn payload
- added fallback assistant-text recovery from the rollout transcript when the app-server no longer returns turn items
- added a regression test that simulates the current Codex CLI behavior where `thread/read` returns `turns: []` after completion

## Why
Codex managed sessions were getting stuck on the first `send_turn` step even after the turn had actually completed. The current Codex CLI/app-server contract can return an idle thread with no matching turn in `thread.turns[]`. Our runtime only trusted `turns[]`, so it never cleared the active turn and the workflow kept heartbeating forever.

## Impact
- Codex managed workflows can advance past the first step again when completion is only visible via thread status and rollout transcript state
- the runtime still preserves the existing in-progress path when a turn payload is present but not terminal

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- rebuilt `ghcr.io/moonladderstudios/moonmind:latest` locally so new managed session containers pick up the patched runtime

## Notes
The originally failed workflow `mm:6891fe26-4ea1-424b-9a64-5aa39b8d6a11` is terminal and not recoverable in place; new executions need to run on the patched image.