### PR TITLE
I want to modify the Jira Task Update skill and name it jira-issue-updater so it aligns more closely with the jira issue creator skill. It should simi

### DIFF
--- a/.agents/skills/jira-issue-updater/SKILL.md
+++ b/.agents/skills/jira-issue-updater/SKILL.md
@@ -1,18 +1,19 @@
 ---
-name: jira-task-update
-description: Update Jira task status and/or description through MoonMind's trusted Jira tool surface. Use when a user asks to move a Jira issue, change workflow status, edit an issue description, or publish a task completion/status summary back to Jira.
+name: jira-issue-updater
+description: Update Jira issues such as tasks, stories, bugs, or subtasks through MoonMind's trusted Jira tool surface. Use when a user asks to edit Jira fields, move workflow status, update descriptions, or publish completion/status summaries back to any Jira issue type.
 ---
 
-# Jira Task Update
+# Jira Issue Updater
 
-Use this skill when the task requires changing an existing Jira issue's workflow status, description, or both. Prefer MoonMind's trusted Jira tools over direct Jira REST calls so credentials stay outside the agent runtime.
+Update an existing Jira task, story, bug, subtask, or other issue type. Use this skill when the request requires changing an issue's workflow status, description, or editable fields. Prefer MoonMind's trusted Jira tools over direct Jira REST calls so credentials stay outside the agent runtime.
 
 ## Inputs
 
 - Required: Jira issue key, for example `ENG-123`.
 - Optional: target status or workflow state, for example `Done`, `In Review`, or `Blocked`.
 - Optional: replacement or appended description text.
-- Optional: field/update payload details from the user or Jira edit metadata.
+- Optional: issue type context, for example `Task`, `Story`, `Bug`, `Sub-task`, or a project-specific Jira issue type.
+- Optional: field/update payload details from the user or Jira edit metadata, including labels, priority, assignee, components, due dates, or project-specific custom fields.
 - Optional: MoonMind API base URL and authenticated session/token, only when calling the HTTP MCP endpoint directly.
 
 ## Outputs
@@ -20,19 +21,23 @@ Use this skill when the task requires changing an existing Jira issue's workflow
 - Confirmation of the issue key updated.
 - Description update result when `jira.edit_issue` is used.
 - Transition result when `jira.transition_issue` is used.
+- Field update result when editable issue fields are changed.
 - Any skipped action with a short reason.
 
 ## Workflow
 
 1. Validate the requested issue key and scope.
    - Use a concrete Jira issue key; do not infer one from unrelated text unless the user clearly identified it.
+   - Treat the issue key, not the issue type, as the update target. The same workflow applies to tasks, stories, bugs, subtasks, and custom issue types unless Jira metadata or policy blocks the requested field.
    - If the user asks for a status change by name, treat that name as the desired end state, not as a transition ID.
+   - If the request references a parent or related issue, distinguish it from the issue being updated before mutating anything.
 
 2. Discover available tools and issue state.
    - If runtime-native Jira tools are available, use them directly.
    - Otherwise, if the MoonMind API is reachable and authenticated, call `GET /mcp/tools` and `POST /mcp/tools/call`.
    - Confirm only the tools needed for the requested action are registered before relying on them.
    - For description updates, require `jira.edit_issue`; also require `jira.get_issue` when preserving current description text for an append, and `jira.get_edit_metadata` when editable field shape is unclear.
+   - For general field updates, require `jira.edit_issue` and use `jira.get_edit_metadata` to map requested field names to Jira's editable schema instead of hardcoding custom field IDs.
    - For status updates, require `jira.get_transitions` and `jira.transition_issue`; use `jira.get_issue` when current status or final verification is needed.
    - If one requested action is unavailable because its tools are disabled by policy, skip that action with a reason instead of blocking other requested actions whose tools are available.
    - Fetch the issue with `jira.get_issue` when current fields or status are needed.
@@ -72,7 +77,30 @@ Example tool payload:
 }
 ```
 
-4. Change status when requested.
+4. Update other editable fields when requested.
+   - Use `jira.get_edit_metadata` to identify editable fields and required shapes for the target issue.
+   - Map human names such as assignee, priority, labels, components, sprint, fix versions, due date, and custom fields through metadata or connector-provided field definitions.
+   - Send only fields the user requested and Jira allows for the selected issue.
+   - Do not invent values for issue type-specific fields. If a required value is missing, stop with the exact missing field instead of guessing.
+
+Example tool payload:
+
+```json
+{
+  "tool": "jira.edit_issue",
+  "arguments": {
+    "issueKey": "ENG-123",
+    "fields": {
+      "labels": ["release-readiness"],
+      "priority": {
+        "name": "High"
+      }
+    }
+  }
+}
+```
+
+5. Change status when requested.
    - Call `jira.get_transitions` for the issue before transitioning.
    - Match the user's requested status against available transition names or target statuses.
    - Use the transition ID returned by Jira; do not guess IDs.
@@ -91,9 +119,9 @@ Example tool payload:
 }
 ```
 
-5. Verify and report.
+6. Verify and report.
    - Re-fetch the issue when possible to confirm the final status or description.
