### PR TITLE
[codex] Terminate Codex managed sessions on finalization

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_session.py
+++ b/moonmind/workflows/temporal/workflows/agent_session.py
@@ -529,7 +529,6 @@ class MoonMindAgentSessionWorkflow:
     ) -> dict[str, Any]:
         request = CodexManagedSessionWorkflowControlRequest.model_validate(payload or {})
         self._status = AGENT_SESSION_STATUS_TERMINATING
-        self._termination_requested = True
         self._last_control_action = "terminate_session"
         self._last_control_reason = request.reason
         if self._container_id and self._thread_id:
@@ -559,6 +558,7 @@ class MoonMindAgentSessionWorkflow:
                     last_control_action="terminate_session",
                     last_control_reason=request.reason,
                 )
+        self._termination_requested = True
         return self.get_status()
 
     @terminate_session_update.validator

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -151,6 +151,11 @@ RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH = "run-task-scoped-session-termination
 # identifier says "update" for in-flight history continuity, but current
 # Temporal external workflow handles expose the session control surface by signal.
 RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH = "run-task-scoped-session-termination-v2"
+# Replay-stable patch id for task-scoped Codex termination through the
+# AgentSession update handler. This path executes the remote terminate activity.
+RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH = (
+    "run-task-scoped-session-termination-v3"
+)
 # Replay-stable patch id for skipping registry reads on agent-runtime-only plans.
 RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
@@ -2312,7 +2317,14 @@ class MoonMindRunWorkflow:
                 session_handle = workflow.get_external_workflow_handle(
                     binding.workflow_id
                 )
-                if workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
+                if workflow.patched(
+                    RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
+                ):
+                    await session_handle.execute_update(
+                        "TerminateSession",
+                        {"reason": reason},
+                    )
+                elif workflow.patched(RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH):
                     await session_handle.signal(
                         "control_action",
                         {

--- a/tests/unit/workflows/temporal/workflows/test_agent_session.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_session.py
@@ -163,6 +163,7 @@ async def test_agent_session_terminate_update_executes_remote_terminate_when_han
     ) -> dict[str, object]:
         captured.append((activity_name, payload, kwargs))
         if activity_name == "agent_runtime.terminate_session":
+            assert workflow._termination_requested is False
             return {
                 "sessionState": {
                     "sessionId": "sess:wf-run-1:codex_cli",

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -9,6 +9,7 @@ from moonmind.schemas.managed_session_models import CodexManagedSessionBinding
 from moonmind.workflows.temporal.workflows import run as run_module
 from moonmind.workflows.temporal.workflows.run import (
     RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
+    RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
     RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
     MoonMindRunWorkflow,
 )
@@ -129,7 +130,51 @@ async def test_run_skips_task_scoped_session_for_non_codex_managed_runtime(
 
 
 @pytest.mark.asyncio
-async def test_run_terminates_active_task_scoped_codex_session(
+async def test_run_termination_v3_executes_session_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindRunWorkflow()
+    _configure_workflow_runtime(monkeypatch)
+    update_calls: list[tuple[str, Any]] = []
+    signal_calls: list[tuple[str, Any]] = []
+    patch_calls: list[str] = []
+
+    def fake_patched(patch_id: str) -> bool:
+        patch_calls.append(patch_id)
+        return patch_id == RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH
+
+    class _FakeHandle:
+        async def execute_update(self, update_name: str, payload: Any = None) -> None:
+            update_calls.append((update_name, payload))
+
+        async def signal(self, signal_name: str, payload: Any = None) -> None:
+            signal_calls.append((signal_name, payload))
+
+    monkeypatch.setattr(run_module.workflow, "patched", fake_patched)
+
+    external_handle = _FakeHandle()
+    _use_external_handle(monkeypatch, external_handle)
+    workflow._codex_session_handle = object()
+    workflow._codex_session_binding = CodexManagedSessionBinding(
+        workflowId="wf-run-1:session:codex_cli",
+        taskRunId="wf-run-1",
+        sessionId="sess:wf-run-1:codex_cli",
+        sessionEpoch=1,
+        runtimeId="codex_cli",
+        executionProfileRef="codex-default",
+    )
+
+    await workflow._terminate_task_scoped_sessions(reason="success")
+
+    assert update_calls == [("TerminateSession", {"reason": "success"})]
+    assert signal_calls == []
+    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH]
+    assert workflow._codex_session_handle is None
+    assert workflow._codex_session_binding is None
+
+
+@pytest.mark.asyncio
+async def test_run_terminates_active_task_scoped_codex_session_with_v2_signal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     workflow = MoonMindRunWorkflow()
@@ -175,7 +220,10 @@ async def test_run_terminates_active_task_scoped_codex_session(
             },
         )
     ]
-    assert patch_calls == [RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH]
+    assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
+        RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
+    ]
     assert workflow._codex_session_handle is None
     assert workflow._codex_session_binding is None
 
@@ -323,6 +371,7 @@ async def test_run_termination_uses_v1_patch_history_for_inflight_runs(
         )
     ]
     assert patch_calls == [
+        RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_EXECUTE_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_UPDATE_PATCH,
         RUN_TASK_SCOPED_SESSION_TERMINATION_PATCH,
     ]


### PR DESCRIPTION
## Summary

- Route new `MoonMind.Run` task-scoped Codex session finalization through the `TerminateSession` update so the session workflow executes the real remote terminate activity.
- Delay the session workflow termination flag until after the terminate activity path has been attempted.
- Add regression coverage for the new finalizer update path while preserving replay coverage for the older signal/activity paths.

## Root Cause

Codex managed session containers were launched detached and only removed by `agent_runtime.terminate_session`. The normal parent finalizer had moved to a signal-only control path that marked the session workflow terminating without invoking the controller cleanup path, leaving Docker containers behind.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py tests/unit/workflows/temporal/workflows/test_agent_session.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- `./tools/test_unit.sh`