### PR TITLE
[codex] Fix Jira issue creator workflow

### DIFF
--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -13,9 +13,9 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - Required: issue type (`Task`, `Story`, `Bug`, or `Sub-task`). Use `jira.list_create_issue_types` to resolve the name to an `issueTypeId`. Default to `Task` only when the user does not specify.
 - Required: summary/title.
 - Required for creation: authenticated Jira access through a connector, API token, OAuth session, or documented local secret.
-- Optional for workflow handoff: `storyBreakdownPath`, `stories`, or `storyOutput` from `moonspec-breakdown`.
+- Optional for breakdown-driven creation: `storyBreakdownPath`, `stories`, or `storyOutput` from `moonspec-breakdown`.
 - Optional: description, acceptance criteria, priority, labels, assignee, reporter, parent issue key, sprint, component, due date, linked issues, attachments.
-- Required when creating Jira issues from a `moonspec-breakdown` handoff: an original source document reference path. Read it from each story's `sourceReference.path` or from the breakdown-level `source.referencePath` / `source.path`.
+- Required when creating Jira issues from `moonspec-breakdown` output: an original source document reference path. Read it from each story's `sourceReference.path` or from the breakdown-level `source.referencePath` / `source.path`.
 
 ## Workflow
 
@@ -30,7 +30,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - For bugs, include sections for observed behavior, expected behavior, reproduction steps, impact, and environment when the information is available.
 - For stories, include sections for user story, acceptance criteria, notes, and out-of-scope items when the information is available.
 - For tasks, include sections for objective, requirements, implementation notes, and verification when the information is available.
-- When creating from a `moonspec-breakdown` handoff, every Jira issue description must include a `Source Document` section that names the original declarative document path and any story-specific source sections or coverage IDs available.
+- When creating from `moonspec-breakdown` output, every Jira issue description must include a `Source Document` section that names the original declarative document path and any story-specific source sections or coverage IDs available.
 - Do not invent business requirements, acceptance criteria, assignees, priorities, or deadlines.
 
 3. Validate before creating.
@@ -43,14 +43,14 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - Use the available Jira connector's `jira.create_issue` or `jira.create_subtask` operations when present.
 - In MoonMind workflow plans, `jira-issue-creator` is an agent skill, not a deterministic executable tool. Use the available Jira connector/API to inspect projects, issue types, and create fields, then create the requested issues.
 - When the task references a story breakdown directory, look for `stories.json` inside that directory unless an exact `storyBreakdownPath` is provided.
-- Before creating any issue from `stories.json`, verify every story has an original source document path available through `story.sourceReference.path`, `source.referencePath`, or `source.path`. If the original document path is missing for any story, do not create Jira issues; report the missing source-reference blocker and the handoff path that must be regenerated or repaired.
+- Before creating any issue from `stories.json`, verify every story has an original source document path available through `story.sourceReference.path`, `source.referencePath`, or `source.path`. If the original document path is missing for any story, do not create Jira issues; report the missing source-reference blocker and the breakdown path that must be regenerated or repaired.
 - Otherwise call Jira REST `POST /rest/api/3/issue` for Jira Cloud or the deployment's documented equivalent.
 - Send only the fields needed for the requested issue.
 - Treat retries carefully: before retrying after an uncertain network failure, use `jira.search_issues` to search by a stable summary/project/reporter marker to avoid duplicate tickets.
 
-## Breakdown Handoff Behavior
+## Breakdown Story Behavior
 
-When invoked after `moonspec-breakdown` or when the request references a story breakdown handoff:
+When invoked after `moonspec-breakdown` or when the request references story breakdown output:
 
 - Read story candidates from the provided JSON breakdown, not from `spec.md`.
 - Require source traceability before Jira creation. Each Jira issue must include `Source Document: <path>` in its description, using the story-level `sourceReference.path` when present and otherwise the breakdown-level `source.referencePath` or `source.path`.
@@ -58,7 +58,7 @@ When invoked after `moonspec-breakdown` or when the request references a story b
 - Treat missing source document references as a hard blocker, not as an optional warning.
 - Do not create or rename `spec.md`.
 - If Jira issue creation succeeds, return Jira keys/URLs and do not request another output format.
-- If Jira is not configured, required Jira fields are missing, or issue creation fails, report the exact blocker and the existing `docs/tmp/story-breakdowns/...` handoff instead of fabricating Jira success.
+- If Jira is not configured, required Jira fields are missing, or issue creation fails, report the exact blocker and the existing `docs/tmp/story-breakdowns/...` output instead of fabricating Jira success.
 - The fallback file must not be named `spec.md`.
 
 5. Return the result.

--- a/.agents/skills/jira-issue-creator/SKILL.md
+++ b/.agents/skills/jira-issue-creator/SKILL.md
@@ -15,6 +15,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - Required for creation: authenticated Jira access through a connector, API token, OAuth session, or documented local secret.
 - Optional for workflow handoff: `storyBreakdownPath`, `stories`, or `storyOutput` from `moonspec-breakdown`.
 - Optional: description, acceptance criteria, priority, labels, assignee, reporter, parent issue key, sprint, component, due date, linked issues, attachments.
+- Required when creating Jira issues from a `moonspec-breakdown` handoff: an original source document reference path. Read it from each story's `sourceReference.path` or from the breakdown-level `source.referencePath` / `source.path`.
 
 ## Workflow
 
@@ -29,6 +30,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - For bugs, include sections for observed behavior, expected behavior, reproduction steps, impact, and environment when the information is available.
 - For stories, include sections for user story, acceptance criteria, notes, and out-of-scope items when the information is available.
 - For tasks, include sections for objective, requirements, implementation notes, and verification when the information is available.
+- When creating from a `moonspec-breakdown` handoff, every Jira issue description must include a `Source Document` section that names the original declarative document path and any story-specific source sections or coverage IDs available.
 - Do not invent business requirements, acceptance criteria, assignees, priorities, or deadlines.
 
 3. Validate before creating.
@@ -41,6 +43,7 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 - Use the available Jira connector's `jira.create_issue` or `jira.create_subtask` operations when present.
 - In MoonMind workflow plans, `jira-issue-creator` is an agent skill, not a deterministic executable tool. Use the available Jira connector/API to inspect projects, issue types, and create fields, then create the requested issues.
 - When the task references a story breakdown directory, look for `stories.json` inside that directory unless an exact `storyBreakdownPath` is provided.
+- Before creating any issue from `stories.json`, verify every story has an original source document path available through `story.sourceReference.path`, `source.referencePath`, or `source.path`. If the original document path is missing for any story, do not create Jira issues; report the missing source-reference blocker and the handoff path that must be regenerated or repaired.
 - Otherwise call Jira REST `POST /rest/api/3/issue` for Jira Cloud or the deployment's documented equivalent.
 - Send only the fields needed for the requested issue.
 - Treat retries carefully: before retrying after an uncertain network failure, use `jira.search_issues` to search by a stable summary/project/reporter marker to avoid duplicate tickets.
@@ -50,6 +53,9 @@ Create a Jira task, story, bug, or subtask from the user's request. Prefer an av
 When invoked after `moonspec-breakdown` or when the request references a story breakdown handoff:
 
 - Read story candidates from the provided JSON breakdown, not from `spec.md`.
+- Require source traceability before Jira creation. Each Jira issue must include `Source Document: <path>` in its description, using the story-level `sourceReference.path` when present and otherwise the breakdown-level `source.referencePath` or `source.path`.
+- Include story-specific `sourceReference.sections` and `sourceReference.coverageIds` when present so the Jira issue points to the relevant part of the original declarative document.
+- Treat missing source document references as a hard blocker, not as an optional warning.
 - Do not create or rename `spec.md`.
 - If Jira issue creation succeeds, return Jira keys/URLs and do not request another output format.
 - If Jira is not configured, required Jira fields are missing, or issue creation fails, report the exact blocker and the existing `docs/tmp/story-breakdowns/...` handoff instead of fabricating Jira success.

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: moonspec-breakdown
-description: Extract coverage-checked, independently testable Moon Spec user stories from a technical or declarative design and write a breakdown handoff under docs/tmp. Use when the user asks to run or reproduce `/speckit.breakdown`, split a broad design into one-story candidates, preserve source coverage, or build a coverage matrix before `/speckit.specify`.
+description: Extract coverage-checked, independently testable Moon Spec user stories from a technical or declarative design and write breakdown output under docs/tmp. Use when the user asks to run or reproduce `/speckit.breakdown`, split a broad design into one-story candidates, preserve source coverage, or build a coverage matrix before `/speckit.specify`.
 ---
 
 # MoonSpec Breakdown
