### PR TITLE
[codex] Fix Codex rollout turn completion handling

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -14,9 +14,10 @@ import sys
 import tempfile
 import threading
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Iterator, Mapping, Sequence
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -53,6 +54,14 @@ _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
 _LOG_RECOVERY_MAX_ROWS = 200
 _LOG_RECOVERY_SQLITE_TIMEOUT_SECONDS = 1.0
+
+
+@dataclass(frozen=True)
+class _RolloutTurnScan:
+    references_turn: bool = False
+    assistant_text: str = ""
+    saw_task_complete: bool = False
+    error_text: str | None = None
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -628,50 +637,93 @@ class CodexManagedSessionRuntime:
         vendor_turn_id: str,
         turn_started_at: float | None = None,
     ) -> str:
+        return self._scan_rollout_for_turn(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+            turn_started_at=turn_started_at,
+        ).assistant_text
+
+    def _scan_rollout_for_turn(
+        self,
+        vendor_thread_path: str | None,
+        *,
+        vendor_turn_id: str,
+        turn_started_at: float | None = None,
+    ) -> _RolloutTurnScan:
         rollout_path = self._allowed_rollout_path(vendor_thread_path)
         if rollout_path is None:
-            return ""
+            return _RolloutTurnScan()
         last_text = ""
         terminal_text = ""
         terminal_cutoff = None
+        references_active_turn = False
+        saw_task_complete = False
+        error_text: str | None = None
         if turn_started_at is not None:
             terminal_cutoff = (
                 float(turn_started_at) - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS
             )
         try:
             rollout_file = Path(rollout_path)
-            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
-                return ""
-            with rollout_file.open(encoding="utf-8") as handle:
-                for raw_line in handle:
-                    stripped = raw_line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        payload = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        continue
-                    if not isinstance(payload, Mapping):
-                        continue
-                    references_turn = self._payload_references_turn(payload, vendor_turn_id)
-                    if references_turn:
-                        text = self._assistant_text_from_rollout_entry(payload)
-                        if text:
-                            last_text = text
-                    text = self._terminal_assistant_text_from_rollout_entry(payload)
+            for stripped in self._iter_rollout_lines(rollout_file):
+                if not stripped:
+                    continue
+                try:
+                    payload = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, Mapping):
+                    continue
+                references_turn = self._payload_references_turn(payload, vendor_turn_id)
+                if references_turn:
+                    references_active_turn = True
+                    text = self._assistant_text_from_rollout_entry(payload)
                     if text:
-                        if references_turn:
-                            terminal_text = text
-                            continue
-                        if terminal_cutoff is None:
-                            continue
-                        entry_timestamp = self._rollout_entry_timestamp(payload)
-                        if entry_timestamp is None or entry_timestamp < terminal_cutoff:
-                            continue
+                        last_text = text
+                text = self._terminal_assistant_text_from_rollout_entry(payload)
+                if text:
+                    if references_turn:
                         terminal_text = text
+                    elif terminal_cutoff is not None:
+                        entry_timestamp = self._rollout_entry_timestamp(payload)
+                        if entry_timestamp is not None and entry_timestamp >= terminal_cutoff:
+                            terminal_text = text
+                if not references_turn:
+                    continue
+                entry_type = str(payload.get("type") or "").strip().lower()
+                if entry_type != "event_msg":
+                    continue
+                event_payload = payload.get("payload")
+                if not isinstance(event_payload, Mapping):
+                    continue
+                event_type = str(event_payload.get("type") or "").strip().lower()
+                if event_type != "task_complete":
+                    continue
+                saw_task_complete = True
+                for field_name in ("error", "reason", "message"):
+                    value = event_payload.get(field_name)
+                    if isinstance(value, str) and value.strip():
+                        error_text = value.strip()
+                        break
         except OSError:
-            return ""
-        return last_text or terminal_text
+            return _RolloutTurnScan()
+        return _RolloutTurnScan(
+            references_turn=references_active_turn,
+            assistant_text=last_text or terminal_text,
+            saw_task_complete=saw_task_complete,
+            error_text=error_text,
+        )
+
+    @staticmethod
+    def _iter_rollout_lines(rollout_file: Path) -> Iterator[str]:
+        file_size = rollout_file.stat().st_size
+        start_offset = max(0, file_size - _ROLLOUT_RECOVERY_MAX_BYTES)
+        with rollout_file.open("rb") as handle:
+            if start_offset:
+                handle.seek(start_offset)
+                handle.readline()
+            for raw_line in handle:
+                yield raw_line.decode("utf-8", errors="replace").strip()
 
     @classmethod
     def _assistant_text_from_rollout_entry(cls, payload: Mapping[str, Any]) -> str:
@@ -722,53 +774,6 @@ class CodexManagedSessionRuntime:
             ):
                 return cls._assistant_text_from_rollout_entry(payload)
         return ""
