### PR TITLE
[codex] Route Jira issue creator as agent skill

### DIFF
--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -39,19 +39,20 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 
 4. Create the issue.
 - Use the available Jira connector's `jira.create_issue` or `jira.create_subtask` operations when present.
-- In MoonMind workflow plans, prefer the first-party `jira-issue-creator`/`story.create_jira_issues` tool path. It reads `stories` directly or reads `storyBreakdownPath` from the breakdown handoff and creates one Jira issue per story.
+- In MoonMind workflow plans, `jira-issue-creator` is an agent skill, not a deterministic executable tool. Use the available Jira connector/API to inspect projects, issue types, and create fields, then create the requested issues.
+- When the task references a story breakdown directory, look for `stories.json` inside that directory unless an exact `storyBreakdownPath` is provided.
 - Otherwise call Jira REST `POST /rest/api/3/issue` for Jira Cloud or the deployment's documented equivalent.
 - Send only the fields needed for the requested issue.
 - Treat retries carefully: before retrying after an uncertain network failure, use `jira.search_issues` to search by a stable summary/project/reporter marker to avoid duplicate tickets.
 
 ## Breakdown Handoff Behavior
 
-When invoked after `moonspec-breakdown`:
+When invoked after `moonspec-breakdown` or when the request references a story breakdown handoff:
 
 - Read story candidates from the provided JSON breakdown, not from `spec.md`.
 - Do not create or rename `spec.md`.
 - If Jira issue creation succeeds, return Jira keys/URLs and do not request another output format.
