### PR TITLE
Implement these documentation improvements to cover our new use of runtime-native commands like /review:

### DIFF
--- a/docs/Tasks/AgentSkillSystem.md
+++ b/docs/Tasks/AgentSkillSystem.md
@@ -111,6 +111,26 @@ Examples:
 ### ResolvedSkillSet
 The immutable, exact set of agent skills selected for a specific run or step after all precedence and override rules have been applied.
 
+### RuntimeCommandSelection
+
+A `RuntimeCommandSelection` is a MoonMind-native request to invoke a
+runtime-provided command inside an `agent_runtime` step.
+
+Examples include:
+
+- `review`
+
+A runtime command is not:
+
+- an `AgentSkillDefinition`
+- a `SkillSet`
+- a `ResolvedSkillSet` entry
+- a `.agents/skills` bundle
+
+UI surfaces may co-present runtime commands beside agent skills for convenience,
+but the backend contract must keep them typed and separate. Runtime commands
+belong to the agent-runtime execution contract, not to the Agent Skill System.
+
 ### Materialization
 The runtime-facing rendering of a `ResolvedSkillSet` into one or more of:
 
@@ -157,6 +177,9 @@ The Agent Skill System does not aim to:
 4. conflate agent skills with executable tool contracts
 5. allow silent, unaudited skill drift within a run
 6. force a repo to adopt any specific checked-in skill layout beyond the documented conventions
+
+Additional non-goal: modeling runtime-native commands as agent skills or as
+members of a `ResolvedSkillSet`.
 
 ---
 

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -365,6 +365,10 @@ Migration rule:
 * Legacy `selectedSkill` and `selectedSkillArgs` payloads may be accepted during
   migration and normalized to
   `inputs.runtimeSelection = { "kind": "agent_skill", ... }`.
+* This legacy acceptance is deprecated and exists only for in-flight runs
+  created before `runtimeSelection` became the canonical contract. Remove
+  `selectedSkill` and `selectedSkillArgs` acceptance once those in-flight runs
+  have completed or been explicitly cut over.
 
 ---
 

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -63,6 +63,25 @@ There are two tool subtypes:
 * `tool.type = "skill"` — dispatched as a Temporal Activity (`mm.tool.execute` / `mm.skill.execute`). Uses a `ToolDefinition` from the tool registry snapshot.
 * `tool.type = "agent_runtime"` — dispatched as a child `MoonMind.AgentRun` workflow. Uses an `AgentExecutionRequest`.
 
+A runtime-native command is not a third `tool.type`.
+
+A runtime-native command is a MoonMind-native typed selection carried inside a
+`tool.type = "agent_runtime"` step and interpreted by the owning runtime adapter
+or managed-session plane.
+
+Examples include:
+
+* `review`
+
+Runtime-native commands are:
+
+* not `ToolDefinition` registry entries
+* not dispatched through `mm.tool.execute`
+* not `AgentSkillDefinition`s
+* not members of a `ResolvedSkillSet`
+
+They are execution-shaping selections for `agent_runtime` steps only.
+
 > **Important:** Executable tool skills and agent instruction skills are separate systems.
 > The term **"Agent Skill"** (in `.agents/skills/` directories and `SKILL.md` files)
 > refers to reusable instruction bundles that AI agents read for guidance as defined in
@@ -263,6 +282,92 @@ Legacy compatibility form (accepted only during migration):
 
 ---
 
+### 4.3.1 Runtime selection for `agent_runtime` steps
+
+`tool.type = "agent_runtime"` steps may carry one optional typed runtime
+selection inside `inputs.runtimeSelection`.
+
+Canonical shapes:
+
+```json
+{
+  "kind": "agent_skill",
+  "name": "jira-issue-creator",
+  "args": {}
+}
+```
+
+```json
+{
+  "kind": "runtime_command",
+  "name": "review",
+  "args": {}
+}
+```
+
+Representative `agent_runtime` step using an agent skill:
+
+```json
+{
+  "id": "n1",
+  "tool": { "type": "agent_runtime", "name": "codex_cli", "version": "1.0" },
+  "inputs": {
+    "instructions": "Use the selected runtime skill to create Jira stories.",
+    "runtimeSelection": {
+      "kind": "agent_skill",
+      "name": "jira-issue-creator",
+      "args": {}
+    },
+    "runtime": {
+      "mode": "codex_cli"
+    }
+  }
+}
+```
+
+Representative `agent_runtime` step using a runtime-native command:
+
+```json
+{
+  "id": "n2",
+  "tool": { "type": "agent_runtime", "name": "codex_cli", "version": "1.0" },
+  "inputs": {
+    "instructions": "Review the current changes and publish the review as artifacts.",
+    "runtimeSelection": {
+      "kind": "runtime_command",
+      "name": "review",
+      "args": {}
+    },
+    "runtime": {
+      "mode": "codex_cli"
+    }
+  }
+}
+```
+
+Rules:
+
+* `runtimeSelection` is valid only for `tool.type = "agent_runtime"`.
+* `kind = "agent_skill"` selects a runtime-facing agent skill or skill preset
+  for that step.
+* `kind = "runtime_command"` selects a MoonMind-native runtime command
+  implemented by the owning runtime adapter or managed-session plane.
+* A runtime command is not resolved from the executable tool registry snapshot.
+* A runtime command must be capability-gated by runtime. Unsupported commands
+  must fail validation or fail fast before the run starts.
+* `args` must remain small JSON and must validate against command-specific
+  runtime validation rules.
+* Any outputs produced by a runtime command use the normal `AgentRunResult` and
+  artifact contracts.
+
+Migration rule:
+
+* Legacy `selectedSkill` and `selectedSkillArgs` payloads may be accepted during
+  migration and normalized to
+  `inputs.runtimeSelection = { "kind": "agent_skill", ... }`.
+
+---
+
 ### 4.4 ToolResult schema
 
 Tool execution returns a structured result:
@@ -362,8 +467,12 @@ When a task requests Jira issue creation from ambiguous user intent, the planner
     "version": "1.0"
   },
   "inputs": {
-    "selectedSkill": "jira-issue-creator",
-    "instructions": "Use $jira-issue-creator.\n\nCreate a Jira story for each story in docs/tmp/story-breakdowns/example.",
+    "runtimeSelection": {
+      "kind": "agent_skill",
+      "name": "jira-issue-creator",
+      "args": {}
+    },
+    "instructions": "Use the selected runtime skill to create a Jira story for each story in docs/tmp/story-breakdowns/example.",
     "runtime": {
       "mode": "codex_cli"
     }
@@ -551,6 +660,10 @@ Planning is expressed as one or more tools (e.g., `plan.generate`) executed as A
 
 * Resolve `ToolDefinition` from the pinned tool registry snapshot.
 * Any agent instruction skill snapshot used by an agent-runtime step is resolved separately and passed as execution context, not looked up in the executable tool registry.
+* For `tool.type = "agent_runtime"`, any `inputs.runtimeSelection` is passed
+  through the `AgentExecutionRequest` or equivalent managed-session input and is
+  interpreted by the owning runtime adapter or managed-session plane. It is not
+  resolved from the executable tool registry snapshot.
 * Derive Activity Type and routing target (task queue) from ToolDefinition + worker capabilities.
 
 **Invocation payload**

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -83,9 +83,11 @@ The Create page already supports all of the following, and this design keeps the
    - one required primary step
    - add / remove / reorder controls
    - per-step instructions
-   - optional per-step skill selection
+   - optional per-step runtime selection from one mixed selector surface:
+     - `agent_skill`
+     - `runtime_command`
    - optional per-step required-capability CSV
-   - optional per-step skill args JSON
+   - optional per-step arguments JSON
 2. a task preset area with:
    - preset selection
    - a preset objective field labeled `Feature Request / Initial Instructions`
@@ -146,7 +148,7 @@ Each step card must expose:
 
 - `Instructions`
 - `Skill (optional)`
-- `Skill Args (optional JSON object)` when a non-empty explicit skill is selected
+- `Arguments (optional JSON object)` when the selected item accepts args
 
 Rules:
 
@@ -154,6 +156,45 @@ Rules:
 - when any additional step is present, the primary step must contain instructions
 - non-primary steps may omit instructions to continue from the task objective
 - non-primary steps may omit skill to inherit the primary-step skill defaults
+
+### 7.2.1 Mixed selector contract
+
+The existing `Skill (optional)` control is a mixed selector surface.
+
+It may present:
+
+- agent skills
+- runtime commands
+
+Representative browser model:
+
+```ts
+type StepRuntimeSelection =
+  | {
+      kind: "agent_skill";
+      name: string;
+      args?: Record<string, unknown> | null;
+    }
+  | {
+      kind: "runtime_command";
+      name: string;
+      args?: Record<string, unknown> | null;
+    };
+```
+
+Rules:
+
+* the browser may keep the visible label `Skill` for continuity, but the
+  submitted payload must preserve the selected item's `kind`
+* `runtime_command` items must be filtered by the currently selected runtime
+* changing runtime must revalidate the current selection and clear or mark
+  invalid any unsupported `runtime_command`
+* `agent_skill` and `runtime_command` items may share one dropdown, but they
+  must not be flattened to one undifferentiated string in the backend
+* `Arguments` applies to the selected item regardless of kind
+* selecting a `runtime_command` does not make that command part of the task's
+  resolved skill set; it is execution configuration for the `agent_runtime`
+  step
 
 ### 7.3 Advanced settings
 
@@ -163,7 +204,7 @@ Rules:
 
 - each step may still author optional skill required capabilities
 - required capabilities remain an advanced routing override, not part of the default visible Create Task flow
-- runtime, publish mode, selected skills, and presets derive the common capability set automatically
+- runtime, publish mode, selected skills, selected runtime commands, and presets derive the common capability set automatically
 
 ### 7.4 Template-bound steps
 
@@ -265,6 +306,11 @@ Rules:
 
 - runtime defaults come from server-provided runtime config
 - provider-profile options are runtime-specific
+- available `runtime_command` items are runtime-specific and must update when
+  `Runtime` changes
+- if a runtime change invalidates an already-selected `runtime_command`, the
+  page must show an explicit validation error until the user clears or replaces
+  that selection
 - resolver-style skills may still force publish mode to `none`
 - repository validation rules remain unchanged by Jira integration
 - Jira import must never bypass or weaken repository validation


### PR DESCRIPTION
Automated changes by MoonMind.