### PR TITLE
[codex] Fix stale Codex session doc path

### DIFF
--- a/docs/ManagedAgents/ClaudeCodeManagedSessions.md
+++ b/docs/ManagedAgents/ClaudeCodeManagedSessions.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft
 **Audience:** Managed Agents platform, runtime integration, client surfaces, security, and enterprise administration
-**Related:** `docs/ManagedAgents/CodexManagedSessionPlane.md`
+**Related:** `docs/ManagedAgents/CodexCliManagedSessions.md`
 
 ## 1. Executive summary
 

--- a/docs/ManagedAgents/DockerOutOfDocker.md
+++ b/docs/ManagedAgents/DockerOutOfDocker.md
@@ -6,7 +6,7 @@
 **Last updated:** 2026-04-09
 
 **Related:**
-- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](../Temporal/ActivityCatalogAndWorkerTopology.md)
 - [`docs/Tasks/SkillAndPlanContracts.md`](../Tasks/SkillAndPlanContracts.md)
@@ -187,7 +187,7 @@ The Codex managed session plane remains:
 - one active Codex thread per session epoch
 - continuity reused only within the same task
 
-This role is governed by `CodexManagedSessionPlane.md`, not by this document.
+This role is governed by `CodexCliManagedSessions.md`, not by this document.
 
 ### 6.2 Role B: one-shot workload container
 

--- a/docs/ManagedAgents/LiveLogs.md
+++ b/docs/ManagedAgents/LiveLogs.md
@@ -9,7 +9,7 @@ Last updated: 2026-04-08
 - `specs/084-live-log-tailing/spec.md`
 
 **Related:**
-- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/ArtifactPresentationContract.md`](../Temporal/ArtifactPresentationContract.md)
 - [`docs/tmp/009-LiveLogsPlan.md`](../tmp/009-LiveLogsPlan.md)

--- a/docs/ManagedAgents/OAuthTerminal.md
+++ b/docs/ManagedAgents/OAuthTerminal.md
@@ -6,7 +6,7 @@
 **Last updated:** 2026-04-14
 
 Related:
-- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)

--- a/docs/ManagedAgents/SharedManagedAgentAbstractions.md
+++ b/docs/ManagedAgents/SharedManagedAgentAbstractions.md
@@ -314,7 +314,7 @@ managedAgents:
         Run relevant tests before marking work complete.
       references:
         - docs/Architecture/ServiceBoundaries.md
-        - docs/ManagedAgents/CodexManagedSessionPlane.md
+        - docs/ManagedAgents/CodexCliManagedSessions.md
     sessionPolicy:
       reuse: resume-or-create
       retention: keep-history
@@ -589,7 +589,7 @@ This document is the shared, runtime-neutral abstraction layer.
 
 It should be read together with runtime-specific documents such as:
 
-- `docs\ManagedAgents\CodexManagedSessionPlane.md`
+- `docs\ManagedAgents\CodexCliManagedSessions.md`
 
 Future runtime docs should follow the same pattern:
 

--- a/docs/ManagedAgents/WorkerVectorEmbedding.md
+++ b/docs/ManagedAgents/WorkerVectorEmbedding.md
@@ -4,7 +4,7 @@ Status: Desired state
 Owners: MoonMind Engineering
 Last Updated: 2026-04-14
 Related:
-- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](./CodexManagedSessionPlane.md)
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
 - [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
 - [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
 - [`docs/Temporal/WorkflowArtifactSystemDesign.md`](../Temporal/WorkflowArtifactSystemDesign.md)

--- a/docs/Temporal/ArtifactPresentationContract.md
+++ b/docs/Temporal/ArtifactPresentationContract.md
@@ -26,7 +26,7 @@ This document is intentionally downstream of the broader Temporal architecture. 
   - Owns execution identity, list/detail query semantics, and task compatibility rules.
 - `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
   - Owns canonical runtime contracts (`AgentRunHandle`, `AgentRunStatus`, `AgentRunResult`) and execution-model boundaries.
-- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/ManagedAgents/CodexCliManagedSessions.md`
   - Owns the desired-state contract for Codex task-scoped session identity, control actions, and clear/reset semantics.
 - `docs/ManagedAgents/LiveLogs.md`
   - Owns live-log and observability APIs, artifact-backed tails, live streaming, and diagnostics presentation for managed runs.

--- a/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
+++ b/docs/Temporal/ManagedAndExternalAgentExecutionModel.md
@@ -9,7 +9,7 @@ Related:
 - [`docs/Temporal/ActivityCatalogAndWorkerTopology.md`](./ActivityCatalogAndWorkerTopology.md)
 - [`docs/Security/ProviderProfiles.md`](../Security/ProviderProfiles.md)
 - [`docs/ManagedAgents/LiveLogs.md`](../ManagedAgents/LiveLogs.md) — canonical design for artifact-first log capture, live observability streaming, and the MoonMind-native log viewer UI
-- [`docs/ManagedAgents/CodexManagedSessionPlane.md`](../ManagedAgents/CodexManagedSessionPlane.md) — desired-state contract for the Codex task-scoped managed session plane
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](../ManagedAgents/CodexCliManagedSessions.md) — desired-state contract for the Codex task-scoped managed session plane
 
 ---
 

--- a/docs/Temporal/TemporalArchitecture.md
+++ b/docs/Temporal/TemporalArchitecture.md
@@ -46,7 +46,7 @@ Detailed true-agent execution lifecycle rules live in `docs/Temporal/ManagedAndE
 - `docs/Temporal/ArtifactPresentationContract.md`
 - `docs/Temporal/ErrorTaxonomy.md`
 - `docs/MoonMindArchitecture.md`
-- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/ManagedAgents/CodexCliManagedSessions.md`
 - `docs/ManagedAgents/LiveLogs.md`
 - `docs/ManagedAgents/DockerOutOfDocker.md`
 - `docs/Tools/JiraIntegration.md`

--- a/docs/tmp/009-LiveLogsPlan.md
+++ b/docs/tmp/009-LiveLogsPlan.md
@@ -5,7 +5,7 @@ Owners: MoonMind Platform
 Last updated: 2026-04-08
 Related:
 - `docs/ManagedAgents/LiveLogs.md`
-- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/ManagedAgents/CodexCliManagedSessions.md`
 - `docs/tmp/009-LiveLogsPlan.md`
 
 ## 1. Objective

--- a/specs/129-codex-managed-session-plane-phase1/plan.md
+++ b/specs/129-codex-managed-session-plane-phase1/plan.md
@@ -28,7 +28,7 @@ Freeze the Codex managed session-plane MVP contract before implementing session 
 | `moonmind/schemas/managed_session_models.py` | Add Codex session-plane contract and state models. | FR-001 through FR-007, NF-001 |
 | `moonmind/schemas/__init__.py` | Export the new session-plane schema symbols. | Keep schema imports consistent for downstream code. |
 | `tests/unit/schemas/test_managed_session_models.py` | Add TDD coverage for fixed MVP defaults and clear/reset semantics. | NF-002 |
-| `docs/ManagedAgents/CodexManagedSessionPlane.md` | Add desired-state canonical doc for the Codex managed session plane. | FR-008 |
+| `docs/ManagedAgents/CodexCliManagedSessions.md` | Add desired-state canonical doc for the Codex managed session plane. | FR-008 |
 | `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` | Add related-doc link to the new canonical session-plane contract. | Keep orchestration docs connected. |
 | `docs/Temporal/ArtifactPresentationContract.md` | Add related-doc link to the new canonical session-plane contract. | Keep artifact continuity docs connected. |
 | `specs/129-codex-managed-session-plane-phase1/*` | Add phase spec artifacts. | Principle XI |

--- a/specs/129-codex-managed-session-plane-phase1/tasks.md
+++ b/specs/129-codex-managed-session-plane-phase1/tasks.md
@@ -16,7 +16,7 @@
 **Independent Test**: `./.venv/bin/pytest -q tests/unit/schemas/test_managed_session_models.py tests/unit/schemas/test_agent_runtime_models.py`
 
 ## T003 — Freeze the desired-state documentation [P]
