### PR TITLE
When you edit a provider profile in the UI, you should be able to check runtime default and then click "Update provider profile" and have the default…

### DIFF
--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -54,15 +54,12 @@ async def normalize_runtime_default_profile(
     selected_id = selected.profile_id
     changed = False
     for row in rows:
-        if row.profile_id != selected_id and row.is_default:
-            row.is_default = False
+        should_be_default = row.profile_id == selected_id
+        if row.is_default != should_be_default:
+            row.is_default = should_be_default
             changed = True
 
     if changed:
-        await session.flush()
-
-    if not selected.is_default:
-        selected.is_default = True
         await session.flush()
 
     return selected_id

--- a/api_service/services/provider_profile_service.py
+++ b/api_service/services/provider_profile_service.py
@@ -54,12 +54,15 @@ async def normalize_runtime_default_profile(
     selected_id = selected.profile_id
     changed = False
     for row in rows:
-        should_be_default = row.profile_id == selected_id
-        if row.is_default != should_be_default:
-            row.is_default = should_be_default
+        if row.profile_id != selected_id and row.is_default:
+            row.is_default = False
             changed = True
 
     if changed:
+        await session.flush()
+
+    if not selected.is_default:
+        selected.is_default = True
         await session.flush()
 
     return selected_id

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
-import { fireEvent, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { ProviderProfile } from './ProviderProfilesManager';
 import {
   defaultFormState,
@@ -12,6 +12,10 @@ import {
   parseClearEnvKeys,
 } from './ProviderProfilesManager';
 import { renderWithClient } from '../../utils/test-utils';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function renderProviderProfilesManager(profiles: ProviderProfile[] = []) {
   const queryClient = new QueryClient({
@@ -273,5 +277,42 @@ describe('ProviderProfilesManager form controls', () => {
 
     expect(screen.getAllByRole('button', { name: 'Cancel edit' })).toHaveLength(1);
     expect(screen.queryByRole('button', { name: 'Reset form' })).toBeNull();
+  });
+
+  it('sends runtime default changes when updating an edited profile', async () => {
+    const fetchSpy = vi.spyOn(window, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...profile, profile_id: 'codex-secondary', is_default: true }),
+    } as Response);
+    const secondaryProfile: ProviderProfile = {
+      ...profile,
+      profile_id: 'codex-secondary',
+      is_default: false,
+    };
+
+    renderProviderProfilesManager([profile, secondaryProfile]);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+    const runtimeDefaultCheckbox = screen.getByLabelText('Runtime default') as HTMLInputElement;
+    expect(runtimeDefaultCheckbox.checked).toBe(false);
+
+    fireEvent.click(runtimeDefaultCheckbox);
+    const submitButton = screen.getByRole('button', { name: 'Update provider profile' });
+    fireEvent.submit(submitButton.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/provider-profiles/codex-secondary',
+        expect.objectContaining({
+          method: 'PATCH',
+        }),
+      );
+    });
+
+    const [, requestInit] = fetchSpy.mock.calls[0];
+    const payload = JSON.parse(String((requestInit as RequestInit).body));
+    expect(payload.profile_id).toBe('codex-secondary');
+    expect(payload.runtime_id).toBe('codex_cli');
+    expect(payload.is_default).toBe(true);
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -311,8 +311,6 @@ describe('ProviderProfilesManager form controls', () => {
 
     const [, requestInit] = fetchSpy.mock.calls[0];
     const payload = JSON.parse(String((requestInit as RequestInit).body));
-    expect(payload.profile_id).toBe('codex-secondary');
-    expect(payload.runtime_id).toBe('codex_cli');
     expect(payload.is_default).toBe(true);
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -292,13 +292,22 @@ describe('ProviderProfilesManager form controls', () => {
 
     renderProviderProfilesManager([profile, secondaryProfile]);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[1]);
+    const editButtons = screen.getAllByRole('button', { name: 'Edit' });
+    const secondaryEditButton = editButtons[1];
+    if (!secondaryEditButton) {
+      throw new Error('Expected secondary provider profile edit button');
+    }
+    fireEvent.click(secondaryEditButton);
     const runtimeDefaultCheckbox = screen.getByLabelText('Runtime default') as HTMLInputElement;
     expect(runtimeDefaultCheckbox.checked).toBe(false);
 
     fireEvent.click(runtimeDefaultCheckbox);
     const submitButton = screen.getByRole('button', { name: 'Update provider profile' });
-    fireEvent.submit(submitButton.closest('form') as HTMLFormElement);
+    const form = submitButton.closest('form');
+    if (!form) {
+      throw new Error('Expected provider profile update form');
+    }
+    fireEvent.submit(form);
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -309,7 +318,11 @@ describe('ProviderProfilesManager form controls', () => {
       );
     });
 
-    const [, requestInit] = fetchSpy.mock.calls[0];
+    const fetchCall = fetchSpy.mock.calls[0];
+    if (!fetchCall) {
+      throw new Error('Expected provider profile update request');
+    }
+    const [, requestInit] = fetchCall;
     const payload = JSON.parse(String((requestInit as RequestInit).body));
     expect(payload.is_default).toBe(true);
   });

--- a/tests/unit/api_service/api/routers/test_provider_profiles.py
+++ b/tests/unit/api_service/api/routers/test_provider_profiles.py
@@ -141,6 +141,52 @@ async def test_create_second_profile_can_become_runtime_default(
 
 
 @pytest.mark.asyncio
+async def test_update_profile_can_become_runtime_default(
+    client_app: AsyncClient,
+    _module_db,
+):
+    first_payload = {
+        "profile_id": "patch_runtime_default_first",
+        "runtime_id": "patch_runtime_default",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://patch_first_secret"},
+        "enabled": True,
+        "is_default": True,
+    }
+    second_payload = {
+        "profile_id": "patch_runtime_default_second",
+        "runtime_id": "patch_runtime_default",
+        "credential_source": "secret_ref",
+        "runtime_materialization_mode": "api_key_env",
+        "secret_refs": {"API_KEY": "env://patch_second_secret"},
+        "enabled": True,
+    }
+
+    async with client_app as client:
+        first_response = await client.post("/api/v1/provider-profiles", json=first_payload)
+        second_response = await client.post("/api/v1/provider-profiles", json=second_payload)
+        update_response = await client.patch(
+            "/api/v1/provider-profiles/patch_runtime_default_second",
+            json={"is_default": True},
+        )
+        listed = await client.get(
+            "/api/v1/provider-profiles",
+            params={"runtime_id": "patch_runtime_default"},
+        )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+    assert update_response.status_code == 200
+    assert update_response.json()["is_default"] is True
+    assert listed.status_code == 200
+
+    profiles = {profile["profile_id"]: profile for profile in listed.json()}
+    assert profiles["patch_runtime_default_first"]["is_default"] is False
+    assert profiles["patch_runtime_default_second"]["is_default"] is True
+
+
+@pytest.mark.asyncio
 async def test_create_provider_profile_invalid_secret_refs(client_app: AsyncClient, _module_db):
     """Test that creating a profile with raw secrets fails."""
     payload = {


### PR DESCRIPTION
When you edit a provider profile in the UI, you should be able to check runtime default and then click "Update provider profile" and have the default change. Implement this and make sure unit and/or integration tests verify this functionality.