@@ -25,7 +25,7 @@ Do not use this skill for a single natural-language feature request. Use `moonsp
 - Treat the user's request text as the source design unless it names a readable file path.
 - If a file path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
 - If no design text or readable design path is provided, stop with: `ERROR "No technical design provided"`.
-- Preserve the original design text verbatim in the breakdown handoff so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
+- Preserve the original design text verbatim in the breakdown output so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
 - Preserve the source document reference path whenever the source design came from a file. Use the repo-relative path when possible; otherwise use the absolute path provided by the user. This reference is required downstream so every Jira story can point back to the original declarative document.
 - Do not implement, plan, generate tasks, create Jira issues, create `spec.md`, or create directories under `specs/`.
 
@@ -127,7 +127,6 @@ For each story, define:
 - Dependencies.
 - Risks or open questions.
 - Owned `DESIGN-REQ-*` coverage points.
-- A short handoff paragraph suitable for a generated one-story `spec.md`.
 
 ### 4. Normalize And Order Stories
 
@@ -158,7 +157,7 @@ After the coverage gate passes, write story candidates under `docs/tmp/story-bre
 
 Use the explicit `storyBreakdownPath` and `storyBreakdownMarkdownPath` values from the prompt when present. If they are not present, create a timestamped folder under `docs/tmp/story-breakdowns/<short-name>-<YYYYMMDD-HHMMSS>/` and write:
 
-- `stories.json`: machine-readable handoff for Jira issue creation or later specify.
+- `stories.json`: machine-readable breakdown output for Jira issue creation or later specify.
 - `stories.md`: human-readable summary.
 
 Never name any breakdown output `spec.md`. Never write to `specs/` during breakdown.
@@ -247,8 +246,8 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 ## Key Rules
 
 - One breakdown story candidate equals one future `spec.md`.
-- Preserve the original technical or declarative design verbatim in the breakdown handoff for later specify.
-- Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file, and the story handoff paragraph must mention that path.
+- Preserve the original technical or declarative design verbatim in the breakdown output for later specify.
+- Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file.
 - Prefer vertical user or operational outcomes over technical-layer slices.
 - Extract stable `DESIGN-REQ-*` coverage points before drafting story candidates.
 - Do not write specs in this skill.

