### PR TITLE
[codex] Fix live log task run binding

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -727,23 +727,34 @@ def _managed_run_store_root() -> str:
     )
 
 
-def _resolve_task_run_id_from_managed_store(workflow_id: str) -> str | None:
-    normalized_workflow_id = str(workflow_id or "").strip()
-    if not normalized_workflow_id:
-        return None
+def _resolve_task_run_ids_from_managed_store(
+    workflow_ids: tuple[str, ...]
+) -> dict[str, str]:
+    normalized_workflow_ids = tuple(
+        dict.fromkeys(
+            str(workflow_id or "").strip()
+            for workflow_id in workflow_ids
+            if str(workflow_id or "").strip()
+        )
+    )
+    if not normalized_workflow_ids:
+        return {}
     try:
         store = ManagedRunStore(_managed_run_store_root())
-        record = store.find_latest_for_workflow(normalized_workflow_id)
+        records = store.find_latest_by_workflow_ids(normalized_workflow_ids)
     except Exception:
         logger.warning(
-            "Failed to resolve managed task run id for workflow %s from run store",
-            normalized_workflow_id,
+            "Failed to resolve managed task run ids for workflows %s from run store",
+            normalized_workflow_ids,
             exc_info=True,
         )
-        return None
-    if record is None:
-        return None
-    return str(record.run_id or "").strip() or None
+        return {}
+    resolved: dict[str, str] = {}
+    for workflow_id, record in records.items():
+        run_id = str(record.run_id or "").strip()
+        if run_id:
+            resolved[workflow_id] = run_id
+    return resolved
 
 
 async def _enrich_step_ledger_task_run_refs(payload: Any) -> Any:
@@ -753,12 +764,58 @@ async def _enrich_step_ledger_task_run_refs(payload: Any) -> Any:
     if not isinstance(steps, list):
         return payload
 
+    missing_agent_child_workflow_ids: list[str] = []
+    seen_child_workflow_ids: set[str] = set()
+
+    for step in steps:
+        if not isinstance(step, Mapping):
+            continue
+        tool = step.get("tool")
+        if (
+            not isinstance(tool, Mapping)
+            or str(tool.get("type") or "").strip() != "agent_runtime"
+        ):
+            continue
+        refs = step.get("refs")
+        if not isinstance(refs, Mapping):
+            continue
+        existing_task_run_id = str(
+            refs.get("taskRunId") or refs.get("task_run_id") or ""
+        ).strip()
+        child_workflow_id = str(
+            refs.get("childWorkflowId") or refs.get("child_workflow_id") or ""
+        ).strip()
+        if (
+            existing_task_run_id
+            or not child_workflow_id
+            or child_workflow_id in seen_child_workflow_ids
+        ):
+            continue
+        seen_child_workflow_ids.add(child_workflow_id)
+        missing_agent_child_workflow_ids.append(child_workflow_id)
+
+    if not missing_agent_child_workflow_ids:
+        return payload
+
+    resolved_by_child_workflow = await asyncio.to_thread(
+        _resolve_task_run_ids_from_managed_store,
+        tuple(missing_agent_child_workflow_ids),
+    )
+    if not resolved_by_child_workflow:
+        return payload
+
     enriched_steps: list[Any] = []
-    resolved_by_child_workflow: dict[str, str | None] = {}
     changed = False
 
     for step in steps:
         if not isinstance(step, Mapping):
+            enriched_steps.append(step)
+            continue
+        tool = step.get("tool")
+        if (
+            not isinstance(tool, Mapping)
+            or str(tool.get("type") or "").strip() != "agent_runtime"
+        ):
             enriched_steps.append(step)
             continue
         refs = step.get("refs")
@@ -774,12 +831,7 @@ async def _enrich_step_ledger_task_run_refs(payload: Any) -> Any:
         if existing_task_run_id or not child_workflow_id:
             enriched_steps.append(step)
             continue
