### PR TITLE
[codex] Fix live logs observability owner lookup

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -109,6 +109,46 @@ def _coerce_owner_id(value: object) -> str | None:
 async def _load_execution_owner_binding(
     workflow_id: str,
 ) -> tuple[str | None, str | None]:
+    for candidate_workflow_id in _execution_owner_binding_candidates(workflow_id):
+        owner_type, owner_id = await _load_exact_execution_owner_binding(
+            candidate_workflow_id
+        )
+        if owner_id or (owner_type and owner_type != "user"):
+            return owner_type, owner_id
+    return None, None
+
+
+def _execution_owner_binding_candidates(workflow_id: str) -> tuple[str, ...]:
+    normalized_workflow_id = str(workflow_id or "").strip()
+    if not normalized_workflow_id:
+        return ()
+
+    candidates: list[str] = [normalized_workflow_id]
+    parent_workflow_id: str | None = None
+    if ":agent:" in normalized_workflow_id:
+        parent_workflow_id = normalized_workflow_id.split(":agent:", 1)[0]
+    elif ":session:" in normalized_workflow_id:
+        parent_workflow_id = normalized_workflow_id.split(":session:", 1)[0]
+    else:
+        parts = normalized_workflow_id.split(":")
+        if normalized_workflow_id.startswith("mm:") and len(parts) >= 2:
+            parent_workflow_id = f"{parts[0]}:{parts[1]}"
+        elif parts:
+            parent_workflow_id = parts[0]
+
+    normalized_parent_workflow_id = str(parent_workflow_id or "").strip()
+    if (
+        normalized_parent_workflow_id
+        and normalized_parent_workflow_id != normalized_workflow_id
+    ):
+        candidates.append(normalized_parent_workflow_id)
+
+    return tuple(dict.fromkeys(candidates))
+
+
+async def _load_exact_execution_owner_binding(
+    workflow_id: str,
+) -> tuple[str | None, str | None]:
     from api_service.db.base import get_async_session_context
     from api_service.db.models import TemporalExecutionCanonicalRecord
 

--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -126,22 +126,20 @@ def _execution_owner_binding_candidates(workflow_id: str) -> tuple[str, ...]:
     candidates: list[str] = [normalized_workflow_id]
     parent_workflow_id: str | None = None
     if ":agent:" in normalized_workflow_id:
-        parent_workflow_id = normalized_workflow_id.split(":agent:", 1)[0]
+        parent_workflow_id = normalized_workflow_id.partition(":agent:")[0]
     elif ":session:" in normalized_workflow_id:
-        parent_workflow_id = normalized_workflow_id.split(":session:", 1)[0]
+        parent_workflow_id = normalized_workflow_id.partition(":session:")[0]
     else:
         parts = normalized_workflow_id.split(":")
         if normalized_workflow_id.startswith("mm:") and len(parts) >= 2:
             parent_workflow_id = f"{parts[0]}:{parts[1]}"
-        elif parts:
+        elif len(parts) > 1:
             parent_workflow_id = parts[0]
 
-    normalized_parent_workflow_id = str(parent_workflow_id or "").strip()
-    if (
-        normalized_parent_workflow_id
-        and normalized_parent_workflow_id != normalized_workflow_id
-    ):
-        candidates.append(normalized_parent_workflow_id)
+    if parent_workflow_id:
+        parent_workflow_id = parent_workflow_id.strip()
+        if parent_workflow_id and parent_workflow_id != normalized_workflow_id:
+            candidates.append(parent_workflow_id)
 
     return tuple(dict.fromkeys(candidates))
 

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -437,6 +437,109 @@ def test_get_observability_summary_allows_owner_access() -> None:
     assert response.json()["summary"]["supportsLiveStreaming"] is True
 
 
