### PR TITLE
[codex] Fix managed session git ownership

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -93,6 +93,8 @@ class CommandRunner(Protocol):
         *,
         input_text: str | None = None,
         env: dict[str, str] | None = None,
+        run_as_uid: int | None = None,
+        run_as_gid: int | None = None,
     ) -> tuple[int, str, str]:
         pass
 
@@ -102,13 +104,24 @@ async def _default_command_runner(
     *,
     input_text: str | None = None,
     env: dict[str, str] | None = None,
+    run_as_uid: int | None = None,
+    run_as_gid: int | None = None,
 ) -> tuple[int, str, str]:
+    subprocess_kwargs: dict[str, Any] = {}
+    geteuid = getattr(os, "geteuid", None)
+    if os.name == "posix" and callable(geteuid) and geteuid() == 0:
+        if run_as_uid is not None:
+            subprocess_kwargs["user"] = run_as_uid
+        if run_as_gid is not None:
+            subprocess_kwargs["group"] = run_as_gid
+            subprocess_kwargs["extra_groups"] = []
     process = await asyncio.create_subprocess_exec(
         *command,
         stdin=asyncio.subprocess.PIPE if input_text is not None else asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env={**os.environ, **(env or {})},
+        **subprocess_kwargs,
     )
     stdout, stderr = await process.communicate(
         input_text.encode("utf-8") if input_text is not None else None
@@ -168,6 +181,16 @@ class DockerCodexManagedSessionController:
         self._turn_poll_interval_seconds = turn_poll_interval_seconds
         self._turn_poll_timeout_seconds = turn_poll_timeout_seconds
         self._command_runner = command_runner
+
+    @staticmethod
+    def _managed_session_user_command_kwargs() -> dict[str, int]:
+        geteuid = getattr(os, "geteuid", None)
+        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+            return {}
+        return {
+            "run_as_uid": _MANAGED_SESSION_CONTAINER_UID,
+            "run_as_gid": _MANAGED_SESSION_CONTAINER_GID,
+        }
 
     def _docker_env(self) -> dict[str, str]:
         env: dict[str, str] = {}
@@ -470,11 +493,21 @@ class DockerCodexManagedSessionController:
         command: Sequence[str],
         *,
         extra_env: Mapping[str, str] | None = None,
+        run_as_managed_session_user: bool = False,
     ) -> tuple[str, str]:
         env = None
         if extra_env:
             env = {str(key): str(value) for key, value in extra_env.items()}
-        returncode, stdout, stderr = await self._command_runner(tuple(command), env=env)
+        command_kwargs = (
+            self._managed_session_user_command_kwargs()
+            if run_as_managed_session_user
+            else {}
+        )
+        returncode, stdout, stderr = await self._command_runner(
+            tuple(command),
+            env=env,
+            **command_kwargs,
+        )
         if returncode != 0:
             rendered_command, rendered_detail = self._scrub_command_failure(
                 command,
@@ -489,7 +522,11 @@ class DockerCodexManagedSessionController:
         self,
         command: Sequence[str],
     ) -> tuple[str, str]:
-        return await self._run_host_command(command, extra_env=_GIT_COMMAND_LOCALE)
+        return await self._run_host_command(
+            command,
+            extra_env=_GIT_COMMAND_LOCALE,
+            run_as_managed_session_user=True,
+        )
 
     @staticmethod
     def _workspace_git_command(
@@ -510,9 +547,11 @@ class DockerCodexManagedSessionController:
         self,
         command: Sequence[str],
     ) -> tuple[int, str, str]:
+        command_kwargs = self._managed_session_user_command_kwargs()
         return await self._command_runner(
             tuple(command),
             env=dict(_GIT_COMMAND_LOCALE),
+            **command_kwargs,
         )
 
     async def _workspace_is_git_repository(self, *, workspace_path: Path) -> bool:
@@ -542,6 +581,7 @@ class DockerCodexManagedSessionController:
     ) -> None:
         workspace_path.parent.mkdir(parents=True, exist_ok=True)
         await self._remove_workspace_path(workspace_path=workspace_path)
+        self._normalize_container_path_owner(workspace_path.parent)
 
         from .launcher import ManagedRuntimeLauncher
 
@@ -724,6 +764,14 @@ class DockerCodexManagedSessionController:
                 target_branch,
             )
         )
