### PR TITLE
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps

### DIFF
--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -170,12 +170,12 @@ h1 {
   margin: 0.35rem 0 0.2rem;
   font-family: "Barlow Condensed", "Arial Narrow", sans-serif;
   letter-spacing: 0.01em;
-  font-size: clamp(1.7rem, 3vw, 2.55rem);
+  font-size: clamp(1.3rem, 2.5vw, 1.65rem);
   line-height: 1;
 }
 
 .masthead-title-row h1 {
-  font-size: clamp(1.5rem, 2.4vw, 2.1rem);
+  font-size: clamp(1.125rem, 2.2vw, 1.375rem);
 }
 
 .masthead-meta {


### PR DESCRIPTION
Shrink the Mission Control title text a bit, it's unusually large compared to most software engineering support web apps