### PR TITLE
When the Jira Breakdown preset is selected, the default behavior of the Create Page should be to set publish mode to none (similar to what happens whe

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2771,6 +2771,70 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("defaults publish mode to none when selecting the Jira Breakdown preset", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown",
+                scope: "global",
+                title: "Jira Breakdown",
+                description: "Create Jira stories from a breakdown.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+              {
+                slug: "moonspec-orchestrate",
+                scope: "global",
+                title: "MoonSpec Orchestrate",
+                description: "Keep the default preset off Jira Breakdown.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Jira Breakdown (Global)",
+        ),
+      ).toBe(true);
+    });
+    await waitFor(() => {
+      expect((presetSelect as HTMLSelectElement).value).toBe(
+        "global::::moonspec-orchestrate",
+      );
+    });
+
+    const publishSelect = screen.getByLabelText(
+      "Publish Mode",
+    ) as HTMLSelectElement;
+    expect(publishSelect.value).toBe("pr");
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::jira-breakdown" },
+    });
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
+    });
+  });
+
   it("submits publish mode none when the selected primary skill is pr-resolver", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2835,6 +2835,46 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
+  it("preserves draft publish mode in edit mode when Jira Breakdown is the selected preset", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/task-step-templates?scope=global")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                slug: "jira-breakdown",
+                scope: "global",
+                title: "Jira Breakdown",
+                description: "Create Jira stories from a breakdown.",
+                latestVersion: "1.0.0",
+                version: "1.0.0",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderForEdit("mm:edit-123");
+
+    expect(await screen.findByRole("heading", { name: "Edit Task" })).toBeTruthy();
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect((presetSelect as HTMLSelectElement).value).toBe(
+        "global::::jira-breakdown",
+      );
+    });
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("branch");
+    });
+  });
+
   it("submits publish mode none when the selected primary skill is pr-resolver", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2480,10 +2480,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     templateItems.find((item) => item.key === selectedPresetKey) || null;
 
   useEffect(() => {
-    if (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG) {
+    if (
+      pageMode.mode === "create" &&
+      selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG
+    ) {
       setPublishMode("none");
     }
-  }, [selectedPreset?.slug]);
+  }, [pageMode.mode, selectedPreset?.slug]);
 
   const availableDependencyOptions = useMemo(
     () =>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -20,6 +20,7 @@ const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
 const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
+const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
 const PROPOSE_TASKS_PREFERENCE_KEY = "moonmind.task-create.propose-tasks";
 const JIRA_LAST_PROJECT_SESSION_KEY =
   "moonmind.task-create.jira.last-project-key";
@@ -2477,6 +2478,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
   const selectedPreset =
     templateItems.find((item) => item.key === selectedPresetKey) || null;
+
+  useEffect(() => {
+    if (selectedPreset?.slug === JIRA_BREAKDOWN_PRESET_SLUG) {
+      setPublishMode("none");
+    }
+  }, [selectedPreset?.slug]);
 
   const availableDependencyOptions = useMemo(
     () =>


### PR DESCRIPTION
When the Jira Breakdown preset is selected, the default behavior of the Create Page should be to set publish mode to none (similar to what happens when pr-resolver is chosen).