-
-    def _rollout_terminal_metadata(
-        self,
-        vendor_thread_path: str | None,
-        *,
-        vendor_turn_id: str,
-    ) -> tuple[bool, str | None]:
-        rollout_path = self._allowed_rollout_path(vendor_thread_path)
-        if rollout_path is None:
-            return False, None
-        saw_task_complete = False
-        error_text: str | None = None
-        try:
-            rollout_file = Path(rollout_path)
-            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
-                return False, None
-            with rollout_file.open(encoding="utf-8") as handle:
-                for raw_line in handle:
-                    stripped = raw_line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        payload = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        continue
-                    if not isinstance(payload, Mapping):
-                        continue
-                    if not self._payload_references_turn(payload, vendor_turn_id):
-                        continue
-                    entry_type = str(payload.get("type") or "").strip().lower()
-                    if entry_type != "event_msg":
-                        continue
-                    event_payload = payload.get("payload")
-                    if not isinstance(event_payload, Mapping):
-                        continue
-                    event_type = str(event_payload.get("type") or "").strip().lower()
-                    if event_type != "task_complete":
-                        continue
-                    saw_task_complete = True
-                    for field_name in ("error", "reason", "message"):
-                        value = event_payload.get(field_name)
-                        if isinstance(value, str) and value.strip():
-                            error_text = value.strip()
-                            break
-        except OSError:
-            return False, None
-        return saw_task_complete, error_text
 
     @staticmethod
     def _log_shard_sort_key(log_path: Path) -> tuple[int, str]:
@@ -866,68 +871,22 @@ class CodexManagedSessionRuntime:
                     return recovered
         return None
 
