### PR TITLE
[codex] Fix Codex session live logs

### DIFF
--- a/docs/tmp/remaining-work/agent-session-deployment-safety-cutover.md
+++ b/docs/tmp/remaining-work/agent-session-deployment-safety-cutover.md
@@ -8,11 +8,31 @@ This file records cutover gates for deployment-sensitive managed-session workflo
 
 ## Shared Prerequisites
 
-- Replay-safe rollout gates or an explicit cutover plan are approved for incompatible workflow-shape changes.
+- replay-safe rollout gates or an explicit cutover plan are approved for incompatible workflow-shape changes.
 - Representative `AgentSessionWorkflow` histories replay successfully.
 - Fault-injected lifecycle tests pass for termination cleanup, cancel semantics, race/idempotency, Continue-As-New carry-forward, and reconcile outcomes.
 - Bounded workflow metadata, Search Attributes, activity summaries, telemetry dimensions, schedule metadata, and replay fixtures are checked for sensitive or unbounded content.
 - `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime` passes before broad rollout.
+
+## Extending Managed Session Record Metadata
+
+Prerequisites:
+
+- New optional record fields are added as bounded metadata only; workflow history continues to carry compact refs and identities rather than raw logs or transcripts.
+- Existing records that lack the new fields have a deterministic replay-safe rollout path. For log offset metadata, reattached supervisors resume from persisted per-stream offsets when present and conservatively replay from the beginning of the spool when only the legacy combined offset exists.
+- Activity and service boundaries persist the new metadata before any dependent UI or observability behavior assumes it is populated.
+
+Validation gates:
+
+- `tests/unit/services/temporal/runtime/test_managed_session_supervisor.py`
+- `tests/unit/services/temporal/runtime/test_managed_session_store.py`
+- `tests/unit/schemas/test_managed_session_models.py`
+- `tests/unit/workflows/temporal/test_agent_session_replayer.py`
+
+Rollback/removal:
+
+- Stop depending on the new metadata fields before removing them from stored records or schema contracts.
+- Keep the conservative replay path until representative active-session records with missing metadata are no longer expected to be reattached.
 
 ## Enabling `SteerTurn`
 

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -2673,6 +2673,7 @@ describe('LiveLogsPanel', () => {
 
     await waitForEventSourceInstance();
     const es = MockEventSource.instances.at(-1)!;
+    expect(es.url).toContain('since=1');
 
     act(() => es.triggerOpen());
     act(() => es.triggerLogChunk({ sequence: 0, stream: 'stdout', text: 'live line\n' }));

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -1838,8 +1838,7 @@ function LiveLogsPanel({
 
     let cancelled = false;
 
-    const nextSince = lastSeqRef.current != null ? lastSeqRef.current + 1 : null;
-    const since = nextSince != null ? `?since=${nextSince}` : '';
+    const since = lastSeqRef.current != null ? `?since=${lastSeqRef.current}` : '';
     const streamUrl = taskRunRoute(
       apiBase,
       routes.logsStream,

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -353,6 +353,8 @@ class CodexManagedSessionRecord(BaseModel):
     latest_reset_boundary_ref: str | None = Field(None, alias="latestResetBoundaryRef")
     active_turn_id: str | None = Field(None, alias="activeTurnId")
     last_log_offset: int | None = Field(None, alias="lastLogOffset", ge=0)
+    stdout_log_offset: int | None = Field(None, alias="stdoutLogOffset", ge=0)
+    stderr_log_offset: int | None = Field(None, alias="stderrLogOffset", ge=0)
     last_log_at: datetime | None = Field(None, alias="lastLogAt")
     error_message: str | None = Field(None, alias="errorMessage")
     started_at: datetime = Field(..., alias="startedAt")

--- a/moonmind/workflows/temporal/runtime/log_streamer.py
+++ b/moonmind/workflows/temporal/runtime/log_streamer.py
@@ -201,9 +201,11 @@ class RuntimeLogStreamer:
         turn_id: str | None = None,
         active_turn_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        preserve_text: bool = False,
     ) -> None:
         """Emit a structured observability event into the shared live stream."""
-        normalized_text = str(text or "").strip()
+        raw_text = str(text or "")
+        normalized_text = raw_text if preserve_text else raw_text.strip()
         if not normalized_text:
             return
         timestamp = self._current_timestamp()

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import json
 import logging
 from datetime import UTC, datetime
@@ -15,6 +16,8 @@ from .log_streamer import RuntimeLogStreamer
 from .managed_session_store import ManagedSessionStore
 
 logger = logging.getLogger(__name__)
+
+_LOG_READ_CHUNK_BYTES = 64 * 1024
 
 
 class ArtifactStorageWriter(Protocol):
@@ -55,33 +58,12 @@ class ManagedSessionSupervisor:
         return Path(record.artifact_spool_path) / "stderr.log"
 
     @staticmethod
-    def _combined_offset(record: CodexManagedSessionRecord) -> int:
-        total = 0
-        for path in (
-            ManagedSessionSupervisor._stdout_path(record),
-            ManagedSessionSupervisor._stderr_path(record),
-        ):
-            if path.exists():
-                total += path.stat().st_size
-        return total
-
-    @staticmethod
     def _initial_stream_offsets(
         record: CodexManagedSessionRecord,
     ) -> dict[str, int]:
-        if not record.last_log_offset:
-            return {"stdout": 0, "stderr": 0}
         return {
-            "stdout": (
-                ManagedSessionSupervisor._stdout_path(record).stat().st_size
-                if ManagedSessionSupervisor._stdout_path(record).exists()
-                else 0
-            ),
-            "stderr": (
-                ManagedSessionSupervisor._stderr_path(record).stat().st_size
-                if ManagedSessionSupervisor._stderr_path(record).exists()
-                else 0
-            ),
+            "stdout": record.stdout_log_offset or 0,
+            "stderr": record.stderr_log_offset or 0,
         }
 
     def _publish_output_chunk(
@@ -121,6 +103,7 @@ class ManagedSessionSupervisor:
         self,
         record: CodexManagedSessionRecord,
         stream_offsets: dict[str, int],
+        stream_decoders: dict[str, codecs.IncrementalDecoder],
     ) -> bool:
         emitted = False
         for stream_name, path in (
@@ -135,24 +118,41 @@ class ManagedSessionSupervisor:
                 previous_offset = stream_offsets.get(stream_name, 0)
                 if current_size < previous_offset:
                     previous_offset = 0
+                    stream_decoders.pop(stream_name, None)
                 if current_size <= previous_offset:
                     stream_offsets[stream_name] = current_size
                     continue
+                decoder = stream_decoders.setdefault(
+                    stream_name,
+                    codecs.getincrementaldecoder("utf-8")(errors="replace"),
+                )
+                committed_offset = previous_offset
                 with path.open("rb") as handle:
                     handle.seek(previous_offset)
-                    data = handle.read(current_size - previous_offset)
-                stream_offsets[stream_name] = current_size
+                    remaining = current_size - previous_offset
+                    while remaining > 0:
+                        chunk = handle.read(min(_LOG_READ_CHUNK_BYTES, remaining))
+                        if not chunk:
+                            break
+                        remaining -= len(chunk)
+                        text = decoder.decode(chunk, final=False)
+                        buffered_bytes = len(decoder.getstate()[0])
+                        decoded_offset = handle.tell() - buffered_bytes
+                        if not text:
+                            continue
+                        self._publish_output_chunk(
+                            record=record,
+                            stream_name=stream_name,
+                            text=text,
+                            offset=committed_offset,
+                        )
+                        committed_offset = decoded_offset
+                        emitted = True
+                if decoder.getstate()[0]:
+                    decoder.reset()
+                stream_offsets[stream_name] = committed_offset
             except OSError:
                 continue
-            if not data:
-                continue
-            self._publish_output_chunk(
-                record=record,
-                stream_name=stream_name,
-                text=data.decode("utf-8", errors="replace"),
-                offset=previous_offset,
-            )
-            emitted = True
         return emitted
 
     def emit_session_event(
@@ -198,16 +198,23 @@ class ManagedSessionSupervisor:
             if initial_record is not None
             else {"stdout": 0, "stderr": 0}
         )
+        stream_decoders: dict[str, codecs.IncrementalDecoder] = {}
         while not stop_event.is_set():
             record = self._store.load(session_id)
             if record is None:
                 return
-            emitted = self._publish_new_output_chunks(record, stream_offsets)
-            combined_offset = self._combined_offset(record)
+            emitted = self._publish_new_output_chunks(
+                record,
+                stream_offsets,
+                stream_decoders,
+            )
+            combined_offset = sum(stream_offsets.values())
             if emitted or combined_offset != (record.last_log_offset or 0):
                 await self._store.update(
                     session_id,
                     last_log_offset=combined_offset,
+                    stdout_log_offset=stream_offsets.get("stdout", 0),
+                    stderr_log_offset=stream_offsets.get("stderr", 0),
                     last_log_at=datetime.now(tz=UTC),
                 )
             try:
@@ -404,6 +411,8 @@ class ManagedSessionSupervisor:
             latest_summary_ref=summary_ref,
             latest_checkpoint_ref=checkpoint_ref,
             last_log_offset=len(stdout_bytes) + len(stderr_bytes),
+            stdout_log_offset=len(stdout_bytes),
+            stderr_log_offset=len(stderr_bytes),
             last_log_at=now,
             updated_at=now,
             error_message=error_message,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -65,6 +65,96 @@ class ManagedSessionSupervisor:
                 total += path.stat().st_size
         return total
 
+    @staticmethod
+    def _initial_stream_offsets(
+        record: CodexManagedSessionRecord,
+    ) -> dict[str, int]:
+        if not record.last_log_offset:
+            return {"stdout": 0, "stderr": 0}
+        return {
+            "stdout": (
+                ManagedSessionSupervisor._stdout_path(record).stat().st_size
+                if ManagedSessionSupervisor._stdout_path(record).exists()
+                else 0
+            ),
+            "stderr": (
+                ManagedSessionSupervisor._stderr_path(record).stat().st_size
+                if ManagedSessionSupervisor._stderr_path(record).exists()
+                else 0
+            ),
+        }
+
+    def _publish_output_chunk(
+        self,
+        *,
+        record: CodexManagedSessionRecord,
+        stream_name: str,
+        text: str,
+        offset: int,
+    ) -> None:
+        try:
+            self._log_streamer.emit_observability_event(
+                run_id=record.task_run_id,
+                workspace_path=record.workspace_path,
+                stream=stream_name,
+                text=text,
+                kind=f"{stream_name}_chunk",
+                offset=offset,
+                session_id=record.session_id,
+                session_epoch=record.session_epoch,
+                container_id=record.container_id,
+                thread_id=record.thread_id,
+                active_turn_id=record.active_turn_id,
+                metadata={"source": "managed_session_artifact_spool"},
+                preserve_text=True,
+            )
+        except Exception:
+            logger.warning(
+                "Session output publication failed for task run %s session %s stream %s",
+                record.task_run_id,
+                record.session_id,
+                stream_name,
+                exc_info=True,
+            )
+
+    def _publish_new_output_chunks(
+        self,
+        record: CodexManagedSessionRecord,
+        stream_offsets: dict[str, int],
+    ) -> bool:
+        emitted = False
+        for stream_name, path in (
+            ("stdout", self._stdout_path(record)),
+            ("stderr", self._stderr_path(record)),
+        ):
+            try:
+                if not path.exists():
+                    stream_offsets.setdefault(stream_name, 0)
+                    continue
+                current_size = path.stat().st_size
+                previous_offset = stream_offsets.get(stream_name, 0)
+                if current_size < previous_offset:
+                    previous_offset = 0
+                if current_size <= previous_offset:
+                    stream_offsets[stream_name] = current_size
+                    continue
+                with path.open("rb") as handle:
+                    handle.seek(previous_offset)
+                    data = handle.read(current_size - previous_offset)
+                stream_offsets[stream_name] = current_size
+            except OSError:
+                continue
+            if not data:
+                continue
+            self._publish_output_chunk(
+                record=record,
+                stream_name=stream_name,
+                text=data.decode("utf-8", errors="replace"),
+                offset=previous_offset,
+            )
+            emitted = True
+        return emitted
+
     def emit_session_event(
         self,
         *,
@@ -102,12 +192,19 @@ class ManagedSessionSupervisor:
 
     async def _watch(self, session_id: str) -> None:
         stop_event = self._stop_events[session_id]
+        initial_record = self._store.load(session_id)
+        stream_offsets = (
+            self._initial_stream_offsets(initial_record)
+            if initial_record is not None
+            else {"stdout": 0, "stderr": 0}
+        )
         while not stop_event.is_set():
             record = self._store.load(session_id)
             if record is None:
                 return
+            emitted = self._publish_new_output_chunks(record, stream_offsets)
             combined_offset = self._combined_offset(record)
-            if combined_offset != (record.last_log_offset or 0):
+            if emitted or combined_offset != (record.last_log_offset or 0):
                 await self._store.update(
                     session_id,
                     last_log_offset=combined_offset,

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -98,6 +98,64 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_session_supervisor_publishes_output_chunks_to_live_spool(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    spool = Path(record.artifact_spool_path)
+
+    await supervisor.start(record)
+    (spool / "stdout.log").write_text("session started\n", encoding="utf-8")
+    await asyncio.sleep(0.05)
+    with (spool / "stdout.log").open("a", encoding="utf-8") as handle:
+        handle.write("assistant: OK\n")
+    (spool / "stderr.log").write_text("warning: none\n", encoding="utf-8")
+    await asyncio.sleep(0.05)
+
+    live_spool = Path(record.workspace_path) / "live_streams.spool"
+    payloads = [
+        json.loads(line)
+        for line in live_spool.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    stdout_events = [
+        item for item in payloads if item["stream"] == "stdout"
+    ]
+    stderr_events = [
+        item for item in payloads if item["stream"] == "stderr"
+    ]
+
+    assert [item["kind"] for item in stdout_events] == ["stdout_chunk", "stdout_chunk"]
+    assert stdout_events[0]["text"] == "session started\n"
+    assert stdout_events[0]["offset"] == 0
+    assert stdout_events[1]["text"] == "assistant: OK\n"
+    assert stdout_events[1]["offset"] == len("session started\n")
+    assert stderr_events[0]["kind"] == "stderr_chunk"
+    assert stderr_events[0]["text"] == "warning: none\n"
+    assert stderr_events[0]["offset"] == 0
+
+    snapshot = await supervisor.publish_snapshot("sess-1")
+    journal = artifact_storage.resolve_storage_path(snapshot.observability_events_ref)
+    journal_text = journal.read_text(encoding="utf-8")
+    assert '"stream":"stdout"' in journal_text
+    assert '"kind":"stdout_chunk"' in journal_text
+    assert '"stream":"stderr"' in journal_text
+    assert '"kind":"stderr_chunk"' in journal_text
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
 async def test_publish_snapshot_keeps_watch_task_running(tmp_path: Path) -> None:
     store = ManagedSessionStore(tmp_path / "store")
     artifact_storage = _LocalArtifactStorage(tmp_path / "published")

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -82,6 +82,8 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
 
     assert watched is not None
     assert watched.last_log_offset == len("session started\nassistant: OK\nwarning: none\n")
+    assert watched.stdout_log_offset == len("session started\nassistant: OK\n")
+    assert watched.stderr_log_offset == len("warning: none\n")
     assert watched.last_log_at is not None
     assert finalized.status == "terminated"
     assert finalized.stdout_artifact_ref == "sess-1/stdout.log"
@@ -90,6 +92,8 @@ async def test_session_supervisor_publishes_artifacts_and_offsets(tmp_path: Path
     assert finalized.latest_summary_ref == "sess-1/session.summary.json"
     assert finalized.latest_checkpoint_ref == "sess-1/session.step_checkpoint.json"
     assert finalized.last_log_offset == len("session started\nassistant: OK\nwarning: none\n")
+    assert finalized.stdout_log_offset == len("session started\nassistant: OK\n")
+    assert finalized.stderr_log_offset == len("warning: none\n")
     assert finalized.last_log_at is not None
     assert artifact_storage.resolve_storage_path("sess-1/stdout.log").read_text(encoding="utf-8") == "session started\nassistant: OK\n"
     assert artifact_storage.resolve_storage_path("sess-1/stderr.log").read_text(encoding="utf-8") == "warning: none\n"
@@ -151,6 +155,134 @@ async def test_session_supervisor_publishes_output_chunks_to_live_spool(
     assert '"kind":"stdout_chunk"' in journal_text
     assert '"stream":"stderr"' in journal_text
     assert '"kind":"stderr_chunk"' in journal_text
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
+async def test_session_supervisor_resumes_from_persisted_stream_offsets(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    spool = Path(record.artifact_spool_path)
+    stdout_prefix = b"old stdout\n"
+    stderr_prefix = b"old stderr\n"
+    (spool / "stdout.log").write_bytes(stdout_prefix)
+    (spool / "stderr.log").write_bytes(stderr_prefix)
+    store.save(
+        record.model_copy(
+            update={
+                "last_log_offset": len(stdout_prefix) + len(stderr_prefix),
+                "stdout_log_offset": len(stdout_prefix),
+                "stderr_log_offset": len(stderr_prefix),
+            }
+        )
+    )
+
+    await supervisor.start(record)
+    with (spool / "stdout.log").open("ab") as handle:
+        handle.write(b"new stdout\n")
+    with (spool / "stderr.log").open("ab") as handle:
+        handle.write(b"new stderr\n")
+    await asyncio.sleep(0.05)
+
+    live_spool = Path(record.workspace_path) / "live_streams.spool"
+    payloads = [
+        json.loads(line)
+        for line in live_spool.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [(item["stream"], item["text"], item["offset"]) for item in payloads] == [
+        ("stdout", "new stdout\n", len(stdout_prefix)),
+        ("stderr", "new stderr\n", len(stderr_prefix)),
+    ]
+    watched = store.load("sess-1")
+    assert watched is not None
+    assert watched.stdout_log_offset == len(stdout_prefix) + len(b"new stdout\n")
+    assert watched.stderr_log_offset == len(stderr_prefix) + len(b"new stderr\n")
+    assert watched.last_log_offset == watched.stdout_log_offset + watched.stderr_log_offset
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
+async def test_session_supervisor_conservatively_replays_without_stream_offsets(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    spool = Path(record.artifact_spool_path)
+    (spool / "stdout.log").write_text("missed while down\n", encoding="utf-8")
+    store.save(record.model_copy(update={"last_log_offset": 123}))
+
+    await supervisor.start(record)
+    await asyncio.sleep(0.05)
+
+    live_spool = Path(record.workspace_path) / "live_streams.spool"
+    payloads = [
+        json.loads(line)
+        for line in live_spool.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [(item["stream"], item["text"], item["offset"]) for item in payloads] == [
+        ("stdout", "missed while down\n", 0),
+    ]
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
+async def test_session_supervisor_waits_for_complete_utf8_sequences(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    spool = Path(record.artifact_spool_path)
+
+    await supervisor.start(record)
+    (spool / "stdout.log").write_bytes("€".encode("utf-8")[:1])
+    await asyncio.sleep(0.05)
+    assert not (Path(record.workspace_path) / "live_streams.spool").exists()
+
+    with (spool / "stdout.log").open("ab") as handle:
+        handle.write("€\n".encode("utf-8")[1:])
+    await asyncio.sleep(0.05)
+
+    live_spool = Path(record.workspace_path) / "live_streams.spool"
+    payloads = [
+        json.loads(line)
+        for line in live_spool.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [(item["stream"], item["text"], item["offset"]) for item in payloads] == [
+        ("stdout", "€\n", 0),
+    ]
+    watched = store.load("sess-1")
+    assert watched is not None
+    assert watched.stdout_log_offset == len("€\n".encode("utf-8"))
 
     await supervisor.finalize("sess-1", status="terminated")
 


### PR DESCRIPTION
## Summary

Fixes Live Logs for Codex managed sessions so ongoing stdout and stderr from the session container reach the MoonMind live observability stream instead of only session lifecycle summary rows.

## Root Cause

Codex managed sessions write ongoing output to the session artifact spool (`stdout.log` / `stderr.log`), while the Live Logs SSE endpoint tails `workspace/live_streams.spool`. The session supervisor was publishing session lifecycle events into that live spool, but it was not forwarding stdout/stderr deltas from the artifact spool.

## Changes

- Tail Codex session stdout/stderr artifact spool files from the session supervisor.
- Publish incremental `stdout_chunk` and `stderr_chunk` events into the shared Live Logs spool with offsets and session metadata.
- Preserve raw output text for emitted output chunks so newline formatting survives transport.
- Fix the frontend SSE resume cursor to send the last seen sequence, matching backend `since` semantics.
- Add backend and frontend regression coverage for the live output path.

## Validation

- `./tools/test_unit.sh --python-only --no-xdist tests/unit/services/temporal/runtime/test_managed_session_supervisor.py tests/unit/services/temporal/runtime/test_log_streamer.py tests/unit/api/routers/test_task_runs.py tests/unit/observability/test_transport.py`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx`
- `./tools/test_unit.sh`