-- [X] T003a [P] Add `docs/ManagedAgents/CodexManagedSessionPlane.md` as the canonical desired-state contract.
+- [X] T003a [P] Add `docs/ManagedAgents/CodexCliManagedSessions.md` as the canonical desired-state contract.
 - [X] T003b [P] Cross-link the new contract from `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
 - [X] T003c [P] Cross-link the new contract from `docs/Temporal/ArtifactPresentationContract.md`.
 - [X] T003d [P] Add spec artifacts under `specs/129-codex-managed-session-plane-phase1/`.

--- a/specs/133-codex-managed-session-plane-phase7/plan.md
+++ b/specs/133-codex-managed-session-plane-phase7/plan.md
@@ -31,7 +31,7 @@ Build the durable reset slice of the Codex managed-session plane. This phase tea
 
 ## Research
 
-- `docs/ManagedAgents/CodexManagedSessionPlane.md` already fixes clear/reset semantics as two artifacts plus an epoch bump, so the implementation only needs to align the Phase 6 durable session layer to that desired-state contract.
+- `docs/ManagedAgents/CodexCliManagedSessions.md` already fixes clear/reset semantics as two artifacts plus an epoch bump, so the implementation only needs to align the Phase 6 durable session layer to that desired-state contract.
 - `CodexManagedSessionRecord` already has `latest_checkpoint_ref` and `latest_control_event_ref`, which means Phase 7 can land without changing activity/workflow schemas.
 - `ManagedSessionSupervisor` already owns durable log/diagnostics publication using the session artifact storage root, making it the correct place to add reset artifact writing instead of embedding file IO in workflow code.
 - The current controller updates epoch/thread/status on `clear_session` but does not publish continuity artifacts, so the minimum viable change is controller-triggered supervisor publication after the remote clear succeeds.

--- a/specs/133-codex-managed-session-plane-phase7/research.md
+++ b/specs/133-codex-managed-session-plane-phase7/research.md
@@ -1,5 +1,5 @@
 # Research: Codex Managed Session Plane Phase 7
 
-- The desired-state reset contract already exists in [`docs/ManagedAgents/CodexManagedSessionPlane.md`](../../docs/ManagedAgents/CodexManagedSessionPlane.md): `clear_session` must write `session.control_event`, write `session.reset_boundary`, then increment `session_epoch`.
+- The desired-state reset contract already exists in [`docs/ManagedAgents/CodexCliManagedSessions.md`](../../docs/ManagedAgents/CodexCliManagedSessions.md): `clear_session` must write `session.control_event`, write `session.reset_boundary`, then increment `session_epoch`.
 - Phase 6 already introduced the durable `CodexManagedSessionRecord` fields needed for this slice: `latest_control_event_ref` and `latest_checkpoint_ref`.
 - The current implementation gap is limited to the service boundary: the remote runtime clears the session and appends spool text, but the controller/supervisor never materialize durable reset artifacts.

--- a/specs/141-codex-managed-session-phase0-1/plan.md
+++ b/specs/141-codex-managed-session-phase0-1/plan.md
@@ -36,7 +36,7 @@ Implement the Phase 0 and Phase 1 slice of the Codex managed-session rollout by:
 
 ## Research
 
-- `docs/ManagedAgents/CodexManagedSessionPlane.md` currently says Temporal is the control plane and system of record, but it does not explicitly describe the current operational role of `ManagedSessionStore`.
+- `docs/ManagedAgents/CodexCliManagedSessions.md` currently says Temporal is the control plane and system of record, but it does not explicitly describe the current operational role of `ManagedSessionStore`.
 - `moonmind/workflows/temporal/workflows/agent_session.py` still initializes binding state from `run()`, exposes a generic mutating `control_action` signal, and only provides `SendFollowUp` plus `ClearSession` updates.
 - `moonmind/workflows/adapters/codex_session_adapter.py`, `moonmind/workflows/temporal/workflows/agent_run.py`, `moonmind/workflows/temporal/workflows/run.py`, and `api_service/api/routers/task_runs.py` still assume the older signal/update names.
 - The controller and activity surfaces already support `agent_runtime.interrupt_turn`, so Phase 1 can wire a real workflow-level `InterruptTurn` without waiting on the later steer-runtime implementation.
@@ -44,7 +44,7 @@ Implement the Phase 0 and Phase 1 slice of the Codex managed-session rollout by:
 
 ## Project Structure
 
-- Update `docs/ManagedAgents/CodexManagedSessionPlane.md` for Phase 0 truth-surface alignment.
+- Update `docs/ManagedAgents/CodexCliManagedSessions.md` for Phase 0 truth-surface alignment.
 - Extend `moonmind/schemas/managed_session_models.py` with typed update request contracts for the workflow boundary.
 - Refactor `moonmind/workflows/temporal/workflows/agent_session.py` to use `@workflow.init`, typed updates, and validators.
 - Update `moonmind/workflows/adapters/codex_session_adapter.py`, `moonmind/workflows/temporal/workflows/agent_run.py`, `moonmind/workflows/temporal/workflows/run.py`, and `api_service/api/routers/task_runs.py` to target the typed update names.
@@ -76,6 +76,6 @@ Implement the Phase 0 and Phase 1 slice of the Codex managed-session rollout by:
 
 ### Manual Validation
 
-1. Read `docs/ManagedAgents/CodexManagedSessionPlane.md` and confirm the production publication/recovery roles are explicit and non-contradictory.
+1. Read `docs/ManagedAgents/CodexCliManagedSessions.md` and confirm the production publication/recovery roles are explicit and non-contradictory.
 2. Inspect `MoonMind.AgentSession` and confirm only `attach_runtime_handles` remains as a signal while mutations use typed updates with validators.
 3. Inspect the parent workflow, session adapter, and task-run router to confirm they call the new typed update names.

--- a/specs/141-codex-managed-session-phase0-1/quickstart.md
+++ b/specs/141-codex-managed-session-phase0-1/quickstart.md
@@ -18,7 +18,7 @@
 
 3. Inspect the canonical doc and the workflow surface:
 
-- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/ManagedAgents/CodexCliManagedSessions.md`
 - `moonmind/workflows/temporal/workflows/agent_session.py`
 
 Expected outcome: the doc distinguishes truth surfaces explicitly, and workflow mutations go through typed updates with validators rather than the generic `control_action` signal.

