### PR TITLE
[codex] Fix managed session live logs

### DIFF
--- a/api_service/api/routers/task_runs.py
+++ b/api_service/api/routers/task_runs.py
@@ -1211,6 +1211,13 @@ async def get_observability_summary(
 
         base = record.model_dump(by_alias=True)
         session_record = await asyncio.to_thread(_load_task_run_session_record, str(id))
+        if session_record is not None:
+            base["sessionId"] = session_record.session_id
+            base["sessionEpoch"] = session_record.session_epoch
+            base["containerId"] = session_record.container_id
+            base["threadId"] = session_record.thread_id
+            base["activeTurnId"] = session_record.active_turn_id
+            base["sessionStatus"] = session_record.status
         base["supportsLiveStreaming"] = supports_live
         base["liveStreamStatus"] = live_stream_status
         base["sessionSnapshot"] = _build_session_snapshot(session_record) or _build_record_session_snapshot(record)

--- a/docs/ManagedAgents/CodexCliManagedSessions.md
+++ b/docs/ManagedAgents/CodexCliManagedSessions.md
@@ -84,6 +84,19 @@ MoonMind maps the managed session plane to Codex App Server concepts:
 
 `codex exec --json` remains a bring-up and smoke-test harness, not the primary long-lived session protocol.
 
+### 3.1 In-flight Live Output
+
+During `send_turn`, the container-side Codex runtime mirrors visible Codex rollout
+events into the managed-session artifact spool while the turn is still running.
+The mirrored stream includes assistant messages, tool-call markers, and tool-call
+outputs that Codex records in the rollout transcript. The managed-session
+supervisor tails that spool and publishes normalized `stdout`/`stderr` chunks into
+the run-global Live Logs sequence.
+
+The rollout transcript remains a container-local runtime cache. MoonMind does not
+present the raw transcript as durable operator truth; it converts selected visible
+entries into artifact-backed output and observability events.
+
 ## 4. Session Identity
 
 The canonical bounded session identity is:
@@ -101,6 +114,12 @@ Rules:
 3. `container_id` identifies the active Docker container for the task-scoped session.
 4. `thread_id` identifies the active Codex App Server thread for the current epoch.
 5. `active_turn_id` identifies the in-flight Codex turn when one exists.
+
+The managed-session supervisor reconciles `active_turn_id` from the
+container-written session state file while `send_turn` is still executing. This
+keeps operator-visible summaries and Live Logs headers truthful during long
+Codex turns, before the long-running `send_turn` activity returns a terminal
+response.
 
 ## 5. Control Actions
 

--- a/docs/ManagedAgents/LiveLogs.md
+++ b/docs/ManagedAgents/LiveLogs.md
@@ -165,6 +165,7 @@ Behavior:
 - upgrades to a live stream only when the run is active and live streaming is supported
 - shows provenance per row or chunk, including `stdout`, `stderr`, `system`, and session-plane events
 - shows the current session snapshot in the panel header: `session_id`, `session_epoch`, `container_id`, `thread_id`, and `active_turn_id` when available
+- for Codex managed sessions, receives in-flight rollout-derived output while `send_turn` is still running, including assistant messages, tool-call markers, and tool-call output
 - renders epoch boundaries and reset boundaries as explicit timeline banners rather than burying them as plain text
 - can reconnect from the last known `sequence`; resume is best-effort and artifacts remain the durable fallback
 - falls back to artifact-backed mode if live streaming is unavailable or reconnect fails
@@ -178,6 +179,7 @@ The merged Live Logs timeline should support at least these row types:
 - `system` annotations from MoonMind supervision
 - session lifecycle rows such as `session_started`, `session_resumed`, `session_cleared`, and `session_terminated`
 - turn lifecycle rows such as `turn_started`, `turn_completed`, and `turn_interrupted`
+- Codex managed-session output rows derived from visible rollout entries, normalized as `stdout`/`stderr` events rather than raw provider transcript records
 - approval rows such as `approval_requested` and `approval_resolved`
 - continuity publication rows such as `summary_published`, `checkpoint_published`, and `reset_boundary_published`
 

--- a/docs/UI/MissionControlArchitecture.md
+++ b/docs/UI/MissionControlArchitecture.md
@@ -385,7 +385,7 @@ Rules:
 
 For the task detail observability area (Live Logs panel), the correct fetch sequence is:
 
-1. `GET /api/task-runs/{id}/observability-summary` — fetch observability summary (run status, artifact refs, live stream availability)
+1. `GET /api/task-runs/{id}/observability-summary` — fetch observability summary (run status, artifact refs, live stream availability, and the freshest managed-session snapshot when present)
 2. `GET /api/task-runs/{id}/logs/merged` — fetch initial merged log tail; **initial content must be visible before any SSE connection is attempted**
 3. If the run is active and `supports_live_streaming: true`, attach to `GET /api/task-runs/{id}/logs/stream`
 4. If the stream connection fails or is unavailable, remain in artifact-backed mode — do not leave the panel blank
@@ -395,6 +395,7 @@ Rules:
 * ended runs must skip step 3 entirely; never attempt a live stream connection on a completed run
 * step 2 must always happen first and must always produce visible content when artifacts exist
 * stream failure at step 3 transitions the viewer to `error` state backed by artifact content
+* for Codex managed sessions, `activeTurnId` and related session header fields come from the managed-session record when it is fresher than the run record
 * this sequence replaces any legacy approach of connecting SSE first and loading content through the stream
 
 ---

--- a/docs/tmp/009-LiveLogsPlan.md
+++ b/docs/tmp/009-LiveLogsPlan.md
@@ -169,7 +169,7 @@ Have the session plane publish passive lifecycle events into the same run-global
 
 ### Tasks
 
-- Add an observability sink/adapter at the session-plane boundary.
+- [x] Add an observability sink/adapter at the session-plane boundary.
 - For each stable session-plane action, emit a normalized `session` event:
   - `start_session`
   - `resume_session`
@@ -182,7 +182,7 @@ Have the session plane publish passive lifecycle events into the same run-global
 - Emit session events for major session lifecycle transitions:
   - session started
   - session resumed
-  - turn started
+  - [x] turn started while `send_turn` is still running
   - turn completed
   - turn interrupted
   - approval requested
@@ -192,9 +192,15 @@ Have the session plane publish passive lifecycle events into the same run-global
 - For `clear_session`, emit both:
   - a passive control event row, and
   - a dedicated `session_reset_boundary` row carrying the new epoch/thread info
-- Ensure each emitted session event includes the latest known session snapshot fields when available.
-- Update the managed session store/workflow adapter so the latest session snapshot is mirrored onto the run record or other summary source.
-- Sanity-check that session-plane publishing failures do not break runtime control or artifact persistence.
+- [x] Ensure emitted in-flight turn events include the latest known session snapshot fields when available.
+- [x] Update the managed session store/API summary path so the latest session snapshot is exposed even when the run record is stale.
+- [x] Sanity-check that session-plane publishing failures do not break runtime control or artifact persistence.
+
+Completed implementation note: Codex managed sessions now mirror selected visible
+rollout entries into the managed-session artifact spool during `send_turn`.
+The managed-session supervisor publishes those chunks into the run-global Live
+Logs sequence and reconciles `activeTurnId` from the container session state file
+while the long-running activity is still executing.
 
 ### Exit criteria
 

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Sequence
@@ -62,6 +62,15 @@ class _RolloutTurnScan:
     assistant_text: str = ""
     saw_task_complete: bool = False
     error_text: str | None = None
+
+
+@dataclass
+class _RolloutLiveMirror:
+    path: str | None = None
+    offset: int = 0
+    turn_started_at: float | None = None
+    emitted_assistant_texts: set[str] = field(default_factory=set)
+    emitted_live_keys: set[str] = field(default_factory=set)
 
 
 class CodexSessionRuntimeState(BaseModel):
@@ -725,6 +734,187 @@ class CodexManagedSessionRuntime:
             for raw_line in handle:
                 yield raw_line.decode("utf-8", errors="replace").strip()
 
+    def _new_rollout_live_mirror(
+        self,
+        state: CodexSessionRuntimeState,
+    ) -> _RolloutLiveMirror:
+        path = self._allowed_rollout_path(state.vendor_thread_path)
+        if path is None:
+            path = self._find_vendor_thread_path(state.vendor_thread_id)
+        offset = 0
+        if path is not None:
+            try:
+                offset = Path(path).stat().st_size
+            except OSError:
+                offset = 0
+        return _RolloutLiveMirror(path=path, offset=offset)
+
+    def _resolve_live_rollout_path(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        thread_payload: Mapping[str, Any],
+        mirror: _RolloutLiveMirror,
+    ) -> Path | None:
+        path = mirror.path
+        if path is None:
+            resolved = self._resolved_rollout_path(
+                state=state,
+                thread_payload=thread_payload,
+            )
+            if resolved is None:
+                return None
+            path = resolved
+            mirror.path = path
+            mirror.offset = 0
+        allowed = self._allowed_rollout_path(path)
+        if allowed is None:
+            mirror.path = None
+            mirror.offset = 0
+            return None
+        return Path(allowed)
+
+    @staticmethod
+    def _rollout_entry_live_key(
+        *,
+        stream_name: str,
+        label: str,
+        text: str,
+    ) -> str:
+        return f"{stream_name}\0{label}\0{text.strip()}"
+
+    @staticmethod
+    def _append_line_suffix(text: str) -> str:
+        return text if text.endswith("\n") else text + "\n"
+
+    @classmethod
+    def _rollout_entry_live_output(
+        cls,
+        payload: Mapping[str, Any],
+    ) -> tuple[str, str, str] | None:
+        entry_type = str(payload.get("type") or "").strip().lower()
+        if entry_type == "response_item":
+            response_payload = payload.get("payload")
+            if not isinstance(response_payload, Mapping):
+                return None
+            response_type = str(response_payload.get("type") or "").strip().lower()
+            if response_type == "message":
+                role = str(response_payload.get("role") or "").strip().lower()
+                if role != "assistant":
+                    return None
+                text = cls._content_text(response_payload.get("content"))
+                if not text:
+                    return None
+                return "stdout", "assistant", f"assistant: {cls._append_line_suffix(text)}"
+            if response_type == "function_call":
+                name = str(response_payload.get("name") or "").strip()
+                if not name:
+                    return None
+                return "stdout", "tool_call", f"tool call: {name}\n"
+            if response_type == "function_call_output":
+                output = str(response_payload.get("output") or "")
+                if not output.strip():
+                    return None
+                return (
+                    "stdout",
+                    "tool_output",
+                    f"tool output:\n{cls._append_line_suffix(output)}",
+                )
+            return None
+        if entry_type == "event_msg":
+            event_payload = payload.get("payload")
+            if not isinstance(event_payload, Mapping):
+                return None
+            event_type = str(event_payload.get("type") or "").strip().lower()
+            if event_type == "agent_message":
+                text = str(event_payload.get("message") or "").strip()
+                if not text:
+                    return None
+                return "stdout", "assistant", f"assistant: {cls._append_line_suffix(text)}"
+            if event_type == "task_complete":
+                error_text = str(event_payload.get("error") or "").strip()
+                if error_text:
+                    return "stderr", "task_complete", f"task complete error: {error_text}\n"
+                return "stdout", "task_complete", "task complete\n"
+        return None
+
+    def _publish_rollout_live_updates(
+        self,
+        *,
+        state: CodexSessionRuntimeState,
+        vendor_turn_id: str,
+        thread_payload: Mapping[str, Any],
+        mirror: _RolloutLiveMirror,
+    ) -> None:
+        rollout_path = self._resolve_live_rollout_path(
+            state=state,
+            thread_payload=thread_payload,
+            mirror=mirror,
+        )
+        if rollout_path is None:
+            return
+        try:
+            current_size = rollout_path.stat().st_size
+        except OSError:
+            return
+        if current_size < mirror.offset:
+            mirror.offset = 0
+        if current_size <= mirror.offset:
+            return
+
+        try:
+            with rollout_path.open("rb") as handle:
+                handle.seek(mirror.offset)
+                for raw_line in handle:
+                    stripped = raw_line.decode("utf-8", errors="replace").strip()
+                    if not stripped:
+                        continue
+                    try:
+                        payload = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(payload, Mapping):
+                        continue
+                    entry_timestamp = self._rollout_entry_timestamp(payload)
+                    references_turn = self._payload_references_turn(
+                        payload,
+                        vendor_turn_id,
+                    )
+                    if (
+                        mirror.turn_started_at is not None
+                        and (
+                            (
+                                entry_timestamp is not None
+                                and entry_timestamp
+                                < mirror.turn_started_at
+                                - _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS
+                            )
+                            or (entry_timestamp is None and not references_turn)
+                        )
+                    ):
+                        continue
+                    live_output = self._rollout_entry_live_output(payload)
+                    if live_output is None:
+                        continue
+                    stream_name, label, text = live_output
+                    live_key = self._rollout_entry_live_key(
+                        stream_name=stream_name,
+                        label=label,
+                        text=text,
+                    )
+                    if live_key in mirror.emitted_live_keys:
+                        continue
+                    mirror.emitted_live_keys.add(live_key)
+                    if label == "assistant":
+                        normalized_text = text.removeprefix("assistant: ").strip()
+                        if normalized_text in mirror.emitted_assistant_texts:
+                            continue
+                        mirror.emitted_assistant_texts.add(normalized_text)
+                    self._append_spool(stream_name, text)
+                mirror.offset = handle.tell()
+        except OSError:
+            return
+
     @classmethod
     def _assistant_text_from_rollout_entry(cls, payload: Mapping[str, Any]) -> str:
         entry_type = str(payload.get("type") or "").strip().lower()
@@ -987,13 +1177,21 @@ class CodexManagedSessionRuntime:
     def _wait_for_turn_completion(
         self,
         *,
+        state: CodexSessionRuntimeState,
         client: CodexAppServerRpcClient,
         vendor_thread_id: str,
         vendor_turn_id: str,
+        rollout_mirror: _RolloutLiveMirror,
     ) -> tuple[Mapping[str, Any], tuple[str, str | None]]:
         deadline = time.monotonic() + self._turn_completion_timeout_seconds
         while True:
             thread_payload = client.request("thread/read", {"threadId": vendor_thread_id})
+            self._publish_rollout_live_updates(
+                state=state,
+                vendor_turn_id=vendor_turn_id,
+                thread_payload=thread_payload,
+                mirror=rollout_mirror,
+            )
             turn_payload = self._find_turn_payload(
                 thread_payload,
                 vendor_turn_id=vendor_turn_id,
@@ -1132,6 +1330,7 @@ class CodexManagedSessionRuntime:
         status: str,
         assistant_text: str | None = None,
         error_text: str | None = None,
+        append_assistant_to_spool: bool = True,
     ) -> None:
         previous_status = state.last_turn_status
         state.active_turn_id = None
@@ -1141,7 +1340,12 @@ class CodexManagedSessionRuntime:
         if status == "completed":
             state.last_assistant_text = assistant_text or None
         self._save_state(state)
-        if status == "completed" and assistant_text and previous_status != "completed":
+        if (
+            append_assistant_to_spool
+            and status == "completed"
+            and assistant_text
+            and previous_status != "completed"
+        ):
             self._append_spool("stdout", f"assistant: {assistant_text}\n")
         if status in {"failed", "interrupted"} and error_text and previous_status != status:
             self._append_spool("stderr", f"turn {status}: {error_text}\n")
@@ -1293,6 +1497,7 @@ class CodexManagedSessionRuntime:
         client = self._app_server_client()
         client.initialize()
         vendor_thread_id = self._resume_thread(client=client, state=state)
+        rollout_mirror = self._new_rollout_live_mirror(state)
 
         started = client.request(
             "turn/start",
@@ -1319,13 +1524,16 @@ class CodexManagedSessionRuntime:
         state.last_turn_error = None
         state.last_control_action = "send_turn"
         state.last_control_at = time.time()
+        rollout_mirror.turn_started_at = state.last_control_at
         self._save_state(state)
         self._append_spool("stdout", f"turn started: {vendor_turn_id}\n")
         try:
             thread_payload, (status, error_text) = self._wait_for_turn_completion(
+                state=state,
                 client=client,
                 vendor_thread_id=vendor_thread_id,
                 vendor_turn_id=vendor_turn_id,
+                rollout_mirror=rollout_mirror,
             )
         except RuntimeError as exc:
             message = str(exc).strip()
@@ -1379,6 +1587,9 @@ class CodexManagedSessionRuntime:
             status=status,
             assistant_text=assistant_text,
             error_text=error_text,
+            append_assistant_to_spool=(
+                assistant_text.strip() not in rollout_mirror.emitted_assistant_texts
+            ),
         )
         return CodexManagedSessionTurnResponse(
             sessionState=self._session_state(state),

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -780,8 +780,27 @@ class CodexManagedSessionRuntime:
         stream_name: str,
         label: str,
         text: str,
+        payload: Mapping[str, Any],
+        line_start_offset: int,
     ) -> str:
-        return f"{stream_name}\0{label}\0{text.strip()}"
+        identity = str(
+            payload.get("id")
+            or payload.get("item_id")
+            or payload.get("event_id")
+            or ""
+        ).strip()
+        response_payload = payload.get("payload")
+        if not identity and isinstance(response_payload, Mapping):
+            identity = str(
+                response_payload.get("id")
+                or response_payload.get("item_id")
+                or response_payload.get("call_id")
+                or response_payload.get("event_id")
+                or ""
+            ).strip()
+        if not identity:
+            identity = f"offset:{line_start_offset}"
+        return f"{stream_name}\0{label}\0{identity}\0{text.strip()}"
 
     @staticmethod
     def _append_line_suffix(text: str) -> str:
@@ -865,15 +884,26 @@ class CodexManagedSessionRuntime:
         try:
             with rollout_path.open("rb") as handle:
                 handle.seek(mirror.offset)
-                for raw_line in handle:
+                updates: list[tuple[str, str]] = []
+                while True:
+                    line_start_offset = handle.tell()
+                    raw_line = handle.readline()
+                    if not raw_line:
+                        break
+                    if not raw_line.endswith(b"\n"):
+                        handle.seek(line_start_offset)
+                        break
                     stripped = raw_line.decode("utf-8", errors="replace").strip()
                     if not stripped:
+                        mirror.offset = handle.tell()
                         continue
                     try:
                         payload = json.loads(stripped)
                     except json.JSONDecodeError:
+                        mirror.offset = handle.tell()
                         continue
                     if not isinstance(payload, Mapping):
+                        mirror.offset = handle.tell()
                         continue
                     entry_timestamp = self._rollout_entry_timestamp(payload)
                     references_turn = self._payload_references_turn(
@@ -892,26 +922,40 @@ class CodexManagedSessionRuntime:
                             or (entry_timestamp is None and not references_turn)
                         )
                     ):