--- a/.agents/skills/moonspec-breakdown/SKILL.md
+++ b/.agents/skills/moonspec-breakdown/SKILL.md
@@ -26,6 +26,7 @@ Do not use this skill for a single natural-language feature request. Use `moonsp
 - If a file path is provided, resolve it relative to the repo root unless it is absolute, then read it before extracting stories.
 - If no design text or readable design path is provided, stop with: `ERROR "No technical design provided"`.
 - Preserve the original design text verbatim in the breakdown handoff so later `/speckit.specify` output can keep it in `spec.md` `**Input**`.
+- Preserve the source document reference path whenever the source design came from a file. Use the repo-relative path when possible; otherwise use the absolute path provided by the user. This reference is required downstream so every Jira story can point back to the original declarative document.
 - Do not implement, plan, generate tasks, create Jira issues, create `spec.md`, or create directories under `specs/`.
 
 ## Pre-Breakdown Hooks
@@ -119,6 +120,7 @@ For each story, define:
 - Title.
 - 2-4 word short name for directory naming.
 - Why the story exists.
+- Source document reference: the original declarative document path plus the relevant source section or heading when available.
 - Scope and out of scope.
 - Independent test.
 - Acceptance criteria.
@@ -163,7 +165,7 @@ Never name any breakdown output `spec.md`. Never write to `specs/` during breakd
 
 The JSON file must be an object with:
 
-- `source`: title or path, plus the original design text.
+- `source`: object containing `title`, `path`, `referencePath`, and the original design text. For file-backed designs, `path` and `referencePath` must both contain the original design document path. For pasted designs without a file path, set them to `null` and use a clear title such as `inline user request`.
 - `extractedAt`: ISO-8601 timestamp.
 - `coverageGate`: exactly `PASS - every major design point is owned by at least one story.`
 - `stories`: ordered list of story objects.
@@ -174,6 +176,7 @@ Each story object must include:
 - `id`: stable story ID, such as `STORY-001`.
 - `summary`: concise title suitable for a Jira issue summary.
 - `description`: user-story or task narrative.
+- `sourceReference`: object containing `path`, `title`, `sections`, and `coverageIds`. For file-backed designs, `path` must be the same original design document path from `source.referencePath`; do not omit it from any story.
 - `independentTest`: how this story can be validated independently.
 - `acceptanceCriteria`: concrete acceptance criteria.
 - `requirements`: functional requirements owned by the story.
@@ -185,6 +188,7 @@ Each story object must include:
 The markdown file must include the same substance for human review:
 
 - Source design title or path.
+- Original source document reference path for the breakdown and for each story.
 - Story extraction date.
 - Design summary.
 - Coverage points.
@@ -244,6 +248,7 @@ If no hooks are registered or `.specify/extensions.yml` does not exist, skip sil
 
 - One breakdown story candidate equals one future `spec.md`.
 - Preserve the original technical or declarative design verbatim in the breakdown handoff for later specify.
+- Every story candidate must carry a `sourceReference.path` back to the original declarative document when the source came from a file, and the story handoff paragraph must mention that path.
 - Prefer vertical user or operational outcomes over technical-layer slices.
 - Extract stable `DESIGN-REQ-*` coverage points before drafting story candidates.
 - Do not write specs in this skill.

--- a/api_service/data/task_step_templates/jira-breakdown.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown.yaml
@@ -1,0 +1,54 @@
+slug: jira-breakdown
+title: Jira Breakdown
+description: Break a declarative design into MoonSpec story candidates, then create Jira Story issues from the generated breakdown.
+scope: global
+version: 1.0.0
+tags:
+  - jira
+  - moonspec
+  - breakdown
+  - stories
+requiredCapabilities:
+  - git
+annotations:
+  sourceSkill: moonspec-breakdown
+  output: jira
+inputs:
+  - name: feature_request
+    label: Declarative Design Path or Text
+    type: markdown
+    required: true
+  - name: jira_project_key
+    label: Jira Project Key
+    type: text
+    required: true
+    default: TOOL
+  - name: jira_issue_type
+    label: Jira Issue Type
+    type: text
+    required: true
+    default: Story
+steps:
+  - title: Break down declarative design
+    instructions: |-
+      Run moonspec-breakdown for this declarative design:
+
+      {{ inputs.feature_request }}
+
+      If the input is a readable repo path, use that file as the original declarative document and preserve its path in every story's sourceReference.
+      Write the coverage-checked story breakdown to the runtime-provided story breakdown paths.
+    skill:
+      id: moonspec-breakdown
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Create Jira stories
+    instructions: |-
+      Create one Jira {{ inputs.jira_issue_type }} issue in project {{ inputs.jira_project_key }} for each story from the generated MoonSpec breakdown.
+
+      Use the runtime-provided story breakdown JSON path.
+      Every Jira issue must include the Source Document path from the story breakdown.
+      Return the created Jira issue keys and URLs.
+    skill:
+      id: jira-issue-creator
+      args: {}

--- a/moonmind/integrations/jira/models.py
+++ b/moonmind/integrations/jira/models.py
@@ -131,8 +131,8 @@ class SearchIssuesRequest(JiraBaseModel):
     jql: str = Field(..., min_length=1, alias="jql")
     project_key: str | None = Field(None, alias="projectKey")
     fields: list[str] = Field(default_factory=list, alias="fields")
-    start_at: int = Field(0, ge=0, alias="startAt")
     max_results: int = Field(50, ge=1, le=200, alias="maxResults")
+    next_page_token: str | None = Field(None, alias="nextPageToken")
 
     @field_validator("project_key", mode="before")
     @classmethod
@@ -143,6 +143,13 @@ class SearchIssuesRequest(JiraBaseModel):
         if not _JIRA_PROJECT_KEY_RE.fullmatch(normalized):
             raise ValueError("projectKey must match a Jira project-key pattern")
         return normalized
+
+    @field_validator("next_page_token", mode="before")
+    @classmethod
+    def _normalize_next_page_token(cls, value: object) -> str | None:
+        if value in (None, ""):
+            return None
+        return str(value).strip()
 
 
 class GetTransitionsRequest(JiraIssueScopedRequest):
@@ -199,4 +206,3 @@ class VerifyConnectionRequest(JiraBaseModel):
         if not _JIRA_PROJECT_KEY_RE.fullmatch(normalized):
             raise ValueError("projectKey must match a Jira project-key pattern")
         return normalized
-

--- a/moonmind/integrations/jira/tool.py
+++ b/moonmind/integrations/jira/tool.py
@@ -159,16 +159,18 @@ class JiraToolService:
         jql = request.jql
         if project_key:
             jql = self._scope_jql_to_project(jql, project_key)
+        body: dict[str, Any] = {
+            "jql": jql,
+            "fields": request.fields,
+            "maxResults": request.max_results,
+        }
+        if request.next_page_token:
+            body["nextPageToken"] = request.next_page_token
         return await self._request_json(
             method="POST",
-            path="/search",
+            path="/search/jql",
             action="search_issues",
-            json_body={
-                "jql": jql,
-                "fields": request.fields,
-                "startAt": request.start_at,
-                "maxResults": request.max_results,
-            },
+            json_body=body,
             context={"projectKey": project_key or ""},
         )
 

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -106,6 +106,39 @@ def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
     return truncated or normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS]
 
 
+def _selected_agent_skill(parameters: Mapping[str, Any] | None) -> str:
+    if not isinstance(parameters, Mapping):
+        return ""
+    return str(parameters.get("selectedSkill") or "").strip().lower()
+
+
+def _jira_issue_creator_blocker_summary(
+    *,
+    parameters: Mapping[str, Any] | None,
+    assistant_text: str,
+) -> str | None:
+    if _selected_agent_skill(parameters) != "jira-issue-creator":
+        return None
+    normalized = " ".join(str(assistant_text or "").lower().split())
+    if not normalized:
+        return None
+    blocker_markers = (
+        "no jira issues were created",
+        "could not create the jira",
+        "could not create jira",
+        "jira access is not configured",
+        "jira tools are not enabled",
+        "jira tool calls are unavailable",
+        "no jira mcp connector/tool is available",
+    )
+    if any(marker in normalized for marker in blocker_markers):
+        return _clamp_agent_run_result_summary(
+            assistant_text,
+            default="Jira issue creation was blocked.",
+        )
+    return None
+
+
 class CodexSessionRunFailedError(RuntimeError):
     """Raised when a Codex session run persisted a structured failed result."""
 
@@ -380,6 +413,17 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                         "turnId": turn_id,
                     },
                 )
+                jira_blocker_summary = _jira_issue_creator_blocker_summary(
+                    parameters=request.parameters,
+                    assistant_text=assistant_text,
+                )
+                if jira_blocker_summary is not None:
+                    result = result.model_copy(
+                        update={
+                            "summary": jira_blocker_summary,
+                            "failure_class": "execution_error",
+                        }
+                    )
             except Exception as exc:
                 failure_result = self._persist_failed_run_state(
                     run_id=run_id,
@@ -409,6 +453,24 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                 )
                 failed_state_persisted = True
                 raise CodexSessionRunFailedError(str(exc), result=failure_result) from exc
+
+            if result.failure_class is not None:
+                self._save_run_state(
+                    run_id=run_id,
+                    agent_id=request.agent_id,
+                    managed_run_id=binding.task_run_id,
+                    binding=binding,
+                    workspace_path=workspace_path,
+                    locator=current_locator.model_dump(mode="json", by_alias=True),
+                    active_turn_id=None,
+                    result=result.model_dump(mode="json", by_alias=True),
+                    status="failed",
+                    started_at=started_at,
+                    finished_at=_current_time(),
+                    profile_id=launch_context.profile_id or None,
+                )
+                failed_state_persisted = True
+                raise CodexSessionRunFailedError(result.summary, result=result)
 
             self._save_run_state(
                 run_id=run_id,

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import datetime
 from pathlib import Path
@@ -95,6 +96,12 @@ PublishArtifactsFunc = Callable[
 ]
 
 _MAX_AGENT_RUN_RESULT_SUMMARY_CHARS = 4096
+_JIRA_CREATED_ISSUE_KEYS_PATTERN = re.compile(
+    r"\b(?:created\s+(?:jira\s+)?(?:issues?|stories?|tickets?)|"
+    r"created\s+(?:issue\s+)?keys?|issue\s+keys?\s+created)\b"
+    r"[\s\S]{0,240}?\b[A-Z][A-Z0-9]+-\d+\b",
+    re.IGNORECASE,
+)
 logger = logging.getLogger(__name__)
 
 
@@ -121,6 +128,8 @@ def _jira_issue_creator_blocker_summary(
         return None
     normalized = " ".join(str(assistant_text or "").lower().split())
     if not normalized:
+        return None
+    if _JIRA_CREATED_ISSUE_KEYS_PATTERN.search(str(assistant_text or "")):
         return None
     blocker_markers = (
         "no jira issues were created",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3083,13 +3083,60 @@ class TemporalAgentRuntimeActivities:
             )
             instruction_ref = str(request.instruction_ref or "").strip()
             if instruction_ref:
-                return append_managed_codex_runtime_note(instruction_ref)
+                return self._prepare_managed_codex_turn_text(
+                    instruction_ref,
+                    parameters=request.parameters,
+                )
         parameters = request.parameters if isinstance(request.parameters, dict) else {}
         instructions = str(parameters.get("instructions") or "").strip()
         if instructions:
-            return append_managed_codex_runtime_note(instructions)
+            return self._prepare_managed_codex_turn_text(
+                instructions,
+                parameters=parameters,
+            )
         raise TemporalActivityRuntimeError(
             "request.instructionRef or request.parameters.instructions is required"
+        )
+
+    @classmethod
+    def _prepare_managed_codex_turn_text(
+        cls,
+        instructions: str,
+        *,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        prepared = cls._append_jira_issue_creator_tool_hint(
+            instructions,
+            parameters=parameters,
+        )
+        return append_managed_codex_runtime_note(prepared)
+
+    @staticmethod
+    def _append_jira_issue_creator_tool_hint(
+        instructions: str,
+        *,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        params = parameters if isinstance(parameters, Mapping) else {}
+        selected_skill = str(params.get("selectedSkill") or "").strip().lower()
+        if selected_skill != "jira-issue-creator":
+            return instructions
+        if "MoonMind trusted Jira tools" in instructions:
+            return instructions
+        return (
+            instructions.rstrip()
+            + "\n\nMoonMind trusted Jira tools:\n"
+            + "- Use the internal MoonMind API from the managed session via "
+            + "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
+            + "credentials in the shell.\n"
+            + "- List available tools with `GET $MOONMIND_URL/mcp/tools`.\n"
+            + "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call` and "
+            + "JSON like `{\"tool\":\"jira.list_create_issue_types\","
+            + "\"arguments\":{\"projectKey\":\"TOOL\"}}`.\n"
+            + "- Resolve the Story issue type through `jira.list_create_issue_types` "
+            + "and create issues through `jira.create_issue`.\n"
+            + "- Treat the task as blocked if Jira tool calls are unavailable or no "
+            + "Jira issue key is returned."
         )
 
     async def agent_runtime_send_turn(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3123,9 +3123,16 @@ class TemporalAgentRuntimeActivities:
             return instructions
         if "MoonMind trusted Jira tools" in instructions:
             return instructions
+        story_breakdown_path = str(params.get("storyBreakdownPath") or "").strip()
+        story_breakdown_hint = (
+            f"- Read MoonSpec story candidates from `{story_breakdown_path}`.\n"
+            if story_breakdown_path
+            else ""
+        )
         return (
             instructions.rstrip()
             + "\n\nMoonMind trusted Jira tools:\n"
+            + story_breakdown_hint
             + "- Use the internal MoonMind API from the managed session via "
             + "`$MOONMIND_URL` for Jira operations; do not look for raw Jira "
             + "credentials in the shell.\n"

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -61,3 +61,19 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         )
         assert "/moonspec-verify" in tasks_step["instructions"]
         assert "/speckit.verify" not in tasks_step["instructions"]
+
+        result = await session.execute(
+            select(TaskStepTemplate)
+            .where(
+                TaskStepTemplate.slug == "jira-breakdown",
+                TaskStepTemplate.scope_type == TaskTemplateScopeType.GLOBAL,
+                TaskStepTemplate.scope_ref.is_(None),
+            )
+            .options(selectinload(TaskStepTemplate.latest_version))
+        )
+        jira_template = result.scalar_one_or_none()
+        assert jira_template is not None
+        assert jira_template.latest_version is not None
+        assert [
+            step["skill"]["id"] for step in jira_template.latest_version.steps
+        ] == ["moonspec-breakdown", "jira-issue-creator"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -415,6 +416,52 @@ async def test_import_seed_templates_skips_existing(tmp_path):
                 seed_dir=seed_dir
             )
             assert created_count_second == 0
+
+
+async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="jira-breakdown",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            assert template.title == "Jira Breakdown"
+            assert template.latest_version is not None
+            assert [step["skill"]["id"] for step in template.latest_version.steps] == [
+                "moonspec-breakdown",
+                "jira-issue-creator",
+            ]
+
+            expanded = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_project_key": "TOOL",
+                    "jira_issue_type": "Story",
+                },
+                context={},
+            )
+
+            assert len(expanded["steps"]) == 2
+            assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
+            assert "docs/Designs/RuntimeTypes.md" in expanded["steps"][0]["instructions"]
+            assert expanded["steps"][1]["skill"]["id"] == "jira-issue-creator"
+            assert "Jira Story issue in project TOOL" in expanded["steps"][1]["instructions"]
+            assert "Source Document path" in expanded["steps"][1]["instructions"]
 
 
 async def test_sync_seed_templates_creates_missing_seed(tmp_path):

