### PR TITLE
[codex] Fix batch PR resolver routing

### DIFF
--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -66,9 +66,9 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      - `payload.repository`: target repo
      - `payload.task.git.startingBranch`: PR head branch
      - `payload.task.publish.mode`: `none`
-     - `payload.task.skill.id`: `pr-resolver`
-     - `payload.task.skill.args`: `{ repo, pr, branch, mergeMethod, maxIterations }`
-   - Submit via internal queue service (`AgentQueueService`).
+     - `payload.task.skill.name`: `pr-resolver`
+     - `payload.task.inputs`: `{ repo, pr, branch, mergeMethod, maxIterations }`
+   - Submit via the internal Temporal execution API (`POST /api/executions`).
 4. Write one summary artifact at `artifacts/batch_pr_resolver_result.json`.
 5. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
 
@@ -78,3 +78,4 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
 - Use `state=open` by default to avoid accidental non-open PR dispatch.
 - `--include-forks` is rejected to avoid unreliable fork-branch checkout behavior in queued jobs.
 - Skip fork PRs by default.
+- Require `MOONMIND_URL` to reach the MoonMind API; the legacy direct-DB queue fallback is intentionally unsupported.

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -492,7 +492,15 @@ async def _submit_jobs_via_http(
                 response = await client.post(API_EXECUTIONS_ENDPOINT, json=body)
                 response.raise_for_status()
                 data = response.json()
-                job_id = str(data.get("taskId", "")) or "(unknown)"
+                job_id = (
+                    str(
+                        data.get("workflowId")
+                        or data.get("taskId")
+                        or data.get("id")
+                        or ""
+                    )
+                    or "(unknown)"
+                )
                 created.append(
                     {
                         "pr": submission.pr_number,
@@ -511,55 +519,10 @@ async def _submit_jobs_via_http(
     return created, errors
 
 
-async def _submit_jobs_via_db(
-    queue_requests: list[JobSubmission],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Fallback: submit jobs directly to the DB queue (skips Temporal routing)."""
-    from api_service.db.base import get_async_session_context
-    from moonmind.workflows import get_agent_queue_service
-
-    created: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
-    async with get_async_session_context() as session:
-        service = get_agent_queue_service(session)
-        for submission in queue_requests:
-            request = submission.queue_request
-            payload = request["payload"]
-            queue_type = str(request["type"])
-            priority = int(request.get("priority", 0))
-            max_attempts = int(request.get("maxAttempts", 3))
-            
-            kwargs = {
-                "job_type": queue_type,
-                "payload": payload,
-                "priority": priority,
-                "max_attempts": max_attempts,
-            }
-
-            try:
-                job = await service.create_job(**kwargs)
-                created.append(
-                    {
-                        "pr": submission.pr_number,
-                        "branch": submission.branch,
-                        "jobId": str(job.id),
-                    }
-                )
-            except Exception as exc:
-                errors.append(
-                    {
-                        "pr": submission.pr_number,
-                        "branch": submission.branch,
-                        "error": str(exc),
-                    }
-                )
-    return created, errors
-
-
 async def _submit_jobs(
     queue_requests: list[JobSubmission],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Submit jobs via the MoonMind HTTP API (Temporal-aware), with DB fallback."""
+    """Submit jobs through the MoonMind Temporal execution API."""
     moonmind_url = str(os.getenv("MOONMIND_URL", "")).strip()
     if moonmind_url:
         worker_token = _read_worker_token()
@@ -568,12 +531,19 @@ async def _submit_jobs(
             moonmind_url=moonmind_url,
             worker_token=worker_token,
         )
-    # Fallback for environments without a running API (e.g. direct invocation).
-    logger.warning(
-        "MOONMIND_URL is not set; submitting jobs directly to the DB queue. "
-        "This bypasses Temporal routing and should only be used in dev/test environments."
+
+    message = (
+        "MOONMIND_URL is not set; batch-pr-resolver requires the MoonMind "
+        "Temporal execution API and cannot submit via the removed legacy DB queue."
     )
-    return await _submit_jobs_via_db(queue_requests)
+    return [], [
+        {
+            "pr": submission.pr_number,
+            "branch": submission.branch,
+            "error": message,
+        }
+        for submission in queue_requests
+    ]
 
 
 def _build_request_records(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -128,6 +128,7 @@ async def _run_command(cmd, **kwargs):
     return CmdRes(stdout)
 
 logger = getLogger(__name__)
+_NON_SECRET_MANAGED_SESSION_ENV_KEYS: tuple[str, ...] = ("MOONMIND_URL",)
 
 HeartbeatCallback = Callable[[Mapping[str, Any]], Awaitable[None] | None]
 PlanGenerator = Callable[
@@ -2811,6 +2812,10 @@ class TemporalAgentRuntimeActivities:
                     profile=profile,
                 )
             )
+        for key in _NON_SECRET_MANAGED_SESSION_ENV_KEYS:
+            value = os.environ.get(key)
+            if value is not None and value.strip() and key not in environment:
+                environment[key] = value
         environment = await shape_launch_github_auth_environment(
             environment,
             ambient_github_token=os.environ.get("GITHUB_TOKEN"),

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -13,6 +13,7 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping, Protocol, Sequence
+from urllib.parse import urlparse
 
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
@@ -54,6 +55,29 @@ _SENSITIVE_ENV_KEY_PATTERN = re.compile(
 _GIT_COMMAND_LOCALE = {"LC_ALL": "C", "LANG": "C"}
 _SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 logger = logging.getLogger(__name__)
+
+
+def _managed_session_docker_network() -> str | None:
+    """Return the Docker network managed session containers should join."""
+
+    for env_key in (
+        "MOONMIND_MANAGED_SESSION_DOCKER_NETWORK",
+        "MOONMIND_DOCKER_NETWORK",
+    ):
+        raw_value = os.environ.get(env_key)
+        if raw_value is None:
+            continue
+        value = raw_value.strip()
+        if value.lower() in {"", "none", "disabled", "off"}:
+            return None
+        return value
+
+    moonmind_url = os.environ.get("MOONMIND_URL", "").strip()
+    if moonmind_url:
+        hostname = (urlparse(moonmind_url).hostname or "").strip().lower()
+        if hostname in {"api", "moonmind-api", "moonmind-api-1"}:
+            return "local-network"
+    return None
 
 
 class CommandRunner(Protocol):
@@ -1091,22 +1115,29 @@ class DockerCodexManagedSessionController:
             _MANAGED_SESSION_CONTAINER_USER,
             "--mount",
             self._volume_mount(self._workspace_volume_name, self._workspace_root),
-            "-e",
-            f"MOONMIND_SESSION_WORKSPACE_PATH={request.workspace_path}",
-            "-e",
-            f"MOONMIND_SESSION_WORKSPACE_STATE_PATH={request.session_workspace_path}",
-            "-e",
-            f"MOONMIND_SESSION_ARTIFACT_SPOOL_PATH={request.artifact_spool_path}",
-            "-e",
-            f"MOONMIND_SESSION_CODEX_HOME_PATH={request.codex_home_path}",
-            "-e",
-            f"MOONMIND_SESSION_IMAGE_REF={request.image_ref}",
-            "-e",
-            f"MOONMIND_SESSION_CONTROL_URL=docker-exec://{container_name}",
-            "-e",
-            "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS="
-            f"{request.turn_completion_timeout_seconds}",
         ]
+        docker_network = _managed_session_docker_network()
+        if docker_network:
+            run_command.extend(["--network", docker_network])
+        run_command.extend(
+            [
+                "-e",
+                f"MOONMIND_SESSION_WORKSPACE_PATH={request.workspace_path}",
+                "-e",
+                f"MOONMIND_SESSION_WORKSPACE_STATE_PATH={request.session_workspace_path}",
+                "-e",
+                f"MOONMIND_SESSION_ARTIFACT_SPOOL_PATH={request.artifact_spool_path}",
+                "-e",
+                f"MOONMIND_SESSION_CODEX_HOME_PATH={request.codex_home_path}",
+                "-e",
+                f"MOONMIND_SESSION_IMAGE_REF={request.image_ref}",
+                "-e",
+                f"MOONMIND_SESSION_CONTROL_URL=docker-exec://{container_name}",
+                "-e",
+                "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS="
+                f"{request.turn_completion_timeout_seconds}",
+            ]
+        )
         auth_volume_path = str(
             request.environment.get("MANAGED_AUTH_VOLUME_PATH") or ""
         ).strip()

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -57,7 +57,9 @@ _SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 logger = logging.getLogger(__name__)
 
 
-def _managed_session_docker_network() -> str | None:
+def _managed_session_docker_network(
+    request_environment: Mapping[str, str] | None = None,
+) -> str | None:
     """Return the Docker network managed session containers should join."""
 
     for env_key in (
@@ -72,7 +74,11 @@ def _managed_session_docker_network() -> str | None:
             return None
         return value
 
-    moonmind_url = os.environ.get("MOONMIND_URL", "").strip()
+    moonmind_url = ""
+    if request_environment is not None:
+        moonmind_url = str(request_environment.get("MOONMIND_URL") or "").strip()
+    if not moonmind_url:
+        moonmind_url = os.environ.get("MOONMIND_URL", "").strip()
     if moonmind_url:
         hostname = (urlparse(moonmind_url).hostname or "").strip().lower()
         if hostname in {"api", "moonmind-api", "moonmind-api-1"}:
@@ -1116,7 +1122,7 @@ class DockerCodexManagedSessionController:
             "--mount",
             self._volume_mount(self._workspace_volume_name, self._workspace_root),
         ]
-        docker_network = _managed_session_docker_network()
+        docker_network = _managed_session_docker_network(request.environment)
         if docker_network:
             run_command.extend(["--network", docker_network])
         run_command.extend(

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -153,6 +153,71 @@ async def test_controller_launches_container_and_returns_typed_handle(
 
 
 @pytest.mark.asyncio
+async def test_controller_uses_request_moonmind_url_for_docker_network(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_URL", raising=False)
+    workspace_root = tmp_path / "agent_jobs"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"MOONMIND_URL": "http://api:5000"},
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-1",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-1",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    run_command = commands[1]
+    assert "--network" in run_command
+    assert "local-network" in run_command
+
+
+@pytest.mark.asyncio
 async def test_controller_launch_normalizes_created_paths_for_container_user(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -62,8 +62,12 @@ def _workspace_git_command(workspace_path: str | Path, *args: str) -> tuple[str,
 
 @pytest.mark.asyncio
 async def test_controller_launches_container_and_returns_typed_handle(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    monkeypatch.setenv("MOONMIND_URL", "http://api:5000")
     workspace_root = tmp_path / "agent_jobs"
     session_store = ManagedSessionStore(tmp_path / "session-store")
     session_supervisor = AsyncMock()
@@ -132,6 +136,8 @@ async def test_controller_launches_container_and_returns_typed_handle(
     assert "1000:1000" in run_command
     assert "--mount" in run_command
     assert "-v" not in run_command
+    assert "--network" in run_command
+    assert "local-network" in run_command
     assert request.image_ref in run_command
     assert (
         "MOONMIND_SESSION_TURN_COMPLETION_TIMEOUT_SECONDS=1800" in run_command

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -389,6 +389,48 @@ def test_submit_jobs_posts_to_api(monkeypatch: Any) -> None:
     assert call_path == "/api/executions"
 
 
+def test_submit_jobs_records_temporal_workflow_id(monkeypatch: Any) -> None:
+    """The Temporal executions API returns workflowId rather than legacy taskId."""
+    module = _load_module()
+    submit_jobs_via_http = module["_submit_jobs_via_http"]
+
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock()
+    fake_response.json = MagicMock(
+        return_value={"workflowId": "mm:wf-123", "status": "queued"}
+    )
+
+    mock_post = AsyncMock(return_value=fake_response)
+
+    import httpx
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            pass
+
+        async def post(self, path: str, **kwargs: Any) -> Any:
+            return await mock_post(path, **kwargs)
+
+    with patch.object(httpx, "AsyncClient", FakeAsyncClient):
+        submission = _make_submission(module)
+        created, errors = asyncio.run(
+            submit_jobs_via_http(
+                [submission],
+                moonmind_url="http://api:5000",
+                worker_token=None,
+            )
+        )
+
+    assert errors == []
+    assert created[0]["jobId"] == "mm:wf-123"
+
+
 def test_submit_jobs_uses_http_when_moonmind_url_set(monkeypatch: Any) -> None:
     """_submit_jobs dispatches to HTTP when MOONMIND_URL is configured."""
     module = _load_module()
@@ -418,27 +460,22 @@ def test_submit_jobs_uses_http_when_moonmind_url_set(monkeypatch: Any) -> None:
     assert errors == []
 
 
-def test_submit_jobs_falls_back_when_no_url(monkeypatch: Any) -> None:
-    """_submit_jobs falls back to DB path and logs a warning when MOONMIND_URL is absent."""
+def test_submit_jobs_errors_when_no_url(monkeypatch: Any) -> None:
+    """The removed legacy DB queue fallback must not be used."""
     module = _load_module()
     submit_jobs = module["_submit_jobs"]
 
     monkeypatch.delenv("MOONMIND_URL", raising=False)
 
-    db_called = []
-
-    async def fake_db(requests: list) -> tuple:
-        db_called.append(True)
-        return [{"pr": 1, "branch": "b", "jobId": "y"}], []
-
     submission = _make_submission(module)
 
-    monkeypatch.setitem(submit_jobs.__globals__, "_submit_jobs_via_db", fake_db)
     created, errors = asyncio.run(submit_jobs([submission]))
 
-    assert db_called == [True]
-    assert len(created) == 1
-    assert errors == []
+    assert created == []
+    assert len(errors) == 1
+    assert errors[0]["pr"] == 42
+    assert "MOONMIND_URL is not set" in errors[0]["error"]
+    assert "removed legacy DB queue" in errors[0]["error"]
 
 
 def test_read_worker_token_from_file(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -402,6 +402,44 @@ async def test_launch_session_injects_github_token_from_activity_environment(
     assert launched_request.environment["GIT_TERMINAL_PROMPT"] == "0"
 
 
+async def test_launch_session_injects_moonmind_url_from_activity_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MOONMIND_URL", "http://api:5000")
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    await activities.agent_runtime_launch_session(
+        {
+            "taskRunId": "task-1",
+            "sessionId": "sess-1",
+            "threadId": "thread-1",
+            "workspacePath": "/work/task/repo",
+            "sessionWorkspacePath": "/work/task/session",
+            "artifactSpoolPath": "/work/task/artifacts",
+            "codexHomePath": "/work/task/codex-home",
+            "imageRef": "moonmind:latest",
+            "environment": {"PATH": "/usr/bin"},
+        }
+    )
+
+    launched_request = controller.launch_session.await_args.args[0]
+    assert launched_request.environment["PATH"] == "/usr/bin"
+    assert launched_request.environment["MOONMIND_URL"] == "http://api:5000"
+
+
 async def test_launch_session_injects_github_token_from_managed_secret_store(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Attach managed Codex session containers to the internal Docker network when `MOONMIND_URL` points at the compose API service.
- Pass `MOONMIND_URL` into managed session launch environments as non-secret runtime configuration.
- Remove the stale batch-pr-resolver direct DB queue fallback and submit only through the Temporal executions API.
- Update unit coverage for managed session networking, `MOONMIND_URL` propagation, and Temporal `workflowId` handling.

## Root Cause
The batch PR resolver found open PRs, but managed session containers were launched on Docker's default bridge network and did not receive `MOONMIND_URL`, so `http://api:5000` was unreachable. The fallback path then tried removed legacy queue wiring instead of failing clearly.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/test_batch_pr_resolver.py tests/unit/services/temporal/runtime/test_managed_session_controller.py::test_controller_launches_container_and_returns_typed_handle tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_launch_session_injects_moonmind_url_from_activity_environment`
- `./tools/test_unit.sh` -> 2798 Python tests passed, 1 xpassed, 16 subtests passed; Vitest 120 tests passed
- `git diff --check`