-- If Jira is not configured, missing required Jira fields, or issue creation fails, return fallback metadata pointing at the existing `docs/tmp/story-breakdowns/...` handoff instead of fabricating Jira success.
+- If Jira is not configured, required Jira fields are missing, or issue creation fails, report the exact blocker and the existing `docs/tmp/story-breakdowns/...` handoff instead of fabricating Jira success.
 - The fallback file must not be named `spec.md`.
 
 5. Return the result.

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -352,13 +352,34 @@ Workers declare capability sets (e.g., `llm`, `sandbox`, `integration:jules`, `i
 
 Broad Moon Spec breakdown is an agent-runtime operation that writes story candidates as durable handoff files under `docs/tmp/story-breakdowns/`. It does not create `spec.md` files and does not write under `specs/`.
 
-When a task requests Jira story output, the planner may add a first-party executable tool step:
+When a task requests Jira issue creation from ambiguous user intent, the planner should dispatch an `agent_runtime` step with the `jira-issue-creator` agent skill selected. The agent uses the Jira connector/API to resolve projects, issue types, create fields, and issue descriptions.
+
+```json
+{
+  "tool": {
+    "type": "agent_runtime",
+    "name": "codex_cli",
+    "version": "1.0"
+  },
+  "inputs": {
+    "selectedSkill": "jira-issue-creator",
+    "instructions": "Use $jira-issue-creator.\n\nCreate a Jira story for each story in docs/tmp/story-breakdowns/example.",
+    "runtime": {
+      "mode": "codex_cli"
+    }
+  }
+}
+```
+
+Pure Jira issue creation does not require branch or PR publishing. A PR is required only when the agent produces repository changes that need to be published.
+
+When a task already has fully structured story JSON and an exact Jira target, the planner may use the narrower deterministic batch tool:
 
 ```json
 {
   "tool": {
     "type": "skill",
-    "name": "jira-issue-creator",
+    "name": "story.create_jira_issues",
     "version": "1.0"
   },
   "inputs": {
@@ -374,7 +395,7 @@ When a task requests Jira story output, the planner may add a first-party execut
 }
 ```
 
-`jira-issue-creator` and `story.create_jira_issues` are executable tool names backed by `mm.tool.execute` and require `integration:jira`. They create one Jira issue per story from inline `stories` or from `storyBreakdownPath`.
+`story.create_jira_issues` is backed by `mm.tool.execute` and requires `integration:jira`. It creates one Jira issue per story from inline `stories` or from `storyBreakdownPath`; it is not the default path for ambiguous Jira requests.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `docs/tmp/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -711,7 +711,7 @@ def _default_registry_skill_payload(*, name: str, version: str) -> dict[str, Any
     if is_dood_tool(name):
         return build_dood_tool_definition_payload(name=name, version=version)
 
-    if name in {"jira-issue-creator", "story.create_jira_issues"}:
+    if name == "story.create_jira_issues":
         return {
             "name": name,
             "version": version,
@@ -840,6 +840,8 @@ def _iter_requested_registry_tools(
             selected_payload.get("name") or selected_payload.get("id") or ""
         ).strip()
         if not tool_name:
+            continue
+        if tool_name.lower() == "jira-issue-creator":
             continue
         tool_version = str(selected_payload.get("version") or "").strip() or "1.0"
         key = (tool_name, tool_version)

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -19,7 +19,7 @@ from moonmind.integrations.jira.tool import JiraToolService
 from moonmind.workflows.adapters.github_service import GitHubService
 from moonmind.workflows.skills.tool_plan_contracts import ToolResult
 
-JIRA_STORY_TOOL_NAMES = frozenset({"jira-issue-creator", "story.create_jira_issues"})
+JIRA_STORY_TOOL_NAMES = frozenset({"story.create_jira_issues"})
 JIRA_DESCRIPTION_MAX_CHARS = 32767
 JIRA_DESCRIPTION_TRUNCATION_SUFFIX = "\n\n[Truncated by MoonMind before Jira export]"
 

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -289,14 +289,15 @@ def _jira_agent_skill_selected(tool_name: str) -> bool:
 def _task_uses_only_jira_agent_skill(
     *, selected_skill_name: str, raw_steps: Any
 ) -> bool:
-    if isinstance(raw_steps, list) and raw_steps:
-        step_tool_names = [
-            _selected_step_tool_name(step).lower()
+    if isinstance(raw_steps, list) and len(raw_steps) > 1:
+        if not all(isinstance(step, Mapping) for step in raw_steps):
+            return False
+        effective_step_tool_names = [
+            (_selected_step_tool_name(step) or selected_skill_name).lower()
             for step in raw_steps
-            if isinstance(step, Mapping)
         ]
-        return bool(step_tool_names) and all(
-            _jira_agent_skill_selected(name) for name in step_tool_names
+        return bool(effective_step_tool_names) and all(
+            _jira_agent_skill_selected(name) for name in effective_step_tool_names
         )
     return _jira_agent_skill_selected(selected_skill_name)
 
@@ -671,14 +672,16 @@ def _build_runtime_planner():
                 step_tool_name = _selected_step_tool_name(step_entry)
                 step_runtime = runtime_mode
                 tool_type = _selected_step_tool_type(step_tool_name)
+                effective_step_skill_name = step_tool_name or selected_skill_name
                 if step_tool_name:
                     step_runtime = step_tool_name
                     step_node_inputs["selectedSkill"] = step_tool_name
                     if _jira_agent_skill_selected(step_tool_name):
                         step_node_inputs["publishMode"] = "none"
+                if effective_step_skill_name:
                     step_node_inputs["instructions"] = _append_agent_skill_instructions(
                         step_node_inputs["instructions"],
-                        selected_skill=step_tool_name,
+                        selected_skill=effective_step_skill_name,
                     )
                 if step_tool_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
                     if story_output_mode == "jira" and not step_node_inputs.get(

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -230,9 +230,8 @@ def _normalize_runtime_mode(raw_mode: Any) -> str:
     return normalized
 
 
-_JIRA_STORY_OUTPUT_TOOLS = frozenset(
-    {"jira-issue-creator", "story.create_jira_issues"}
-)
+_JIRA_AGENT_SKILLS = frozenset({"jira-issue-creator"})
+_JIRA_STORY_OUTPUT_TOOLS = frozenset({"story.create_jira_issues"})
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
 
@@ -281,6 +280,42 @@ def _selected_step_tool_type(tool_name: str) -> str:
     if tool_name.lower() in _JIRA_STORY_OUTPUT_TOOLS:
         return "skill"
     return "agent_runtime"
+
+
+def _jira_agent_skill_selected(tool_name: str) -> bool:
+    return tool_name.lower() in _JIRA_AGENT_SKILLS
+
+
+def _task_uses_only_jira_agent_skill(
+    *, selected_skill_name: str, raw_steps: Any
+) -> bool:
+    if isinstance(raw_steps, list) and raw_steps:
+        step_tool_names = [
+            _selected_step_tool_name(step).lower()
+            for step in raw_steps
+            if isinstance(step, Mapping)
+        ]
+        return bool(step_tool_names) and all(
+            _jira_agent_skill_selected(name) for name in step_tool_names
+        )
+    return _jira_agent_skill_selected(selected_skill_name)
+
+
+def _append_agent_skill_instructions(instructions: str, *, selected_skill: str) -> str:
+    selected = selected_skill.strip()
+    if not _jira_agent_skill_selected(selected):
+        return instructions
+    marker = f"${selected}"
+    if marker in instructions:
+        return instructions
+    return f"Use {marker}.\n\n{instructions.strip()}"
+
+
+def _plan_node_selected_skill(node: Mapping[str, Any]) -> str:
+    inputs = node.get("inputs")
+    if not isinstance(inputs, Mapping):
+        return ""
+    return str(inputs.get("selectedSkill") or "").strip()
 
 
 def _append_story_breakdown_instructions(
@@ -479,6 +514,14 @@ def _build_runtime_planner():
         if selected_skill_name:
             node_inputs["selectedSkill"] = selected_skill_name
 
+        raw_steps = task_payload.get("steps")
+        publish_uses_git = not _task_uses_only_jira_agent_skill(
+            selected_skill_name=selected_skill_name,
+            raw_steps=raw_steps,
+        )
+        node_publish_mode = str(node_inputs.get("publishMode") or "").lower()
+        if not publish_uses_git and node_publish_mode in {"pr", "branch"}:
+            node_inputs["publishMode"] = "none"
         for git_key in ("startingBranch", "targetBranch", "branch"):
             git_val = (
                 git_payload.get(git_key)
@@ -490,7 +533,11 @@ def _build_runtime_planner():
             if isinstance(git_val, str) and git_val.strip():
                 node_inputs[git_key] = git_val.strip()
 
-        if isinstance(publish_mode, str) and publish_mode.strip().lower() == "pr":
+        if (
+            publish_uses_git
+            and isinstance(publish_mode, str)
+            and publish_mode.strip().lower() == "pr"
+        ):
             if not node_inputs.get("targetBranch") and not node_inputs.get("branch"):
                 prefix = _derive_pr_branch_prefix(
                     task_payload=task_payload,
@@ -546,7 +593,6 @@ def _build_runtime_planner():
         should_prepare_story_breakdown = bool(story_output_payload)
 
         # --- Expand task.steps[] or stepCount into multiple plan nodes ---
-        raw_steps = task_payload.get("steps")
         has_multi_steps = (
             isinstance(raw_steps, list)
             and len(raw_steps) > 1
@@ -628,6 +674,12 @@ def _build_runtime_planner():
                 if step_tool_name:
                     step_runtime = step_tool_name
                     step_node_inputs["selectedSkill"] = step_tool_name
+                    if _jira_agent_skill_selected(step_tool_name):
+                        step_node_inputs["publishMode"] = "none"
+                    step_node_inputs["instructions"] = _append_agent_skill_instructions(
+                        step_node_inputs["instructions"],
+                        selected_skill=step_tool_name,
+                    )
                 if step_tool_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
                     if story_output_mode == "jira" and not step_node_inputs.get(
                         "publishMode"
@@ -683,6 +735,12 @@ def _build_runtime_planner():
                             story_output_mode=story_output_mode,
                         )
                     )
+                expanded_inputs["instructions"] = _append_agent_skill_instructions(
+                    str(expanded_inputs.get("instructions") or ""),
+                    selected_skill=selected_skill_name,
+                )
+                if _jira_agent_skill_selected(selected_skill_name):
+                    expanded_inputs["publishMode"] = "none"
                 step_id = f"node-{idx + 1}"
                 nodes.append({
                     "id": step_id,
@@ -711,6 +769,10 @@ def _build_runtime_planner():
                     ),
                     story_output_mode=story_output_mode,
                 )
+            node_inputs["instructions"] = _append_agent_skill_instructions(
+                str(node_inputs.get("instructions") or ""),
+                selected_skill=selected_skill_name,
+            )
             node_tool_type = (
                 "skill"
                 if selected_skill_name.lower() in _JIRA_STORY_OUTPUT_TOOLS
@@ -737,6 +799,7 @@ def _build_runtime_planner():
         publish_requested = (
             isinstance(publish_mode, str)
             and publish_mode.strip().lower() in ("pr", "branch")
+            and publish_uses_git
         )
         if publish_requested or story_output_mode == "jira":
             publish_node = next(
@@ -745,13 +808,18 @@ def _build_runtime_planner():
                     for node in reversed(nodes)
                     if str(node.get("tool", {}).get("type") or "").strip().lower()
                     == "agent_runtime"
+                    and not _jira_agent_skill_selected(_plan_node_selected_skill(node))
                 ),
                 nodes[-1],
             )
             publish_tool = str(
                 publish_node.get("tool", {}).get("name") or ""
             ).strip().lower()
-            if publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION:
+            publish_selected_skill = _plan_node_selected_skill(publish_node)
+            if (
+                publish_tool not in _TOOLS_WITH_AUTO_PR_CREATION
+                and not _jira_agent_skill_selected(publish_selected_skill)
+            ):
                 publish_inputs = publish_node["inputs"]
                 if story_output_mode == "jira" and not publish_inputs.get(
                     "publishMode"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -88,6 +88,7 @@ DEPENDENCY_RECONCILE_INTERVAL = timedelta(seconds=30)
 _TERMINAL_LAST_ERROR_UNSET = object()
 
 DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
+_PR_OPTIONAL_AGENT_SKILLS = frozenset({"jira-issue-creator"})
 
 
 class RunWorkflowInput(TypedDict, total=False):
@@ -1650,7 +1651,12 @@ class MoonMindRunWorkflow:
         registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
         failure_mode = plan_definition.policy.failure_mode
         publish_mode = self._publish_mode(parameters)
-        require_pull_request_url = publish_mode == "pr" and self._integration is None
+        pr_publish_optional = self._pr_publish_optional_for_plan(ordered_nodes)
+        require_pull_request_url = (
+            publish_mode == "pr"
+            and self._integration is None
+            and not pr_publish_optional
+        )
         pull_request_url: str | None = None
         skill_definitions_by_key: dict[tuple[str, str], Any] = {}
         requires_registry_lookup = any(
@@ -2093,6 +2099,12 @@ class MoonMindRunWorkflow:
                 parameters=parameters,
                 execution_result=execution_result,
             )
+            if (
+                pr_publish_optional
+                and publish_mode == "pr"
+                and self._execution_result_has_publishable_changes(execution_result)
+            ):
+                require_pull_request_url = True
             outputs_for_story_output = self._get_from_result(
                 execution_result, "outputs"
             )
@@ -2293,6 +2305,16 @@ class MoonMindRunWorkflow:
                         raise ValueError(
                             f"publishMode 'pr' requested; native PR creation failed: {e}"
                         ) from e
+        if (
+            pr_publish_optional
+            and publish_mode == "pr"
+            and self._publish_status is None
+            and pull_request_url is None
+        ):
+            self._publish_status = "not_required"
+            self._publish_reason = (
+                "Jira issue agent completed; no PR output required"
+            )
         # Persist the PR URL so the workflow output can determine if a PR was created.
         self._pull_request_url = pull_request_url
         publish_mode = self._publish_mode(parameters)
@@ -2818,6 +2840,58 @@ class MoonMindRunWorkflow:
             self._publish_context["pullRequestUrl"] = pull_request_url
 
     @staticmethod
+    def _node_selected_skill(node: Mapping[str, Any]) -> str:
+        inputs = node.get("inputs")
+        if not isinstance(inputs, Mapping):
+            return ""
+        selected_skill = str(inputs.get("selectedSkill") or "").strip().lower()
+        if selected_skill:
+            return selected_skill
+        runtime = inputs.get("runtime")
+        if isinstance(runtime, Mapping):
+            metadata = runtime.get("metadata")
+            if isinstance(metadata, Mapping):
+                moonmind = metadata.get("moonmind")
+                if isinstance(moonmind, Mapping):
+                    return str(moonmind.get("selectedSkill") or "").strip().lower()
+        return ""
+
+    @classmethod
+    def _pr_publish_optional_for_plan(cls, nodes: list[Mapping[str, Any]]) -> bool:
+        if not nodes:
+            return False
+        for node in nodes:
+            tool = node.get("tool")
+            if not isinstance(tool, Mapping):
+                return False
+            tool_type = str(tool.get("type") or tool.get("kind") or "").strip().lower()
+            if tool_type != "agent_runtime":
+                return False
+            if cls._node_selected_skill(node) not in _PR_OPTIONAL_AGENT_SKILLS:
+                return False
+        return True
+
+    def _execution_result_has_publishable_changes(self, execution_result: Any) -> bool:
+        if self._extract_pull_request_url(execution_result):
+            return True
+        outputs = self._get_from_result(execution_result, "outputs")
+        if not isinstance(outputs, Mapping):
+            return False
+        push_status = str(outputs.get("push_status") or "").strip().lower()
+        if push_status in {"pushed", "published"}:
+            return True
+        commit_count = outputs.get("push_commit_count")
+        if commit_count is None:
+            commit_count = outputs.get("pushCommitCount")
+        if isinstance(commit_count, bool):
+            return False
+        if isinstance(commit_count, (int, float)):
+            return int(commit_count) > 0
+        if isinstance(commit_count, str) and commit_count.strip().isdigit():
+            return int(commit_count.strip()) > 0
+        return False
+
+    @staticmethod
     def _sanitize_operator_summary(summary: str | None) -> str | None:
         if not summary:
             return None
@@ -2886,6 +2960,13 @@ class MoonMindRunWorkflow:
                     True,
                 )
             return ("no_changes", "Workflow completed with no local changes", False)
+
+        if self._publish_status == "not_required":
+            return (
+                "success",
+                self._publish_reason or "Workflow completed successfully",
+                False,
+            )
 
         if self._publish_status == "failed":
             return (
@@ -3651,6 +3732,12 @@ class MoonMindRunWorkflow:
                         publish_status = "skipped"
                         publish_reason = (
                             self._publish_reason or "publish skipped: no local changes"
+                        )
+                    elif self._publish_status == "not_required":
+                        code = "PUBLISH_DISABLED"
+                        publish_status = "skipped"
+                        publish_reason = (
+                            self._publish_reason or "publish output not required"
                         )
                     elif publish_mode == "pr":
                         code = "PUBLISHED_PR"

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2847,13 +2847,11 @@ class MoonMindRunWorkflow:
         selected_skill = str(inputs.get("selectedSkill") or "").strip().lower()
         if selected_skill:
             return selected_skill
-        runtime = inputs.get("runtime")
-        if isinstance(runtime, Mapping):
-            metadata = runtime.get("metadata")
-            if isinstance(metadata, Mapping):
-                moonmind = metadata.get("moonmind")
-                if isinstance(moonmind, Mapping):
-                    return str(moonmind.get("selectedSkill") or "").strip().lower()
+        metadata = inputs.get("metadata")
+        if isinstance(metadata, Mapping):
+            moonmind = metadata.get("moonmind")
+            if isinstance(moonmind, Mapping):
+                return str(moonmind.get("selectedSkill") or "").strip().lower()
         return ""
 
     @classmethod

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -473,6 +473,22 @@ async def test_default_skill_registry_payload_auto_placeholder_filtered():
     assert ("auto", "1.0") not in keyset
 
 
+async def test_default_skill_registry_payload_excludes_agent_only_jira_skill():
+    payload = _default_skill_registry_payload(
+        parameters={
+            "task": {
+                "tool": {
+                    "type": "skill",
+                    "name": "jira-issue-creator",
+                    "version": "1.0",
+                }
+            }
+        }
+    )
+    skills = payload.get("skills")
+    assert skills == []
+
+
 async def test_default_skill_registry_payload_uses_dood_tool_definitions():
     payload = _default_skill_registry_payload(
         parameters={

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -326,6 +326,101 @@ def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     assert "commit your work" not in node["inputs"]["instructions"]
 
 
+def test_runtime_planner_inherits_top_level_jira_skill_for_multi_step_publish():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "tool": {"type": "skill", "name": "jira-issue-creator"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {"id": "one", "instructions": "Create the first Jira story."},
+                    {"id": "two", "instructions": "Create the second Jira story."},
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    assert len(plan["nodes"]) == 2
+    for node in plan["nodes"]:
+        assert node["tool"]["type"] == "agent_runtime"
+        assert node["inputs"]["selectedSkill"] == "jira-issue-creator"
+        assert node["inputs"]["publishMode"] == "none"
+        assert "targetBranch" not in node["inputs"]
+        assert node["inputs"]["instructions"].startswith("Use $jira-issue-creator.")
+
+
+def test_runtime_planner_single_step_tool_does_not_override_top_level_publish_scope():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "tool": {"type": "skill", "name": "pr-resolver"},
+                "inputs": {"pr": "1434"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {
+                        "id": "ignored",
+                        "tool": {"type": "skill", "name": "jira-issue-creator"},
+                        "instructions": "This single step is not expanded.",
+                    }
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+    assert node["inputs"]["selectedSkill"] == "pr-resolver"
+    assert node["inputs"]["publishMode"] == "pr"
+    assert "targetBranch" in node["inputs"]
+
+
+def test_runtime_planner_invalid_step_list_keeps_non_jira_publish_scope():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "tool": {"type": "skill", "name": "pr-resolver"},
+                "inputs": {"pr": "1434"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {"tool": {"type": "skill", "name": "jira-issue-creator"}},
+                    "not-a-step",
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+    assert node["inputs"]["selectedSkill"] == "pr-resolver"
+    assert node["inputs"]["publishMode"] == "pr"
+    assert "targetBranch" in node["inputs"]
+
+
 def test_runtime_planner_pr_resolver_injects_branch_selector_into_instruction():
     """When pr-resolver has no inputs.pr but git.startingBranch is set,
     the auto-generated instruction must include the branch as the pr selector

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -228,7 +228,7 @@ def test_runtime_planner_embeds_skill_inputs_for_generated_skill_instructions():
     assert node_inputs["selectedSkill"] == "pr-resolver"
 
 
-def test_runtime_planner_routes_jira_issue_creator_as_integration_skill_step():
+def test_runtime_planner_routes_jira_issue_creator_as_agent_skill_step():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(
         digest="reg:sha256:test",
@@ -278,17 +278,52 @@ def test_runtime_planner_routes_jira_issue_creator_as_integration_skill_step():
     assert "commit your work" in breakdown["inputs"]["instructions"]
 
     assert jira["tool"] == {
-        "type": "skill",
+        "type": "agent_runtime",
         "name": "jira-issue-creator",
         "version": "1.0",
     }
     assert jira["inputs"]["selectedSkill"] == "jira-issue-creator"
+    assert jira["inputs"]["publishMode"] == "none"
+    assert jira["inputs"]["instructions"].startswith("Use $jira-issue-creator.")
     assert "commit your work" not in jira["inputs"]["instructions"]
     assert jira["inputs"]["storyOutput"]["mode"] == "jira"
     assert (
         jira["inputs"]["storyBreakdownPath"]
         == breakdown["inputs"]["storyBreakdownPath"]
     )
+
+
+def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Create Jira stories from docs/tmp/story-breakdowns/example.",
+                "tool": {"type": "skill", "name": "jira-issue-creator"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node = plan["nodes"][0]
+    assert node["tool"] == {
+        "type": "agent_runtime",
+        "name": "codex_cli",
+        "version": "1.0",
+    }
+    assert node["inputs"]["selectedSkill"] == "jira-issue-creator"
+    assert node["inputs"]["publishMode"] == "none"
+    assert node["inputs"]["instructions"].startswith("Use $jira-issue-creator.")
+    assert "targetBranch" not in node["inputs"]
+    assert "commit your work" not in node["inputs"]["instructions"]
 
 
 def test_runtime_planner_pr_resolver_injects_branch_selector_into_instruction():

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -41,6 +41,46 @@ class TestAgentKindForId(unittest.TestCase):
             )
 
 
+class TestJiraAgentPublishHelpers(unittest.TestCase):
+    def test_jira_issue_creator_agent_plan_makes_pr_publish_optional(self) -> None:
+        nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"selectedSkill": "jira-issue-creator"},
+            }
+        ]
+
+        self.assertTrue(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
+
+    def test_mixed_agent_plan_still_requires_requested_pr_publish(self) -> None:
+        nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"selectedSkill": "jira-issue-creator"},
+            },
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"selectedSkill": "moonspec-breakdown"},
+            },
+        ]
+
+        self.assertFalse(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
+
+    def test_publishable_changes_are_detected_from_agent_outputs(self) -> None:
+        wf = MoonMindRunWorkflow()
+
+        self.assertTrue(
+            wf._execution_result_has_publishable_changes(
+                {"outputs": {"push_status": "pushed", "push_branch": "jira-edits"}}
+            )
+        )
+        self.assertFalse(
+            wf._execution_result_has_publishable_changes(
+                {"outputs": {"push_status": "no_commits"}}
+            )
+        )
+
+
 class TestMapAgentRunResult(unittest.TestCase):
     """Verify the _map_agent_run_result helper."""
 

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -52,6 +52,36 @@ class TestJiraAgentPublishHelpers(unittest.TestCase):
 
         self.assertTrue(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
 
+    def test_jira_issue_creator_metadata_on_inputs_makes_pr_publish_optional(self) -> None:
+        nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {
+                    "metadata": {"moonmind": {"selectedSkill": "jira-issue-creator"}}
+                },
+            }
+        ]
+
+        self.assertTrue(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
+
+    def test_runtime_metadata_skill_does_not_affect_plan_publish_classification(
+        self,
+    ) -> None:
+        nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {
+                    "runtime": {
+                        "metadata": {
+                            "moonmind": {"selectedSkill": "jira-issue-creator"}
+                        }
+                    }
+                },
+            }
+        ]
+
+        self.assertFalse(MoonMindRunWorkflow._pr_publish_optional_for_plan(nodes))
+
     def test_mixed_agent_plan_still_requires_requested_pr_publish(self) -> None:
         nodes = [
             {


### PR DESCRIPTION
## Summary
- Route `jira-issue-creator` through `agent_runtime` as an agent skill instead of a deterministic `mm.tool.execute` integration.
- Keep the structured batch path limited to `story.create_jira_issues`.
- Treat pure Jira issue creation as PR-optional so Jira-only runs can complete without creating a GitHub branch or PR.
- Update Jira skill guidance, plan-contract docs, and workflow/runtime unit coverage.

## Root Cause
The workflow planner treated `jira-issue-creator` as a strict executable tool even when the user request required agent interpretation. That bypassed the agent skill adaptation and made ambiguous Jira requests fail or fall back before an agent could inspect Jira metadata or infer the story breakdown input.

## Validation
- `python3 -m py_compile moonmind/workflows/temporal/worker_runtime.py moonmind/workflows/temporal/workflows/run.py moonmind/workflows/temporal/activity_runtime.py moonmind/workflows/temporal/story_output_tools.py`
- `./tools/test_unit.sh` passed: Python `3067 passed, 1 xpassed`; frontend/Vitest `216 passed` across `10` files.