### PR TITLE
When Jira tasks are retrieved, MoonMind should be able to pull down images as well and include them for runtimes that support them

### DIFF
--- a/api_service/api/routers/jira_browser.py
+++ b/api_service/api/routers/jira_browser.py
@@ -196,8 +196,9 @@ async def download_issue_attachment(
             issue_key.upper(),
             attachment_id,
         )
-        filename = attachment.filename.replace('"', "")
-        disposition = f"attachment; filename*=UTF-8''{quote(filename)}"
+        disposition = (
+            f"attachment; filename*=UTF-8''{quote(attachment.filename, safe='')}"
+        )
         return Response(
             content=payload,
             media_type=content_type or attachment.content_type,

--- a/api_service/api/routers/jira_browser.py
+++ b/api_service/api/routers/jira_browser.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import re
+from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
@@ -174,6 +175,34 @@ async def get_issue(
 ) -> JiraIssueDetail:
     try:
         return await service.get_issue(issue_key.upper(), board_id=board_id)
+    except JiraToolError as exc:
+        raise _to_http_exception(exc) from None
+    except Exception:
+        raise _unexpected_http_exception() from None
+
+
+@router.get(
+    "/issues/{issue_key}/attachments/{attachment_id}/content",
+    response_class=Response,
+)
+async def download_issue_attachment(
+    issue_key: str,
+    attachment_id: str,
+    _user: User = Depends(get_current_user()),
+    service: JiraBrowserService = Depends(_get_service),
+) -> Response:
+    try:
+        attachment, payload, content_type = await service.download_issue_image_attachment(
+            issue_key.upper(),
+            attachment_id,
+        )
+        filename = attachment.filename.replace('"', "")
+        disposition = f"attachment; filename*=UTF-8''{quote(filename)}"
+        return Response(
+            content=payload,
+            media_type=content_type or attachment.content_type,
+            headers={"content-disposition": disposition},
+        )
     except JiraToolError as exc:
         raise _to_http_exception(exc) from None
     except Exception:

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2451,7 +2451,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
     setJiraImageImporting(true);
     try {
-      const downloaded = await Promise.all(
+      const downloaded = await Promise.allSettled(
         toDownload.map(async (attachment) => {
           const response = await fetch(attachment.downloadUrl);
           if (!response.ok) {
@@ -2469,7 +2469,23 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             : file;
         }),
       );
-      const files = downloaded.filter((file): file is File => file !== null);
+      const files = downloaded
+        .filter(
+          (result): result is PromiseFulfilledResult<File | null> =>
+            result.status === "fulfilled",
+        )
+        .map((result) => result.value)
+        .filter((file): file is File => file !== null);
+      const failures = downloaded
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        )
+        .map((result) =>
+          result.reason instanceof Error
+            ? result.reason.message
+            : "Failed to download Jira image.",
+        );
       if (files.length > 0) {
         const combinedFiles = [...selectedAttachmentFiles, ...files];
         const validation = validateAttachmentFiles(combinedFiles, attachmentPolicy);
@@ -2479,10 +2495,24 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         }
         setSelectedAttachmentFiles(combinedFiles);
       }
+      const messages: string[] = [];
       if (eligible.length > toDownload.length) {
-        setSubmitMessage(
+        messages.push(
           "Some Jira images were skipped because the attachment limit was reached.",
         );
+      }
+      if (failures.length > 0) {
+        const uniqueFailures = Array.from(new Set(failures));
+        messages.push(
+          uniqueFailures.length === 1
+            ? (uniqueFailures[0] ?? "Failed to download Jira image.")
+            : `${failures.length} Jira images failed to download. ${uniqueFailures
+                .slice(0, 3)
+                .join(" ")}`,
+        );
+      }
+      if (messages.length > 0) {
+        setSubmitMessage(messages.join(" "));
       }
     } catch (error) {
       const failure =

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -201,6 +201,15 @@ interface JiraIssueDetail extends JiraIssueSummary {
     presetInstructions?: string | null;
     stepInstructions?: string | null;
   } | null;
+  attachments?: JiraIssueAttachment[];
+}
+
+interface JiraIssueAttachment {
+  id: string;
+  filename: string;
+  contentType: string;
+  sizeBytes?: number | null;
+  downloadUrl: string;
 }
 
 type JiraImportTarget =
@@ -931,6 +940,25 @@ function validateAttachmentFiles(
   return { ok: errors.length === 0, errors, totalBytes };
 }
 
+function validateJiraImageAttachment(
+  attachment: JiraIssueAttachment,
+  policy: AttachmentPolicy,
+): string | null {
+  const type = String(attachment.contentType || "")
+    .trim()
+    .toLowerCase();
+  if (!policy.allowedContentTypes.includes(type)) {
+    return `${attachment.filename || "Jira image"} uses an unsupported image type.`;
+  }
+  const sizeBytes = Math.max(0, Number(attachment.sizeBytes) || 0);
+  if (sizeBytes > policy.maxBytes) {
+    return `${attachment.filename || "Jira image"} exceeds ${formatAttachmentBytes(
+      policy.maxBytes,
+    )}.`;
+  }
+  return null;
+}
+
 function deriveRequiredCapabilities(args: {
   runtimeMode: string;
   publishMode: string;
@@ -1602,6 +1630,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedAttachmentFiles, setSelectedAttachmentFiles] = useState<
     File[]
   >([]);
+  const [jiraImageImporting, setJiraImageImporting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -2392,7 +2421,81 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     setSelectedJiraIssueKey("");
   }
 
-  function importSelectedJiraIssue(writeMode: JiraWriteMode) {
+  async function importSelectedJiraImages(issue: JiraIssueDetail): Promise<void> {
+    const attachments = Array.isArray(issue.attachments) ? issue.attachments : [];
+    if (!attachmentPolicy.enabled || attachments.length === 0) {
+      return;
+    }
+    const eligible = attachments.filter(
+      (attachment) => !validateJiraImageAttachment(attachment, attachmentPolicy),
+    );
+    if (eligible.length === 0) {
+      setSubmitMessage(
+        "Jira images are not supported by the current attachment policy.",
+      );
+      return;
+    }
+    const existingKeys = new Set(
+      selectedAttachmentFiles.map(
+        (file) => `${file.name}:${file.size}:${file.type}`,
+      ),
+    );
+    const room = Math.max(
+      0,
+      attachmentPolicy.maxCount - selectedAttachmentFiles.length,
+    );
+    const toDownload = eligible.slice(0, room);
+    if (toDownload.length === 0) {
+      setSubmitMessage("Attachment limit reached before Jira images could be added.");
+      return;
+    }
+    setJiraImageImporting(true);
+    try {
+      const downloaded = await Promise.all(
+        toDownload.map(async (attachment) => {
+          const response = await fetch(attachment.downloadUrl);
+          if (!response.ok) {
+            throw new Error(
+              await responseErrorMessage(response, "Failed to download Jira image."),
+            );
+          }
+          const blob = await response.blob();
+          const type = String(
+            blob.type || attachment.contentType || "",
+          ).toLowerCase();
+          const file = new File([blob], attachment.filename, { type });
+          return existingKeys.has(`${file.name}:${file.size}:${file.type}`)
+            ? null
+            : file;
+        }),
+      );
+      const files = downloaded.filter((file): file is File => file !== null);
+      if (files.length > 0) {
+        const combinedFiles = [...selectedAttachmentFiles, ...files];
+        const validation = validateAttachmentFiles(combinedFiles, attachmentPolicy);
+        if (!validation.ok) {
+          setSubmitMessage(validation.errors.join(" "));
+          return;
+        }
+        setSelectedAttachmentFiles(combinedFiles);
+      }
+      if (eligible.length > toDownload.length) {
+        setSubmitMessage(
+          "Some Jira images were skipped because the attachment limit was reached.",
+        );
+      }
+    } catch (error) {
+      const failure =
+        error instanceof Error
+          ? error
+          : new Error("Failed to download Jira images.");
+      setSubmitMessage(failure.message);
+    } finally {
+      setJiraImageImporting(false);
+    }
+  }
+
+  async function importSelectedJiraIssue(writeMode: JiraWriteMode) {
     if (!selectedJiraIssue || !jiraImportTarget) {
       return;
     }
@@ -2420,6 +2523,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (appliedTemplates.length > 0) {
         setPresetReapplyNeeded(true);
       }
+      await importSelectedJiraImages(selectedJiraIssue);
       return;
     }
 
@@ -2455,6 +2559,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const { [jiraImportTarget.localId]: _removed, ...rest } = current;
       return rest;
     });
+    await importSelectedJiraImages(selectedJiraIssue);
   }
 
   function handleTemplateFeatureRequestChange(value: string) {
@@ -3876,6 +3981,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         </p>
                       </section>
                     ) : null}
