### PR TITLE
[codex] Fix batch PR resolver duplicate dispatch

### DIFF
--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -63,6 +63,7 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
    - Skip PRs identified as cross-repository (`isCrossRepository=true`) or whose head is not on `owner/repo`.
    - Build a canonical queue task with:
      - `type: "task"`
+     - `payload.idempotencyKey`: stable per parent batch run and PR, so rerunning the same batch task does not create duplicate resolver workflows.
      - `payload.repository`: target repo
      - `payload.task.git.startingBranch`: PR head branch
      - `payload.task.publish.mode`: `none`
@@ -70,7 +71,7 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
      - `payload.task.inputs`: `{ repo, pr, branch, mergeMethod, maxIterations }`
    - Submit via the internal Temporal execution API (`POST /api/executions`);
      `MOONMIND_URL` must point at the MoonMind API from the managed session.
-4. Write one summary artifact at `artifacts/batch_pr_resolver_result.json`.
+4. Write one summary artifact at `batch_pr_resolver_result.json` under the managed session artifact spool path when available, otherwise under the configured `--artifacts-dir`.
 5. Print a short count summary to stdout (`queued`, `skipped`, `errors`).
 
 ## Safety constraints

--- a/.agents/skills/batch-pr-resolver/SKILL.md
+++ b/.agents/skills/batch-pr-resolver/SKILL.md
@@ -63,7 +63,7 @@ python3 .agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py \
    - Skip PRs identified as cross-repository (`isCrossRepository=true`) or whose head is not on `owner/repo`.
    - Build a canonical queue task with:
      - `type: "task"`
-     - `payload.idempotencyKey`: stable per parent batch run and PR, so rerunning the same batch task does not create duplicate resolver workflows.
+     - `payload.idempotencyKey`: stable per parent batch run and PR, hash-backed and capped to the execution persistence limit, so rerunning the same batch task does not create duplicate resolver workflows.
      - `payload.repository`: target repo
      - `payload.task.git.startingBranch`: PR head branch
      - `payload.task.publish.mode`: `none`

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -231,6 +231,71 @@ def _runtime_text(value: Any) -> str | None:
     return text or None
 
 
+def _session_artifact_spool_path() -> Path | None:
+    raw = _runtime_text(os.getenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"))
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def _parent_run_scope(task_context_path: str | None = None) -> str | None:
+    for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
+        value = _runtime_text(os.getenv(env_key))
+        if value:
+            return value
+
+    spool_path = _session_artifact_spool_path()
+    if spool_path is not None and spool_path.parent.name:
+        return spool_path.parent.name
+
+    for candidate in _repo_context_candidates(task_context_path):
+        try:
+            resolved = candidate.resolve(strict=False)
+        except OSError:
+            resolved = candidate
+        if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
+            parent_name = resolved.parent.parent.name
+            if parent_name:
+                return parent_name
+    return None
+
+
+def _resolve_artifacts_dir(
+    raw_artifacts_dir: str,
+    task_context_path: str | None = None,
+) -> Path:
+    raw = str(raw_artifacts_dir or "").strip()
+    if raw and raw != "artifacts":
+        return Path(raw)
+
+    spool_path = _session_artifact_spool_path()
+    if spool_path is not None:
+        return spool_path
+
+    for candidate in _repo_context_candidates(task_context_path):
+        try:
+            resolved = candidate.resolve(strict=False)
+        except OSError:
+            resolved = candidate
+        if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
+            return resolved.parent
+
+    return Path(raw or "artifacts")
+
+
+def _child_idempotency_key(
+    *,
+    batch_scope: str | None,
+    repo: str,
+    pr_number: int | str,
+    branch: str,
+) -> str | None:
+    scope = _runtime_text(batch_scope)
+    if not scope:
+        return None
+    return f"batch-pr-resolver:{scope}:{repo}:pr:{pr_number}:branch:{branch}"[:512]
+
+
 def _load_parent_runtime_selection(
     task_context_path: str | None = None,
 ) -> RuntimeSelection | None:
@@ -328,6 +393,7 @@ def _build_queue_request(
     max_iterations: int,
     priority: int,
     max_attempts: int,
+    batch_scope: str | None = None,
     skill_version: str = "1.0",
 ) -> dict[str, Any]:
     publish_mode = resolve_publish_mode_for_skill("pr-resolver", "none")
@@ -365,6 +431,14 @@ def _build_queue_request(
             "publish": {"mode": publish_mode},
         },
     }