--- a/specs/141-codex-managed-session-phase0-1/spec.md
+++ b/specs/141-codex-managed-session-phase0-1/spec.md
@@ -49,7 +49,7 @@ MoonMind workflow callers need the `MoonMind.AgentSession` workflow to expose th
 
 ### Functional Requirements
 
-- **FR-001**: The canonical `docs/ManagedAgents/CodexManagedSessionPlane.md` doc MUST describe artifacts plus bounded workflow metadata as operator/audit truth and `ManagedSessionStore` as the operational recovery/reconciliation index.
+- **FR-001**: The canonical `docs/ManagedAgents/CodexCliManagedSessions.md` doc MUST describe artifacts plus bounded workflow metadata as operator/audit truth and `ManagedSessionStore` as the operational recovery/reconciliation index.
 - **FR-002**: The canonical doc MUST identify the managed-session controller/supervisor path as the production artifact publisher and MUST not present the transitional in-container summary/publication helpers as the production path.
 - **FR-003**: `MoonMind.AgentSession` MUST initialize handler-visible workflow binding state via `@workflow.init`.
 - **FR-004**: `MoonMind.AgentSession` MUST replace the generic mutating `control_action` signal with typed Updates for `SendFollowUp`, `InterruptTurn`, `SteerTurn`, `ClearSession`, `CancelSession`, and `TerminateSession`.

--- a/specs/141-codex-managed-session-phase0-1/tasks.md
+++ b/specs/141-codex-managed-session-phase0-1/tasks.md
@@ -20,7 +20,7 @@
 
 **Purpose**: Align docs and schema contracts with the intended Phase 0 and Phase 1 surface.
 
-- [X] T005 Update `docs/ManagedAgents/CodexManagedSessionPlane.md` to distinguish operator truth, recovery index, and disposable cache state
+- [X] T005 Update `docs/ManagedAgents/CodexCliManagedSessions.md` to distinguish operator truth, recovery index, and disposable cache state
 - [X] T006 Add typed workflow update request models to `moonmind/schemas/managed_session_models.py`
 
 ---
@@ -31,7 +31,7 @@
 
 **Independent Test**: Read the canonical doc and confirm the production artifact publisher and truth surfaces are explicit.
 
