### PR TITLE
[codex] Fix Codex rollout task-complete recovery

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -644,12 +644,13 @@ class CodexManagedSessionRuntime:
                         event_payload = payload.get("payload")
                         if not isinstance(event_payload, Mapping):
                             continue
-                        if (
-                            str(event_payload.get("type") or "").strip().lower()
-                            != "agent_message"
-                        ):
+                        event_type = str(event_payload.get("type") or "").strip().lower()
+                        if event_type == "agent_message":
+                            text = str(event_payload.get("message") or "").strip()
+                        elif event_type == "task_complete":
+                            text = str(event_payload.get("last_agent_message") or "").strip()
+                        else:
                             continue
-                        text = str(event_payload.get("message") or "").strip()
                         if text:
                             last_text = text
         except OSError:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers."""

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from moonmind.schemas.managed_session_models import LaunchCodexManagedSessionRequest
+
+
+def write_fake_app_server(
+    tmp_path: Path,
+    *,
+    completion_notification_method: str | None = "turn/completed",
+    complete_turn_on_read: bool = True,
+    omit_turns_on_read: bool = False,
+    omit_turns_when_incomplete: bool = False,
+    assistant_text: str = "OK",
+    thread_status_type: str = "idle",
+    thread_status_reason: str | None = None,
+    fail_thread_resume: bool = False,
+    resume_requires_existing_rollout_path: bool = False,
+    start_thread_id: str = "vendor-thread-1",
+    start_thread_path: str | None = "/tmp/vendor-thread-1.jsonl",
+    interrupt_record_path: Path | None = None,
+    codex_home_record_path: Path | None = None,
+) -> Path:
+    script = tmp_path / "fake_app_server.py"
+    completion_block = """
+        turn_completed = True
+        sys.stdout.write(json.dumps({
+            "method": COMPLETION_NOTIFICATION_METHOD,
+            "params": {
+                "threadId": thread_id,
+                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
+            },
+        }) + "\\n")
+""".rstrip()
+    if not completion_notification_method:
+        completion_block = ""
+    script_template = """
+import json
+import os
+import sys
+
+INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
+CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
+FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
+RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
+START_THREAD_ID = __START_THREAD_ID__
+START_THREAD_PATH = __START_THREAD_PATH__
+COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
+COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
+OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
+OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
+ASSISTANT_TEXT = __ASSISTANT_TEXT__
+THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
+THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
+turn_completed = False
+
+for line in sys.stdin:
+    message = json.loads(line)
+    msg_id = message.get("id")
+    method = message.get("method")
+    if method == "initialize":
+        capabilities = message["params"].get("capabilities") or {}
+        assert capabilities.get("experimentalApi") is True
+        if CODEX_HOME_RECORD_PATH:
+            with open(CODEX_HOME_RECORD_PATH, "w", encoding="utf-8") as handle:
+                handle.write(sys.argv[0] + "\\n")
+                handle.write(os.environ.get("CODEX_HOME", ""))
+        sys.stdout.write(json.dumps({
+            "method": "configWarning",
+            "params": {"summary": "fake-warning", "details": None},
+        }) + "\\n")
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "userAgent": "fake/0.1",
+                "codexHome": "/tmp/fake-codex-home",
+                "platformFamily": "unix",
+                "platformOs": "linux",
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/start":
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": START_THREAD_ID,
+                    "preview": "",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 1,
+                    "status": {"type": "idle"},
+                    "path": START_THREAD_PATH,
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [],
+                },
+                "model": "gpt-5.4",
+                "modelProvider": "openai",
+                "serviceTier": None,
+                "cwd": "/work/repo",
+                "approvalPolicy": "never",
+                "approvalsReviewer": "user",
+                "sandbox": {
+                    "type": "workspaceWrite",
+                    "writableRoots": [],
+                    "readOnlyAccess": {"type": "fullAccess"},
+                    "networkAccess": False,
+                    "excludeTmpdirEnvVar": False,
+                    "excludeSlashTmp": False,
+                },
+                "reasoningEffort": "high",
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/resume":
+        thread_path = message["params"].get("path")
+        if RESUME_REQUIRES_EXISTING_ROLLOUT_PATH:
+            if not thread_path:
+                sys.stdout.write(json.dumps({
+                    "id": msg_id,
+                    "error": {"code": -32600, "message": "thread not found"},
+                }) + "\\n")
+                sys.stdout.flush()
+                continue
+            if not os.path.isfile(thread_path):
+                sys.stdout.write(json.dumps({
+                    "id": msg_id,
+                    "error": {
+                        "code": -32600,
+                        "message": f"failed to load rollout `{thread_path}`: No such file or directory (os error 2)",
+                    },
+                }) + "\\n")
+                sys.stdout.flush()
+                continue
+        if FAIL_THREAD_RESUME:
+            sys.stdout.write(json.dumps({
+                "id": msg_id,
+                "error": {"code": -32600, "message": "no rollout found for thread id vendor-thread-1"},
+            }) + "\\n")
+            sys.stdout.flush()
+            continue
+        if thread_path is not None:
+            assert str(thread_path).endswith("vendor-thread-1.jsonl")
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": "vendor-thread-1",
+                    "preview": "",
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 1,
+                    "status": {"type": "idle"},
+                    "path": thread_path or "/tmp/vendor-thread-1.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": [],
+                }
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "turn/start":
+        thread_id = message["params"]["threadId"]
+        input_items = message["params"]["input"]
+        assert isinstance(input_items, list)
+        assert input_items[0]["type"] == "text"
+        assert input_items[0]["text"] == "Reply with exactly the word OK"
+        turn_completed = COMPLETE_TURN_ON_READ and not COMPLETION_NOTIFICATION_METHOD
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
+        }) + "\\n")
+__COMPLETION_BLOCK__
+        sys.stdout.flush()
+    elif method == "turn/interrupt":
+        if INTERRUPT_RECORD_PATH:
+            with open(INTERRUPT_RECORD_PATH, "w", encoding="utf-8") as handle:
+                json.dump(message["params"], handle)
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {"status": "interrupted"},
+        }) + "\\n")
+        sys.stdout.flush()
+    elif method == "thread/read":
+        thread_id = message["params"]["threadId"]
+        turn_status = "completed" if turn_completed else "inProgress"
+        turn_items = []
+        if turn_completed:
+            turn_items = [
+                {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
+            ]
+        should_omit_turns = OMIT_TURNS_ON_READ and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
+        turns = []
+        preview = ""
+        if not should_omit_turns:
+            turns = [
+                {
+                    "id": "vendor-turn-1",
+                    "status": turn_status,
+                    "error": None,
+                    "items": turn_items,
+                }
+            ]
+            preview = ASSISTANT_TEXT
+        status_payload = {"type": THREAD_STATUS_TYPE}
+        if THREAD_STATUS_REASON:
+            status_payload["reason"] = THREAD_STATUS_REASON
+        sys.stdout.write(json.dumps({
+            "id": msg_id,
+            "result": {
+                "thread": {
+                    "id": thread_id,
+                    "preview": preview,
+                    "ephemeral": False,
+                    "modelProvider": "openai",
+                    "createdAt": 1,
+                    "updatedAt": 2,
+                    "status": status_payload,
+                    "path": f"/tmp/{thread_id}.jsonl",
+                    "cwd": "/work/repo",
+                    "cliVersion": "0.118.0",
+                    "source": "app-server",
+                    "agentNickname": None,
+                    "agentRole": None,
+                    "gitInfo": None,
+                    "name": None,
+                    "turns": turns,
+                }
+            },
+        }) + "\\n")
+        sys.stdout.flush()
+    else:
+        sys.stdout.write(json.dumps({"id": msg_id, "result": {}}) + "\\n")
+        sys.stdout.flush()
+""".strip() + "\n"
+    script.write_text(
+        script_template.replace(
+            "__INTERRUPT_RECORD_PATH__",
+            repr(str(interrupt_record_path) if interrupt_record_path is not None else ""),
+        )
+        .replace(
+            "__CODEX_HOME_RECORD_PATH__",
+            repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
+        )
+        .replace("__FAIL_THREAD_RESUME__", "True" if fail_thread_resume else "False")
+        .replace(
+            "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
+            "True" if resume_requires_existing_rollout_path else "False",
+        )
+        .replace(
+            "__COMPLETION_NOTIFICATION_METHOD__",
+            repr(completion_notification_method),
+        )
+        .replace(
+            "__COMPLETE_TURN_ON_READ__",
+            "True" if complete_turn_on_read else "False",
+        )
+        .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
+        .replace(
+            "__OMIT_TURNS_WHEN_INCOMPLETE__",
+            "True" if omit_turns_when_incomplete else "False",
+        )
+        .replace("__START_THREAD_ID__", repr(start_thread_id))
+        .replace("__START_THREAD_PATH__", repr(start_thread_path))
+        .replace("__ASSISTANT_TEXT__", repr(assistant_text))
+        .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
+        .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
+        .replace("__COMPLETION_BLOCK__", completion_block),
+        encoding="utf-8",
+    )
+    return script
+
+
+def launch_request(tmp_path: Path) -> LaunchCodexManagedSessionRequest:
+    workspace_path = tmp_path / "repo"
+    session_workspace_path = tmp_path / "session"
+    artifact_spool_path = tmp_path / "artifacts"
+    codex_home_path = tmp_path / "codex-home"
+    workspace_path.mkdir()
+    session_workspace_path.mkdir()
+    artifact_spool_path.mkdir()
+    codex_home_path.mkdir()
+    return LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(session_workspace_path),
+        artifactSpoolPath=str(artifact_spool_path),
+        codexHomePath=str(codex_home_path),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -12,19 +12,18 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
 )
-from tests.unit.services.temporal.runtime.test_codex_session_runtime import (
-    _launch_request,
-    _write_fake_app_server,
+from tests.helpers.codex_session_runtime import (
+    launch_request,
+    write_fake_app_server,
 )
 
-
-pytestmark = [pytest.mark.integration]
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
 
 
 def test_runtime_send_turn_recovers_task_complete_message_from_rollout_transcript(
     tmp_path: Path,
 ) -> None:
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -65,7 +64,7 @@ def test_runtime_send_turn_recovers_task_complete_message_from_rollout_transcrip
         + "\n",
         encoding="utf-8",
     )
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),

--- a/tests/integration/services/temporal/test_codex_session_runtime.py
+++ b/tests/integration/services/temporal/test_codex_session_runtime.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionLocator,
+    SendCodexManagedSessionTurnRequest,
+)
+from moonmind.workflows.temporal.runtime.codex_session_runtime import (
+    CodexManagedSessionRuntime,
+)
+from tests.unit.services.temporal.runtime.test_codex_session_runtime import (
+    _launch_request,
+    _write_fake_app_server,
+)
+
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_runtime_send_turn_recovers_task_complete_message_from_rollout_transcript(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T17:55:16.922Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_started",
+                            "turn_id": "vendor-turn-1",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T17:57:55.661Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_complete",
+                            "turn_id": "vendor-turn-1",
+                            "last_agent_message": (
+                                "Recovered from durable task_complete event"
+                            ),
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.metadata["assistantText"] == (
+        "Recovered from durable task_complete event"
+    )
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == (
+        "Recovered from durable task_complete event"
+    )

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -637,6 +637,91 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
     assert handle.metadata["lastAssistantText"] == "Recovered from rollout transcript"
 
 
+def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T17:55:16.922Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_started",
+                            "turn_id": "vendor-turn-1",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T17:57:55.661Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_complete",
+                            "turn_id": "vendor-turn-1",
+                            "last_agent_message": "Recovered from task_complete event",
+                        },
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["assistantText"] == "Recovered from task_complete event"
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert handle.metadata["lastAssistantText"] == "Recovered from task_complete event"
+
+
 def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -9,7 +9,6 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionClearRequest,
     CodexManagedSessionLocator,
     InterruptCodexManagedSessionTurnRequest,
-    LaunchCodexManagedSessionRequest,
     SendCodexManagedSessionTurnRequest,
 )
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
@@ -17,313 +16,16 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
     _run_ready,
 )
-
-
-def _write_fake_app_server(
-    tmp_path: Path,
-    *,
-    completion_notification_method: str | None = "turn/completed",
-    complete_turn_on_read: bool = True,
-    omit_turns_on_read: bool = False,
-    omit_turns_when_incomplete: bool = False,
-    assistant_text: str = "OK",
-    thread_status_type: str = "idle",
-    thread_status_reason: str | None = None,
-    fail_thread_resume: bool = False,
-    resume_requires_existing_rollout_path: bool = False,
-    start_thread_id: str = "vendor-thread-1",
-    start_thread_path: str | None = "/tmp/vendor-thread-1.jsonl",
-    interrupt_record_path: Path | None = None,
-    codex_home_record_path: Path | None = None,
-) -> Path:
-    script = tmp_path / "fake_app_server.py"
-    completion_block = """
-        turn_completed = True
-        sys.stdout.write(json.dumps({
-            "method": COMPLETION_NOTIFICATION_METHOD,
-            "params": {
-                "threadId": thread_id,
-                "turn": {"id": "vendor-turn-1", "items": [], "status": "completed", "error": None},
-            },
-        }) + "\\n")
-""".rstrip()
-    if not completion_notification_method:
-        completion_block = ""
-    script_template = """
-import json
-import os
-import sys
-
-INTERRUPT_RECORD_PATH = __INTERRUPT_RECORD_PATH__
-CODEX_HOME_RECORD_PATH = __CODEX_HOME_RECORD_PATH__
-FAIL_THREAD_RESUME = __FAIL_THREAD_RESUME__
-RESUME_REQUIRES_EXISTING_ROLLOUT_PATH = __RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__
-START_THREAD_ID = __START_THREAD_ID__
-START_THREAD_PATH = __START_THREAD_PATH__
-COMPLETION_NOTIFICATION_METHOD = __COMPLETION_NOTIFICATION_METHOD__
-COMPLETE_TURN_ON_READ = __COMPLETE_TURN_ON_READ__
-OMIT_TURNS_ON_READ = __OMIT_TURNS_ON_READ__
-OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
-ASSISTANT_TEXT = __ASSISTANT_TEXT__
-THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
-THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
-turn_completed = False
-
-for line in sys.stdin:
-    message = json.loads(line)
-    msg_id = message.get("id")
-    method = message.get("method")
-    if method == "initialize":
-        capabilities = message["params"].get("capabilities") or {}
-        assert capabilities.get("experimentalApi") is True
-        if CODEX_HOME_RECORD_PATH:
-            with open(CODEX_HOME_RECORD_PATH, "w", encoding="utf-8") as handle:
-                handle.write(sys.argv[0] + "\\n")
-                handle.write(os.environ.get("CODEX_HOME", ""))
-        sys.stdout.write(json.dumps({
-            "method": "configWarning",
-            "params": {"summary": "fake-warning", "details": None},
-        }) + "\\n")
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {
-                "userAgent": "fake/0.1",
-                "codexHome": "/tmp/fake-codex-home",
-                "platformFamily": "unix",
-                "platformOs": "linux",
-            },
-        }) + "\\n")
-        sys.stdout.flush()
-    elif method == "thread/start":
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {
-                "thread": {
-                    "id": START_THREAD_ID,
-                    "preview": "",
-                    "ephemeral": False,
-                    "modelProvider": "openai",
-                    "createdAt": 1,
-                    "updatedAt": 1,
-                    "status": {"type": "idle"},
-                    "path": START_THREAD_PATH,
-                    "cwd": "/work/repo",
-                    "cliVersion": "0.118.0",
-                    "source": "app-server",
-                    "agentNickname": None,
-                    "agentRole": None,
-                    "gitInfo": None,
-                    "name": None,
-                    "turns": [],
-                },
-                "model": "gpt-5.4",
-                "modelProvider": "openai",
-                "serviceTier": None,
-                "cwd": "/work/repo",
-                "approvalPolicy": "never",
-                "approvalsReviewer": "user",
-                "sandbox": {
-                    "type": "workspaceWrite",
-                    "writableRoots": [],
-                    "readOnlyAccess": {"type": "fullAccess"},
-                    "networkAccess": False,
-                    "excludeTmpdirEnvVar": False,
-                    "excludeSlashTmp": False,
-                },
-                "reasoningEffort": "high",
-            },
-        }) + "\\n")
-        sys.stdout.flush()
-    elif method == "thread/resume":
-        thread_path = message["params"].get("path")
-        if RESUME_REQUIRES_EXISTING_ROLLOUT_PATH:
-            if not thread_path:
-                sys.stdout.write(json.dumps({
-                    "id": msg_id,
-                    "error": {"code": -32600, "message": "thread not found"},
-                }) + "\\n")
-                sys.stdout.flush()
-                continue
-            if not os.path.isfile(thread_path):
-                sys.stdout.write(json.dumps({
-                    "id": msg_id,
-                    "error": {
-                        "code": -32600,
-                        "message": f"failed to load rollout `{thread_path}`: No such file or directory (os error 2)",
-                    },
-                }) + "\\n")
-                sys.stdout.flush()
-                continue
-        if FAIL_THREAD_RESUME:
-            sys.stdout.write(json.dumps({
-                "id": msg_id,
-                "error": {"code": -32600, "message": "no rollout found for thread id vendor-thread-1"},
-            }) + "\\n")
-            sys.stdout.flush()
-            continue
-        if thread_path is not None:
-            assert str(thread_path).endswith("vendor-thread-1.jsonl")
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {
-                "thread": {
-                    "id": "vendor-thread-1",
-                    "preview": "",
-                    "ephemeral": False,
-                    "modelProvider": "openai",
-                    "createdAt": 1,
-                    "updatedAt": 1,
-                    "status": {"type": "idle"},
-                    "path": thread_path or "/tmp/vendor-thread-1.jsonl",
-                    "cwd": "/work/repo",
-                    "cliVersion": "0.118.0",
-                    "source": "app-server",
-                    "agentNickname": None,
-                    "agentRole": None,
-                    "gitInfo": None,
-                    "name": None,
-                    "turns": [],
-                }
-            },
-        }) + "\\n")
-        sys.stdout.flush()
-    elif method == "turn/start":
-        thread_id = message["params"]["threadId"]
-        input_items = message["params"]["input"]
-        assert isinstance(input_items, list)
-        assert input_items[0]["type"] == "text"
-        assert input_items[0]["text"] == "Reply with exactly the word OK"
-        turn_completed = COMPLETE_TURN_ON_READ and not COMPLETION_NOTIFICATION_METHOD
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {"turn": {"id": "vendor-turn-1", "items": [], "status": "inProgress", "error": None}},
-        }) + "\\n")
-__COMPLETION_BLOCK__
-        sys.stdout.flush()
-    elif method == "turn/interrupt":
-        if INTERRUPT_RECORD_PATH:
-            with open(INTERRUPT_RECORD_PATH, "w", encoding="utf-8") as handle:
-                json.dump(message["params"], handle)
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {"status": "interrupted"},
-        }) + "\\n")
-        sys.stdout.flush()
-    elif method == "thread/read":
-        thread_id = message["params"]["threadId"]
-        turn_status = "completed" if turn_completed else "inProgress"
-        turn_items = []
-        if turn_completed:
-            turn_items = [
-                {"type": "agentMessage", "id": "msg-1", "text": ASSISTANT_TEXT, "phase": "final_answer", "memoryCitation": None}
-            ]
-        should_omit_turns = OMIT_TURNS_ON_READ and (turn_completed or OMIT_TURNS_WHEN_INCOMPLETE)
-        turns = []
-        preview = ""
-        if not should_omit_turns:
-            turns = [
-                {
-                    "id": "vendor-turn-1",
-                    "status": turn_status,
-                    "error": None,
-                    "items": turn_items,
-                }
-            ]
-            preview = ASSISTANT_TEXT
-        status_payload = {"type": THREAD_STATUS_TYPE}
-        if THREAD_STATUS_REASON:
-            status_payload["reason"] = THREAD_STATUS_REASON
-        sys.stdout.write(json.dumps({
-            "id": msg_id,
-            "result": {
-                "thread": {
-                    "id": thread_id,
-                    "preview": preview,
-                    "ephemeral": False,
-                    "modelProvider": "openai",
-                    "createdAt": 1,
-                    "updatedAt": 2,
-                    "status": status_payload,
-                    "path": f"/tmp/{thread_id}.jsonl",
-                    "cwd": "/work/repo",
-                    "cliVersion": "0.118.0",
-                    "source": "app-server",
-                    "agentNickname": None,
-                    "agentRole": None,
-                    "gitInfo": None,
-                    "name": None,
-                    "turns": turns,
-                }
-            },
-        }) + "\\n")
-        sys.stdout.flush()
-    else:
-        sys.stdout.write(json.dumps({"id": msg_id, "result": {}}) + "\\n")
-        sys.stdout.flush()
-""".strip() + "\n"
-    script.write_text(
-        script_template.replace(
-            "__INTERRUPT_RECORD_PATH__",
-            repr(str(interrupt_record_path) if interrupt_record_path is not None else ""),
-        )
-        .replace(
-            "__CODEX_HOME_RECORD_PATH__",
-            repr(str(codex_home_record_path) if codex_home_record_path is not None else ""),
-        )
-        .replace("__FAIL_THREAD_RESUME__", "True" if fail_thread_resume else "False")
-        .replace(
-            "__RESUME_REQUIRES_EXISTING_ROLLOUT_PATH__",
-            "True" if resume_requires_existing_rollout_path else "False",
-        )
-        .replace(
-            "__COMPLETION_NOTIFICATION_METHOD__",
-            repr(completion_notification_method),
-        )
-        .replace(
-            "__COMPLETE_TURN_ON_READ__",
-            "True" if complete_turn_on_read else "False",
-        )
-        .replace("__OMIT_TURNS_ON_READ__", "True" if omit_turns_on_read else "False")
-        .replace(
-            "__OMIT_TURNS_WHEN_INCOMPLETE__",
-            "True" if omit_turns_when_incomplete else "False",
-        )
-        .replace("__START_THREAD_ID__", repr(start_thread_id))
-        .replace("__START_THREAD_PATH__", repr(start_thread_path))
-        .replace("__ASSISTANT_TEXT__", repr(assistant_text))
-        .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
-        .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
-        .replace("__COMPLETION_BLOCK__", completion_block),
-        encoding="utf-8",
-    )
-    return script
-
-
-def _launch_request(tmp_path: Path) -> LaunchCodexManagedSessionRequest:
-    workspace_path = tmp_path / "repo"
-    session_workspace_path = tmp_path / "session"
-    artifact_spool_path = tmp_path / "artifacts"
-    codex_home_path = tmp_path / "codex-home"
-    workspace_path.mkdir()
-    session_workspace_path.mkdir()
-    artifact_spool_path.mkdir()
-    codex_home_path.mkdir()
-    return LaunchCodexManagedSessionRequest(
-        taskRunId="task-1",
-        sessionId="sess-1",
-        threadId="logical-thread-1",
-        workspacePath=str(workspace_path),
-        sessionWorkspacePath=str(session_workspace_path),
-        artifactSpoolPath=str(artifact_spool_path),
-        codexHomePath=str(codex_home_path),
-        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
-    )
+from tests.helpers.codex_session_runtime import (
+    launch_request,
+    write_fake_app_server,
+)
 
 
 def test_app_server_client_ignores_notifications_until_matching_response(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path)
+    script = write_fake_app_server(tmp_path)
     client = CodexAppServerRpcClient(
         command=("python3", str(script)),
         client_name="MoonMindTest",
@@ -337,8 +39,8 @@ def test_app_server_client_ignores_notifications_until_matching_response(
 
 
 def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) -> None:
-    script = _write_fake_app_server(tmp_path)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -368,8 +70,8 @@ def test_runtime_launch_session_persists_logical_thread_mapping(tmp_path: Path) 
 def test_runtime_send_turn_returns_terminal_completed_response(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -413,8 +115,8 @@ def test_runtime_send_turn_returns_terminal_completed_response(
 def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_output(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path, assistant_text="")
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path, assistant_text="")
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -476,11 +178,11 @@ def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_outpu
 def test_runtime_send_turn_accepts_item_completed_notification_contract(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         completion_notification_method="item/completed",
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -511,11 +213,11 @@ def test_runtime_send_turn_accepts_item_completed_notification_contract(
 def test_runtime_send_turn_completes_via_thread_read_without_notification(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         completion_notification_method=None,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -558,7 +260,7 @@ def test_runtime_send_turn_completes_via_thread_read_without_notification(
 def test_runtime_send_turn_completes_when_thread_read_omits_turns(
     tmp_path: Path,
 ) -> None:
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -594,7 +296,7 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
         + "\n",
         encoding="utf-8",
     )
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
@@ -640,7 +342,7 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
 def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
     tmp_path: Path,
 ) -> None:
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -679,7 +381,7 @@ def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
         + "\n",
         encoding="utf-8",
     )
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
@@ -725,7 +427,7 @@ def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
 def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     tmp_path: Path,
 ) -> None:
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -757,7 +459,7 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
         + "\n",
         encoding="utf-8",
     )
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
@@ -804,7 +506,7 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
 def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
     tmp_path: Path,
 ) -> None:
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     transcript_path = tmp_path / "vendor-thread-1.jsonl"
     transcript_path.write_text(
         json.dumps(
@@ -828,7 +530,7 @@ def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
         + "\n",
         encoding="utf-8",
     )
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         omit_turns_on_read=True,
         start_thread_path=str(transcript_path),
@@ -877,7 +579,7 @@ def test_runtime_send_turn_uses_terminal_thread_status_when_turn_missing(
     expected_status: str,
     expected_reason: str,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         completion_notification_method=None,
         complete_turn_on_read=False,
@@ -886,7 +588,7 @@ def test_runtime_send_turn_uses_terminal_thread_status_when_turn_missing(
         thread_status_type=thread_status_type,
         thread_status_reason=thread_status_reason,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -916,8 +618,8 @@ def test_runtime_send_turn_uses_terminal_thread_status_when_turn_missing(
 def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -973,8 +675,8 @@ def test_runtime_send_turn_recovers_vendor_thread_path_from_sessions_dir(
 def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path, fail_thread_resume=True)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path, fail_thread_resume=True)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1018,13 +720,13 @@ def test_runtime_send_turn_falls_back_to_new_thread_when_resume_fails(
 def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_new_thread(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         fail_thread_resume=True,
         start_thread_id="vendor-thread-2",
         start_thread_path=None,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1069,11 +771,11 @@ def test_runtime_send_turn_drops_stale_vendor_thread_path_when_fallback_starts_n
 def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         resume_requires_existing_rollout_path=True,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1117,8 +819,8 @@ def test_runtime_send_turn_ignores_nonexistent_vendor_thread_path_from_state(
 
 
 def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) -> None:
-    script = _write_fake_app_server(tmp_path)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1150,12 +852,12 @@ def test_runtime_clear_session_rotates_logical_thread_and_epoch(tmp_path: Path) 
 def test_runtime_session_status_remains_busy_without_completion_notification(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         completion_notification_method=None,
         complete_turn_on_read=False,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1200,11 +902,11 @@ def test_runtime_session_status_remains_busy_without_completion_notification(
 
 def test_runtime_interrupt_turn_uses_app_server_transport(tmp_path: Path) -> None:
     interrupt_record_path = tmp_path / "interrupt.json"
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         interrupt_record_path=interrupt_record_path,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1244,11 +946,11 @@ def test_runtime_interrupt_turn_uses_app_server_transport(tmp_path: Path) -> Non
 
 def test_runtime_launch_session_exports_codex_home(tmp_path: Path) -> None:
     codex_home_record_path = tmp_path / "codex-home.txt"
-    script = _write_fake_app_server(
+    script = write_fake_app_server(
         tmp_path,
         codex_home_record_path=codex_home_record_path,
     )
-    request = _launch_request(tmp_path)
+    request = launch_request(tmp_path)
     runtime = CodexManagedSessionRuntime(
         workspace_path=request.workspace_path,
         session_workspace_path=request.session_workspace_path,
@@ -1270,8 +972,8 @@ def test_runtime_launch_session_exports_codex_home(tmp_path: Path) -> None:
 def test_runtime_launch_session_seeds_auth_volume_without_overwriting_materialized_config(
     tmp_path: Path,
 ) -> None:
-    script = _write_fake_app_server(tmp_path)
-    request = _launch_request(tmp_path)
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
     auth_volume_path = tmp_path / "auth-volume"
     auth_volume_path.mkdir()
     (auth_volume_path / "auth.json").write_text('{"token":"oauth"}', encoding="utf-8")


### PR DESCRIPTION
## Summary
- recover Codex managed-session assistant output from durable rollout `event_msg` records when the final answer is stored on `task_complete.last_agent_message`
- add a unit regression covering the exact transcript shape that caused workflow `mm:3487fd24-6a38-4b46-98fe-f78151c1c7a3` to fail
- add a runtime-level integration test that exercises the real `CodexManagedSessionRuntime` against a subprocess-backed fake app server and durable rollout transcript

## Root Cause
The managed-session runtime treated a completed turn as failed when `thread/read` did not expose assistant text inline, even if the durable rollout transcript already contained the final answer on a `task_complete` event. That caused `MoonMind.AgentRun` to return `execution_error` even though the Codex turn had actually completed successfully.

## Validation
- `./.venv/bin/pytest -q tests/integration/services/temporal/test_codex_session_runtime.py`
- `./.venv/bin/pytest -q tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`