### PR TITLE
[codex] Fix stuck managed session cancel

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -388,6 +388,25 @@ class MoonMindAgentRun:
 
         return result.model_copy(update={"metadata": metadata})
 
+    def _managed_start_failure_result(
+        self,
+        *,
+        request: AgentExecutionRequest,
+        error: Exception,
+    ) -> AgentRunResult:
+        summary = str(error).strip() or "Managed agent failed before execution started."
+        metadata: dict[str, Any] = {"phase": "start"}
+        if request.managed_session is not None:
+            metadata["managedSession"] = request.managed_session.model_dump(
+                mode="json",
+                by_alias=True,
+            )
+        return AgentRunResult(
+            summary=summary,
+            failureClass="execution_error",
+            metadata=metadata,
+        )
+
     @staticmethod
     def _uses_codex_session_adapter(request: AgentExecutionRequest) -> bool:
         return request.agent_kind == "managed" and request.managed_session is not None
@@ -1248,20 +1267,37 @@ class MoonMindAgentRun:
                             type="ProfileResolutionError",
                             non_retryable=True,
                         ) from exc
-                    self.run_id = handle.run_id
-                    self.run_status = handle.status
-                    poll_interval = handle.poll_hint_seconds or 10
-                    if (
-                        uses_codex_session_adapter
-                        and handle.status in _TERMINAL_RUN_STATUSES
-                    ):
-                        self.final_result = await self._fetch_managed_result(
+                    except RuntimeError as exc:
+                        self._get_logger().warning(
+                            "Managed agent start failed",
+                            extra={
+                                "agent_id": request.agent_id,
+                                "workflow_id": workflow.info().workflow_id,
+                                "error": str(exc),
+                            },
+                        )
+                        self.run_status = RunStatus.failed
+                        self.final_result = self._managed_start_failure_result(
                             request=request,
-                            adapter=adapter,
-                            uses_codex_session_adapter=uses_codex_session_adapter,
-                            use_managed_status_activity=use_managed_status_activity,
+                            error=exc,
                         )
                         skip_poll_and_fetch = True
+                        handle = None
+                    if handle is not None:
+                        self.run_id = handle.run_id
+                        self.run_status = handle.status
+                        poll_interval = handle.poll_hint_seconds or 10
+                        if (
+                            uses_codex_session_adapter
+                            and handle.status in _TERMINAL_RUN_STATUSES
+                        ):
+                            self.final_result = await self._fetch_managed_result(
+                                request=request,
+                                adapter=adapter,
+                                uses_codex_session_adapter=uses_codex_session_adapter,
+                                use_managed_status_activity=use_managed_status_activity,
+                            )
+                            skip_poll_and_fetch = True
 
                 elif request.agent_kind == "external":
                     # Validate adapter availability and resolve execution style.

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
         AgentRunHandle,
         AgentRunResult,
         AgentRunStatus as AgentRunStatusModel,
+        _MAX_SUMMARY_CHARS,
     )
     from moonmind.workflows.adapters.agent_adapter import AgentAdapter
     from moonmind.workflows.adapters.managed_agent_adapter import (
@@ -394,7 +395,11 @@ class MoonMindAgentRun:
         request: AgentExecutionRequest,
         error: Exception,
     ) -> AgentRunResult:
-        summary = str(error).strip() or "Managed agent failed before execution started."
+        summary = str(error).strip()
+        if len(summary) > _MAX_SUMMARY_CHARS:
+            summary = summary[: _MAX_SUMMARY_CHARS - 3] + "..."
+        if not summary:
+            summary = "Managed agent failed before execution started."
         metadata: dict[str, Any] = {"phase": "start"}
         if request.managed_session is not None:
             metadata["managedSession"] = request.managed_session.model_dump(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -11,6 +11,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunHandle,
     AgentRunResult,
     AgentRunStatus,
+    _MAX_SUMMARY_CHARS,
 )
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
@@ -630,6 +631,106 @@ async def test_agent_run_managed_session_start_runtime_error_returns_failed_resu
             "profile_id": "codex-default",
         },
     )
+
+
+async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            raise RuntimeError("managed start failed: " + ("x" * 5000))
+
+        async def status(self, run_id: str) -> AgentRunStatus:
+            raise AssertionError("status should not be polled after start failure")
+
+        async def fetch_result(self, run_id: str) -> AgentRunResult:
+            raise AssertionError("fetch_result should not run after start failure")
+
+        async def cancel(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="canceled",
+            )
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "CodexSessionAdapter",
+        _FakeCodexSessionAdapter,
+    )
+    monkeypatch.setattr(
+        run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal
+    )
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+
+    result = await run.run(_managed_session_request())
+
+    assert result.failure_class == "execution_error"
+    assert result.summary is not None
+    assert len(result.summary) == _MAX_SUMMARY_CHARS
+    assert result.summary.endswith("...")
+    assert result.summary.startswith("managed start failed: ")
 
 
 async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -518,6 +518,120 @@ async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_
     assert fetch_payload["head_branch"] == "feature/recover-detached-head"
 
 
+async def test_agent_run_managed_session_start_runtime_error_returns_failed_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+    manager_signals: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            raise RuntimeError(
+                "codex app-server request thread/resume failed: "
+                "{'code': -32600, 'message': 'no rollout found for thread id thread-1'}"
+            )
+
+        async def status(self, run_id: str) -> AgentRunStatus:
+            raise AssertionError("status should not be polled after start failure")
+
+        async def fetch_result(self, run_id: str) -> AgentRunResult:
+            raise AssertionError("fetch_result should not run after start failure")
+
+        async def cancel(self, run_id: str) -> AgentRunStatus:
+            return AgentRunStatus(
+                runId=run_id,
+                agentKind="managed",
+                agentId="codex",
+                status="canceled",
+            )
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            manager_signals.append((signal_name, payload))
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = execution_profile_ref or "codex-default"
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        return 1
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(
+        agent_run_module,
+        "ManagedAgentAdapter",
+        _FakeManagedAgentAdapter,
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "CodexSessionAdapter",
+        _FakeCodexSessionAdapter,
+    )
+    monkeypatch.setattr(
+        run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal
+    )
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+
+    result = await run.run(_managed_session_request())
+
+    assert result.failure_class == "execution_error"
+    assert "no rollout found for thread id" in result.summary
+    assert result.metadata["childWorkflowId"] == "wf-agent-run-1"
+    assert result.metadata["childRunId"] == "run-1"
+    assert result.metadata["taskRunId"] == "wf-task-1"
+    assert [name for name, _payload in routed_calls] == ["agent_runtime.publish_artifacts"]
+    assert manager_signals[-1] == (
+        "release_slot",
+        {
+            "requester_workflow_id": "wf-agent-run-1",
+            "profile_id": "codex-default",
+        },
+    )
+
+
 async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- convert managed-session startup `RuntimeError`s into a failed `AgentRunResult` instead of letting the workflow fail before execution starts
- keep the normal managed-run metadata, artifact publication, and slot-release path intact when startup fails
- add a workflow regression test covering the Codex session startup failure path

## Why

Managed Codex session startup could raise before returning a run handle, which bypassed the normal result-handling path. That left the workflow without a structured execution failure result and could strand cleanup/cancellation behavior.

## Impact

Managed-session runs now fail fast with a normal `execution_error` result when startup cannot resume the remote thread, making the failure visible to operators and allowing the workflow to complete cleanup consistently.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`