### PR TITLE
Complete Jira issue MM-326: Fix Docker image build ID shown in Mission Control

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,23 @@ env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
 
 jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      image_name: ${{ steps.meta.outputs.image_name }}
+      version_tag: ${{ steps.meta.outputs.version_tag }}
+    steps:
+      - name: Generate image metadata
+        id: meta
+        run: |
+          VERSION_TAG="$(date -u +'%Y%m%d').${{ github.run_number }}"
+          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          IMAGE_NAME="${{ env.REGISTRY_IMAGE }}"
+          IMAGE_NAME="$(printf '%s' "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: metadata
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -74,8 +90,8 @@ jobs:
         id: meta
         run: |
           platform=${{ matrix.platform }}
-          echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
-          echo "image_name=$(echo '${{ env.REGISTRY_IMAGE }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "pair=${platform//\//-}" >> "$GITHUB_OUTPUT"
+          echo "image_name=${{ needs.metadata.outputs.image_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest
         id: build
@@ -86,6 +102,7 @@ jobs:
           build-args: |
             INSTALL_CODEX_CLI=true
             INSTALL_GEMINI_CLI=true
+            MOONMIND_BUILD_ID=${{ needs.metadata.outputs.version_tag }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ steps.meta.outputs.image_name }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=build-${{ steps.meta.outputs.pair }}
@@ -107,7 +124,9 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - metadata
+      - build
     permissions:
       contents: read
       packages: write
@@ -129,24 +148,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Generate Image Tags
-        id: meta
-        run: |
-          VERSION_TAG=$(date +'%Y%m%d').${{ github.run_number }}
-          echo "version_tag=${VERSION_TAG}" >> $GITHUB_OUTPUT
-          IMAGE_NAME="${{ env.REGISTRY_IMAGE }}"
-          echo "image_name=$(echo $IMAGE_NAME | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
-          IMAGE_NAME="${{ steps.meta.outputs.image_name }}"
+          IMAGE_NAME="${{ needs.metadata.outputs.image_name }}"
           docker buildx imagetools create \
-            -t "${IMAGE_NAME}:${{ steps.meta.outputs.version_tag }}" \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}" \
             -t "${IMAGE_NAME}:latest" \
             $(printf "${IMAGE_NAME}@sha256:%s " *)
 
       - name: Inspect image
         run: |
-          IMAGE_NAME="${{ steps.meta.outputs.image_name }}"
+          IMAGE_NAME="${{ needs.metadata.outputs.image_name }}"
           docker buildx imagetools inspect "${IMAGE_NAME}:latest"

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docker-publish.yml"
+
+
+def _load_workflow() -> dict:
+    assert WORKFLOW_PATH.exists(), f"Missing workflow: {WORKFLOW_PATH}"
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def test_docker_publish_generates_version_before_platform_builds() -> None:
+    workflow = _load_workflow()
+
+    metadata_job = workflow["jobs"]["metadata"]
+    assert metadata_job["outputs"]["version_tag"] == "${{ steps.meta.outputs.version_tag }}"
+
+    metadata_run = next(
+        step["run"] for step in metadata_job["steps"] if step["name"] == "Generate image metadata"
+    )
+    assert "date -u +'%Y%m%d'" in metadata_run
+    assert "github.run_number" in metadata_run
+    assert "version_tag=${VERSION_TAG}" in metadata_run
+
+    build_job = workflow["jobs"]["build"]
+    assert build_job["needs"] == "metadata"
+
+
+def test_docker_publish_passes_manifest_tag_into_image_build_metadata() -> None:
+    workflow = _load_workflow()
+
+    build_steps = workflow["jobs"]["build"]["steps"]
+    build_push_step = next(
+        step for step in build_steps if step["name"] == "Build and push by digest"
+    )
+    build_args = build_push_step["with"]["build-args"]
+    assert "MOONMIND_BUILD_ID=${{ needs.metadata.outputs.version_tag }}" in build_args
+
+    merge_job = workflow["jobs"]["merge"]
+    assert merge_job["needs"] == ["metadata", "build"]
+
+    merge_run_steps = [step["run"] for step in merge_job["steps"] if "run" in step]
+    assert any(
+        "-t \"${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}\"" in run
+        for run in merge_run_steps
+    )
+    assert all("date +" not in run and "VERSION_TAG=" not in run for run in merge_run_steps)

--- a/tests/unit/test_docker_publish_workflow.py
+++ b/tests/unit/test_docker_publish_workflow.py
@@ -18,11 +18,20 @@ def test_docker_publish_generates_version_before_platform_builds() -> None:
     workflow = _load_workflow()
 
     metadata_job = workflow["jobs"]["metadata"]