+                    {Array.isArray(selectedJiraIssue.attachments) &&
+                    selectedJiraIssue.attachments.length > 0 ? (
+                      <section>
+                        <strong>Images</strong>
+                        <ul className="list">
+                          {selectedJiraIssue.attachments.map((attachment) => (
+                            <li key={attachment.id}>
+                              {attachment.filename}
+                              {attachment.sizeBytes
+                                ? ` (${formatAttachmentBytes(attachment.sizeBytes)})`
+                                : ""}
+                            </li>
+                          ))}
+                        </ul>
+                        <p className="small">
+                          {attachmentPolicy.enabled
+                            ? "Imported text will add supported Jira images to task attachments."
+                            : "Jira images are available, but image attachments are disabled for this runtime."}
+                        </p>
+                      </section>
+                    ) : null}
                     <label>
                       Import mode
                       <select
@@ -3901,14 +4027,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     <div className="actions">
                       <button
                         type="button"
-                        onClick={() => importSelectedJiraIssue("replace")}
+                        disabled={jiraImageImporting}
+                        onClick={() => void importSelectedJiraIssue("replace")}
                       >
                         Replace target text
                       </button>
                       <button
                         type="button"
                         className="secondary"
-                        onClick={() => importSelectedJiraIssue("append")}
+                        disabled={jiraImageImporting}
+                        onClick={() => void importSelectedJiraIssue("append")}
                       >
                         Append to target text
                       </button>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -373,6 +373,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jira/issues/{issue_key}/attachments/{attachment_id}/content": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download Issue Attachment */
