### PR TITLE
I want to hide skill required capabilities behind an advanced settings toggle that will not be part of the steps region of the UI.

### DIFF
--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -146,7 +146,6 @@ Each step card must expose:
 
 - `Instructions`
 - `Skill (optional)`
-- `Skill Required Capabilities (optional CSV)`
 - `Skill Args (optional JSON object)` when a non-empty explicit skill is selected
 
 Rules:
@@ -156,7 +155,17 @@ Rules:
 - non-primary steps may omit instructions to continue from the task objective
 - non-primary steps may omit skill to inherit the primary-step skill defaults
 
-### 7.3 Template-bound steps
+### 7.3 Advanced settings
+
+The page must expose `Skill Required Capabilities (optional CSV)` behind a collapsed Advanced Settings section outside the step-list region.
+
+Rules:
+
+- each step may still author optional skill required capabilities
+- required capabilities remain an advanced routing override, not part of the default visible Create Task flow
+- runtime, publish mode, selected skills, and presets derive the common capability set automatically
+
+### 7.4 Template-bound steps
 
 Preset-expanded steps may carry template step identity.
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2375,6 +2375,64 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("keeps manual skill capability routing in advanced settings", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    expect(
+      within(primaryStep as HTMLElement).queryByLabelText(
+        /skill required capabilities/i,
+      ),
+    ).toBeNull();
+
+    const advancedSettings = screen
+      .getByText("Advanced Settings")
+      .closest("details") as HTMLDetailsElement | null;
+    expect(advancedSettings).not.toBeNull();
+    expect(advancedSettings?.open).toBe(false);
+
+    fireEvent.click(screen.getByText("Advanced Settings"));
+    fireEvent.change(
+      screen.getByLabelText("Step 1 skill required capabilities (optional CSV)"),
+      {
+        target: { value: "docker, qdrant" },
+      },
+    );
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Run advanced routing regression flow." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+    expect(request.payload.task.tool.requiredCapabilities).toEqual([
+      "docker",
+      "qdrant",
+    ]);
+    expect(request.payload.requiredCapabilities).toEqual([
+      "codex_cli",
+      "git",
+      "gh",
+      "docker",
+      "qdrant",
+    ]);
+  });
+
   it("uploads a step attachment and includes it with the step instructions", async () => {
     renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -4551,47 +4551,30 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     ) : null}
                   </div>
 
-                  <div className="grid-2">
-                    <label>
-                      Skill (optional)
-                      <input
-                        data-step-field="skillId"
-                        data-step-index={String(index)}
-                        list={SKILL_OPTIONS_DATALIST_ID}
-                        value={step.skillId}
-                        placeholder={
-                          isPrimaryStep
-                            ? "auto (default), moonspec-orchestrate, ..."
-                            : "inherit primary step skill"
-                        }
-                        onChange={(event) =>
-                          updateStep(step.localId, {
-                            skillId: event.target.value,
-                          })
-                        }
-                      />
-                      <span className="small">
-                        {isPrimaryStep
-                          ? "Primary step must include instructions or an explicit skill."
-                          : "Leave skill blank to inherit primary step defaults."}
-                      </span>
-                    </label>
-
-                    <label>
-                      Skill Required Capabilities (optional CSV)
-                      <input
-                        data-step-field="skillRequiredCapabilities"
-                        data-step-index={String(index)}
-                        value={step.skillRequiredCapabilities}
-                        placeholder="docker,qdrant,unity"
-                        onChange={(event) =>
-                          updateStep(step.localId, {
-                            skillRequiredCapabilities: event.target.value,
-                          })
-                        }
-                      />
-                    </label>
-                  </div>
+                  <label>
+                    Skill (optional)
+                    <input
+                      data-step-field="skillId"
+                      data-step-index={String(index)}
+                      list={SKILL_OPTIONS_DATALIST_ID}
+                      value={step.skillId}
+                      placeholder={
+                        isPrimaryStep
+                          ? "auto (default), moonspec-orchestrate, ..."
+                          : "inherit primary step skill"
+                      }
+                      onChange={(event) =>
+                        updateStep(step.localId, {
+                          skillId: event.target.value,
+                        })
+                      }
+                    />
+                    <span className="small">
+                      {isPrimaryStep
+                        ? "Primary step must include instructions or an explicit skill."
+                        : "Leave skill blank to inherit primary step defaults."}
+                    </span>
+                  </label>
 
                   <label
                     className={
@@ -4626,6 +4609,36 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             </div>
           </div>
         </section>
+
+        <details className="card stack" id="queue-advanced-settings">
+          <summary>
+            <strong>Advanced Settings</strong>
+          </summary>
+          <div className="stack queue-advanced-settings-body">
+            <div>
+              <strong>Skill Required Capabilities</strong>
+              <p className="small">
+                Optional worker routing overrides. Runtime, publish mode, skills, and presets already add the common capabilities automatically.
+              </p>
+            </div>
+            {steps.map((step, index) => (
+              <label key={step.localId}>
+                {`Step ${index + 1} skill required capabilities (optional CSV)`}
+                <input
+                  data-step-field="skillRequiredCapabilities"
+                  data-step-index={String(index)}
+                  value={step.skillRequiredCapabilities}
+                  placeholder="docker,qdrant,unity"
+                  onChange={(event) =>
+                    updateStep(step.localId, {
+                      skillRequiredCapabilities: event.target.value,
+                    })
+                  }
+                />
+              </label>
+            ))}
+          </div>
+        </details>
 
         {taskTemplateCatalogEnabled ? (
           <div className="card stack">

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1510,6 +1510,10 @@ button.secondary:hover {
   margin-top: 0;
 }
 
+.queue-advanced-settings-body {
+  margin-top: 0.75rem;
+}
+
 .queue-step-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
I want to hide skill required capabilities behind an advanced settings toggle that will not be part of the steps region of the UI.

See this analysis for reasoning: It does not look essential for the main Create Task UX anymore.

The strongest signal is that the current Create page already derives required capabilities automatically from runtime, publish mode, task skill caps, step skill caps, and template caps via `deriveRequiredCapabilities(...)` rather than relying on the user to type them manually . And the happy-path create test submits a task with a selected skill and still gets derived capabilities like `["codex_cli", "git", "gh"]` without any manual capability CSV input being involved .

What the field is still doing is mostly acting as an advanced escape hatch. The docs still explicitly include `Skill Required Capabilities (optional CSV)` in the step editor contract , and the older task-steps spec also bakes in the idea that step-level required capabilities participate in the final capability union . The backend contract still supports `task.skill.requiredCapabilities` and validates it, so the system has not fully moved away from that model yet .

So my recommendation is:

Remove it from the default visible Create page UI, or hide it behind an Advanced section. Keep backend support for now.

That gives you most of the simplification benefit without losing much real functionality. Most users should not need to think about worker capability routing manually, especially when runtime, publish mode, and preset/template metadata already cover the common cases . Preset expansion even appears to import template-provided required capabilities automatically into step state already .

I would only fully delete the field from the system if you also want to remove the manual override concept entirely. That would require aligning the docs/specs/tests, since they still treat step-level capability requirements as part of the contract  .