-- [X] T007 [US1] Document the controller/supervisor publication path and demote the in-container summary/publication helpers to fallback-only language in `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- [X] T007 [US1] Document the controller/supervisor publication path and demote the in-container summary/publication helpers to fallback-only language in `docs/ManagedAgents/CodexCliManagedSessions.md`
 
 ---
 

--- a/specs/142-live-logs-session-timeline-ui/research.md
+++ b/specs/142-live-logs-session-timeline-ui/research.md
@@ -3,7 +3,7 @@
 ## Inputs reviewed
 
 - `docs/ManagedAgents/LiveLogs.md`
-- `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- `docs/ManagedAgents/CodexCliManagedSessions.md`
 - `docs/tmp/009-LiveLogsPlan.md`
 - `specs/141-live-logs-history-events/*`
 - `frontend/src/entrypoints/task-detail.tsx`

--- a/specs/143-dood-phase0/contracts/dood-phase0-doc-contract.md
+++ b/specs/143-dood-phase0/contracts/dood-phase0-doc-contract.md
@@ -7,7 +7,7 @@ Define the exact documentation assertions that Phase 0 must lock before Phase 1 
 ## Required canonical surfaces
 
 1. `docs/ManagedAgents/DockerOutOfDocker.md`
-2. `docs/ManagedAgents/CodexManagedSessionPlane.md`
+2. `docs/ManagedAgents/CodexCliManagedSessions.md`
 3. `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`
 4. `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md`
 

--- a/specs/143-dood-phase0/plan.md
+++ b/specs/143-dood-phase0/plan.md
@@ -37,7 +37,7 @@ Implement Phase 0 of the Docker-out-of-Docker rollout by locking the canonical a
 ## Research
 
 - `docs/ManagedAgents/DockerOutOfDocker.md` already contains the target glossary (`session container`, `workload container`, `runner profile`, `session-assisted workload`) and already states that one-shot workload containers are the initial emphasis.
-- `docs/ManagedAgents/CodexManagedSessionPlane.md` currently links to the DooD doc but does not explicitly say that session-plane steps may invoke control-plane workload tools whose containers remain outside session identity.
+- `docs/ManagedAgents/CodexCliManagedSessions.md` currently links to the DooD doc but does not explicitly say that session-plane steps may invoke control-plane workload tools whose containers remain outside session identity.
 - `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` currently defines `MoonMind.AgentRun` for true agent runtimes and excludes generic executable tools, but it does not yet name Docker-backed workload tools as ordinary executable tools distinct from managed agent runs.
 - `docs/tmp/remaining-work/README.md` lists active trackers but there is no DooD rollout tracker yet, even though `docs/ManagedAgents/DockerOutOfDocker.md` already links to one.
 - The repo does not already contain a documentation-contract unit test for this DooD boundary, so the fastest durable guard is a focused pytest file that asserts the required phrases and tracker path exist.
@@ -45,7 +45,7 @@ Implement Phase 0 of the Docker-out-of-Docker rollout by locking the canonical a
 ## Project Structure
 
 - Update `docs/ManagedAgents/DockerOutOfDocker.md` to ensure the tracker link and Phase 0 contract wording stay aligned.
-- Update `docs/ManagedAgents/CodexManagedSessionPlane.md` with a short cross-reference for session-assisted workload tools.
+- Update `docs/ManagedAgents/CodexCliManagedSessions.md` with a short cross-reference for session-assisted workload tools.
 - Update `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` with a short note that Docker-backed workload tools are ordinary executable tools unless they launch a true managed runtime.
 - Add `docs/tmp/remaining-work/ManagedAgents-DockerOutOfDocker.md` as the DooD rollout tracker and list it in `docs/tmp/remaining-work/README.md`.
 - Add `tests/unit/docs/test_dood_phase0_contract.py` for automated validation.

--- a/specs/143-dood-phase0/quickstart.md
+++ b/specs/143-dood-phase0/quickstart.md
@@ -3,7 +3,7 @@
 ## Verify the canonical docs
 
 1. Read `docs/ManagedAgents/DockerOutOfDocker.md`.
