### PR TITLE
Implement Phase 3 using test-driven development from the Live Logs plan: The public `main` I checked is still centered on the simpler path: the UI fet

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -803,6 +803,8 @@ def _load_task_run_observability_events(
     since: int | None = None,
     streams: set[str] | None = None,
     kinds: set[str] | None = None,
+    session_epochs: set[int] | None = None,
+    thread_ids: set[str] | None = None,
 ) -> tuple[list[dict[str, object]], str]:
     workspace_path = getattr(record, "workspace_path", None)
     started_at = getattr(record, "started_at", None)
@@ -827,6 +829,8 @@ def _load_task_run_observability_events(
                 since=since,
                 streams=streams,
                 kinds=kinds,
+                session_epochs=session_epochs,
+                thread_ids=thread_ids,
             )
         )
         source = "journal"
@@ -843,6 +847,8 @@ def _load_task_run_observability_events(
                 since=since,
                 streams=streams,
                 kinds=kinds,
+                session_epochs=session_epochs,
+                thread_ids=thread_ids,
             )
         )
         source = "spool"
@@ -864,6 +870,8 @@ def _event_matches_observability_filters(
     since: int | None = None,
     streams: set[str] | None = None,
     kinds: set[str] | None = None,
+    session_epochs: set[int] | None = None,
+    thread_ids: set[str] | None = None,
 ) -> bool:
     sequence = _coerce_sequence(event.get("sequence"))
     if since is not None and sequence is not None and sequence > 0 and sequence <= since:
@@ -873,6 +881,14 @@ def _event_matches_observability_filters(
         return False
     kind = str(event.get("kind") or "").strip()
     if kinds and kind not in kinds:
+        return False
+    raw_session_epoch = event.get("sessionEpoch")
+    if raw_session_epoch is None:
+        raw_session_epoch = event.get("session_epoch")
+    if session_epochs and raw_session_epoch not in session_epochs:
+        return False
+    thread_id = str(event.get("threadId") or event.get("thread_id") or "").strip()
+    if thread_ids and thread_id not in thread_ids:
         return False
     return True
 
@@ -884,6 +900,8 @@ def _collect_matching_observability_events(
     since: int | None = None,
     streams: set[str] | None = None,
     kinds: set[str] | None = None,
+    session_epochs: set[int] | None = None,
+    thread_ids: set[str] | None = None,
 ) -> list[dict[str, object]]:
     collected: list[dict[str, object]] = []
     max_events = max(1, limit) + 1
@@ -893,6 +911,8 @@ def _collect_matching_observability_events(
             since=since,
             streams=streams,
             kinds=kinds,
+            session_epochs=session_epochs,
+            thread_ids=thread_ids,
         ):
             continue
         collected.append(event)
@@ -907,6 +927,8 @@ def _filter_observability_events(
     since: int | None = None,
     streams: set[str] | None = None,
     kinds: set[str] | None = None,
+    session_epochs: set[int] | None = None,
+    thread_ids: set[str] | None = None,
 ) -> list[dict[str, object]]:
     filtered: list[dict[str, object]] = []
     for event in events:
@@ -915,6 +937,8 @@ def _filter_observability_events(
             since=since,
             streams=streams,
             kinds=kinds,
+            session_epochs=session_epochs,
+            thread_ids=thread_ids,
         ):
             continue
         filtered.append(event)
@@ -1239,6 +1263,8 @@ async def get_task_run_observability_events(
     limit: int = Query(default=500, ge=1, le=5000),
     stream: list[Literal["stdout", "stderr", "system", "session"]] | None = Query(default=None),
     kind: list[str] | None = Query(default=None),
+    session_epoch: list[int] | None = Query(default=None, alias="sessionEpoch"),
+    thread_id: list[str] | None = Query(default=None, alias="threadId"),
     _user: User = Depends(get_current_user()),
 ) -> dict:
     """Return structured observability history for one task run."""
@@ -1253,6 +1279,8 @@ async def get_task_run_observability_events(
     started = time.perf_counter()
     stream_filters = set(stream or [])
     kind_filters = {item for item in (kind or []) if item}
+    session_epoch_filters = {item for item in (session_epoch or []) if item >= 1}
+    thread_id_filters = {item.strip() for item in (thread_id or []) if item.strip()}
     try:
         session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
         events, source = await asyncio.to_thread(
@@ -1263,6 +1291,8 @@ async def get_task_run_observability_events(
             since=since,
             streams=stream_filters,
             kinds=kind_filters,
+            session_epochs=session_epoch_filters,
+            thread_ids=thread_id_filters,
         )
         if source == "artifacts":
             events = _filter_observability_events(
@@ -1270,6 +1300,8 @@ async def get_task_run_observability_events(
                 since=since,
                 streams=stream_filters,
                 kinds=kind_filters,
+                session_epochs=session_epoch_filters,
+                thread_ids=thread_id_filters,
             )
         events.sort(key=_event_sort_key)
         truncated = len(events) > limit

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -502,6 +502,22 @@ def _coerce_sequence(value: object) -> int | None:
     return value if isinstance(value, int) else None
 
 
+def _coerce_session_epoch(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        candidate = value.strip()
+        if not candidate:
+            return None
+        try:
+            return int(candidate)
+        except ValueError:
+            return None
+    return None
+
+
 def _normalize_live_event(payload: dict[str, object]) -> dict[str, object] | None:
     try:
         chunk = RunObservabilityEvent.model_validate(payload)
@@ -885,7 +901,7 @@ def _event_matches_observability_filters(
     raw_session_epoch = event.get("sessionEpoch")
     if raw_session_epoch is None:
         raw_session_epoch = event.get("session_epoch")
-    if session_epochs and raw_session_epoch not in session_epochs:
+    if session_epochs and _coerce_session_epoch(raw_session_epoch) not in session_epochs:
         return False
     thread_id = str(event.get("threadId") or event.get("thread_id") or "").strip()
     if thread_ids and thread_id not in thread_ids:
@@ -1268,6 +1284,16 @@ async def get_task_run_observability_events(
     _user: User = Depends(get_current_user()),
 ) -> dict:
     """Return structured observability history for one task run."""
+    if session_epoch is not None and any(item < 1 for item in session_epoch):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="sessionEpoch must contain only integers greater than or equal to 1",
+        )
+    if thread_id is not None and any(not item.strip() for item in thread_id):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="threadId must not contain blank values",
+        )
     store = ManagedRunStore(_get_agent_runtime_store_root())
     record = await asyncio.to_thread(store.load, str(id))
     if not record:
@@ -1279,7 +1305,7 @@ async def get_task_run_observability_events(
     started = time.perf_counter()
     stream_filters = set(stream or [])
     kind_filters = {item for item in (kind or []) if item}
-    session_epoch_filters = {item for item in (session_epoch or []) if item >= 1}
+    session_epoch_filters = set(session_epoch or [])
     thread_id_filters = {item.strip() for item in (thread_id or []) if item.strip()}
     try:
         session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -8487,6 +8487,8 @@ export interface operations {
                 limit?: number;
                 stream?: ("stdout" | "stderr" | "system" | "session")[] | null;
                 kind?: string[] | null;
+                sessionEpoch?: number[] | null;
+                threadId?: string[] | null;
             };
             header?: never;
             path: {

--- a/specs/149-live-logs-history-filters/checklists/requirements.md
+++ b/specs/149-live-logs-history-filters/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Live Logs History Filters
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-11  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime scope guard is preserved in the input, edge cases, requirements, and assumptions: production runtime code changes plus validation tests are required; docs-only work is insufficient.
+- User-provided compatibility constraints are preserved: existing summary, merged-tail, and live stream behavior must remain intact.

--- a/specs/149-live-logs-history-filters/spec.md
+++ b/specs/149-live-logs-history-filters/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: Live Logs History Filters
+
+**Feature Branch**: `149-live-logs-history-filters`  
+**Created**: 2026-04-11  
+**Status**: Draft  
+**Input**: User description: "Implement Phase 3 using test-driven development from the Live Logs plan: add first-class structured historical observability retrieval for task runs while preserving the existing summary, merged-tail, and SSE paths. The endpoint must serve ordered RunObservabilityEvent rows from durable event history, support since, limit, stream, kind, sessionEpoch, and threadId filters, return the latest session snapshot with the event history, and keep existing live-log compatibility behavior intact. Required deliverables include production runtime code changes (not docs/spec-only) plus validation tests."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Load Structured Observability History (Priority: P1)
+
+Operators need Live Logs to load a structured historical event timeline for a task run so refreshes, reconnects, and completed-run views do not depend on live streaming.
+
+**Why this priority**: This is the core Phase 3 capability. Without a durable structured history source, the session-aware Live Logs experience remains tied to merged text fallbacks and transient live transport.
+
+**Independent Test**: Create or simulate a task run with durable structured observability events and verify the history surface returns ordered events and a session snapshot without opening a live stream.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task run with durable observability events, **When** an operator loads structured history, **Then** the response contains the matching events in chronological order.
+2. **Given** a task run has session metadata, **When** structured history is loaded, **Then** the response includes the latest available session snapshot alongside the event rows.
+3. **Given** a task run is completed, **When** structured history is loaded, **Then** the event history remains available without requiring SSE or an active run.
+
+---
+
+### User Story 2 - Narrow History To Relevant Session Context (Priority: P2)
+
+Operators need to filter structured history by position, stream, event kind, session epoch, and thread so a timeline can focus on the relevant execution window.
+
+**Why this priority**: Session-aware timelines must distinguish reset boundaries, resumed sessions, and thread changes without forcing clients to download and filter unrelated rows.
+
+**Independent Test**: Create mixed observability rows across streams, kinds, epochs, and threads, then verify each supported filter returns only matching events while preserving ordering and limit semantics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a history contains stdout, stderr, system, and session rows, **When** a stream filter is applied, **Then** only rows from the requested streams are returned.
+2. **Given** a history contains multiple event kinds, **When** one or more kind filters are applied, **Then** only matching event kinds are returned.
+3. **Given** a history contains multiple session epochs and thread IDs, **When** epoch and thread filters are applied together, **Then** only rows matching both filters are returned.
+4. **Given** a caller provides a sequence cursor and a limit, **When** history is loaded, **Then** only rows after the cursor are considered and the response indicates whether more matching rows exist.
+
+---
+
+### User Story 3 - Preserve Existing Live Logs Compatibility (Priority: P3)
+
+Operators need the existing summary, merged-tail, and live stream behavior to keep working while structured history becomes the preferred source for timeline views.
+
+**Why this priority**: Phase 3 must be additive for existing users and frontend rollout paths. Older consumers still rely on summary, merged text, and SSE behavior.
+
+**Independent Test**: Run existing Live Logs summary, merged-tail, and SSE tests together with the structured-history tests and verify no compatibility behavior regresses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task run supports live streaming, **When** a client uses the existing live stream path, **Then** the live event payload remains compatible with current consumers.
+2. **Given** structured history is unavailable for a run, **When** the client requests log content through existing fallback paths, **Then** merged or artifact-backed content remains available as before.
+3. **Given** a run is terminal, **When** the summary and live stream paths are used, **Then** summary truthfully reports ended live status and live streaming is not attempted.
+
+### Edge Cases
+
+- A structured event history can be empty while merged or artifact-backed content still exists.
+- Some historical rows may lack session-scoped fields; session filters must exclude those rows only when the corresponding filter is requested.
+- Invalid, malformed, or partial event rows must not prevent valid rows from being returned.
+- Multiple filters can be combined; the returned rows must satisfy all requested filters.
+- The response must remain bounded by the requested limit and expose whether the result was truncated.
+- Runtime deliverables must include production behavior changes and validation tests, not docs-only updates.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a first-class structured historical observability read path for task runs.
+- **FR-002**: The system MUST return normalized observability events with sequence, stream, timestamp, text, and kind fields when available.
+- **FR-003**: The system MUST include additive session metadata on event rows when available, including session ID, session epoch, container ID, thread ID, and active turn ID.
+- **FR-004**: The system MUST support filtering structured history by sequence cursor, result limit, stream, event kind, session epoch, and thread ID.
+- **FR-005**: The system MUST apply combined filters conjunctively so returned rows satisfy every requested filter.
+- **FR-006**: The system MUST return the latest available session snapshot with structured history responses.
+- **FR-007**: The system MUST preserve existing summary, merged-tail, and live stream behavior while adding structured history.
+- **FR-008**: The system MUST keep ended-run behavior truthful: completed or otherwise terminal runs must expose historical content without advertising active live streaming.
+- **FR-009**: The system MUST tolerate malformed or unrelated history rows by skipping them without failing the entire history response.
+- **FR-010**: The implementation MUST include production runtime code changes and validation tests for the structured-history behavior.
+
+### Key Entities
+
+- **Task Run**: A managed execution record whose observability history, live capability, terminal status, and session snapshot can be inspected.
+- **Observability Event**: A normalized timeline row representing output, system annotations, or session lifecycle facts.
+- **Session Snapshot**: The latest known session context for a task run, including session identity, epoch, container, thread, active turn, and status details when available.
+- **History Filter**: A caller-supplied constraint used to narrow the returned event timeline by cursor, limit, stream, kind, epoch, or thread.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Structured history for a run with persisted events can be loaded successfully without opening a live stream.
+- **SC-002**: Filtering by stream, kind, session epoch, and thread ID returns only matching rows in validation tests.
+- **SC-003**: Cursor and limit behavior is covered by validation tests, including a truncated response when more matching rows exist than requested.
+- **SC-004**: Existing summary, merged-tail, and live stream validation tests continue to pass after the structured-history changes.
+- **SC-005**: Completed runs retain useful structured or fallback history while never presenting active live streaming as available.
+
+## Assumptions
+
+- Structured history is the preferred source for session-aware timelines, while merged text remains a compatibility and fallback surface.
+- Session epoch and thread filters are optional; callers that do not provide them receive the same results they would have received before those filters existed.
+- Runtime behavior is the deliverable for this feature. Documentation-only changes are insufficient for completion.

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1500,6 +1500,58 @@ def test_get_task_run_observability_events_applies_session_epoch_and_thread_filt
     assert body["events"][0]["threadId"] == "thread-2"
 
 
+def test_get_task_run_observability_events_rejects_invalid_session_epoch_filter(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load") as load_record:
+        response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events?sessionEpoch=0")
+
+    assert response.status_code == 422
+    load_record.assert_not_called()
+
+
+def test_get_task_run_observability_events_rejects_blank_thread_id_filter(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load") as load_record:
+        response = test_client.get(f"/api/task-runs/{uuid4()}/observability/events?threadId=%20%20%20")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "threadId must not contain blank values"
+    load_record.assert_not_called()
+
+
+def test_observability_event_session_epoch_filter_coerces_string_rows() -> None:
+    events = [
+        {
+            "sequence": 1,
+            "stream": "session",
+            "kind": "summary_published",
+            "sessionEpoch": "2",
+            "threadId": "thread-2",
+        },
+        {
+            "sequence": 2,
+            "stream": "session",
+            "kind": "summary_published",
+            "sessionEpoch": "not-an-int",
+            "threadId": "thread-2",
+        },
+    ]
+
+    filtered = task_runs_router._filter_observability_events(
+        events,
+        session_epochs={2},
+        thread_ids={"thread-2"},
+    )
+
+    assert [event["sequence"] for event in filtered] == [1]
+
+
 def test_get_task_run_observability_events_limits_to_oldest_matching_rows_after_since(
     client: tuple[TestClient, AsyncMock],
     tmp_path,

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -1423,6 +1423,83 @@ def test_get_task_run_observability_events_applies_since_stream_and_kind_filters
     assert all(event["stream"] == "session" for event in body["events"])
 
 
+def test_get_task_run_observability_events_applies_session_epoch_and_thread_filters(
+    client: tuple[TestClient, AsyncMock],
+    tmp_path,
+) -> None:
+    test_client, _ = client
+    artifacts_root = tmp_path / "artifacts"
+    run_dir = artifacts_root / "run-1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "observability.events.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 6,
+                        "stream": "session",
+                        "text": "old thread\n",
+                        "timestamp": "2026-04-08T00:00:01Z",
+                        "kind": "session_reset_boundary",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 1,
+                        "threadId": "thread-1",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 7,
+                        "stream": "session",
+                        "text": "current thread\n",
+                        "timestamp": "2026-04-08T00:00:02Z",
+                        "kind": "summary_published",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                        "threadId": "thread-2",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "runId": "run-1",
+                        "sequence": 8,
+                        "stream": "session",
+                        "text": "other thread same epoch\n",
+                        "timestamp": "2026-04-08T00:00:03Z",
+                        "kind": "checkpoint_published",
+                        "sessionId": "sess-1",
+                        "sessionEpoch": 2,
+                        "threadId": "thread-3",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mock_record = MagicMock()
+    mock_record.workspace_path = str(tmp_path / "workspace")
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+    mock_record.observability_events_ref = "run-1/observability.events.jsonl"
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._get_agent_runtime_artifacts_root",
+            return_value=str(artifacts_root),
+        ):
+            response = test_client.get(
+                f"/api/task-runs/{uuid4()}/observability/events?sessionEpoch=2&threadId=thread-2"
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [event["sequence"] for event in body["events"]] == [7]
+    assert body["events"][0]["sessionEpoch"] == 2
+    assert body["events"][0]["threadId"] == "thread-2"
+
+
 def test_get_task_run_observability_events_limits_to_oldest_matching_rows_after_since(
     client: tuple[TestClient, AsyncMock],
     tmp_path,

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -276,9 +276,19 @@ def test_parent_run_scope_hashes_nonstandard_session_spool_path(
     assert parent_run_scope() == stable_scope_from_path(spool)
 
 
-def test_parent_run_scope_reuses_task_context_artifacts_helper(tmp_path: Path) -> None:
+def test_parent_run_scope_reuses_task_context_artifacts_helper(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
     module = _load_module()
     parent_run_scope = module["_parent_run_scope"]
+    for env_key in (
+        "MOONMIND_TASK_RUN_ID",
+        "MOONMIND_RUN_ID",
+        "TASK_RUN_ID",
+        "MOONMIND_SESSION_ARTIFACT_SPOOL_PATH",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
 
     task_context = tmp_path / "task-parent" / "artifacts" / "task_context.json"
     task_context.parent.mkdir(parents=True)


### PR DESCRIPTION
Automated changes by MoonMind.