### PR TITLE
[codex] Fix Jira browse project policy

### DIFF
--- a/api_service/api/routers/jira_browser.py
+++ b/api_service/api/routers/jira_browser.py
@@ -132,11 +132,12 @@ async def list_project_boards(
 )
 async def list_board_columns(
     board_id: str,
+    project_key: str | None = Query(None, alias="projectKey"),
     _user: User = Depends(get_current_user()),
     service: JiraBrowserService = Depends(_get_service),
 ) -> JiraBoardColumns:
     try:
-        return await service.list_columns(board_id)
+        return await service.list_columns(board_id, project_key=project_key)
     except JiraToolError as exc:
         raise _to_http_exception(exc) from None
     except Exception:
@@ -151,11 +152,12 @@ async def list_board_columns(
 async def list_board_issues(
     board_id: str,
     q: str | None = Query(None),
+    project_key: str | None = Query(None, alias="projectKey"),
     _user: User = Depends(get_current_user()),
     service: JiraBrowserService = Depends(_get_service),
 ) -> JiraBoardIssues:
     try:
-        return await service.list_issues(board_id, q=q)
+        return await service.list_issues(board_id, q=q, project_key=project_key)
     except JiraToolError as exc:
         raise _to_http_exception(exc) from None
     except Exception:
@@ -170,11 +172,16 @@ async def list_board_issues(
 async def get_issue(
     issue_key: str,
     board_id: str | None = Query(None, alias="boardId"),
+    project_key: str | None = Query(None, alias="projectKey"),
     _user: User = Depends(get_current_user()),
     service: JiraBrowserService = Depends(_get_service),
 ) -> JiraIssueDetail:
     try:
-        return await service.get_issue(issue_key.upper(), board_id=board_id)
+        return await service.get_issue(
+            issue_key.upper(),
+            board_id=board_id,
+            project_key=project_key,
+        )
     except JiraToolError as exc:
         raise _to_http_exception(exc) from None
     except Exception:

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -371,6 +371,7 @@ Rules:
 - the MoonMind API must resolve columns from Jira board configuration
 - the MoonMind API, not the browser, is responsible for translating Jira status-to-column mapping into a board-column model
 - the browser must render board columns in board order
+- board-scoped column requests may include the selected `projectKey` query parameter; when present, the API verifies the board is listed for that project instead of relying only on Jira board location metadata
 
 Representative column response:
 
@@ -422,11 +423,15 @@ Rules:
 
 - the browser must not infer column membership from raw issue status text
 - the issue list may optionally support `q=` filtering by issue key or summary
+- the issue list may include the selected `projectKey` query parameter, and the server filters returned stories to that selected project and configured project allowlist
 - empty columns must still be renderable
 
 ### 15.3 Issue-detail contract
 
 The issue-detail endpoint must return normalized story content suitable for preview and import.
+When a board context is present, the browser may send both `boardId` and selected
+`projectKey` query parameters so the server can preserve project policy context
+while resolving the story's board column.
 
 Representative response:
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -214,6 +214,7 @@ describe("Task Create Entrypoint", () => {
       .spyOn(window, "fetch")
       .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
+        const path = url.split("?")[0];
         if (url.startsWith("/api/tasks/skills")) {
           return Promise.resolve({
             ok: true,
@@ -1112,7 +1113,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/boards/42/columns") {
+        if (path === "/api/jira/boards/42/columns") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -1124,7 +1125,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/boards/84/columns") {
+        if (path === "/api/jira/boards/84/columns") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -1133,7 +1134,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/boards/42/issues") {
+        if (path === "/api/jira/boards/42/issues") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -1167,7 +1168,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/boards/84/issues") {
+        if (path === "/api/jira/boards/84/issues") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -1188,7 +1189,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/issues/ENG-202") {
+        if (path === "/api/jira/issues/ENG-202") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -1210,7 +1211,7 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
-        if (url === "/api/jira/issues/MY-PROJ-123") {
+        if (path === "/api/jira/issues/MY-PROJ-123") {
           return Promise.resolve({
             ok: true,
             json: async () => ({
@@ -3586,6 +3587,27 @@ describe("Task Create Entrypoint", () => {
     expect(screen.queryByText("ENG-101")).toBeNull();
   });
 
+  it("sends the selected Jira project scope with board and story requests", async () => {
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Browse Jira story for preset instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+
+    expect(await screen.findByText("Let operators browse Jira stories."))
+      .toBeTruthy();
+    const requestUrls = fetchSpy.mock.calls.map(([input]) => String(input));
+    expect(requestUrls).toContain("/api/jira/boards/42/columns?projectKey=ENG");
+    expect(requestUrls).toContain("/api/jira/boards/42/issues?projectKey=ENG");
+    expect(requestUrls).toContain(
+      "/api/jira/issues/ENG-202?boardId=42&projectKey=ENG",
+    );
+  });
+
   it("shows project load failures only inside the Jira browser and keeps manual editing available", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
@@ -3690,7 +3712,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/boards/42/columns") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/boards/42/columns") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -3699,7 +3722,7 @@ describe("Task Create Entrypoint", () => {
           }),
         } as Response);
       }
-      if (url === "/api/jira/boards/42/issues") {
+      if (path === "/api/jira/boards/42/issues") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -3731,7 +3754,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/boards/42/columns") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/boards/42/columns") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -3740,7 +3764,7 @@ describe("Task Create Entrypoint", () => {
           }),
         } as Response);
       }
-      if (url === "/api/jira/boards/42/issues") {
+      if (path === "/api/jira/boards/42/issues") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -3963,7 +3987,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/issues/ENG-202") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
         return Promise.resolve({
           ok: false,
           status: 502,
@@ -4150,7 +4175,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/issues/ENG-202") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -4196,7 +4222,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/issues/ENG-202") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
         return Promise.resolve({
           ok: true,
           json: async () => ({
@@ -4744,7 +4771,8 @@ describe("Task Create Entrypoint", () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === "/api/jira/issues/ENG-202") {
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
         return Promise.resolve({
           ok: true,
           json: async () => ({

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2213,14 +2213,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       "columns",
       jiraIntegration?.endpoints.columns,
       selectedJiraBoardId,
+      selectedJiraProjectKey,
     ],
     enabled: Boolean(
       jiraIntegration?.enabled && jiraBrowserOpen && selectedJiraBoardId,
     ),
     queryFn: async (): Promise<JiraColumn[]> => {
-      const endpoint = interpolatePath(
-        jiraIntegration?.endpoints.columns || "",
-        { boardId: selectedJiraBoardId },
+      const endpoint = withQueryParams(
+        interpolatePath(jiraIntegration?.endpoints.columns || "", {
+          boardId: selectedJiraBoardId,
+        }),
+        { projectKey: selectedJiraProjectKey },
       );
       const response = await fetch(endpoint, {
         headers: { Accept: "application/json" },
@@ -2242,14 +2245,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       "issues",
       jiraIntegration?.endpoints.issues,
       selectedJiraBoardId,
+      selectedJiraProjectKey,
     ],
     enabled: Boolean(
       jiraIntegration?.enabled && jiraBrowserOpen && selectedJiraBoardId,
     ),
     queryFn: async (): Promise<Record<string, JiraIssueSummary[]>> => {
-      const endpoint = interpolatePath(
-        jiraIntegration?.endpoints.issues || "",
-        { boardId: selectedJiraBoardId },
+      const endpoint = withQueryParams(
+        interpolatePath(jiraIntegration?.endpoints.issues || "", {
+          boardId: selectedJiraBoardId,
+        }),
+        { projectKey: selectedJiraProjectKey },
       );
       const response = await fetch(endpoint, {
         headers: { Accept: "application/json" },
@@ -2273,6 +2279,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       "issue",
       jiraIntegration?.endpoints.issue,
       selectedJiraIssueKey,
+      selectedJiraBoardId,
+      selectedJiraProjectKey,
     ],
     enabled: Boolean(
       jiraIntegration?.enabled &&
@@ -2280,9 +2288,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         selectedJiraIssueKey,
     ),
     queryFn: async (): Promise<JiraIssueDetail> => {
-      const endpoint = interpolatePath(
-        jiraIntegration?.endpoints.issue || "",
-        { issueKey: selectedJiraIssueKey },
+      const endpoint = withQueryParams(
+        interpolatePath(jiraIntegration?.endpoints.issue || "", {
+          issueKey: selectedJiraIssueKey,
+        }),
+        {
+          boardId: selectedJiraBoardId,
+          projectKey: selectedJiraProjectKey,
+        },
       );
       const response = await fetch(endpoint, {
         headers: { Accept: "application/json" },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -6560,7 +6560,9 @@ export interface operations {
     };
     list_board_columns_api_jira_boards__board_id__columns_get: {
         parameters: {
-            query?: never;
+            query?: {
+                projectKey?: string | null;
+            };
             header?: never;
             path: {
                 board_id: string;
@@ -6593,6 +6595,7 @@ export interface operations {
         parameters: {
             query?: {
                 q?: string | null;
+                projectKey?: string | null;
             };
             header?: never;
             path: {
@@ -6626,6 +6629,7 @@ export interface operations {
         parameters: {
             query?: {
                 boardId?: string | null;
+                projectKey?: string | null;
             };
             header?: never;
             path: {

--- a/moonmind/integrations/jira/browser.py
+++ b/moonmind/integrations/jira/browser.py
@@ -293,12 +293,25 @@ class JiraBrowserService:
         ]
         return JiraListResponse[JiraBoard](projectKey=normalized_project, items=boards)
 
-    async def list_columns(self, board_id: str) -> JiraBoardColumns:
+    async def list_columns(
+        self,
+        board_id: str,
+        project_key: str | None = None,
+    ) -> JiraBoardColumns:
         self._ensure_enabled()
         normalized_board_id = self._normalize_board_id(board_id)
+        normalized_project = self._normalize_project_key_optional(project_key)
         async with self._jira_client() as client:
-            board = await self._fetch_board(normalized_board_id, client=client)
-            config = await self._fetch_board_configuration(normalized_board_id, client=client)
+            board = await self._fetch_board(
+                normalized_board_id,
+                client=client,
+                policy_project_key=normalized_project,
+            )
+            config = await self._fetch_board_configuration(
+                normalized_board_id,
+                client=client,
+                policy_project_key=normalized_project,
+            )
         columns = self._normalize_columns(config)
         return JiraBoardColumns(board=board, columns=columns)
 
@@ -306,13 +319,16 @@ class JiraBrowserService:
         self,
         board_id: str,
         q: str | None = None,
+        project_key: str | None = None,
     ) -> JiraBoardIssues:
         self._ensure_enabled()
         normalized_board_id = self._normalize_board_id(board_id)
+        normalized_project = self._normalize_project_key_optional(project_key)
         async with self._jira_client() as client:
             columns_response = await self._list_columns_with_client(
                 normalized_board_id,
                 client=client,
+                policy_project_key=normalized_project,
             )
             issues_payload = await self._fetch_board_issues(
                 normalized_board_id,
@@ -330,6 +346,8 @@ class JiraBrowserService:
         unmapped_items: list[JiraIssueSummary] = []
         filter_text = str(q or "").strip().lower()
         for raw_issue in issues_payload:
+            if not self._issue_matches_policy_scope(raw_issue, normalized_project):
+                continue
             summary = self._normalize_issue_summary(raw_issue, status_to_column)
             if (
                 filter_text
@@ -357,10 +375,22 @@ class JiraBrowserService:
         self,
         issue_key: str,
         board_id: str | None = None,
+        project_key: str | None = None,
     ) -> JiraIssueDetail:
         self._ensure_enabled()
         normalized_issue_key = self._normalize_issue_key(issue_key)
-        self._ensure_project_allowed(self._project_from_issue_key(normalized_issue_key))
+        issue_project = self._project_from_issue_key(normalized_issue_key)
+        normalized_project = self._normalize_project_key_optional(project_key)
+        self._ensure_project_allowed(issue_project)
+        if normalized_project is not None:
+            self._ensure_project_allowed(normalized_project)
+            if issue_project != normalized_project:
+                raise JiraToolError(
+                    "Project is not allowed by Jira policy.",
+                    code="jira_policy_denied",
+                    status_code=403,
+                    action="jira_browser.policy",
+                )
         normalized_board_id = (
             self._normalize_board_id(board_id) if board_id is not None else None
         )
@@ -381,6 +411,7 @@ class JiraBrowserService:
                     await self._list_columns_with_client(
                         normalized_board_id,
                         client=client,
+                        policy_project_key=normalized_project,
                     )
                 ).columns
         return self._normalize_issue_detail(payload, board_columns=board_columns)
@@ -510,13 +541,28 @@ class JiraBrowserService:
         board_id: str,
         *,
         client: JiraClient,
+        policy_project_key: str | None = None,
     ) -> JiraBoardColumns:
-        board = await self._fetch_board(board_id, client=client)
-        config = await self._fetch_board_configuration(board_id, client=client)
+        board = await self._fetch_board(
+            board_id,
+            client=client,
+            policy_project_key=policy_project_key,
+        )
+        config = await self._fetch_board_configuration(
+            board_id,
+            client=client,
+            policy_project_key=policy_project_key,
+        )
         columns = self._normalize_columns(config)
         return JiraBoardColumns(board=board, columns=columns)
 
-    async def _fetch_board(self, board_id: str, *, client: JiraClient) -> JiraBoard:
+    async def _fetch_board(
+        self,
+        board_id: str,
+        *,
+        client: JiraClient,
+        policy_project_key: str | None = None,
+    ) -> JiraBoard:
         payload = await self._request_json_with_client(
             client,
             method="GET",
@@ -525,6 +571,14 @@ class JiraBrowserService:
             context={"boardId": board_id},
         )
         board = self._normalize_board(payload)
+        if policy_project_key is not None:
+            self._ensure_project_allowed(policy_project_key)
+            await self._ensure_board_listed_for_project(
+                board_id,
+                policy_project_key,
+                client=client,
+            )
+            return board.model_copy(update={"project_key": policy_project_key})
         if board.project_key:
             self._ensure_project_allowed(board.project_key)
         return board
@@ -534,6 +588,7 @@ class JiraBrowserService:
         board_id: str,
         *,
         client: JiraClient,
+        policy_project_key: str | None = None,
     ) -> Mapping[str, Any]:
         payload = await self._request_json_with_client(
             client,
@@ -547,9 +602,55 @@ class JiraBrowserService:
         location = payload.get("location")
         if isinstance(location, Mapping):
             project_key = str(location.get("projectKey") or "").strip().upper()
-            if project_key:
+            if policy_project_key is not None:
+                self._ensure_project_allowed(policy_project_key)
+            elif project_key:
                 self._ensure_project_allowed(project_key)
         return payload
+
+    async def _ensure_board_listed_for_project(
+        self,
+        board_id: str,
+        project_key: str,
+        *,
+        client: JiraClient,
+    ) -> None:
+        start_at = 0
+        while True:
+            payload = await self._request_json_with_client(
+                client,
+                method="GET",
+                path="agile:/board",
+                action="jira_browser.list_boards",
+                params={
+                    "projectKeyOrId": project_key,
+                    "maxResults": _JIRA_BROWSER_PAGE_SIZE,
+                    "startAt": start_at,
+                },
+                context={"projectKey": project_key},
+            )
+            values = payload.get("values", []) if isinstance(payload, Mapping) else []
+            page_items = values if isinstance(values, list) else []
+            if any(
+                str(item.get("id") or "").strip() == board_id
+                for item in page_items
+                if isinstance(item, Mapping)
+            ):
+                return
+
+            total = payload.get("total") if isinstance(payload, Mapping) else None
+            returned = len(page_items)
+            start_at += returned
+            if returned < _JIRA_BROWSER_PAGE_SIZE:
+                break
+            if isinstance(total, int) and start_at >= total:
+                break
+        raise JiraToolError(
+            "Project is not allowed by Jira policy.",
+            code="jira_policy_denied",
+            status_code=403,
+            action="jira_browser.policy",
+        )
 
     async def _fetch_board_issues(
         self,
@@ -608,6 +709,18 @@ class JiraBrowserService:
                 status_code=403,
                 action="jira_browser.policy",
             )
+
+    def _issue_matches_policy_scope(
+        self,
+        payload: Mapping[str, Any],
+        policy_project_key: str | None,
+    ) -> bool:
+        issue_key = str(payload.get("key") or "").strip().upper()
+        issue_project = self._project_from_issue_key(issue_key) if "-" in issue_key else ""
+        if policy_project_key is not None and issue_project != policy_project_key:
+            return False
+        allowed = self._allowed_projects()
+        return not allowed or issue_project in allowed
 
     def _normalize_project(
         self,

--- a/specs/171-jira-rollout-hardening/contracts/jira-browser.openapi.yaml
+++ b/specs/171-jira-rollout-hardening/contracts/jira-browser.openapi.yaml
@@ -71,6 +71,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: projectKey
+          in: query
+          required: false
+          description: Selected project scope from the project-to-board browse path.
+          schema:
+            type: string
       responses:
         "200":
           description: Board columns.
@@ -97,6 +103,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: projectKey
+          in: query
+          required: false
+          description: Selected project scope used for policy checks and issue filtering.
+          schema:
+            type: string
       responses:
         "200":
           description: Issues grouped by column.
@@ -121,6 +133,12 @@ paths:
         - name: boardId
           in: query
           required: false
+          schema:
+            type: string
+        - name: projectKey
+          in: query
+          required: false
+          description: Selected project scope used for policy checks and column context.
           schema:
             type: string
       responses:

--- a/tests/unit/api/routers/test_jira_browser.py
+++ b/tests/unit/api/routers/test_jira_browser.py
@@ -66,8 +66,12 @@ class _FakeJiraBrowserService:
             items=[JiraBoard(id="42", name="Delivery", projectKey=project_key)],
         )
 
-    async def list_columns(self, board_id: str) -> JiraBoardColumns:
-        self.calls.append(("list_columns", board_id))
+    async def list_columns(
+        self,
+        board_id: str,
+        project_key: str | None = None,
+    ) -> JiraBoardColumns:
+        self.calls.append(("list_columns", {"board_id": board_id, "project_key": project_key}))
         self._maybe_raise()
         board = JiraBoard(id=board_id, name="Delivery", projectKey="ENG")
         return JiraBoardColumns(
@@ -77,8 +81,18 @@ class _FakeJiraBrowserService:
             ],
         )
 
-    async def list_issues(self, board_id: str, q: str | None = None) -> JiraBoardIssues:
-        self.calls.append(("list_issues", {"board_id": board_id, "q": q}))
+    async def list_issues(
+        self,
+        board_id: str,
+        q: str | None = None,
+        project_key: str | None = None,
+    ) -> JiraBoardIssues:
+        self.calls.append(
+            (
+                "list_issues",
+                {"board_id": board_id, "q": q, "project_key": project_key},
+            )
+        )
         self._maybe_raise()
         column = JiraColumn(id="to-do", name="To Do", order=0, count=1, statusIds=["1"])
         item = JiraIssueSummary(
@@ -98,8 +112,18 @@ class _FakeJiraBrowserService:
         self,
         issue_key: str,
         board_id: str | None = None,
+        project_key: str | None = None,
     ) -> JiraIssueDetail:
-        self.calls.append(("get_issue", {"issue_key": issue_key, "board_id": board_id}))
+        self.calls.append(
+            (
+                "get_issue",
+                {
+                    "issue_key": issue_key,
+                    "board_id": board_id,
+                    "project_key": project_key,
+                },
+            )
+        )
         self._maybe_raise()
         return JiraIssueDetail(
             issueKey=issue_key,
@@ -197,16 +221,19 @@ async def test_project_boards_endpoint(router_app: tuple[FastAPI, _FakeJiraBrows
 
 
 async def test_board_columns_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowserService]) -> None:
-    app, _service = router_app
+    app, service = router_app
 
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://testserver",
     ) as client:
-        response = await client.get("/api/jira/boards/42/columns")
+        response = await client.get("/api/jira/boards/42/columns?projectKey=ENG")
 
     assert response.status_code == 200
     assert response.json()["columns"][0]["statusIds"] == ["1"]
+    assert service.calls == [
+        ("list_columns", {"board_id": "42", "project_key": "ENG"})
+    ]
 
 
 async def test_board_issues_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowserService]) -> None:
@@ -216,11 +243,13 @@ async def test_board_issues_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowser
         transport=ASGITransport(app=app),
         base_url="http://testserver",
     ) as client:
-        response = await client.get("/api/jira/boards/42/issues?q=browser")
+        response = await client.get("/api/jira/boards/42/issues?q=browser&projectKey=ENG")
 
     assert response.status_code == 200
     assert response.json()["itemsByColumn"]["to-do"][0]["issueKey"] == "ENG-1"
-    assert service.calls == [("list_issues", {"board_id": "42", "q": "browser"})]
+    assert service.calls == [
+        ("list_issues", {"board_id": "42", "q": "browser", "project_key": "ENG"})
+    ]
 
 
 async def test_issue_detail_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowserService]) -> None:
@@ -230,12 +259,17 @@ async def test_issue_detail_endpoint(router_app: tuple[FastAPI, _FakeJiraBrowser
         transport=ASGITransport(app=app),
         base_url="http://testserver",
     ) as client:
-        response = await client.get("/api/jira/issues/eng-1?boardId=42")
+        response = await client.get("/api/jira/issues/eng-1?boardId=42&projectKey=ENG")
 
     assert response.status_code == 200
     assert response.json()["recommendedImports"]["stepInstructions"] == "Complete Jira story ENG-1"
     assert response.json()["column"] == {"id": "to-do", "name": "To Do"}
-    assert service.calls == [("get_issue", {"issue_key": "ENG-1", "board_id": "42"})]
+    assert service.calls == [
+        (
+            "get_issue",
+            {"issue_key": "ENG-1", "board_id": "42", "project_key": "ENG"},
+        )
+    ]
 
 
 async def test_issue_attachment_download_endpoint(

--- a/tests/unit/integrations/test_jira_browser_service.py
+++ b/tests/unit/integrations/test_jira_browser_service.py
@@ -124,6 +124,20 @@ def _settings(
     allowed_projects: str | None = None,
 ) -> AtlassianSettings:
     return AtlassianSettings(
+        atlassian_api_key=None,
+        atlassian_api_key_secret_ref=None,
+        atlassian_auth_mode=None,
+        atlassian_auth_mode_secret_ref=None,
+        atlassian_cloud_id=None,
+        atlassian_cloud_id_secret_ref=None,
+        atlassian_email=None,
+        atlassian_email_secret_ref=None,
+        atlassian_service_account_email=None,
+        atlassian_service_account_email_secret_ref=None,
+        atlassian_site_url=None,
+        atlassian_site_url_secret_ref=None,
+        atlassian_username=None,
+        atlassian_url=None,
         jira=JiraSettings(jira_allowed_projects=allowed_projects),
     )
 
@@ -362,6 +376,81 @@ async def test_board_columns_preserve_order_and_status_mapping() -> None:
     ]
 
 
+async def test_board_columns_use_selected_project_scope_when_board_location_differs() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=_settings(allowed_projects="ENG"),
+        responses=[
+            {
+                "id": 42,
+                "name": "Shared Delivery",
+                "type": "kanban",
+                "location": {"projectKey": "OPS"},
+            },
+            {
+                "values": [
+                    {
+                        "id": 42,
+                        "name": "Shared Delivery",
+                        "type": "kanban",
+                        "location": {"projectKey": "OPS"},
+                    }
+                ],
+                "total": 1,
+            },
+            {
+                "location": {"projectKey": "OPS"},
+                "columnConfig": {
+                    "columns": [
+                        {
+                            "name": "Selected",
+                            "statuses": [{"id": "1", "name": "Selected"}],
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+
+    result = await service.list_columns("42", project_key="ENG")
+
+    assert result.board.project_key == "ENG"
+    assert [column.id for column in result.columns] == ["selected"]
+    assert [call["path"] for call in service.calls] == [
+        "agile:/board/42",
+        "agile:/board",
+        "agile:/board/42/configuration",
+    ]
+    assert service.calls[1]["params"] == {
+        "projectKeyOrId": "ENG",
+        "maxResults": 50,
+        "startAt": 0,
+    }
+
+
+async def test_board_columns_deny_selected_project_scope_when_board_is_not_listed() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=_settings(allowed_projects="ENG"),
+        responses=[
+            {
+                "id": 42,
+                "name": "Shared Delivery",
+                "type": "kanban",
+                "location": {"projectKey": "OPS"},
+            },
+            {"values": [], "total": 0},
+        ],
+    )
+
+    with pytest.raises(JiraToolError) as excinfo:
+        await service.list_columns("42", project_key="ENG")
+
+    assert excinfo.value.code == "jira_policy_denied"
+    assert [call["path"] for call in service.calls] == [
+        "agile:/board/42",
+        "agile:/board",
+    ]
+
+
 async def test_board_columns_returns_empty_columns_when_configuration_has_no_columns() -> None:
     service = _StubJiraBrowserService(
         atlassian_settings=_settings(allowed_projects="ENG"),
@@ -441,6 +530,56 @@ async def test_board_issues_group_by_status_and_keep_unmapped_bucket() -> None:
         "maxResults": 50,
         "startAt": 0,
     }
+
+
+async def test_board_issues_filter_to_selected_project_scope() -> None:
+    service = _StubJiraBrowserService(
+        atlassian_settings=_settings(allowed_projects="ENG,OPS"),
+        responses=[
+            {
+                "id": 42,
+                "name": "Shared Delivery",
+                "type": "kanban",
+                "location": {"projectKey": "OPS"},
+            },
+            {
+                "values": [
+                    {
+                        "id": 42,
+                        "name": "Shared Delivery",
+                        "type": "kanban",
+                        "location": {"projectKey": "OPS"},
+                    }
+                ],
+                "total": 1,
+            },
+            {
+                "location": {"projectKey": "OPS"},
+                "columnConfig": {
+                    "columns": [
+                        {"name": "Selected", "statuses": [{"id": "1"}]},
+                    ]
+                },
+            },
+            {
+                "issues": [
+                    {
+                        "key": "ENG-1",
+                        "fields": {"summary": "Allowed", "status": {"id": "1"}},
+                    },
+                    {
+                        "key": "OPS-2",
+                        "fields": {"summary": "Other project", "status": {"id": "1"}},
+                    },
+                ],
+                "total": 2,
+            },
+        ],
+    )
+
+    result = await service.list_issues("42", project_key="ENG")
+
+    assert [item.issue_key for item in result.items_by_column["selected"]] == ["ENG-1"]
 
 
 async def test_board_issues_returns_empty_column_buckets_when_jira_has_no_issues() -> None:

--- a/tests/unit/integrations/test_jira_tool_service.py
+++ b/tests/unit/integrations/test_jira_tool_service.py
@@ -66,7 +66,26 @@ def _build_settings(
     **overrides: object,
 ) -> AtlassianSettings:
     return AtlassianSettings(
-        jira=jira or JiraSettings(jira_tool_enabled=True),
+        atlassian_api_key=None,
+        atlassian_api_key_secret_ref=None,
+        atlassian_auth_mode=None,
+        atlassian_auth_mode_secret_ref=None,
+        atlassian_cloud_id=None,
+        atlassian_cloud_id_secret_ref=None,
+        atlassian_email=None,
+        atlassian_email_secret_ref=None,
+        atlassian_service_account_email=None,
+        atlassian_service_account_email_secret_ref=None,
+        atlassian_site_url=None,
+        atlassian_site_url_secret_ref=None,
+        atlassian_username=None,
+        atlassian_url=None,
+        jira=jira
+        or JiraSettings(
+            jira_tool_enabled=True,
+            jira_allowed_projects=None,
+            jira_allowed_actions=None,
+        ),
         **overrides,
     )
 
@@ -150,6 +169,7 @@ async def test_transition_issue_requires_explicit_lookup_and_rejects_stale_trans
             jira=JiraSettings(
                 jira_tool_enabled=True,
                 jira_require_explicit_transition_lookup=True,
+                jira_allowed_projects=None,
             )
         ),
         responses=[{"transitions": [{"id": "11", "name": "Done"}]}],
@@ -176,6 +196,7 @@ async def test_transition_issue_allows_preflight_without_get_transitions_allowli
                 jira_tool_enabled=True,
                 jira_allowed_actions="transition_issue",
                 jira_require_explicit_transition_lookup=True,
+                jira_allowed_projects=None,
             )
         ),
         responses=[
@@ -259,6 +280,7 @@ async def test_action_allowlist_denies_disallowed_mutation_before_request() -> N
             jira=JiraSettings(
                 jira_tool_enabled=True,
                 jira_allowed_actions="get_issue,search_issues",
+                jira_allowed_projects=None,
             )
         )
     )


### PR DESCRIPTION
## Summary

Fixes the Create-page Jira browser flow where selecting a project and board could still fail while loading stories with `Project is not allowed by Jira policy`.

The browser now sends the selected `projectKey` with board-scoped column, issue-list, and issue-detail requests. The backend preserves that selected project scope, verifies the board is actually listed for the selected project, and filters returned stories to the selected project plus the configured allowlist. This avoids relying only on Jira board `location.projectKey`, which can differ for shared boards returned by a project-scoped board lookup.

## Changes

- Accept optional `projectKey` on board column, board issue, and issue detail Jira browser endpoints.
- Preserve selected project scope in the Jira browser service while verifying board membership.
- Filter board issues to the selected/allowed project scope.
- Update Create-page Jira fetchers to include selected project context.
- Regenerate OpenAPI TypeScript types and update contract/docs.
- Add regression tests for board-location mismatch, project-scope denial, issue filtering, router query propagation, and frontend request URLs.
- Make Jira unit-test settings explicit so local Jira policy environment variables do not leak into deterministic unit tests.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_task_dashboard_view_model.py tests/unit/config/test_settings.py tests/unit/api/routers/test_jira_browser.py tests/unit/integrations/test_jira_browser_service.py tests/unit/integrations/test_jira_client.py` -> 152 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx` -> 96 passed
- `npm run generate`
- `npm run ui:typecheck`
- `npm run ui:lint`
- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` -> Python 3051 passed, dashboard 211 passed