-   - Report only sanitized results: issue key, final status, changed fields, and tool result IDs.
+   - Report only sanitized results: issue key, issue type when known, final status, changed fields, and tool result IDs.
    - Never print auth headers, SecretRefs resolved to plaintext, API tokens, cookies, or full environment dumps.
 
 ## HTTP MCP Invocation
@@ -120,6 +148,7 @@ Use the authentication mechanism already provided by the runtime or user. Do not
 - `jira_not_configured`: report that MoonMind Jira credentials/configuration are missing.
 - `jira_policy_denied`: report that the requested project or action is outside configured policy.
 - `jira_validation_failed`: re-check issue key, editable fields, required transition fields, and transition ID.
+- Unsupported issue type or field: explain which value is unsupported for the selected issue and which metadata check blocked it.
 - `jira_auth_failed` or HTTP 401/403: report an auth or permission problem without exposing secrets.
 - Rate limiting or transient Jira failure: retry only through the trusted tool's normal retry behavior; do not build an ad hoc raw Jira client.
 

--- a/docs/ManagedAgents/CodexManagedSessionPlane.md
+++ b/docs/ManagedAgents/CodexManagedSessionPlane.md
@@ -1,0 +1,38 @@
+# Codex Managed Session Plane
+
+Status: Desired state
+Owners: MoonMind Platform
+Last updated: 2026-04-14
+Related:
+- [`docs/ManagedAgents/CodexCliManagedSessions.md`](./CodexCliManagedSessions.md)
+- [`docs/ManagedAgents/DockerOutOfDocker.md`](./DockerOutOfDocker.md)
+- [`docs/Temporal/ManagedAndExternalAgentExecutionModel.md`](../Temporal/ManagedAndExternalAgentExecutionModel.md)
+
+## Purpose
+
+This document preserves the canonical Codex managed session plane entrypoint used
+by managed-agent architecture references. The detailed Codex CLI session
+contract lives in [`CodexCliManagedSessions.md`](./CodexCliManagedSessions.md).
+
+The Codex managed session plane is the task-scoped managed runtime environment
+for Codex continuity. It owns the session container, thread and turn lifecycle,
+session reset boundaries, and continuity artifacts for one MoonMind task.
+
+Managed-session steps may invoke **control-plane tools** that launch separate
+workload containers as described in
+[`DockerOutOfDocker.md`](./DockerOutOfDocker.md). Those workload containers remain outside session identity: they do not become `session_id`, `session_epoch`, `container_id`, `thread_id`, or `active_turn_id`, and they do not replace the task-scoped session container.
+
+## Contract
+
+The bounded session identity remains:
+
+- `session_id`
+- `session_epoch`
+- `container_id`
+- `thread_id`
+- `active_turn_id`
+
+Docker-backed workload containers are sibling workload executions launched
+through MoonMind's control plane. They are not hidden Codex session children, and
+they are not `MoonMind.AgentRun` executions unless the launched runtime is itself
+an agent runtime.

--- a/tests/unit/workflows/test_skills_resolver.py
+++ b/tests/unit/workflows/test_skills_resolver.py
@@ -143,6 +143,41 @@ def test_resolve_run_skill_selection_falls_back_to_legacy_root(skills_mirror):
     assert resolved.skills[0].source_uri == (legacy / "legacy").resolve().as_uri()
 
 
+def test_resolve_run_skill_selection_resolves_jira_issue_updater_repo_skill(
+    monkeypatch,
+):
+    repo_root = Path(__file__).resolve().parents[3]
+    active_skill = repo_root / ".agents" / "skills" / "jira-issue-updater"
+    retired_skill = repo_root / ".agents" / "skills" / ("jira-" + "task-update")
+
+    assert (active_skill / "SKILL.md").is_file()
+    assert not retired_skill.exists()
+
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.repo_root",
+        str(repo_root),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_local_mirror_root",
+        ".agents/skills/local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.skills.resolver.settings.workflow.skills_legacy_mirror_root",
+        ".agents/skills",
+        raising=False,
+    )
+
+    resolved = resolve_run_skill_selection(
+        run_id="run-jira-updater",
+        context={"skill_selection": ["jira-issue-updater:local"]},
+    )
+
+    assert resolved.skills[0].skill_name == "jira-issue-updater"
+    assert resolved.skills[0].source_uri == active_skill.resolve().as_uri()
+
+
 def test_resolve_run_skill_selection_requires_source(monkeypatch, tmp_path):
     empty_root = tmp_path / "empty"
     empty_root.mkdir(parents=True)
@@ -362,7 +397,4 @@ def test_project_root_fallback_handles_shallow_paths(monkeypatch):
     monkeypatch.setattr(resolver_module, "__file__", "/x.py", raising=False)
 
     assert resolver_module._project_root() == Path("/")
-
-
-
 


### PR DESCRIPTION
I want to modify the Jira Task Update skill and name it jira-issue-updater so it aligns more closely with the jira issue creator skill. It should similarly be able to modify tasks, stories, bugs (or any type of jira issue)