### PR TITLE
[codex] Recover managed Codex rollout final answers

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -608,6 +608,7 @@ class CodexManagedSessionRuntime:
         if rollout_path is None:
             return ""
         last_text = ""
+        terminal_text = ""
         try:
             rollout_file = Path(rollout_path)
             if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
@@ -623,38 +624,70 @@ class CodexManagedSessionRuntime:
                         continue
                     if not isinstance(payload, Mapping):
                         continue
-                    if not self._payload_references_turn(payload, vendor_turn_id):
-                        continue
-                    entry_type = str(payload.get("type") or "").strip().lower()
-                    if entry_type == "response_item":
-                        response_payload = payload.get("payload")
-                        if not isinstance(response_payload, Mapping):
-                            continue
-                        if (
-                            str(response_payload.get("type") or "").strip().lower()
-                            != "message"
-                            or str(response_payload.get("role") or "").strip().lower()
-                            != "assistant"
-                        ):
-                            continue
-                        text = self._content_text(response_payload.get("content"))
+                    if self._payload_references_turn(payload, vendor_turn_id):
+                        text = self._assistant_text_from_rollout_entry(payload)
                         if text:
                             last_text = text
-                    elif entry_type == "event_msg":
-                        event_payload = payload.get("payload")
-                        if not isinstance(event_payload, Mapping):
-                            continue
-                        if (
-                            str(event_payload.get("type") or "").strip().lower()
-                            != "agent_message"
-                        ):
-                            continue
-                        text = str(event_payload.get("message") or "").strip()
-                        if text:
-                            last_text = text
+                    text = self._terminal_assistant_text_from_rollout_entry(payload)
+                    if text:
+                        terminal_text = text
         except OSError:
             return ""
-        return last_text
+        return last_text or terminal_text
+
+    @classmethod
+    def _assistant_text_from_rollout_entry(cls, payload: Mapping[str, Any]) -> str:
+        entry_type = str(payload.get("type") or "").strip().lower()
+        if entry_type == "response_item":
+            response_payload = payload.get("payload")
+            if not isinstance(response_payload, Mapping):
+                return ""
+            if (
+                str(response_payload.get("type") or "").strip().lower() != "message"
+                or str(response_payload.get("role") or "").strip().lower()
+                != "assistant"
+            ):
+                return ""
+            return cls._content_text(response_payload.get("content"))
+        if entry_type == "event_msg":
+            event_payload = payload.get("payload")
+            if not isinstance(event_payload, Mapping):
+                return ""
+            if str(event_payload.get("type") or "").strip().lower() != "agent_message":
+                return ""
+            return str(event_payload.get("message") or "").strip()
+        return ""
+
+    @classmethod
+    def _terminal_assistant_text_from_rollout_entry(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> str:
+        entry_type = str(payload.get("type") or "").strip().lower()
+        if entry_type == "response_item":
+            response_payload = payload.get("payload")
+            if not isinstance(response_payload, Mapping):
+                return ""
+            if (
+                str(response_payload.get("phase") or "").strip().lower()
+                != "final_answer"
+            ):
+                return ""
+            return cls._assistant_text_from_rollout_entry(payload)
+        if entry_type != "event_msg":
+            return ""
+        event_payload = payload.get("payload")
+        if not isinstance(event_payload, Mapping):
+            return ""
+        event_type = str(event_payload.get("type") or "").strip().lower()
+        if event_type == "task_complete":
+            return str(event_payload.get("last_agent_message") or "").strip()
+        if (
+            event_type == "agent_message"
+            and str(event_payload.get("phase") or "").strip().lower() == "final_answer"
+        ):
+            return cls._assistant_text_from_rollout_entry(payload)
+        return ""
 
     def _resolved_rollout_path(
         self,

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import threading
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
@@ -48,6 +49,7 @@ _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
+_ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -585,6 +587,24 @@ class CodexManagedSessionRuntime:
             )
         return False
 
+    @staticmethod
+    def _rollout_entry_timestamp(payload: Mapping[str, Any]) -> float | None:
+        timestamp_text = str(payload.get("timestamp") or "").strip()
+        if not timestamp_text:
+            return None
+        try:
+            parsed = datetime.fromisoformat(timestamp_text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.timestamp()
+
+    @staticmethod
+    def _is_terminal_rollout_phase(value: Any) -> bool:
+        phase = str(value or "").strip().lower()
+        return phase in {"final", "final_answer"}
+
     def _allowed_rollout_path(self, path_value: str | None) -> str | None:
         normalized = self._normalized_thread_path(path_value)
         if normalized is None:
@@ -603,12 +623,18 @@ class CodexManagedSessionRuntime:
         vendor_thread_path: str | None,
         *,
         vendor_turn_id: str,
+        turn_started_at: float | None = None,
     ) -> str:
         rollout_path = self._allowed_rollout_path(vendor_thread_path)
         if rollout_path is None:
             return ""
         last_text = ""
         terminal_text = ""
+        terminal_cutoff = None
+        if turn_started_at is not None:
+            terminal_cutoff = (
+                float(turn_started_at) - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS
+            )
         try:
             rollout_file = Path(rollout_path)
             if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
@@ -624,12 +650,21 @@ class CodexManagedSessionRuntime:
                         continue
                     if not isinstance(payload, Mapping):
                         continue
-                    if self._payload_references_turn(payload, vendor_turn_id):
+                    references_turn = self._payload_references_turn(payload, vendor_turn_id)
+                    if references_turn:
                         text = self._assistant_text_from_rollout_entry(payload)
                         if text:
                             last_text = text
                     text = self._terminal_assistant_text_from_rollout_entry(payload)
                     if text:
+                        if references_turn:
+                            terminal_text = text
+                            continue
+                        if terminal_cutoff is None:
+                            continue
+                        entry_timestamp = self._rollout_entry_timestamp(payload)
+                        if entry_timestamp is None or entry_timestamp < terminal_cutoff:
+                            continue
                         terminal_text = text
         except OSError:
             return ""
@@ -649,7 +684,7 @@ class CodexManagedSessionRuntime:
             ):
                 return ""
             return cls._content_text(response_payload.get("content"))
