### PR TITLE
When you click either the Replace target text or the Append to target text option in the jira story pop-up window, it should execute the requested opt

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4797,6 +4797,99 @@ describe("Task Create Entrypoint", () => {
     ).toBe("Jira: ENG-202");
   });
 
+  it("keeps a reopened Jira browser open after a slow image import finishes", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    const imageDownload: { resolve: (() => void) | null } = { resolve: null };
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            url: "https://jira.example.test/browse/ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            acceptanceCriteriaText:
+              "Given a board, users can select a story preview.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        return new Promise<Response>((resolve) => {
+          imageDownload.resolve = () => {
+            resolve({
+              ok: true,
+              blob: async () => new Blob(["fake image"], { type: "image/png" }),
+            } as Response);
+          };
+        });
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Browse Jira issue for preset instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    expect(await screen.findByText("Let operators browse Jira stories."))
+      .toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Replace target text" }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
+    await waitFor(() => {
+      expect(imageDownload.resolve).not.toBeNull();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 instructions",
+      }),
+    );
+    expect(
+      await screen.findByRole("dialog", { name: "Browse Jira issue" }),
+    ).toBeTruthy();
+
+    if (!imageDownload.resolve) {
+      throw new Error("Expected Jira image download to be pending.");
+    }
+    imageDownload.resolve();
+    expect(await screen.findByText("wireframe.png (10 B)")).toBeTruthy();
+    expect(
+      screen.getByRole("dialog", { name: "Browse Jira issue" }),
+    ).toBeTruthy();
+  });
+
   it("reopens Jira from an imported field with the prior issue selected", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4463,8 +4463,12 @@ describe("Task Create Entrypoint", () => {
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing preset instructions.",
     );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
 
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
     fireEvent.click(
       screen.getByRole("button", {
         name: "Browse Jira issue for Step 1 instructions",
@@ -4483,6 +4487,11 @@ describe("Task Create Entrypoint", () => {
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing step instructions.",
     );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
   });
 
   it("imports selected Jira text by mode", async () => {
@@ -4512,6 +4521,11 @@ describe("Task Create Entrypoint", () => {
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Given a board, users can select a story preview.",
     );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
   });
 
   it("marks preset instructions as needing reapply after Jira import changes an applied preset", async () => {
@@ -4760,8 +4774,12 @@ describe("Task Create Entrypoint", () => {
         "Jira import provenance for Feature Request / Initial Instructions",
       ).textContent,
     ).toBe("Jira: ENG-202");
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
 
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
     fireEvent.click(
       screen.getByRole("button", {
         name: "Browse Jira issue for Step 1 instructions",
@@ -4794,7 +4812,11 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Replace target text" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -4849,7 +4871,11 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Replace target text" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -4902,8 +4928,12 @@ describe("Task Create Entrypoint", () => {
         "Jira import provenance for Feature Request / Initial Instructions",
       ),
     ).toBeNull();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
 
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
     fireEvent.click(
       screen.getByRole("button", {
         name: "Browse Jira issue for Step 1 instructions",
@@ -5016,7 +5046,11 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Replace target text" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Close Jira browser" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2762,67 +2762,71 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!selectedJiraIssue || !jiraImportTarget) {
       return;
     }
-    if (!selectedJiraImportText.trim()) {
-      return;
-    }
-    if (jiraImportTarget.kind === "preset") {
-      const nextText = writeJiraImportedText(
-        templateFeatureRequest,
-        selectedJiraImportText,
-        writeMode,
-      );
-      if (nextText.trim() === templateFeatureRequest.trim()) {
+    try {
+      if (!selectedJiraImportText.trim()) {
         return;
       }
-      setTemplateFeatureRequest(nextText);
-      setPresetJiraProvenance(
-        createJiraProvenance(
-          selectedJiraIssue,
-          selectedJiraBoardId,
-          jiraImportMode,
-          jiraImportTarget,
-        ),
-      );
-      if (appliedTemplates.length > 0) {
-        setPresetReapplyNeeded(true);
+      if (jiraImportTarget.kind === "preset") {
+        const nextText = writeJiraImportedText(
+          templateFeatureRequest,
+          selectedJiraImportText,
+          writeMode,
+        );
+        if (nextText.trim() === templateFeatureRequest.trim()) {
+          return;
+        }
+        setTemplateFeatureRequest(nextText);
+        setPresetJiraProvenance(
+          createJiraProvenance(
+            selectedJiraIssue,
+            selectedJiraBoardId,
+            jiraImportMode,
+            jiraImportTarget,
+          ),
+        );
+        if (appliedTemplates.length > 0) {
+          setPresetReapplyNeeded(true);
+        }
+        await importSelectedJiraImages(selectedJiraIssue, steps[0]?.localId);
+        return;
       }
-      await importSelectedJiraImages(selectedJiraIssue, steps[0]?.localId);
-      return;
-    }
 
-    const targetStep = steps.find(
-      (step) => step.localId === jiraImportTarget.localId,
-    );
-    if (!targetStep) {
-      return;
+      const targetStep = steps.find(
+        (step) => step.localId === jiraImportTarget.localId,
+      );
+      if (!targetStep) {
+        return;
+      }
+      updateStep(jiraImportTarget.localId, {
+        instructions: writeJiraImportedText(
+          targetStep.instructions,
+          selectedJiraImportText,
+          writeMode,
+        ),
+      });
+      const provenance = createJiraProvenance(
+        selectedJiraIssue,
+        selectedJiraBoardId,
+        jiraImportMode,
+        jiraImportTarget,
+      );
+      setStepJiraProvenance((current) => {
+        if (provenance) {
+          return {
+            ...current,
+            [jiraImportTarget.localId]: provenance,
+          };
+        }
+        if (!current[jiraImportTarget.localId]) {
+          return current;
+        }
+        const { [jiraImportTarget.localId]: _removed, ...rest } = current;
+        return rest;
+      });
+      await importSelectedJiraImages(selectedJiraIssue, jiraImportTarget.localId);
+    } finally {
+      closeJiraBrowser();
     }
-    updateStep(jiraImportTarget.localId, {
-      instructions: writeJiraImportedText(
-        targetStep.instructions,
-        selectedJiraImportText,
-        writeMode,
-      ),
-    });
-    const provenance = createJiraProvenance(
-      selectedJiraIssue,
-      selectedJiraBoardId,
-      jiraImportMode,
-      jiraImportTarget,
-    );
-    setStepJiraProvenance((current) => {
-      if (provenance) {
-        return {
-          ...current,
-          [jiraImportTarget.localId]: provenance,
-        };
-      }
-      if (!current[jiraImportTarget.localId]) {
-        return current;
-      }
-      const { [jiraImportTarget.localId]: _removed, ...rest } = current;
-      return rest;
-    });
-    await importSelectedJiraImages(selectedJiraIssue, jiraImportTarget.localId);
   }
 
   function handleTemplateFeatureRequestChange(value: string) {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2759,74 +2759,71 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }
 
   async function importSelectedJiraIssue(writeMode: JiraWriteMode) {
-    if (!selectedJiraIssue || !jiraImportTarget) {
+    closeJiraBrowser();
+    const issue = selectedJiraIssue;
+    const importTarget = jiraImportTarget;
+    if (!issue || !importTarget) {
       return;
     }
-    try {
-      if (!selectedJiraImportText.trim()) {
-        return;
-      }
-      if (jiraImportTarget.kind === "preset") {
-        const nextText = writeJiraImportedText(
-          templateFeatureRequest,
-          selectedJiraImportText,
-          writeMode,
-        );
-        if (nextText.trim() === templateFeatureRequest.trim()) {
-          return;
-        }
-        setTemplateFeatureRequest(nextText);
-        setPresetJiraProvenance(
-          createJiraProvenance(
-            selectedJiraIssue,
-            selectedJiraBoardId,
-            jiraImportMode,
-            jiraImportTarget,
-          ),
-        );
-        if (appliedTemplates.length > 0) {
-          setPresetReapplyNeeded(true);
-        }
-        await importSelectedJiraImages(selectedJiraIssue, steps[0]?.localId);
-        return;
-      }
-
-      const targetStep = steps.find(
-        (step) => step.localId === jiraImportTarget.localId,
-      );
-      if (!targetStep) {
-        return;
-      }
-      updateStep(jiraImportTarget.localId, {
-        instructions: writeJiraImportedText(
-          targetStep.instructions,
-          selectedJiraImportText,
-          writeMode,
-        ),
-      });
-      const provenance = createJiraProvenance(
-        selectedJiraIssue,
-        selectedJiraBoardId,
-        jiraImportMode,
-        jiraImportTarget,
-      );
-      setStepJiraProvenance((current) => {
-        if (provenance) {
-          return {
-            ...current,
-            [jiraImportTarget.localId]: provenance,
-          };
-        }
-        if (!current[jiraImportTarget.localId]) {
-          return current;
-        }
-        const { [jiraImportTarget.localId]: _removed, ...rest } = current;
-        return rest;
-      });
-      await importSelectedJiraImages(selectedJiraIssue, jiraImportTarget.localId);
-    } finally {
-      closeJiraBrowser();
+    if (!selectedJiraImportText.trim()) {
+      return;
     }
+    if (importTarget.kind === "preset") {
+      const nextText = writeJiraImportedText(
+        templateFeatureRequest,
+        selectedJiraImportText,
+        writeMode,
+      );
+      if (nextText.trim() === templateFeatureRequest.trim()) {
+        return;
+      }
+      setTemplateFeatureRequest(nextText);
+      setPresetJiraProvenance(
+        createJiraProvenance(
+          issue,
+          selectedJiraBoardId,
+          jiraImportMode,
+          importTarget,
+        ),
+      );
+      if (appliedTemplates.length > 0) {
+        setPresetReapplyNeeded(true);
+      }
+      await importSelectedJiraImages(issue, steps[0]?.localId);
+      return;
+    }
+
+    const targetStep = steps.find((step) => step.localId === importTarget.localId);
+    if (!targetStep) {
+      return;
+    }
+    updateStep(importTarget.localId, {
+      instructions: writeJiraImportedText(
+        targetStep.instructions,
+        selectedJiraImportText,
+        writeMode,
+      ),
+    });
+    const provenance = createJiraProvenance(
+      issue,
+      selectedJiraBoardId,
+      jiraImportMode,
+      importTarget,
+    );
+    setStepJiraProvenance((current) => {
+      if (provenance) {
+        return {
+          ...current,
+          [importTarget.localId]: provenance,
+        };
+      }
+      if (!current[importTarget.localId]) {
+        return current;
+      }
+      const { [importTarget.localId]: _removed, ...rest } = current;
+      return rest;
+    });
+    await importSelectedJiraImages(issue, importTarget.localId);
   }
 
   function handleTemplateFeatureRequestChange(value: string) {


### PR DESCRIPTION
When you click either the Replace target text or the Append to target text option in the jira story pop-up window, it should execute the requested option and then close the pop-up. It should not wait for you to close it manually afterward.