-    assert metadata_job["outputs"]["version_tag"] == "${{ steps.meta.outputs.version_tag }}"
+    assert (
+        metadata_job.get("outputs", {}).get("version_tag")
+        == "${{ steps.meta.outputs.version_tag }}"
+    )
 
     metadata_run = next(
-        step["run"] for step in metadata_job["steps"] if step["name"] == "Generate image metadata"
+        (
+            step["run"]
+            for step in metadata_job.get("steps", [])
+            if step.get("name") == "Generate image metadata" and "run" in step
+        ),
+        None,
     )
+    assert metadata_run, "Step 'Generate image metadata' with 'run' command not found"
     assert "date -u +'%Y%m%d'" in metadata_run
     assert "github.run_number" in metadata_run
     assert "version_tag=${VERSION_TAG}" in metadata_run
@@ -36,17 +45,21 @@ def test_docker_publish_passes_manifest_tag_into_image_build_metadata() -> None:
 
     build_steps = workflow["jobs"]["build"]["steps"]
     build_push_step = next(
-        step for step in build_steps if step["name"] == "Build and push by digest"
+        (step for step in build_steps if step.get("name") == "Build and push by digest"),
+        None,
     )
-    build_args = build_push_step["with"]["build-args"]
+    assert (
+        build_push_step and "with" in build_push_step
+    ), "Step 'Build and push by digest' not found or missing 'with' key"
+    build_args = build_push_step["with"].get("build-args", "")
     assert "MOONMIND_BUILD_ID=${{ needs.metadata.outputs.version_tag }}" in build_args
 
     merge_job = workflow["jobs"]["merge"]
-    assert merge_job["needs"] == ["metadata", "build"]
+    assert set(merge_job.get("needs", [])) == {"metadata", "build"}
 
     merge_run_steps = [step["run"] for step in merge_job["steps"] if "run" in step]
     assert any(
-        "-t \"${IMAGE_NAME}:${{ needs.metadata.outputs.version_tag }}\"" in run
+        "${IMAGE_NAME}:" in run and "${{ needs.metadata.outputs.version_tag }}" in run
         for run in merge_run_steps
     )
     assert all("date +" not in run and "VERSION_TAG=" not in run for run in merge_run_steps)


### PR DESCRIPTION
Complete Jira issue MM-326: Fix Docker image build ID shown in Mission Control

Description
Objective
Fix the Docker publish pipeline so the Mission Control header build badge reflects the actual published MoonMind image tag/version.
Observed behavior
The operator pulled and recreated containers for ghcr.io/moonladderstudios/moonmind:latest / 20260415.1896. Docker shows latest and 20260415.1896 resolving to the same fresh digest sha256:28b395134369291944633cfe27988ef0483f168213a17c5c98de2cf0b6c07945, with the local image created on 2026-04-15 at 06:24 UTC and the API container recreated at 06:33 UTC. Mission Control still renders v20260408.0543.
Root cause hypothesis
Mission Control reads build metadata from /app/.moonmind-build-id through moonmind/utils/build_info.py and renders it in api_service/templates/react_dashboard.html. The Dockerfile writes that file from ARG MOONMIND_BUILD_ID, or falls back to date -u. The GitHub Docker publish workflow currently computes the version tag in the merge job, after the platform images are already built, and the build job does not pass MOONMIND_BUILD_ID. Because the build metadata RUN layer has no changing input, BuildKit can reuse a stale layer from 2026-04-08 even for a fresh 20260415.1896 manifest.
Requirements
- Compute the MoonMind image version before docker/build-push-action builds each platform image, or otherwise make the generated version available to the build job.
- Pass the version into api_service/Dockerfile as MOONMIND_BUILD_ID so /app/.moonmind-build-id equals the published version tag.
- Prevent Docker cache reuse from preserving an old build-id file when a new version is published.
- Keep MOONMIND_BUILD_ID environment override behavior intact for local/operator overrides.
Implementation notes
Likely files: .github/workflows/docker-publish.yml and api_service/Dockerfile. Consider generating VERSION_TAG once at workflow level or in a preliminary job, using it both for build args and manifest tags. The current manifest tag format is YYYYMMDD.github_run_number, for example 20260415.1896.

Acceptance criteria
- A newly published image tagged 20260415.x has /app/.moonmind-build-id set to that same 20260415.x value for both amd64 and arm64 platform images.
- Mission Control header and boot payload system.buildId show the same current build id after docker compose pull and container recreation.
- docker build cache cannot leave /app/.moonmind-build-id at a previous publish date when the version tag changes.
- Add or update workflow/Docker metadata validation where practical, or document why this is covered by publish inspection instead.
Verification commands
- docker buildx imagetools inspect ghcr.io/moonladderstudios/moonmind:<new-version>
- docker run --rm --entrypoint sh ghcr.io/moonladderstudios/moonmind:<new-version> -lc 'head -n 1 /app/.moonmind-build-id'
- curl -fsS http://localhost:5000/tasks/list | rg "version-badge|buildId