+                        mirror.offset = handle.tell()
                         continue
                     live_output = self._rollout_entry_live_output(payload)
                     if live_output is None:
+                        mirror.offset = handle.tell()
                         continue
                     stream_name, label, text = live_output
                     live_key = self._rollout_entry_live_key(
                         stream_name=stream_name,
                         label=label,
                         text=text,
+                        payload=payload,
+                        line_start_offset=line_start_offset,
                     )
                     if live_key in mirror.emitted_live_keys:
+                        mirror.offset = handle.tell()
                         continue
                     mirror.emitted_live_keys.add(live_key)
                     if label == "assistant":
                         normalized_text = text.removeprefix("assistant: ").strip()
                         if normalized_text in mirror.emitted_assistant_texts:
+                            mirror.offset = handle.tell()
                             continue
                         mirror.emitted_assistant_texts.add(normalized_text)
-                    self._append_spool(stream_name, text)
-                mirror.offset = handle.tell()
+                    updates.append((stream_name, text))
+                    mirror.offset = handle.tell()
+                for stream_name in ("stdout", "stderr"):
+                    stream_text = "".join(
+                        text
+                        for update_stream_name, text in updates
+                        if update_stream_name == stream_name
+                    )
+                    if stream_text:
+                        self._append_spool(stream_name, stream_text)
         except OSError:
             return
 

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -18,6 +18,7 @@ from .managed_session_store import ManagedSessionStore
 logger = logging.getLogger(__name__)
 
 _LOG_READ_CHUNK_BYTES = 64 * 1024
