### PR TITLE
[codex] Fix terminal rerun submission

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -2606,7 +2606,10 @@ async def update_execution(
             },
         ) from exc
 
-    refreshed_record = await service.describe_execution(record.workflow_id)
+    response_workflow_id = (
+        str(update_result.get("workflow_id") or "").strip() or record.workflow_id
+    )
+    refreshed_record = await service.describe_execution(response_workflow_id)
     if is_task_editing_update:
         accepted = bool(update_result.get("accepted", True))
         applied = str(update_result.get("applied") or "").strip() or None

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -805,8 +805,8 @@ describe("Task Create Entrypoint", () => {
             json: async () => ({
               accepted: true,
               applied: "continue_as_new",
-              message: "Rerun requested.",
-              execution: { workflowId: "mm:rerun-123" },
+              message: "Rerun requested. New execution created.",
+              execution: { workflowId: "mm:rerun-created" },
               continueAsNewCause: "manual_rerun",
             }),
           } as Response);
@@ -1640,7 +1640,7 @@ describe("Task Create Entrypoint", () => {
     expect(screen.getByRole("button", { name: "Rerun Task" })).toBeTruthy();
   });
 
-  it("submits terminal rerun mode through RequestRerun and returns to the Temporal detail view", async () => {
+  it("submits terminal rerun mode through RequestRerun and opens the created rerun detail view", async () => {
     window.history.pushState(
       {},
       "Task Rerun",
@@ -1710,7 +1710,7 @@ describe("Task Create Entrypoint", () => {
     ).toBe(false);
     await waitFor(() => {
       expect(navigateTo).toHaveBeenCalledWith(
-        "/tasks/mm%3Arerun-123?source=temporal",
+        "/tasks/mm%3Arerun-created?source=temporal",
       );
     });
     expect(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -895,14 +895,23 @@ class TemporalExecutionService:
                 "message": "Workflow is in a terminal state and no longer accepts updates.",
             }
 
-        skip_temporal_update = (
-            update_name == "RequestRerun" and record.state in TERMINAL_STATES
-        )
-        if skip_temporal_update:
-            logger.info(
-                "Skipping Temporal update call for terminal rerun request on %s",
-                record.workflow_id,
+        if update_name == "RequestRerun" and record.state in TERMINAL_STATES:
+            # Closed Temporal workflows cannot execute updates; terminal rerun
+            # is a fresh execution seeded from the reviewed source inputs.
+            response = await self._create_fresh_rerun_execution(
+                record,
+                input_artifact_ref=input_artifact_ref,
+                plan_artifact_ref=plan_artifact_ref,
+                parameters_patch=parameters_patch,
+                idempotency_key=idempotency_key,
             )
+            await self._session.refresh(record)
+            if idempotency_key:
+                record.last_update_idempotency_key = idempotency_key
+                record.last_update_response = dict(response)
+            await self._session.commit()
+            return response
+
         else:
             update_arg = {
                 "input_artifact_ref": input_artifact_ref,
@@ -925,10 +934,23 @@ class TemporalExecutionService:
                     exc
                 ):
                     logger.info(
-                        "Temporal rerun update ignored for terminal workflow %s: %s",
+                        "Temporal rerun update found closed workflow %s; creating fresh rerun: %s",
                         record.workflow_id,
                         exc,
                     )
+                    response = await self._create_fresh_rerun_execution(
+                        record,
+                        input_artifact_ref=input_artifact_ref,
+                        plan_artifact_ref=plan_artifact_ref,
+                        parameters_patch=parameters_patch,
+                        idempotency_key=idempotency_key,
+                    )
+                    await self._session.refresh(record)
+                    if idempotency_key:
+                        record.last_update_idempotency_key = idempotency_key
+                        record.last_update_response = dict(response)
+                    await self._session.commit()
+                    return response
                 else:
                     raise TemporalExecutionValidationError(
                         f"Temporal update failed: {exc}"
@@ -1942,6 +1964,63 @@ class TemporalExecutionService:
             "continue_as_new_cause": "manual_rerun",
         }
 
+    async def _create_fresh_rerun_execution(
+        self,
+        record: TemporalExecutionCanonicalRecord,
+        *,
+        input_artifact_ref: str | None,
+        plan_artifact_ref: str | None,
+        parameters_patch: dict[str, Any] | None,
+        idempotency_key: str | None,
+    ) -> dict[str, Any]:
+        params = dict(record.parameters or {})
+        if parameters_patch:
+            params.update(parameters_patch)
+
+        rerun_source = {
+            "workflowId": record.workflow_id,
+            "runId": record.run_id,
+        }
+        params["rerunSource"] = rerun_source
+
+        next_input_ref = input_artifact_ref or record.input_ref
+        next_plan_ref = plan_artifact_ref or record.plan_ref
+        task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
+        repository = str(params.get("repository") or "").strip() or None
+        title = (
+            str(task_params.get("title") or "").strip()
+            or str((record.memo or {}).get("title") or "").strip()
+            or None
+        )
+
+        rerun_create_idempotency_key = (
+            f"rerun:{record.workflow_id}:{idempotency_key}"
+            if idempotency_key
+            else None
+        )
+        created = await self.create_execution(
+            workflow_type=record.workflow_type.value,
+            owner_id=record.owner_id,
+            owner_type=record.owner_type.value if record.owner_type else "user",
+            title=title,
+            input_artifact_ref=next_input_ref,
+            plan_artifact_ref=next_plan_ref,
+            manifest_artifact_ref=record.manifest_ref,
+            failure_policy=None,
+            initial_parameters=params,
+            idempotency_key=rerun_create_idempotency_key,
+            repository=repository,
+            integration=None,
+            summary=f"Rerun of {record.workflow_id}.",
+        )
+        return {
+            "accepted": True,
+            "applied": "continue_as_new",
+            "message": "Rerun requested. New execution created.",
+            "continue_as_new_cause": "manual_rerun",
+            "workflow_id": created.workflow_id,
+        }
+
     def _continue_as_new(
         self,
         record: TemporalExecutionCanonicalRecord,
@@ -2628,9 +2707,12 @@ class TemporalExecutionService:
         workflow_id: str,
     ) -> TemporalExecutionCanonicalRecord | None:
         canonical_workflow_id = self.canonicalize_workflow_id(workflow_id)
-        return await self._session.get(
+        record = await self._session.get(
             TemporalExecutionCanonicalRecord, canonical_workflow_id
         )
+        if record is not None:
+            await self._session.refresh(record)
+        return record
 
     async def _require_source_execution(
         self,

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -67,6 +68,7 @@ TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.FAILED,
     MoonMindWorkflowState.CANCELED,
 }
+CREATE_IDEMPOTENCY_KEY_MAX_LENGTH = 128
 
 import logging
 
@@ -910,6 +912,7 @@ class TemporalExecutionService:
                 record.last_update_idempotency_key = idempotency_key
                 record.last_update_response = dict(response)
             await self._session.commit()
+            await self._session.refresh(record)
             return response
 
         else:
@@ -950,6 +953,7 @@ class TemporalExecutionService:
                         record.last_update_idempotency_key = idempotency_key
                         record.last_update_response = dict(response)
                     await self._session.commit()
+                    await self._session.refresh(record)
                     return response
                 else:
                     raise TemporalExecutionValidationError(
@@ -1976,6 +1980,8 @@ class TemporalExecutionService:
         params = dict(record.parameters or {})
         if parameters_patch:
             params.update(parameters_patch)
+        for key in TASK_RUN_ID_PARAM_KEYS:
+            params.pop(key, None)
 
         rerun_source = {
             "workflowId": record.workflow_id,
@@ -1993,10 +1999,9 @@ class TemporalExecutionService:
             or None
         )
 
-        rerun_create_idempotency_key = (
-            f"rerun:{record.workflow_id}:{idempotency_key}"
-            if idempotency_key
-            else None
+        rerun_create_idempotency_key = self._rerun_create_idempotency_key(
+            record.workflow_id,
+            idempotency_key,
         )
         created = await self.create_execution(
             workflow_type=record.workflow_type.value,
@@ -2020,6 +2025,19 @@ class TemporalExecutionService:
             "continue_as_new_cause": "manual_rerun",
             "workflow_id": created.workflow_id,
         }
+
+    @staticmethod
+    def _rerun_create_idempotency_key(
+        workflow_id: str,
+        idempotency_key: str | None,
+    ) -> str | None:
+        if not idempotency_key:
+            return None
+        derived_key = f"rerun:{workflow_id}:{idempotency_key}"
+        if len(derived_key) <= CREATE_IDEMPOTENCY_KEY_MAX_LENGTH:
+            return derived_key
+        digest = hashlib.sha256(derived_key.encode("utf-8")).hexdigest()
+        return f"rerun:{digest}"
 
     def _continue_as_new(
         self,
@@ -2710,8 +2728,6 @@ class TemporalExecutionService:
         record = await self._session.get(
             TemporalExecutionCanonicalRecord, canonical_workflow_id
         )
-        if record is not None:
-            await self._session.refresh(record)
         return record
 
     async def _require_source_execution(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2041,6 +2041,44 @@ def test_request_rerun_update_response_includes_continue_as_new_cause() -> None:
         assert response.json()["continueAsNewCause"] == "manual_rerun"
 
 
+def test_request_rerun_update_redirects_response_to_created_rerun_execution() -> None:
+    for test_client, service in _client_with_service():
+        source_record = _build_execution_record()
+        rerun_record = _build_execution_record()
+        rerun_record.workflow_id = "mm:rerun-created"
+        rerun_record.run_id = "run-rerun"
+        rerun_record.memo = {
+            **rerun_record.memo,
+            "latest_temporal_run_id": "run-rerun",
+        }
+        service.describe_execution.side_effect = [source_record, rerun_record]
+        service.update_execution.return_value = {
+            "accepted": True,
+            "applied": "continue_as_new",
+            "message": "Rerun requested. New execution created.",
+            "continue_as_new_cause": "manual_rerun",
+            "workflow_id": "mm:rerun-created",
+        }
+
+        response = test_client.post(
+            "/api/executions/mm:wf-1/update",
+            json={
+                "updateName": "RequestRerun",
+                "idempotencyKey": "rerun-1",
+            },
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["execution"]["workflowId"] == "mm:rerun-created"
+        assert body["execution"]["redirectPath"] == (
+            "/tasks/mm:rerun-created?source=temporal"
+        )
+        assert service.describe_execution.await_args_list[-1].args == (
+            "mm:rerun-created",
+        )
+
+
 def test_task_editing_update_route_emits_attempt_and_result_metrics() -> None:
     metrics = Mock()
     for test_client, service in _client_with_service():

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -991,7 +991,7 @@ async def test_request_rerun_uses_continue_as_new_same_workflow_id(
 
 
 @pytest.mark.asyncio
-async def test_request_rerun_allowed_for_terminal_execution(
+async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
     tmp_path, mock_client_adapter
 ):
     async with temporal_db(tmp_path) as session:
@@ -1016,6 +1016,9 @@ async def test_request_rerun_allowed_for_terminal_execution(
             graceful=True,
         )
 
+        source_workflow_id = created.workflow_id
+        source_run_id = created.run_id
+
         response = await service.update_execution(
             workflow_id=created.workflow_id,
             update_name="RequestRerun",
@@ -1029,20 +1032,25 @@ async def test_request_rerun_allowed_for_terminal_execution(
             node_ids=None,
             idempotency_key="rerun-terminal",
         )
-        refreshed = await service.describe_execution(created.workflow_id)
+        source = await service.describe_execution(source_workflow_id)
+        rerun = await service.describe_execution(response["workflow_id"])
 
         assert response["accepted"] is True
         assert response["applied"] == "continue_as_new"
         assert response["continue_as_new_cause"] == "manual_rerun"
-        assert refreshed.state is MoonMindWorkflowState.EXECUTING
-        assert refreshed.close_status is None
-        assert refreshed.closed_at is None
-        assert refreshed.rerun_count == 1
+        assert response["workflow_id"] != source_workflow_id
+        assert source.state is MoonMindWorkflowState.CANCELED
+        assert source.close_status is TemporalExecutionCloseStatus.CANCELED
+        assert rerun.state is MoonMindWorkflowState.INITIALIZING
+        assert rerun.parameters["rerunSource"] == {
+            "workflowId": source_workflow_id,
+            "runId": source_run_id,
+        }
         assert service._client_adapter.update_workflow.await_count == 0
 
 
 @pytest.mark.asyncio
-async def test_request_rerun_falls_back_when_temporal_reports_completed(
+async def test_request_rerun_creates_fresh_execution_when_temporal_reports_completed(
     tmp_path, mock_client_adapter
 ):
     async with temporal_db(tmp_path) as session:
@@ -1065,6 +1073,7 @@ async def test_request_rerun_falls_back_when_temporal_reports_completed(
             "workflow execution already completed"
         )
 
+        source_workflow_id = created.workflow_id
         response = await service.update_execution(
             workflow_id=created.workflow_id,
             update_name="RequestRerun",
@@ -1078,13 +1087,16 @@ async def test_request_rerun_falls_back_when_temporal_reports_completed(
             node_ids=None,
             idempotency_key="rerun-temporal-completed",
         )
-        refreshed = await service.describe_execution(created.workflow_id)
+        source = await service.describe_execution(source_workflow_id)
+        rerun = await service.describe_execution(response["workflow_id"])
 
         assert response["accepted"] is True
         assert response["applied"] == "continue_as_new"
         assert response["continue_as_new_cause"] == "manual_rerun"
-        assert refreshed.state is MoonMindWorkflowState.EXECUTING
-        assert refreshed.rerun_count == 1
+        assert response["workflow_id"] != source_workflow_id
+        assert source.state is MoonMindWorkflowState.INITIALIZING
+        assert rerun.state is MoonMindWorkflowState.INITIALIZING
+        assert rerun.parameters["rerunSource"]["workflowId"] == source_workflow_id
         assert service._client_adapter.update_workflow.await_count == 1
 
 

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1006,7 +1006,10 @@ async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
             plan_artifact_ref="artifact://plan/1",
             manifest_artifact_ref=None,
             failure_policy=None,
-            initial_parameters={},
+            initial_parameters={
+                "taskRunId": "old-task-run",
+                "task_run_id": "old-task-run-snake",
+            },
             idempotency_key=None,
         )
 
@@ -1046,7 +1049,69 @@ async def test_request_rerun_creates_fresh_execution_for_terminal_execution(
             "workflowId": source_workflow_id,
             "runId": source_run_id,
         }
+        assert "taskRunId" not in rerun.parameters
+        assert "task_run_id" not in rerun.parameters
         assert service._client_adapter.update_workflow.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_request_rerun_bounds_fresh_execution_idempotency_key(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="done",
+            graceful=True,
+        )
+
+        long_idempotency_key = "k" * 128
+        first_response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="RequestRerun",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title=None,
+            new_manifest_artifact_ref=None,
+            mode=None,
+            max_concurrency=None,
+            node_ids=None,
+            idempotency_key=long_idempotency_key,
+        )
+        second_response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="RequestRerun",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title=None,
+            new_manifest_artifact_ref=None,
+            mode=None,
+            max_concurrency=None,
+            node_ids=None,
+            idempotency_key=long_idempotency_key,
+        )
+
+        rerun = await service.describe_execution(first_response["workflow_id"])
+        assert first_response["workflow_id"] == second_response["workflow_id"]
+        assert rerun.create_idempotency_key is not None
+        assert len(rerun.create_idempotency_key) <= 128
+        assert rerun.create_idempotency_key.startswith("rerun:")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes terminal task rerun submission so rerun mode creates a fresh Temporal execution when the source workflow is already closed, instead of sending the operator back to the failed source detail page.

## What changed

- Terminal `RequestRerun` now creates a new execution seeded from the reviewed rerun inputs.
- Rerun lineage is preserved with `rerunSource` metadata on the created execution parameters.
- The update API response now serializes the created rerun execution when the service returns one, so the UI navigates to the new run detail.
- Regression coverage was updated across service, API router, and task-create frontend tests.

## Root cause

The rerun form submitted `RequestRerun`, but terminal workflows cannot execute Temporal updates. The service skipped the Temporal update and only changed local projection state for the old execution, so the UI redirected back to the failed source run rather than a newly submitted task.

## Validation

- `./tools/test_unit.sh` passed: `3074 passed, 1 xpassed, 16 subtests passed`
- Frontend unit pack passed: `216 passed`