### PR TITLE
[codex] Fix Jira project selector contract

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1056,9 +1056,9 @@ describe("Task Create Entrypoint", () => {
             ok: true,
             json: async () => ({
               items: [
-                { key: "OPS", name: "Operations" },
-                { key: "ENG", name: "Engineering" },
-                { key: "MY-PROJ", name: "Hyphenated Project" },
+                { projectKey: "OPS", name: "Operations" },
+                { projectKey: "ENG", name: "Engineering" },
+                { projectKey: "MY-PROJ", name: "Hyphenated Project" },
               ],
             }),
           } as Response);

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -163,8 +163,9 @@ interface JiraIntegrationConfig {
 type JiraEndpointTemplates = JiraIntegrationConfig["endpoints"];
 
 interface JiraProject {
-  key: string;
+  projectKey: string;
   name: string;
+  id?: string | null;
 }
 
 interface JiraBoard {
@@ -2126,7 +2127,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const projects = jiraProjectsQuery.data || [];
     if (selectedJiraProjectKey) {
       const selectedProjectExists = projects.some(
-        (project) => project.key === selectedJiraProjectKey,
+        (project) => project.projectKey === selectedJiraProjectKey,
       );
       if (jiraProjectsQuery.data && !selectedProjectExists) {
         if (jiraIntegration.rememberLastBoardInSession) {
@@ -2148,9 +2149,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
     const configured = projects.find(
-      (project) => project.key === jiraIntegration.defaultProjectKey,
+      (project) => project.projectKey === jiraIntegration.defaultProjectKey,
     );
-    setSelectedJiraProjectKey((configured || projects[0])?.key || "");
+    setSelectedJiraProjectKey((configured || projects[0])?.projectKey || "");
     jiraProjectSelectionInitializedRef.current = true;
     jiraBoardSelectionInitializedRef.current = false;
   }, [
@@ -3741,10 +3742,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 >
                   <option value="">Select project...</option>
                   {(jiraProjectsQuery.data || []).map((project) => (
-                    <option key={project.key} value={project.key}>
+                    <option key={project.projectKey} value={project.projectKey}>
                       {project.name
-                        ? `${project.name} (${project.key})`
-                        : project.key}
+                        ? `${project.name} (${project.projectKey})`
+                        : project.projectKey}
                     </option>
                   ))}
                 </select>


### PR DESCRIPTION
## Summary

Fix the Create page Jira browser project selector to use the backend contract field `projectKey` instead of the mock-only `key` field.

This resolves the dropdown rendering projects as values like `MoonMind (undefined)` and prevents project selection from clearing or failing before board loading.

## Changes

- Updated the `JiraProject` frontend type to match the MoonMind Jira browser API response.
- Updated project defaulting, selected-project validation, and `<option>` values/labels to use `projectKey`.
- Updated Create page Jira test fixtures to use the real API shape so this regression is covered.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:lint`
- `ATLASSIAN_* and Jira policy vars blanked for hermeticity, MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed: Python unit tests and dashboard tests completed cleanly.

Note: Running the full unit suite without blanking local Atlassian/Jira config failed because existing Jira backend unit tests loaded operator `.env` credentials/policy settings. The sanitized run avoids using local provider configuration and passed.