-        if child_workflow_id not in resolved_by_child_workflow:
-            resolved_by_child_workflow[child_workflow_id] = await asyncio.to_thread(
-                _resolve_task_run_id_from_managed_store,
-                child_workflow_id,
-            )
-        task_run_id = resolved_by_child_workflow[child_workflow_id]
+        task_run_id = resolved_by_child_workflow.get(child_workflow_id)
         if not task_run_id:
             enriched_steps.append(step)
             continue
@@ -2281,10 +2333,11 @@ async def describe_execution(
             update["temporal_run_id"] = queried_run_id
         execution = execution.model_copy(update=update)
     if not execution.task_run_id:
-        task_run_id = await asyncio.to_thread(
-            _resolve_task_run_id_from_managed_store,
-            execution.workflow_id,
+        task_run_ids = await asyncio.to_thread(
+            _resolve_task_run_ids_from_managed_store,
+            (execution.workflow_id,),
         )
+        task_run_id = task_run_ids.get(execution.workflow_id)
         if task_run_id:
             execution = execution.model_copy(update={"task_run_id": task_run_id})
     return execution

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -746,6 +746,58 @@ def _resolve_task_run_id_from_managed_store(workflow_id: str) -> str | None:
     return str(record.run_id or "").strip() or None
 
 
+async def _enrich_step_ledger_task_run_refs(payload: Any) -> Any:
+    if not isinstance(payload, Mapping):
+        return payload
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return payload
+
+    enriched_steps: list[Any] = []
+    resolved_by_child_workflow: dict[str, str | None] = {}
+    changed = False
+
+    for step in steps:
+        if not isinstance(step, Mapping):
+            enriched_steps.append(step)
+            continue
+        refs = step.get("refs")
+        if not isinstance(refs, Mapping):
+            enriched_steps.append(step)
+            continue
+        existing_task_run_id = str(
+            refs.get("taskRunId") or refs.get("task_run_id") or ""
+        ).strip()
+        child_workflow_id = str(
+            refs.get("childWorkflowId") or refs.get("child_workflow_id") or ""
+        ).strip()
+        if existing_task_run_id or not child_workflow_id:
+            enriched_steps.append(step)
+            continue
+        if child_workflow_id not in resolved_by_child_workflow:
+            resolved_by_child_workflow[child_workflow_id] = await asyncio.to_thread(
+                _resolve_task_run_id_from_managed_store,
+                child_workflow_id,
+            )
+        task_run_id = resolved_by_child_workflow[child_workflow_id]
+        if not task_run_id:
+            enriched_steps.append(step)
+            continue
+
+        enriched_refs = dict(refs)
+        enriched_refs["taskRunId"] = task_run_id
+        enriched_step = dict(step)
+        enriched_step["refs"] = enriched_refs
+        enriched_steps.append(enriched_step)
+        changed = True
+
+    if not changed:
+        return payload
+    enriched_payload = dict(payload)
+    enriched_payload["steps"] = enriched_steps
+    return enriched_payload
+
+
 async def _load_execution_progress(
     *,
     temporal_client: Client,
@@ -811,8 +863,10 @@ async def _load_execution_step_ledger(
             },
         ) from exc
 
+    enriched_payload = await _enrich_step_ledger_task_run_refs(payload)
+
     try:
-        return StepLedgerSnapshotModel.model_validate(payload)
+        return StepLedgerSnapshotModel.model_validate(enriched_payload)
     except ValidationError as exc:
         logger.warning(
             "Invalid execution step ledger payload for %s: %s",

--- a/moonmind/workflows/temporal/runtime/store.py
+++ b/moonmind/workflows/temporal/runtime/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Union
@@ -55,7 +56,7 @@ class ManagedRunStore:
             try:
                 os.unlink(tmp_path)
             except OSError:
-                pass  # Best-effort temp-file cleanup; original error is re-raised below
+                pass
             raise
         return path
 
@@ -111,27 +112,49 @@ class ManagedRunStore:
         if not normalized_workflow_id:
             raise ValueError("workflow_id must not be empty")
 
+        return self.find_latest_by_workflow_ids([normalized_workflow_id]).get(
+            normalized_workflow_id
+        )
+
+    def find_latest_by_workflow_ids(
+        self, workflow_ids: Iterable[str]
+    ) -> dict[str, ManagedRunRecord]:
+        """Return newest managed runs for the requested logical workflows."""
+        normalized_workflow_ids = {
+            str(workflow_id or "").strip()
+            for workflow_id in workflow_ids
+            if str(workflow_id or "").strip()
+        }
+        if not normalized_workflow_ids:
+            return {}
+
         self.store_root.mkdir(parents=True, exist_ok=True)
-        candidates: list[ManagedRunRecord] = []
+        candidates_by_workflow: dict[str, list[ManagedRunRecord]] = {
+            workflow_id: [] for workflow_id in normalized_workflow_ids
+        }
         for path in self.store_root.glob("*.json"):
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 record = ManagedRunRecord(**data)
             except (json.JSONDecodeError, ValueError):
                 continue
-            if str(record.workflow_id or "").strip() != normalized_workflow_id:
+            record_workflow_id = str(record.workflow_id or "").strip()
+            if record_workflow_id not in normalized_workflow_ids:
                 continue
-            candidates.append(record)
-
-        if not candidates:
-            return None
+            candidates_by_workflow[record_workflow_id].append(record)
 
         epoch = datetime.min.replace(tzinfo=UTC)
 
         def _sort_key(record: ManagedRunRecord) -> tuple[int, datetime, datetime]:
-            active_priority = 1 if record.status not in TERMINAL_AGENT_RUN_STATES else 0
+            active_priority = (
+                1 if record.status not in TERMINAL_AGENT_RUN_STATES else 0
+            )
             activity_time = record.finished_at or record.started_at or epoch
             started_at = record.started_at or epoch
             return (active_priority, activity_time, started_at)
 
-        return max(candidates, key=_sort_key)
+        return {
+            workflow_id: max(candidates, key=_sort_key)
+            for workflow_id, candidates in candidates_by_workflow.items()
+            if candidates
+        }

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1723,7 +1723,10 @@ class MoonMindRunWorkflow:
                                 updated_at=workflow.now(),
                                 waiting_reason="Awaiting child workflow progress",
                                 summary=f"Awaiting child workflow for {tool_name}",
-                                refs={"childWorkflowId": child_workflow_id},
+                                refs=self._pending_agent_step_refs(
+                                    child_workflow_id=child_workflow_id,
+                                    request=request,
+                                ),
                             )
                             try:
                                 child_result = await workflow.execute_child_workflow(
@@ -2274,6 +2277,19 @@ class MoonMindRunWorkflow:
 
     def _task_scoped_session_workflow_id(self, runtime_id: str) -> str:
         return f"{workflow.info().workflow_id}:session:{runtime_id}"
+
+    def _pending_agent_step_refs(
+        self,
+        *,
+        child_workflow_id: str,
+        request: AgentExecutionRequest,
+    ) -> dict[str, str]:
+        refs = {"childWorkflowId": child_workflow_id}
+        if request.managed_session is not None:
+            task_run_id = str(request.managed_session.task_run_id or "").strip()
+            if task_run_id:
+                refs["taskRunId"] = task_run_id
+        return refs
 
     async def _ensure_task_scoped_codex_session(
         self, request: AgentExecutionRequest

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1570,6 +1570,76 @@ def test_get_execution_steps_returns_latest_run_ledger() -> None:
     assert payload["steps"][0]["refs"]["taskRunId"] == "task-run-1"
 
 
+def test_get_execution_steps_enriches_missing_task_run_id_from_managed_store() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record()
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        ledger={
+            "workflowId": "mm:wf-1",
+            "runId": "run-99",
+            "runScope": "latest",
+            "steps": [
+                {
+                    "logicalStepId": "delegate-agent",
+                    "order": 1,
+                    "title": "Delegate agent",
+                    "tool": {
+                        "type": "agent_runtime",
+                        "name": "codex_cli",
+                        "version": "1",
+                    },
+                    "dependsOn": [],
+                    "status": "awaiting_external",
+                    "waitingReason": "Awaiting child workflow progress",
+                    "attentionRequired": False,
+                    "attempt": 1,
+                    "startedAt": "2026-04-08T12:00:00Z",
+                    "updatedAt": "2026-04-08T12:01:00Z",
+                    "summary": "Awaiting child workflow",
+                    "checks": [],
+                    "refs": {
+                        "childWorkflowId": "mm:wf-1:agent:delegate-agent",
+                        "childRunId": None,
+                        "taskRunId": None,
+                    },
+                    "artifacts": {
+                        "outputSummary": None,
+                        "outputPrimary": None,
+                        "runtimeStdout": None,
+                        "runtimeStderr": None,
+                        "runtimeMergedLogs": None,
+                        "runtimeDiagnostics": None,
+                        "providerSnapshot": None,
+                    },
+                    "lastError": None,
+                }
+            ],
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+    to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+    async def _fake_to_thread(func: object, /, *args: object, **kwargs: object) -> str:
+        to_thread_calls.append((func, args, kwargs))
+        return "mm:wf-1"
+
+    with patch(
+        "api_service.api.routers.executions.asyncio.to_thread",
+        new=_fake_to_thread,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get("/api/executions/mm:wf-1/steps")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["steps"][0]["refs"]["taskRunId"] == "mm:wf-1"
+    assert to_thread_calls[0][1] == ("mm:wf-1:agent:delegate-agent",)
+
+
 def test_get_execution_steps_returns_503_for_temporal_rpc_errors() -> None:
     app = FastAPI()
     app.include_router(router)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1570,12 +1570,59 @@ def test_get_execution_steps_returns_latest_run_ledger() -> None:
     assert payload["steps"][0]["refs"]["taskRunId"] == "task-run-1"
 
 
-def test_get_execution_steps_enriches_missing_task_run_id_from_managed_store() -> None:
+def test_get_execution_steps_enriches_missing_agent_task_run_ids_once() -> None:
     app = FastAPI()
     app.include_router(router)
     mock_service = AsyncMock()
     mock_service.describe_execution.return_value = _build_execution_record()
     app.dependency_overrides[_get_service] = lambda: mock_service
+
+    def _ledger_step(
+        *,
+        logical_step_id: str,
+        order: int,
+        tool_type: str,
+        child_workflow_id: str,
+    ) -> dict[str, object]:
+        return {
+            "logicalStepId": logical_step_id,
+            "order": order,
+            "title": logical_step_id,
+            "tool": {
+                "type": tool_type,
+                "name": (
+                    "codex_cli"
+                    if tool_type == "agent_runtime"
+                    else "repo.run_tests"
+                ),
+                "version": "1",
+            },
+            "dependsOn": [],
+            "status": "awaiting_external",
+            "waitingReason": "Awaiting child workflow progress",
+            "attentionRequired": False,
+            "attempt": 1,
+            "startedAt": "2026-04-08T12:00:00Z",
+            "updatedAt": "2026-04-08T12:01:00Z",
+            "summary": "Awaiting child workflow",
+            "checks": [],
+            "refs": {
+                "childWorkflowId": child_workflow_id,
+                "childRunId": None,
+                "taskRunId": None,
+            },
+            "artifacts": {
+                "outputSummary": None,
+                "outputPrimary": None,
+                "runtimeStdout": None,
+                "runtimeStderr": None,
+                "runtimeMergedLogs": None,
+                "runtimeDiagnostics": None,
+                "providerSnapshot": None,
+            },
+            "lastError": None,
+        }
+
     _override_query_client(
         app,
         ledger={
@@ -1583,49 +1630,38 @@ def test_get_execution_steps_enriches_missing_task_run_id_from_managed_store() -
             "runId": "run-99",
             "runScope": "latest",
             "steps": [
-                {
-                    "logicalStepId": "delegate-agent",
-                    "order": 1,
-                    "title": "Delegate agent",
-                    "tool": {
-                        "type": "agent_runtime",
-                        "name": "codex_cli",
-                        "version": "1",
-                    },
-                    "dependsOn": [],
-                    "status": "awaiting_external",
-                    "waitingReason": "Awaiting child workflow progress",
-                    "attentionRequired": False,
-                    "attempt": 1,
-                    "startedAt": "2026-04-08T12:00:00Z",
-                    "updatedAt": "2026-04-08T12:01:00Z",
-                    "summary": "Awaiting child workflow",
-                    "checks": [],
-                    "refs": {
-                        "childWorkflowId": "mm:wf-1:agent:delegate-agent",
-                        "childRunId": None,
-                        "taskRunId": None,
-                    },
-                    "artifacts": {
-                        "outputSummary": None,
-                        "outputPrimary": None,
-                        "runtimeStdout": None,
-                        "runtimeStderr": None,
-                        "runtimeMergedLogs": None,
-                        "runtimeDiagnostics": None,
-                        "providerSnapshot": None,
-                    },
-                    "lastError": None,
-                }
+                _ledger_step(
+                    logical_step_id="delegate-agent",
+                    order=1,
+                    tool_type="agent_runtime",
+                    child_workflow_id="mm:wf-1:agent:delegate-agent",
+                ),
+                _ledger_step(
+                    logical_step_id="second-agent",
+                    order=2,
+                    tool_type="agent_runtime",
+                    child_workflow_id="mm:wf-1:agent:second-agent",
+                ),
+                _ledger_step(
+                    logical_step_id="run-tests",
+                    order=3,
+                    tool_type="skill",
+                    child_workflow_id="mm:wf-1:tool:run-tests",
+                ),
             ],
         },
     )
     _override_user_dependencies(app, is_superuser=True)
     to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
 
-    async def _fake_to_thread(func: object, /, *args: object, **kwargs: object) -> str:
+    async def _fake_to_thread(
+        func: object, /, *args: object, **kwargs: object
+    ) -> dict[str, str]:
         to_thread_calls.append((func, args, kwargs))
-        return "mm:wf-1"
+        return {
+            "mm:wf-1:agent:delegate-agent": "task-run-1",
+            "mm:wf-1:agent:second-agent": "task-run-2",
+        }
 
     with patch(
         "api_service.api.routers.executions.asyncio.to_thread",
@@ -1636,8 +1672,16 @@ def test_get_execution_steps_enriches_missing_task_run_id_from_managed_store() -
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["steps"][0]["refs"]["taskRunId"] == "mm:wf-1"
-    assert to_thread_calls[0][1] == ("mm:wf-1:agent:delegate-agent",)
+    assert payload["steps"][0]["refs"]["taskRunId"] == "task-run-1"
+    assert payload["steps"][1]["refs"]["taskRunId"] == "task-run-2"
+    assert payload["steps"][2]["refs"]["taskRunId"] is None
+    assert len(to_thread_calls) == 1
+    assert to_thread_calls[0][1] == (
+        (
+            "mm:wf-1:agent:delegate-agent",
+            "mm:wf-1:agent:second-agent",
+        ),
+    )
 
 
 def test_get_execution_steps_returns_503_for_temporal_rpc_errors() -> None:
@@ -1739,9 +1783,11 @@ def test_describe_execution_falls_back_to_managed_run_store_task_run_id(
 
     to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
 
-    async def _fake_to_thread(func: object, /, *args: object, **kwargs: object) -> str:
+    async def _fake_to_thread(
+        func: object, /, *args: object, **kwargs: object
+    ) -> dict[str, str]:
         to_thread_calls.append((func, args, kwargs))
-        return "550e8400-e29b-41d4-a716-446655440000"
+        return {"mm:wf-1": "550e8400-e29b-41d4-a716-446655440000"}
 
     with patch(
         "api_service.api.routers.executions.asyncio.to_thread",
@@ -1754,6 +1800,7 @@ def test_describe_execution_falls_back_to_managed_run_store_task_run_id(
         response.json()["taskRunId"] == "550e8400-e29b-41d4-a716-446655440000"
     )
     assert len(to_thread_calls) == 1
+    assert to_thread_calls[0][1] == (("mm:wf-1",),)
 
 
 def test_request_rerun_update_response_includes_continue_as_new_cause() -> None:

--- a/tests/unit/services/temporal/runtime/test_store.py
+++ b/tests/unit/services/temporal/runtime/test_store.py
@@ -136,6 +136,52 @@ def test_find_latest_for_workflow_returns_latest_terminal_when_no_active_exists(
     assert found.run_id == "run-second"
 
 
+def test_find_latest_by_workflow_ids_returns_latest_for_each_requested_workflow(
+    tmp_path,
+):
+    store = ManagedRunStore(tmp_path)
+    started_at = datetime.now(tz=UTC)
+
+    store.save(
+        _make_record("run-wf-1-old", "completed").model_copy(
+            update={
+                "workflow_id": "mm:wf-1",
+                "started_at": started_at,
+                "finished_at": started_at,
+            }
+        )
+    )
+    store.save(
+        _make_record("run-wf-1-active", "running").model_copy(
+            update={
+                "workflow_id": "mm:wf-1",
+                "started_at": started_at + timedelta(microseconds=1),
+            }
+        )
+    )
+    store.save(
+        _make_record("run-wf-2", "completed").model_copy(
+            update={
+                "workflow_id": "mm:wf-2",
+                "started_at": started_at + timedelta(microseconds=2),
+                "finished_at": started_at + timedelta(microseconds=3),
+            }
+        )
+    )
+    store.save(
+        _make_record("run-unrequested", "running").model_copy(
+            update={"workflow_id": "mm:wf-3"}
+        )
+    )
+
+    found = store.find_latest_by_workflow_ids(["mm:wf-1", "mm:wf-2", "missing"])
+
+    assert {workflow_id: record.run_id for workflow_id, record in found.items()} == {
+        "mm:wf-1": "run-wf-1-active",
+        "mm:wf-2": "run-wf-2",
+    }
+
+
 def test_path_traversal_rejected(tmp_path):
     store = ManagedRunStore(tmp_path)
 

--- a/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_codex_sessions.py
@@ -129,6 +129,30 @@ async def test_run_skips_task_scoped_session_for_non_codex_managed_runtime(
     assert started is False
 
 
+def test_run_pending_agent_step_refs_include_session_task_run_id() -> None:
+    workflow = MoonMindRunWorkflow()
+    request = _managed_request("codex").model_copy(
+        update={
+            "managed_session": CodexManagedSessionBinding(
+                workflowId="wf-run-1:session:codex_cli",
+                taskRunId="wf-run-1",
+                sessionId="sess:wf-run-1:codex_cli",
+                sessionEpoch=1,
+                runtimeId="codex_cli",
+                executionProfileRef="codex-default",
+            )
+        }
+    )
+
+    assert workflow._pending_agent_step_refs(
+        child_workflow_id="wf-run-1:agent:node-1",
+        request=request,
+    ) == {
+        "childWorkflowId": "wf-run-1:agent:node-1",
+        "taskRunId": "wf-run-1",
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_termination_v3_executes_session_update(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Fixes live-log attachment for executing managed-agent workflow steps.

The running step ledger previously recorded the child workflow id before the managed runtime completed, but left `refs.taskRunId` empty until final result metadata came back. Mission Control gates step-level Live Logs on that task-run binding, so active Codex runs could stay stuck on "Waiting for managed runtime launch to create live logs" even while the agent session was running and producing artifacts.

This change writes the session-backed `taskRunId` into pending agent step refs as soon as the parent starts the child workflow. It also enriches step-ledger API responses from the managed-run store when older in-flight workflows still have a missing step binding.

## Validation

- `./tools/test_unit.sh`
- Verified the affected workflow step endpoint returns `refs.taskRunId = mm:44e3e5ce-721d-4b0d-a812-97d1753c6d12`
