### PR TITLE
[codex] Fix managed session support path ownership

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -650,14 +650,18 @@ class DockerCodexManagedSessionController:
         workspace_path = Path(request.workspace_path)
         session_workspace_path = Path(request.session_workspace_path)
         artifact_spool_path = Path(request.artifact_spool_path)
-        created_paths: list[Path] = []
+        support_paths: list[Path] = [
+            session_workspace_path,
+            artifact_spool_path,
+        ]
 
-        if not session_workspace_path.exists():
-            session_workspace_path.mkdir(parents=True, exist_ok=True)
-            created_paths.append(session_workspace_path)
-        if not artifact_spool_path.exists():
-            artifact_spool_path.mkdir(parents=True, exist_ok=True)
-            created_paths.append(artifact_spool_path)
+        session_workspace_path.mkdir(parents=True, exist_ok=True)
+        artifact_spool_path.mkdir(parents=True, exist_ok=True)
+        self._collect_managed_support_paths(
+            request=request,
+            owned_paths=support_paths,
+        )
+        self._normalize_container_path_ownership(support_paths)
 
         repository = str(
             request.workspace_spec.get("repository")
@@ -665,10 +669,6 @@ class DockerCodexManagedSessionController:
             or ""
         ).strip()
         if workspace_path.exists():
-            self._collect_managed_support_paths(
-                request=request,
-                owned_paths=created_paths,
-            )
             self._normalize_container_path_ownership([workspace_path])
             if repository:
                 if not await self._workspace_is_git_repository(workspace_path=workspace_path):
@@ -681,18 +681,12 @@ class DockerCodexManagedSessionController:
                     workspace_path=workspace_path,
                     request=request,
                 )
-            self._normalize_container_path_ownership(created_paths)
             return
 
         if not repository:
             workspace_path.parent.mkdir(parents=True, exist_ok=True)
             workspace_path.mkdir(parents=True, exist_ok=True)
-            created_paths.append(workspace_path)
-            self._collect_managed_support_paths(
-                request=request,
-                owned_paths=created_paths,
-            )
-            self._normalize_container_path_ownership(created_paths)
+            self._normalize_container_path_ownership([workspace_path])
             return
 
         await self._clone_workspace(
@@ -704,11 +698,6 @@ class DockerCodexManagedSessionController:
             workspace_path=workspace_path,
             request=request,
         )
