### PR TITLE
[codex] Fix agent slot wait manager reset

### DIFF
--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -486,6 +486,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
         ),
         TemporalActivityDefinition(
+            activity_type="provider_profile.manager_state",
+            family="provider_profile",
+            capability_class="artifacts",
+            task_queue=cfg.activity_artifacts_task_queue,
+            fleet=ARTIFACTS_FLEET,
+            timeouts=TemporalActivityTimeouts(30, 60),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=30),
+        ),
+        TemporalActivityDefinition(
             activity_type="provider_profile.verify_lease_holders",
             family="provider_profile",
             capability_class="artifacts",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -331,6 +331,7 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
     "provider_profile.list": ("artifacts", "provider_profile_list"),
     "provider_profile.ensure_manager": ("artifacts", "provider_profile_ensure_manager"),
     "provider_profile.reset_manager": ("artifacts", "provider_profile_reset_manager"),
+    "provider_profile.manager_state": ("artifacts", "provider_profile_manager_state"),
     "provider_profile.verify_lease_holders": (
         "artifacts",
         "provider_profile_verify_lease_holders",

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2388,6 +2388,47 @@ class TemporalArtifactActivities:
         )
         return {"reset": True, "workflow_id": workflow_id}
 
+    async def provider_profile_manager_state(
+        self,
+        *,
+        runtime_id: str,
+    ) -> dict[str, Any]:
+        """Return the ProviderProfileManager query state for slot-wait diagnosis."""
+
+        from temporalio.service import RPCError
+
+        from moonmind.workflows.temporal.client import TemporalClientAdapter
+        from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+            workflow_id_for_runtime,
+        )
+
+        workflow_id = workflow_id_for_runtime(runtime_id)
+        adapter = TemporalClientAdapter()
+        client = await adapter.get_client()
+
+        try:
+            state = await client.get_workflow_handle(workflow_id).query("get_state")
+        except RPCError as exc:
+            return {
+                "running": False,
+                "workflow_id": workflow_id,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            }
+
+        if not isinstance(state, dict):
+            return {
+                "running": False,
+                "workflow_id": workflow_id,
+                "error_type": "InvalidQueryPayload",
+            }
+
+        return {
+            "running": True,
+            "workflow_id": workflow_id,
+            "state": state,
+        }
+
     async def provider_profile_verify_lease_holders(
         self,
         *,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -2392,8 +2392,9 @@ class TemporalArtifactActivities:
         self,
         *,
         runtime_id: str,
+        requester_workflow_id: str | None = None,
     ) -> dict[str, Any]:
-        """Return the ProviderProfileManager query state for slot-wait diagnosis."""
+        """Return a compact ProviderProfileManager health snapshot."""
 
         from temporalio.service import RPCError
 
@@ -2405,13 +2406,34 @@ class TemporalArtifactActivities:
         workflow_id = workflow_id_for_runtime(runtime_id)
         adapter = TemporalClientAdapter()
         client = await adapter.get_client()
+        handle = client.get_workflow_handle(workflow_id)
 
         try:
-            state = await client.get_workflow_handle(workflow_id).query("get_state")
+            description = await handle.describe()
         except RPCError as exc:
             return {
                 "running": False,
                 "workflow_id": workflow_id,
+                "status": f"RPC_ERROR_{exc.status.name}",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            }
+
+        status_name = description.status.name
+        if status_name != "RUNNING":
+            return {
+                "running": False,
+                "workflow_id": workflow_id,
+                "status": status_name,
+            }
+
+        try:
+            state = await handle.query("get_state")
+        except RPCError as exc:
+            return {
+                "running": False,
+                "workflow_id": workflow_id,
+                "status": f"RPC_ERROR_{exc.status.name}",
                 "error_type": type(exc).__name__,
                 "error": str(exc),
             }
@@ -2420,13 +2442,31 @@ class TemporalArtifactActivities:
             return {
                 "running": False,
                 "workflow_id": workflow_id,
+                "status": status_name,
                 "error_type": "InvalidQueryPayload",
             }
