### PR TITLE
[codex] Fix Codex send_turn notLoaded recovery

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -8,6 +8,7 @@ import os
 import queue
 import shutil
 import signal
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -48,6 +49,7 @@ _STDOUT_EOF = object()
 _AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
+_LOG_RECOVERY_MAX_ROWS = 200
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -656,6 +658,121 @@ class CodexManagedSessionRuntime:
             return ""
         return last_text
 
+    def _rollout_terminal_metadata(
+        self,
+        vendor_thread_path: str | None,
+        *,
+        vendor_turn_id: str,
+    ) -> tuple[bool, str | None]:
+        rollout_path = self._allowed_rollout_path(vendor_thread_path)
+        if rollout_path is None:
+            return False, None
+        saw_task_complete = False
+        error_text: str | None = None
+        try:
+            rollout_file = Path(rollout_path)
+            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
+                return False, None
+            with rollout_file.open(encoding="utf-8") as handle:
+                for raw_line in handle:
+                    stripped = raw_line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        payload = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(payload, Mapping):
+                        continue
+                    if not self._payload_references_turn(payload, vendor_turn_id):
+                        continue
+                    entry_type = str(payload.get("type") or "").strip().lower()
+                    if entry_type != "event_msg":
+                        continue
+                    event_payload = payload.get("payload")
+                    if not isinstance(event_payload, Mapping):
+                        continue
+                    event_type = str(event_payload.get("type") or "").strip().lower()
+                    if event_type != "task_complete":
+                        continue
+                    saw_task_complete = True
+                    for field_name in ("error", "reason", "message"):
+                        value = event_payload.get(field_name)
+                        if isinstance(value, str) and value.strip():
+                            error_text = value.strip()
+                            break
+        except OSError:
+            return False, None
+        return saw_task_complete, error_text
+
+    def _extract_turn_error_from_logs(self, vendor_turn_id: str) -> str | None:
+        for log_path in sorted(self._codex_home_path.glob("logs_*.sqlite"), reverse=True):
+            if not log_path.is_file():
+                continue
+            try:
+                with sqlite3.connect(f"file:{log_path}?mode=ro", uri=True) as connection:
+                    column_rows = connection.execute(
+                        "PRAGMA table_info(logs)"
+                    ).fetchall()
+                    if not column_rows:
+                        continue
+                    available_columns = {str(row[1]) for row in column_rows if len(row) > 1}
+                    text_column = None
+                    for candidate in ("feedback_log_body", "message"):
+                        if candidate in available_columns:
+                            text_column = candidate
+                            break
+                    if text_column is None:
+                        continue
+                    rows = connection.execute(
+                        (
+                            f"SELECT {text_column} FROM logs "
+                            f"WHERE {text_column} LIKE ? ORDER BY id DESC LIMIT ?"
+                        ),
+                        (f"%{vendor_turn_id}%", _LOG_RECOVERY_MAX_ROWS),
+                    ).fetchall()
+            except sqlite3.Error:
+                continue
+            for (raw_text,) in rows:
+                text = str(raw_text or "").strip()
+                marker = "Turn error:"
+                marker_index = text.find(marker)
+                if marker_index >= 0:
+                    recovered = text[marker_index + len(marker) :].strip()
+                    if recovered:
+                        return recovered
+        return None
+
+    def _rollout_terminal_outcome(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> tuple[str, str | None] | None:
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        assistant_text = self._extract_assistant_text_from_rollout(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if assistant_text:
+            return "completed", None
+        saw_task_complete, rollout_error = self._rollout_terminal_metadata(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if not saw_task_complete and not rollout_error:
+            return None
+        return (
+            "failed",
+            rollout_error
+            or self._extract_turn_error_from_logs(vendor_turn_id)
+            or "codex app-server turn/completed produced no assistant output",
+        )
+
     def _resolved_rollout_path(
         self,
         *,
@@ -742,6 +859,13 @@ class CodexManagedSessionRuntime:
                 thread_outcome = self._terminal_thread_outcome(thread_payload)
                 if thread_outcome is not None:
                     return thread_payload, thread_outcome
+                rollout_outcome = self._rollout_terminal_outcome(
+                    state=self._load_state(),
+                    thread_payload=thread_payload,
+                    vendor_turn_id=vendor_turn_id,
+                )
+                if rollout_outcome is not None:
+                    return thread_payload, rollout_outcome
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -921,7 +1045,13 @@ class CodexManagedSessionRuntime:
         else:
             outcome = self._terminal_thread_outcome(thread_payload)
             if outcome is None:
-                return state
+                outcome = self._rollout_terminal_outcome(
+                    state=state,
+                    thread_payload=thread_payload,
+                    vendor_turn_id=active_turn_id,
+                )
+                if outcome is None:
+                    return state
 
         status, error_text = outcome
         assistant_text = ""

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -50,6 +50,7 @@ _AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _LOG_RECOVERY_MAX_ROWS = 200
+_LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -705,12 +706,44 @@ class CodexManagedSessionRuntime:
             return False, None
         return saw_task_complete, error_text
 
+    @staticmethod
+    def _log_shard_sort_key(log_path: Path) -> tuple[int, str]:
+        filename = log_path.name
+        prefix = "logs_"
+        suffix = ".sqlite"
+        if filename.startswith(prefix) and filename.endswith(suffix):
+            shard_suffix = filename[len(prefix) : -len(suffix)]
+            try:
+                return int(shard_suffix), filename
+            except ValueError:
+                pass
+        return -1, filename
+
+    @staticmethod
+    def _quoted_sqlite_identifier(identifier: str) -> str:
+        normalized = identifier.strip()
+        if not normalized:
+            raise ValueError("sqlite identifier must not be blank")
+        if not (normalized[0].isalpha() or normalized[0] == "_"):
+            raise ValueError(f"unsupported sqlite identifier: {identifier!r}")
+        if any(not (character.isalnum() or character == "_") for character in normalized):
+            raise ValueError(f"unsupported sqlite identifier: {identifier!r}")
+        return f'"{normalized}"'
+
     def _extract_turn_error_from_logs(self, vendor_turn_id: str) -> str | None:
-        for log_path in sorted(self._codex_home_path.glob("logs_*.sqlite"), reverse=True):
+        for log_path in sorted(
+            self._codex_home_path.glob("logs_*.sqlite"),
+            key=self._log_shard_sort_key,
+            reverse=True,
+        ):
             if not log_path.is_file():
                 continue
             try:
-                with sqlite3.connect(f"file:{log_path}?mode=ro", uri=True) as connection:
+                with sqlite3.connect(
+                    f"file:{log_path}?mode=ro",
+                    uri=True,
+                    timeout=_LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS,
+                ) as connection:
                     column_rows = connection.execute(
                         "PRAGMA table_info(logs)"
                     ).fetchall()
@@ -724,14 +757,16 @@ class CodexManagedSessionRuntime:
                             break
                     if text_column is None:
                         continue
+                    quoted_text_column = self._quoted_sqlite_identifier(text_column)
                     rows = connection.execute(
                         (
-                            f"SELECT {text_column} FROM logs "
-                            f"WHERE {text_column} LIKE ? ORDER BY id DESC LIMIT ?"
+                            f"SELECT {quoted_text_column} FROM \"logs\" "
+                            f"WHERE {quoted_text_column} LIKE ? "
+                            f"ORDER BY \"id\" DESC LIMIT ?"
                         ),
                         (f"%{vendor_turn_id}%", _LOG_RECOVERY_MAX_ROWS),
                     ).fetchall()
-            except sqlite3.Error:
+            except (ValueError, sqlite3.Error):
                 continue
             for (raw_text,) in rows:
                 text = str(raw_text or "").strip()
@@ -758,20 +793,22 @@ class CodexManagedSessionRuntime:
             vendor_thread_path,
             vendor_turn_id=vendor_turn_id,
         )
-        if assistant_text:
-            return "completed", None
         saw_task_complete, rollout_error = self._rollout_terminal_metadata(
             vendor_thread_path,
             vendor_turn_id=vendor_turn_id,
         )
-        if not saw_task_complete and not rollout_error:
-            return None
-        return (
-            "failed",
-            rollout_error
-            or self._extract_turn_error_from_logs(vendor_turn_id)
-            or "codex app-server turn/completed produced no assistant output",
-        )
+        if saw_task_complete or rollout_error:
+            recovered_error = rollout_error or self._extract_turn_error_from_logs(
+                vendor_turn_id
+            )
+            if recovered_error:
+                return "failed", recovered_error
+            if saw_task_complete and assistant_text:
+                return "completed", None
+            return "failed", "codex app-server turn/completed produced no assistant output"
+        if assistant_text:
+            return "completed", None
+        return None
 
     def _resolved_rollout_path(
         self,

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -325,8 +325,9 @@ def _write_fake_codex_logs(
     codex_home_path: str | Path,
     *,
     entries: list[str],
+    filename: str = "logs_1.sqlite",
 ) -> Path:
-    log_path = Path(codex_home_path) / "logs_1.sqlite"
+    log_path = Path(codex_home_path) / filename
     connection = sqlite3.connect(log_path)
     try:
         connection.execute(
@@ -886,6 +887,118 @@ def test_runtime_send_turn_fails_from_rollout_completion_when_thread_read_is_not
     assert handle.session_state.active_turn_id is None
     assert handle.metadata["lastTurnStatus"] == "failed"
     assert handle.metadata["lastTurnError"] == expected_reason
+
+
+def test_runtime_send_turn_prefers_rollout_task_complete_failure_over_agent_message(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        (
+            json.dumps(
+                {
+                    "timestamp": "2026-04-10T07:21:32.088Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "agent_message",
+                        "turn_id": "vendor-turn-1",
+                        "message": "Interim text that should not mask a failure",
+                    },
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "timestamp": "2026-04-10T07:21:33.088Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_complete",
+                        "turn_id": "vendor-turn-1",
+                        "error": "provider returned exit code 1",
+                    },
+                }
+            )
+            + "\n"
+        ),
+        encoding="utf-8",
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+        thread_status_type="notLoaded",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["reason"] == "provider returned exit code 1"
+
+
+def test_runtime_extract_turn_error_from_logs_prefers_highest_numeric_shard(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "raise SystemExit(0)"),
+    )
+    _write_fake_codex_logs(
+        request.codex_home_path,
+        filename="logs_9.sqlite",
+        entries=[
+            (
+                "session_loop{thread_id=vendor-thread-1}:turn{turn.id=vendor-turn-1}: "
+                "Turn error: stale shard"
+            )
+        ],
+    )
+    _write_fake_codex_logs(
+        request.codex_home_path,
+        filename="logs_10.sqlite",
+        entries=[
+            (
+                "session_loop{thread_id=vendor-thread-1}:turn{turn.id=vendor-turn-1}: "
+                "Turn error: latest shard"
+            )
+        ],
+    )
+
+    assert runtime._extract_turn_error_from_logs("vendor-turn-1") == "latest shard"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -318,6 +319,28 @@ def _launch_request(tmp_path: Path) -> LaunchCodexManagedSessionRequest:
         codexHomePath=str(codex_home_path),
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
     )
+
+
+def _write_fake_codex_logs(
+    codex_home_path: str | Path,
+    *,
+    entries: list[str],
+) -> Path:
+    log_path = Path(codex_home_path) / "logs_1.sqlite"
+    connection = sqlite3.connect(log_path)
+    try:
+        connection.execute(
+            "CREATE TABLE logs (id INTEGER PRIMARY KEY AUTOINCREMENT, feedback_log_body TEXT)"
+        )
+        for entry in entries:
+            connection.execute(
+                "INSERT INTO logs (feedback_log_body) VALUES (?)",
+                (entry,),
+            )
+        connection.commit()
+    finally:
+        connection.close()
+    return log_path
 
 
 def test_app_server_client_ignores_notifications_until_matching_response(
@@ -775,6 +798,94 @@ def test_runtime_send_turn_ignores_rollout_paths_outside_codex_sessions(
         response.metadata["reason"]
         == "codex app-server turn/completed produced no assistant output"
     )
+
+
+def test_runtime_send_turn_fails_from_rollout_completion_when_thread_read_is_not_loaded(
+    tmp_path: Path,
+) -> None:
+    request = _launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.860Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_complete",
+                    "turn_id": "vendor-turn-1",
+                    "last_agent_message": None,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_fake_codex_logs(
+        request.codex_home_path,
+        entries=[
+            (
+                "session_loop{thread_id=vendor-thread-1}:turn{turn.id=vendor-turn-1}: "
+                "Turn error: unexpected status 404 Not Found: The free model has been "
+                "deprecated. Transition to qwen/qwen3.6-plus for continued paid access."
+            )
+        ],
+    )
+    script = _write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+        thread_status_type="notLoaded",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    expected_reason = (
+        "unexpected status 404 Not Found: The free model has been deprecated. "
+        "Transition to qwen/qwen3.6-plus for continued paid access."
+    )
+    assert response.status == "failed"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id is None
+    assert response.metadata["reason"] == expected_reason
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "failed"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.metadata["lastTurnError"] == expected_reason
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -943,6 +943,70 @@ async def test_controller_send_turn_polls_session_status_until_completed() -> No
 
 
 @pytest.mark.asyncio
+async def test_controller_send_turn_does_not_poll_session_status_for_terminal_failure() -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "exec", "-i") and "send_turn" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": "logical-thread-1",
+                    "activeTurnId": None,
+                },
+                "turnId": "vendor-turn-1",
+                "status": "failed",
+                "metadata": {"reason": "provider model deprecated"},
+            }
+            return 0, json.dumps(payload), ""
+        if command[:3] == ("docker", "exec", "-i") and "session_status" in command:
+            raise AssertionError("session_status should not be called for terminal failure")
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        turn_poll_interval_seconds=0,
+    )
+
+    response = await controller.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["reason"] == "provider model deprecated"
+    assert commands == [
+        (
+            "docker",
+            "exec",
+            "-i",
+            "ctr-1",
+            "python3",
+            "-m",
+            "moonmind.workflows.temporal.runtime.codex_session_runtime",
+            "invoke",
+            "send_turn",
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_controller_send_turn_recovers_from_blank_output_using_runtime_state(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
This fixes a managed Codex session failure mode where `agent_runtime.send_turn` can wedge after the underlying Codex turn has already terminated.

## What Changed
- classify rollout `task_complete` as terminal evidence when `thread/read` falls back to `status.type = notLoaded` with no turns
- recover concrete terminal turn errors from local Codex `logs_*.sqlite` when the app-server no longer exposes a failed turn payload
- use the same rollout-based terminal recovery path during both in-process `send_turn` waiting and later `session_status` refresh
- add runtime regression coverage for `notLoaded` plus rollout/log recovery
- add controller boundary coverage proving terminal failed `send_turn` responses do not trigger follow-up `session_status` polling

## Root Cause
In the failing path, the provider request terminated inside Codex and the rollout transcript wrote `task_complete`, but subsequent `thread/read` calls only returned `status.type = notLoaded` with an empty `turns` list. MoonMind only treated explicit turn payloads or a narrow set of terminal thread statuses as terminal, so it kept polling forever and left the Temporal activity heartbeating.

## Validation
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `./tools/test_unit.sh`