-        self._collect_managed_support_paths(
-            request=request,
-            owned_paths=created_paths,
-        )
-        self._normalize_container_path_ownership(created_paths)
 
     def _collect_managed_support_paths(
         self,
@@ -1102,6 +1091,13 @@ class DockerCodexManagedSessionController:
                 payload = json.loads(stdout.strip() or "{}")
             except (RuntimeError, json.JSONDecodeError) as exc:
                 last_error = exc
+                if self._ready_probe_suggests_container_exited(exc):
+                    logs = await self._container_logs_excerpt(container_id)
+                    log_detail = f"; logs: {logs}" if logs else ""
+                    raise RuntimeError(
+                        f"managed session container {container_id} exited before "
+                        f"ready: {exc}{log_detail}"
+                    ) from exc
             else:
                 if payload.get("ready") is True:
                     return
@@ -1111,6 +1107,44 @@ class DockerCodexManagedSessionController:
         raise RuntimeError(
             f"managed session container {container_id} did not become ready{details}"
         )
+
+    @staticmethod
+    def _ready_probe_suggests_container_exited(exc: Exception) -> bool:
+        detail = str(exc).lower()
+        return any(
+            marker in detail
+            for marker in (
+                "container is not running",
+                "is not running",
+                "not running",
+                "exited",
+                "is stopped",
+                "cannot exec in a stopped",
+            )
+        )
+
+    async def _container_logs_excerpt(self, container_id: str) -> str:
+        command = (
+            self._docker_binary,
+            "logs",
+            "--tail",
+            "40",
+            container_id,
+        )
+        returncode, stdout, stderr = await self._command_runner(
+            command,
+            env=self._docker_env(),
+        )
+        if returncode != 0:
+            return ""
+        detail = "\n".join(part for part in (stdout.strip(), stderr.strip()) if part)
+        if not detail:
+            return ""
+        _rendered_command, scrubbed_detail = self._scrub_command_failure(
+            command,
+            detail,
+        )
+        return scrubbed_detail[-2000:]
 
     async def _persist_handle_transition(
         self,

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -54,6 +54,8 @@ _SENSITIVE_ENV_KEY_PATTERN = re.compile(
 )
 _GIT_COMMAND_LOCALE = {"LC_ALL": "C", "LANG": "C"}
 _SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
+_CONTAINER_LOG_EXCERPT_TAIL_LINES = 40
+_CONTAINER_LOG_EXCERPT_MAX_CHARS = 2000
 logger = logging.getLogger(__name__)
 
 
@@ -650,18 +652,21 @@ class DockerCodexManagedSessionController:
         workspace_path = Path(request.workspace_path)
         session_workspace_path = Path(request.session_workspace_path)
         artifact_spool_path = Path(request.artifact_spool_path)
-        support_paths: list[Path] = [
+        support_root_paths: list[Path] = [
             session_workspace_path,
             artifact_spool_path,
         ]
+        recursive_support_paths: list[Path] = []
 
         session_workspace_path.mkdir(parents=True, exist_ok=True)
         artifact_spool_path.mkdir(parents=True, exist_ok=True)
         self._collect_managed_support_paths(
             request=request,
-            owned_paths=support_paths,
+            owned_root_paths=support_root_paths,
+            recursively_owned_paths=recursive_support_paths,
         )
-        self._normalize_container_path_ownership(support_paths)
+        self._normalize_container_path_owners(support_root_paths)
+        self._normalize_container_path_ownership(recursive_support_paths)
 
         repository = str(
             request.workspace_spec.get("repository")
@@ -703,7 +708,8 @@ class DockerCodexManagedSessionController:
         self,
         *,
         request: LaunchCodexManagedSessionRequest,
-        owned_paths: list[Path],
+        owned_root_paths: list[Path],
+        recursively_owned_paths: list[Path],
     ) -> None:
         codex_home_path = Path(request.codex_home_path)
         if not self._is_within_workspace_root(codex_home_path):
@@ -712,11 +718,11 @@ class DockerCodexManagedSessionController:
         runtime_support_path = codex_home_path.parent
         if not runtime_support_path.exists():
             runtime_support_path.mkdir(parents=True, exist_ok=True)
-        owned_paths.append(runtime_support_path)
+        owned_root_paths.append(runtime_support_path)
 
         if not codex_home_path.exists():
             codex_home_path.mkdir(parents=True, exist_ok=True)
-        owned_paths.append(codex_home_path)
+        recursively_owned_paths.append(codex_home_path)
 
     async def _ensure_target_branch(
         self,
@@ -784,19 +790,40 @@ class DockerCodexManagedSessionController:
         )
 
     @staticmethod
-    def _normalize_container_path_owner(path: Path) -> None:
+    def _can_normalize_container_path_ownership() -> bool:
         geteuid = getattr(os, "geteuid", None)
-        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+        return os.name == "posix" and callable(geteuid) and geteuid() == 0
+
+    @staticmethod
+    def _normalize_container_path_owner(path: Path) -> None:
+        if (
+            not DockerCodexManagedSessionController
+            ._can_normalize_container_path_ownership()
+        ):
             return
         if path.exists():
             DockerCodexManagedSessionController._chown_path(path)
 
     @staticmethod
-    def _normalize_container_path_ownership(paths: Sequence[Path]) -> None:
-        geteuid = getattr(os, "geteuid", None)
-        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+    def _normalize_container_path_owners(paths: Sequence[Path]) -> None:
+        if (
+            not DockerCodexManagedSessionController
+            ._can_normalize_container_path_ownership()
+        ):
             return
         for path in paths:
+            if path.exists():
+                DockerCodexManagedSessionController._chown_path(path)
+
+    @staticmethod
+    def _normalize_container_path_ownership(paths: Sequence[Path]) -> None:
+        if (
+            not DockerCodexManagedSessionController
+            ._can_normalize_container_path_ownership()
+        ):
+            return
+        roots = DockerCodexManagedSessionController._deduplicate_ownership_roots(paths)
+        for path in roots:
             if not path.exists():
                 continue
             DockerCodexManagedSessionController._chown_path(path)
@@ -806,6 +833,16 @@ class DockerCodexManagedSessionController:
                     DockerCodexManagedSessionController._chown_path(root_path / dirname)
                 for filename in filenames:
                     DockerCodexManagedSessionController._chown_path(root_path / filename)
+
+    @staticmethod
+    def _deduplicate_ownership_roots(paths: Sequence[Path]) -> list[Path]:
+        deduplicated: list[Path] = []
+        roots = sorted({Path(item) for item in paths}, key=lambda item: len(item.parts))
+        for path in roots:
+            if any(path == root or path.is_relative_to(root) for root in deduplicated):
+                continue
+            deduplicated.append(path)
+        return deduplicated
 
     @staticmethod
     def _chown_path(path: Path) -> None:
@@ -1120,6 +1157,10 @@ class DockerCodexManagedSessionController:
                 "exited",
                 "is stopped",
                 "cannot exec in a stopped",
+                "no such container",
+                "no such object",
+                "not found",
+                "container not found",
             )
         )
 
@@ -1128,7 +1169,7 @@ class DockerCodexManagedSessionController:
             self._docker_binary,
             "logs",
             "--tail",
-            "40",
+            str(_CONTAINER_LOG_EXCERPT_TAIL_LINES),
             container_id,
         )
         returncode, stdout, stderr = await self._command_runner(
@@ -1144,7 +1185,7 @@ class DockerCodexManagedSessionController:
             command,
             detail,
         )
