### PR TITLE
[codex] Handle provider capacity failures

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -48,6 +48,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
 from moonmind.workflows.codex_session_timeouts import (
     MAX_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
+from moonmind.workflows.provider_failures import classify_retryable_provider_failure
 from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
@@ -100,6 +101,14 @@ def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
         return normalized
     truncated = normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS].rstrip()
     return truncated or normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS]
+
+
+class CodexSessionRunFailedError(RuntimeError):
+    """Raised when a Codex session run persisted a structured failed result."""
+
+    def __init__(self, message: str, *, result: AgentRunResult) -> None:
+        super().__init__(message)
+        self.agent_run_result = result
 
 
 class CodexSessionExecutionState(BaseModel):
@@ -282,7 +291,12 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         f" with status '{turn_response.status}'"
                     ),
                 )
-                self._persist_failed_run_state(
+                publication = await self._publish_failure_artifacts(
+                    locator=current_locator,
+                    managed_run_id=binding.task_run_id,
+                    run_id=run_id,
+                )
+                failure_result = self._persist_failed_run_state(
                     run_id=run_id,
                     agent_id=request.agent_id,
                     managed_run_id=binding.task_run_id,
@@ -292,16 +306,30 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     active_turn_id=current_active_turn_id,
                     summary=reason,
                     default_summary=reason,
-                    output_refs=turn_response.output_refs,
+                    output_refs=self._merge_output_refs(
+                        turn_response.output_refs,
+                        (
+                            publication.published_artifact_refs
+                            if publication is not None
+                            else ()
+                        ),
+                    ),
                     started_at=started_at,
                     finished_at=_current_time(),
                     instruction_ref=original_instruction_ref,
                     resolved_skillset_ref=original_skillset_ref,
                     turn_id=turn_id,
                     profile_id=launch_context.profile_id or None,
+                    session_artifacts=(
+                        publication.model_dump(mode="json", by_alias=True)
+                        if publication is not None
+                        else None
+                    ),
+                    turn_status=turn_response.status,
+                    turn_metadata=turn_response.metadata,
                 )
                 failed_state_persisted = True
-                raise RuntimeError(reason)
+                raise CodexSessionRunFailedError(reason, result=failure_result)
 
             publication: CodexManagedSessionArtifactsPublication | None = None
             try:
@@ -349,7 +377,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     },
                 )
             except Exception as exc:
-                self._persist_failed_run_state(
+                failure_result = self._persist_failed_run_state(
                     run_id=run_id,
                     agent_id=request.agent_id,
                     managed_run_id=binding.task_run_id,
@@ -369,9 +397,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     resolved_skillset_ref=original_skillset_ref,
                     turn_id=turn_id,
                     profile_id=launch_context.profile_id or None,
+                    session_artifacts=(
+                        publication.model_dump(mode="json", by_alias=True)
+                        if publication is not None
+                        else None
+                    ),
                 )
                 failed_state_persisted = True
-                raise
+                raise CodexSessionRunFailedError(str(exc), result=failure_result) from exc
 
             self._save_run_state(
                 run_id=run_id,
@@ -404,7 +437,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             )
         except Exception as exc:
             if not failed_state_persisted:
-                self._persist_failed_run_state(
+                failure_result = self._persist_failed_run_state(
                     run_id=run_id,
                     agent_id=request.agent_id,
                     managed_run_id=binding.task_run_id,
@@ -421,6 +454,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     turn_id=turn_id,
                     profile_id=launch_context.profile_id or None,
                 )
+                raise CodexSessionRunFailedError(
+                    str(exc) or "Codex managed-session turn failed",
+                    result=failure_result,
+                ) from exc
             raise
 
     async def status(self, run_id: str) -> AgentRunStatus:
@@ -1107,20 +1144,53 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         profile_id: str | None,
         output_refs: tuple[str, ...] | list[str] = (),
         turn_id: str | None = None,
-    ) -> None:
+        session_artifacts: Mapping[str, Any] | None = None,
+        turn_status: str | None = None,
+        turn_metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRunResult:
+        summary_text = _clamp_agent_run_result_summary(
+            summary,
+            default=default_summary,
+        )
+        classification = classify_retryable_provider_failure(summary_text)
         metadata: dict[str, Any] = {
             "instructionRef": instruction_ref,
             "resolvedSkillsetRef": resolved_skillset_ref,
         }
+        if profile_id:
+            metadata["profileId"] = profile_id
         if turn_id:
             metadata["turnId"] = turn_id
+        if turn_status:
+            metadata["turnStatus"] = turn_status
+        if turn_metadata:
+            metadata["turnMetadata"] = dict(turn_metadata)
+        if session_artifacts is not None:
+            metadata["sessionArtifacts"] = dict(session_artifacts)
+        if classification is not None:
+            metadata["providerFailure"] = {
+                "providerErrorCode": classification.provider_error_code,
+                "retryRecommendation": classification.retry_recommendation,
+                "reason": classification.reason,
+            }
         failure_result = AgentRunResult(
             outputRefs=list(output_refs),
-            summary=_clamp_agent_run_result_summary(
-                summary,
-                default=default_summary,
+            summary=summary_text,
+            failureClass=(
+                classification.failure_class
+                if classification is not None
+                else "execution_error"
             ),
-            failureClass="execution_error",
+            providerErrorCode=(
+                classification.provider_error_code
+                if classification is not None
+                else None
+            ),
+            retryRecommendation=(
+                classification.retry_recommendation
+                if classification is not None
+                else None
+            ),
             metadata=metadata,
         )
         self._save_run_state(
@@ -1137,6 +1207,30 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             finished_at=finished_at,
             profile_id=profile_id,
         )
+        return failure_result
+
+    async def _publish_failure_artifacts(
+        self,
+        *,
+        locator: CodexManagedSessionLocator,
+        managed_run_id: str | None,
+        run_id: str,
+    ) -> CodexManagedSessionArtifactsPublication | None:
+        try:
+            return await self._coerce_publication(
+                self._publish_remote_artifacts(
+                    PublishCodexManagedSessionArtifactsRequest(
+                        sessionId=locator.session_id,
+                        sessionEpoch=locator.session_epoch,
+                        containerId=locator.container_id,
+                        threadId=locator.thread_id,
+                        taskRunId=managed_run_id or run_id,
+                        metadata={"runId": run_id, "workflowId": self._workflow_id},
+                    )
+                )
+            )
+        except Exception:
+            return None
 
     def _merge_output_refs(self, *groups: Any) -> list[str]:
         seen: list[str] = []

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime
 from pathlib import Path
@@ -93,6 +95,7 @@ PublishArtifactsFunc = Callable[
 ]
 
 _MAX_AGENT_RUN_RESULT_SUMMARY_CHARS = 4096
+logger = logging.getLogger(__name__)
 
 
 def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
@@ -284,8 +287,9 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             )
             current_active_turn_id = turn_response.session_state.active_turn_id
             if turn_response.status != "completed":
+                raw_reason = turn_response.metadata.get("reason")
                 reason = _clamp_agent_run_result_summary(
-                    turn_response.metadata.get("reason"),
+                    raw_reason,
                     default=(
                         "Codex managed-session turn failed"
                         f" with status '{turn_response.status}'"
@@ -304,7 +308,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     workspace_path=workspace_path,
                     locator=current_locator.model_dump(mode="json", by_alias=True),
                     active_turn_id=current_active_turn_id,
-                    summary=reason,
+                    summary=raw_reason,
                     default_summary=reason,
                     output_refs=self._merge_output_refs(
                         turn_response.output_refs,
@@ -1148,11 +1152,14 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         turn_status: str | None = None,
         turn_metadata: Mapping[str, Any] | None = None,
     ) -> AgentRunResult:
+        classification_source = (
+            summary if str(summary or "").strip() else default_summary
+        )
+        classification = classify_retryable_provider_failure(classification_source)
         summary_text = _clamp_agent_run_result_summary(
             summary,
             default=default_summary,
         )
-        classification = classify_retryable_provider_failure(summary_text)
         metadata: dict[str, Any] = {
             "instructionRef": instruction_ref,
             "resolvedSkillsetRef": resolved_skillset_ref,
@@ -1171,7 +1178,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             metadata["providerFailure"] = {
                 "providerErrorCode": classification.provider_error_code,
                 "retryRecommendation": classification.retry_recommendation,
-                "reason": classification.reason,
+                "reason": summary_text,
             }
         failure_result = AgentRunResult(
             outputRefs=list(output_refs),
@@ -1229,7 +1236,15 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     )
                 )
             )
-        except Exception:
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "Failed to publish Codex session failure artifacts for run %s: %s",
+                run_id,
+                exc,
+                exc_info=True,
+            )
             return None
 
     def _merge_output_refs(self, *groups: Any) -> list[str]:

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -520,10 +520,16 @@ class ManagedAgentAdapter:
             record = self._run_store.load(run_id)
             if record is not None and record.status in TERMINAL_AGENT_RUN_STATES:
                 output_refs: list[str] = []
-                if record.log_artifact_ref:
-                    output_refs.append(record.log_artifact_ref)
-                if record.diagnostics_ref:
-                    output_refs.append(record.diagnostics_ref)
+                for ref in (
+                    record.log_artifact_ref,
+                    record.stdout_artifact_ref,
+                    record.stderr_artifact_ref,
+                    record.merged_log_artifact_ref,
+                    record.diagnostics_ref,
+                    record.observability_events_ref,
+                ):
+                    if ref and ref not in output_refs:
+                        output_refs.append(ref)
                 summary = record.error_message or f"Completed with status {record.status}"
                 failure_class = record.failure_class
                 if pr_resolver_expected:

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -1,0 +1,98 @@
+"""Shared classification helpers for managed-provider failures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+PROVIDER_RATE_LIMIT_ERROR_CODE = "429"
+PROVIDER_CAPACITY_ERROR_CODE = "provider_capacity"
+RETRY_AFTER_COOLDOWN_RECOMMENDATION = "retry_after_cooldown"
+
+_RATE_LIMIT_MARKERS = (
+    "429",
+    "rate limit",
+    "rate-limit",
+    "too many requests",
+)
+
+_CAPACITY_MARKERS = (
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "status 500",
+    "status 502",
+    "status 503",
+    "status 504",
+    "500 internal server error",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "high demand",
+    "overloaded",
+    "temporarily unavailable",
+    "temporary errors",
+    "service unavailable",
+    "gateway timeout",
+    "try again later",
+)
+
+
+@dataclass(frozen=True)
+class ProviderFailureClassification:
+    failure_class: str
+    provider_error_code: str
+    retry_recommendation: str
+    reason: str
+
+
+def classify_retryable_provider_failure(
+    reason: Any,
+) -> ProviderFailureClassification | None:
+    """Return structured metadata for retryable provider capacity failures."""
+
+    rendered = str(reason or "").strip()
+    if not rendered:
+        return None
+    normalized = rendered.lower()
+    if any(marker in normalized for marker in _RATE_LIMIT_MARKERS):
+        return ProviderFailureClassification(
+            failure_class="integration_error",
+            provider_error_code=PROVIDER_RATE_LIMIT_ERROR_CODE,
+            retry_recommendation=RETRY_AFTER_COOLDOWN_RECOMMENDATION,
+            reason=rendered,
+        )
+    if any(marker in normalized for marker in _CAPACITY_MARKERS):
+        return ProviderFailureClassification(
+            failure_class="integration_error",
+            provider_error_code=PROVIDER_CAPACITY_ERROR_CODE,
+            retry_recommendation=RETRY_AFTER_COOLDOWN_RECOMMENDATION,
+            reason=rendered,
+        )
+    return None
+
+
+def provider_error_requires_cooldown(
+    *,
+    provider_error_code: str | None,
+    retry_recommendation: str | None = None,
+) -> bool:
+    """Return whether an agent result should be routed through profile cooldown."""
+
+    normalized_code = str(provider_error_code or "").strip().lower()
+    normalized_retry = str(retry_recommendation or "").strip().lower()
+    return normalized_code in {
+        PROVIDER_RATE_LIMIT_ERROR_CODE,
+        PROVIDER_CAPACITY_ERROR_CODE,
+    } or normalized_retry == RETRY_AFTER_COOLDOWN_RECOMMENDATION
+
+
+__all__ = [
+    "PROVIDER_CAPACITY_ERROR_CODE",
+    "PROVIDER_RATE_LIMIT_ERROR_CODE",
+    "RETRY_AFTER_COOLDOWN_RECOMMENDATION",
+    "ProviderFailureClassification",
+    "classify_retryable_provider_failure",
+    "provider_error_requires_cooldown",
+]

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -23,6 +23,7 @@ with workflow.unsafe.imports_passed_through():
         ProfileResolutionError,
     )
     from moonmind.workflows.adapters.codex_session_adapter import (
+        CodexSessionRunFailedError,
         CodexSessionAdapter,
     )
     from moonmind.workflows.adapters.external_adapter_registry import (
@@ -38,6 +39,10 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.temporal.runtime.store import ManagedRunStore
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
+    )
+    from moonmind.workflows.provider_failures import (
+        classify_retryable_provider_failure,
+        provider_error_requires_cooldown,
     )
 
 # Map canonical AgentRunState literals to workflow-usable status constants.
@@ -86,8 +91,6 @@ _EXTERNAL_STATUS_TO_RUN_STATUS: dict[str, str] = {
     "timed-out": RunStatus.timed_out,
     "unknown": RunStatus.awaiting_callback,
 }
-
-PROVIDER_RATE_LIMIT_ERROR_CODE = "429"
 
 # Default workflow-level execution timeouts
 DEFAULT_MANAGED_TIMEOUT_SECONDS = 3600      # 1 hour
@@ -343,7 +346,8 @@ class MoonMindAgentRun:
         retry_at = workflow.now() + timedelta(seconds=max(cooldown_seconds, 0))
         profile_fragment = f" on profile {profile_id}" if profile_id else ""
         return (
-            f"Gemini capacity exhausted for {runtime_id}{profile_fragment}; retry scheduled for "
+            "Managed provider capacity exhausted for "
+            f"{runtime_id}{profile_fragment}; retry scheduled for "
             f"{self._format_retry_timestamp(retry_at)} after {cooldown_seconds}s cooldown."
         )
 
@@ -406,9 +410,30 @@ class MoonMindAgentRun:
                 mode="json",
                 by_alias=True,
             )
+        classification = classify_retryable_provider_failure(summary)
+        if classification is not None:
+            metadata["providerFailure"] = {
+                "providerErrorCode": classification.provider_error_code,
+                "retryRecommendation": classification.retry_recommendation,
+                "reason": classification.reason,
+            }
         return AgentRunResult(
             summary=summary,
-            failureClass="execution_error",
+            failureClass=(
+                classification.failure_class
+                if classification is not None
+                else "execution_error"
+            ),
+            providerErrorCode=(
+                classification.provider_error_code
+                if classification is not None
+                else None
+            ),
+            retryRecommendation=(
+                classification.retry_recommendation
+                if classification is not None
+                else None
+            ),
             metadata=metadata,
         )
 
@@ -1282,10 +1307,16 @@ class MoonMindAgentRun:
                             },
                         )
                         self.run_status = RunStatus.failed
-                        self.final_result = self._managed_start_failure_result(
-                            request=request,
-                            error=exc,
-                        )
+                        if (
+                            isinstance(exc, CodexSessionRunFailedError)
+                            and isinstance(exc.agent_run_result, AgentRunResult)
+                        ):
+                            self.final_result = exc.agent_run_result
+                        else:
+                            self.final_result = self._managed_start_failure_result(
+                                request=request,
+                                error=exc,
+                            )
                         skip_poll_and_fetch = True
                         handle = None
                     if handle is not None:
@@ -1649,8 +1680,14 @@ class MoonMindAgentRun:
                                     }
                                 )
 
-                # Check for 429
-                if request.agent_kind == "managed" and manager_handle and self.final_result.provider_error_code == PROVIDER_RATE_LIMIT_ERROR_CODE:
+                if (
+                    request.agent_kind == "managed"
+                    and manager_handle
+                    and provider_error_requires_cooldown(
+                        provider_error_code=self.final_result.provider_error_code,
+                        retry_recommendation=self.final_result.retry_recommendation,
+                    )
+                ):
                     if workflow.patched("gemini-429-cooldown-retry-signal"):
                         runtime_id = self._managed_runtime_id(request.agent_id)
                         profile_id = str(request.execution_profile_ref or self._assigned_profile_id or "").strip() or None

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2308,9 +2308,12 @@ class MoonMindRunWorkflow:
         binding = self._codex_session_binding
         try:
             if handle is not None and binding is not None:
+                session_handle = workflow.get_external_workflow_handle(
+                    binding.workflow_id
+                )
                 if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
                     try:
-                        await handle.execute_update(
+                        await session_handle.execute_update(
                             "TerminateSession",
                             {
                                 "reason": reason,
@@ -2322,7 +2325,7 @@ class MoonMindRunWorkflow:
                             binding.session_id,
                             exc,
                         )
-                        await handle.signal(
+                        await session_handle.signal(
                             "control_action",
                             {
                                 "action": "terminate_session",
@@ -2366,7 +2369,7 @@ class MoonMindRunWorkflow:
                             binding.session_id,
                             exc,
                         )
-                    await handle.signal(
+                    await session_handle.signal(
                         "control_action",
                         {
                             "action": "terminate_session",
@@ -2374,7 +2377,7 @@ class MoonMindRunWorkflow:
                         },
                     )
                 else:
-                    await handle.signal(
+                    await session_handle.signal(
                         "control_action",
                         {
                             "action": "terminate_session",

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2304,10 +2304,9 @@ class MoonMindRunWorkflow:
         return request.model_copy(update={"managed_session": binding})
 
     async def _terminate_task_scoped_sessions(self, *, reason: str) -> None:
-        handle = self._codex_session_handle
         binding = self._codex_session_binding
         try:
-            if handle is not None and binding is not None:
+            if binding is not None:
                 session_handle = workflow.get_external_workflow_handle(
                     binding.workflow_id
                 )

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -556,7 +556,7 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
 
     assert str(excinfo.value) == expected_reason
     assert summary_calls == []
-    assert publication_calls == []
+    assert len(publication_calls) == 1
     persisted_record = run_store.load(binding.task_run_id)
     assert persisted_record is not None
     assert persisted_record.status == "failed"
@@ -564,10 +564,106 @@ async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path)
     assert persisted_record.live_stream_capable is True
     assert persisted_record.error_message == expected_reason
     assert persisted_record.failure_class == "execution_error"
+    assert persisted_record.stdout_artifact_ref == "artifact:stdout"
+    assert persisted_record.stderr_artifact_ref == "artifact:stderr"
+    assert persisted_record.diagnostics_ref == "artifact:diagnostics"
     assert persisted_record.session_id == binding.session_id
     assert persisted_record.session_epoch == binding.session_epoch + 1
     assert persisted_record.container_id == "container-2"
     assert persisted_record.thread_id == "thread-2"
+
+
+async def test_start_classifies_codex_provider_capacity_failure_and_publishes_artifacts(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    reason = "We're currently experiencing high demand, which may cause temporary errors."
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            status="failed",
+            assistant_text="",
+        ).model_copy(update={"metadata": {"reason": reason}})
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    result = excinfo.value.agent_run_result
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "provider_capacity"
+    assert result.retry_recommendation == "retry_after_cooldown"
+    assert result.output_refs == [
+        "artifact:turn-output",
+        "artifact:stdout",
+        "artifact:stderr",
+        "artifact:diagnostics",
+        "artifact:observability.events.jsonl",
+        "artifact:session-summary",
+        "artifact:session-checkpoint",
+    ]
+    assert result.metadata["providerFailure"]["providerErrorCode"] == "provider_capacity"
+    assert result.metadata["profileId"] == "codex-default"
+
+    persisted_record = run_store.load(binding.task_run_id)
+    assert persisted_record is not None
+    assert persisted_record.failure_class == "integration_error"
+    assert persisted_record.provider_error_code == "provider_capacity"
+    assert persisted_record.stdout_artifact_ref == "artifact:stdout"
+    assert persisted_record.stderr_artifact_ref == "artifact:stderr"
+    assert persisted_record.diagnostics_ref == "artifact:diagnostics"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -16,6 +16,7 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionArtifactsPublication,
     CodexManagedSessionBinding,
     CodexManagedSessionHandle,
+    CodexManagedSessionLocator,
     CodexManagedSessionSnapshot,
     CodexManagedSessionSummary,
     CodexManagedSessionTurnResponse,
@@ -579,7 +580,11 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
     binding = _binding()
     workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
     run_store = ManagedRunStore(tmp_path / "managed_runs")
-    reason = "We're currently experiencing high demand, which may cause temporary errors."
+    reason = (
+        "provider emitted verbose diagnostics "
+        + ("x" * 5000)
+        + " http 503 high demand"
+    )
 
     async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
         return _snapshot(binding=binding)
@@ -645,6 +650,7 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
     assert result.failure_class == "integration_error"
     assert result.provider_error_code == "provider_capacity"
     assert result.retry_recommendation == "retry_after_cooldown"
+    assert "high demand" not in result.summary
     assert result.output_refs == [
         "artifact:turn-output",
         "artifact:stdout",
@@ -664,6 +670,113 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
     assert persisted_record.stdout_artifact_ref == "artifact:stdout"
     assert persisted_record.stderr_artifact_ref == "artifact:stderr"
     assert persisted_record.diagnostics_ref == "artifact:diagnostics"
+
+
+async def test_publish_failure_artifacts_logs_best_effort_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    binding = _binding()
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        raise RuntimeError("artifact store unavailable")
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=AsyncMock(),
+        launch_session=AsyncMock(),
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    caplog.set_level(
+        "WARNING",
+        logger="moonmind.workflows.adapters.codex_session_adapter",
+    )
+
+    publication = await adapter._publish_failure_artifacts(
+        locator=CodexManagedSessionLocator(
+            sessionId=binding.session_id,
+            sessionEpoch=binding.session_epoch,
+            containerId="container-1",
+            threadId="thread-1",
+        ),
+        managed_run_id=binding.task_run_id,
+        run_id="run-1",
+    )
+
+    assert publication is None
+    assert (
+        "Failed to publish Codex session failure artifacts for run run-1"
+        in caplog.text
+    )
+    assert "artifact store unavailable" in caplog.text
+
+
+async def test_publish_failure_artifacts_preserves_cancellation(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        raise asyncio.CancelledError
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles([]),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=AsyncMock(),
+        launch_session=AsyncMock(),
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._publish_failure_artifacts(
+            locator=CodexManagedSessionLocator(
+                sessionId=binding.session_id,
+                sessionEpoch=binding.session_epoch,
+                containerId="container-1",
+                threadId="thread-1",
+            ),
+            managed_run_id=binding.task_run_id,
+            run_id="run-1",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -44,6 +44,14 @@ def _managed_request(agent_id: str = "codex") -> AgentExecutionRequest:
     )
 
 
+def _use_external_handle(monkeypatch: pytest.MonkeyPatch, handle: Any) -> None:
+    monkeypatch.setattr(
+        run_module.workflow,
+        "get_external_workflow_handle",
+        lambda _workflow_id, run_id=None: handle,
+    )
+
+
 @pytest.mark.asyncio
 async def test_run_starts_one_task_scoped_codex_session_and_reuses_it(
     monkeypatch: pytest.MonkeyPatch,
@@ -143,7 +151,9 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",
@@ -234,7 +244,9 @@ async def test_run_termination_uses_v1_patch_history_for_inflight_runs(
     )
     monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",
@@ -317,7 +329,9 @@ async def test_run_termination_uses_v1_signal_fallback_without_runtime_handles(
         fake_execute_activity,
     )
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",
@@ -365,7 +379,9 @@ async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
     monkeypatch.setattr(run_module.workflow, "patched", lambda _patch_id: False)
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",
@@ -420,7 +436,9 @@ async def test_run_termination_logs_when_terminate_update_fails(
     )
     monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",
@@ -509,7 +527,9 @@ async def test_run_termination_signals_session_when_v1_terminate_activity_fails(
     monkeypatch.setattr(run_module.workflow, "execute_activity", fake_execute_activity)
     monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
 
-    workflow._codex_session_handle = _FakeHandle()
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
     workflow._codex_session_binding = CodexManagedSessionBinding(
         workflowId="wf-run-1:session:codex_cli",
         taskRunId="wf-run-1",

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -180,6 +180,53 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
 
 @pytest.mark.asyncio
+async def test_run_terminates_task_scoped_codex_session_with_binding_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
+
+    class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
+        async def signal(self, _signal_name: str, _payload: Any = None) -> None:
+            raise AssertionError("signal should not be used when update succeeds")
+
+    monkeypatch.setattr(
+        run_module.workflow,
+        "patched",
+        lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
+    )
+
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = None
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert update_calls == [
+        (
+            "TerminateSession",
+            {
+                "reason": "success",
+            },
+        )
+    ]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
 async def test_run_termination_uses_v1_patch_history_for_inflight_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from moonmind.workflows.provider_failures import (
+    classify_retryable_provider_failure,
+    provider_error_requires_cooldown,
+)
+
+
+def test_classifies_high_demand_as_provider_capacity() -> None:
+    result = classify_retryable_provider_failure(
+        "We're currently experiencing high demand, which may cause temporary errors."
+    )
+
+    assert result is not None
+    assert result.failure_class == "integration_error"
+    assert result.provider_error_code == "provider_capacity"
+    assert result.retry_recommendation == "retry_after_cooldown"
+
+
+def test_classifies_http_500_as_provider_capacity() -> None:
+    result = classify_retryable_provider_failure("http 500")
+
+    assert result is not None
+    assert result.provider_error_code == "provider_capacity"
+
+
+def test_classifies_rate_limit_as_429() -> None:
+    result = classify_retryable_provider_failure("Too many requests: rate limit")
+
+    assert result is not None
+    assert result.provider_error_code == "429"
+
+
+def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> None:
+    assert provider_error_requires_cooldown(
+        provider_error_code="provider_capacity",
+        retry_recommendation=None,
+    )
+    assert provider_error_requires_cooldown(
+        provider_error_code=None,
+        retry_recommendation="retry_after_cooldown",
+    )
+    assert not provider_error_requires_cooldown(
+        provider_error_code="branch_publish_failed",
+        retry_recommendation=None,
+    )


### PR DESCRIPTION
## Summary

- Classify Codex provider capacity failures such as `http 500` and high-demand responses as structured retryable provider failures.
- Preserve failed-turn diagnostics by publishing stdout, stderr, diagnostics, and session artifact refs before persisting Codex session failures.
- Route provider-capacity failures through managed profile cooldown handling, not only explicit 429s.
- Fix task-scoped Codex session cleanup by using an external workflow handle for termination updates/signals.

## Root Cause

A burst of PR resolver workflows hit transient Codex provider capacity errors. The runtime collapsed those responses into generic `execution_error` results with no provider error code, so profile cooldown did not engage and parent workflows retried immediately. Task-scoped session cleanup also attempted `execute_update` on the child handle shape, which left cleanup warnings and could leak session containers.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only --no-xdist`
- Result: `2820 passed, 1 xpassed, 86 warnings in 228.57s`