+    idempotency_key = _child_idempotency_key(
+        batch_scope=batch_scope,
+        repo=repo,
+        pr_number=pr_number,
+        branch=branch,
+    )
+    if idempotency_key:
+        payload_dict["idempotencyKey"] = idempotency_key
 
     if runtime.mode:
         payload_dict["targetRuntime"] = runtime.mode
@@ -573,6 +647,7 @@ def _build_request_records(
             return 0
 
     open_prs_sorted = sorted(open_prs, key=_get_pr_number)
+    batch_scope = _parent_run_scope(args.task_context_path)
 
     for pr in open_prs_sorted:
         number = pr.get("number")
@@ -590,6 +665,7 @@ def _build_request_records(
             max_iterations=args.max_iterations,
             priority=args.priority,
             max_attempts=args.max_attempts,
+            batch_scope=batch_scope,
             skill_version=args.skill_version,
         )
         queue_requests.append(
@@ -637,7 +713,10 @@ async def main() -> int:
     if payload["created"] == 0:
         payload["message"] = "No matching PRs were queued."
 
-    artifacts_path = Path(args.artifacts_dir) / "batch_pr_resolver_result.json"
+    artifacts_path = (
+        _resolve_artifacts_dir(args.artifacts_dir, args.task_context_path)
+        / "batch_pr_resolver_result.json"
+    )
     _write_artifacts(artifacts_path, payload)
 
     print(json.dumps(payload, indent=2))

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -22,6 +23,7 @@ from moonmind.workflows.tasks.task_contract import resolve_publish_mode_for_skil
 logger = logging.getLogger(__name__)
 
 API_EXECUTIONS_ENDPOINT = "/api/executions"
+IDEMPOTENCY_KEY_MAX_LENGTH = 128
 
 
 @dataclass
@@ -238,6 +240,57 @@ def _session_artifact_spool_path() -> Path | None:
     return Path(raw)
 
 
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except OSError:
+        return path
+
+
+def _default_artifacts_dir_requested(raw_artifacts_dir: str) -> bool:
+    raw = str(raw_artifacts_dir or "").strip()
+    if not raw:
+        return True
+    candidate = Path(raw)
+    return not candidate.is_absolute() and candidate.parts == ("artifacts",)
+
+
+def _artifacts_dir_from_task_context_path(path: Path) -> Path | None:
+    resolved = _resolve_path(path)
+    if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
+        return resolved.parent
+    return None
+
+
+def _looks_like_parent_run_scope(value: str) -> bool:
+    if re.fullmatch(
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+        value,
+    ):
+        return True
+    return bool(re.fullmatch(r"(?:mm:|task-)[A-Za-z0-9_.:-]+", value))
+
+
+def _stable_scope_from_path(path: Path) -> str:
+    resolved = _resolve_path(path)
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:24]
+    return f"path:{digest}"
+
+
+def _parent_run_scope_from_artifacts_dir(path: Path) -> str | None:
+    resolved = _resolve_path(path)
+    if resolved.name != "artifacts":
+        return _stable_scope_from_path(resolved)
+
+    parent_name = resolved.parent.name
+    if not parent_name:
+        return _stable_scope_from_path(resolved)
+    if _looks_like_parent_run_scope(parent_name):
+        return parent_name
+    return _stable_scope_from_path(resolved.parent)
+
+
 def _parent_run_scope(task_context_path: str | None = None) -> str | None:
     for env_key in ("MOONMIND_TASK_RUN_ID", "MOONMIND_RUN_ID", "TASK_RUN_ID"):
         value = _runtime_text(os.getenv(env_key))
@@ -245,18 +298,13 @@ def _parent_run_scope(task_context_path: str | None = None) -> str | None:
             return value
 
     spool_path = _session_artifact_spool_path()
-    if spool_path is not None and spool_path.parent.name:
-        return spool_path.parent.name
+    if spool_path is not None:
+        return _parent_run_scope_from_artifacts_dir(spool_path)
 
     for candidate in _repo_context_candidates(task_context_path):
-        try:
-            resolved = candidate.resolve(strict=False)
-        except OSError:
-            resolved = candidate
-        if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
-            parent_name = resolved.parent.parent.name
-            if parent_name:
-                return parent_name
+        artifacts_dir = _artifacts_dir_from_task_context_path(candidate)
+        if artifacts_dir is not None:
+            return _parent_run_scope_from_artifacts_dir(artifacts_dir)
     return None
 
 
@@ -265,7 +313,7 @@ def _resolve_artifacts_dir(
     task_context_path: str | None = None,
 ) -> Path:
     raw = str(raw_artifacts_dir or "").strip()
-    if raw and raw != "artifacts":
+    if not _default_artifacts_dir_requested(raw):
         return Path(raw)
 
     spool_path = _session_artifact_spool_path()
@@ -273,12 +321,9 @@ def _resolve_artifacts_dir(
         return spool_path
 
     for candidate in _repo_context_candidates(task_context_path):
-        try:
-            resolved = candidate.resolve(strict=False)
-        except OSError:
-            resolved = candidate
-        if resolved.name == "task_context.json" and resolved.parent.name == "artifacts":
-            return resolved.parent
+        artifacts_dir = _artifacts_dir_from_task_context_path(candidate)
+        if artifacts_dir is not None:
+            return artifacts_dir
 
     return Path(raw or "artifacts")
 
@@ -293,7 +338,19 @@ def _child_idempotency_key(
     scope = _runtime_text(batch_scope)
     if not scope:
         return None
-    return f"batch-pr-resolver:{scope}:{repo}:pr:{pr_number}:branch:{branch}"[:512]
+
+    components = {
+        "scope": scope,
+        "repo": repo,
+        "pr": str(pr_number),
+        "branch": branch,
+    }
+    canonical = json.dumps(components, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    key = f"batch-pr-resolver:pr:{pr_number}:sha256:{digest}"
+    if len(key) > IDEMPOTENCY_KEY_MAX_LENGTH:
+        raise RuntimeError("generated child idempotency key exceeds storage limit")
+    return key
 
 
 def _load_parent_runtime_selection(

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import runpy
 import threading
@@ -71,6 +72,27 @@ def _run_command_env(command: tuple[str, ...]) -> dict[str, str]:
             continue
         index += 1
     return env
+
+
+def _expected_child_idempotency_key(
+    *,
+    batch_scope: str,
+    repo: str,
+    pr_number: int | str,
+    branch: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "scope": batch_scope,
+            "repo": repo,
+            "pr": str(pr_number),
+            "branch": branch,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"batch-pr-resolver:pr:{pr_number}:sha256:{digest}"
 
 
 @pytest.mark.asyncio
@@ -195,9 +217,11 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
         body = captured["body"]
         assert body["type"] == "task"
         assert body["payload"]["targetRuntime"] == "codex_cli"
-        assert body["payload"]["idempotencyKey"] == (
-            "batch-pr-resolver:task-parent:MoonLadderStudios/MoonMind:"
-            "pr:1337:branch:codex/session-child-task"
+        assert body["payload"]["idempotencyKey"] == _expected_child_idempotency_key(
+            batch_scope="task-parent",
+            repo="MoonLadderStudios/MoonMind",
+            pr_number=1337,
+            branch="codex/session-child-task",
         )
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
         assert body["payload"]["task"]["inputs"]["pr"] == "1337"

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -169,6 +169,7 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
                 max_iterations=3,
                 priority=0,
                 max_attempts=3,
+                batch_scope="task-parent",
             ),
             pr_number=1337,
             branch="codex/session-child-task",
@@ -194,6 +195,10 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
         body = captured["body"]
         assert body["type"] == "task"
         assert body["payload"]["targetRuntime"] == "codex_cli"
+        assert body["payload"]["idempotencyKey"] == (
+            "batch-pr-resolver:task-parent:MoonLadderStudios/MoonMind:"
+            "pr:1337:branch:codex/session-child-task"
+        )
         assert body["payload"]["task"]["skill"]["name"] == "pr-resolver"
         assert body["payload"]["task"]["inputs"]["pr"] == "1337"
     finally:

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -91,6 +91,48 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert git["targetBranch"] == "feature/example"
 
 
+def test_build_queue_request_adds_batch_scoped_idempotency_key() -> None:
+    module = _load_module()
+    build_queue_request = module["_build_queue_request"]
+    runtime_selection = module["RuntimeSelection"]
+
+    request = build_queue_request(
+        "MoonLadderStudios/MoonMind",
+        pr_number=42,
+        branch="feature/example",
+        runtime=runtime_selection(mode="codex", model=None, effort=None),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+        batch_scope="mm:parent-run",
+    )
+
+    assert request["payload"]["idempotencyKey"] == (
+        "batch-pr-resolver:mm:parent-run:MoonLadderStudios/MoonMind:"
+        "pr:42:branch:feature/example"
+    )
+
+
+def test_build_queue_request_omits_idempotency_without_batch_scope() -> None:
+    module = _load_module()
+    build_queue_request = module["_build_queue_request"]
+    runtime_selection = module["RuntimeSelection"]
+
+    request = build_queue_request(
+        "MoonLadderStudios/MoonMind",
+        pr_number=42,
+        branch="feature/example",
+        runtime=runtime_selection(mode="codex", model=None, effort=None),
+        merge_method="squash",
+        max_iterations=3,
+        priority=0,
+        max_attempts=3,
+    )
+
+    assert "idempotencyKey" not in request["payload"]
+
+
 def test_build_queue_request_enqueues_without_manual_publish_patch() -> None:
     module = _load_module()
     build_queue_request = module["_build_queue_request"]
@@ -112,6 +154,50 @@ def test_build_queue_request_enqueues_without_manual_publish_patch() -> None:
     # skill.name shape.  Publish and skill identity assertions are covered by the
     # dedicated contract tests below.
     assert request["payload"]["task"]["publish"]["mode"] == "none"
+
+
+def test_resolve_artifacts_dir_prefers_managed_session_spool(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    resolve_artifacts_dir = module["_resolve_artifacts_dir"]
+
+    spool = tmp_path / "mm-parent" / "artifacts"
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))
+
+    assert resolve_artifacts_dir("artifacts") == spool
+
+
+def test_resolve_artifacts_dir_respects_explicit_path(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    resolve_artifacts_dir = module["_resolve_artifacts_dir"]
+
+    explicit = tmp_path / "custom-artifacts"
+    monkeypatch.setenv(
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+        str(tmp_path / "mm-parent" / "artifacts"),
+    )
+
+    assert resolve_artifacts_dir(str(explicit)) == explicit
+
+
+def test_parent_run_scope_uses_managed_session_spool(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    parent_run_scope = module["_parent_run_scope"]
+
+    monkeypatch.setenv(
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+        str(tmp_path / "mm:parent-run" / "artifacts"),
+    )
+
+    assert parent_run_scope() == "mm:parent-run"
 
 
 def test_load_parent_repository_reads_task_context(tmp_path: Path):

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import runpy
 from pathlib import Path
 from typing import Any
@@ -19,6 +21,27 @@ def _load_module() -> dict[str, Any]:
             / "batch_pr_resolver.py"
         )
     )
+
+
+def _expected_child_idempotency_key(
+    *,
+    batch_scope: str,
+    repo: str,
+    pr_number: int | str,
+    branch: str,
+) -> str:
+    canonical = json.dumps(
+        {
+            "scope": batch_scope,
+            "repo": repo,
+            "pr": str(pr_number),
+            "branch": branch,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"batch-pr-resolver:pr:{pr_number}:sha256:{digest}"
 
 
 def test_is_local_head_uses_cross_repository_flag():
@@ -108,10 +131,35 @@ def test_build_queue_request_adds_batch_scoped_idempotency_key() -> None:
         batch_scope="mm:parent-run",
     )
 
-    assert request["payload"]["idempotencyKey"] == (
-        "batch-pr-resolver:mm:parent-run:MoonLadderStudios/MoonMind:"
-        "pr:42:branch:feature/example"
+    assert request["payload"]["idempotencyKey"] == _expected_child_idempotency_key(
+        batch_scope="mm:parent-run",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=42,
+        branch="feature/example",
     )
+
+
+def test_child_idempotency_key_is_fixed_length_and_collision_resistant() -> None:
+    module = _load_module()
+    child_idempotency_key = module["_child_idempotency_key"]
+
+    common_prefix = "feature/" + ("very-long-branch-" * 20)
+    key_one = child_idempotency_key(
+        batch_scope="mm:parent-run",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=42,
+        branch=f"{common_prefix}one",
+    )
+    key_two = child_idempotency_key(
+        batch_scope="mm:parent-run",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=42,
+        branch=f"{common_prefix}two",
+    )
+
+    assert key_one != key_two
+    assert len(key_one) <= 128
+    assert len(key_two) <= 128
 
 
 def test_build_queue_request_omits_idempotency_without_batch_scope() -> None:
@@ -169,6 +217,20 @@ def test_resolve_artifacts_dir_prefers_managed_session_spool(
     assert resolve_artifacts_dir("artifacts") == spool
 
 
+def test_resolve_artifacts_dir_treats_default_aliases_as_managed_spool(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    resolve_artifacts_dir = module["_resolve_artifacts_dir"]
+
+    spool = tmp_path / "mm-parent" / "artifacts"
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))
+
+    assert resolve_artifacts_dir("./artifacts") == spool
+    assert resolve_artifacts_dir("artifacts/") == spool
+
+
 def test_resolve_artifacts_dir_respects_explicit_path(
     monkeypatch: Any,
     tmp_path: Path,
@@ -198,6 +260,31 @@ def test_parent_run_scope_uses_managed_session_spool(
     )
 
     assert parent_run_scope() == "mm:parent-run"
+
+
+def test_parent_run_scope_hashes_nonstandard_session_spool_path(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    parent_run_scope = module["_parent_run_scope"]
+    stable_scope_from_path = module["_stable_scope_from_path"]
+
+    spool = tmp_path / "custom-spool" / "output"
+    monkeypatch.setenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH", str(spool))
+
+    assert parent_run_scope() == stable_scope_from_path(spool)
+
+
+def test_parent_run_scope_reuses_task_context_artifacts_helper(tmp_path: Path) -> None:
+    module = _load_module()
+    parent_run_scope = module["_parent_run_scope"]
+
+    task_context = tmp_path / "task-parent" / "artifacts" / "task_context.json"
+    task_context.parent.mkdir(parents=True)
+    task_context.write_text("{}", encoding="utf-8")
+
+    assert parent_run_scope(str(task_context)) == "task-parent"
 
 
 def test_load_parent_repository_reads_task_context(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes the `batch-pr-resolver` rerun behavior that could create duplicate `pr-resolver` executions after a successful enqueue followed by a local artifact write failure.

## Root Cause

The helper submitted child resolver tasks before writing its summary artifact. In managed Codex sessions, the default `artifacts/` path could resolve inside the checked-out repo and be unwritable. When the helper was rerun for diagnostics, child submissions had no stable idempotency key, so the same PRs were enqueued again and the duplicates had to be canceled.

## Changes

- Prefer `MOONMIND_SESSION_ARTIFACT_SPOOL_PATH` for the batch summary artifact when available.
- Stamp child resolver submissions with a stable idempotency key scoped to the parent batch run and PR.
- Document the idempotency and artifact-spool behavior in the skill contract.
- Add unit and integration coverage for the new submission contract.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_batch_pr_resolver.py -q`
- `.venv/bin/python -m pytest tests/integration/services/temporal/test_codex_session_task_creation.py -q`
- `./tools/test_unit.sh` (`2813 passed`, frontend `122 passed`)