### PR TITLE
[codex] Add DooD workload contract

### DIFF
--- a/.specify/scripts/bash/validate-implementation-scope.sh
+++ b/.specify/scripts/bash/validate-implementation-scope.sh
@@ -134,18 +134,19 @@ validate_diff_scope() {
     return 1
   fi
 
-  mapfile -t committed < <(git diff --name-only "${merge_base}"..HEAD)
-  mapfile -t staged < <(git diff --name-only --cached)
-  mapfile -t unstaged < <(git diff --name-only)
-  mapfile -t untracked < <(git ls-files --others --exclude-standard)
+  local committed staged unstaged untracked all_files
+  committed="$(git diff --name-only "${merge_base}"..HEAD)"
+  staged="$(git diff --name-only --cached)"
+  unstaged="$(git diff --name-only)"
+  untracked="$(git ls-files --others --exclude-standard)"
 
-  local all_files
   all_files="$(
-    printf '%s\n' \
-      "${committed[@]:-}" \
-      "${staged[@]:-}" \
-      "${unstaged[@]:-}" \
-      "${untracked[@]:-}" \
+    {
+      printf '%s\n' "$committed"
+      printf '%s\n' "$staged"
+      printf '%s\n' "$unstaged"
+      printf '%s\n' "$untracked"
+    } \
       | unique_nonempty_lines
   )"
 

--- a/docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md
+++ b/docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md
@@ -1,13 +1,13 @@
 # DockerOutOfDocker Remaining Work
 
 Source doc: [`docs/ManagedAgents/DockerOutOfDocker.md`](../../ManagedAgents/DockerOutOfDocker.md)
-Status: Phase 0 complete; Phases 1 through 7 pending
-Last updated: 2026-04-09
+Status: Phase 0 and Phase 1 complete; Phases 2 through 7 pending
+Last updated: 2026-04-10
 
 ## Phase checklist
 
 - [x] Phase 0: Lock the contract and carve the boundary across the canonical DooD, session-plane, and execution-model docs.
-- [ ] Phase 1: Define the control-plane workload contract (`WorkloadRequest`, `WorkloadResult`, `RunnerProfile`, ownership metadata, validation rules).
+- [x] Phase 1: Define the control-plane workload contract (`WorkloadRequest`, `WorkloadResult`, `RunnerProfile`, ownership metadata, validation rules).
 - [ ] Phase 2: Build the Docker workload launcher on the existing Docker-capable `agent_runtime` worker fleet.
 - [ ] Phase 3: Expose DooD through executable tools such as `container.run_workload` and `unreal.run_tests`.
 - [ ] Phase 4: Publish durable workload artifacts, live-log linkage, and optional session-association metadata without confusing workload identity with session identity.
@@ -21,6 +21,13 @@ Last updated: 2026-04-09
 - Session-plane doc now states that managed-session steps may invoke control-plane workload tools whose containers remain outside session identity.
 - Execution-model doc now states that Docker-backed workload tools remain ordinary executable tools unless they launch a true managed agent runtime.
 - A focused unit test guards the tracker reference and the agreed boundary wording.
