### PR TITLE
[codex] Fix provider slot runtime state

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -367,7 +367,7 @@ def _serialize_execution(
         and not bool(getattr(record, "paused", False))
         and not attention_required
     ):
-        waiting_reason = ""
+        waiting_reason = None
     dashboard_status = _DASHBOARD_STATUS_BY_STATE.get(record.state, "queued")
     actions = _build_action_capabilities(record)
     intervention_audit = _parse_intervention_audit_entries(memo)

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -361,6 +361,13 @@ def _serialize_execution(
     )
     if raw_state == "awaiting_external":
         attention_required = True
+    if (
+        raw_state
+        not in {"awaiting_slot", "awaiting_external", "waiting_on_dependencies"}
+        and not bool(getattr(record, "paused", False))
+        and not attention_required
+    ):
+        waiting_reason = ""
     dashboard_status = _DASHBOARD_STATUS_BY_STATE.get(record.state, "queued")
     actions = _build_action_capabilities(record)
     intervention_audit = _parse_intervention_audit_entries(memo)
@@ -1456,6 +1463,7 @@ async def _create_execution_from_task_request(
     raw_target_runtime = (
         payload.get("targetRuntime")
         or runtime_payload.get("mode")
+        or settings.workflow.default_task_runtime
         or ""
     )
     raw_profile_id = str(
@@ -1483,6 +1491,13 @@ async def _create_execution_from_task_request(
                 "Must be one of: codex_cli, gemini_cli, claude_code, codex_cloud, jules."
             )
         canonical_target_runtime = normalized_rt
+
+    if canonical_target_runtime:
+        normalized_runtime_for_planner = dict(
+            normalized_task_for_planner.get("runtime") or {}
+        )
+        normalized_runtime_for_planner["mode"] = canonical_target_runtime
+        normalized_task_for_planner["runtime"] = normalized_runtime_for_planner
 
     # Load provider profile when a profileId is supplied.
     _provider_profile = None

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -927,6 +927,7 @@ class MoonMindAgentRun:
         use_managed_status_activity = workflow.patched(
             MANAGED_STATUS_ACTIVITY_PATCH_ID
         )
+        requested_execution_profile_ref = request.execution_profile_ref
 
         try:
             while True:
@@ -1728,6 +1729,7 @@ class MoonMindAgentRun:
                         self.completion_event.clear()
                         self.final_result = None
                         self._assigned_profile_id = None
+                        request.execution_profile_ref = requested_execution_profile_ref
                         self.run_status = RunStatus.awaiting_slot
                         continue # Retries loop
                     else:
@@ -1735,6 +1737,7 @@ class MoonMindAgentRun:
                         await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
                         self.completion_event.clear()
                         self.final_result = None
+                        request.execution_profile_ref = requested_execution_profile_ref
                         continue # Retries loop
 
                 # Not a 429 or external agent

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -147,7 +147,9 @@ INTEGRATION_POLL_LOOP_PATCH = "refactor-loop-1.2"
 RUN_DEFENSIVE_SLOT_RELEASE_ON_CHILD_TERMINAL_PATCH = "run-defensive-slot-release-1"
 # Replay-stable patch id for task-scoped Codex terminate activity+signal finalization.
 RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination-v1"
-# Replay-stable patch id for task-scoped Codex terminate child-workflow updates.
+# Replay-stable patch id for the v2 task-scoped Codex termination path. The
+# identifier says "update" for in-flight history continuity, but current
+# Temporal external workflow handles expose the session control surface by signal.
 RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH = "run-task-scoped-session-termination-v2"
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
@@ -2311,26 +2313,13 @@ class MoonMindRunWorkflow:
                     binding.workflow_id
                 )
                 if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
-                    try:
-                        await session_handle.execute_update(
-                            "TerminateSession",
-                            {
-                                "reason": reason,
-                            },
-                        )
-                    except Exception as exc:
-                        self._get_logger().warning(
-                            "Task-scoped Codex terminate update failed for %s: %s",
-                            binding.session_id,
-                            exc,
-                        )
-                        await session_handle.signal(
-                            "control_action",
-                            {
-                                "action": "terminate_session",
-                                "reason": reason,
-                            },
-                        )
+                    await session_handle.signal(
+                        "control_action",
+                        {
+                            "action": "terminate_session",
+                            "reason": reason,
+                        },
+                    )
                 elif workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH):
                     try:
                         snapshot_route = DEFAULT_ACTIVITY_CATALOG.resolve_activity(
@@ -3837,10 +3826,14 @@ class MoonMindRunWorkflow:
     @workflow.signal
     def child_state_changed(self, new_state: str, reason: str) -> None:
         if new_state == "awaiting_slot":
+            self._waiting_reason = "provider_profile_slot"
+            self._attention_required = False
             self._set_state(STATE_AWAITING_SLOT, summary=reason)
         elif new_state == "launching":
+            self._waiting_reason = None
             self._set_state(STATE_EXECUTING, summary="Launching agent...")
         elif new_state == "running":
+            self._waiting_reason = None
             self._set_state(STATE_EXECUTING, summary="Agent is running.")
         elif new_state in ("completed", "failed", "canceled", "timed_out"):
             # Child has reached a terminal state. If we have an assigned profile

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3831,9 +3831,11 @@ class MoonMindRunWorkflow:
             self._set_state(STATE_AWAITING_SLOT, summary=reason)
         elif new_state == "launching":
             self._waiting_reason = None
+            self._attention_required = False
             self._set_state(STATE_EXECUTING, summary="Launching agent...")
         elif new_state == "running":
             self._waiting_reason = None
+            self._attention_required = False
             self._set_state(STATE_EXECUTING, summary="Agent is running.")
         elif new_state in ("completed", "failed", "canceled", "timed_out"):
             # Child has reached a terminal state. If we have an assigned profile

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1215,7 +1215,9 @@ def test_serialize_execution_surfaces_runtime_from_nested_parameters_runtime_key
     assert dumped["targetRuntime"] == "gemini_cli"
 
 
-def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run() -> None:
+def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
     record.memo = {
         "title": "Temporal task",
@@ -1223,6 +1225,7 @@ def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run() ->
         "waiting_reason": "provider_profile_slot",
     }
     record.waiting_reason = None
+    monkeypatch.setattr(settings.temporal_dashboard, "debug_fields_enabled", True)
 
     payload = _serialize_execution(
         record,
@@ -1231,6 +1234,8 @@ def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run() ->
 
     assert payload.state == "executing"
     assert payload.waiting_reason is None
+    assert payload.debug_fields is not None
+    assert payload.debug_fields.waiting_reason is None
 
 
 def test_serialize_execution_surfaces_task_run_id_from_memo() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -621,6 +621,36 @@ def test_create_task_shaped_execution_preserves_task_title_and_publish_overrides
     assert initial_parameters["task"]["publish"]["prBody"] == "Adds integration tests and updates callback routing."
 
 
+def test_create_task_shaped_execution_defaults_runtime_into_parameters(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+    monkeypatch.setattr(settings.workflow, "default_task_runtime", "codex_cli")
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "task": {
+                    "title": "Resolve queued PR",
+                    "instructions": "Run pr-resolver for the branch.",
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["targetRuntime"] == "codex_cli"
+    assert initial_parameters["task"]["runtime"]["mode"] == "codex_cli"
+
+
 def test_create_task_shaped_execution_preserves_steps_and_uses_step_title_defaults(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:
@@ -1183,6 +1213,24 @@ def test_serialize_execution_surfaces_runtime_from_nested_parameters_runtime_key
     assert payload.target_runtime == "gemini_cli"
     dumped = payload.model_dump(by_alias=True)
     assert dumped["targetRuntime"] == "gemini_cli"
+
+
+def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.memo = {
+        "title": "Temporal task",
+        "summary": "Launching agent...",
+        "waiting_reason": "provider_profile_slot",
+    }
+    record.waiting_reason = None
+
+    payload = _serialize_execution(
+        record,
+        user=SimpleNamespace(is_superuser=True, id=record.owner_id),
+    )
+
+    assert payload.state == "executing"
+    assert payload.waiting_reason is None
 
 
 def test_serialize_execution_surfaces_task_run_id_from_memo() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -733,6 +733,133 @@ async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
     assert result.summary.startswith("managed start failed: ")
 
 
+async def test_agent_run_clears_auto_profile_after_provider_cooldown_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    ensure_profile_refs: list[str | None] = []
+    manager_signals: list[tuple[str, dict[str, Any]]] = []
+    fetch_results = [
+        AgentRunResult(
+            failureClass="execution_error",
+            providerErrorCode="provider_capacity",
+            retryRecommendation="retry_after_cooldown",
+            summary="provider capacity",
+        ),
+        AgentRunResult(summary="Recovered on fallback profile."),
+    ]
+
+    _configure_workflow_runtime(monkeypatch)
+
+    class _FakeManagedAgentAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            raise AssertionError(
+                "ManagedAgentAdapter should not be used for managedSession requests"
+            )
+
+    class _FakeCodexSessionAdapter:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        async def start(self, request: AgentExecutionRequest) -> AgentRunHandle:
+            return AgentRunHandle(
+                runId=f"managed-session-run-{len(ensure_profile_refs)}",
+                agentKind="managed",
+                agentId=request.agent_id,
+                status="completed",
+                startedAt=agent_run_module.workflow.now(),
+            )
+
+    class _FakeManagerHandle:
+        async def signal(self, signal_name: str, payload: dict[str, Any]) -> None:
+            manager_signals.append((signal_name, payload))
+
+    class _FakeSessionWorkflowHandle:
+        async def signal(self, signal_name: str, payload: Any) -> None:
+            return None
+
+    async def fake_ensure_manager_and_signal(
+        manager_id: str,
+        runtime_id: str,
+        *,
+        request_slot: bool,
+        execution_profile_ref: str | None,
+        profile_selector: dict[str, Any],
+    ) -> _FakeManagerHandle:
+        ensure_profile_refs.append(execution_profile_ref)
+        run.slot_assigned_event.set()
+        run._assigned_profile_id = (
+            "codex_openrouter_qwen36_plus"
+            if len(ensure_profile_refs) == 1
+            else "codex-default"
+        )
+        return _FakeManagerHandle()
+
+    async def fake_sync_manager_profiles(
+        *,
+        manager_handle: object,
+        runtime_id: str,
+    ) -> int:
+        run._profile_snapshots = {
+            "codex_openrouter_qwen36_plus": {
+                "cooldown_after_429_seconds": 0,
+            },
+            "codex-default": {
+                "cooldown_after_429_seconds": 0,
+            },
+        }
+        return 2
+
+    async def fake_fetch_managed_result(**_kwargs: Any) -> AgentRunResult:
+        return fetch_results.pop(0)
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        if activity_name == "agent_runtime.publish_artifacts":
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module, "ManagedAgentAdapter", _FakeManagedAgentAdapter)
+    monkeypatch.setattr(agent_run_module, "CodexSessionAdapter", _FakeCodexSessionAdapter)
+    monkeypatch.setattr(run, "_ensure_manager_and_signal", fake_ensure_manager_and_signal)
+    monkeypatch.setattr(run, "_sync_manager_profiles", fake_sync_manager_profiles)
+    monkeypatch.setattr(run, "_fetch_managed_result", fake_fetch_managed_result)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+    monkeypatch.setattr(
+        agent_run_module.workflow,
+        "get_external_workflow_handle",
+        lambda *_args, **_kwargs: _FakeSessionWorkflowHandle(),
+    )
+
+    request = _managed_session_request().model_copy(
+        update={"execution_profile_ref": None}
+    )
+
+    result = await run.run(request)
+
+    assert result.summary == "Recovered on fallback profile."
+    assert ensure_profile_refs == [None, None]
+    assert manager_signals[:2] == [
+        (
+            "report_cooldown",
+            {
+                "profile_id": "codex_openrouter_qwen36_plus",
+                "cooldown_seconds": 0,
+            },
+        ),
+        (
+            "release_slot",
+            {
+                "requester_workflow_id": "wf-agent-run-1",
+                "profile_id": "codex_openrouter_qwen36_plus",
+            },
+        ),
+    ]
+
+
 async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -165,15 +165,16 @@ async def test_run_terminates_active_task_scoped_codex_session(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert update_calls == [
+    assert update_calls == []
+    assert signal_calls == [
         (
-            "TerminateSession",
+            "control_action",
             {
+                "action": "terminate_session",
                 "reason": "success",
             },
         )
     ]
-    assert signal_calls == []
     assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
@@ -186,13 +187,14 @@ async def test_run_terminates_task_scoped_codex_session_with_binding_only(
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
     update_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
 
     class _FakeHandle:
         async def execute_update(self, update_name: str, payload: Any = None) -> None:
             update_calls.append((update_name, payload))
 
-        async def signal(self, _signal_name: str, _payload: Any = None) -> None:
-            raise AssertionError("signal should not be used when update succeeds")
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
 
     monkeypatch.setattr(
         run_module.workflow,
@@ -214,10 +216,12 @@ async def test_run_terminates_task_scoped_codex_session_with_binding_only(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert update_calls == [
+    assert update_calls == []
+    assert signal_calls == [
         (
-            "TerminateSession",
+            "control_action",
             {
+                "action": "terminate_session",
                 "reason": "success",
             },
         )
@@ -455,33 +459,26 @@ async def test_run_termination_keeps_legacy_signal_only_path_when_patch_unset(
 
 
 @pytest.mark.asyncio
-async def test_run_termination_logs_when_terminate_update_fails(
+async def test_run_termination_v2_uses_session_control_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
     _configure_workflow_runtime(monkeypatch)
     update_calls: list[tuple[str, Any]] = []
     signal_calls: list[tuple[str, Any]] = []
-    warnings: list[str] = []
 
     class _FakeHandle:
         async def execute_update(self, update_name: str, payload: Any = None) -> None:
             update_calls.append((update_name, payload))
-            raise RuntimeError("terminate update failed")
 
         async def signal(self, signal_name: str, payload: Any = None) -> None:
             signal_calls.append((signal_name, payload))
-
-    class _FakeLogger:
-        def warning(self, message: str, *args: Any) -> None:
-            warnings.append(message % args)
 
     monkeypatch.setattr(
         run_module.workflow,
         "patched",
         lambda patch_id: patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
     )
-    monkeypatch.setattr(workflow, "_get_logger", lambda: _FakeLogger())
 
     external_handle = _FakeHandle()
     _use_external_handle(monkeypatch, external_handle)
@@ -497,14 +494,7 @@ async def test_run_termination_logs_when_terminate_update_fails(
 
     await workflow._terminate_task_scoped_sessions(reason="success")
 
-    assert update_calls == [
-        (
-            "TerminateSession",
-            {
-                "reason": "success",
-            },
-        )
-    ]
+    assert update_calls == []
     assert signal_calls == [
         (
             "control_action",
@@ -513,10 +503,6 @@ async def test_run_termination_logs_when_terminate_update_fails(
                 "reason": "success",
             },
         )
-    ]
-    assert warnings == [
-        "Task-scoped Codex terminate update failed for sess:wf-run-1:codex_cli: "
-        "terminate update failed"
     ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -10,6 +10,7 @@ from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 from temporalio import workflow
 from moonmind.workflows.temporal.workflows.run import (
     DEPENDENCY_RECONCILE_INTERVAL,
+    STATE_AWAITING_SLOT,
     STATE_WAITING_ON_DEPENDENCIES,
     MoonMindRunWorkflow,
 )
@@ -420,6 +421,26 @@ async def test_wait_for_dependencies_records_dependency_metadata(monkeypatch):
         (memo.get("dependencies") or {}).get("declaredIds") == ["dep-1", "dep-2"]
         for memo in memo_updates
     )
+
+
+def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    monkeypatch.setattr(workflow_instance, "_update_search_attributes", lambda: None)
+    monkeypatch.setattr(workflow_instance, "_update_memo", lambda: None)
+
+    workflow_instance.child_state_changed(
+        "awaiting_slot",
+        "Managed provider capacity exhausted.",
+    )
+
+    assert workflow_instance._state == STATE_AWAITING_SLOT
+    assert workflow_instance._summary == "Managed provider capacity exhausted."
+    assert workflow_instance._waiting_reason == "provider_profile_slot"
+    assert workflow_instance._attention_required is False
+
+    workflow_instance.child_state_changed("launching", "Slot acquired.")
+
+    assert workflow_instance._waiting_reason is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -438,9 +438,17 @@ def test_child_state_changed_sets_provider_profile_waiting_reason(monkeypatch):
     assert workflow_instance._waiting_reason == "provider_profile_slot"
     assert workflow_instance._attention_required is False
 
+    workflow_instance._attention_required = True
     workflow_instance.child_state_changed("launching", "Slot acquired.")
 
     assert workflow_instance._waiting_reason is None
+    assert workflow_instance._attention_required is False
+
+    workflow_instance._attention_required = True
+    workflow_instance.child_state_changed("running", "Agent started.")
+
+    assert workflow_instance._waiting_reason is None
+    assert workflow_instance._attention_required is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the MoonMind runtime/slot state issues observed during PR resolver runs:

- persist the default task runtime into task-created execution parameters so Mission Control does not show a blank Runtime column when the request omits an explicit runtime
- restore the original auto-profile selection intent after a provider cooldown so retries are not pinned to the failed assigned profile
- replace task-scoped Codex session termination via unsupported external workflow updates with the existing session control signal path
- suppress stale waiting reasons once an execution has returned to a non-blocked state

## Root Cause

Several independent issues combined into the same dashboard symptom. Provider calls were returning retryable capacity failures, but retries mutated an auto profile request into an exact provider profile request. Existing task records also stored `targetRuntime: null`, and stale session cleanup used an external workflow API surface that is unavailable in the current Temporal Python SDK.

## Validation

- `./tools/test_unit.sh` passed: 2827 passed, 1 xpassed
- `git diff --check` passed

## Operational Notes

During diagnosis, stale local `auth-profile-manager:*` workflows were terminated and stale local Codex session containers were stopped. Those operational cleanup actions are not part of this PR; this PR contains the code and test changes that prevent recurrence.