--- a/tests/unit/integrations/test_jira_tool_service.py
+++ b/tests/unit/integrations/test_jira_tool_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from moonmind.config.settings import AtlassianSettings, JiraSettings
 from moonmind.integrations.jira.errors import JiraToolError
@@ -252,10 +253,45 @@ async def test_search_issues_preserves_order_by_after_project_scoping() -> None:
         )
     )
 
+    assert service.calls[0]["method"] == "POST"
+    assert service.calls[0]["path"] == "/search/jql"
     assert (
         service.calls[0]["json_body"]["jql"]
         == "project = ENG AND (status = 'Todo') ORDER BY created DESC"
     )
+    assert "startAt" not in service.calls[0]["json_body"]
+
+
+async def test_search_issues_sends_next_page_token() -> None:
+    service = _StubJiraToolService(
+        atlassian_settings=_build_settings(),
+        responses=[{"issues": [], "isLast": True}],
+    )
+
+    await service.search_issues(
+        SearchIssuesRequest(
+            projectKey="ENG",
+            jql="status = 'Todo'",
+            nextPageToken="opaque-token",
+            maxResults=25,
+        )
+    )
+
+    assert service.calls[0]["path"] == "/search/jql"
+    assert service.calls[0]["json_body"] == {
+        "jql": "project = ENG AND (status = 'Todo')",
+        "fields": [],
+        "maxResults": 25,
+        "nextPageToken": "opaque-token",
+    }
+
+
+async def test_search_issues_rejects_removed_start_at_contract() -> None:
+    with pytest.raises(ValidationError):
+        SearchIssuesRequest.model_validate(
+            {"projectKey": "ENG", "jql": "status = 'Todo'", "startAt": 50}
+        )
+
 
 
 async def test_verify_connection_returns_project_result() -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -570,6 +570,104 @@ async def test_start_fails_jira_issue_creator_when_no_issues_created(
     assert persisted_record.failure_class == "execution_error"
 
 
+async def test_start_allows_jira_issue_creator_mixed_output_with_created_issue_keys(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    assistant_text = (
+        "An earlier attempt reported that no Jira issues were created.\n\n"
+        "Created issue keys:\n"
+        "- PROJ-1\n"
+        "- PROJ-2"
+    )
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_locator: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            assistant_text=assistant_text,
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            last_assistant_text=assistant_text,
+        )
+
+    async def _publish_artifacts(_request: Any) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    request = _request(binding, workspace_path=str(workspace_path))
+    request.parameters["selectedSkill"] = "jira-issue-creator"
+
+    handle = await adapter.start(request)
+    result = await adapter.fetch_result(handle.run_id)
+
+    persisted_record = run_store.load(binding.task_run_id)
+    assert handle.status == "completed"
+    assert persisted_record is not None
+    assert persisted_record.status == "completed"
+    assert persisted_record.failure_class is None
+    assert result.failure_class is None
+    assert result.summary == assistant_text
+
+
 async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path) -> None:
     binding = _binding()
     workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -25,7 +25,10 @@ from moonmind.workflows.codex_session_timeouts import (
     DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
     MAX_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
-from moonmind.workflows.adapters.codex_session_adapter import CodexSessionAdapter
+from moonmind.workflows.adapters.codex_session_adapter import (
+    CodexSessionAdapter,
+    CodexSessionRunFailedError,
+)
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 
 
@@ -470,6 +473,101 @@ async def test_start_persists_running_live_capable_record_before_send_turn_compl
     assert persisted_completed is not None
     assert persisted_completed.status == "completed"
     assert persisted_completed.live_stream_capable is True
+
+
+async def test_start_fails_jira_issue_creator_when_no_issues_created(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    workspace_path = tmp_path / "agent_jobs" / binding.task_run_id / "repo"
+    run_store = ManagedRunStore(tmp_path / "managed_runs")
+    assistant_text = (
+        "I could not create the Jira stories because Jira access is not configured. "
+        "No Jira issues were created."
+    )
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _session_status(_locator: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    async def _send_turn(_request: Any) -> CodexManagedSessionTurnResponse:
+        return _turn_response(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            assistant_text=assistant_text,
+        )
+
+    async def _fetch_summary(_request: Any) -> CodexManagedSessionSummary:
+        return _summary(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+            last_assistant_text=assistant_text,
+        )
+
+    async def _publish_artifacts(_request: Any) -> CodexManagedSessionArtifactsPublication:
+        return _publication(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=run_store,
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=_session_status,
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=_send_turn,
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=_fetch_summary,
+        publish_remote_artifacts=_publish_artifacts,
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+    request = _request(binding, workspace_path=str(workspace_path))
+    request.parameters["selectedSkill"] = "jira-issue-creator"
+
+    with pytest.raises(CodexSessionRunFailedError) as exc_info:
+        await adapter.start(request)
+
+    persisted_record = run_store.load(binding.task_run_id)
+    assert exc_info.value.agent_run_result.failure_class == "execution_error"
+    assert "No Jira issues were created" in exc_info.value.agent_run_result.summary
+    assert persisted_record is not None
+    assert persisted_record.status == "failed"
+    assert persisted_record.failure_class == "execution_error"
 
 
 async def test_start_raises_when_send_turn_returns_failed_status(tmp_path: Path) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1671,6 +1671,33 @@ async def test_agent_runtime_prepare_turn_instructions_injects_context(
 
 
 @pytest.mark.asyncio
+async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_prepare_turn_instructions(
+        {
+            "request": {
+                "agentKind": "managed",
+                "agentId": "codex",
+                "correlationId": "corr-1",
+                "idempotencyKey": "idem-1",
+                "parameters": {
+                    "instructions": "Create Jira stories from the breakdown.",
+                    "selectedSkill": "jira-issue-creator",
+                    "publishMode": "none",
+                },
+            },
+        }
+    )
+
+    assert "MoonMind trusted Jira tools:" in result
+    assert "`$MOONMIND_URL`" in result
+    assert "POST $MOONMIND_URL/mcp/tools/call" in result
+    assert "jira.create_issue" in result
+    assert "Managed Codex CLI note:" in result
+
+
+@pytest.mark.asyncio
 async def test_agent_runtime_prepare_turn_instructions_requires_workspace_for_instruction_ref() -> None:
     activities = TemporalAgentRuntimeActivities()
 

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1685,12 +1685,14 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint() -> 
                     "instructions": "Create Jira stories from the breakdown.",
                     "selectedSkill": "jira-issue-creator",
                     "publishMode": "none",
+                    "storyBreakdownPath": "docs/tmp/story-breakdowns/demo/stories.json",
                 },
             },
         }
     )
 
     assert "MoonMind trusted Jira tools:" in result
+    assert "docs/tmp/story-breakdowns/demo/stories.json" in result
     assert "`$MOONMIND_URL`" in result
     assert "POST $MOONMIND_URL/mcp/tools/call" in result
     assert "jira.create_issue" in result

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -293,6 +293,52 @@ def test_runtime_planner_routes_jira_issue_creator_as_agent_skill_step():
     )
 
 
