### PR TITLE
[codex] fix live log task run ids

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -8,7 +8,6 @@ from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import Literal
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status, Request
 from fastapi.responses import FileResponse, StreamingResponse
@@ -1129,7 +1128,7 @@ def _resolve_legacy_log_artifact_path(
     },
 )
 async def get_observability_summary(
-    id: UUID,
+    id: str,
     _user: User = Depends(get_current_user()),
 ) -> dict:
     """Fetch the observability summary for a task run from the shared agent jobs volume."""
@@ -1274,7 +1273,7 @@ async def control_task_run_artifact_session(
     },
 )
 async def get_task_run_observability_events(
-    id: UUID,
+    id: str,
     since: int | None = Query(default=None, ge=0),
     limit: int = Query(default=500, ge=1, le=5000),
     stream: list[Literal["stdout", "stderr", "system", "session"]] | None = Query(default=None),
@@ -1366,7 +1365,7 @@ async def get_task_run_observability_events(
     },
 )
 async def stream_task_run_live_logs(
-    id: UUID,
+    id: str,
     request: Request,
     since: int | None = Query(default=None, ge=0, description="Resume from sequence number"),
     _user: User = Depends(get_current_user()),
@@ -1459,7 +1458,7 @@ async def stream_task_run_live_logs(
     },
 )
 async def stream_task_run_log(
-    id: UUID,
+    id: str,
     stream_name: str,
     _user: User = Depends(get_current_user()),
 ):
@@ -1609,7 +1608,7 @@ async def stream_task_run_log(
     },
 )
 async def get_task_run_diagnostics(
-    id: UUID,
+    id: str,
     _user: User = Depends(get_current_user()),
 ):
     """Return the diagnostics.json payload for a task run."""

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -73,6 +73,19 @@ def _get_agent_runtime_artifacts_root() -> str:
     return str(managed_runtime_artifact_root())
 
 
+async def _load_managed_run_record(
+    store: ManagedRunStore,
+    run_id: str,
+) -> object | None:
+    try:
+        return await asyncio.to_thread(store.load, str(run_id))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid task run id",
+        ) from exc
+
+
 @lru_cache(maxsize=1)
 def get_temporal_client_adapter() -> TemporalClientAdapter:
     return TemporalClientAdapter()
