### PR TITLE
[codex] Prefer pushed branch for native PR creation

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2114,7 +2114,8 @@ class MoonMindRunWorkflow:
                     ordered_nodes[-1].get("inputs", {}) if ordered_nodes else {}
                 )
                 head_branch = (
-                    agent_outputs.get("branch")
+                    agent_outputs.get("push_branch")
+                    or agent_outputs.get("branch")
                     or agent_outputs.get("targetBranch")
                     or ws.get("targetBranch")
                     or ws.get("branch")

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1354,6 +1354,145 @@ async def test_run_execution_stage_publish_mode_pr_defaults_title_from_task_inte
     )
 
 
+@pytest.mark.asyncio
+async def test_run_execution_stage_publish_mode_pr_prefers_pushed_branch_for_native_pr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._owner_id = "owner-1"
+    workflow._repo = "MoonLadderStudios/MoonMind"
+    captured_create_payload: dict[str, Any] = {}
+
+    async def fake_bind_task_scoped_session(
+        self: MoonMindRunWorkflow,
+        request: object,
+    ) -> object:
+        return request
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        if activity_type == "repo.create_pr":
+            captured_create_payload["payload"] = _normalize_payload(payload)
+            return {
+                "url": "https://github.com/MoonLadderStudios/MoonMind/pull/1001",
+                "created": True,
+            }
+
+        if activity_type == "artifact.read":
+            if (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            ) == "artifact://registry/1":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "auto",
+                                "version": "1.0",
+                                "description": "Auto",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Publish Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "node-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "codex_cli",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "codex_cli", "model": "gpt-5.4"},
+                                "instructions": "Tighten the Mission Control title size.",
+                                "targetBranch": "planned-title-branch",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Completed with status completed",
+            "metadata": {
+                "push_status": "pushed",
+                "push_branch": "actual-pushed-branch",
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
+    monkeypatch.setattr(
+        MoonMindRunWorkflow,
+        "_maybe_bind_task_scoped_session",
+        fake_bind_task_scoped_session,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await workflow._run_execution_stage(
+        parameters={
+            "repo": "MoonLadderStudios/MoonMind",
+            "publishMode": "pr",
+            "workspaceSpec": {"targetBranch": "planned-title-branch"},
+        },
+        plan_ref="art_plan_1",
+    )
+
+    assert captured_create_payload["payload"]["head"] == "actual-pushed-branch"
+
+
 def test_activity_result_failure_message_prefers_stderr_tail_over_progress_details() -> None:
     workflow = MoonMindRunWorkflow()
     message = workflow._activity_result_failure_message(


### PR DESCRIPTION
## Summary

Fixes native PR creation for managed agent runs when the runtime pushes a different branch than the branch planned in the workflow inputs.

## Root Cause

The workflow's native PR publish path chose the PR head branch from generic `branch` or planned target branch fields before considering the actual `push_branch` returned by the managed agent. A run could therefore successfully push commits to one branch, then fail PR creation against a non-existent or stale planned branch.

## Changes

- Prefer `push_branch` when constructing the native `repo.create_pr` payload.
- Add regression coverage for a Codex-style managed agent result where `push_branch` differs from the planned target branch.

## Validation

- `python3 -m py_compile moonmind/workflows/temporal/workflows/run.py tests/unit/workflows/temporal/test_run_artifacts.py`
- `.venv/bin/pytest -q tests/unit/workflows/temporal/test_run_artifacts.py -k 'prefers_pushed_branch_for_native_pr'`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`