+def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Jira Breakdown",
+                "instructions": "Break down docs/Design.md into Jira stories.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+                "steps": [
+                    {
+                        "id": "breakdown",
+                        "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                        "instructions": "Extract MoonSpec stories.",
+                    },
+                    {
+                        "id": "jira",
+                        "tool": {"type": "skill", "name": "jira-issue-creator"},
+                        "instructions": "Create Jira issues from the generated breakdown.",
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    breakdown = plan["nodes"][0]
+    jira = plan["nodes"][1]
+
+    assert breakdown["inputs"]["storyBreakdownPath"].startswith(
+        "docs/tmp/story-breakdowns/"
+    )
+    assert (
+        jira["inputs"]["storyBreakdownPath"]
+        == breakdown["inputs"]["storyBreakdownPath"]
+    )
+    assert jira["inputs"]["selectedSkill"] == "jira-issue-creator"
+    assert jira["inputs"]["publishMode"] == "none"
+
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary

Fixes the Jira issue creator workflow path so managed Codex sessions can reach MoonMind's trusted Jira tools and workflow runs no longer report success when no Jira issues were created.

Also updates the MoonSpec-to-Jira story flow so generated Jira stories preserve a reference to the original declarative document, removes the unwanted handoff subsection from breakdown output, and adds a global `Jira Breakdown` preset that runs `moonspec-breakdown` followed by `jira-issue-creator`.

## Root Cause

The failed workflow completed at the Temporal level because the managed Codex session exited normally, but its output said Jira access was unavailable and no issues were created. The workflow adapter did not classify that response as a failed business outcome.

During remediation, the Jira duplicate-check tool also failed because `jira.search_issues` still posted to Jira Cloud's old `/search` endpoint, which returned HTTP 410 in the live environment.

The breakdown-to-Jira story path also lacked a hard requirement to carry the original source document path through `stories.json`, story descriptions, and Jira issue descriptions.

## Changes

- Add Jira tool guidance to managed `jira-issue-creator` instructions, using `$MOONMIND_URL/mcp/tools/call` instead of raw Jira credentials.
- Classify blocked Jira issue-creator output as `execution_error` so false-success workflow completions fail visibly.
- Move `jira.search_issues` to Jira Cloud's `/search/jql` endpoint and replace `startAt` with `nextPageToken`.
- Require MoonSpec breakdown output and Jira story descriptions to preserve the original declarative document path.
- Remove the handoff subsection from the MoonSpec breakdown skill output contract.
- Add the global `Jira Breakdown` task preset with `moonspec-breakdown` then `jira-issue-creator`.
- Share the runtime-generated story breakdown JSON path with the Jira creation step.
- Add unit and integration coverage for the preset seed, expansion, runtime planning, Jira instruction preparation, adapter failure classification, and Jira search contract.

## Validation

- `git diff --check`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/test_task_step_templates_service.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_temporal_worker_runtime.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_agent_runtime_activities.py -q`
- `./tools/test_integration.sh`
- Live `jira.search_issues` call returned the five created workflow issues instead of HTTP 410.
- Restarted `api`, `temporal-worker-workflow`, and `temporal-worker-agent-runtime`; all reported healthy.
