### PR TITLE
When you edit a provider profile in the UI, you should be able to check runtime default and then click "Update provider profile" and have the default…

### DIFF
--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { ProviderProfile } from './ProviderProfilesManager';
 import {
   defaultFormState,
+  PROVIDER_PROFILE_QUERY_KEY,
   ProviderProfilesManager,
   toFormState,
   parseCommandBehavior,
@@ -48,13 +49,13 @@ function renderProviderProfilesManagerWithQuery(profiles: ProviderProfile[] = []
       },
     },
   });
-  queryClient.setQueryData(['provider-profiles'], profiles);
+  queryClient.setQueryData(PROVIDER_PROFILE_QUERY_KEY, profiles);
   const onNotice = vi.fn();
 
   function ProviderProfilesHarness() {
     const { data = [] } = useQuery<ProviderProfile[]>({
-      queryKey: ['provider-profiles'],
-      queryFn: async () => queryClient.getQueryData<ProviderProfile[]>(['provider-profiles']) ?? profiles,
+      queryKey: PROVIDER_PROFILE_QUERY_KEY,
+      queryFn: async () => queryClient.getQueryData<ProviderProfile[]>(PROVIDER_PROFILE_QUERY_KEY) ?? profiles,
       initialData: profiles,
       staleTime: Infinity,
     });

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1,5 +1,5 @@
-import { QueryClient } from '@tanstack/react-query';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { ProviderProfile } from './ProviderProfilesManager';
 import {
@@ -35,6 +35,45 @@ function renderProviderProfilesManager(profiles: ProviderProfile[] = []) {
       queryClient={queryClient}
       defaultTaskModelByRuntime={{}}
     />,
+  );
+
+  return { onNotice, queryClient };
+}
+
+function renderProviderProfilesManagerWithQuery(profiles: ProviderProfile[] = []) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  queryClient.setQueryData(['provider-profiles'], profiles);
+  const onNotice = vi.fn();
+
+  function ProviderProfilesHarness() {
+    const { data = [] } = useQuery<ProviderProfile[]>({
+      queryKey: ['provider-profiles'],
+      queryFn: async () => queryClient.getQueryData<ProviderProfile[]>(['provider-profiles']) ?? profiles,
+      initialData: profiles,
+      staleTime: Infinity,
+    });
+
+    return (
+      <ProviderProfilesManager
+        profiles={data}
+        secretSlugs={['OPENAI_API_KEY']}
+        onNotice={onNotice}
+        queryClient={queryClient}
+        defaultTaskModelByRuntime={{}}
+      />
+    );
+  }
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProviderProfilesHarness />
+    </QueryClientProvider>,
   );
 
   return { onNotice, queryClient };
@@ -290,7 +329,7 @@ describe('ProviderProfilesManager form controls', () => {
       is_default: false,
     };
 
-    renderProviderProfilesManager([profile, secondaryProfile]);
+    renderProviderProfilesManagerWithQuery([profile, secondaryProfile]);
 
     const editButtons = screen.getAllByRole('button', { name: 'Edit' });
     const secondaryEditButton = editButtons[1];
@@ -325,5 +364,11 @@ describe('ProviderProfilesManager form controls', () => {
     const [, requestInit] = fetchCall;
     const payload = JSON.parse(String((requestInit as RequestInit).body));
     expect(payload.is_default).toBe(true);
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]?.textContent).not.toContain('Runtime default');
+      expect(rows[2]?.textContent).toContain('Runtime default');
+    });
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -61,7 +61,7 @@ interface ProviderProfileFormState {
   accountLabel: string;
 }
 
-const PROVIDER_PROFILE_QUERY_KEY = ['provider-profiles'] as const;
+export const PROVIDER_PROFILE_QUERY_KEY = ['provider-profiles'] as const;
 
 export function defaultFormState(): ProviderProfileFormState {
   return {
@@ -277,7 +277,8 @@ export function ProviderProfilesManager({
 
           return nextProfiles.map((profile) =>
             profile.runtime_id === savedProfile.runtime_id &&
-            profile.profile_id !== savedProfile.profile_id
+            profile.profile_id !== savedProfile.profile_id &&
+            profile.is_default
               ? { ...profile, is_default: false }
               : profile,
           );

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -249,8 +249,9 @@ export function ProviderProfilesManager({
             : `Failed to ${isEditing ? 'update' : 'create'} provider profile.`;
         throw new Error(detail);
       }
+      return response.json() as Promise<ProviderProfile>;
     },
-    onSuccess: () => {
+    onSuccess: (savedProfile) => {
       onNotice({
         level: 'ok',
         text: isEditing
@@ -259,6 +260,29 @@ export function ProviderProfilesManager({
       });
       setEditingProfileId(null);
       setForm(defaultFormState());
+      queryClient.setQueryData<ProviderProfile[]>(
+        PROVIDER_PROFILE_QUERY_KEY,
+        (currentProfiles = []) => {
+          const nextProfiles = currentProfiles.some(
+            (profile) => profile.profile_id === savedProfile.profile_id,
+          )
+            ? currentProfiles.map((profile) =>
+                profile.profile_id === savedProfile.profile_id ? savedProfile : profile,
+              )
+            : [...currentProfiles, savedProfile];
+
+          if (!savedProfile.is_default) {
+            return nextProfiles;
+          }
+
+          return nextProfiles.map((profile) =>
+            profile.runtime_id === savedProfile.runtime_id &&
+            profile.profile_id !== savedProfile.profile_id
+              ? { ...profile, is_default: false }
+              : profile,
+          );
+        },
+      );
       queryClient.invalidateQueries({ queryKey: PROVIDER_PROFILE_QUERY_KEY });
     },
     onError: (error: Error) => {

--- a/frontend/src/entrypoints/settings.tsx
+++ b/frontend/src/entrypoints/settings.tsx
@@ -7,6 +7,7 @@ import {
   type WorkerPauseConfig,
 } from '../components/settings/OperationsSettingsSection';
 import {
+  PROVIDER_PROFILE_QUERY_KEY,
   ProviderProfilesManager,
   type ProviderProfile,
 } from '../components/settings/ProviderProfilesManager';
@@ -135,7 +136,7 @@ export function SettingsPage({ payload }: { payload: BootPayload }) {
     isLoading: areProfilesLoading,
     isError: areProfilesErrored,
   } = useQuery<ProviderProfile[]>({
-    queryKey: ['provider-profiles'],
+    queryKey: PROVIDER_PROFILE_QUERY_KEY,
     queryFn: async () => {
       const response = await fetch('/api/v1/provider-profiles', {
         headers: { Accept: 'application/json' },


### PR DESCRIPTION
When you edit a provider profile in the UI, you should be able to check runtime default and then click "Update provider profile" and have the default change. Implement this and make sure unit and/or integration tests verify this functionality.