-        if entry_type == "event_msg":
+        elif entry_type == "event_msg":
             event_payload = payload.get("payload")
             if not isinstance(event_payload, Mapping):
                 return ""
@@ -668,25 +703,21 @@ class CodexManagedSessionRuntime:
             response_payload = payload.get("payload")
             if not isinstance(response_payload, Mapping):
                 return ""
-            if (
-                str(response_payload.get("phase") or "").strip().lower()
-                != "final_answer"
-            ):
+            if not cls._is_terminal_rollout_phase(response_payload.get("phase")):
                 return ""
             return cls._assistant_text_from_rollout_entry(payload)
-        if entry_type != "event_msg":
-            return ""
-        event_payload = payload.get("payload")
-        if not isinstance(event_payload, Mapping):
-            return ""
-        event_type = str(event_payload.get("type") or "").strip().lower()
-        if event_type == "task_complete":
-            return str(event_payload.get("last_agent_message") or "").strip()
-        if (
-            event_type == "agent_message"
-            and str(event_payload.get("phase") or "").strip().lower() == "final_answer"
-        ):
-            return cls._assistant_text_from_rollout_entry(payload)
+        elif entry_type == "event_msg":
+            event_payload = payload.get("payload")
+            if not isinstance(event_payload, Mapping):
+                return ""
+            event_type = str(event_payload.get("type") or "").strip().lower()
+            if event_type == "task_complete":
+                return str(event_payload.get("last_agent_message") or "").strip()
+            if (
+                event_type == "agent_message"
+                and cls._is_terminal_rollout_phase(event_payload.get("phase"))
+            ):
+                return cls._assistant_text_from_rollout_entry(payload)
         return ""
 
     def _resolved_rollout_path(
@@ -731,6 +762,7 @@ class CodexManagedSessionRuntime:
         return self._extract_assistant_text_from_rollout(
             vendor_thread_path,
             vendor_turn_id=vendor_turn_id,
+            turn_started_at=state.last_control_at,
         )
 
     @staticmethod

--- a/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 from temporalio import activity as _activity
 from temporalio import workflow
+from temporalio.service import RPCError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
@@ -460,7 +461,8 @@ async def test_agent_run_managed_codex_session_recovers_terminal_rollout_without
                         try:
                             await manager_handle.signal(MockProviderProfileManager.shutdown)
                             await manager_handle.result()
-                        except Exception:
+                        except RPCError:
+                            # Best-effort teardown can race the worker shutdown path.
                             pass
 
                     assert isinstance(result, AgentRunResult)

--- a/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
+++ b/tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from temporalio import activity as _activity
+from temporalio import workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from moonmind.config.settings import settings
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRunResult
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionArtifactsPublication,
+    CodexManagedSessionBinding,
+    CodexManagedSessionHandle,
+    CodexManagedSessionSnapshot,
+    CodexManagedSessionSummary,
+    CodexManagedSessionTurnResponse,
+    FetchCodexManagedSessionSummaryRequest,
+    LaunchCodexManagedSessionRequest,
+    PublishCodexManagedSessionArtifactsRequest,
+    SendCodexManagedSessionTurnRequest,
+)
+from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
+from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
+
+
+# NOTE: This test uses the Temporal time-skipping test server and is not
+# suitable for the required integration_ci suite.
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
+
+
+@workflow.defn(name="MoonMind.ProviderProfileManager")
+class MockProviderProfileManager:
+    def __init__(self) -> None:
+        self._shutdown = False
+        self.pending_requests: list[dict[str, Any]] = []
+        self._leases: dict[str, str] = {}
+
+    @workflow.signal
+    def request_slot(self, payload: dict[str, Any]) -> None:
+        self.pending_requests.append(dict(payload))
+
+    @workflow.signal
+    def release_slot(self, payload: dict[str, Any]) -> None:
+        requester_id = payload.get("requester_workflow_id")
+        if not isinstance(requester_id, str):
+            return
+        for profile_id, workflow_id in list(self._leases.items()):
+            if workflow_id == requester_id:
+                del self._leases[profile_id]
+
+    @workflow.signal
+    def report_cooldown(self, payload: dict[str, Any]) -> None:
+        del payload
+
+    @workflow.signal
+    def sync_profiles(self, payload: dict[str, Any]) -> None:
+        del payload
+
+    @workflow.signal
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    @workflow.run
+    async def run(self, input_payload: dict[str, Any]) -> dict[str, Any]:
+        del input_payload
+        while not self._shutdown:
+            await workflow.wait_condition(
+                lambda: bool(self.pending_requests) or self._shutdown
+            )
+            while self.pending_requests:
+                request = self.pending_requests.pop(0)
+                profile_id = str(
+                    request.get("execution_profile_ref")
+                    or request.get("profile_id")
+                    or "default-managed"
+                ).strip()
+                self._leases[profile_id] = str(request["requester_workflow_id"])
+                handle = workflow.get_external_workflow_handle(
+                    str(request["requester_workflow_id"])
+                )
+                await handle.signal("slot_assigned", {"profile_id": profile_id})
+        return {}
+
+
+@workflow.defn(name="DummyCodexSessionWorkflow")
+class DummyCodexSessionWorkflow:
+    def __init__(self) -> None:
+        self._status: dict[str, Any] = {
+            "status": "active",
+            "binding": None,
+            "containerId": None,
+            "threadId": None,
+            "activeTurnId": None,
+            "terminationRequested": False,
+        }
+        self._shutdown = False
+
+    @workflow.signal
+    def attach_runtime_handles(self, payload: dict[str, Any]) -> None:
+        self._status.update(dict(payload))
+
+    @workflow.signal
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    @workflow.query
+    def get_status(self) -> dict[str, Any]:
+        return dict(self._status)
+
+    @workflow.run
+    async def run(self, binding_payload: dict[str, Any]) -> dict[str, Any]:
+        self._status["binding"] = dict(binding_payload)
+        await workflow.wait_condition(lambda: self._shutdown)
+        return dict(self._status)
+
+
+@_activity.defn(name="agent_runtime.publish_artifacts")
+async def mock_publish_artifacts(
+    result: AgentRunResult | None = None,
+) -> AgentRunResult | None:
+    return result
+
+
+@_activity.defn(name="agent_runtime.cancel")
+async def mock_cancel(request: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "runId": request.get("run_id", "unknown"),
+        "agentKind": request.get("agent_kind", "managed"),
+        "agentId": request.get("agent_id", "codex"),
+        "status": "canceled",
+    }
+
+
+@_activity.defn(name="provider_profile.list")
+async def mock_provider_profile_list(request: dict[str, Any]) -> dict[str, Any]:
+    runtime_id = str(request.get("runtime_id") or "codex_cli").strip() or "codex_cli"
+    return {
+        "profiles": [
+            {
+                "profile_id": "default-managed",
+                "runtime_id": runtime_id,
+                "provider_id": "openai",
+                "auth_mode": "volume",
+                "volume_ref": "test-volume",
+                "volume_mount_path": "/tmp/auth",
+                "account_label": "test-openai",
+                "api_key_ref": None,
+                "runtime_env_overrides": {},
+                "api_key_env_var": None,
+                "max_parallel_runs": 1,
+                "cooldown_after_429_seconds": 900,
+                "rate_limit_policy": "pause_and_retry",
+                "max_lease_duration_seconds": 7200,
+                "enabled": True,
+            }
+        ]
+    }
+
+
+@_activity.defn(name="provider_profile.ensure_manager")
+async def mock_provider_profile_ensure_manager(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "started": True,
+        "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'codex_cli')}",
+    }
+
+
+@_activity.defn(name="provider_profile.reset_manager")
+async def mock_provider_profile_reset_manager(
+    request: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "reset": True,
+        "workflow_id": f"provider-profile-manager:{request.get('runtime_id', 'codex_cli')}",
+    }
+
+
+class FakeCodexSessionController:
+    async def launch_session(self, request: Any) -> CodexManagedSessionHandle:
+        return CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": "ctr-test-codex",
+                "threadId": "thread-test-codex",
+            },
+            status="ready",
+            imageRef=str(request.image_ref),
+        )
+
+    async def send_turn(self, request: Any) -> CodexManagedSessionTurnResponse:
+        return CodexManagedSessionTurnResponse(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": request.container_id,
+                "threadId": request.thread_id,
+            },
+            turnId="turn-test-codex",
+            status="completed",
+            metadata={
+                "assistantText": "Recovered final answer without vendor turn id",
+            },
+        )
+
+    async def fetch_session_summary(self, request: Any) -> CodexManagedSessionSummary:
+        return CodexManagedSessionSummary(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": request.container_id,
+                "threadId": request.thread_id,
+            },
+            latestSummaryRef=None,
+            latestCheckpointRef=None,
+            latestControlEventRef=None,
+            metadata={
+                "lastAssistantText": "Recovered final answer without vendor turn id",
+                "lastTurnId": "turn-test-codex",
+                "lastTurnStatus": "completed",
+                "lastTurnError": None,
+            },
+        )
+
+    async def publish_session_artifacts(
+        self,
+        request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return CodexManagedSessionArtifactsPublication(
+            sessionState={
+                "sessionId": request.session_id,
+                "sessionEpoch": request.session_epoch,
+                "containerId": request.container_id,
+                "threadId": request.thread_id,
+            },
+            publishedArtifactRefs=(),
+            latestSummaryRef=None,
+            latestCheckpointRef=None,
+            latestControlEventRef=None,
+            metadata=dict(request.metadata),
+        )
+
+
+async def test_agent_run_managed_codex_session_recovers_terminal_rollout_without_turn_reference(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    managed_runtime_root = tmp_path / "agent_jobs"
+    managed_run_root = managed_runtime_root / "managed_runs"
+    monkeypatch.setattr(
+        agent_run_module,
+        "_MANAGED_RUNTIME_STORE_ROOT",
+        str(managed_runtime_root),
+    )
+    monkeypatch.setattr(
+        agent_run_module,
+        "_MANAGED_RUN_STORE_ROOT",
+        str(managed_run_root),
+    )
+    controller = FakeCodexSessionController()
+
+    @_activity.defn(name="agent_runtime.build_launch_context")
+    async def build_launch_context(payload: dict[str, Any]) -> dict[str, Any]:
+        profile = payload["profile"]
+        return {
+            "profile_id": profile["profile_id"],
+            "credential_source": "volume",
+            "delta_env_overrides": {},
+            "passthrough_env_keys": [],
+            "env_keys_count": 0,
+        }
+
+    @_activity.defn(name="agent_runtime.load_session_snapshot")
+    async def load_session_snapshot(
+        payload: dict[str, Any],
+    ) -> CodexManagedSessionSnapshot:
+        binding = CodexManagedSessionBinding.model_validate(payload)
+        return CodexManagedSessionSnapshot(
+            binding=binding,
+            status="active",
+            containerId=None,
+            threadId=None,
+            activeTurnId=None,
+            terminationRequested=False,
+        )
+
+    @_activity.defn(name="agent_runtime.launch_session")
+    async def launch_session(payload: dict[str, Any]) -> CodexManagedSessionHandle:
+        request = LaunchCodexManagedSessionRequest.model_validate(payload["request"])
+        return await controller.launch_session(
+            type(
+                "LaunchRequest",
+                (),
+                {
+                    "session_id": request.session_id,
+                    "session_epoch": request.session_epoch,
+                    "image_ref": request.image_ref,
+                },
+            )()
+        )
+
+    @_activity.defn(name="agent_runtime.prepare_turn_instructions")
+    async def prepare_turn_instructions(payload: dict[str, Any]) -> str:
+        request = payload["request"]
+        parameters = request.get("parameters") or {}
+        return str(parameters.get("instructions") or "").strip() or "prepared instructions"
+
+    @_activity.defn(name="agent_runtime.send_turn")
+    async def send_turn(payload: dict[str, Any]) -> CodexManagedSessionTurnResponse:
+        request = SendCodexManagedSessionTurnRequest.model_validate(payload)
+        return await controller.send_turn(
+            type(
+                "SendTurnRequest",
+                (),
+                {
+                    "session_id": request.session_id,
+                    "session_epoch": request.session_epoch,
+                    "container_id": request.container_id,
+                    "thread_id": request.thread_id,
+                },
+            )()
+        )
+
+    @_activity.defn(name="agent_runtime.fetch_session_summary")
+    async def fetch_session_summary(
+        payload: dict[str, Any],
+    ) -> CodexManagedSessionSummary:
+        request = FetchCodexManagedSessionSummaryRequest.model_validate(payload)
+        return await controller.fetch_session_summary(
+            type(
+                "SummaryRequest",
+                (),
+                {
+                    "session_id": request.session_id,
+                    "session_epoch": request.session_epoch,
+                    "container_id": request.container_id,
+                    "thread_id": request.thread_id,
+                },
+            )()
+        )
+
+    @_activity.defn(name="agent_runtime.publish_session_artifacts")
+    async def publish_session_artifacts(
+        payload: dict[str, Any],
+    ) -> CodexManagedSessionArtifactsPublication:
+        request = PublishCodexManagedSessionArtifactsRequest.model_validate(payload)
+        return await controller.publish_session_artifacts(
+            type(
+                "PublishRequest",
+                (),
+                {
+                    "session_id": request.session_id,
+                    "session_epoch": request.session_epoch,
+                    "container_id": request.container_id,
+                    "thread_id": request.thread_id,
+                    "metadata": dict(request.metadata),
+                },
+            )()
+        )
+
+    @_activity.defn(name="agent_runtime.fetch_result")
+    async def fetch_result(payload: dict[str, Any]) -> AgentRunResult:
+        del payload
+        return AgentRunResult(
+            summary="Recovered final answer without vendor turn id",
+            metadata={
+                "sessionSummary": {
+                    "metadata": {
+                        "lastAssistantText": "Recovered final answer without vendor turn id",
+                    }
+                }
+            },
+        )
+
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex",
+        executionProfileRef="default-managed",
+        correlationId="corr-codex-rollout",
+        idempotencyKey="idem-codex-rollout",
+        parameters={
+            "publishMode": "none",
+            "instructions": "Shrink the Mission Control title text a bit",
+        },
+        managedSession={
+            "workflowId": "test-codex-session-workflow",
+            "taskRunId": "task-run-codex-rollout",
+            "sessionId": "sess:test-codex-session-workflow",
+            "sessionEpoch": 1,
+            "runtimeId": "codex_cli",
+            "executionProfileRef": "default-managed",
+        },
+    )
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue="agent-run-task-queue",
+            workflows=[
+                MoonMindAgentRun,
+                MockProviderProfileManager,
+                DummyCodexSessionWorkflow,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            async with Worker(
+                env.client,
+                task_queue=settings.temporal.activity_artifacts_task_queue,
+                activities=[
+                    mock_provider_profile_list,
+                    mock_provider_profile_ensure_manager,
+                    mock_provider_profile_reset_manager,
+                ],
+            ):
+                async with Worker(
+                    env.client,
+                    task_queue=settings.temporal.activity_agent_runtime_task_queue,
+                    activities=[
+                        mock_publish_artifacts,
+                        mock_cancel,
+                        build_launch_context,
+                        load_session_snapshot,
+                        launch_session,
+                        prepare_turn_instructions,
+                        send_turn,
+                        fetch_session_summary,
+                        publish_session_artifacts,
+                        fetch_result,
+                    ],
+                ):
+                    manager_handle = await env.client.start_workflow(
+                        MockProviderProfileManager.run,
+                        {"runtime_id": "codex_cli"},
+                        id="provider-profile-manager:codex_cli",
+                        task_queue="agent-run-task-queue",
+                    )
+                    session_handle = await env.client.start_workflow(
+                        DummyCodexSessionWorkflow.run,
+                        request.managed_session.model_dump(mode="json", by_alias=True),
+                        id=request.managed_session.workflow_id,
+                        task_queue="agent-run-task-queue",
+                    )
+
+                    try:
+                        result = await env.client.execute_workflow(
+                            MoonMindAgentRun.run,
+                            request,
+                            id="test-agent-run-managed-codex-rollout-recovery",
+                            task_queue="agent-run-task-queue",
+                        )
+                    finally:
+                        await session_handle.signal(DummyCodexSessionWorkflow.shutdown)
+                        await session_handle.result()
+                        try:
+                            await manager_handle.signal(MockProviderProfileManager.shutdown)
+                            await manager_handle.result()
+                        except Exception:
+                            pass
+
+                    assert isinstance(result, AgentRunResult)
+                    assert result.failure_class is None
+                    assert result.summary == "Recovered final answer without vendor turn id"
+                    assert isinstance(result.metadata, dict)
+                    assert result.metadata["sessionSummary"]["metadata"][
+                        "lastAssistantText"
+                    ] == "Recovered final answer without vendor turn id"

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,12 @@ from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexManagedSessionRuntime,
     _run_ready,
 )
+
+
+def _iso_timestamp(*, minutes_offset: int) -> str:
+    return (
+        datetime.now(UTC) + timedelta(minutes=minutes_offset)
+    ).isoformat().replace("+00:00", "Z")
 
 
 def _write_fake_app_server(
@@ -641,6 +648,7 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
     tmp_path: Path,
 ) -> None:
     request = _launch_request(tmp_path)
+    future_timestamp = _iso_timestamp(minutes_offset=5)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -655,7 +663,7 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
             (
                 json.dumps(
                     {
-                        "timestamp": "2026-04-10T07:21:32.088Z",
+                        "timestamp": future_timestamp,
                         "type": "event_msg",
                         "payload": {
                             "type": "task_started",
@@ -665,19 +673,19 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
                 ),
                 json.dumps(
                     {
-                        "timestamp": "2026-04-10T07:21:40.000Z",
+                        "timestamp": future_timestamp,
                         "type": "event_msg",
                         "payload": {
                             "type": "agent_message",
                             "message": "Recovered final answer without vendor turn id",
-                            "phase": "final_answer",
+                            "phase": "final",
                             "memory_citation": None,
                         },
                     }
                 ),
                 json.dumps(
                     {
-                        "timestamp": "2026-04-10T07:21:40.001Z",
+                        "timestamp": future_timestamp,
                         "type": "response_item",
                         "payload": {
                             "type": "message",
@@ -688,13 +696,13 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
                                     "text": "Recovered final answer without vendor turn id",
                                 }
                             ],
-                            "phase": "final_answer",
+                            "phase": "final",
                         },
                     }
                 ),
                 json.dumps(
                     {
-                        "timestamp": "2026-04-10T07:21:40.002Z",
+                        "timestamp": future_timestamp,
                         "type": "event_msg",
                         "payload": {
                             "type": "task_complete",
@@ -758,10 +766,106 @@ def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
     )
 
 
+def test_runtime_send_turn_ignores_stale_terminal_rollout_without_turn_reference(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    past_timestamp = _iso_timestamp(minutes_offset=-5)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        "\n".join(
+            (
+                json.dumps(
+                    {
+                        "timestamp": past_timestamp,
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "agent_message",
+                            "message": "Stale final answer from a previous turn",
+                            "phase": "final",
+                            "memory_citation": None,
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": past_timestamp,
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "Stale final answer from a previous turn",
+                                }
+                            ],
+                            "phase": "final",
+                        },
+                    }
+                ),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert (
+        response.metadata["reason"]
+        == "codex app-server turn/completed produced no assistant output"
+    )
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "failed"
+    assert handle.metadata["lastTurnStatus"] == "failed"
+
+
 def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     tmp_path: Path,
 ) -> None:
     request = _launch_request(tmp_path)
+    past_timestamp = _iso_timestamp(minutes_offset=-5)
     transcript_path = (
         Path(request.codex_home_path)
         / "sessions"
@@ -774,7 +878,7 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     transcript_path.write_text(
         json.dumps(
             {
-                "timestamp": "2026-04-10T07:21:32.088Z",
+                "timestamp": past_timestamp,
                 "type": "response_item",
                 "turnId": "vendor-turn-0",
                 "payload": {
@@ -786,7 +890,7 @@ def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
                             "text": "Stale text from a previous turn",
                         }
                     ],
-                    "phase": "final",
+                    "phase": "final_answer",
                 },
             }
         )

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -637,6 +637,127 @@ def test_runtime_send_turn_completes_when_thread_read_omits_turns(
     assert handle.metadata["lastAssistantText"] == "Recovered from rollout transcript"
 
 
+def test_runtime_send_turn_recovers_terminal_rollout_without_turn_reference(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        "\n".join(
+            (
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T07:21:32.088Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_started",
+                            "turn_id": "codex-turn-1",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T07:21:40.000Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "agent_message",
+                            "message": "Recovered final answer without vendor turn id",
+                            "phase": "final_answer",
+                            "memory_citation": None,
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T07:21:40.001Z",
+                        "type": "response_item",
+                        "payload": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": "Recovered final answer without vendor turn id",
+                                }
+                            ],
+                            "phase": "final_answer",
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "timestamp": "2026-04-10T07:21:40.002Z",
+                        "type": "event_msg",
+                        "payload": {
+                            "type": "task_complete",
+                            "turn_id": "codex-turn-1",
+                            "last_agent_message": (
+                                "Recovered final answer without vendor turn id"
+                            ),
+                        },
+                    }
+                ),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    assert response.turn_id == "vendor-turn-1"
+    assert (
+        response.metadata["assistantText"]
+        == "Recovered final answer without vendor turn id"
+    )
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "ready"
+    assert (
+        handle.metadata["lastAssistantText"]
+        == "Recovered final answer without vendor turn id"
+    )
+
+
 def test_runtime_send_turn_fails_when_rollout_only_has_other_turn_output(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed
This PR fixes managed Codex session runs that completed successfully but were still marked failed because the rollout recovery path could not find assistant output when terminal transcript entries omitted the vendor turn reference.

It updates the Codex managed-session runtime to recover assistant text from terminal-only rollout entries when a turn-linked entry is missing, and adds coverage at both the runtime unit boundary and the `MoonMind.AgentRun` Temporal workflow boundary.

## Root cause
The failing workflow shape produced a real final assistant message in the rollout transcript, but the recovery parser only accepted entries explicitly linked to the `vendor_turn_id`. Some terminal transcript records, including final-answer and task-complete entries, did not carry that turn reference, so the runtime incorrectly concluded that no assistant output existed.

## Impact
Managed Codex child workflows can now complete successfully when the final assistant output is present only in terminal rollout entries. This prevents false `execution_error` failures for otherwise successful runs and adds a regression test for the exact workflow path.

## Validation
- `./.venv/bin/pytest -q tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/integration/services/temporal/workflows/test_agent_run_codex_session_rollout.py`