+_SESSION_STATE_FILENAME = ".moonmind-codex-session-state.json"
 
 
 class ArtifactStorageWriter(Protocol):
@@ -56,6 +57,10 @@ class ManagedSessionSupervisor:
     @staticmethod
     def _stderr_path(record: CodexManagedSessionRecord) -> Path:
         return Path(record.artifact_spool_path) / "stderr.log"
+
+    @staticmethod
+    def _session_state_path(record: CodexManagedSessionRecord) -> Path:
+        return Path(record.session_workspace_path) / _SESSION_STATE_FILENAME
 
     @staticmethod
     def _initial_stream_offsets(
@@ -155,6 +160,65 @@ class ManagedSessionSupervisor:
                 continue
         return emitted
 
+    @staticmethod
+    def _runtime_state_active_turn_id(
+        record: CodexManagedSessionRecord,
+    ) -> str | None:
+        state_path = ManagedSessionSupervisor._session_state_path(record)
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        if str(payload.get("sessionId") or "").strip() != record.session_id:
+            return None
+        if str(payload.get("containerId") or "").strip() != record.container_id:
+            return None
+        if str(payload.get("logicalThreadId") or "").strip() != record.thread_id:
+            return None
+        try:
+            session_epoch = int(payload.get("sessionEpoch"))
+        except (TypeError, ValueError):
+            return None
+        if session_epoch != record.session_epoch:
+            return None
+        last_turn_status = str(payload.get("lastTurnStatus") or "").strip().lower()
+        active_turn_id = str(payload.get("activeTurnId") or "").strip() or None
+        if active_turn_id is None and last_turn_status not in {"accepted", "running"}:
+            return None
+        return active_turn_id
+
+    async def _sync_active_turn_state(
+        self,
+        record: CodexManagedSessionRecord,
+    ) -> CodexManagedSessionRecord:
+        active_turn_id = self._runtime_state_active_turn_id(record)
+        if not active_turn_id:
+            return record
+        if record.active_turn_id == active_turn_id and record.status == "busy":
+            return record
+
+        updated = await self._store.update(
+            record.session_id,
+            active_turn_id=active_turn_id,
+            status="busy",
+            updated_at=datetime.now(tz=UTC),
+        )
+        if record.active_turn_id != active_turn_id:
+            self.emit_session_event(
+                record=updated,
+                kind="turn_started",
+                text=f"Turn started: {active_turn_id}.",
+                turn_id=active_turn_id,
+                active_turn_id=active_turn_id,
+                metadata={
+                    "action": "send_turn",
+                    "source": "managed_session_runtime_state",
+                },
+            )
+        return updated
+
     def emit_session_event(
         self,
         *,
@@ -203,6 +267,7 @@ class ManagedSessionSupervisor:
             record = self._store.load(session_id)
             if record is None:
                 return
+            record = await self._sync_active_turn_state(record)
             emitted = self._publish_new_output_chunks(
                 record,
                 stream_offsets,

--- a/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_supervisor.py
@@ -185,9 +185,9 @@ class ManagedSessionSupervisor:
             return None
         last_turn_status = str(payload.get("lastTurnStatus") or "").strip().lower()
         active_turn_id = str(payload.get("activeTurnId") or "").strip() or None
-        if active_turn_id is None and last_turn_status not in {"accepted", "running"}:
-            return None
-        return active_turn_id
+        if active_turn_id and last_turn_status in {"accepted", "running"}:
+            return active_turn_id
+        return None
 
     async def _sync_active_turn_state(
         self,

--- a/tests/helpers/codex_session_runtime.py
+++ b/tests/helpers/codex_session_runtime.py
@@ -19,6 +19,7 @@ def write_fake_app_server(
     resume_requires_existing_rollout_path: bool = False,
     start_thread_id: str = "vendor-thread-1",
     start_thread_path: str | None = "/tmp/vendor-thread-1.jsonl",
+    rollout_entries_on_read: list[dict] | None = None,
     steer_record_path: Path | None = None,
     interrupt_record_path: Path | None = None,
     codex_home_record_path: Path | None = None,
@@ -55,6 +56,7 @@ OMIT_TURNS_WHEN_INCOMPLETE = __OMIT_TURNS_WHEN_INCOMPLETE__
 ASSISTANT_TEXT = __ASSISTANT_TEXT__
 THREAD_STATUS_TYPE = __THREAD_STATUS_TYPE__
 THREAD_STATUS_REASON = __THREAD_STATUS_REASON__
+ROLLOUT_ENTRIES_ON_READ = __ROLLOUT_ENTRIES_ON_READ__
 turn_completed = False
 
 for line in sys.stdin:
@@ -208,6 +210,11 @@ __COMPLETION_BLOCK__
         sys.stdout.flush()
     elif method == "thread/read":
         thread_id = message["params"]["threadId"]
+        if START_THREAD_PATH and ROLLOUT_ENTRIES_ON_READ:
+            os.makedirs(os.path.dirname(START_THREAD_PATH), exist_ok=True)
+            with open(START_THREAD_PATH, "a", encoding="utf-8") as rollout_handle:
+                for rollout_entry in ROLLOUT_ENTRIES_ON_READ:
+                    rollout_handle.write(json.dumps(rollout_entry) + "\\n")
         turn_status = "completed" if turn_completed else "inProgress"
         turn_items = []
         if turn_completed:
@@ -294,6 +301,7 @@ __COMPLETION_BLOCK__
         .replace("__ASSISTANT_TEXT__", repr(assistant_text))
         .replace("__THREAD_STATUS_TYPE__", repr(thread_status_type))
         .replace("__THREAD_STATUS_REASON__", repr(thread_status_reason))
+        .replace("__ROLLOUT_ENTRIES_ON_READ__", repr(rollout_entries_on_read or []))
         .replace("__COMPLETION_BLOCK__", completion_block),
         encoding="utf-8",
     )

--- a/tests/unit/api/routers/test_task_runs.py
+++ b/tests/unit/api/routers/test_task_runs.py
@@ -367,6 +367,57 @@ def test_get_observability_summary_preserves_active_record_snapshot_and_events_r
     }
 
 
+def test_get_observability_summary_prefers_fresh_session_record(
+    client: tuple[TestClient, AsyncMock],
+) -> None:
+    test_client, _ = client
+    run_id = uuid4()
+    mock_record = MagicMock()
+    mock_record.model_dump.return_value = {
+        "status": "running",
+        "sessionId": "sess-stale",
+        "sessionEpoch": 1,
+        "containerId": "ctr-stale",
+        "threadId": "thread-stale",
+        "activeTurnId": None,
+    }
+    mock_record.status = "running"
+    mock_record.live_stream_capable = True
+    session_record = CodexManagedSessionRecord(
+        sessionId="sess-fresh",
+        sessionEpoch=2,
+        taskRunId=str(run_id),
+        containerId="ctr-fresh",
+        threadId="thread-fresh",
+        runtimeId="codex_cli",
+        imageRef="img",
+        controlUrl="docker-exec://ctr-fresh",
+        status="busy",
+        workspacePath="/work/repo",
+        sessionWorkspacePath="/work/session",
+        artifactSpoolPath="/work/artifacts",
+        activeTurnId="turn-fresh",
+        startedAt=datetime(2026, 4, 6, 12, 0, tzinfo=UTC),
+    )
+
+    with patch("api_service.api.routers.task_runs.ManagedRunStore.load", return_value=mock_record):
+        with patch(
+            "api_service.api.routers.task_runs._load_task_run_session_record",
+            return_value=session_record,
+        ):
+            response = test_client.get(f"/api/task-runs/{run_id}/observability-summary")
+
+    assert response.status_code == 200
+    body = response.json()["summary"]
+    assert body["sessionId"] == "sess-fresh"
+    assert body["sessionEpoch"] == 2
+    assert body["containerId"] == "ctr-fresh"
+    assert body["threadId"] == "thread-fresh"
+    assert body["activeTurnId"] == "turn-fresh"
+    assert body["sessionStatus"] == "busy"
+    assert body["sessionSnapshot"]["activeTurnId"] == "turn-fresh"
+
+
 def test_get_observability_summary_live_stream_ended_for_terminal_run(
     client: tuple[TestClient, AsyncMock],
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -145,6 +145,98 @@ def test_runtime_send_turn_returns_terminal_completed_response(
     assert handle.metadata["lastAssistantText"] == "OK"
 
 
+def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
+    tmp_path: Path,
+) -> None:
+    request = launch_request(tmp_path)
+    rollout_path = (
+        Path(request.codex_home_path)
+        / "sessions"
+        / "2026"
+        / "04"
+        / "15"
+        / "rollout-2026-04-15T06-04-58-vendor-thread-1.jsonl"
+    )
+    rollout_path.parent.mkdir(parents=True)
+    rollout_path.write_text("", encoding="utf-8")
+    script = write_fake_app_server(
+        tmp_path,
+        start_thread_path=str(rollout_path),
+        rollout_entries_on_read=[
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "arguments": "{}",
+                    "call_id": "call-1",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "live-output-works\n",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "event_msg",
+                "payload": {
+                    "type": "agent_message",
+                    "message": "Streaming update",
+                    "phase": "commentary",
+                },
+            },
+            {
+                "timestamp": _iso_timestamp(minutes_offset=0),
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Streaming update"},
+                    ],
+                    "phase": "commentary",
+                },
+            },
+        ],
+    )
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+    runtime.launch_session(request)
+
+    response = runtime.send_turn(
+        SendCodexManagedSessionTurnRequest(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="ctr-1",
+            threadId="logical-thread-1",
+            instructions="Reply with exactly the word OK",
+        )
+    )
+
+    assert response.status == "completed"
+    stdout_text = (Path(request.artifact_spool_path) / "stdout.log").read_text(
+        encoding="utf-8"
+    )
+    assert "turn started: vendor-turn-1" in stdout_text
+    assert "tool call: exec_command" in stdout_text
+    assert "tool output:\nlive-output-works\n" in stdout_text
+    assert stdout_text.count("assistant: Streaming update\n") == 1
+
+
 def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_output(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -17,7 +17,9 @@ from moonmind.schemas.managed_session_models import (
 from moonmind.workflows.temporal.runtime.codex_session_runtime import (
     CodexAppServerRpcClient,
     CodexManagedSessionRuntime,
+    CodexSessionRuntimeState,
     _ROLLOUT_RECOVERY_MAX_BYTES,
+    _RolloutLiveMirror,
     _run_ready,
 )
 from tests.helpers.codex_session_runtime import (
@@ -53,6 +55,34 @@ def _write_fake_codex_logs(
     finally:
         connection.close()
     return log_path
+
+
+def _runtime_for_rollout_mirror(tmp_path: Path) -> CodexManagedSessionRuntime:
+    request = launch_request(tmp_path)
+    return CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", "-c", "pass"),
+    )
+
+
+def _rollout_state(*, rollout_path: Path) -> CodexSessionRuntimeState:
+    return CodexSessionRuntimeState(
+        sessionId="sess-1",
+        sessionEpoch=1,
+        logicalThreadId="logical-thread-1",
+        vendorThreadId="vendor-thread-1",
+        vendorThreadPath=str(rollout_path),
+        containerId="ctr-1",
+        activeTurnId="vendor-turn-1",
+        lastTurnId="vendor-turn-1",
+        lastTurnStatus="running",
+    )
 
 
 def test_app_server_client_ignores_notifications_until_matching_response(
@@ -235,6 +265,128 @@ def test_runtime_send_turn_mirrors_rollout_updates_to_stdout_spool(
     assert "tool call: exec_command" in stdout_text
     assert "tool output:\nlive-output-works\n" in stdout_text
     assert stdout_text.count("assistant: Streaming update\n") == 1
+
+
+def test_runtime_rollout_live_mirror_preserves_incomplete_tail(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_for_rollout_mirror(tmp_path)
+    rollout_path = (
+        runtime._codex_home_path
+        / "sessions"
+        / "2026"
+        / "04"
+        / "15"
+        / "rollout-2026-04-15T06-04-58-vendor-thread-1.jsonl"
+    )
+    rollout_path.parent.mkdir(parents=True)
+    complete_line = json.dumps(
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call-1",
+            },
+        }
+    )
+    partial_line = json.dumps(
+        {
+            "timestamp": _iso_timestamp(minutes_offset=0),
+            "type": "response_item",
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "call-1",
+                "output": "complete after next poll",
+            },
+        }
+    )
+    split_at = partial_line.index("complete after")
+    rollout_path.write_text(
+        complete_line + "\n" + partial_line[:split_at],
+        encoding="utf-8",
+    )
+    mirror = _RolloutLiveMirror(path=str(rollout_path), offset=0)
+
+    runtime._publish_rollout_live_updates(
+        state=_rollout_state(rollout_path=rollout_path),
+        vendor_turn_id="vendor-turn-1",
+        thread_payload={},
+        mirror=mirror,
+    )
+
+    stdout_path = runtime._artifact_spool_path / "stdout.log"
+    assert stdout_path.read_text(encoding="utf-8") == "tool call: exec_command\n"
+    assert mirror.offset == len((complete_line + "\n").encode("utf-8"))
+
+    with rollout_path.open("a", encoding="utf-8") as handle:
+        handle.write(partial_line[split_at:] + "\n")
+
+    runtime._publish_rollout_live_updates(
+        state=_rollout_state(rollout_path=rollout_path),
+        vendor_turn_id="vendor-turn-1",
+        thread_payload={},
+        mirror=mirror,
+    )
+
+    assert stdout_path.read_text(encoding="utf-8") == (
+        "tool call: exec_command\n"
+        "tool output:\ncomplete after next poll\n"
+    )
+    assert mirror.offset == rollout_path.stat().st_size
+
+
+def test_runtime_rollout_live_mirror_keeps_repeated_identical_tool_events(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_for_rollout_mirror(tmp_path)
+    rollout_path = (
+        runtime._codex_home_path
+        / "sessions"
+        / "2026"
+        / "04"
+        / "15"
+        / "rollout-2026-04-15T06-04-58-vendor-thread-1.jsonl"
+    )
+    rollout_path.parent.mkdir(parents=True)
+    duplicate_call = {
+        "timestamp": _iso_timestamp(minutes_offset=0),
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "name": "exec_command",
+        },
+    }
+    rollout_path.write_text(
+        json.dumps(duplicate_call) + "\n" + json.dumps(duplicate_call) + "\n",
+        encoding="utf-8",
+    )
+    mirror = _RolloutLiveMirror(path=str(rollout_path), offset=0)
+
+    runtime._publish_rollout_live_updates(
+        state=_rollout_state(rollout_path=rollout_path),
+        vendor_turn_id="vendor-turn-1",
+        thread_payload={},
+        mirror=mirror,
+    )
+
+    stdout_text = (runtime._artifact_spool_path / "stdout.log").read_text(
+        encoding="utf-8"
+    )
+    assert stdout_text == "tool call: exec_command\ntool call: exec_command\n"
+    assert mirror.offset == rollout_path.stat().st_size
+
+    runtime._publish_rollout_live_updates(
+        state=_rollout_state(rollout_path=rollout_path),
+        vendor_turn_id="vendor-turn-1",
+        thread_payload={},
+        mirror=mirror,
+    )
+
+    assert (runtime._artifact_spool_path / "stdout.log").read_text(
+        encoding="utf-8"
+    ) == stdout_text
 
 
 def test_runtime_session_status_fails_when_completed_turn_has_no_assistant_output(

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -231,6 +231,50 @@ async def test_session_supervisor_syncs_active_turn_from_runtime_state(
 
 
 @pytest.mark.asyncio
+async def test_session_supervisor_ignores_terminal_runtime_active_turn(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    state_path = Path(record.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessionId": record.session_id,
+                "sessionEpoch": record.session_epoch,
+                "logicalThreadId": record.thread_id,
+                "vendorThreadId": "vendor-thread-1",
+                "containerId": record.container_id,
+                "activeTurnId": "vendor-turn-1",
+                "lastTurnId": "vendor-turn-1",
+                "lastTurnStatus": "completed",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    await supervisor.start(record)
+    await asyncio.sleep(0.05)
+
+    watched = store.load("sess-1")
+    assert watched is not None
+    assert watched.status == "ready"
+    assert watched.active_turn_id is None
+    assert not (Path(record.workspace_path) / "live_streams.spool").exists()
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
 async def test_session_supervisor_resumes_from_persisted_stream_offsets(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_supervisor.py
@@ -160,6 +160,77 @@ async def test_session_supervisor_publishes_output_chunks_to_live_spool(
 
 
 @pytest.mark.asyncio
+async def test_session_supervisor_syncs_active_turn_from_runtime_state(
+    tmp_path: Path,
+) -> None:
+    store = ManagedSessionStore(tmp_path / "store")
+    artifact_storage = _LocalArtifactStorage(tmp_path / "published")
+    supervisor = ManagedSessionSupervisor(
+        store=store,
+        log_streamer=RuntimeLogStreamer(artifact_storage),
+        artifact_storage=artifact_storage,
+        poll_interval_seconds=0.01,
+    )
+    record = _record(tmp_path)
+    store.save(record)
+    state_path = Path(record.session_workspace_path) / ".moonmind-codex-session-state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessionId": record.session_id,
+                "sessionEpoch": record.session_epoch,
+                "logicalThreadId": record.thread_id,
+                "vendorThreadId": "vendor-thread-1",
+                "containerId": record.container_id,
+                "activeTurnId": "vendor-turn-1",
+                "lastTurnId": "vendor-turn-1",
+                "lastTurnStatus": "running",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    await supervisor.start(record)
+    await asyncio.sleep(0.05)
+
+    watched = store.load("sess-1")
+    assert watched is not None
+    assert watched.status == "busy"
+    assert watched.active_turn_id == "vendor-turn-1"
+    assert watched.updated_at is not None
+
+    live_spool = Path(record.workspace_path) / "live_streams.spool"
+    payloads = [
+        json.loads(line)
+        for line in live_spool.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert payloads == [
+        {
+            "runId": "task-1",
+            "sequence": 1,
+            "stream": "session",
+            "timestamp": payloads[0]["timestamp"],
+            "text": "Turn started: vendor-turn-1.",
+            "kind": "turn_started",
+            "sessionId": "sess-1",
+            "sessionEpoch": 1,
+            "containerId": "ctr-1",
+            "threadId": "thread-1",
+            "turnId": "vendor-turn-1",
+            "activeTurnId": "vendor-turn-1",
+            "metadata": {
+                "action": "send_turn",
+                "source": "managed_session_runtime_state",
+            },
+        }
+    ]
+
+    await supervisor.finalize("sess-1", status="terminated")
+
+
+@pytest.mark.asyncio
 async def test_session_supervisor_resumes_from_persisted_stream_offsets(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_agent_session_deployment_safety.py
+++ b/tests/unit/workflows/temporal/test_agent_session_deployment_safety.py
@@ -103,7 +103,7 @@ def test_validate_cli_main_includes_git_stderr_in_failure(monkeypatch, capsys) -
         lambda *, repo_root, active_feature: None,
     )
 
-    assert cli.main() == 1
+    assert cli.main([]) == 1
     captured = capsys.readouterr()
     assert "fatal: bad revision" in captured.err
     assert "merge-base failed" in captured.err

--- a/tools/validate_agent_session_deployment_safety.py
+++ b/tools/validate_agent_session_deployment_safety.py
@@ -45,7 +45,7 @@ def _repo_paths() -> list[str]:
     return sorted(set(tracked + untracked))
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Validate AgentSession workflow deployment-safety gates."
     )
@@ -59,7 +59,7 @@ def main() -> int:
             "the intended feature artifacts."
         ),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     playbook = REPO_ROOT / AGENT_SESSION_CUTOVER_PLAYBOOK_PATH
     playbook_text = playbook.read_text(encoding="utf-8") if playbook.exists() else ""


### PR DESCRIPTION
## Summary

Fixes Codex managed-session Live Logs so running turns publish visible in-flight output instead of only showing session start and turn start rows.

## What changed

- Mirrors selected Codex rollout entries into the managed-session stdout/stderr spool while `send_turn` is still running.
- Reconciles active turn state from the container session state file so Live Logs and observability summaries expose the current `activeTurnId` before the long-running activity returns.
- Makes `/observability-summary` prefer the fresher managed-session record for session header fields when the run record is stale.
- Updates canonical Live Logs, Codex managed-session, Mission Control, and temporary tracker docs.
- Adds focused regression coverage for rollout mirroring, active-turn reconciliation, and summary freshness.
- Fixes the deployment-safety CLI test boundary by allowing explicit argv injection.

## Root Cause

Codex App Server was writing useful in-flight activity to its rollout transcript, but MoonMind only copied session startup, turn startup, and final assistant/error text into the artifact spool that Live Logs tails. The API summary could also report stale session state because the managed run record was not updated until `send_turn` reached a terminal response.

## Validation

- `./tools/test_unit.sh --python-only --no-xdist`
  - `3075 passed, 1 xpassed, 89 warnings`