-2. Read `docs/ManagedAgents/CodexManagedSessionPlane.md`.
+2. Read `docs/ManagedAgents/CodexCliManagedSessions.md`.
 3. Read `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
 4. Confirm the three docs share the same glossary and preserve the tool-path boundary for Docker-backed workloads.
 

--- a/specs/143-dood-phase0/research.md
+++ b/specs/143-dood-phase0/research.md
@@ -14,7 +14,7 @@ Phase 0 of the DooD rollout is a contract-locking step. The main question is not
 
 ### Decision: Add short cross-reference wording instead of duplicating the full DooD design
 
-- **What was chosen**: Add concise references in `docs/ManagedAgents/CodexManagedSessionPlane.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- **What was chosen**: Add concise references in `docs/ManagedAgents/CodexCliManagedSessions.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
 - **Rationale**: Constitution Principle XII requires canonical docs to stay declarative and avoid duplicating volatile rollout detail. The DooD doc should remain the detailed source while adjacent docs state only the boundary relevant to their scope.
 - **Alternatives considered**: Copy large DooD sections into the session-plane and execution-model docs. Rejected because duplication would make drift more likely.
 
@@ -35,7 +35,7 @@ Phase 0 of the DooD rollout is a contract-locking step. The main question is not
 | Area | Current state | Phase 0 action |
 |------|---------------|----------------|
 | `docs/ManagedAgents/DockerOutOfDocker.md` | Already defines glossary and one-shot workload emphasis | Tighten only where tracker/Phase 0 wording needs to stay explicit |
-| `docs/ManagedAgents/CodexManagedSessionPlane.md` | Links to DooD doc but does not explicitly describe session-assisted workload tools | Add short cross-reference paragraph |
+| `docs/ManagedAgents/CodexCliManagedSessions.md` | Links to DooD doc but does not explicitly describe session-assisted workload tools | Add short cross-reference paragraph |
 | `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` | Defines true agent-runtime boundary but does not name Docker-backed workload tools explicitly | Add short execution-model note |
 | `docs/tmp/remaining-work/` | No DooD tracker exists yet | Add tracker and register it in README |
 | `tests/unit/` | No DooD Phase 0 documentation contract test exists | Add focused pytest coverage |

--- a/specs/143-dood-phase0/spec.md
+++ b/specs/143-dood-phase0/spec.md
@@ -13,7 +13,7 @@ MoonMind engineers need the canonical Docker-out-of-Docker documentation set to 
 
 **Why this priority**: Phase 0 exists specifically to freeze terminology and boundary rules before launcher and tool-path code spreads in multiple directions.
 
-**Independent Test**: Read `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexManagedSessionPlane.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` and confirm they use the same glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
+**Independent Test**: Read `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` and confirm they use the same glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
 
 **Acceptance Scenarios**:
 
@@ -61,8 +61,8 @@ MoonMind maintainers need a temporary implementation tracker plus an automated t
 ### Functional Requirements
 
 - **FR-001**: `docs/ManagedAgents/DockerOutOfDocker.md` MUST remain the canonical desired-state document for MoonMind's Docker-backed specialized workload-container architecture.
-- **FR-002**: `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexManagedSessionPlane.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` MUST use one consistent glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
-- **FR-003**: `docs/ManagedAgents/CodexManagedSessionPlane.md` MUST state that the managed session plane may invoke control-plane tools that launch separate workload containers, but those workload containers remain outside session identity.
+- **FR-002**: `docs/ManagedAgents/DockerOutOfDocker.md`, `docs/ManagedAgents/CodexCliManagedSessions.md`, and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` MUST use one consistent glossary for `session container`, `workload container`, `runner profile`, and `session-assisted workload`.
+- **FR-003**: `docs/ManagedAgents/CodexCliManagedSessions.md` MUST state that the managed session plane may invoke control-plane tools that launch separate workload containers, but those workload containers remain outside session identity.
 - **FR-004**: `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` MUST state that Docker-backed workload launches are ordinary executable tools and MUST NOT be treated as new `MoonMind.AgentRun` instances unless the launched runtime is itself a true managed agent runtime.
 - **FR-005**: The canonical documentation set MUST state that the initial DooD implementation scope for Phases 1 through 4 is one-shot workload containers and that bounded helper containers remain a later phase.
 - **FR-006**: The canonical documentation set MUST state that `tool.type = "skill"` is the initial execution primitive for Docker-backed workload launches and MUST preserve `tool.type = "agent_runtime"` for true long-lived agent runtimes only.

--- a/specs/143-dood-phase0/tasks.md
+++ b/specs/143-dood-phase0/tasks.md
@@ -38,7 +38,7 @@
 
 ### Implementation for User Story 1
 
-- [X] T005 [US1] Add the session-assisted workload cross-reference and outside-session-identity wording to `docs/ManagedAgents/CodexManagedSessionPlane.md`.
+- [X] T005 [US1] Add the session-assisted workload cross-reference and outside-session-identity wording to `docs/ManagedAgents/CodexCliManagedSessions.md`.
 - [X] T006 [US1] Tighten glossary/tracker wording in `docs/ManagedAgents/DockerOutOfDocker.md` so the canonical doc remains the clear desired-state source for Phase 0.
 
 **Checkpoint**: The session-plane doc and canonical DooD doc tell the same glossary and identity story.

--- a/specs/165-agent-session-deployment-safety/tasks.md
+++ b/specs/165-agent-session-deployment-safety/tasks.md
@@ -170,7 +170,7 @@
 
 - [X] T070 [P] Update cross-story managed-session lifecycle validation commands in `specs/165-agent-session-deployment-safety/quickstart.md`
 - [X] T071 [P] Remove obsolete or indefinite legacy managed-session bridge paths after replay/cutover conditions are satisfied in `moonmind/workflows/temporal/workflows/agent_session.py`
-- [X] T072 [P] Update affected managed-session architecture notes while keeping desired-state docs separate from migration backlog in `docs/ManagedAgents/CodexManagedSessionPlane.md`
+- [X] T072 [P] Update affected managed-session architecture notes while keeping desired-state docs separate from migration backlog in `docs/ManagedAgents/CodexCliManagedSessions.md`
 - [X] T073 Run full required unit validation with `./tools/test_unit.sh`
 - [X] T074 Run hermetic integration validation with `./tools/test_integration.sh` if implementation changed an `integration_ci` seam
 - [X] T075 Run `git diff --check` and `.specify/scripts/bash/validate-implementation-scope.sh --check diff --mode runtime`

--- a/tests/unit/docs/test_dood_phase0_contract.py
+++ b/tests/unit/docs/test_dood_phase0_contract.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DOOD_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "DockerOutOfDocker.md"
-SESSION_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "CodexManagedSessionPlane.md"
+SESSION_DOC = REPO_ROOT / "docs" / "ManagedAgents" / "CodexCliManagedSessions.md"
 EXECUTION_DOC = (
     REPO_ROOT / "docs" / "Temporal" / "ManagedAndExternalAgentExecutionModel.md"
 )

--- a/tests/unit/workflows/temporal/test_agent_session_deployment_safety.py
+++ b/tests/unit/workflows/temporal/test_agent_session_deployment_safety.py
@@ -173,7 +173,7 @@ def test_active_feature_override_requires_complete_artifact_set(tmp_path) -> Non
 
 def test_agent_session_deployment_safety_gate_passes_for_non_sensitive_changes() -> None:
     report = validate_agent_session_deployment_safety(
-        changed_paths=["docs/ManagedAgents/CodexManagedSessionPlane.md"],
+        changed_paths=["docs/ManagedAgents/CodexCliManagedSessions.md"],
         repo_paths=[],
         cutover_playbook_text="",
     )


### PR DESCRIPTION
## Summary

- Update the CI doc contract test to read the renamed `docs/ManagedAgents/CodexCliManagedSessions.md` document.
- Update related managed-session docs, specs, and deployment-safety test fixtures so they no longer point at the removed `CodexManagedSessionPlane.md` path.
- Remove the stale filename from repo-wide references instead of adding a compatibility copy.

## Root Cause

CI failed after `docs/ManagedAgents/CodexManagedSessionPlane.md` was renamed to `docs/ManagedAgents/CodexCliManagedSessions.md`, while `tests/unit/docs/test_dood_phase0_contract.py` still tried to read the old path.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/docs/test_dood_phase0_contract.py tests/unit/workflows/temporal/test_agent_session_deployment_safety.py` -> `18 passed`
- `./tools/test_unit.sh --python-only` with local Atlassian settings overridden to match CI's no-Jira-credentials shape -> `3048 passed, 1 xpassed, 103 warnings, 16 subtests passed`
- `git diff --check` -> clean
- `rg -n "CodexManagedSessionPlane\.md" -S` -> no matches