+
+## Phase 1 completion notes
+
+- Canonical workload request/result, runner profile, and ownership metadata models are defined in code without invoking Docker.
+- A deployment-owned runner profile registry can load JSON/YAML profile files and fails closed when no registry exists.
+- Profile-aware validation rejects unknown profiles, unsafe images/mounts/network/device policy, disallowed env overrides, workspace paths outside the configured root, excessive resource overrides, and timeout overrides above profile limits.
+- Focused unit tests cover valid request construction, deterministic `moonmind.*` labels, registry loading, fail-closed behavior, and policy denials.
 
 ## Guardrails to preserve during later phases
 

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -1,0 +1,459 @@
+"""Canonical contracts for Docker-backed workload execution."""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from moonmind.schemas._validation import NonBlankStr, require_non_blank
+
+
+_ENV_NAME_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_CONTAINER_NAME_SAFE_PATTERN = re.compile(r"[^a-zA-Z0-9_.-]+")
+_SIZE_PATTERN = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgtp]?i?b?)?$", re.I)
+_SIZE_MULTIPLIERS: dict[str, int] = {
+    "": 1,
+    "b": 1,
+    "k": 1000,
+    "kb": 1000,
+    "m": 1000**2,
+    "mb": 1000**2,
+    "g": 1000**3,
+    "gb": 1000**3,
+    "t": 1000**4,
+    "tb": 1000**4,
+    "ki": 1024,
+    "kib": 1024,
+    "mi": 1024**2,
+    "mib": 1024**2,
+    "gi": 1024**3,
+    "gib": 1024**3,
+    "ti": 1024**4,
+    "tib": 1024**4,
+}
+
+
+WorkloadStatus = Literal["succeeded", "failed", "timed_out", "canceled"]
+WorkloadKind = Literal["one_shot"]
+WorkloadNetworkPolicy = Literal["none", "bridge"]
+WorkloadDeviceMode = Literal["none"]
+
+
+def parse_cpu_units(value: str) -> float:
+    """Parse a Docker CPU quota-style value for numeric comparison."""
+
+    normalized = require_non_blank(value, field_name="cpu").lower()
+    if normalized.endswith("m"):
+        raw = normalized[:-1]
+        if not raw:
+            raise ValueError("cpu must be a positive number")
+        parsed = float(raw) / 1000
+    else:
+        parsed = float(normalized)
+    if parsed <= 0:
+        raise ValueError("cpu must be positive")
+    return parsed
+
+
+def parse_size_bytes(value: str) -> int:
+    """Parse a Docker size string such as ``512m`` or ``2g``."""
+
+    normalized = require_non_blank(value, field_name="size").lower()
+    match = _SIZE_PATTERN.match(normalized)
+    if match is None:
+        raise ValueError(f"invalid size value: {value!r}")
+    amount = float(match.group("value"))
+    unit = match.group("unit") or ""
+    multiplier = _SIZE_MULTIPLIERS.get(unit)
+    if multiplier is None:
+        raise ValueError(f"invalid size unit: {unit!r}")
+    parsed = int(amount * multiplier)
+    if parsed <= 0:
+        raise ValueError("size must be positive")
+    return parsed
+
+
+def workload_container_name(
+    *,
+    task_run_id: str,
+    step_id: str,
+    attempt: int,
+) -> str:
+    """Return the deterministic Phase 1 workload container name."""
+
+    task = _sanitize_name_part(task_run_id)
+    step = _sanitize_name_part(step_id)
+    return f"mm-workload-{task}-{step}-{attempt}"
+
+
+def _sanitize_name_part(value: str) -> str:
+    normalized = _CONTAINER_NAME_SAFE_PATTERN.sub("-", str(value).strip())
+    normalized = normalized.strip("-._")
+    return normalized or "unknown"
+
+
+def _normalize_env_name(value: str, *, field_name: str) -> str:
+    normalized = require_non_blank(value, field_name=field_name).upper()
+    if _ENV_NAME_PATTERN.match(normalized) is None:
+        raise ValueError(
+            f"{field_name} must be an uppercase environment variable name"
+        )
+    return normalized
+
+
+def _image_has_tag_or_digest(image: str) -> bool:
+    if "@sha256:" in image:
+        return True
+    last_segment = image.rsplit("/", 1)[-1]
+    return ":" in last_segment
+
+
+class WorkloadMount(BaseModel):
+    """Allowed container mount declaration for a runner profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    type: str = Field("volume", alias="type")
+    source: NonBlankStr = Field(..., alias="source")
+    target: NonBlankStr = Field(..., alias="target")
+    read_only: bool = Field(False, alias="readOnly")
+
+    @model_validator(mode="after")
+    def _validate_mount(self) -> "WorkloadMount":
+        if self.type != "volume":
+            raise ValueError("mount type must be volume")
+        if self.source.startswith("/") or ".." in self.source.split("/"):
+            raise ValueError("mount source must be a Docker named volume")
+        if not self.target.startswith("/work/") and self.target != "/work":
+            raise ValueError("mount target must be under /work")
+        if self.target == "/var/run/docker.sock" or "docker.sock" in self.target:
+            raise ValueError("mount target must not expose the Docker socket")
+        return self
+
+
+class WorkloadResourceOverrides(BaseModel):
+    """Per-request resource overrides capped by the selected runner profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    cpu: str | None = Field(None, alias="cpu")
+    memory: str | None = Field(None, alias="memory")
+    shm_size: str | None = Field(None, alias="shmSize")
+
+    @model_validator(mode="after")
+    def _validate_values(self) -> "WorkloadResourceOverrides":
+        if self.cpu is not None:
+            self.cpu = require_non_blank(self.cpu, field_name="cpu")
+            parse_cpu_units(self.cpu)
+        if self.memory is not None:
+            self.memory = require_non_blank(self.memory, field_name="memory")
+            parse_size_bytes(self.memory)
+        if self.shm_size is not None:
+            self.shm_size = require_non_blank(self.shm_size, field_name="shmSize")
+            parse_size_bytes(self.shm_size)
+        return self
+
+
+class RunnerResourceProfile(BaseModel):
+    """Default and maximum resources for one runner profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    cpu: NonBlankStr | None = Field(None, alias="cpu")
+    memory: NonBlankStr | None = Field(None, alias="memory")
+    shm_size: NonBlankStr | None = Field(None, alias="shmSize")
+    max_cpu: NonBlankStr | None = Field(None, alias="maxCpu")
+    max_memory: NonBlankStr | None = Field(None, alias="maxMemory")
+    max_shm_size: NonBlankStr | None = Field(None, alias="maxShmSize")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_snake_case(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        aliases = {
+            "shm_size": "shmSize",
+            "max_cpu": "maxCpu",
+            "max_memory": "maxMemory",
+            "max_shm_size": "maxShmSize",
+        }
+        return {aliases.get(str(key), key): item for key, item in value.items()}
+
+    @model_validator(mode="after")
+    def _validate_limits(self) -> "RunnerResourceProfile":
+        if self.cpu is not None:
+            parse_cpu_units(self.cpu)
+        if self.max_cpu is not None:
+            parse_cpu_units(self.max_cpu)
+        if self.cpu is not None and self.max_cpu is not None:
+            if parse_cpu_units(self.cpu) > parse_cpu_units(self.max_cpu):
+                raise ValueError("cpu default must not exceed maxCpu")
+
+        if self.memory is not None:
+            parse_size_bytes(self.memory)
+        if self.max_memory is not None:
+            parse_size_bytes(self.max_memory)
+        if self.memory is not None and self.max_memory is not None:
+            if parse_size_bytes(self.memory) > parse_size_bytes(self.max_memory):
+                raise ValueError("memory default must not exceed maxMemory")
+
+        if self.shm_size is not None:
+            parse_size_bytes(self.shm_size)
+        if self.max_shm_size is not None:
+            parse_size_bytes(self.max_shm_size)
+        if self.shm_size is not None and self.max_shm_size is not None:
+            if parse_size_bytes(self.shm_size) > parse_size_bytes(self.max_shm_size):
+                raise ValueError("shmSize default must not exceed maxShmSize")
+        return self
+
+
+class WorkloadCleanupPolicy(BaseModel):
+    """Cleanup behavior for a workload container."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    remove_container_on_exit: bool = Field(True, alias="removeContainerOnExit")
+    kill_grace_seconds: int = Field(30, alias="killGraceSeconds", ge=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_snake_case(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        aliases = {
+            "remove_container_on_exit": "removeContainerOnExit",
+            "kill_grace_seconds": "killGraceSeconds",
+        }
+        return {aliases.get(str(key), key): item for key, item in value.items()}
+
+
+class WorkloadDevicePolicy(BaseModel):
+    """Device access policy for Phase 1 runner profiles."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    mode: WorkloadDeviceMode = Field("none", alias="mode")
+
+
+class RunnerProfile(BaseModel):
+    """Deployment-owned workload runner profile."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    id: NonBlankStr = Field(..., alias="id")
+    kind: WorkloadKind = Field("one_shot", alias="kind")
+    image: NonBlankStr = Field(..., alias="image")
+    entrypoint: tuple[NonBlankStr, ...] = Field(default_factory=tuple, alias="entrypoint")
+    command_wrapper: tuple[NonBlankStr, ...] = Field(
+        default_factory=tuple,
+        alias="commandWrapper",
+    )
+    workdir_template: NonBlankStr = Field(..., alias="workdirTemplate")
+    required_mounts: tuple[WorkloadMount, ...] = Field(
+        default_factory=tuple,
+        alias="requiredMounts",
+    )
+    optional_mounts: tuple[WorkloadMount, ...] = Field(
+        default_factory=tuple,
+        alias="optionalMounts",
+    )
+    env_allowlist: tuple[str, ...] = Field(default_factory=tuple, alias="envAllowlist")
+    network_policy: WorkloadNetworkPolicy = Field("none", alias="networkPolicy")
+    resources: RunnerResourceProfile = Field(
+        default_factory=RunnerResourceProfile,
+        alias="resources",
+    )
+    timeout_seconds: int = Field(300, alias="timeoutSeconds", ge=1)
+    max_timeout_seconds: int | None = Field(None, alias="maxTimeoutSeconds", ge=1)
+    cleanup: WorkloadCleanupPolicy = Field(
+        default_factory=WorkloadCleanupPolicy,
+        alias="cleanup",
+    )
+    device_policy: WorkloadDevicePolicy = Field(
+        default_factory=WorkloadDevicePolicy,
+        alias="devicePolicy",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_snake_case(cls, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        aliases = {
+            "command_wrapper": "commandWrapper",
+            "workdir_template": "workdirTemplate",
+            "required_mounts": "requiredMounts",
+            "optional_mounts": "optionalMounts",
+            "env_allowlist": "envAllowlist",
+            "network_policy": "networkPolicy",
+            "timeout_seconds": "timeoutSeconds",
+            "max_timeout_seconds": "maxTimeoutSeconds",
+            "device_policy": "devicePolicy",
+        }
+        return {aliases.get(str(key), key): item for key, item in value.items()}
+
+    @model_validator(mode="after")
+    def _validate_profile(self) -> "RunnerProfile":
+        if not _image_has_tag_or_digest(self.image):
+            raise ValueError("image must include an explicit tag or digest")
+        if self.image.rsplit("/", 1)[-1].endswith(":latest"):
+            raise ValueError("image must not use the latest tag")
+        if not self.workdir_template.startswith("/work/"):
+            raise ValueError("workdirTemplate must be under /work")
+        if not self.required_mounts:
+            raise ValueError("requiredMounts must include a workspace mount")
+        self.env_allowlist = tuple(
+            dict.fromkeys(
+                _normalize_env_name(key, field_name="envAllowlist[]")
+                for key in self.env_allowlist
+            )
+        )
+        if self.max_timeout_seconds is not None:
+            if self.timeout_seconds > self.max_timeout_seconds:
+                raise ValueError("timeoutSeconds must not exceed maxTimeoutSeconds")
+        return self
+
+
+class WorkloadOwnershipMetadata(BaseModel):
+    """Deterministic ownership labels for a workload request."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    kind: Literal["workload"] = Field("workload", alias="kind")
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    step_id: NonBlankStr = Field(..., alias="stepId")
+    attempt: int = Field(..., alias="attempt", ge=1)
+    tool_name: NonBlankStr = Field(..., alias="toolName")
+    workload_profile: NonBlankStr = Field(..., alias="workloadProfile")
+    session_id: NonBlankStr | None = Field(None, alias="sessionId")
+    session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+
+    @property
+    def labels(self) -> dict[str, str]:
+        labels = {
+            "moonmind.kind": self.kind,
+            "moonmind.task_run_id": self.task_run_id,
+            "moonmind.step_id": self.step_id,
+            "moonmind.attempt": str(self.attempt),
+            "moonmind.tool_name": self.tool_name,
+            "moonmind.workload_profile": self.workload_profile,
+        }
+        if self.session_id is not None:
+            labels["moonmind.session_id"] = self.session_id
+        if self.session_epoch is not None:
+            labels["moonmind.session_epoch"] = str(self.session_epoch)
+        return labels
+
+
+class WorkloadRequest(BaseModel):
+    """Canonical request payload for one Docker-backed workload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    profile_id: NonBlankStr = Field(..., alias="profileId")
+    task_run_id: NonBlankStr = Field(..., alias="taskRunId")
+    step_id: NonBlankStr = Field(..., alias="stepId")
+    attempt: int = Field(..., alias="attempt", ge=1)
+    tool_name: NonBlankStr = Field(..., alias="toolName")
+    repo_dir: NonBlankStr = Field(..., alias="repoDir")
+    artifacts_dir: NonBlankStr = Field(..., alias="artifactsDir")
+    command: tuple[NonBlankStr, ...] = Field(..., alias="command", min_length=1)
+    env_overrides: dict[str, str] = Field(default_factory=dict, alias="envOverrides")
+    timeout_seconds: int | None = Field(None, alias="timeoutSeconds", ge=1)
+    resources: WorkloadResourceOverrides = Field(
+        default_factory=WorkloadResourceOverrides,
+        alias="resources",
+    )
+    session_id: NonBlankStr | None = Field(None, alias="sessionId")
+    session_epoch: int | None = Field(None, alias="sessionEpoch", ge=1)
+    source_turn_id: NonBlankStr | None = Field(None, alias="sourceTurnId")
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "WorkloadRequest":
+        self.command = tuple(
+            require_non_blank(item, field_name="command[]") for item in self.command
+        )
+        normalized_env: dict[str, str] = {}
+        for raw_key, raw_value in self.env_overrides.items():
+            key = _normalize_env_name(str(raw_key), field_name="envOverrides key")
+            normalized_env[key] = str(raw_value)
+        self.env_overrides = normalized_env
+        if self.session_id is None:
+            if self.session_epoch is not None or self.source_turn_id is not None:
+                raise ValueError(
+                    "sessionEpoch/sourceTurnId require sessionId association metadata"
+                )
+        return self
+
+    def ownership_metadata(self) -> WorkloadOwnershipMetadata:
+        return WorkloadOwnershipMetadata(
+            taskRunId=self.task_run_id,
+            stepId=self.step_id,
+            attempt=self.attempt,
+            toolName=self.tool_name,
+            workloadProfile=self.profile_id,
+            sessionId=self.session_id,
+            sessionEpoch=self.session_epoch,
+        )
+
+    @property
+    def container_name(self) -> str:
+        return workload_container_name(
+            task_run_id=self.task_run_id,
+            step_id=self.step_id,
+            attempt=self.attempt,
+        )
+
+
+class ValidatedWorkloadRequest(BaseModel):
+    """Profile-aware validated workload request."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    request: WorkloadRequest = Field(..., alias="request")
+    profile: RunnerProfile = Field(..., alias="profile")
+    ownership: WorkloadOwnershipMetadata = Field(..., alias="ownership")
+    container_name: NonBlankStr = Field(..., alias="containerName")
+
+
+class WorkloadResult(BaseModel):
+    """Bounded workload execution result metadata."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    request_id: NonBlankStr = Field(..., alias="requestId")
+    profile_id: NonBlankStr = Field(..., alias="profileId")
+    status: WorkloadStatus = Field(..., alias="status")
+    labels: dict[str, str] = Field(default_factory=dict, alias="labels")
+    exit_code: int | None = Field(None, alias="exitCode")
+    started_at: datetime | None = Field(None, alias="startedAt")
+    completed_at: datetime | None = Field(None, alias="completedAt")
+    duration_seconds: float | None = Field(None, alias="durationSeconds", ge=0)
+    timeout_reason: str | None = Field(None, alias="timeoutReason")
+    stdout_ref: str | None = Field(None, alias="stdoutRef")
+    stderr_ref: str | None = Field(None, alias="stderrRef")
+    diagnostics_ref: str | None = Field(None, alias="diagnosticsRef")
+    output_refs: dict[str, str] = Field(default_factory=dict, alias="outputRefs")
+    metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+
+    @model_validator(mode="after")
+    def _normalize_result(self) -> "WorkloadResult":
+        for field_name in (
+            "started_at",
+            "completed_at",
+        ):
+            value = getattr(self, field_name)
+            if isinstance(value, datetime) and value.tzinfo is None:
+                setattr(self, field_name, value.replace(tzinfo=UTC))
+        self.labels = {str(key): str(value) for key, value in self.labels.items()}
+        self.output_refs = {
+            require_non_blank(key, field_name="outputRefs key"): require_non_blank(
+                value,
+                field_name="outputRefs value",
+            )
+            for key, value in self.output_refs.items()
+        }
+        return self

--- a/moonmind/schemas/workload_models.py
+++ b/moonmind/schemas/workload_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import posixpath
 import re
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -13,18 +14,19 @@ from moonmind.schemas._validation import NonBlankStr, require_non_blank
 
 _ENV_NAME_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 _CONTAINER_NAME_SAFE_PATTERN = re.compile(r"[^a-zA-Z0-9_.-]+")
-_SIZE_PATTERN = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgtp]?i?b?)?$", re.I)
+_SIZE_PATTERN = re.compile(r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>[kmgt]?i?b?)?$", re.I)
+_VOLUME_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 _SIZE_MULTIPLIERS: dict[str, int] = {
     "": 1,
     "b": 1,
-    "k": 1000,
-    "kb": 1000,
-    "m": 1000**2,
-    "mb": 1000**2,
-    "g": 1000**3,
-    "gb": 1000**3,
-    "t": 1000**4,
-    "tb": 1000**4,
+    "k": 1024,
+    "kb": 1024,
+    "m": 1024**2,
+    "mb": 1024**2,
+    "g": 1024**3,
+    "gb": 1024**3,
+    "t": 1024**4,
+    "tb": 1024**4,
     "ki": 1024,
     "kib": 1024,
     "mi": 1024**2,
@@ -111,6 +113,15 @@ def _image_has_tag_or_digest(image: str) -> bool:
     return ":" in last_segment
 
 
+def _is_under_work_path(value: str, *, allow_work_root: bool) -> bool:
+    normalized = posixpath.normpath(value)
+    if not normalized.startswith("/"):
+        return False
+    if normalized == "/work":
+        return allow_work_root
+    return normalized.startswith("/work/")
+
+
 class WorkloadMount(BaseModel):
     """Allowed container mount declaration for a runner profile."""
 
@@ -125,9 +136,9 @@ class WorkloadMount(BaseModel):
     def _validate_mount(self) -> "WorkloadMount":
         if self.type != "volume":
             raise ValueError("mount type must be volume")
-        if self.source.startswith("/") or ".." in self.source.split("/"):
+        if _VOLUME_NAME_PATTERN.match(self.source) is None:
             raise ValueError("mount source must be a Docker named volume")
-        if not self.target.startswith("/work/") and self.target != "/work":
+        if not _is_under_work_path(self.target, allow_work_root=True):
             raise ValueError("mount target must be under /work")
         if self.target == "/var/run/docker.sock" or "docker.sock" in self.target:
             raise ValueError("mount target must not expose the Docker socket")
@@ -169,19 +180,6 @@ class RunnerResourceProfile(BaseModel):
     max_memory: NonBlankStr | None = Field(None, alias="maxMemory")
     max_shm_size: NonBlankStr | None = Field(None, alias="maxShmSize")
 
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_snake_case(cls, value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-        aliases = {
-            "shm_size": "shmSize",
-            "max_cpu": "maxCpu",
-            "max_memory": "maxMemory",
-            "max_shm_size": "maxShmSize",
-        }
-        return {aliases.get(str(key), key): item for key, item in value.items()}
-
     @model_validator(mode="after")
     def _validate_limits(self) -> "RunnerResourceProfile":
         if self.cpu is not None:
@@ -217,17 +215,6 @@ class WorkloadCleanupPolicy(BaseModel):
 
     remove_container_on_exit: bool = Field(True, alias="removeContainerOnExit")
     kill_grace_seconds: int = Field(30, alias="killGraceSeconds", ge=0)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_snake_case(cls, value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-        aliases = {
-            "remove_container_on_exit": "removeContainerOnExit",
-            "kill_grace_seconds": "killGraceSeconds",
-        }
-        return {aliases.get(str(key), key): item for key, item in value.items()}
 
 
 class WorkloadDevicePolicy(BaseModel):
@@ -277,31 +264,13 @@ class RunnerProfile(BaseModel):
         alias="devicePolicy",
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _accept_snake_case(cls, value: Any) -> Any:
-        if not isinstance(value, dict):
-            return value
-        aliases = {
-            "command_wrapper": "commandWrapper",
-            "workdir_template": "workdirTemplate",
-            "required_mounts": "requiredMounts",
-            "optional_mounts": "optionalMounts",
-            "env_allowlist": "envAllowlist",
-            "network_policy": "networkPolicy",
-            "timeout_seconds": "timeoutSeconds",
-            "max_timeout_seconds": "maxTimeoutSeconds",
-            "device_policy": "devicePolicy",
-        }
-        return {aliases.get(str(key), key): item for key, item in value.items()}
-
     @model_validator(mode="after")
     def _validate_profile(self) -> "RunnerProfile":
         if not _image_has_tag_or_digest(self.image):
             raise ValueError("image must include an explicit tag or digest")
         if self.image.rsplit("/", 1)[-1].endswith(":latest"):
             raise ValueError("image must not use the latest tag")
-        if not self.workdir_template.startswith("/work/"):
+        if not _is_under_work_path(self.workdir_template, allow_work_root=False):
             raise ValueError("workdirTemplate must be under /work")
         if not self.required_mounts:
             raise ValueError("requiredMounts must include a workspace mount")

--- a/moonmind/workloads/__init__.py
+++ b/moonmind/workloads/__init__.py
@@ -1,0 +1,20 @@
+"""Docker-backed workload contract helpers."""
+
+from moonmind.schemas.workload_models import (
+    RunnerProfile,
+    ValidatedWorkloadRequest,
+    WorkloadOwnershipMetadata,
+    WorkloadRequest,
+    WorkloadResult,
+)
+from moonmind.workloads.registry import RunnerProfileRegistry, WorkloadPolicyError
+
+__all__ = [
+    "RunnerProfile",
+    "RunnerProfileRegistry",
+    "ValidatedWorkloadRequest",
+    "WorkloadOwnershipMetadata",
+    "WorkloadPolicyError",
+    "WorkloadRequest",
+    "WorkloadResult",
+]

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -170,9 +170,24 @@ class RunnerProfileRegistry:
 
 
 def _load_registry_payload(path: Path, raw_text: str) -> Any:
-    if path.suffix.lower() == ".json":
-        return json.loads(raw_text or "{}")
-    return yaml.safe_load(raw_text) or {}
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
+            return json.loads(raw_text or "{}")
+        except json.JSONDecodeError as exc:
+            raise WorkloadPolicyError(
+                f"invalid runner profile registry JSON: {exc}"
+            ) from exc
+    if suffix in {".yaml", ".yml"}:
+        try:
+            return yaml.safe_load(raw_text) or {}
+        except yaml.YAMLError as exc:
+            raise WorkloadPolicyError(
+                f"invalid runner profile registry YAML: {exc}"
+            ) from exc
+    raise WorkloadPolicyError(
+        "runner profile registry must use a .json, .yaml, or .yml file extension"
+    )
 
 
 def _extract_profiles(payload: Any) -> list[RunnerProfile]:

--- a/moonmind/workloads/registry.py
+++ b/moonmind/workloads/registry.py
@@ -1,0 +1,213 @@
+"""Runner profile registry and policy validation for workload requests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+import yaml
+from pydantic import ValidationError
+
+from moonmind.schemas.workload_models import (
+    RunnerProfile,
+    ValidatedWorkloadRequest,
+    WorkloadRequest,
+    parse_cpu_units,
+    parse_size_bytes,
+)
+
+
+class WorkloadPolicyError(ValueError):
+    """Raised when workload profile or request policy validation fails."""
+
+
+class RunnerProfileRegistry:
+    """Deployment-owned registry of curated workload runner profiles."""
+
+    def __init__(
+        self,
+        profiles: Iterable[RunnerProfile] = (),
+        *,
+        workspace_root: str | Path,
+    ) -> None:
+        self._workspace_root = Path(workspace_root).expanduser().resolve()
+        self._profiles: dict[str, RunnerProfile] = {}
+        for profile in profiles:
+            if profile.id in self._profiles:
+                raise WorkloadPolicyError(
+                    f"duplicate runner profile id: {profile.id}"
+                )
+            self._profiles[profile.id] = profile
+
+    @property
+    def workspace_root(self) -> Path:
+        return self._workspace_root
+
+    @property
+    def profile_ids(self) -> tuple[str, ...]:
+        return tuple(self._profiles)
+
+    def get(self, profile_id: str) -> RunnerProfile | None:
+        return self._profiles.get(profile_id)
+
+    @classmethod
+    def empty(cls, *, workspace_root: str | Path) -> "RunnerProfileRegistry":
+        return cls((), workspace_root=workspace_root)
+
+    @classmethod
+    def load_optional_file(
+        cls,
+        path: str | Path,
+        *,
+        workspace_root: str | Path,
+    ) -> "RunnerProfileRegistry":
+        registry_path = Path(path)
+        if not registry_path.exists():
+            return cls.empty(workspace_root=workspace_root)
+        return cls.load_file(registry_path, workspace_root=workspace_root)
+
+    @classmethod
+    def load_file(
+        cls,
+        path: str | Path,
+        *,
+        workspace_root: str | Path,
+    ) -> "RunnerProfileRegistry":
+        registry_path = Path(path)
+        raw_text = registry_path.read_text(encoding="utf-8")
+        payload = _load_registry_payload(registry_path, raw_text)
+        profiles = _extract_profiles(payload)
+        return cls(profiles, workspace_root=workspace_root)
+
+    def validate_request(
+        self,
+        request: WorkloadRequest | Mapping[str, Any],
+    ) -> ValidatedWorkloadRequest:
+        parsed_request = (
+            request
+            if isinstance(request, WorkloadRequest)
+            else WorkloadRequest.model_validate(request)
+        )
+        profile = self._profiles.get(parsed_request.profile_id)
+        if profile is None:
+            raise WorkloadPolicyError(
+                f"unknown runner profile: {parsed_request.profile_id}"
+            )
+
+        self._validate_workspace_path(parsed_request.repo_dir, field_name="repoDir")
+        self._validate_workspace_path(
+            parsed_request.artifacts_dir,
+            field_name="artifactsDir",
+        )
+        self._validate_env_overrides(parsed_request, profile)
+        self._validate_timeout(parsed_request, profile)
+        self._validate_resources(parsed_request, profile)
+
+        return ValidatedWorkloadRequest(
+            request=parsed_request,
+            profile=profile,
+            ownership=parsed_request.ownership_metadata(),
+            containerName=parsed_request.container_name,
+        )
+
+    def _validate_workspace_path(self, value: str, *, field_name: str) -> None:
+        resolved = Path(value).expanduser().resolve()
+        try:
+            resolved.relative_to(self._workspace_root)
+        except ValueError as exc:
+            raise WorkloadPolicyError(
+                f"{field_name} must be under workspace root {self._workspace_root}"
+            ) from exc
+
+    @staticmethod
+    def _validate_env_overrides(
+        request: WorkloadRequest,
+        profile: RunnerProfile,
+    ) -> None:
+        allowed = set(profile.env_allowlist)
+        for key in request.env_overrides:
+            if key not in allowed:
+                raise WorkloadPolicyError(
+                    f"environment override {key!r} is not allowed by profile "
+                    f"{profile.id}"
+                )
+
+    @staticmethod
+    def _validate_timeout(
+        request: WorkloadRequest,
+        profile: RunnerProfile,
+    ) -> None:
+        if request.timeout_seconds is None or profile.max_timeout_seconds is None:
+            return
+        if request.timeout_seconds > profile.max_timeout_seconds:
+            raise WorkloadPolicyError(
+                "timeoutSeconds exceeds profile maxTimeoutSeconds"
+            )
+
+    @staticmethod
+    def _validate_resources(
+        request: WorkloadRequest,
+        profile: RunnerProfile,
+    ) -> None:
+        resources = request.resources
+        limits = profile.resources
+        if resources.cpu is not None and limits.max_cpu is not None:
+            if parse_cpu_units(resources.cpu) > parse_cpu_units(limits.max_cpu):
+                raise WorkloadPolicyError("cpu override exceeds profile maxCpu")
+        if resources.memory is not None and limits.max_memory is not None:
+            if parse_size_bytes(resources.memory) > parse_size_bytes(limits.max_memory):
+                raise WorkloadPolicyError(
+                    "memory override exceeds profile maxMemory"
+                )
+        if resources.shm_size is not None and limits.max_shm_size is not None:
+            if parse_size_bytes(resources.shm_size) > parse_size_bytes(
+                limits.max_shm_size
+            ):
+                raise WorkloadPolicyError(
+                    "shmSize override exceeds profile maxShmSize"
+                )
+
+
+def _load_registry_payload(path: Path, raw_text: str) -> Any:
+    if path.suffix.lower() == ".json":
+        return json.loads(raw_text or "{}")
+    return yaml.safe_load(raw_text) or {}
+
+
+def _extract_profiles(payload: Any) -> list[RunnerProfile]:
+    if isinstance(payload, Mapping):
+        if "profiles" in payload:
+            raw_profiles = payload["profiles"]
+        else:
+            raw_profiles = []
+            for profile_id, raw_profile in payload.items():
+                if not isinstance(raw_profile, Mapping):
+                    raise WorkloadPolicyError(
+                        "runner profile mapping values must be objects"
+                    )
+                profile_payload = dict(raw_profile)
+                profile_payload.setdefault("id", str(profile_id))
+                raw_profiles.append(profile_payload)
+    else:
+        raw_profiles = payload
+
+    if raw_profiles in (None, ""):
+        return []
+    if not isinstance(raw_profiles, list):
+        raise WorkloadPolicyError("runner profile registry must contain a list")
+
+    profiles: list[RunnerProfile] = []
+    seen: set[str] = set()
+    for raw_profile in raw_profiles:
+        try:
+            profile = RunnerProfile.model_validate(raw_profile)
+        except ValidationError:
+            raise
+        except Exception as exc:
+            raise WorkloadPolicyError(f"invalid runner profile: {exc}") from exc
+        if profile.id in seen:
+            raise WorkloadPolicyError(f"duplicate runner profile id: {profile.id}")
+        seen.add(profile.id)
+        profiles.append(profile)
+    return profiles

--- a/specs/148-dood-workload-contract/checklists/requirements.md
+++ b/specs/148-dood-workload-contract/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Docker-Out-of-Docker Workload Contract
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Phase 0 is represented as a locked prerequisite because `specs/143-dood-phase0/tasks.md` is already complete on the base branch.
+- Runtime intent is explicit through production workload contract models, registry loading, policy validation, and automated tests.

--- a/specs/148-dood-workload-contract/contracts/workload-contract.md
+++ b/specs/148-dood-workload-contract/contracts/workload-contract.md
@@ -1,0 +1,88 @@
+# Workload Contract
+
+## Scope
+
+This contract covers Phase 1 validation and serialization only. It does not launch Docker containers and does not define executable tool wiring.
+
+## Registry File Shape
+
+The deployment-owned registry file may be JSON or YAML. It may contain either a top-level `profiles` list or a mapping keyed by profile ID.
+
+```yaml
+profiles:
+  - id: local-python
+    kind: one_shot
+    image: python:3.12-slim
+    entrypoint: ["/bin/bash", "-lc"]
+    workdir_template: /work/agent_jobs/${task_run_id}/repo
+    required_mounts:
+      - type: volume
+        source: agent_workspaces
+        target: /work/agent_jobs
+    env_allowlist:
+      - CI
+    network_policy: none
+    resources:
+      cpu: "2"
+      memory: "2g"
+      shm_size: "512m"
+      max_cpu: "4"
+      max_memory: "4g"
+      max_shm_size: "1g"
+    timeout_seconds: 300
+    max_timeout_seconds: 600
+    cleanup:
+      remove_container_on_exit: true
+      kill_grace_seconds: 30
+    device_policy:
+      mode: none
+```
+
+## Workload Request Shape
+
+```json
+{
+  "profileId": "local-python",
+  "taskRunId": "task-1",
+  "stepId": "step-test",
+  "attempt": 1,
+  "toolName": "container.run_workload",
+  "repoDir": "/work/agent_jobs/task-1/repo",
+  "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+  "command": ["pytest", "-q"],
+  "envOverrides": {"CI": "1"},
+  "timeoutSeconds": 300,
+  "resources": {"cpu": "2", "memory": "2g"},
+  "sessionId": "session-1",
+  "sessionEpoch": 2,
+  "sourceTurnId": "turn-1"
+}
+```
+
+## Required Labels
+
+The registry validator must derive these labels for every validated request:
+
+- `moonmind.kind=workload`
+- `moonmind.task_run_id=<task_run_id>`
+- `moonmind.step_id=<step_id>`
+- `moonmind.attempt=<attempt>`
+- `moonmind.tool_name=<tool_name>`
+- `moonmind.workload_profile=<profile_id>`
+
+Optional session labels may be included when the request carries session association metadata.
+
+## Validation Errors
+
+Validation must fail before Docker launch code for:
+
+- unknown profile ID
+- blank or unpinned image
+- `latest` image tag
+- host networking
+- privileged or GPU device policy in Phase 1
+- non-volume or unsafe mount targets
+- environment override key outside the profile allowlist
+- workspace path outside `workspace_root`
+- resource override above profile maximum
+- timeout override above profile maximum

--- a/specs/148-dood-workload-contract/data-model.md
+++ b/specs/148-dood-workload-contract/data-model.md
@@ -1,0 +1,104 @@
+# Data Model: Docker-Out-of-Docker Workload Contract
+
+## WorkloadRequest
+
+- `profile_id`: Required runner profile ID.
+- `task_run_id`: Required task/run owner identifier.
+- `step_id`: Required producing step identifier.
+- `attempt`: Required positive attempt number.
+- `tool_name`: Required executable tool name used for labels and diagnostics.
+- `repo_dir`: Required repository working directory inside the shared workspace root.
+- `artifacts_dir`: Required output artifact directory inside the shared workspace root.
+- `command`: Required non-empty command argument list.
+- `env_overrides`: Optional string key/value overrides limited by the selected profile allowlist.
+- `timeout_seconds`: Optional positive timeout, capped by the selected profile.
+- `resources`: Optional CPU/memory/shm overrides, capped by the selected profile.
+- `session_id`: Optional session association context.
+- `session_epoch`: Optional positive session epoch; valid only with `session_id`.
+- `source_turn_id`: Optional source turn association context; valid only with `session_id`.
+
+Validation rules:
+
+- Profile ID must exist in the registry.
+- Command must contain at least one non-blank argument.
+- `repo_dir` and `artifacts_dir` must resolve under the registry workspace root.
+- Env override keys must be valid uppercase environment names and must appear in the profile allowlist.
+- Timeout/resource overrides must not exceed profile ceilings.
+- Session metadata is association context only and never creates an agent-run identity.
+
+## WorkloadResult
+
+- `request_id`: Deterministic workload request/name identifier.
+- `profile_id`: Selected profile ID.
+- `status`: `succeeded`, `failed`, `timed_out`, or `canceled`.
+- `labels`: Deterministic `moonmind.*` labels.
+- `exit_code`: Optional process exit code.
+- `started_at`: Optional start timestamp.
+- `completed_at`: Optional completion timestamp.
+- `duration_seconds`: Optional non-negative duration.
+- `timeout_reason`: Optional timeout/cancel explanation.
+- `stdout_ref`: Optional durable stdout artifact ref.
+- `stderr_ref`: Optional durable stderr artifact ref.
+- `diagnostics_ref`: Optional durable diagnostics artifact ref.
+- `output_refs`: Optional declared output artifact refs.
+- `metadata`: Bounded structured metadata, not large log content.
+
+## RunnerProfile
+
+- `id`: Stable profile ID selected by requests/tools.
+- `kind`: `one_shot` for Phase 1.
+- `image`: Approved image reference with explicit tag or digest.
+- `entrypoint`: Optional command wrapper list.
+- `command_wrapper`: Optional wrapper list appended before request command.
+- `workdir_template`: Required template rooted in the shared workspace contract.
+- `required_mounts`: Required mount contracts, usually `agent_workspaces` to `/work/agent_jobs`.
+- `optional_mounts`: Optional deployment-owned cache mounts.
+- `env_allowlist`: Environment variable names allowed in request overrides.
+- `network_policy`: `none` or `bridge` for Phase 1.
+- `resources`: Default and maximum CPU/memory/shm values.
+- `timeout_seconds`: Default timeout.
+- `max_timeout_seconds`: Maximum allowed request timeout.
+- `cleanup`: Remove-on-exit and kill-grace policy.
+- `device_policy`: `none` for Phase 1 unless explicitly modeled later.
+
+Validation rules:
+
+- Image must be non-blank and pinned by tag or digest; `latest` is rejected.
+- Mounts must be Docker named volumes and must target approved container paths only.
+- Env allowlist entries must be uppercase environment names.
+- Network policy defaults to `none`; host networking is rejected.
+- Device policy defaults to `none`; privileged/GPU access is not accepted in Phase 1.
+- Resource maxima must be greater than or equal to defaults.
+
+## WorkloadOwnershipMetadata
+
+- `kind`: Always `workload`.
+- `task_run_id`: Owner task run.
+- `step_id`: Owner step.
+- `attempt`: Positive attempt number.
+- `tool_name`: Producing tool name.
+- `workload_profile`: Runner profile ID.
+- `session_id`: Optional grouping context.
+- `session_epoch`: Optional grouping context.
+
+Derived labels:
+
+- `moonmind.kind=workload`
+- `moonmind.task_run_id`
+- `moonmind.step_id`
+- `moonmind.attempt`
+- `moonmind.tool_name`
+- `moonmind.workload_profile`
+- optional `moonmind.session_id`
+- optional `moonmind.session_epoch`
+
+## RunnerProfileRegistry
+
+- `workspace_root`: Allowed shared workspace root.
+- `profiles`: Mapping from profile ID to `RunnerProfile`.
+
+Validation rules:
+
+- Duplicate profile IDs are rejected.
+- Unknown profile selections are rejected.
+- Absent configuration yields an empty registry unless the caller explicitly provides profiles.

--- a/specs/148-dood-workload-contract/plan.md
+++ b/specs/148-dood-workload-contract/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Docker-Out-of-Docker Workload Contract
+
+**Branch**: `148-dood-workload-contract` | **Date**: 2026-04-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/148-dood-workload-contract/spec.md`
+
+## Summary
+
+Preserve the completed Phase 0 DooD documentation boundary and implement the Phase 1 control-plane workload contract without launching Docker. The implementation adds canonical Pydantic models for workload requests, results, runner profiles, ownership metadata, and policy validation, plus a deployment-owned registry loader that fails closed and rejects unsafe profile/request shapes. Tests are written first around request/profile validation and the existing Phase 0 doc contract.
+
+## Technical Context
+
+**Language/Version**: Python 3.10+
+**Primary Dependencies**: Pydantic v2, PyYAML, stdlib `json`, `pathlib`, `datetime`
+**Storage**: Deployment-owned YAML/JSON files for runner profile registry input; no database changes
+**Testing**: pytest through `./tools/test_unit.sh`
+**Target Platform**: MoonMind control plane and Docker-capable `agent_runtime` worker fleet
+**Project Type**: Python service modules
+**Performance Goals**: Registry loading and request validation are synchronous bounded operations for small curated profile sets
+**Constraints**: No Docker launch code in Phase 1; no arbitrary image strings in normal execution; fail closed on absent/invalid registry input; preserve Phase 0 docs boundary
+**Scale/Scope**: One-shot workload contract and registry validation only, with launcher/tool/artifact phases left for later specs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Coverage |
+| --- | --- | --- |
+| I. Orchestrate, Don't Recreate | PASS | Workloads remain MoonMind-orchestrated executable tools, not a competing agent model. |
+| II. One-Click Agent Deployment | PASS | Registry defaults fail closed and do not add mandatory external services. |
+| III. Avoid Vendor Lock-In | PASS | The contract is generic for curated workload profiles, not Unreal-only. |
+| IV. Own Your Data | PASS | Durable truth remains bounded metadata and artifact refs. |
+| V. Skills Are First-Class | PASS | Phase 1 preserves the future `tool.type = "skill"` path and does not change skill semantics. |
+| VI. Bittersweet Lesson | PASS | The stable contract isolates future launcher implementation churn. |
+| VII. Powerful Runtime Configurability | PASS | Runner profiles are deployment-owned configuration with deterministic validation. |
+| VIII. Modular and Extensible | PASS | New models/registry live behind explicit modules and contracts. |
+| IX. Resilient by Default | PASS | Validation rejects unsafe or unsupported inputs before launch. |
+| X. Continuous Improvement | PASS | Results carry bounded diagnostics refs for later observability phases. |
+| XI. Spec-Driven Development | PASS | Spec, plan, tasks, tests, and code are included in this feature. |
+| XII. Canonical Docs vs tmp | PASS | Phase tracking updates remain in `docs/tmp/remaining-work/`. |
+| XIII. Delete, Don't Deprecate | PASS | No compatibility aliases or fallback image behavior are introduced. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/148-dood-workload-contract/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── workload-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/
+│   └── workload_models.py
+└── workloads/
+    ├── __init__.py
+    └── registry.py
+
+tests/
+└── unit/
+    ├── docs/
+    │   └── test_dood_phase0_contract.py
+    └── workloads/
+        └── test_workload_contract.py
+
+docs/
+└── tmp/
+    └── remaining-work/
+        └── ManagedAgents-DockerOutOfDocker.md
+```
+
+**Structure Decision**: Canonical payloads belong under `moonmind/schemas/` with other Pydantic contracts. Registry loading and cross-object policy validation belong under `moonmind/workloads/` so later Docker launcher and tool integration can depend on it without coupling schema definitions to Temporal activity code.
+
+## Complexity Tracking
+
+No constitution violations require complexity waivers.

--- a/specs/148-dood-workload-contract/quickstart.md
+++ b/specs/148-dood-workload-contract/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Docker-Out-of-Docker Workload Contract
+
+## Focused Validation
+
+Run the Phase 1 workload contract tests:
+
+```bash
+./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py
+```
+
+Run the existing Phase 0 documentation contract:
+
+```bash
+./tools/test_unit.sh tests/unit/docs/test_dood_phase0_contract.py
+```
+
+## Full Unit Validation
+
+Run the complete unit suite before finalizing:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Manual Contract Smoke Check
+
+1. Load a valid JSON or YAML runner profile registry with one curated profile.
+2. Construct a workload request using only the profile ID, task/step metadata, workspace paths under `/work/agent_jobs`, allowed environment overrides, and resource overrides within the profile maximum.
+3. Confirm validation returns deterministic `moonmind.*` labels.
+4. Change the request to use an unknown profile, a path outside `/work/agent_jobs`, a disallowed env key, or excessive memory.
+5. Confirm validation rejects the request without invoking Docker.
+
+Expected result: Phase 1 can validate workload intent and policy without Docker access, launcher code, or tool executor integration.

--- a/specs/148-dood-workload-contract/research.md
+++ b/specs/148-dood-workload-contract/research.md
@@ -1,0 +1,37 @@
+# Research: Docker-Out-of-Docker Workload Contract
+
+## Decision 1: Keep Phase 1 Docker-free
+
+- **Decision**: Implement only schema, registry loading, and validation in Phase 1.
+- **Rationale**: The DooD plan's exit criteria require a validated request before Docker exists, which makes policy failures testable without side effects.
+- **Alternatives considered**: Starting a minimal launcher now was rejected because it would mix Phase 1 and Phase 2 ownership and weaken the TDD boundary.
+
+## Decision 2: Use Pydantic models for the canonical contract
+
+- **Decision**: Define `WorkloadRequest`, `WorkloadResult`, `RunnerProfile`, and `WorkloadOwnershipMetadata` as Pydantic v2 models.
+- **Rationale**: MoonMind already uses Pydantic for Temporal and agent-runtime contracts, and the Temporal data converter is already Pydantic-aware.
+- **Alternatives considered**: Dataclasses were rejected because cross-field validation, aliases, and serialization contracts are already standardized on Pydantic.
+
+## Decision 3: Put registry validation outside the request model
+
+- **Decision**: Keep shape validation inside models and profile-aware policy validation inside a `RunnerProfileRegistry`.
+- **Rationale**: Request validity depends on the selected profile and deployment workspace root, which are external policy context.
+- **Alternatives considered**: Embedding a global registry in model validators was rejected because it would hide runtime configuration and make tests order-dependent.
+
+## Decision 4: Support JSON and YAML deployment registry files
+
+- **Decision**: Load registry files from JSON or YAML mappings/lists and validate each profile through the canonical `RunnerProfile` model.
+- **Rationale**: PyYAML is already a dependency, while JSON remains a portable fallback for operators and tests.
+- **Alternatives considered**: Static code-only registry was rejected because the plan selects deployment-owned registry files as the simplest starting point.
+
+## Decision 5: Fail closed when no registry is configured
+
+- **Decision**: The default empty registry allows no workload profiles.
+- **Rationale**: Empty/default behavior must not silently permit arbitrary workload images.
+- **Alternatives considered**: A built-in permissive debug profile was rejected because it violates the runner-profile replacement rule.
+
+## Decision 6: Validate workspace paths through a configured workspace root
+
+- **Decision**: Request validation resolves `repo_dir` and `artifacts_dir` against a registry-owned workspace root and rejects paths outside it.
+- **Rationale**: Phase 1 must reject invalid mounts and workspace traversal before launcher mount generation exists.
+- **Alternatives considered**: Checking only string prefixes was rejected because normalized path resolution catches traversal more reliably.

--- a/specs/148-dood-workload-contract/spec.md
+++ b/specs/148-dood-workload-contract/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Docker-Out-of-Docker Workload Contract
+
+**Feature Branch**: `148-dood-workload-contract`
+**Created**: 2026-04-10
+**Status**: Draft
+**Input**: User description: "Implement Phase 0 and Phase 1 using test-driven development of the DooD plan."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve the Phase 0 boundary contract (Priority: P1)
+
+MoonMind engineers need the completed Docker-out-of-Docker Phase 0 documentation contract to remain stable while Phase 1 runtime models are added, so the new workload contract does not blur session containers, workload containers, runner profiles, or session-assisted workloads.
+
+**Why this priority**: The Phase 1 contract must build on the already locked Phase 0 architecture and cannot safely proceed if the execution primitive or glossary regresses.
+
+**Independent Test**: Run the existing DooD Phase 0 documentation-contract unit test and confirm the canonical DooD, session-plane, execution-model, and remaining-work tracker references still pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phase 0 documentation contract is present, **When** the Phase 1 contract code is added, **Then** the docs still state that Docker-backed workloads use ordinary executable tools and remain outside managed-session identity.
+2. **Given** the DooD tracker contains future rollout phases, **When** maintainers review remaining implementation work, **Then** Phase 1 contract completion is visible without moving rollout checklists into canonical docs.
+
+---
+
+### User Story 2 - Validate workload requests before Docker exists (Priority: P1)
+
+MoonMind engineers need a canonical validated workload request and result contract that can be constructed, rejected, or serialized without touching Docker, so later launcher and tool-path phases consume one authoritative payload shape.
+
+**Why this priority**: Phase 1 exit criteria require a single validated workload request and rejection of invalid images, mounts, environment keys, and resource requests before Docker launch code is introduced.
+
+**Independent Test**: Instantiate workload request and result objects against a curated runner profile and verify valid inputs are accepted while disallowed profile IDs, command shapes, environment overrides, resource requests, and workspace paths fail with clear validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployment-owned runner profile and a task workspace path under the allowed workspace root, **When** a workload request includes allowed environment overrides and resource overrides within the profile limits, **Then** MoonMind accepts the request and derives deterministic workload labels.
+2. **Given** a workload request uses an unknown profile, an empty command, a path outside the allowed workspace root, or an unapproved environment key, **When** validation runs, **Then** MoonMind rejects the request before any Docker command can be built.
+3. **Given** a workload result is produced by a future launcher, **When** it is serialized, **Then** it carries bounded execution metadata such as selected profile, labels, exit code, duration, stdout/stderr refs, diagnostics, and timeout/cancel status without embedding large log content.
+
+---
+
+### User Story 3 - Load deployment-owned runner profiles safely (Priority: P2)
+
+MoonMind operators need a deployment-owned runner profile registry that accepts only curated workload shapes, so normal execution uses profile IDs instead of arbitrary image strings or mounts.
+
+**Why this priority**: Runner profiles are the policy boundary between plans/session requests and Docker authority.
+
+**Independent Test**: Load a profile registry from a local configuration file and verify schema validation rejects invalid image references, unsupported network policy, disallowed mount targets, malformed environment allowlists, excessive resource limits, and unsafe device policy.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry file with a valid lightweight profile, **When** MoonMind loads the registry, **Then** the profile can be selected by ID and exposes image, wrapper, workspace mount, optional cache mounts, environment allowlist, resource limits, timeout defaults, cleanup policy, network policy, and device policy.
+2. **Given** a registry file includes a profile with an unpinned or malformed image, host networking, privileged device access, absolute host mounts, or invalid resource ceilings, **When** MoonMind loads the registry, **Then** loading fails with a deterministic policy error.
+3. **Given** no deployment registry path is configured, **When** the registry is requested, **Then** MoonMind provides a safe empty/default registry behavior that does not silently allow arbitrary workload images.
+
+### Edge Cases
+
+- A session-assisted workload includes session metadata, but the metadata is grouping context only and must not make the workload a `MoonMind.AgentRun`.
+- A request attempts to override secrets or provider auth variables that the profile did not explicitly allow.
+- A request points `repo_dir` or `artifacts_dir` outside the task workspace root or uses symlink-style traversal.
+- A profile asks for cache mounts or device access that are not deployment-owned and explicitly allowed.
+- A resource override exceeds the selected profile's configured ceiling.
+- A registry file is missing, empty, malformed, or contains duplicate profile IDs.
+- A future launcher needs deterministic names and labels even when `tool_name` or `step_id` includes characters unsafe for Docker labels or names.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: MoonMind MUST preserve the Phase 0 DooD documentation contract while adding the Phase 1 workload data contract.
+- **FR-002**: MoonMind MUST define canonical workload request, result, runner profile, and ownership metadata entities that can be validated and serialized without invoking Docker.
+- **FR-003**: A workload request MUST include `profile_id`, `task_run_id`, `step_id`, `attempt`, `repo_dir`, `artifacts_dir`, command arguments, allowlisted environment overrides, timeout/resource overrides, and optional session association metadata.
+- **FR-004**: Workload ownership metadata MUST include deterministic labels for `moonmind.kind=workload`, `moonmind.task_run_id`, `moonmind.step_id`, `moonmind.attempt`, `moonmind.tool_name`, and `moonmind.workload_profile`.
+- **FR-005**: Request validation MUST reject unknown runner profiles, empty commands, invalid attempts, invalid timeout/resource overrides, environment keys not allowed by the selected profile, and workspace paths outside the allowed task workspace root.
+- **FR-006**: Runner profiles MUST replace arbitrary free-form image strings in normal workload execution.
+- **FR-007**: Runner profiles MUST define image, entrypoint/command wrapper, workspace mount contract, optional cache mounts, environment allowlist, network policy, resource profile, timeout defaults, cleanup policy, and optional device policy.
+- **FR-008**: Runner profile validation MUST reject invalid or unapproved image references, unsupported network policy, privileged defaults, unsafe mount targets, invalid environment allowlists, and resource ceilings outside deployment policy.
+- **FR-009**: MoonMind MUST provide a deployment-owned runner profile registry source that can load profiles from configuration and fails closed instead of allowing arbitrary images when configuration is absent or invalid.
+- **FR-010**: Workload results MUST capture bounded execution metadata including selected profile, deterministic labels, status, exit code when available, started/completed timestamps, duration, timeout/cancel reason, artifact refs, and diagnostics without embedding large stdout/stderr contents.
+- **FR-011**: Optional session association metadata (`session_id`, `session_epoch`, `source_turn_id`) MUST remain contextual and MUST NOT create or imply a new managed agent run.
+- **FR-012**: The Phase 1 implementation MUST include automated unit tests proving valid requests are accepted and invalid images, mounts, environment keys, paths, and resource requests are rejected.
+
+### Key Entities *(include if feature involves data)*
+
+- **WorkloadRequest**: A validated control-plane request for one bounded workload container execution.
+- **WorkloadResult**: A bounded summary of workload execution outcome and artifact references produced by a future launcher.
+- **RunnerProfile**: A deployment-owned profile that defines the allowed image, command wrapper, workspace/cache mounts, environment keys, network/device policy, resource ceilings, timeout defaults, and cleanup behavior.
+- **WorkloadOwnershipMetadata**: Deterministic identity and labels tying a workload to the producing task run, step, attempt, tool name, and runner profile.
+- **Session Association Metadata**: Optional grouping context linking a workload request to a managed-session epoch and source turn without changing the workload lifecycle.
+- **Runner Profile Registry**: A deployment-owned source of curated runner profiles used for profile lookup and policy validation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Existing Phase 0 documentation-contract validation still passes after Phase 1 changes.
+- **SC-002**: A valid workload request can be constructed and serialized using a curated runner profile without touching Docker.
+- **SC-003**: Unit tests reject invalid images, unsafe mounts, disallowed environment keys, invalid workspace paths, and excessive resource overrides.
+- **SC-004**: Runner profile registry loading accepts a valid deployment-owned profile file and rejects malformed or unsafe profile definitions deterministically.
+- **SC-005**: Workload request labels are deterministic and include all required `moonmind.*` ownership keys.

--- a/specs/148-dood-workload-contract/speckit_analyze_report.md
+++ b/specs/148-dood-workload-contract/speckit_analyze_report.md
@@ -1,0 +1,45 @@
+# Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+| --- | --- | --- | --- | --- | --- |
+| N1 | No Issues | LOW | spec.md, plan.md, tasks.md | The artifacts are aligned on Phase 0 preservation plus Phase 1 Docker-free workload contract implementation. | Proceed with implementation using the TDD order in tasks.md. |
+
+## Coverage Summary Table
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+| --- | --- | --- | --- |
+| preserve-phase-0-contract | Yes | T002, T004, T005, T011 | Existing documentation contract remains guarded and tracker gets updated. |
+| canonical-workload-entities | Yes | T003, T007, T011 | Models are covered by failing tests before implementation. |
+| minimum-request-fields | Yes | T003, T007, T008, T011 | Tests and implementation cover required request shape. |
+| deterministic-labels | Yes | T003, T007, T008, T011 | Ownership metadata label derivation is explicitly covered. |
+| reject-invalid-request-policy | Yes | T003, T008, T011 | Env, workspace path, resource, and unknown profile rejection are covered. |
+| runner-profiles-replace-images | Yes | T003, T008, T009, T011 | Registry/profile validation rejects arbitrary unsafe profile input. |
+| runner-profile-schema | Yes | T003, T009, T011 | Data model and tests cover profile fields. |
+| profile-validation-policy | Yes | T003, T009, T011 | Unsafe image, mount, network, device, and resource ceilings are covered. |
+| deployment-owned-registry | Yes | T003, T009, T010, T011 | JSON/YAML loading and empty-registry behavior are covered. |
+| bounded-result-metadata | Yes | T003, T007, T011 | Result metadata model is covered without large log embedding. |
+| session-association-context | Yes | T003, T007, T008, T011 | Optional session metadata remains contextual. |
+| automated-unit-tests | Yes | T003, T006, T011 | TDD and focused validation are explicit. |
+
+## Constitution Alignment Issues
+
+None.
+
+## Unmapped Tasks
+
+None. Scope validation passed for runtime tasks.
+
+## Metrics
+
+- Total Requirements: 12
+- Total Tasks: 14
+- Coverage %: 100
+- Ambiguity Count: 0
+- Duplication Count: 0
+- Critical Issues Count: 0
+
+## Next Actions
+
+- Implement the workload contract tests first and confirm their initial failure.
+- Implement the schema and registry modules.
+- Re-run focused validation and runtime scope gates before finalizing.

--- a/specs/148-dood-workload-contract/tasks.md
+++ b/specs/148-dood-workload-contract/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: Docker-Out-of-Docker Workload Contract
+
+**Input**: Design documents from `/specs/148-dood-workload-contract/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: TDD is required. Add failing workload contract tests first, run them to confirm the expected failure, then implement models/registry until they pass.
+
+**Organization**: Tasks are grouped by user story so Phase 0 preservation, request validation, and registry loading are independently testable.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm feature artifacts and existing Phase 0 baseline before code changes.
+
+- [X] T001 Review `specs/148-dood-workload-contract/spec.md`, `plan.md`, `data-model.md`, and `contracts/workload-contract.md`.
+- [X] T002 Run `./tools/test_unit.sh tests/unit/docs/test_dood_phase0_contract.py` to verify the Phase 0 documentation contract still passes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create the TDD validation surface before implementing runtime contract code.
+
+- [X] T003 [P] Add failing workload contract tests in `tests/unit/workloads/test_workload_contract.py` for valid request construction, deterministic labels, invalid env keys, invalid workspace paths, invalid resources, invalid images, invalid mounts, and registry loading failures.
+
+**Checkpoint**: Workload contract tests fail because the Phase 1 models/registry do not exist yet.
+
+---
+
+## Phase 3: User Story 1 - Preserve the Phase 0 boundary contract (Priority: P1)
+
+**Goal**: Keep Phase 0 docs and tracker aligned while Phase 1 code lands.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/docs/test_dood_phase0_contract.py`
+
+### Tests for User Story 1
+
+- [X] T004 [US1] Re-run `./tools/test_unit.sh tests/unit/docs/test_dood_phase0_contract.py` after Phase 1 edits.
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md` to mark Phase 1 contract work complete and keep later launcher/tool/artifact phases pending.
+
+**Checkpoint**: Phase 0 validation remains green and the remaining-work tracker reflects Phase 1 completion.
+
+---
+
+## Phase 4: User Story 2 - Validate workload requests before Docker exists (Priority: P1) 🎯 MVP
+
+**Goal**: Provide canonical Docker-free workload request/result/ownership models and profile-aware request validation.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py`
+
+### Tests for User Story 2
+
+- [X] T006 [US2] Confirm `tests/unit/workloads/test_workload_contract.py` fails before implementation because `moonmind.schemas.workload_models` and `moonmind.workloads.registry` are absent.
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Implement `WorkloadRequest`, `WorkloadResult`, resource models, mount models, and `WorkloadOwnershipMetadata` in `moonmind/schemas/workload_models.py`.
+- [X] T008 [US2] Implement profile-aware request validation, workspace-root checks, env allowlist enforcement, resource limit enforcement, and deterministic ownership label derivation in `moonmind/workloads/registry.py`.
+
+**Checkpoint**: A valid request can be constructed and invalid request inputs are rejected without Docker.
+
+---
+
+## Phase 5: User Story 3 - Load deployment-owned runner profiles safely (Priority: P2)
+
+**Goal**: Provide a deployment-owned runner profile registry loader that accepts curated profiles and fails closed.
+
+**Independent Test**: `./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py`
+
+### Implementation for User Story 3
+
+- [X] T009 [US3] Implement `RunnerProfile`, profile policy validation, JSON/YAML registry loading, duplicate detection, and empty-registry behavior in `moonmind/schemas/workload_models.py` and `moonmind/workloads/registry.py`.
+- [X] T010 [US3] Export workload contract APIs from `moonmind/workloads/__init__.py`.
+
+**Checkpoint**: Registry tests accept valid JSON/YAML profile input and reject unsafe images, mounts, network, devices, and resource ceilings.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, artifact consistency, and completed task state.
+
+- [X] T011 Run `./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/docs/test_dood_phase0_contract.py`.
+- [X] T012 Run `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`.
+- [X] T013 Run `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`, keeping the validator portable under the repository's Bash when required.
+- [X] T014 Mark completed work in `specs/148-dood-workload-contract/tasks.md`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately.
+- **Foundational (Phase 2)**: Depends on Setup and blocks implementation.
+- **User Story 1 (Phase 3)**: Can proceed after tests exist.
+- **User Story 2 (Phase 4)**: Depends on failing tests and is the MVP.
+- **User Story 3 (Phase 5)**: Extends US2 registry loading.
+- **Polish (Phase 6)**: Depends on all selected implementation phases.
+
+### Parallel Opportunities
+
+- T003 can be written independently of docs tracker updates.
+- T007 and T009 touch shared model files and must be coordinated sequentially despite different story labels.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Preserve Phase 0 doc validation.
+2. Add failing tests for workload request/profile validation.
+3. Implement request/result/ownership models and registry validation.
+4. Update tracker and run focused validation.
+
+### TDD Order
+
+1. Write `tests/unit/workloads/test_workload_contract.py`.
+2. Run the focused test and confirm it fails on missing implementation.
+3. Implement models and registry loader.
+4. Re-run focused tests until green.
+5. Run scope gates and full unit validation as feasible.

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.workload_models import (
+    WorkloadRequest,
+    WorkloadResult,
+)
+from moonmind.workloads.registry import (
+    RunnerProfileRegistry,
+    WorkloadPolicyError,
+)
+
+
+WORKSPACE_ROOT = Path("/work/agent_jobs")
+
+
+def _profile_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": "local-python",
+        "kind": "one_shot",
+        "image": "python:3.12-slim",
+        "entrypoint": ["/bin/bash", "-lc"],
+        "workdir_template": "/work/agent_jobs/${task_run_id}/repo",
+        "required_mounts": [
+            {
+                "type": "volume",
+                "source": "agent_workspaces",
+                "target": "/work/agent_jobs",
+            }
+        ],
+        "optional_mounts": [
+            {
+                "type": "volume",
+                "source": "build_cache",
+                "target": "/work/cache",
+            }
+        ],
+        "env_allowlist": ["CI", "UE_PROJECT_PATH"],
+        "network_policy": "none",
+        "resources": {
+            "cpu": "2",
+            "memory": "2g",
+            "shm_size": "512m",
+            "max_cpu": "4",
+            "max_memory": "4g",
+            "max_shm_size": "1g",
+        },
+        "timeout_seconds": 300,
+        "max_timeout_seconds": 600,
+        "cleanup": {
+            "remove_container_on_exit": True,
+            "kill_grace_seconds": 30,
+        },
+        "device_policy": {"mode": "none"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _registry(tmp_path: Path, *profiles: dict[str, object]) -> RunnerProfileRegistry:
+    registry_path = tmp_path / "profiles.json"
+    registry_path.write_text(
+        json.dumps({"profiles": list(profiles or [_profile_payload()])}),
+        encoding="utf-8",
+    )
+    return RunnerProfileRegistry.load_file(
+        registry_path,
+        workspace_root=WORKSPACE_ROOT,
+    )
+
+
+def _request(**overrides: object) -> WorkloadRequest:
+    payload: dict[str, object] = {
+        "profileId": "local-python",
+        "taskRunId": "task-1",
+        "stepId": "step-test",
+        "attempt": 1,
+        "toolName": "container.run_workload",
+        "repoDir": "/work/agent_jobs/task-1/repo",
+        "artifactsDir": "/work/agent_jobs/task-1/artifacts/step-test",
+        "command": ["pytest", "-q"],
+        "envOverrides": {"CI": "1"},
+        "timeoutSeconds": 300,
+        "resources": {"cpu": "2", "memory": "2g"},
+        "sessionId": "session-1",
+        "sessionEpoch": 2,
+        "sourceTurnId": "turn-1",
+    }
+    payload.update(overrides)
+    return WorkloadRequest.model_validate(payload)
+
+
+def test_registry_validates_request_and_derives_required_labels(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    validated = registry.validate_request(_request())
+
+    assert validated.profile.id == "local-python"
+    assert validated.ownership.labels == {
+        "moonmind.kind": "workload",
+        "moonmind.task_run_id": "task-1",
+        "moonmind.step_id": "step-test",
+        "moonmind.attempt": "1",
+        "moonmind.tool_name": "container.run_workload",
+        "moonmind.workload_profile": "local-python",
+        "moonmind.session_id": "session-1",
+        "moonmind.session_epoch": "2",
+    }
+    assert validated.container_name == "mm-workload-task-1-step-test-1"
+
+
+def test_registry_loads_yaml_profiles(tmp_path: Path) -> None:
+    registry_path = tmp_path / "profiles.yaml"
+    registry_path.write_text(
+        """
+profiles:
+  - id: local-python
+    kind: one_shot
+    image: python:3.12-slim
+    entrypoint:
+      - /bin/bash
+      - -lc
+    workdir_template: /work/agent_jobs/${task_run_id}/repo
+    required_mounts:
+      - type: volume
+        source: agent_workspaces
+        target: /work/agent_jobs
+    env_allowlist:
+      - CI
+    network_policy: none
+    resources:
+      cpu: "2"
+      memory: 2g
+      max_cpu: "4"
+      max_memory: 4g
+    timeout_seconds: 300
+    max_timeout_seconds: 600
+""",
+        encoding="utf-8",
+    )
+
+    registry = RunnerProfileRegistry.load_file(
+        registry_path,
+        workspace_root=WORKSPACE_ROOT,
+    )
+
+    assert registry.profile_ids == ("local-python",)
+
+
+def test_registry_loads_profile_mapping_keyed_by_profile_id(tmp_path: Path) -> None:
+    profile = _profile_payload()
+    profile.pop("id")
+    registry_path = tmp_path / "profiles.json"
+    registry_path.write_text(
+        json.dumps({"local-python": profile}),
+        encoding="utf-8",
+    )
+
+    registry = RunnerProfileRegistry.load_file(
+        registry_path,
+        workspace_root=WORKSPACE_ROOT,
+    )
+
+    assert registry.profile_ids == ("local-python",)
+
+
+def test_request_rejects_empty_command() -> None:
+    with pytest.raises(ValidationError, match="command"):
+        _request(command=[])
+
+
+def test_registry_rejects_unknown_profile(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    with pytest.raises(WorkloadPolicyError, match="unknown runner profile"):
+        registry.validate_request(_request(profileId="missing-profile"))
+
+
+def test_registry_rejects_env_key_outside_profile_allowlist(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    with pytest.raises(WorkloadPolicyError, match="environment override"):
+        registry.validate_request(_request(envOverrides={"SECRET_TOKEN": "raw"}))
+
+
+def test_registry_rejects_workspace_paths_outside_workspace_root(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+
+    with pytest.raises(WorkloadPolicyError, match="repoDir"):
+        registry.validate_request(_request(repoDir="/tmp/repo"))
+
+    with pytest.raises(WorkloadPolicyError, match="artifactsDir"):
+        registry.validate_request(
+            _request(artifactsDir="/work/agent_jobs/../outside/artifacts")
+        )
+
+
+def test_registry_rejects_resource_overrides_above_profile_maximum(
+    tmp_path: Path,
+) -> None:
+    registry = _registry(tmp_path)
+
+    with pytest.raises(WorkloadPolicyError, match="memory"):
+        registry.validate_request(_request(resources={"memory": "8g"}))
+
+    with pytest.raises(WorkloadPolicyError, match="cpu"):
+        registry.validate_request(_request(resources={"cpu": "8"}))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"image": "python:latest"}, "latest"),
+        ({"image": "python"}, "tag or digest"),
+        ({"network_policy": "host"}, "network"),
+        ({"device_policy": {"mode": "gpu"}}, "device"),
+        (
+            {
+                "required_mounts": [
+                    {
+                        "type": "bind",
+                        "source": "/var/run/docker.sock",
+                        "target": "/var/run/docker.sock",
+                    }
+                ]
+            },
+            "mount",
+        ),
+    ],
+)
+def test_registry_rejects_unsafe_profile_policy(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    registry_path = tmp_path / "profiles.json"
+    registry_path.write_text(
+        json.dumps({"profiles": [_profile_payload(**overrides)]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises((ValidationError, WorkloadPolicyError), match=message):
+        RunnerProfileRegistry.load_file(
+            registry_path,
+            workspace_root=WORKSPACE_ROOT,
+        )
+
+
+def test_registry_rejects_duplicate_profile_ids(tmp_path: Path) -> None:
+    registry_path = tmp_path / "profiles.json"
+    registry_path.write_text(
+        json.dumps({"profiles": [_profile_payload(), _profile_payload()]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkloadPolicyError, match="duplicate runner profile"):
+        RunnerProfileRegistry.load_file(
+            registry_path,
+            workspace_root=WORKSPACE_ROOT,
+        )
+
+
+def test_missing_registry_returns_empty_fail_closed_registry(tmp_path: Path) -> None:
+    registry = RunnerProfileRegistry.load_optional_file(
+        tmp_path / "missing.json",
+        workspace_root=WORKSPACE_ROOT,
+    )
+
+    assert registry.profile_ids == ()
+    with pytest.raises(WorkloadPolicyError, match="unknown runner profile"):
+        registry.validate_request(_request())
+
+
+def test_workload_result_serializes_bounded_metadata() -> None:
+    result = WorkloadResult.model_validate(
+        {
+            "requestId": "mm-workload-task-1-step-test-1",
+            "profileId": "local-python",
+            "status": "failed",
+            "labels": {
+                "moonmind.kind": "workload",
+                "moonmind.task_run_id": "task-1",
+            },
+            "exitCode": 2,
+            "durationSeconds": 12.5,
+            "stdoutRef": "artifact:stdout",
+            "stderrRef": "artifact:stderr",
+            "diagnosticsRef": "artifact:diagnostics",
+            "outputRefs": {"report": "artifact:report"},
+            "metadata": {"summary": "pytest failed"},
+        }
+    )
+
+    dumped = result.model_dump(by_alias=True)
+    assert dumped["stdoutRef"] == "artifact:stdout"
+    assert dumped["stderrRef"] == "artifact:stderr"
+    assert dumped["metadata"] == {"summary": "pytest failed"}

--- a/tests/unit/workloads/test_workload_contract.py
+++ b/tests/unit/workloads/test_workload_contract.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from moonmind.schemas.workload_models import (
     WorkloadRequest,
     WorkloadResult,
+    parse_size_bytes,
 )
 from moonmind.workloads.registry import (
     RunnerProfileRegistry,
@@ -169,6 +170,15 @@ def test_registry_loads_profile_mapping_keyed_by_profile_id(tmp_path: Path) -> N
     assert registry.profile_ids == ("local-python",)
 
 
+def test_size_parser_uses_docker_binary_units() -> None:
+    assert parse_size_bytes("512m") == 512 * 1024**2
+    assert parse_size_bytes("2gb") == 2 * 1024**3
+    assert parse_size_bytes("1ti") == 1024**4
+
+    with pytest.raises(ValueError, match="invalid size"):
+        parse_size_bytes("1p")
+
+
 def test_request_rejects_empty_command() -> None:
     with pytest.raises(ValidationError, match="command"):
         _request(command=[])
@@ -231,6 +241,31 @@ def test_registry_rejects_resource_overrides_above_profile_maximum(
             },
             "mount",
         ),
+        (
+            {
+                "required_mounts": [
+                    {
+                        "type": "volume",
+                        "source": "relative/cache",
+                        "target": "/work/cache",
+                    }
+                ]
+            },
+            "mount source",
+        ),
+        (
+            {
+                "required_mounts": [
+                    {
+                        "type": "volume",
+                        "source": "agent_workspaces",
+                        "target": "/work/../etc",
+                    }
+                ]
+            },
+            "mount target",
+        ),
+        ({"workdir_template": "/work/../tmp"}, "workdirTemplate"),
     ],
 )
 def test_registry_rejects_unsafe_profile_policy(
@@ -245,6 +280,31 @@ def test_registry_rejects_unsafe_profile_policy(
     )
 
     with pytest.raises((ValidationError, WorkloadPolicyError), match=message):
+        RunnerProfileRegistry.load_file(
+            registry_path,
+            workspace_root=WORKSPACE_ROOT,
+        )
+
+
+def test_registry_rejects_unsupported_registry_extension(tmp_path: Path) -> None:
+    registry_path = tmp_path / "profiles.toml"
+    registry_path.write_text("profiles = []", encoding="utf-8")
+
+    with pytest.raises(WorkloadPolicyError, match=".json, .yaml, or .yml"):
+        RunnerProfileRegistry.load_file(
+            registry_path,
+            workspace_root=WORKSPACE_ROOT,
+        )
+
+
+def test_registry_wraps_yaml_parse_errors(tmp_path: Path) -> None:
+    registry_path = tmp_path / "profiles.yaml"
+    registry_path.write_text("profiles: [", encoding="utf-8")
+
+    with pytest.raises(
+        WorkloadPolicyError,
+        match="invalid runner profile registry YAML",
+    ):
         RunnerProfileRegistry.load_file(
             registry_path,
             workspace_root=WORKSPACE_ROOT,


### PR DESCRIPTION
## Summary

Implements the Docker-out-of-Docker Phase 1 control-plane workload contract while preserving the completed Phase 0 documentation boundary.

## Changes

- Adds canonical workload request, result, runner profile, ownership metadata, and validated request models.
- Adds a deployment-owned runner profile registry that loads JSON/YAML profiles and fails closed when no registry is configured.
- Adds policy validation for unknown profiles, unsafe images and mounts, network/device policy, disallowed env overrides, workspace paths outside the configured root, and excessive timeout/resource overrides.
- Updates the DooD remaining-work tracker to mark Phase 1 complete.
- Keeps the Spec Kit diff-scope validator portable under the repository default Bash.
- Adds Spec Kit artifacts for feature 148 and focused workload contract tests.

## Validation

- `./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py`
- `./tools/test_unit.sh tests/unit/docs/test_dood_phase0_contract.py`
- `./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/docs/test_dood_phase0_contract.py`
- `.specify/scripts/bash/validate-implementation-scope.sh --check tasks --mode runtime`
- `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime --base-ref origin/main`
- `git diff --check`

Full `./tools/test_unit.sh` Python phase passed, but the UI Vitest phase repeatedly timed out in existing `entrypoints/task-detail.test.tsx` LiveLogsPanel tests. A targeted rerun failed a different LiveLogsPanel timeout; this PR does not touch frontend code.