### PR TITLE
[codex] Fix Jira browser column counts

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -3587,6 +3587,68 @@ describe("Task Create Entrypoint", () => {
     expect(screen.queryByText("ENG-101")).toBeNull();
   });
 
+  it("uses validated Jira issue columns as the count source of truth", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/boards/42/columns") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            board: { id: "42", name: "Delivery", projectKey: "ENG" },
+            columns: [
+              { id: "todo", name: "To Do", count: 7 },
+              { id: "doing", name: "Doing", count: 9 },
+              { id: "", count: 3 },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/boards/42/issues") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            boardId: "42",
+            columns: [
+              { id: "todo", name: "To Do" },
+              { id: "doing", name: "Doing", count: 2 },
+              { id: 17, name: "Invalid" },
+              { id: "missing-name", count: 1 },
+            ],
+            itemsByColumn: {
+              todo: [
+                {
+                  issueKey: "ENG-101",
+                  summary: "Plan controls",
+                  issueType: "Story",
+                  statusName: "Selected",
+                  assignee: "Ada",
+                },
+              ],
+              doing: [],
+            },
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Browse Jira story for preset instructions",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "To Do 0" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Doing 2" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: "Invalid 0" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "missing-name 1" })).toBeNull();
+  });
+
   it("sends the selected Jira project scope with board and story requests", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
@@ -4654,7 +4716,7 @@ describe("Task Create Entrypoint", () => {
         "84",
       );
     });
-    fireEvent.click(await screen.findByRole("button", { name: "Selected 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Selected 0" }));
     fireEvent.click(
       await screen.findByRole("button", { name: /MY-PROJ-123/ }),
     );

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1119,8 +1119,8 @@ describe("Task Create Entrypoint", () => {
             json: async () => ({
               board: { id: "42", name: "Delivery", projectKey: "ENG" },
               columns: [
-                { id: "todo", name: "To Do", count: 1 },
-                { id: "doing", name: "Doing", count: 1 },
+                { id: "todo", name: "To Do", count: 0 },
+                { id: "doing", name: "Doing", count: 0 },
               ],
             }),
           } as Response);
@@ -1140,8 +1140,8 @@ describe("Task Create Entrypoint", () => {
             json: async () => ({
               boardId: "42",
               columns: [
-                { id: "todo", name: "To Do" },
-                { id: "doing", name: "Doing" },
+                { id: "todo", name: "To Do", count: 1 },
+                { id: "doing", name: "Doing", count: 1 },
               ],
               itemsByColumn: {
                 todo: [

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -194,6 +194,24 @@ interface JiraBoardIssues {
   itemsByColumn: Record<string, JiraIssueSummary[]>;
 }
 
+function isJiraColumn(value: unknown): value is JiraColumn {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const column = value as Record<string, unknown>;
+  return (
+    typeof column.id === "string" &&
+    typeof column.name === "string" &&
+    (column.count === undefined ||
+      column.count === null ||
+      typeof column.count === "number")
+  );
+}
+
+function parseJiraColumns(value: unknown): JiraColumn[] {
+  return Array.isArray(value) ? value.filter(isJiraColumn) : [];
+}
+
 interface JiraIssueDetail extends JiraIssueSummary {
   url?: string | null;
   column?: JiraColumn | null;
@@ -2239,7 +2257,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       const data = (await response.json()) as { columns?: unknown } | null;
-      return Array.isArray(data?.columns) ? (data.columns as JiraColumn[]) : [];
+      return parseJiraColumns(data?.columns);
     },
   });
 
@@ -2275,7 +2293,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         itemsByColumn?: Record<string, JiraIssueSummary[]>;
       } | null;
       return {
-        columns: Array.isArray(data?.columns) ? (data.columns as JiraColumn[]) : [],
+        columns: parseJiraColumns(data?.columns),
         itemsByColumn: data?.itemsByColumn || {},
       };
     },
@@ -2336,7 +2354,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             }
             return {
               ...column,
-              count: counted.count ?? column.count ?? 0,
+              count: counted.count ?? 0,
             };
           })
         : countedColumns;

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -189,6 +189,11 @@ interface JiraIssueSummary {
   updatedAt?: string | null;
 }
 