+def test_observability_summary_allows_parent_workflow_owner() -> None:
+    owner_id = uuid4()
+    task_run_id = f"mm:{uuid4()}"
+    child_workflow_id = (
+        f"{task_run_id}:agent:tpl:speckit-orchestrate:1.0.0:12:faa43a52"
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=owner_id,
+        email="owner@example.com",
+        is_superuser=False,
+    )
+
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.workflow_id = child_workflow_id
+
+    async def load_exact_owner_binding(
+        workflow_id: str,
+    ) -> tuple[str | None, str | None]:
+        if workflow_id == child_workflow_id:
+            return None, None
+        if workflow_id == task_run_id:
+            return "user", str(owner_id)
+        return None, None
+
+    exact_lookup = AsyncMock(side_effect=load_exact_owner_binding)
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedRunStore.load",
+            return_value=mock_record,
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_exact_execution_owner_binding",
+                new=exact_lookup,
+            ):
+                response = test_client.get(
+                    f"{_task_run_api_path(task_run_id)}/observability-summary"
+                )
+
+    assert response.status_code == 200
+    assert response.json()["summary"]["supportsLiveStreaming"] is True
+    assert [call.args[0] for call in exact_lookup.await_args_list] == [
+        child_workflow_id,
+        task_run_id,
+    ]
+
+
+def test_observability_summary_child_owner_blocks_parent_fallback() -> None:
+    owner_id = uuid4()
+    child_owner_id = uuid4()
+    task_run_id = f"mm:{uuid4()}"
+    child_workflow_id = (
+        f"{task_run_id}:agent:tpl:speckit-orchestrate:1.0.0:12:faa43a52"
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_current_user()] = lambda: SimpleNamespace(
+        id=owner_id,
+        email="owner@example.com",
+        is_superuser=False,
+    )
+
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {"status": "running"}
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    mock_record.workflow_id = child_workflow_id
+
+    async def load_exact_owner_binding(
+        workflow_id: str,
+    ) -> tuple[str | None, str | None]:
+        if workflow_id == child_workflow_id:
+            return "user", str(child_owner_id)
+        if workflow_id == task_run_id:
+            return "user", str(owner_id)
+        return None, None
+
+    exact_lookup = AsyncMock(side_effect=load_exact_owner_binding)
+
+    with TestClient(app) as test_client:
+        with patch(
+            "api_service.api.routers.task_runs.ManagedRunStore.load",
+            return_value=mock_record,
+        ):
+            with patch(
+                "api_service.api.routers.task_runs._load_exact_execution_owner_binding",
+                new=exact_lookup,
+            ):
+                response = test_client.get(
+                    f"{_task_run_api_path(task_run_id)}/observability-summary"
+                )
+
+    assert response.status_code == 403
+    assert [call.args[0] for call in exact_lookup.await_args_list] == [
+        child_workflow_id,
+    ]
+
+
 def test_get_observability_summary_forbids_cross_owner_access() -> None:
     owner_id = uuid4()
     other_id = uuid4()


### PR DESCRIPTION
## Summary

Fixes Live Logs authorization for Codex managed sessions whose managed-run record points at a child `MoonMind.AgentRun` workflow while ownership is stored on the parent `MoonMind.Run` workflow.

The observability router now resolves owner bindings by checking the exact workflow id first, then falling back to the parent workflow id only when the child has no owner binding. This keeps explicit child ownership authoritative while allowing owners to view logs for their own Codex managed-session runs.

## Root Cause

Codex managed-session records can be keyed by the parent task run id but store a child workflow id in `workflowId`, for example `mm:<id>:agent:...`. The database may only have the canonical owner row for `mm:<id>`, so `/api/task-runs/{id}/observability-summary` returned 403 for non-admin owners.

## Validation

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_task_runs.py -q`
- `./tools/test_unit.sh --python-only --no-xdist tests/unit/api/routers/test_task_runs.py tests/unit/api/routers/test_executions.py -q`
- `git diff --check`

Also manually verified the reported example now returns 200 for `/observability-summary`, `/observability/events`, and `/logs/merged`.