### PR TITLE
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -175,7 +175,7 @@ h1 {
 }
 
 .masthead-title-row h1 {
-  font-size: clamp(1.5rem, 2.4vw, 2.1rem);
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
 }
 
 .masthead-meta {


### PR DESCRIPTION
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps