### PR TITLE
[codex] Inherit provider profile for batch PR children

### DIFF
--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import httpx
 from moonmind.workflows.tasks.task_contract import resolve_publish_mode_for_skill
+from moonmind.workflows.tasks.runtime_defaults import normalize_runtime_id
 
 
 logger = logging.getLogger(__name__)
@@ -233,6 +234,12 @@ def _runtime_text(value: Any) -> str | None:
     return text or None
 
 
+def _runtime_modes_match(left: str | None, right: str | None) -> bool:
+    if not left or not right:
+        return False
+    return normalize_runtime_id(left) == normalize_runtime_id(right)
+
+
 def _session_artifact_spool_path() -> Path | None:
     raw = _runtime_text(os.getenv("MOONMIND_SESSION_ARTIFACT_SPOOL_PATH"))
     if not raw:
@@ -430,13 +437,21 @@ def _resolve_runtime_selection(args: argparse.Namespace) -> RuntimeSelection:
     runtime_execution_profile_ref = _runtime_text(
         os.getenv("MOONMIND_EXECUTION_PROFILE_REF")
     )
+    runtime_execution_profile_runtime = _runtime_text(
+        os.getenv("MOONMIND_EXECUTION_PROFILE_RUNTIME")
+    )
+    if runtime_mode is None and runtime_execution_profile_ref:
+        runtime_mode = _normalize_runtime_mode(runtime_execution_profile_runtime)
     if runtime_model is None and inherited is not None:
         runtime_model = inherited.model
     if runtime_effort is None and inherited is not None:
         runtime_effort = inherited.effort
     if runtime_provider_profile is None and inherited is not None:
         runtime_provider_profile = inherited.provider_profile
-    if runtime_provider_profile is None:
+    if runtime_provider_profile is None and _runtime_modes_match(
+        runtime_mode,
+        runtime_execution_profile_runtime,
+    ):
         runtime_provider_profile = runtime_execution_profile_ref
 
     return RuntimeSelection(
@@ -469,7 +484,6 @@ def _build_queue_request(
     if runtime.effort:
         runtime_payload["effort"] = runtime.effort
     if runtime.provider_profile:
-        runtime_payload["providerProfile"] = runtime.provider_profile
         runtime_payload["executionProfileRef"] = runtime.provider_profile
 
     payload_dict: dict[str, Any] = {
@@ -767,7 +781,7 @@ async def main() -> int:
             "mode": runtime.mode,
             "model": runtime.model,
             "effort": runtime.effort,
-            "providerProfile": runtime.provider_profile,
+            "executionProfileRef": runtime.provider_profile,
         },
         "requested": len(open_prs),
         "created": len(created),

--- a/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
+++ b/.agents/skills/batch-pr-resolver/bin/batch_pr_resolver.py
@@ -424,13 +424,20 @@ def _resolve_runtime_selection(args: argparse.Namespace) -> RuntimeSelection:
     )
     runtime_model = _runtime_text(args.runtime_model)
     runtime_effort = _runtime_text(args.runtime_effort)
-    runtime_provider_profile = _runtime_text(getattr(args, "runtime_provider_profile", None))
+    runtime_provider_profile = _runtime_text(
+        getattr(args, "runtime_provider_profile", None)
+    )
+    runtime_execution_profile_ref = _runtime_text(
+        os.getenv("MOONMIND_EXECUTION_PROFILE_REF")
+    )
     if runtime_model is None and inherited is not None:
         runtime_model = inherited.model
     if runtime_effort is None and inherited is not None:
         runtime_effort = inherited.effort
     if runtime_provider_profile is None and inherited is not None:
         runtime_provider_profile = inherited.provider_profile
+    if runtime_provider_profile is None:
+        runtime_provider_profile = runtime_execution_profile_ref
 
     return RuntimeSelection(
         mode=runtime_mode,
@@ -463,6 +470,7 @@ def _build_queue_request(
         runtime_payload["effort"] = runtime.effort
     if runtime.provider_profile:
         runtime_payload["providerProfile"] = runtime.provider_profile
+        runtime_payload["executionProfileRef"] = runtime.provider_profile
 
     payload_dict: dict[str, Any] = {
         "repository": repo,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -50,7 +50,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
 from moonmind.workflows.codex_session_timeouts import (
     MAX_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
-from moonmind.workflows.provider_failures import classify_retryable_provider_failure
+from moonmind.workflows.provider_failures import classify_provider_failure
 from moonmind.workflows.tasks.runtime_defaults import resolve_runtime_defaults
 from moonmind.workflows.temporal.runtime.strategies.codex_cli import (
     append_managed_codex_runtime_note,
@@ -1155,7 +1155,7 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         classification_source = (
             summary if str(summary or "").strip() else default_summary
         )
-        classification = classify_retryable_provider_failure(classification_source)
+        classification = classify_provider_failure(classification_source)
         summary_text = _clamp_agent_run_result_summary(
             summary,
             default=default_summary,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -112,6 +112,10 @@ def build_managed_profile_launch_context(
     if account_label:
         delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = str(account_label)
 
+    profile_id = str(profile.get("profile_id") or "").strip()
+    if profile_id:
+        delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"] = profile_id
+
     runtime_env_overrides = profile.get("runtime_env_overrides") or {}
     if isinstance(runtime_env_overrides, dict):
         for key, value in runtime_env_overrides.items():
@@ -127,7 +131,7 @@ def build_managed_profile_launch_context(
 
     passthrough_env_keys = list(_SECRET_ENV_PASSTHROUGH_KEYS)
     return ManagedProfileLaunchContext(
-        profile_id=str(profile.get("profile_id") or "").strip(),
+        profile_id=profile_id,
         credential_source=credential_source,
         delta_env_overrides=delta_env_overrides,
         passthrough_env_keys=passthrough_env_keys,

--- a/moonmind/workflows/adapters/managed_agent_adapter.py
+++ b/moonmind/workflows/adapters/managed_agent_adapter.py
@@ -54,6 +54,12 @@ logger = logging.getLogger(__name__)
 # Only the *key names* are propagated through workflow/activity payloads; the
 # values are injected at launch time by the agent-runtime activity worker.
 _SECRET_ENV_PASSTHROUGH_KEYS: tuple[str, ...] = ("GITHUB_TOKEN",)
+_RESERVED_MANAGED_LAUNCH_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        "MOONMIND_EXECUTION_PROFILE_REF",
+        "MOONMIND_EXECUTION_PROFILE_RUNTIME",
+    }
+)
 
 _PR_RESOLVER_RESULT_PATHS: tuple[Path, ...] = (
     Path("var/pr_resolver/result.json"),
@@ -98,7 +104,7 @@ def build_managed_profile_launch_context(
 ) -> ManagedProfileLaunchContext:
     """Build deterministic launch metadata safe to compute in workflow code."""
 
-    del runtime_for_profile, workflow_id  # Reserved for activity-side shaping.
+    del workflow_id  # Reserved for activity-side shaping.
     credential_source = str(
         profile.get("credential_source") or default_credential_source
     ).strip() or default_credential_source
@@ -113,8 +119,7 @@ def build_managed_profile_launch_context(
         delta_env_overrides["MANAGED_ACCOUNT_LABEL"] = str(account_label)
 
     profile_id = str(profile.get("profile_id") or "").strip()
-    if profile_id:
-        delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"] = profile_id
+    profile_runtime = str(runtime_for_profile or "").strip()
 
     runtime_env_overrides = profile.get("runtime_env_overrides") or {}
     if isinstance(runtime_env_overrides, dict):
@@ -122,12 +127,19 @@ def build_managed_profile_launch_context(
             ks = str(key).strip()
             if not ks:
                 continue
+            if ks in _RESERVED_MANAGED_LAUNCH_ENV_KEYS:
+                continue
             if _contains_sensitive_key(
                 {ks: value},
                 allowed_sensitive_keys=_ALLOWED_MANAGED_LAUNCH_METADATA_KEYS,
             ):
                 continue
             delta_env_overrides[ks] = str(value) if value is not None else ""
+
+    if profile_id:
+        delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"] = profile_id
+    if profile_runtime:
+        delta_env_overrides["MOONMIND_EXECUTION_PROFILE_RUNTIME"] = profile_runtime
 
     passthrough_env_keys = list(_SECRET_ENV_PASSTHROUGH_KEYS)
     return ManagedProfileLaunchContext(

--- a/moonmind/workflows/provider_failures.py
+++ b/moonmind/workflows/provider_failures.py
@@ -7,7 +7,9 @@ from typing import Any
 
 PROVIDER_RATE_LIMIT_ERROR_CODE = "429"
 PROVIDER_CAPACITY_ERROR_CODE = "provider_capacity"
+PROVIDER_AUTH_ERROR_CODE = "401"
 RETRY_AFTER_COOLDOWN_RECOMMENDATION = "retry_after_cooldown"
+REAUTHENTICATE_RECOMMENDATION = "reauthenticate"
 
 _RATE_LIMIT_MARKERS = (
     "429",
@@ -38,6 +40,17 @@ _CAPACITY_MARKERS = (
     "try again later",
 )
 
+_AUTH_FAILURE_MARKERS = (
+    "http 401",
+    "status 401",
+    "401 unauthorized",
+    "unauthorized",
+    "invalid api key",
+    "invalid token",
+    "expired token",
+    "authentication failed",
+)
+
 
 @dataclass(frozen=True)
 class ProviderFailureClassification:
@@ -47,15 +60,22 @@ class ProviderFailureClassification:
     reason: str
 
 
-def classify_retryable_provider_failure(
+def classify_provider_failure(
     reason: Any,
 ) -> ProviderFailureClassification | None:
-    """Return structured metadata for retryable provider capacity failures."""
+    """Return structured metadata for provider failures that need policy handling."""
 
     rendered = str(reason or "").strip()
     if not rendered:
         return None
     normalized = rendered.lower()
+    if any(marker in normalized for marker in _AUTH_FAILURE_MARKERS):
+        return ProviderFailureClassification(
+            failure_class="user_error",
+            provider_error_code=PROVIDER_AUTH_ERROR_CODE,
+            retry_recommendation=REAUTHENTICATE_RECOMMENDATION,
+            reason=rendered,
+        )
     if any(marker in normalized for marker in _RATE_LIMIT_MARKERS):
         return ProviderFailureClassification(
             failure_class="integration_error",
@@ -89,10 +109,12 @@ def provider_error_requires_cooldown(
 
 
 __all__ = [
+    "PROVIDER_AUTH_ERROR_CODE",
     "PROVIDER_CAPACITY_ERROR_CODE",
     "PROVIDER_RATE_LIMIT_ERROR_CODE",
+    "REAUTHENTICATE_RECOMMENDATION",
     "RETRY_AFTER_COOLDOWN_RECOMMENDATION",
     "ProviderFailureClassification",
-    "classify_retryable_provider_failure",
+    "classify_provider_failure",
     "provider_error_requires_cooldown",
 ]

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -41,7 +41,7 @@ with workflow.unsafe.imports_passed_through():
         workflow_id_for_runtime,
     )
     from moonmind.workflows.provider_failures import (
-        classify_retryable_provider_failure,
+        classify_provider_failure,
         provider_error_requires_cooldown,
     )
 
@@ -410,7 +410,7 @@ class MoonMindAgentRun:
                 mode="json",
                 by_alias=True,
             )
-        classification = classify_retryable_provider_failure(summary)
+        classification = classify_provider_failure(summary)
         if classification is not None:
             metadata["providerFailure"] = {
                 "providerErrorCode": classification.provider_error_code,

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -107,8 +107,8 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["runtime"]["mode"] == "codex"
     assert task["runtime"]["model"] == "gpt-5-codex"
     assert task["runtime"]["effort"] == "high"
-    assert task["runtime"]["providerProfile"] == "test-profile"
     assert task["runtime"]["executionProfileRef"] == "test-profile"
+    assert "providerProfile" not in task["runtime"]
     assert task["title"] == "feature/example"
     assert task["publish"]["mode"] == "none"
     assert git["startingBranch"] == "feature/example"
@@ -433,6 +433,7 @@ def test_resolve_runtime_selection_uses_execution_profile_env(
 
     monkeypatch.delenv("MOONMIND_DEFAULT_TASK_RUNTIME", raising=False)
     monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_REF", "codex_default")
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_RUNTIME", "codex_cli")
 
     args = type(
         "Args",
@@ -447,7 +448,34 @@ def test_resolve_runtime_selection_uses_execution_profile_env(
     )()
 
     runtime = resolve_runtime_selection(args)
+    assert runtime.mode == "codex_cli"
     assert runtime.provider_profile == "codex_default"
+
+
+def test_resolve_runtime_selection_ignores_env_profile_for_other_runtime(
+    monkeypatch: Any,
+) -> None:
+    module = _load_module()
+    resolve_runtime_selection = module["_resolve_runtime_selection"]
+
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_REF", "codex_default")
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_RUNTIME", "codex_cli")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "task_context_path": None,
+            "runtime_mode": "gemini_cli",
+            "runtime_model": None,
+            "runtime_effort": None,
+            "runtime_provider_profile": None,
+        },
+    )()
+
+    runtime = resolve_runtime_selection(args)
+    assert runtime.mode == "gemini_cli"
+    assert runtime.provider_profile is None
 
 
 def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Path):

--- a/tests/unit/test_batch_pr_resolver.py
+++ b/tests/unit/test_batch_pr_resolver.py
@@ -108,6 +108,7 @@ def test_build_queue_request_sets_none_publish_with_matching_branches():
     assert task["runtime"]["model"] == "gpt-5-codex"
     assert task["runtime"]["effort"] == "high"
     assert task["runtime"]["providerProfile"] == "test-profile"
+    assert task["runtime"]["executionProfileRef"] == "test-profile"
     assert task["title"] == "feature/example"
     assert task["publish"]["mode"] == "none"
     assert git["startingBranch"] == "feature/example"
@@ -422,6 +423,31 @@ def test_resolve_runtime_selection_uses_inherited_values(tmp_path: Path):
     assert runtime.model == "claude-3.7-sonnet"
     assert runtime.effort == "low"
     assert runtime.provider_profile == "inherited-profile"
+
+
+def test_resolve_runtime_selection_uses_execution_profile_env(
+    monkeypatch: Any,
+) -> None:
+    module = _load_module()
+    resolve_runtime_selection = module["_resolve_runtime_selection"]
+
+    monkeypatch.delenv("MOONMIND_DEFAULT_TASK_RUNTIME", raising=False)
+    monkeypatch.setenv("MOONMIND_EXECUTION_PROFILE_REF", "codex_default")
+
+    args = type(
+        "Args",
+        (),
+        {
+            "task_context_path": None,
+            "runtime_mode": None,
+            "runtime_model": None,
+            "runtime_effort": None,
+            "runtime_provider_profile": None,
+        },
+    )()
+
+    runtime = resolve_runtime_selection(args)
+    assert runtime.provider_profile == "codex_default"
 
 
 def test_resolve_runtime_selection_prefers_explicit_over_inherited(tmp_path: Path):

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -672,6 +672,87 @@ async def test_start_classifies_codex_provider_capacity_failure_and_publishes_ar
     assert persisted_record.diagnostics_ref == "artifact:diagnostics"
 
 
+async def test_start_classifies_codex_auth_failure_as_user_error(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    reason = "turn failed: http 401"
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            status="failed",
+            assistant_text="",
+        ).model_copy(update={"metadata": {"reason": reason}})
+
+    async def _publish_artifacts(
+        _request: Any,
+    ) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(),
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await adapter.start(_request(binding, workspace_path=str(workspace_path)))
+
+    result = excinfo.value.agent_run_result
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
+    assert result.metadata["providerFailure"]["providerErrorCode"] == "401"
+    assert result.metadata["profileId"] == "codex-default"
+
+    persisted_record = run_store.load(binding.task_run_id)
+    assert persisted_record is not None
+    assert persisted_record.failure_class == "user_error"
+    assert persisted_record.provider_error_code == "401"
+
+
 async def test_publish_failure_artifacts_logs_best_effort_failure(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -163,6 +163,37 @@ async def test_launch_context_exports_execution_profile_ref() -> None:
         context.delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"]
         == "codex_default"
     )
+    assert (
+        context.delta_env_overrides["MOONMIND_EXECUTION_PROFILE_RUNTIME"]
+        == "codex_cli"
+    )
+
+
+async def test_launch_context_reserved_execution_profile_keys_cannot_be_overridden() -> None:
+    context = build_managed_profile_launch_context(
+        profile={
+            "profile_id": "codex_default",
+            "credential_source": "oauth_volume",
+            "runtime_env_overrides": {
+                "MOONMIND_EXECUTION_PROFILE_REF": "wrong-profile",
+                "MOONMIND_EXECUTION_PROFILE_RUNTIME": "gemini_cli",
+                "SAFE_RUNTIME_FLAG": "enabled",
+            },
+        },
+        runtime_for_profile="codex_cli",
+        workflow_id="wf-agent-run-1",
+        default_credential_source="oauth_volume",
+    )
+
+    assert (
+        context.delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"]
+        == "codex_default"
+    )
+    assert (
+        context.delta_env_overrides["MOONMIND_EXECUTION_PROFILE_RUNTIME"]
+        == "codex_cli"
+    )
+    assert context.delta_env_overrides["SAFE_RUNTIME_FLAG"] == "enabled"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/adapters/test_managed_agent_adapter.py
+++ b/tests/unit/workflows/adapters/test_managed_agent_adapter.py
@@ -36,6 +36,7 @@ from moonmind.auth.env_shaping import (
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ProfileResolutionError,
+    build_managed_profile_launch_context,
 )
 from moonmind.workflows.temporal.artifacts import (
     LocalTemporalArtifactStore,
@@ -144,6 +145,24 @@ async def test_shape_environment_for_api_key_without_ref():
     shaped = shape_environment_for_api_key(base, api_key_ref=None, account_label=None)
     assert "MANAGED_API_KEY_REF" not in shaped
     assert "MANAGED_ACCOUNT_LABEL" not in shaped
+
+
+async def test_launch_context_exports_execution_profile_ref() -> None:
+    context = build_managed_profile_launch_context(
+        profile={
+            "profile_id": "codex_default",
+            "credential_source": "oauth_volume",
+        },
+        runtime_for_profile="codex_cli",
+        workflow_id="wf-agent-run-1",
+        default_credential_source="oauth_volume",
+    )
+
+    assert context.profile_id == "codex_default"
+    assert (
+        context.delta_env_overrides["MOONMIND_EXECUTION_PROFILE_REF"]
+        == "codex_default"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/test_provider_failures.py
+++ b/tests/unit/workflows/test_provider_failures.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from moonmind.workflows.provider_failures import (
-    classify_retryable_provider_failure,
+    classify_provider_failure,
     provider_error_requires_cooldown,
 )
 
 
 def test_classifies_high_demand_as_provider_capacity() -> None:
-    result = classify_retryable_provider_failure(
+    result = classify_provider_failure(
         "We're currently experiencing high demand, which may cause temporary errors."
     )
 
@@ -18,17 +18,26 @@ def test_classifies_high_demand_as_provider_capacity() -> None:
 
 
 def test_classifies_http_500_as_provider_capacity() -> None:
-    result = classify_retryable_provider_failure("http 500")
+    result = classify_provider_failure("http 500")
 
     assert result is not None
     assert result.provider_error_code == "provider_capacity"
 
 
 def test_classifies_rate_limit_as_429() -> None:
-    result = classify_retryable_provider_failure("Too many requests: rate limit")
+    result = classify_provider_failure("Too many requests: rate limit")
 
     assert result is not None
     assert result.provider_error_code == "429"
+
+
+def test_classifies_http_401_as_auth_user_error() -> None:
+    result = classify_provider_failure("turn failed: http 401")
+
+    assert result is not None
+    assert result.failure_class == "user_error"
+    assert result.provider_error_code == "401"
+    assert result.retry_recommendation == "reauthenticate"
 
 
 def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> None:
@@ -43,4 +52,11 @@ def test_provider_cooldown_accepts_capacity_code_or_retry_recommendation() -> No
     assert not provider_error_requires_cooldown(
         provider_error_code="branch_publish_failed",
         retry_recommendation=None,
+    )
+
+
+def test_provider_cooldown_rejects_auth_reauthenticate_failure() -> None:
+    assert not provider_error_requires_cooldown(
+        provider_error_code="401",
+        retry_recommendation="reauthenticate",
     )


### PR DESCRIPTION
## Summary

- propagate the selected managed provider profile into Codex launch environments as `MOONMIND_EXECUTION_PROFILE_REF`
- have `batch-pr-resolver` use that execution profile when queueing child `pr-resolver` tasks
- classify provider auth failures separately from retryable capacity/rate-limit failures so they surface as reauthentication-required user errors instead of cooldown waits

## Root Cause

`batch-pr-resolver` children were queued with only the runtime kind unless an explicit provider profile was passed into the skill. After the batch task released its profile, child tasks could fall back to other Codex profiles and sit behind cooldown behavior. Separately, auth failures were grouped with retryable provider failures, which made operator action less clear.

## Validation

- `git diff --check`
- `./tools/test_unit.sh --python-only tests/unit/workflows/test_provider_failures.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/test_batch_pr_resolver.py tests/unit/workflows/adapters/test_managed_agent_adapter.py`
- `./tools/test_unit.sh`