### PR TITLE
When I choose the codex_default provider profile, I’m seeing MoonLadder provided as the provider ID. The provider ID for this should actually be OpenA

### DIFF
--- a/api_service/main.py
+++ b/api_service/main.py
@@ -789,20 +789,23 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 profile_id = profile_def["profile_id"]
                 desired_default_model = profile_def.get("default_model")
                 if profile_id in existing_by_id:
-                    current_provider_id = str(
-                        existing_by_id[profile_id]["provider_id"] or ""
-                    ).strip()
-                    if profile_id == "codex_default" and current_provider_id == "moonladder":
-                        stmt = (
-                            update(ManagedAgentProviderProfile)
-                            .where(ManagedAgentProviderProfile.profile_id == profile_id)
-                            .values(
-                                provider_id=profile_def["provider_id"],
-                                provider_label=profile_def.get("provider_label"),
+                    if profile_id == "codex_default":
+                        current_provider_id = str(
+                            existing_by_id[profile_id]["provider_id"] or ""
+                        ).strip()
+                        if current_provider_id == "moonladder":
+                            stmt = (
+                                update(ManagedAgentProviderProfile)
+                                .where(
+                                    ManagedAgentProviderProfile.profile_id == profile_id
+                                )
+                                .values(
+                                    provider_id=profile_def["provider_id"],
+                                    provider_label=profile_def.get("provider_label"),
+                                )
                             )
-                        )
-                        await session.execute(stmt)
-                        needs_commit = True
+                            await session.execute(stmt)
+                            needs_commit = True
                     current_model = existing_by_id[profile_id]["default_model"]
                     # Only reconcile when the seeded profile has an explicit desired model
                     # (non-None) and the existing row is blank or contains an old

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -655,8 +655,8 @@ async def _auto_seed_provider_profiles() -> list[str]:
             "profile_id": "codex_default",
             "runtime_id": "codex_cli",
             "is_default": True,
-            "provider_id": "moonladder",
-            "provider_label": "MoonLadder",
+            "provider_id": "openai",
+            "provider_label": "OpenAI",
             "default_model": None,  # inherits runtime default: gpt-5.4
             "credential_source": ProviderCredentialSource.OAUTH_VOLUME,
             "runtime_materialization_mode": RuntimeMaterializationMode.OAUTH_HOME,
@@ -764,6 +764,8 @@ async def _auto_seed_provider_profiles() -> list[str]:
             existing_result = await session.execute(
                 select(
                     ManagedAgentProviderProfile.profile_id,
+                    ManagedAgentProviderProfile.provider_id,
+                    ManagedAgentProviderProfile.provider_label,
                     ManagedAgentProviderProfile.default_model,
                     ManagedAgentProviderProfile.file_templates,
                 )
@@ -771,6 +773,8 @@ async def _auto_seed_provider_profiles() -> list[str]:
             existing_rows = existing_result.all()
             existing_by_id = {
                 row.profile_id: {
+                    "provider_id": row.provider_id,
+                    "provider_label": row.provider_label,
                     "default_model": row.default_model,
                     "file_templates": row.file_templates,
                 }
@@ -785,6 +789,20 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 profile_id = profile_def["profile_id"]
                 desired_default_model = profile_def.get("default_model")
                 if profile_id in existing_by_id:
+                    current_provider_id = str(
+                        existing_by_id[profile_id]["provider_id"] or ""
+                    ).strip()
+                    if profile_id == "codex_default" and current_provider_id == "moonladder":
+                        stmt = (
+                            update(ManagedAgentProviderProfile)
+                            .where(ManagedAgentProviderProfile.profile_id == profile_id)
+                            .values(
+                                provider_id=profile_def["provider_id"],
+                                provider_label=profile_def.get("provider_label"),
+                            )
+                        )
+                        await session.execute(stmt)
+                        needs_commit = True
                     current_model = existing_by_id[profile_id]["default_model"]
                     # Only reconcile when the seeded profile has an explicit desired model
                     # (non-None) and the existing row is blank or contains an old

--- a/tests/unit/api_service/test_provider_profile_auto_seed.py
+++ b/tests/unit/api_service/test_provider_profile_auto_seed.py
@@ -68,6 +68,10 @@ async def test_auto_seed_creates_default_profiles(_module_db, monkeypatch):
     assert runtime_defaults["gemini_default"] is True
     assert runtime_defaults["codex_default"] is True
     assert runtime_defaults["claude_anthropic"] is True
+    provider_ids = {p.profile_id: p.provider_id for p in profiles}
+    assert provider_ids["codex_default"] == "openai"
+    provider_labels = {p.profile_id: p.provider_label for p in profiles}
+    assert provider_labels["codex_default"] == "OpenAI"
 
 
 
@@ -199,6 +203,34 @@ async def test_auto_seed_reconcile_does_not_overwrite_user_default_model(_module
         # User-set value must be preserved; reconciliation loop is a no-op
         # because desired_default_model is None for the standard profiles.
         assert profile.default_model == "gpt-user-custom"
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_reconciles_legacy_codex_default_provider(
+    _module_db, monkeypatch
+):
+    """Legacy codex_default rows should be corrected from MoonLadder to OpenAI."""
+    from api_service.main import _auto_seed_provider_profiles
+
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    await _auto_seed_provider_profiles()
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, "codex_default")
+        assert profile is not None
+        profile.provider_id = "moonladder"
+        profile.provider_label = "MoonLadder"
+        await session.commit()
+
+    seeded = await _auto_seed_provider_profiles()
+    assert seeded == []
+
+    async with db_base.async_session_maker() as session:
+        profile = await session.get(ManagedAgentProviderProfile, "codex_default")
+        assert profile is not None
+        assert profile.provider_id == "openai"
+        assert profile.provider_label == "OpenAI"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When I choose the codex_default provider profile, I’m seeing MoonLadder provided as the provider ID. The provider ID for this should actually be OpenAI.

Provider Profile:MoonLadderProfile ID: codex_defaultProvider ID: moonladder