+interface JiraBoardIssues {
+  columns: JiraColumn[];
+  itemsByColumn: Record<string, JiraIssueSummary[]>;
+}
+
 interface JiraIssueDetail extends JiraIssueSummary {
   url?: string | null;
   column?: JiraColumn | null;
@@ -2250,7 +2255,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     enabled: Boolean(
       jiraIntegration?.enabled && jiraBrowserOpen && selectedJiraBoardId,
     ),
-    queryFn: async (): Promise<Record<string, JiraIssueSummary[]>> => {
+    queryFn: async (): Promise<JiraBoardIssues> => {
       const endpoint = withQueryParams(
         interpolatePath(jiraIntegration?.endpoints.issues || "", {
           boardId: selectedJiraBoardId,
@@ -2266,9 +2271,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         );
       }
       const data = (await response.json()) as {
+        columns?: unknown;
         itemsByColumn?: Record<string, JiraIssueSummary[]>;
       } | null;
-      return data?.itemsByColumn || {};
+      return {
+        columns: Array.isArray(data?.columns) ? (data.columns as JiraColumn[]) : [],
+        itemsByColumn: data?.itemsByColumn || {},
+      };
     },
   });
 
@@ -2308,6 +2317,35 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return (await response.json()) as JiraIssueDetail;
     },
   });
+
+  const jiraBrowserColumns = useMemo(() => {
+    const configuredColumns = jiraColumnsQuery.data || [];
+    const countedColumns = jiraIssuesQuery.data?.columns || [];
+    if (countedColumns.length === 0) {
+      return configuredColumns;
+    }
+    const countedById = new Map(
+      countedColumns.map((column) => [column.id, column]),
+    );
+    const mergedColumns =
+      configuredColumns.length > 0
+        ? configuredColumns.map((column) => {
+            const counted = countedById.get(column.id);
+            if (!counted) {
+              return column;
+            }
+            return {
+              ...column,
+              count: counted.count ?? column.count ?? 0,
+            };
+          })
+        : countedColumns;
+    const mergedIds = new Set(mergedColumns.map((column) => column.id));
+    return [
+      ...mergedColumns,
+      ...countedColumns.filter((column) => !mergedIds.has(column.id)),
+    ];
+  }, [jiraColumnsQuery.data, jiraIssuesQuery.data?.columns]);
 
   const templateItems = templateOptionsQuery.data?.items || [];
 
@@ -2393,7 +2431,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!jiraBrowserOpen) {
       return;
     }
-    const columns = jiraColumnsQuery.data || [];
+    const columns = jiraBrowserColumns;
     const activeStillExists = columns.some(
       (column) => column.id === activeJiraColumnId,
     );
@@ -2401,7 +2439,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
     setActiveJiraColumnId(columns[0]?.id || "");
-  }, [activeJiraColumnId, jiraBrowserOpen, jiraColumnsQuery.data]);
+  }, [activeJiraColumnId, jiraBrowserOpen, jiraBrowserColumns]);
 
   useEffect(() => {
     if (!taskTemplateCatalogEnabled || templateItems.length === 0) {
@@ -2431,7 +2469,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   );
 
   const activeJiraIssues =
-    (activeJiraColumnId && jiraIssuesQuery.data?.[activeJiraColumnId]) || [];
+    (activeJiraColumnId &&
+      jiraIssuesQuery.data?.itemsByColumn[activeJiraColumnId]) ||
+    [];
   const selectedJiraIssue = jiraIssueDetailQuery.isError
     ? null
     : jiraIssueDetailQuery.data || null;
@@ -4235,7 +4275,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   className="jira-column-tabs"
                   aria-label="Jira board columns"
                 >
-                  {(jiraColumnsQuery.data || []).map((column) => (
+                  {jiraBrowserColumns.map((column) => (
                     <button
                       key={column.id}
                       type="button"


### PR DESCRIPTION
## Summary

- Fix the Jira story browser to consume counted board columns from the issue-list response.
- Preserve column ordering from board configuration while overlaying the selectable issue counts returned by `/api/jira/boards/{boardId}/issues`.
- Add a regression fixture where the columns endpoint reports zero counts and the issues endpoint provides the real counts.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/integrations/test_jira_browser_service.py tests/unit/api/routers/test_jira_browser.py`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:lint`
- `git diff --check`