+        get: operations["download_issue_attachment_api_jira_issues__issue_key__attachments__attachment_id__content_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/manifests": {
         parameters: {
             query?: never;
@@ -3707,6 +3724,19 @@ export interface components {
             /** Projectname */
             projectName?: string | null;
         };
+        /** JiraIssueAttachment */
+        JiraIssueAttachment: {
+            /** Id */
+            id: string;
+            /** Filename */
+            filename: string;
+            /** Contenttype */
+            contentType: string;
+            /** Sizebytes */
+            sizeBytes?: number | null;
+            /** Downloadurl */
+            downloadUrl: string;
+        };
         /** JiraIssueColumn */
         JiraIssueColumn: {
             /** Id */
@@ -3736,6 +3766,8 @@ export interface components {
              * @default
              */
             acceptanceCriteriaText: string;
+            /** Attachments */
+            attachments?: components["schemas"]["JiraIssueAttachment"][];
             recommendedImports: components["schemas"]["JiraIssueRecommendations"];
         };
         /** JiraIssueRecommendations */
@@ -6611,6 +6643,36 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["JiraIssueDetail"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_issue_attachment_api_jira_issues__issue_key__attachments__attachment_id__content_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                issue_key: string;
+                attachment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/moonmind/integrations/jira/browser.py
+++ b/moonmind/integrations/jira/browser.py
@@ -8,6 +8,7 @@ import re
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Generic, TypeVar
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -27,6 +28,7 @@ T = TypeVar("T")
 _JIRA_PROJECT_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]+$")
 _JIRA_ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]+-\d+$")
 _BOARD_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_JIRA_ATTACHMENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 _JIRA_BROWSER_PAGE_SIZE = 50
 _ACCEPTANCE_HEADING_RE = re.compile(
     r"(?im)^\s*(acceptance\s+criteria|acceptance|ac)\s*:?\s*$"
@@ -151,6 +153,14 @@ class JiraIssueRecommendations(JiraBrowserModel):
     step_instructions: str = Field(..., alias="stepInstructions")
 
 
+class JiraIssueAttachment(JiraBrowserModel):
+    id: str
+    filename: str
+    content_type: str = Field(..., alias="contentType")
+    size_bytes: int | None = Field(None, alias="sizeBytes")
+    download_url: str = Field(..., alias="downloadUrl")
+
+
 class JiraIssueDetail(JiraBrowserModel):
     issue_key: str = Field(..., alias="issueKey")
     url: str | None = None
@@ -160,6 +170,7 @@ class JiraIssueDetail(JiraBrowserModel):
     status: JiraIssueStatus | None = None
     description_text: str = Field("", alias="descriptionText")
     acceptance_criteria_text: str = Field("", alias="acceptanceCriteriaText")
+    attachments: list[JiraIssueAttachment] = Field(default_factory=list)
     recommended_imports: JiraIssueRecommendations = Field(..., alias="recommendedImports")
 
 
@@ -368,6 +379,58 @@ class JiraBrowserService:
                 ).columns
         return self._normalize_issue_detail(payload, board_columns=board_columns)
 
+    async def download_issue_image_attachment(
+        self,
+        issue_key: str,
+        attachment_id: str,
+    ) -> tuple[JiraIssueAttachment, bytes, str]:
+        self._ensure_enabled()
+        normalized_issue_key = self._normalize_issue_key(issue_key)
+        normalized_attachment_id = self._normalize_attachment_id(attachment_id)
+        self._ensure_project_allowed(self._project_from_issue_key(normalized_issue_key))
+        payload = await self._request_json(
+            method="GET",
+            path=f"/issue/{normalized_issue_key}",
+            action="jira_browser.get_issue_attachment",
+            params={"fields": "attachment"},
+            context={"issueKey": normalized_issue_key},
+        )
+        fields = payload.get("fields") if isinstance(payload, Mapping) else {}
+        if not isinstance(fields, Mapping):
+            fields = {}
+        attachment, content_url = self._find_issue_image_attachment(
+            fields,
+            issue_key=normalized_issue_key,
+            attachment_id=normalized_attachment_id,
+        )
+        if attachment is None or not content_url:
+            raise JiraToolError(
+                "Jira could not find the requested image attachment on this issue.",
+                code="jira_not_found",
+                status_code=404,
+                action="jira_browser.download_attachment",
+            )
+
+        download_path = self._safe_attachment_download_path(content_url)
+        payload_bytes, response_content_type = await self._request_bytes(
+            method="GET",
+            path=download_path,
+            action="jira_browser.download_attachment",
+            context={
+                "issueKey": normalized_issue_key,
+                "attachmentId": normalized_attachment_id,
+            },
+        )
+        content_type = response_content_type or attachment.content_type
+        if not self._is_image_content_type(content_type):
+            raise JiraToolError(
+                "Jira attachment is not an image.",
+                code="jira_validation_failed",
+                status_code=422,
+                action="jira_browser.download_attachment",
+            )
+        return attachment, payload_bytes, content_type
+
     @asynccontextmanager
     async def _jira_client(self) -> AsyncIterator[JiraClient]:
         connection = await resolve_jira_connection(self._settings)
@@ -417,6 +480,24 @@ class JiraBrowserService:
             json_body=json_body,
             context=context,
         )
+
+    async def _request_bytes(
+        self,
+        *,
+        method: str,
+        path: str,
+        action: str,
+        params: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[bytes, str]:
+        async with self._jira_client() as client:
+            return await client.request_bytes(
+                method=method,
+                path=path,
+                action=action,
+                params=params,
+                context=context,
+            )
 
     async def _list_columns_with_client(
         self,
@@ -630,6 +711,7 @@ class JiraBrowserService:
             acceptance_text=acceptance_text,
         )
         url = self._issue_url(payload)
+        attachments = self._normalize_issue_attachments(fields, issue_key=issue_key)
         return JiraIssueDetail(
             issueKey=issue_key,
             url=url,
@@ -642,6 +724,7 @@ class JiraBrowserService:
             ),
             descriptionText=description_text,
             acceptanceCriteriaText=acceptance_text,
+            attachments=attachments,
             recommendedImports=recommended,
         )
 
@@ -711,6 +794,114 @@ class JiraBrowserService:
             return f"{self_url.split(marker, 1)[0]}/browse/{payload.get('key')}"
         return None
 
+    def _normalize_issue_attachments(
+        self,
+        fields: Mapping[str, Any],
+        *,
+        issue_key: str,
+    ) -> list[JiraIssueAttachment]:
+        raw_attachments = fields.get("attachment")
+        if not isinstance(raw_attachments, list):
+            return []
+        attachments: list[JiraIssueAttachment] = []
+        for item in raw_attachments:
+            if not isinstance(item, Mapping):
+                continue
+            attachment = self._normalize_issue_attachment(
+                item,
+                issue_key=issue_key,
+            )
+            if attachment is not None:
+                attachments.append(attachment)
+        return attachments
+
+    def _find_issue_image_attachment(
+        self,
+        fields: Mapping[str, Any],
+        *,
+        issue_key: str,
+        attachment_id: str,
+    ) -> tuple[JiraIssueAttachment | None, str | None]:
+        raw_attachments = fields.get("attachment")
+        if not isinstance(raw_attachments, list):
+            return None, None
+        for item in raw_attachments:
+            if not isinstance(item, Mapping):
+                continue
+            normalized_id = str(item.get("id") or "").strip()
+            if normalized_id != attachment_id:
+                continue
+            attachment = self._normalize_issue_attachment(
+                item,
+                issue_key=issue_key,
+            )
+            return attachment, str(item.get("content") or "").strip() or None
+        return None, None
+
+    def _normalize_issue_attachment(
+        self,
+        item: Mapping[str, Any],
+        *,
+        issue_key: str,
+    ) -> JiraIssueAttachment | None:
+        attachment_id = str(item.get("id") or "").strip()
+        filename = str(item.get("filename") or "").strip()
+        content_type = (
+            str(item.get("mimeType") or item.get("contentType") or "").strip().lower()
+        )
+        content_url = str(item.get("content") or "").strip()
+        if (
+            not attachment_id
+            or not filename
+            or not content_url
+            or not self._is_image_content_type(content_type)
+        ):
+            return None
+        size_value = item.get("size")
+        try:
+            size_bytes = int(size_value) if size_value is not None else None
+        except (TypeError, ValueError):
+            size_bytes = None
+        return JiraIssueAttachment(
+            id=attachment_id,
+            filename=filename,
+            contentType=content_type,
+            sizeBytes=size_bytes,
+            downloadUrl=f"/api/jira/issues/{issue_key}/attachments/{attachment_id}/content",
+        )
+
+    def _safe_attachment_download_path(self, download_url: str) -> str:
+        parsed = urlparse(download_url)
+        if not parsed.scheme and not parsed.netloc:
+            path = parsed.path or download_url
+            if parsed.query:
+                path = f"{path}?{parsed.query}"
+            return path
+        allowed_origins = set()
+        for raw_base in (
+            self._settings.atlassian_site_url,
+            self._settings.atlassian_url,
+        ):
+            base = urlparse(str(raw_base or ""))
+            if base.scheme and base.netloc:
+                allowed_origins.add((base.scheme, base.netloc))
+        if self._settings.atlassian_cloud_id:
+            allowed_origins.add(("https", "api.atlassian.com"))
+        if not allowed_origins or (parsed.scheme, parsed.netloc) not in allowed_origins:
+            raise JiraToolError(
+                "Jira attachment download URL is outside the configured Jira origin.",
+                code="jira_validation_failed",
+                status_code=422,
+                action="jira_browser.download_attachment",
+            )
+        path = parsed.path
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+        return path
+
+    def _is_image_content_type(self, value: str) -> bool:
+        return str(value or "").strip().lower().startswith("image/")
+
     def _normalize_project_key(self, value: object) -> str:
         normalized = str(value or "").strip().upper()
         if not _JIRA_PROJECT_KEY_RE.fullmatch(normalized):
@@ -743,6 +934,17 @@ class JiraBrowserService:
         if not _BOARD_ID_RE.fullmatch(normalized):
             raise JiraToolError(
                 "boardId must be a non-empty Jira board identifier.",
+                code="jira_validation_failed",
+                status_code=422,
+                action="jira_browser.validation",
+            )
+        return normalized
+
+    def _normalize_attachment_id(self, value: object) -> str:
+        normalized = str(value or "").strip()
+        if not _JIRA_ATTACHMENT_ID_RE.fullmatch(normalized):
+            raise JiraToolError(
+                "attachmentId must be a non-empty Jira attachment identifier.",
                 code="jira_validation_failed",
                 status_code=422,
                 action="jira_browser.validation",

--- a/moonmind/integrations/jira/browser.py
+++ b/moonmind/integrations/jira/browser.py
@@ -887,6 +887,10 @@ class JiraBrowserService:
                 allowed_origins.add((base.scheme, base.netloc))
         if self._settings.atlassian_cloud_id:
             allowed_origins.add(("https", "api.atlassian.com"))
+            if parsed.scheme == "https" and self._is_atlassian_tenant_host(
+                parsed.netloc
+            ):
+                allowed_origins.add((parsed.scheme, parsed.netloc))
         if not allowed_origins or (parsed.scheme, parsed.netloc) not in allowed_origins:
             raise JiraToolError(
                 "Jira attachment download URL is outside the configured Jira origin.",
@@ -898,6 +902,10 @@ class JiraBrowserService:
         if parsed.query:
             path = f"{path}?{parsed.query}"
         return path
+
+    def _is_atlassian_tenant_host(self, host: str) -> bool:
+        normalized = str(host or "").strip().lower()
+        return normalized == "atlassian.net" or normalized.endswith(".atlassian.net")
 
     def _is_image_content_type(self, value: str) -> bool:
         return str(value or "").strip().lower().startswith("image/")

--- a/moonmind/integrations/jira/client.py
+++ b/moonmind/integrations/jira/client.py
@@ -63,6 +63,59 @@ class JiraClient:
     ) -> Any:
         """Perform one Jira request with bounded retry handling."""
 
+        response = await self._request_raw(
+            method=method,
+            path=path,
+            action=action,
+            params=params,
+            json_body=json_body,
+            context=context,
+        )
+        try:
+            return self._decode_response(response)
+        except Exception as exc:
+            raise JiraToolError(
+                "Jira response could not be decoded.",
+                code="jira_request_failed",
+                status_code=502,
+                action=action,
+            ) from exc
+
+    async def request_bytes(
+        self,
+        *,
+        method: str,
+        path: str,
+        action: str,
+        params: Mapping[str, Any] | None = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> tuple[bytes, str]:
+        """Perform one Jira request and return raw bytes plus content type."""
+
+        response = await self._request_raw(
+            method=method,
+            path=path,
+            action=action,
+            params=params,
+            context=context,
+        )
+        return (
+            bytes(response.content or b""),
+            response.headers.get("content-type", "").split(";", 1)[0].strip(),
+        )
+
+    async def _request_raw(
+        self,
+        *,
+        method: str,
+        path: str,
+        action: str,
+        params: Mapping[str, Any] | None = None,
+        json_body: Any = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Perform one Jira request and return the successful raw response."""
+
         attempts = max(self._connection.retry_attempts, 1)
         retry_delay = 1.0
         request_id: str | None = None
@@ -149,123 +202,7 @@ class JiraClient:
                 request_id,
                 safe_context,
             )
-            try:
-                return self._decode_response(response)
-            except Exception as exc:
-                raise JiraToolError(
-                    "Jira response could not be decoded.",
-                    code="jira_request_failed",
-                    status_code=502,
-                    action=action,
-                ) from exc
-
-        raise JiraToolError(
-            "Jira request failed unexpectedly before a response could be returned.",
-            code="jira_request_failed",
-            status_code=502,
-            action=action,
-        )
-
-    async def request_bytes(
-        self,
-        *,
-        method: str,
-        path: str,
-        action: str,
-        params: Mapping[str, Any] | None = None,
-        context: Mapping[str, Any] | None = None,
-    ) -> tuple[bytes, str]:
-        """Perform one Jira request and return raw bytes plus content type."""
-
-        attempts = max(self._connection.retry_attempts, 1)
-        retry_delay = 1.0
-        request_id: str | None = None
-        safe_context = dict(context or {})
-
-        for attempt in range(1, attempts + 1):
-            try:
-                response = await self._client.request(
-                    method=method,
-                    url=self._resolve_request_path(path),
-                    params=params,
-                )
-            except (httpx.TransportError, httpx.TimeoutException) as exc:
-                if attempt < attempts:
-                    logger.info(
-                        "jira_retrying action=%s reason=transport attempt=%s request_id=%s context=%s",
-                        action,
-                        attempt,
-                        request_id,
-                        safe_context,
-                    )
-                    await asyncio.sleep(retry_delay)
-                    retry_delay *= 2
-                    continue
-                raise JiraToolError(
-                    "Jira request could not reach Atlassian.",
-                    code="jira_request_failed",
-                    status_code=502,
-                    action=action,
-                ) from exc
-
-            request_id = (
-                response.headers.get("x-arequestid")
-                or response.headers.get("x-request-id")
-                or response.headers.get("atl-traceid")
-            )
-
-            if response.status_code in _RETRYABLE_STATUS_CODES and attempt < attempts:
-                wait_seconds = self._retry_after_seconds(response) or retry_delay
-                logger.info(
-                    "jira_retrying action=%s status=%s attempt=%s request_id=%s context=%s",
-                    action,
-                    response.status_code,
-                    attempt,
-                    request_id,
-                    safe_context,
-                )
-                await asyncio.sleep(wait_seconds)
-                retry_delay = max(wait_seconds * 2, retry_delay * 2)
-                continue
-
-            if response.status_code in _RETRYABLE_STATUS_CODES and attempt >= attempts:
-                if response.status_code == 429:
-                    raise JiraToolError(
-                        "Jira rate limited the request after the configured retries were exhausted.",
-                        code="jira_rate_limited",
-                        status_code=429,
-                        action=action,
-                    )
-                raise JiraToolError(
-                    "Jira was temporarily unavailable after the configured retries were exhausted.",
-                    code="jira_request_failed",
-                    status_code=502,
-                    action=action,
-                )
-
-            if response.status_code >= 400:
-                self._log_failure(
-                    action=action,
-                    response=response,
-                    request_id=request_id,
-                    context=safe_context,
-                )
-                raise self._response_error(
-                    action=action,
-                    response=response,
-                )
-
-            logger.info(
-                "jira_request_completed action=%s status=%s request_id=%s context=%s",
-                action,
-                response.status_code,
-                request_id,
-                safe_context,
-            )
-            return (
-                bytes(response.content or b""),
-                response.headers.get("content-type", "").split(";", 1)[0].strip(),
-            )
+            return response
 
         raise JiraToolError(
             "Jira request failed unexpectedly before a response could be returned.",

--- a/moonmind/integrations/jira/client.py
+++ b/moonmind/integrations/jira/client.py
@@ -166,6 +166,114 @@ class JiraClient:
             action=action,
         )
 
+    async def request_bytes(
+        self,
+        *,
+        method: str,
+        path: str,
+        action: str,
+        params: Mapping[str, Any] | None = None,
+        context: Mapping[str, Any] | None = None,
+    ) -> tuple[bytes, str]:
+        """Perform one Jira request and return raw bytes plus content type."""
+
+        attempts = max(self._connection.retry_attempts, 1)
+        retry_delay = 1.0
+        request_id: str | None = None
+        safe_context = dict(context or {})
+
+        for attempt in range(1, attempts + 1):
+            try:
+                response = await self._client.request(
+                    method=method,
+                    url=self._resolve_request_path(path),
+                    params=params,
+                )
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                if attempt < attempts:
+                    logger.info(
+                        "jira_retrying action=%s reason=transport attempt=%s request_id=%s context=%s",
+                        action,
+                        attempt,
+                        request_id,
+                        safe_context,
+                    )
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue
+                raise JiraToolError(
+                    "Jira request could not reach Atlassian.",
+                    code="jira_request_failed",
+                    status_code=502,
+                    action=action,
+                ) from exc
+
+            request_id = (
+                response.headers.get("x-arequestid")
+                or response.headers.get("x-request-id")
+                or response.headers.get("atl-traceid")
+            )
+
+            if response.status_code in _RETRYABLE_STATUS_CODES and attempt < attempts:
+                wait_seconds = self._retry_after_seconds(response) or retry_delay
+                logger.info(
+                    "jira_retrying action=%s status=%s attempt=%s request_id=%s context=%s",
+                    action,
+                    response.status_code,
+                    attempt,
+                    request_id,
+                    safe_context,
+                )
+                await asyncio.sleep(wait_seconds)
+                retry_delay = max(wait_seconds * 2, retry_delay * 2)
+                continue
+
+            if response.status_code in _RETRYABLE_STATUS_CODES and attempt >= attempts:
+                if response.status_code == 429:
+                    raise JiraToolError(
+                        "Jira rate limited the request after the configured retries were exhausted.",
+                        code="jira_rate_limited",
+                        status_code=429,
+                        action=action,
+                    )
+                raise JiraToolError(
+                    "Jira was temporarily unavailable after the configured retries were exhausted.",
+                    code="jira_request_failed",
+                    status_code=502,
+                    action=action,
+                )
+
+            if response.status_code >= 400:
+                self._log_failure(
+                    action=action,
+                    response=response,
+                    request_id=request_id,
+                    context=safe_context,
+                )
+                raise self._response_error(
+                    action=action,
+                    response=response,
+                )
+
+            logger.info(
+                "jira_request_completed action=%s status=%s request_id=%s context=%s",
+                action,
+                response.status_code,
+                request_id,
+                safe_context,
+            )
+            return (
+                bytes(response.content or b""),
+                response.headers.get("content-type", "").split(";", 1)[0].strip(),
+            )
+
+        raise JiraToolError(
+            "Jira request failed unexpectedly before a response could be returned.",
+            code="jira_request_failed",
+            status_code=502,
+            action=action,
+        )
+
     def _decode_response(self, response: httpx.Response) -> Any:
         if not response.content:
             return {}

--- a/tests/unit/api/routers/test_jira_browser.py
+++ b/tests/unit/api/routers/test_jira_browser.py
@@ -17,6 +17,7 @@ from moonmind.integrations.jira.browser import (
     JiraBoardIssues,
     JiraColumn,
     JiraConnectionVerification,
+    JiraIssueAttachment,
     JiraIssueColumn,
     JiraIssueDetail,
     JiraIssueRecommendations,
@@ -115,6 +116,30 @@ class _FakeJiraBrowserService:
             ),
         )
 
+    async def download_issue_image_attachment(
+        self,
+        issue_key: str,
+        attachment_id: str,
+    ) -> tuple[JiraIssueAttachment, bytes, str]:
+        self.calls.append(
+            (
+                "download_issue_image_attachment",
+                {"issue_key": issue_key, "attachment_id": attachment_id},
+            )
+        )
+        self._maybe_raise()
+        return (
+            JiraIssueAttachment(
+                id=attachment_id,
+                filename="wireframe.png",
+                contentType="image/png",
+                sizeBytes=4,
+                downloadUrl=f"/api/jira/issues/{issue_key}/attachments/{attachment_id}/content",
+            ),
+            b"img\n",
+            "image/png",
+        )
+
 
 @pytest.fixture
 def router_app() -> tuple[FastAPI, _FakeJiraBrowserService]:
@@ -210,6 +235,29 @@ async def test_issue_detail_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowser
     assert response.json()["recommendedImports"]["stepInstructions"] == "Complete Jira story ENG-1"
     assert response.json()["column"] == {"id": "to-do", "name": "To Do"}
     assert service.calls == [("get_issue", {"issue_key": "ENG-1", "board_id": "42"})]
+
+
+async def test_issue_attachment_download_endpoint(
+    router_app: tuple[FastAPI, _FakeJiraBrowserService],
+) -> None:
+    app, service = router_app
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/jira/issues/eng-1/attachments/100/content")
+
+    assert response.status_code == 200
+    assert response.content == b"img\n"
+    assert response.headers["content-type"] == "image/png"
+    assert "wireframe.png" in response.headers["content-disposition"]
+    assert service.calls == [
+        (
+            "download_issue_image_attachment",
+            {"issue_key": "ENG-1", "attachment_id": "100"},
+        )
+    ]
 
 
 async def test_router_maps_jira_errors_to_safe_details(

--- a/tests/unit/api/routers/test_jira_browser.py
+++ b/tests/unit/api/routers/test_jira_browser.py
@@ -37,6 +37,7 @@ class _FakeJiraBrowserService:
         self.calls: list[tuple[str, Any]] = []
         self.raise_error: JiraToolError | None = None
         self.raise_unexpected = False
+        self.attachment_filename = "wireframe.png"
 
     def _maybe_raise(self) -> None:
         if self.raise_unexpected:
@@ -131,7 +132,7 @@ class _FakeJiraBrowserService:
         return (
             JiraIssueAttachment(
                 id=attachment_id,
-                filename="wireframe.png",
+                filename=self.attachment_filename,
                 contentType="image/png",
                 sizeBytes=4,
                 downloadUrl=f"/api/jira/issues/{issue_key}/attachments/{attachment_id}/content",
@@ -258,6 +259,25 @@ async def test_issue_attachment_download_endpoint(
             {"issue_key": "ENG-1", "attachment_id": "100"},
         )
     ]
+
+
+async def test_issue_attachment_download_preserves_quoted_filename(
+    router_app: tuple[FastAPI, _FakeJiraBrowserService],
+) -> None:
+    app, service = router_app
+    service.attachment_filename = 'my "file".png'
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/jira/issues/eng-1/attachments/100/content")
+
+    assert response.status_code == 200
+    assert (
+        response.headers["content-disposition"]
+        == "attachment; filename*=UTF-8''my%20%22file%22.png"
+    )
 
 
 async def test_router_maps_jira_errors_to_safe_details(

--- a/tests/unit/integrations/test_jira_browser_service.py
+++ b/tests/unit/integrations/test_jira_browser_service.py
@@ -667,6 +667,47 @@ async def test_download_issue_image_attachment_validates_membership_and_origin()
     ]
 
 
+async def test_download_issue_image_attachment_allows_tenant_origin_in_scoped_mode() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=AtlassianSettings(
+            atlassian_cloud_id="cloud-123",
+            jira=JiraSettings(
+                jira_allowed_projects="ENG",
+            ),
+        ),
+        responses=[
+            {
+                "key": "ENG-123",
+                "fields": {
+                    "attachment": [
+                        {
+                            "id": "10001",
+                            "filename": "wireframe.png",
+                            "mimeType": "image/png",
+                            "size": 128,
+                            "content": "https://example.atlassian.net/secure/attachment/10001/wireframe.png",
+                        }
+                    ]
+                },
+            },
+            (b"image-bytes", "image/png"),
+        ],
+    )
+
+    attachment, payload, content_type = await service.download_issue_image_attachment(
+        "ENG-123",
+        "10001",
+    )
+
+    assert attachment.filename == "wireframe.png"
+    assert payload == b"image-bytes"
+    assert content_type == "image/png"
+    assert [call["path"] for call in service.calls] == [
+        "/issue/ENG-123",
+        "/secure/attachment/10001/wireframe.png",
+    ]
+
+
 async def test_issue_detail_ignores_blank_browse_url_and_falls_back_to_self_url() -> None:
     service = _StubJiraBrowserService(
         atlassian_settings=_settings(allowed_projects="ENG"),

--- a/tests/unit/integrations/test_jira_browser_service.py
+++ b/tests/unit/integrations/test_jira_browser_service.py
@@ -72,6 +72,25 @@ class _StubJiraBrowserService(JiraBrowserService):
             context=context,
         )
 
+    async def _request_bytes(
+        self,
+        *,
+        method: str,
+        path: str,
+        action: str,
+        params: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[bytes, str]:
+        response = await self._pop_response(
+            method=method,
+            path=path,
+            action=action,
+            params=params,
+            json_body=None,
+            context=context,
+        )
+        return response
+
     async def _pop_response(
         self,
         *,
@@ -565,6 +584,87 @@ async def test_issue_detail_normalizes_text_and_recommended_imports() -> None:
     assert result.acceptance_criteria_text == "Given a board"
     assert "ENG-123: Add Jira browser" in result.recommended_imports.preset_instructions
     assert "Acceptance criteria\nGiven a board" in result.recommended_imports.step_instructions
+
+
+async def test_issue_detail_exposes_only_image_attachments() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=_settings(allowed_projects="ENG"),
+        responses=[
+            {
+                "key": "ENG-123",
+                "fields": {
+                    "summary": "Add Jira browser",
+                    "description": "Do the work",
+                    "attachment": [
+                        {
+                            "id": "10001",
+                            "filename": "wireframe.png",
+                            "mimeType": "image/png",
+                            "size": 128,
+                            "content": "https://example.atlassian.net/secure/attachment/10001/wireframe.png",
+                        },
+                        {
+                            "id": "10002",
+                            "filename": "notes.txt",
+                            "mimeType": "text/plain",
+                            "size": 20,
+                            "content": "https://example.atlassian.net/secure/attachment/10002/notes.txt",
+                        },
+                    ],
+                },
+            }
+        ],
+    )
+
+    result = await service.get_issue("ENG-123")
+
+    assert len(result.attachments) == 1
+    assert result.attachments[0].filename == "wireframe.png"
+    assert result.attachments[0].content_type == "image/png"
+    assert result.attachments[0].download_url == (
+        "/api/jira/issues/ENG-123/attachments/10001/content"
+    )
+
+
+async def test_download_issue_image_attachment_validates_membership_and_origin() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=AtlassianSettings(
+            atlassian_site_url="https://example.atlassian.net",
+            jira=JiraSettings(
+                jira_allowed_projects="ENG",
+            ),
+        ),
+        responses=[
+            {
+                "key": "ENG-123",
+                "fields": {
+                    "attachment": [
+                        {
+                            "id": "10001",
+                            "filename": "wireframe.png",
+                            "mimeType": "image/png",
+                            "size": 128,
+                            "content": "https://example.atlassian.net/secure/attachment/10001/wireframe.png",
+                        }
+                    ]
+                },
+            },
+            (b"image-bytes", "image/png"),
+        ],
+    )
+
+    attachment, payload, content_type = await service.download_issue_image_attachment(
+        "ENG-123",
+        "10001",
+    )
+
+    assert attachment.filename == "wireframe.png"
+    assert payload == b"image-bytes"
+    assert content_type == "image/png"
+    assert [call["path"] for call in service.calls] == [
+        "/issue/ENG-123",
+        "/secure/attachment/10001/wireframe.png",
+    ]
 
 
 async def test_issue_detail_ignores_blank_browse_url_and_falls_back_to_self_url() -> None:


### PR DESCRIPTION
When Jira tasks are retrieved, MoonMind should be able to pull down images as well and include them for runtimes that support them