@@ -1136,7 +1149,7 @@ async def get_observability_summary(
     started = time.perf_counter()
 
     try:
-        record = await asyncio.to_thread(store.load, str(id))
+        record = await _load_managed_run_record(store, id)
         if not record:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -1294,7 +1307,7 @@ async def get_task_run_observability_events(
             detail="threadId must not contain blank values",
         )
     store = ManagedRunStore(_get_agent_runtime_store_root())
-    record = await asyncio.to_thread(store.load, str(id))
+    record = await _load_managed_run_record(store, id)
     if not record:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -1372,7 +1385,7 @@ async def stream_task_run_live_logs(
 ):
     """Serve SSE real-time stream for active runs."""
     store = ManagedRunStore(_get_agent_runtime_store_root())
-    record = await asyncio.to_thread(store.load, str(id))
+    record = await _load_managed_run_record(store, id)
 
     if not record:
         raise HTTPException(
@@ -1470,7 +1483,7 @@ async def stream_task_run_log(
         )
     
     store = ManagedRunStore(_get_agent_runtime_store_root())
-    record = await asyncio.to_thread(store.load, str(id))
+    record = await _load_managed_run_record(store, id)
     
     if not record:
         raise HTTPException(
@@ -1613,7 +1626,7 @@ async def get_task_run_diagnostics(
 ):
     """Return the diagnostics.json payload for a task run."""
     store = ManagedRunStore(_get_agent_runtime_store_root())
-    record = await asyncio.to_thread(store.load, str(id))
+    record = await _load_managed_run_record(store, id)
     
     if not record or not record.diagnostics_ref:
         raise HTTPException(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from typing import Iterator
-from uuid import uuid4
-from unittest.mock import AsyncMock, MagicMock, patch
 from types import SimpleNamespace
+from typing import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import quote
+from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
@@ -60,11 +61,38 @@ def client(test_user: User, test_worker_auth: _WorkerRequestAuth) -> Iterator[tu
 
 
 def _encoded_task_run_path_id(task_run_id: str) -> str:
-    return task_run_id.replace(":", "%3A")
+    return quote(task_run_id, safe="")
 
 
 def _task_run_api_path(task_run_id: str) -> str:
     return f"/api/task-runs/{_encoded_task_run_path_id(task_run_id)}"
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "/observability-summary",
+        "/observability/events",
+        "/logs/stream",
+        "/logs/stdout",
+        "/diagnostics",
+    ],
+)
+def test_task_run_observability_endpoints_reject_invalid_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+    suffix: str,
+) -> None:
+    test_client, _ = client
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        side_effect=ValueError("run_id resolves outside store root"),
+    ) as load_record:
+        response = test_client.get(f"/api/task-runs/invalid-run-id{suffix}")
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "Invalid task run id"
+    load_record.assert_called_once_with("invalid-run-id")
 
 
 # ---------------------------------------------------------------------------
@@ -513,13 +541,43 @@ def test_stream_task_run_log_returns_file_response(
     assert response.content == b"mock_log_data"
 
 
-def test_stream_task_run_log_accepts_moonmind_task_run_id(
+@pytest.mark.parametrize(
+    (
+        "suffix",
+        "artifact_ref_attr",
+        "artifact_ref",
+        "media_type",
+        "response_content",
+    ),
+    [
+        (
+            "/logs/stdout",
+            "stdout_artifact_ref",
+            "test/stdout.log",
+            "text/plain",
+            b"prefixed task output",
+        ),
+        (
+            "/diagnostics",
+            "diagnostics_ref",
+            "test/diagnostics.json",
+            "application/json",
+            b'{"prefixed":true}',
+        ),
+    ],
+)
+def test_file_backed_task_run_endpoints_accept_moonmind_task_run_id(
     client: tuple[TestClient, AsyncMock],
+    suffix: str,
+    artifact_ref_attr: str,
+    artifact_ref: str,
+    media_type: str,
+    response_content: bytes,
 ) -> None:
     test_client, _ = client
     task_run_id = f"mm:{uuid4()}"
     mock_record = MagicMock()
-    mock_record.stdout_artifact_ref = "test/stdout.log"
+    setattr(mock_record, artifact_ref_attr, artifact_ref)
 
     with patch(
         "api_service.api.routers.task_runs.ManagedRunStore.load",
@@ -533,16 +591,17 @@ def test_stream_task_run_log_accepts_moonmind_task_run_id(
                     from fastapi.responses import Response
 
                     mock_file_response.return_value = Response(
-                        content=b"prefixed task output",
-                        media_type="text/plain",
+                        content=response_content,
+                        media_type=media_type,
                     )
                     response = test_client.get(
-                        f"{_task_run_api_path(task_run_id)}/logs/stdout"
+                        f"{_task_run_api_path(task_run_id)}{suffix}"
                     )
 
     assert response.status_code == 200
     load_record.assert_called_once_with(task_run_id)
-    assert response.content == b"prefixed task output"
+    assert mock_file_response.call_args[1]["media_type"] == media_type
+    assert response.content == response_content
 
 
 @pytest.mark.parametrize(
@@ -1166,38 +1225,6 @@ def test_get_task_run_diagnostics_returns_file_response(
     assert mock_file_response.call_args[1]["media_type"] == "application/json"
     assert response.status_code == 200
     assert response.content == b'{"mock":"diag"}'
-
-
-def test_get_task_run_diagnostics_accepts_moonmind_task_run_id(
-    client: tuple[TestClient, AsyncMock],
-) -> None:
-    test_client, _ = client
-    task_run_id = f"mm:{uuid4()}"
-    mock_record = MagicMock()
-    mock_record.diagnostics_ref = "test/diagnostics.json"
-
-    with patch(
-        "api_service.api.routers.task_runs.ManagedRunStore.load",
-        return_value=mock_record,
-    ) as load_record:
-        with patch("pathlib.Path.is_file", return_value=True):
-            with patch("pathlib.Path.is_relative_to", return_value=True):
-                with patch(
-                    "api_service.api.routers.task_runs.FileResponse"
-                ) as mock_file_response:
-                    from fastapi.responses import Response
-
-                    mock_file_response.return_value = Response(
-                        content=b'{"prefixed":true}',
-                        media_type="application/json",
-                    )
-                    response = test_client.get(
-                        f"{_task_run_api_path(task_run_id)}/diagnostics"
-                    )
-
-    assert response.status_code == 200
-    load_record.assert_called_once_with(task_run_id)
-    assert response.content == b'{"prefixed":true}'
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -59,6 +59,14 @@ def client(test_user: User, test_worker_auth: _WorkerRequestAuth) -> Iterator[tu
 # Legacy web_ro session unit tests removed in Phase 6.
 
 
+def _encoded_task_run_path_id(task_run_id: str) -> str:
+    return task_run_id.replace(":", "%3A")
+
+
+def _task_run_api_path(task_run_id: str) -> str:
+    return f"/api/task-runs/{_encoded_task_run_path_id(task_run_id)}"
+
+
 # ---------------------------------------------------------------------------
 # Observability summary
 # ---------------------------------------------------------------------------
@@ -106,6 +114,30 @@ def test_get_observability_summary_returns_200(
     body = response.json()["summary"]
     assert body["runId"] == str(run_id)
     assert body["status"] == "running"
+
+
+def test_get_observability_summary_accepts_moonmind_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    task_run_id = f"mm:{uuid4()}"
+
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"runId": task_run_id, "status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ) as load_record:
+        response = test_client.get(
+            f"{_task_run_api_path(task_run_id)}/observability-summary"
+        )
+
+    assert response.status_code == 200
+    load_record.assert_called_once_with(task_run_id)
+    assert response.json()["summary"]["runId"] == task_run_id
 
 
 def test_get_observability_summary_returns_session_backed_artifact_refs(
@@ -479,6 +511,38 @@ def test_stream_task_run_log_returns_file_response(
     assert mock_file_response.call_args[1]["media_type"] == "text/plain"
     assert response.status_code == 200
     assert response.content == b"mock_log_data"
+
+
+def test_stream_task_run_log_accepts_moonmind_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    task_run_id = f"mm:{uuid4()}"
+    mock_record = MagicMock()
+    mock_record.stdout_artifact_ref = "test/stdout.log"
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ) as load_record:
+        with patch("pathlib.Path.is_file", return_value=True):
+            with patch("pathlib.Path.is_relative_to", return_value=True):
+                with patch(
+                    "api_service.api.routers.task_runs.FileResponse"
+                ) as mock_file_response:
+                    from fastapi.responses import Response
+
+                    mock_file_response.return_value = Response(
+                        content=b"prefixed task output",
+                        media_type="text/plain",
+                    )
+                    response = test_client.get(
+                        f"{_task_run_api_path(task_run_id)}/logs/stdout"
+                    )
+
+    assert response.status_code == 200
+    load_record.assert_called_once_with(task_run_id)
+    assert response.content == b"prefixed task output"
 
 
 @pytest.mark.parametrize(
@@ -1104,6 +1168,38 @@ def test_get_task_run_diagnostics_returns_file_response(
     assert response.content == b'{"mock":"diag"}'
 
 
+def test_get_task_run_diagnostics_accepts_moonmind_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    task_run_id = f"mm:{uuid4()}"
+    mock_record = MagicMock()
+    mock_record.diagnostics_ref = "test/diagnostics.json"
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ) as load_record:
+        with patch("pathlib.Path.is_file", return_value=True):
+            with patch("pathlib.Path.is_relative_to", return_value=True):
+                with patch(
+                    "api_service.api.routers.task_runs.FileResponse"
+                ) as mock_file_response:
+                    from fastapi.responses import Response
+
+                    mock_file_response.return_value = Response(
+                        content=b'{"prefixed":true}',
+                        media_type="application/json",
+                    )
+                    response = test_client.get(
+                        f"{_task_run_api_path(task_run_id)}/diagnostics"
+                    )
+
+    assert response.status_code == 200
+    load_record.assert_called_once_with(task_run_id)
+    assert response.content == b'{"prefixed":true}'
+
+
 @pytest.mark.parametrize(
     ("env_root_name", "artifact_root_name"),
     [
@@ -1196,6 +1292,36 @@ def test_get_task_run_observability_events_reads_structured_spool_history(
     assert body["events"][1]["sessionEpoch"] == 2
     assert body["events"][1]["threadId"] == "thread-2"
     assert "session_id" not in body["events"][1]
+
+
+def test_get_task_run_observability_events_accepts_moonmind_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    task_run_id = f"mm:{uuid4()}"
+    mock_record = MagicMock()
+    mock_record.workspace_path = "/tmp/workspace"
+    mock_record.started_at = datetime(2026, 4, 8, 0, 0, tzinfo=UTC)
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ) as load_record:
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_session_record",
+            return_value=None,
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_task_run_observability_events",
+                return_value=([], "artifacts"),
+            ):
+                response = test_client.get(
+                    f"{_task_run_api_path(task_run_id)}/observability/events"
+                )
+
+    assert response.status_code == 200
+    load_record.assert_called_once_with(task_run_id)
+    assert response.json()["events"] == []
 
 
 def test_get_task_run_observability_events_filters_spool_fallback_rows(
@@ -1882,6 +2008,27 @@ def test_stream_task_run_live_logs_rejects_non_live_capable_active_run(
         response = test_client.get(f"/api/task-runs/{uuid4()}/logs/stream")
 
     assert response.status_code == 400
+    assert response.json()["detail"] == "Live streaming is not supported for this run."
+
+
+def test_stream_task_run_live_logs_accepts_moonmind_task_run_id(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    task_run_id = f"mm:{uuid4()}"
+    mock_record = MagicMock()
+    mock_record.status = "running"
+    mock_record.live_stream_capable = False
+    mock_record.workspace_path = "/tmp/workspace"
+
+    with patch(
+        "api_service.api.routers.task_runs.ManagedRunStore.load",
+        return_value=mock_record,
+    ) as load_record:
+        response = test_client.get(f"{_task_run_api_path(task_run_id)}/logs/stream")
+
+    assert response.status_code == 400
+    load_record.assert_called_once_with(task_run_id)
     assert response.json()["detail"] == "Live streaming is not supported for this run."
 
 


### PR DESCRIPTION
## Summary

Fixes Live Logs failing with `422 Unprocessable Entity` for MoonMind task run ids such as `mm:<uuid>`.

The observability router previously typed task-run path parameters as UUIDs, but the runtime and Mission Control use string task-run ids that can include the `mm:` prefix. FastAPI rejected those requests before the handlers could load the managed run record, leaving the Live Logs viewer stuck waiting for output.

## Changes

- Accept string task-run ids across the task-run observability endpoints.
- Preserve existing managed-run store lookup behavior for UUID and `mm:<uuid>` ids.
- Add regression coverage for encoded `mm%3A...` ids across observability summary, structured events, stdout logs, live stream capability checks, and diagnostics.

## Validation

- `./tools/test_unit.sh tests/unit/api/routers/test_task_runs.py`
- `./tools/test_unit.sh`
- `git diff --check`

Note: `ruff` is not installed in the local virtualenv, so direct ruff verification was unavailable.