-    def _rollout_references_active_turn(
+    def _rollout_terminal_outcome_from_scan(
         self,
+        scan: _RolloutTurnScan,
         *,
-        state: CodexSessionRuntimeState,
-        thread_payload: Mapping[str, Any],
-        vendor_turn_id: str,
-    ) -> bool:
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        rollout_path = self._allowed_rollout_path(vendor_thread_path)
-        if rollout_path is None:
-            return False
-        try:
-            rollout_file = Path(rollout_path)
-            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
-                return False
-            with rollout_file.open(encoding="utf-8") as handle:
-                for raw_line in handle:
-                    stripped = raw_line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        payload = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        continue
-                    if self._payload_references_turn(payload, vendor_turn_id):
-                        return True
-        except OSError:
-            return False
-        return False
-
-    def _rollout_terminal_outcome(
-        self,
-        *,
-        state: CodexSessionRuntimeState,
-        thread_payload: Mapping[str, Any],
         vendor_turn_id: str,
     ) -> tuple[str, str | None] | None:
-        vendor_thread_path = self._resolved_rollout_path(
-            state=state,
-            thread_payload=thread_payload,
-        )
-        assistant_text = self._extract_assistant_text_from_rollout(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-        )
-        saw_task_complete, rollout_error = self._rollout_terminal_metadata(
-            vendor_thread_path,
-            vendor_turn_id=vendor_turn_id,
-        )
-        if rollout_error:
-            return "failed", rollout_error
-        if saw_task_complete:
-            if assistant_text:
+        if scan.error_text:
+            return "failed", scan.error_text
+        if scan.saw_task_complete:
+            if scan.assistant_text:
                 return "completed", None
             recovered_error = self._extract_turn_error_from_logs(vendor_turn_id)
             if recovered_error:
                 return "failed", recovered_error
             return "failed", "codex app-server turn/completed produced no assistant output"
-        if assistant_text:
+        if scan.assistant_text:
             return "completed", None
         return None
 
@@ -996,6 +955,35 @@ class CodexManagedSessionRuntime:
             return turn
         return None
 
+    def _missing_turn_terminal_outcome(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> tuple[str, str | None] | None:
+        thread_outcome = self._terminal_thread_outcome(thread_payload)
+        if thread_outcome is not None and thread_outcome[0] != "completed":
+            return thread_outcome
+
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        rollout_scan = self._scan_rollout_for_turn(
+            vendor_thread_path,
+            vendor_turn_id=vendor_turn_id,
+        )
+        rollout_outcome = self._rollout_terminal_outcome_from_scan(
+            rollout_scan,
+            vendor_turn_id=vendor_turn_id,
+        )
+        if rollout_outcome is not None:
+            return rollout_outcome
+        if thread_outcome is not None and not rollout_scan.references_turn:
+            return thread_outcome
+        return None
+
     def _wait_for_turn_completion(
         self,
         *,
@@ -1016,24 +1004,13 @@ class CodexManagedSessionRuntime:
                     return thread_payload, outcome
             else:
                 state = self._load_state()
-                rollout_outcome = self._rollout_terminal_outcome(
+                outcome = self._missing_turn_terminal_outcome(
                     state=state,
                     thread_payload=thread_payload,
                     vendor_turn_id=vendor_turn_id,
                 )
-                if rollout_outcome is not None:
-                    return thread_payload, rollout_outcome
-                thread_outcome = self._terminal_thread_outcome(thread_payload)
-                if thread_outcome is not None:
-                    if not (
-                        thread_outcome[0] == "completed"
-                        and self._rollout_references_active_turn(
-                            state=state,
-                            thread_payload=thread_payload,
-                            vendor_turn_id=vendor_turn_id,
-                        )
-                    ):
-                        return thread_payload, thread_outcome
+                if outcome is not None:
+                    return thread_payload, outcome
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -1211,25 +1188,13 @@ class CodexManagedSessionRuntime:
             if outcome is None:
                 return state
         else:
-            outcome = self._rollout_terminal_outcome(
+            outcome = self._missing_turn_terminal_outcome(
                 state=state,
                 thread_payload=thread_payload,
                 vendor_turn_id=active_turn_id,
             )
             if outcome is None:
-                outcome = self._terminal_thread_outcome(thread_payload)
-                if (
-                    outcome is not None
-                    and outcome[0] == "completed"
-                    and self._rollout_references_active_turn(
-                        state=state,
-                        thread_payload=thread_payload,
-                        vendor_turn_id=active_turn_id,
-                    )
-                ):
-                    return state
-                if outcome is None:
-                    return state
+                return state
 
         status, error_text = outcome
         assistant_text = ""

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -866,6 +866,39 @@ class CodexManagedSessionRuntime:
                     return recovered
         return None
 
+    def _rollout_references_active_turn(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        vendor_turn_id: str,
+    ) -> bool:
+        vendor_thread_path = self._resolved_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+        )
+        rollout_path = self._allowed_rollout_path(vendor_thread_path)
+        if rollout_path is None:
+            return False
+        try:
+            rollout_file = Path(rollout_path)
+            if rollout_file.stat().st_size > _ROLLOUT_RECOVERY_MAX_BYTES:
+                return False
+            with rollout_file.open(encoding="utf-8") as handle:
+                for raw_line in handle:
+                    stripped = raw_line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        payload = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if self._payload_references_turn(payload, vendor_turn_id):
+                        return True
+        except OSError:
+            return False
+        return False
+
     def _rollout_terminal_outcome(
         self,
         *,
@@ -982,16 +1015,25 @@ class CodexManagedSessionRuntime:
                 if outcome is not None:
                     return thread_payload, outcome
             else:
-                thread_outcome = self._terminal_thread_outcome(thread_payload)
-                if thread_outcome is not None:
-                    return thread_payload, thread_outcome
+                state = self._load_state()
                 rollout_outcome = self._rollout_terminal_outcome(
-                    state=self._load_state(),
+                    state=state,
                     thread_payload=thread_payload,
                     vendor_turn_id=vendor_turn_id,
                 )
                 if rollout_outcome is not None:
                     return thread_payload, rollout_outcome
+                thread_outcome = self._terminal_thread_outcome(thread_payload)
+                if thread_outcome is not None:
+                    if not (
+                        thread_outcome[0] == "completed"
+                        and self._rollout_references_active_turn(
+                            state=state,
+                            thread_payload=thread_payload,
+                            vendor_turn_id=vendor_turn_id,
+                        )
+                    ):
+                        return thread_payload, thread_outcome
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -1169,13 +1211,23 @@ class CodexManagedSessionRuntime:
             if outcome is None:
                 return state
         else:
-            outcome = self._terminal_thread_outcome(thread_payload)
+            outcome = self._rollout_terminal_outcome(
+                state=state,
+                thread_payload=thread_payload,
+                vendor_turn_id=active_turn_id,
+            )
             if outcome is None:
-                outcome = self._rollout_terminal_outcome(
-                    state=state,
-                    thread_payload=thread_payload,
-                    vendor_turn_id=active_turn_id,
-                )
+                outcome = self._terminal_thread_outcome(thread_payload)
+                if (
+                    outcome is not None
+                    and outcome[0] == "completed"
+                    and self._rollout_references_active_turn(
+                        state=state,
+                        thread_payload=thread_payload,
+                        vendor_turn_id=active_turn_id,
+                    )
+                ):
+                    return state
                 if outcome is None:
                     return state
 

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -16,6 +16,7 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexAppServerRpcClient,
     CodexManagedSessionRuntime,
+    _ROLLOUT_RECOVERY_MAX_BYTES,
     _run_ready,
 )
 from tests.helpers.codex_session_runtime import (
@@ -524,6 +525,67 @@ def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
     )
     assert handle.status == "busy"
     assert handle.metadata["lastTurnStatus"] == "running"
+
+
+def test_runtime_send_turn_stays_running_when_large_rollout_tail_has_active_turn(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        ("x" * (_ROLLOUT_RECOVERY_MAX_BYTES + 16))
+        + "\n"
+        + json.dumps(
+            {
+                "timestamp": "2026-04-10T17:55:16.922Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "running"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
 
 
 def test_runtime_send_turn_ignores_transient_log_error_when_rollout_has_final_answer(
@@ -1130,6 +1192,74 @@ def test_runtime_send_turn_prefers_rollout_task_complete_failure_over_agent_mess
     assert response.metadata["reason"] == "provider returned exit code 1"
 
 
+def test_runtime_send_turn_prefers_failed_thread_status_over_rollout_success(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.088Z",
+                "type": "response_item",
+                "turnId": "vendor-turn-1",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Do not hide the thread failure",
+                        }
+                    ],
+                    "phase": "final",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+        thread_status_type="failed",
+        thread_status_reason="provider failed the thread",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "failed"
+    assert response.metadata["reason"] == "provider failed the thread"
+
+
 def test_runtime_extract_turn_error_from_logs_prefers_highest_numeric_shard(
     tmp_path: Path,
 ) -> None:
@@ -1530,6 +1660,82 @@ def test_runtime_session_status_remains_busy_without_completion_notification(
         )
     )
     assert state_payload["activeTurnId"] == "vendor-turn-1"
+
+
+def test_runtime_session_status_prefers_failed_thread_status_over_rollout_success(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T07-21-32-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T07:21:32.088Z",
+                "type": "response_item",
+                "turnId": "vendor-turn-1",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Do not hide the refreshed thread failure",
+                        }
+                    ],
+                    "phase": "final",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        omit_turns_when_incomplete=True,
+        start_thread_path=str(transcript_path),
+        thread_status_type="failed",
+        thread_status_reason="refresh saw a provider failure",
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+    state_path = Path(request.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_payload = json.loads(state_path.read_text(encoding="utf-8"))
+    state_payload["activeTurnId"] = "vendor-turn-1"
+    state_payload["lastTurnId"] = "vendor-turn-1"
+    state_payload["lastTurnStatus"] = "running"
+    state_path.write_text(json.dumps(state_payload) + "\n", encoding="utf-8")
+
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+
+    assert handle.status == "failed"
+    assert handle.session_state.active_turn_id is None
+    assert handle.metadata["lastTurnStatus"] == "failed"
+    assert handle.metadata["lastTurnError"] == "refresh saw a provider failure"
 
 
 def test_runtime_interrupt_turn_uses_app_server_transport(tmp_path: Path) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -455,6 +455,77 @@ def test_runtime_send_turn_recovers_last_agent_message_from_task_complete_event(
     assert handle.metadata["lastAssistantText"] == "Recovered from task_complete event"
 
 
+def test_runtime_send_turn_stays_running_when_rollout_turn_has_not_completed(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    transcript_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "10"
+        / "rollout-2026-04-10T17-55-14-vendor-thread-1.jsonl"
+    )
+    transcript_path.parent.mkdir(parents=True, exist_ok=True)
+    transcript_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-10T17:55:16.922Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "task_started",
+                    "turn_id": "vendor-turn-1",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script = write_fake_app_server(
+        tmp_path,
+        omit_turns_on_read=True,
+        start_thread_path=str(transcript_path),
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+        turn_completion_timeout_seconds=0.01,
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "running"
+    assert response.turn_id == "vendor-turn-1"
+    assert response.session_state.active_turn_id == "vendor-turn-1"
+    assert response.metadata == {}
+    handle = runtime.session_status(
+        CodexManagedSessionLocator(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+        )
+    )
+    assert handle.status == "busy"
+    assert handle.metadata["lastTurnStatus"] == "running"
+
+
 def test_runtime_send_turn_ignores_transient_log_error_when_rollout_has_final_answer(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes a Codex managed-session runtime race where MoonMind could treat a thread-level `idle` status as active-turn completion even when the rollout transcript only contained `task_started` for that turn and no terminal output yet.

## Root Cause

Workflow `mm:55824ea7-127e-4e61-a3d8-045611cd7b89` failed because the Codex session runtime saw `thread/read` omit the active turn while the thread status was `idle`. The runtime accepted that as completion, then failed the turn because no assistant output was available. The parent workflow retried the same plan node and ultimately failed with `execution_error`.

## Changes

- Prefer turn-specific rollout terminal evidence before accepting thread-level terminal status when `thread/read` omits the active turn.
- Keep the turn `running`/session `busy` when the rollout references the active turn but has not reached `task_complete` or final assistant output yet.
- Add a regression test covering the failed workflow shape.

## Validation

- `.venv/bin/pytest tests/unit/services/temporal/runtime/test_codex_session_runtime.py -q`
- `.venv/bin/pytest tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`