+
+    @staticmethod
+    def _normalize_container_path_owner(path: Path) -> None:
+        geteuid = getattr(os, "geteuid", None)
+        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+            return
+        if path.exists():
+            DockerCodexManagedSessionController._chown_path(path)
 
     @staticmethod
     def _normalize_container_path_ownership(paths: Sequence[Path]) -> None:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -110,11 +110,12 @@ async def _default_command_runner(
     subprocess_kwargs: dict[str, Any] = {}
     geteuid = getattr(os, "geteuid", None)
     if os.name == "posix" and callable(geteuid) and geteuid() == 0:
+        if run_as_uid is not None or run_as_gid is not None:
+            subprocess_kwargs["extra_groups"] = []
         if run_as_uid is not None:
             subprocess_kwargs["user"] = run_as_uid
         if run_as_gid is not None:
             subprocess_kwargs["group"] = run_as_gid
-            subprocess_kwargs["extra_groups"] = []
     process = await asyncio.create_subprocess_exec(
         *command,
         stdin=asyncio.subprocess.PIPE if input_text is not None else asyncio.subprocess.DEVNULL,
@@ -641,6 +642,7 @@ class DockerCodexManagedSessionController:
                 request=request,
                 owned_paths=created_paths,
             )
+            self._normalize_container_path_ownership([workspace_path])
             if repository:
                 if not await self._workspace_is_git_repository(workspace_path=workspace_path):
                     await self._clone_workspace(

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import runpy
+import stat
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -14,6 +16,8 @@ import pytest
 from moonmind.schemas.managed_session_models import LaunchCodexManagedSessionRequest
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
+    _MANAGED_SESSION_CONTAINER_GID,
+    _MANAGED_SESSION_CONTAINER_UID,
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
@@ -72,6 +76,101 @@ def _run_command_env(command: tuple[str, ...]) -> dict[str, str]:
             continue
         index += 1
     return env
+
+
+async def _run_checked(
+    *command: str,
+    cwd: Path | None = None,
+    run_as_uid: int | None = None,
+    run_as_gid: int | None = None,
+) -> None:
+    kwargs: dict[str, Any] = {}
+    if os.name == "posix" and os.geteuid() == 0:
+        if run_as_uid is not None:
+            kwargs["user"] = run_as_uid
+        if run_as_gid is not None:
+            kwargs["group"] = run_as_gid
+            kwargs["extra_groups"] = []
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        cwd=str(cwd) if cwd is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        **kwargs,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode != 0:
+        raise AssertionError(
+            f"{' '.join(command)} failed with exit code {process.returncode}: "
+            f"{stderr.decode(errors='replace') or stdout.decode(errors='replace')}"
+        )
+
+
+def _make_world_readable(path: Path) -> None:
+    directory_bits = (
+        stat.S_IXUSR
+        | stat.S_IXGRP
+        | stat.S_IXOTH
+        | stat.S_IRUSR
+        | stat.S_IRGRP
+        | stat.S_IROTH
+    )
+    file_bits = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    for root, dirnames, filenames in os.walk(path):
+        root_path = Path(root)
+        root_path.chmod(root_path.stat().st_mode | directory_bits)
+        for dirname in dirnames:
+            child = root_path / dirname
+            child.chmod(child.stat().st_mode | directory_bits)
+        for filename in filenames:
+            child = root_path / filename
+            child.chmod(child.stat().st_mode | file_bits)
+
+
+def _make_tmp_path_accessible(path: Path) -> None:
+    temp_root = Path("/tmp").resolve()
+    for directory in (path, *path.parents):
+        resolved = directory.resolve()
+        if resolved == resolved.parent:
+            break
+        if temp_root not in (resolved, *resolved.parents):
+            break
+        directory.chmod(
+            directory.stat().st_mode
+            | stat.S_IXUSR
+            | stat.S_IXGRP
+            | stat.S_IXOTH
+            | stat.S_IRUSR
+            | stat.S_IRGRP
+            | stat.S_IROTH
+        )
+
+
+def _chown_tree(path: Path, *, uid: int, gid: int) -> None:
+    for root, dirnames, filenames in os.walk(path):
+        root_path = Path(root)
+        os.chown(root_path, uid, gid)
+        for dirname in dirnames:
+            os.chown(root_path / dirname, uid, gid)
+        for filename in filenames:
+            os.chown(root_path / filename, uid, gid)
+
+
+async def _create_source_repo(path: Path) -> None:
+    path.mkdir(parents=True)
+    await _run_checked("git", "init", "--initial-branch", "main", cwd=path)
+    await _run_checked("git", "config", "user.name", "MoonMind Test", cwd=path)
+    await _run_checked(
+        "git",
+        "config",
+        "user.email",
+        "moonmind-test@example.invalid",
+        cwd=path,
+    )
+    (path / "README.md").write_text("source\n", encoding="utf-8")
+    await _run_checked("git", "add", "README.md", cwd=path)
+    await _run_checked("git", "commit", "-m", "Initial commit", cwd=path)
+    _make_world_readable(path)
 
 
 def _expected_child_idempotency_key(
@@ -229,3 +328,77 @@ async def test_codex_session_launch_environment_can_create_child_tasks(
         await asyncio.to_thread(server.shutdown)
         await asyncio.to_thread(server.server_close)
         server_thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_codex_session_workspace_git_metadata_is_managed_user_writable(
+    tmp_path: Path,
+) -> None:
+    if os.name != "posix" or os.geteuid() != 0:
+        pytest.skip("managed-session UID/GID permission integration requires root")
+
+    _make_tmp_path_accessible(tmp_path)
+    source_repo = tmp_path / "source-repo"
+    await _create_source_repo(source_repo)
+    _chown_tree(
+        source_repo,
+        uid=_MANAGED_SESSION_CONTAINER_UID,
+        gid=_MANAGED_SESSION_CONTAINER_GID,
+    )
+
+    workspace_root = tmp_path / "agent_jobs"
+    workspace_root.mkdir()
+    workspace_root.chmod(0o755)
+    target_branch = "feature/owned-ref"
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-parent",
+        sessionId="sess-parent:codex_cli",
+        threadId="thread-parent",
+        workspacePath=str(workspace_root / "task-parent" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-parent" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-parent" / "artifacts"),
+        codexHomePath=str(workspace_root / "task-parent" / ".moonmind" / "codex-home"),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": str(source_repo),
+            "startingBranch": "main",
+            "targetBranch": target_branch,
+        },
+    )
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller._ensure_workspace_paths(request)
+
+    workspace_path = Path(request.workspace_path)
+    branch_ref = workspace_path / ".git" / "refs" / "heads" / "feature" / "owned-ref"
+    branch_log = workspace_path / ".git" / "logs" / "refs" / "heads" / "feature" / "owned-ref"
+    assert branch_ref.exists()
+    assert branch_log.exists()
+    assert (branch_ref.stat().st_uid, branch_ref.stat().st_gid) == (
+        _MANAGED_SESSION_CONTAINER_UID,
+        _MANAGED_SESSION_CONTAINER_GID,
+    )
+    assert (branch_log.stat().st_uid, branch_log.stat().st_gid) == (
+        _MANAGED_SESSION_CONTAINER_UID,
+        _MANAGED_SESSION_CONTAINER_GID,
+    )
+
+    await _run_checked(
+        "bash",
+        "-lc",
+        (
+            "printf 'managed update\\n' >> README.md && "
+            "git add README.md && "
+            "git -c user.name='MoonMind Test' "
+            "-c user.email='moonmind-test@example.invalid' "
+            "commit -m 'Managed user commit'"
+        ),
+        cwd=workspace_path,
+        run_as_uid=_MANAGED_SESSION_CONTAINER_UID,
+        run_as_gid=_MANAGED_SESSION_CONTAINER_GID,
+    )

--- a/tests/integration/services/temporal/test_codex_session_task_creation.py
+++ b/tests/integration/services/temporal/test_codex_session_task_creation.py
@@ -86,11 +86,12 @@ async def _run_checked(
 ) -> None:
     kwargs: dict[str, Any] = {}
     if os.name == "posix" and os.geteuid() == 0:
+        if run_as_uid is not None or run_as_gid is not None:
+            kwargs["extra_groups"] = []
         if run_as_uid is not None:
             kwargs["user"] = run_as_uid
         if run_as_gid is not None:
             kwargs["group"] = run_as_gid
-            kwargs["extra_groups"] = []
     process = await asyncio.create_subprocess_exec(
         *command,
         cwd=str(cwd) if cwd is not None else None,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -414,10 +414,13 @@ async def test_controller_launch_clones_workspace_before_starting_container(
         *,
         input_text: str | None = None,
         env: dict[str, str] | None = None,
+        run_as_uid: int | None = None,
+        run_as_gid: int | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
         if command[0] == "git":
             git_envs.append(env)
+            assert (run_as_uid, run_as_gid) == (1000, 1000)
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
         if command[:2] == ("git", "clone"):
@@ -510,6 +513,7 @@ async def test_controller_launch_clones_workspace_before_starting_container(
     assert Path(request.session_workspace_path).exists()
     assert Path(request.artifact_spool_path).exists()
     chowned_paths = {path for path, _uid, _gid, _follow_symlinks in chown_calls}
+    assert Path(request.workspace_path).parent in chowned_paths
     assert Path(request.workspace_path) in chowned_paths
     assert Path(request.workspace_path, "README.md") in chowned_paths
     assert Path(request.session_workspace_path) in chowned_paths
@@ -664,6 +668,7 @@ async def test_controller_launch_creates_target_branch_when_remote_branch_missin
 
 @pytest.mark.asyncio
 async def test_controller_launch_reuses_existing_workspace_and_checks_out_target_branch(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     workspace_root = tmp_path / "agent_jobs"
@@ -685,14 +690,28 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
         },
     )
     commands: list[tuple[str, ...]] = []
+    git_identities: list[tuple[int | None, int | None]] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        lambda *args, **kwargs: None,
+    )
 
     async def _fake_runner(
         command: tuple[str, ...],
         *,
         input_text: str | None = None,
         env: dict[str, str] | None = None,
+        run_as_uid: int | None = None,
+        run_as_gid: int | None = None,
     ) -> tuple[int, str, str]:
         commands.append(command)
+        if command[0] == "git":
+            git_identities.append((run_as_uid, run_as_gid))
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
         if command == _workspace_git_command(
@@ -747,6 +766,7 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
         "checkout",
         "codex/session-fix",
     )
+    assert git_identities == [(1000, 1000), (1000, 1000)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -21,6 +21,7 @@ from moonmind.schemas.managed_session_models import (
 )
 from moonmind.workflows.temporal.runtime.managed_session_controller import (
     DockerCodexManagedSessionController,
+    _default_command_runner,
 )
 from moonmind.workflows.temporal.runtime.managed_session_store import (
     ManagedSessionStore,
@@ -58,6 +59,42 @@ def _workspace_git_command(workspace_path: str | Path, *args: str) -> tuple[str,
         resolved_workspace,
         *args,
     )
+
+
+@pytest.mark.asyncio
+async def test_default_command_runner_clears_supplemental_groups_when_uid_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    class _FakeProcess:
+        returncode = 0
+
+        async def communicate(self, _input: bytes | None = None) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(
+        *_command: str,
+        **kwargs: object,
+    ) -> _FakeProcess:
+        captured_kwargs.update(kwargs)
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.asyncio.create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    await _default_command_runner(("id",), run_as_uid=1000)
+
+    assert captured_kwargs["user"] == 1000
+    assert captured_kwargs["extra_groups"] == []
+    assert "group" not in captured_kwargs
 
 
 @pytest.mark.asyncio
@@ -674,6 +711,9 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
     workspace_root = tmp_path / "agent_jobs"
     workspace_path = workspace_root / "mm:task-1" / "repo"
     workspace_path.mkdir(parents=True, exist_ok=True)
+    existing_git_ref = workspace_path / ".git" / "refs" / "heads" / "main"
+    existing_git_ref.parent.mkdir(parents=True, exist_ok=True)
+    existing_git_ref.write_text("abc123\n", encoding="utf-8")
     request = LaunchCodexManagedSessionRequest(
         taskRunId="mm:task-1",
         sessionId="sess-1",
@@ -691,14 +731,24 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
     )
     commands: list[tuple[str, ...]] = []
     git_identities: list[tuple[int | None, int | None]] = []
+    chown_calls: list[tuple[Path, int, int, bool]] = []
 
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
         lambda: 0,
     )
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        chown_calls.append((Path(path), uid, gid, follow_symlinks))
+
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
-        lambda *args, **kwargs: None,
+        _fake_chown,
     )
 
     async def _fake_runner(
@@ -711,6 +761,10 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
     ) -> tuple[int, str, str]:
         commands.append(command)
         if command[0] == "git":
+            chowned_paths = {path for path, _uid, _gid, _follow in chown_calls}
+            assert workspace_path in chowned_paths
+            assert workspace_path / ".git" in chowned_paths
+            assert existing_git_ref in chowned_paths
             git_identities.append((run_as_uid, run_as_gid))
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
@@ -766,6 +820,12 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
         "checkout",
         "codex/session-fix",
     )
+    chowned_paths = {path for path, _uid, _gid, _follow in chown_calls}
+    assert workspace_path in chowned_paths
+    assert workspace_path / ".git" in chowned_paths
+    assert existing_git_ref in chowned_paths
+    assert all(uid == 1000 and gid == 1000 for _path, uid, gid, _follow in chown_calls)
+    assert all(follow is False for _path, _uid, _gid, follow in chown_calls)
     assert git_identities == [(1000, 1000), (1000, 1000)]
 
 


### PR DESCRIPTION
## Summary

- Run managed-session host Git commands as the managed container UID/GID when the controller process is root.
- Chown the workspace parent before privilege-dropped clone so the managed user can create the repository and Git refs.
- Add unit and integration coverage proving Git refs/reflogs are writable by the managed session user.

## Root Cause

Managed session workspace preparation could run host-side Git operations as root. That left branch refs and reflogs owned by root, so later Codex commands running as the managed `app` user could not append to `.git/refs` or `.git/logs/refs` during commit or checkout flows.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `./tools/test_unit.sh --python-only tests/integration/services/temporal/test_codex_session_task_creation.py`
- `docker compose -f docker-compose.test.yaml --project-directory /Users/nsticco/MoonMind run --rm --build pytest bash -lc "pytest tests/integration/services/temporal/test_codex_session_task_creation.py::test_codex_session_workspace_git_metadata_is_managed_user_writable -q --tb=short --timeout 120 --timeout-method=thread"`
- `git diff --check`