-        return scrubbed_detail[-2000:]
+        return scrubbed_detail[-_CONTAINER_LOG_EXCERPT_MAX_CHARS:]
 
     async def _persist_handle_transition(
         self,

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -3081,16 +3081,25 @@ async def test_controller_launch_retries_ready_probe_errors(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
-async def test_controller_launch_reports_exited_container_logs_during_ready_probe(
+@pytest.mark.parametrize(
+    "ready_stderr",
+    [
+        "Error response from daemon: container ctr-1 is not running",
+        "Error response from daemon: No such container: ctr-1",
+    ],
+)
+async def test_controller_launch_reports_terminal_container_logs_during_ready_probe(
     tmp_path: Path,
+    ready_stderr: str,
 ) -> None:
+    workspace_root = tmp_path / "agent_jobs"
     request = LaunchCodexManagedSessionRequest(
         taskRunId="task-1",
         sessionId="sess-1",
         threadId="logical-thread-1",
-        workspacePath="/tmp/agent_jobs/task-1/repo",
-        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
-        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        workspacePath=str(workspace_root / "task-1" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-1" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-1" / "artifacts"),
         codexHomePath="/home/app/.codex",
         imageRef="ghcr.io/moonladderstudios/moonmind:latest",
     )
@@ -3108,11 +3117,7 @@ async def test_controller_launch_reports_exited_container_logs_during_ready_prob
         if command[:2] == ("docker", "run"):
             return 0, "ctr-1\n", ""
         if "ready" in command:
-            return (
-                1,
-                "",
-                "Error response from daemon: container ctr-1 is not running",
-            )
+            return 1, "", ready_stderr
         if command[:3] == ("docker", "logs", "--tail"):
             return (
                 0,
@@ -3125,7 +3130,7 @@ async def test_controller_launch_reports_exited_container_logs_during_ready_prob
     controller = DockerCodexManagedSessionController(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
-        workspace_root="/tmp/agent_jobs",
+        workspace_root=str(workspace_root),
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
         ready_poll_attempts=3,
@@ -3137,6 +3142,7 @@ async def test_controller_launch_reports_exited_container_logs_during_ready_prob
     message = str(exc_info.value)
     assert "exited before ready" in message
     assert "MOONMIND_SESSION_WORKSPACE_STATE_PATH must be writable" in message
+    assert ("docker", "logs", "--tail", "40", "ctr-1") in commands
     assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
 
 

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -830,6 +830,104 @@ async def test_controller_launch_reuses_existing_workspace_and_checks_out_target
 
 
 @pytest.mark.asyncio
+async def test_controller_launch_normalizes_support_paths_before_git_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "agent_jobs"
+    task_root = workspace_root / "mm:task-1"
+    workspace_path = task_root / "repo"
+    session_path = task_root / "session"
+    artifacts_path = task_root / "artifacts"
+    workspace_path.mkdir(parents=True, exist_ok=True)
+    (workspace_path / ".git").mkdir()
+    session_path.mkdir()
+    artifacts_path.mkdir()
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="mm:task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_path),
+        sessionWorkspacePath=str(session_path),
+        artifactSpoolPath=str(artifacts_path),
+        codexHomePath=str(task_root / ".moonmind" / "codex-home"),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        workspaceSpec={
+            "repository": "MoonLadderStudios/MoonMind",
+            "startingBranch": "main",
+            "targetBranch": "codex/session-fix",
+        },
+    )
+    commands: list[tuple[str, ...]] = []
+    chown_calls: list[Path] = []
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
+        lambda: 0,
+    )
+
+    def _fake_chown(
+        path: str | Path,
+        uid: int,
+        gid: int,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        assert uid == 1000
+        assert gid == 1000
+        assert follow_symlinks is False
+        chown_calls.append(Path(path))
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
+        _fake_chown,
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+        run_as_uid: int | None = None,
+        run_as_gid: int | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[0] == "git":
+            assert session_path in chown_calls
+            assert artifacts_path in chown_calls
+            assert task_root / ".moonmind" in chown_calls
+            assert task_root / ".moonmind" / "codex-home" in chown_calls
+        if command == _workspace_git_command(
+            request.workspace_path,
+            "rev-parse",
+            "--is-inside-work-tree",
+        ):
+            return 0, "true\n", ""
+        if command == _workspace_git_command(
+            request.workspace_path,
+            "checkout",
+            "codex/session-fix",
+        ):
+            return 2, "", "fatal: checkout backend aborted"
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    with pytest.raises(RuntimeError, match="checkout backend aborted"):
+        await controller.launch_session(request)
+
+    assert all(command[:2] != ("docker", "run") for command in commands)
+    assert session_path in chown_calls
+    assert artifacts_path in chown_calls
+
+
+@pytest.mark.asyncio
 async def test_controller_launch_reclones_invalid_workspace_before_target_checkout(
     tmp_path: Path,
 ) -> None:
@@ -2980,6 +3078,66 @@ async def test_controller_launch_retries_ready_probe_errors(tmp_path: Path) -> N
 
     assert handle.status == "ready"
     assert ready_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_reports_exited_container_logs_during_ready_probe(
+    tmp_path: Path,
+) -> None:
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-1",
+        sessionId="sess-1",
+        threadId="logical-thread-1",
+        workspacePath="/tmp/agent_jobs/task-1/repo",
+        sessionWorkspacePath="/tmp/agent_jobs/task-1/session",
+        artifactSpoolPath="/tmp/agent_jobs/task-1/artifacts",
+        codexHomePath="/home/app/.codex",
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    commands: list[tuple[str, ...]] = []
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        commands.append(command)
+        if command[:3] == ("docker", "rm", "-f"):
+            return 0, "", ""
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-1\n", ""
+        if "ready" in command:
+            return (
+                1,
+                "",
+                "Error response from daemon: container ctr-1 is not running",
+            )
+        if command[:3] == ("docker", "logs", "--tail"):
+            return (
+                0,
+                '{"error":"MOONMIND_SESSION_WORKSPACE_STATE_PATH must be writable",'
+                '"ready":false}\n',
+                "",
+            )
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root="/tmp/agent_jobs",
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+        ready_poll_attempts=3,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await controller.launch_session(request)
+
+    message = str(exc_info.value)
+    assert "exited before ready" in message
+    assert "MOONMIND_SESSION_WORKSPACE_STATE_PATH must be writable" in message
+    assert commands[-1] == ("docker", "rm", "-f", "ctr-1")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes managed Codex session launch retries after an early git failure leaves support directories in a state the session container cannot write to.

## Root Cause

`agent_runtime.launch_session` created `session/` and `artifacts/` as root-owned support paths, then performed git branch setup before normalizing ownership. If branch checkout failed before ownership normalization, a retry reused root-owned support directories. The managed session container runs as `1000:1000`, so it exited immediately when it could not write session state. Temporal then surfaced the problem as a heartbeat timeout, obscuring the actionable container error.

## Changes

- Always create and normalize session, artifact spool, and Codex support path ownership before any workspace git operations.
- Keep workspace ownership normalization for repository paths scoped to the existing workspace flow.
- Fail fast when readiness probing detects an exited/stopped container and include a scrubbed `docker logs --tail 40` excerpt.
- Add regression coverage for support-path ownership before git failures and exited-container readiness diagnostics.

## Validation

- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
  - Python: `2972 passed, 1 xpassed, 102 warnings`
  - Frontend: `9 passed`, `128 passed`