+
+        profiles = state.get("profiles")
+        pending_requests = state.get("pending_requests")
+        event_count = state.get("event_count")
+        requester_pending = False
+        if requester_workflow_id and isinstance(pending_requests, list):
+            requester_pending = any(
+                isinstance(request, dict)
+                and request.get("requester_workflow_id") == requester_workflow_id
+                for request in pending_requests
+            )
 
         return {
             "running": True,
             "workflow_id": workflow_id,
-            "state": state,
+            "status": status_name,
+            "profile_count": len(profiles) if isinstance(profiles, dict) else 0,
+            "pending_requests_count": (
+                len(pending_requests) if isinstance(pending_requests, list) else 0
+            ),
+            "event_count": event_count if isinstance(event_count, int) else None,
+            "requester_pending": requester_pending,
         }
 
     async def provider_profile_verify_lease_holders(

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -106,6 +106,7 @@ MANAGED_SESSION_FETCH_RESULT_ACTIVITY_PATCH_ID = (
 MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-prepare-turn-instructions-activity-v1"
 )
+MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.Run (run.py:50).
@@ -596,13 +597,18 @@ class MoonMindAgentRun:
             signal_payload["profile_selector"] = profile_selector
         if not request_slot:
             return manager_handle
-        try:
-            await manager_handle.signal("request_slot", signal_payload)
-        except ApplicationError as exc:
-            if "ExternalWorkflowExecutionNotFound" not in (
-                getattr(exc, "type", None) or str(exc)
-            ):
-                raise
+
+        for attempt in range(2):
+            try:
+                await manager_handle.signal("request_slot", signal_payload)
+                return manager_handle
+            except ApplicationError as exc:
+                if "ExternalWorkflowExecutionNotFound" not in (
+                    getattr(exc, "type", None) or str(exc)
+                ):
+                    raise
+                if attempt > 0:
+                    raise
             self._get_logger().warning(
                 "ProviderProfileManager %s not found, auto-starting via activity",
                 manager_id,
@@ -612,10 +618,25 @@ class MoonMindAgentRun:
                 {"runtime_id": runtime_id},
                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
             )
-            # Re-acquire handle and retry signal once.
+            # Re-acquire handle and retry the signal.
             manager_handle = workflow.get_external_workflow_handle(manager_id)
-            await manager_handle.signal("request_slot", signal_payload)
         return manager_handle
+
+    async def _manager_state_for_slot_wait(
+        self,
+        *,
+        runtime_id: str,
+    ) -> dict[str, Any]:
+        """Fetch a compact manager-health snapshot before resetting it."""
+
+        result = await self._execute_routed_activity(
+            "provider_profile.manager_state",
+            {"runtime_id": runtime_id},
+            cancellation_type=ActivityCancellationType.TRY_CANCEL,
+        )
+        if isinstance(result, dict):
+            return result
+        return {"running": False, "error": "invalid_manager_state_payload"}
 
     async def _reset_and_request_slot(
         self,
@@ -639,18 +660,13 @@ class MoonMindAgentRun:
             {"runtime_id": runtime_id},
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
-        # Re-acquire handle and request slot from the fresh manager.
-        manager_handle = workflow.get_external_workflow_handle(manager_id)
-        signal_payload = {
-            "requester_workflow_id": workflow.info().workflow_id,
-            "runtime_id": runtime_id,
-        }
-        if execution_profile_ref:
-            signal_payload["execution_profile_ref"] = execution_profile_ref
-        if profile_selector:
-            signal_payload["profile_selector"] = profile_selector
-        await manager_handle.signal("request_slot", signal_payload)
-        return manager_handle
+        return await self._ensure_manager_and_signal(
+            manager_id,
+            runtime_id,
+            request_slot=True,
+            execution_profile_ref=execution_profile_ref,
+            profile_selector=profile_selector,
+        )
 
     async def _sync_manager_profiles(
         self,
@@ -1024,12 +1040,42 @@ class MoonMindAgentRun:
                                         type="SlotAcquisitionTimeout",
                                         non_retryable=True,
                                     )
+                                if workflow.patched(MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID):
+                                    manager_state = await self._manager_state_for_slot_wait(
+                                        runtime_id=runtime_id,
+                                    )
+                                    if manager_state.get("running") is True:
+                                        selector_payload = request.profile_selector.model_dump(
+                                            by_alias=True,
+                                            exclude_none=True,
+                                        )
+                                        self._get_logger().warning(
+                                            "Auth profile manager %s is responsive while %s waits for a slot; re-requesting without reset",
+                                            manager_id,
+                                            workflow.info().workflow_id,
+                                        )
+                                        manager_handle = await self._ensure_manager_and_signal(
+                                            manager_id,
+                                            runtime_id,
+                                            request_slot=True,
+                                            execution_profile_ref=request.execution_profile_ref,
+                                            profile_selector=selector_payload,
+                                        )
+                                        await self._sync_manager_profiles(
+                                            manager_handle=manager_handle,
+                                            runtime_id=runtime_id,
+                                        )
+                                        continue
                                 self.slot_assigned_event.clear()
+                                selector_payload = request.profile_selector.model_dump(
+                                    by_alias=True,
+                                    exclude_none=True,
+                                )
                                 manager_handle = await self._reset_and_request_slot(
-                                    manager_id, 
+                                    manager_id,
                                     runtime_id,
                                     execution_profile_ref=request.execution_profile_ref,
-                                    profile_selector=request.profile_selector.model_dump(by_alias=True, exclude_none=True),
+                                    profile_selector=selector_payload,
                                 )
                                 await self._sync_manager_profiles(
                                     manager_handle=manager_handle,

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -626,12 +626,16 @@ class MoonMindAgentRun:
         self,
         *,
         runtime_id: str,
+        requester_workflow_id: str,
     ) -> dict[str, Any]:
         """Fetch a compact manager-health snapshot before resetting it."""
 
         result = await self._execute_routed_activity(
             "provider_profile.manager_state",
-            {"runtime_id": runtime_id},
+            {
+                "runtime_id": runtime_id,
+                "requester_workflow_id": requester_workflow_id,
+            },
             cancellation_type=ActivityCancellationType.TRY_CANCEL,
         )
         if isinstance(result, dict):
@@ -1040,15 +1044,41 @@ class MoonMindAgentRun:
                                         type="SlotAcquisitionTimeout",
                                         non_retryable=True,
                                     )
+                                selector_payload = request.profile_selector.model_dump(
+                                    by_alias=True,
+                                    exclude_none=True,
+                                )
                                 if workflow.patched(MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID):
-                                    manager_state = await self._manager_state_for_slot_wait(
-                                        runtime_id=runtime_id,
-                                    )
-                                    if manager_state.get("running") is True:
-                                        selector_payload = request.profile_selector.model_dump(
-                                            by_alias=True,
-                                            exclude_none=True,
+                                    try:
+                                        manager_state = await self._manager_state_for_slot_wait(
+                                            runtime_id=runtime_id,
+                                            requester_workflow_id=workflow.info().workflow_id,
                                         )
+                                    except CancelledError:
+                                        raise
+                                    except Exception as exc:
+                                        self._get_logger().warning(
+                                            "Auth profile manager %s state inspection failed while %s waits for a slot; falling back to reset path: %s",
+                                            manager_id,
+                                            workflow.info().workflow_id,
+                                            exc,
+                                        )
+                                        manager_state = {"running": False}
+                                    if manager_state.get("running") is True:
+                                        if manager_state.get("requester_pending") is True:
+                                            self._get_logger().warning(
+                                                "Auth profile manager %s is responsive while %s already waits in the pending queue; continuing without reset or duplicate request",
+                                                manager_id,
+                                                workflow.info().workflow_id,
+                                            )
+                                            manager_handle = workflow.get_external_workflow_handle(
+                                                manager_id
+                                            )
+                                            await self._sync_manager_profiles(
+                                                manager_handle=manager_handle,
+                                                runtime_id=runtime_id,
+                                            )
+                                            continue
                                         self._get_logger().warning(
                                             "Auth profile manager %s is responsive while %s waits for a slot; re-requesting without reset",
                                             manager_id,
@@ -1067,10 +1097,6 @@ class MoonMindAgentRun:
                                         )
                                         continue
                                 self.slot_assigned_event.clear()
-                                selector_payload = request.profile_selector.model_dump(
-                                    by_alias=True,
-                                    exclude_none=True,
-                                )
                                 manager_handle = await self._reset_and_request_slot(
                                     manager_id,
                                     runtime_id,

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -582,6 +582,26 @@ def test_provider_profile_sync_slot_leases_in_catalog():
     assert route.fleet == "artifacts"
 
 
+def test_provider_profile_manager_state_activity_in_catalog():
+    from moonmind.workflows.temporal.activity_catalog import (
+        build_default_activity_catalog,
+    )
+
+    catalog = build_default_activity_catalog()
+    route = catalog.resolve_activity("provider_profile.manager_state")
+    assert route.task_queue == "mm.activity.artifacts"
+    assert route.fleet == "artifacts"
+
+
+def test_provider_profile_manager_state_runtime_binding():
+    from moonmind.workflows.temporal.activity_runtime import _ACTIVITY_HANDLER_ATTRS
+
+    assert _ACTIVITY_HANDLER_ATTRS["provider_profile.manager_state"] == (
+        "artifacts",
+        "provider_profile_manager_state",
+    )
+
+
 # ---------------------------------------------------------------------------
 # DB Lease Sync: workflow-side behavior tests
 # ---------------------------------------------------------------------------
@@ -793,3 +813,9 @@ def test_verify_lease_holders_exists():
     assert hasattr(MoonMindProviderProfileManagerWorkflow, "_verify_lease_holders")
     verify_lease_holders = getattr(MoonMindProviderProfileManagerWorkflow, "_verify_lease_holders")
     assert callable(verify_lease_holders)
+
+
+def test_provider_profile_manager_state_activity_exists():
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    assert hasattr(TemporalArtifactActivities, "provider_profile_manager_state")

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import patch
+
+import pytest
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     WORKFLOW_NAME,
@@ -819,3 +822,100 @@ def test_provider_profile_manager_state_activity_exists():
     from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
 
     assert hasattr(TemporalArtifactActivities, "provider_profile_manager_state")
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_manager_state_returns_compact_running_snapshot(
+    monkeypatch,
+):
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    class FakeHandle:
+        async def describe(self):
+            return SimpleNamespace(status=SimpleNamespace(name="RUNNING"))
+
+        async def query(self, query_name):
+            assert query_name == "get_state"
+            return {
+                "profiles": {"p1": {}, "p2": {}},
+                "pending_requests": [
+                    {"requester_workflow_id": "agent-run-1"},
+                    {"requester_workflow_id": "agent-run-2"},
+                ],
+                "event_count": 7,
+            }
+
+    class FakeClient:
+        def get_workflow_handle(self, workflow_id):
+            assert workflow_id == "provider-profile-manager:gemini_cli"
+            return FakeHandle()
+
+    class FakeAdapter:
+        async def get_client(self):
+            return FakeClient()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        FakeAdapter,
+    )
+
+    result = await TemporalArtifactActivities(
+        object()
+    ).provider_profile_manager_state(
+        runtime_id="gemini_cli",
+        requester_workflow_id="agent-run-1",
+    )
+
+    assert result == {
+        "running": True,
+        "workflow_id": "provider-profile-manager:gemini_cli",
+        "status": "RUNNING",
+        "profile_count": 2,
+        "pending_requests_count": 2,
+        "event_count": 7,
+        "requester_pending": True,
+    }
+    assert "state" not in result
+
+
+@pytest.mark.asyncio
+async def test_provider_profile_manager_state_checks_status_before_query(
+    monkeypatch,
+):
+    from moonmind.workflows.temporal.artifacts import TemporalArtifactActivities
+
+    class FakeHandle:
+        queried = False
+
+        async def describe(self):
+            return SimpleNamespace(status=SimpleNamespace(name="COMPLETED"))
+
+        async def query(self, query_name):
+            self.queried = True
+            raise AssertionError("terminal managers must not be queried")
+
+    handle = FakeHandle()
+
+    class FakeClient:
+        def get_workflow_handle(self, workflow_id):
+            return handle
+
+    class FakeAdapter:
+        async def get_client(self):
+            return FakeClient()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.client.TemporalClientAdapter",
+        FakeAdapter,
+    )
+
+    result = await TemporalArtifactActivities(
+        object()
+    ).provider_profile_manager_state(runtime_id="gemini_cli")
+
+    assert result == {
+        "running": False,
+        "workflow_id": "provider-profile-manager:gemini_cli",
+        "status": "COMPLETED",
+    }
+    assert handle.queried is False

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -140,3 +140,21 @@ class TestSlotWaitRetryBehavior:
 
         assert "_ensure_manager_and_signal" in source
         assert "manager_handle.signal(\"request_slot\"" not in source
+
+    def test_slot_timeout_probe_failure_falls_back_to_reset(self):
+        """Manager inspection errors must not fail the AgentRun timeout path."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+
+        assert "except CancelledError:" in source
+        assert "falling back to reset path" in source
+        assert 'manager_state = {"running": False}' in source
+
+    def test_healthy_manager_does_not_duplicate_pending_request(self):
+        """If this workflow is already pending, timeout recovery must not re-signal."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+        pending_index = source.index('manager_state.get("requester_pending") is True')
+        rerequest_index = source.index("re-requesting without reset")
+
+        assert pending_index < rerequest_index
+        assert "continuing without reset or duplicate request" in source
+        assert "requester_workflow_id=workflow.info().workflow_id" in source

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py
@@ -12,6 +12,7 @@ import inspect
 import textwrap
 
 from moonmind.workflows.temporal.workflows.agent_run import (
+    MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID,
     MoonMindAgentRun,
     _SLOT_WAIT_TIMEOUT_SECONDS,
     _SLOT_WAIT_MAX_RESETS,
@@ -115,3 +116,27 @@ class TestSlotWaitRetryBehavior:
             "MoonMindAgentRun must have _reset_and_request_slot method "
             "for resetting a stuck manager during slot acquisition"
         )
+
+    def test_slot_timeout_inspects_manager_before_reset(self):
+        """A responsive manager means the run is waiting on capacity, not a reset."""
+        source = inspect.getsource(MoonMindAgentRun.run)
+
+        assert "MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID" in source
+        assert (
+            MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID
+            == "agent-run-slot-wait-manager-inspection-v1"
+        )
+        assert "provider_profile.manager_state" in inspect.getsource(
+            MoonMindAgentRun._manager_state_for_slot_wait
+        )
+        assert source.index("_manager_state_for_slot_wait") < source.index(
+            "_reset_and_request_slot"
+        )
+        assert "re-requesting without reset" in source
+
+    def test_reset_and_request_slot_uses_ensure_signal_fallback(self):
+        """The reset path must tolerate the fresh-manager signal race."""
+        source = inspect.getsource(MoonMindAgentRun._reset_and_request_slot)
+
+        assert "_ensure_manager_and_signal" in source
+        assert "manager_handle.signal(\"request_slot\"" not in source


### PR DESCRIPTION
## Summary

- Add a provider-profile manager state activity so AgentRun can distinguish normal slot contention from an unhealthy manager.
- Re-request profile slots without resetting the singleton manager when the manager is responsive.
- Route reset re-requests through the existing ensure-and-signal fallback to avoid fresh-manager signal races.
- Add focused unit coverage for the slot-wait path and provider-profile activity routing.

## Root Cause

A managed AgentRun waiting for a Codex profile slot treated a 120s slot wait as a stuck ProviderProfileManager. During reset, the immediate `request_slot` signal could race the freshly started manager and raise `ExternalWorkflowExecutionNotFound`, failing the child workflow and then the parent run.

## Validation

- `./.venv/bin/python -m py_compile moonmind/workflows/temporal/workflows/agent_run.py`
- `./.venv/bin/pytest -q tests/unit/workflows/temporal/workflows/test_agent_run_slot_wait_timeout.py tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py`
- `./tools/test_unit.sh`