### PR TITLE
[codex] Preserve provider slot continuity between steps

### DIFF
--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -185,10 +185,14 @@ def _request_reserves_slot_for_immediate_followup(
     moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
     continuity = moonmind_map.get("slotContinuity")
     continuity_map = continuity if isinstance(continuity, Mapping) else {}
-    return bool(
-        continuity_map.get("reserveForImmediateFollowup")
-        or continuity_map.get("hasImmediateManagedFollowup")
-    )
+    return bool(continuity_map.get("reserveForImmediateFollowup"))
+
+
+def _normalize_agent_runtime_id(agent_id: str) -> str:
+    """Normalize runtime identifiers for managed runtime routing."""
+
+    return str(agent_id).strip().lower().replace("-", "_")
+
 
 def _legacy_manager_workflow_id(runtime_id: str) -> str:
     # Preserve legacy workflow IDs for in-flight histories. New executions use
@@ -342,9 +346,12 @@ class MoonMindAgentRun:
         runtime_mapping = {
             "gemini_cli": "gemini_cli",
             "claude": "claude_code",
+            "claude_code": "claude_code",
             "codex": "codex_cli",
+            "codex_cli": "codex_cli",
         }
-        return runtime_mapping.get(agent_id, agent_id)
+        normalized_agent_id = _normalize_agent_runtime_id(agent_id)
+        return runtime_mapping.get(normalized_agent_id, normalized_agent_id)
 
     def _cooldown_seconds_for_profile(self, profile_id: str | None) -> int:
         normalized_profile_id = str(profile_id or "").strip()

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -107,6 +107,7 @@ MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID = (
     "agent-run-managed-session-prepare-turn-instructions-activity-v1"
 )
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
+SLOT_HANDOFF_PATCH_ID = "agent-run-slot-handoff-v1"
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.Run (run.py:50).
@@ -125,6 +126,7 @@ _DEFAULT_SESSION_IMAGE_REF = os.environ.get(
     "WORKFLOW_JOB_IMAGE",
     "ghcr.io/moonladderstudios/moonmind:latest",
 )
+_SLOT_HANDOFF_TTL_SECONDS = 10
 
 
 def _request_selected_skill(request: AgentExecutionRequest) -> str | None:
@@ -169,6 +171,24 @@ def _request_step_ledger_context(
     if scope:
         context["scope"] = scope
     return context
+
+
+def _request_reserves_slot_for_immediate_followup(
+    request: AgentExecutionRequest,
+) -> bool:
+    """Return whether a successful run should reserve its slot for next step."""
+
+    parameters = request.parameters if isinstance(request.parameters, dict) else {}
+    metadata = parameters.get("metadata")
+    metadata_map = metadata if isinstance(metadata, Mapping) else {}
+    moonmind = metadata_map.get("moonmind")
+    moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+    continuity = moonmind_map.get("slotContinuity")
+    continuity_map = continuity if isinstance(continuity, Mapping) else {}
+    return bool(
+        continuity_map.get("reserveForImmediateFollowup")
+        or continuity_map.get("hasImmediateManagedFollowup")
+    )
 
 def _legacy_manager_workflow_id(runtime_id: str) -> str:
     # Preserve legacy workflow IDs for in-flight histories. New executions use
@@ -600,6 +620,10 @@ class MoonMindAgentRun:
             "requester_workflow_id": workflow.info().workflow_id,
             "runtime_id": runtime_id,
         }
+        if workflow.patched(SLOT_HANDOFF_PATCH_ID):
+            lease_group_id = self._lease_group_id()
+            if lease_group_id:
+                signal_payload["lease_group_id"] = lease_group_id
         if execution_profile_ref:
             signal_payload["execution_profile_ref"] = execution_profile_ref
         if profile_selector:
@@ -720,6 +744,33 @@ class MoonMindAgentRun:
         if workflow.patched(PROVIDER_PROFILE_MANAGER_ID_PATCH):
             return workflow_id_for_runtime(runtime_id)
         return _legacy_manager_workflow_id(runtime_id)
+
+    def _lease_group_id(self) -> str | None:
+        parent_info = workflow.info().parent
+        if parent_info is None:
+            return None
+        return str(parent_info.workflow_id or "").strip() or None
+
+    def _release_slot_payload(
+        self,
+        *,
+        profile_id: str | None,
+        request: AgentExecutionRequest,
+        reserve_for_followup: bool = False,
+    ) -> dict[str, Any]:
+        payload = {
+            "requester_workflow_id": workflow.info().workflow_id,
+            "profile_id": profile_id,
+        }
+        if workflow.patched(SLOT_HANDOFF_PATCH_ID):
+            lease_group_id = self._lease_group_id()
+            if lease_group_id:
+                payload["lease_group_id"] = lease_group_id
+            if reserve_for_followup and _request_reserves_slot_for_immediate_followup(
+                request
+            ):
+                payload["handoff_ttl_seconds"] = _SLOT_HANDOFF_TTL_SECONDS
+        return payload
 
     @workflow.signal
     def completion_signal(self, result_dict: dict) -> None:
@@ -1179,20 +1230,35 @@ class MoonMindAgentRun:
                             "requester_workflow_id": wf_id,
                             "runtime_id": kw.get("runtime_id", runtime_id),
                         }
+                        if workflow.patched(SLOT_HANDOFF_PATCH_ID):
+                            lease_group_id = self._lease_group_id()
+                            if lease_group_id:
+                                payload["lease_group_id"] = lease_group_id
                         exact_profile_id = kw.get(
                             "execution_profile_ref", request.execution_profile_ref
                         )
                         if exact_profile_id:
                             payload["execution_profile_ref"] = exact_profile_id
                         if request.profile_selector:
-                            payload["profile_selector"] = request.profile_selector.model_dump(by_alias=True, exclude_none=True)
+                            payload["profile_selector"] = (
+                                request.profile_selector.model_dump(
+                                    by_alias=True,
+                                    exclude_none=True,
+                                )
+                            )
                         await manager_handle.signal("request_slot", payload)
 
                     async def _slot_releaser(**kw):
-                        await manager_handle.signal("release_slot", {
-                            "requester_workflow_id": wf_id,
-                            "profile_id": kw.get("profile_id", request.execution_profile_ref),
-                        })
+                        await manager_handle.signal(
+                            "release_slot",
+                            self._release_slot_payload(
+                                profile_id=kw.get(
+                                    "profile_id",
+                                    request.execution_profile_ref,
+                                ),
+                                request=request,
+                            ),
+                        )
 
                     async def _cooldown_reporter(**kw):
                         await manager_handle.signal("report_cooldown", {
@@ -1652,7 +1718,13 @@ class MoonMindAgentRun:
                 if elapsed >= timeout_seconds and not self.completion_event.is_set():
                     self.run_status = RunStatus.timed_out
                     if manager_handle and request.execution_profile_ref:
-                        await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                        await manager_handle.signal(
+                            "release_slot",
+                            self._release_slot_payload(
+                                profile_id=request.execution_profile_ref,
+                                request=request,
+                            ),
+                        )
                     return AgentRunResult(failure_class="execution_error")
 
                 if self.final_result is None:
@@ -1797,10 +1869,10 @@ class MoonMindAgentRun:
                         )
                         await manager_handle.signal(
                             "release_slot",
-                            {
-                                "requester_workflow_id": workflow.info().workflow_id,
-                                "profile_id": profile_id or request.execution_profile_ref,
-                            },
+                            self._release_slot_payload(
+                                profile_id=profile_id or request.execution_profile_ref,
+                                request=request,
+                            ),
                         )
                         self._awaiting_slot_reason_override = waiting_reason
                         self._slot_wait_timeout_override_seconds = max(
@@ -1812,18 +1884,37 @@ class MoonMindAgentRun:
                         self._assigned_profile_id = None
                         request.execution_profile_ref = requested_execution_profile_ref
                         self.run_status = RunStatus.awaiting_slot
-                        continue # Retries loop
+                        continue  # Retries loop
                     else:
-                        await manager_handle.signal("report_cooldown", {"profile_id": request.execution_profile_ref, "cooldown_seconds": 300})
-                        await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                        await manager_handle.signal(
+                            "report_cooldown",
+                            {
+                                "profile_id": request.execution_profile_ref,
+                                "cooldown_seconds": 300,
+                            },
+                        )
+                        await manager_handle.signal(
+                            "release_slot",
+                            self._release_slot_payload(
+                                profile_id=request.execution_profile_ref,
+                                request=request,
+                            ),
+                        )
                         self.completion_event.clear()
                         self.final_result = None
                         request.execution_profile_ref = requested_execution_profile_ref
-                        continue # Retries loop
+                        continue  # Retries loop
 
                 # Not a 429 or external agent
                 if manager_handle and request.execution_profile_ref:
-                    await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                    await manager_handle.signal(
+                        "release_slot",
+                        self._release_slot_payload(
+                            profile_id=request.execution_profile_ref,
+                            request=request,
+                            reserve_for_followup=True,
+                        ),
+                    )
 
                 self.final_result = self._enrich_result_metadata(
                     request=request,
@@ -1856,7 +1947,13 @@ class MoonMindAgentRun:
                     runtime_id = runtime_mapping.get(request.agent_id, request.agent_id)
                     manager_id = self._manager_workflow_id(runtime_id)
                     manager_handle = workflow.get_external_workflow_handle(manager_id)
-                    await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                    await manager_handle.signal(
+                        "release_slot",
+                        self._release_slot_payload(
+                            profile_id=request.execution_profile_ref,
+                            request=request,
+                        ),
+                    )
                 except Exception:
                     self._get_logger().warning("Failed to release slot on timeout, which may lead to a leak.", exc_info=True)
             return AgentRunResult(failure_class="execution_error")
@@ -1872,7 +1969,13 @@ class MoonMindAgentRun:
                 async def _release_slot():
                     try:
                         manager_handle = workflow.get_external_workflow_handle(manager_id)
-                        await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                        await manager_handle.signal(
+                            "release_slot",
+                            self._release_slot_payload(
+                                profile_id=request.execution_profile_ref,
+                                request=request,
+                            ),
+                        )
                     except Exception:
                         # Errors are intentionally ignored to avoid masking the original cancellation
                         self._get_logger().warning("Failed to release slot on cancellation, which may lead to a leak.", exc_info=True)
@@ -1914,7 +2017,13 @@ class MoonMindAgentRun:
                 manager_id = self._manager_workflow_id(runtime_id)
                 try:
                     manager_handle = workflow.get_external_workflow_handle(manager_id)
-                    await manager_handle.signal("release_slot", {"requester_workflow_id": workflow.info().workflow_id, "profile_id": request.execution_profile_ref})
+                    await manager_handle.signal(
+                        "release_slot",
+                        self._release_slot_payload(
+                            profile_id=request.execution_profile_ref,
+                            request=request,
+                        ),
+                    )
                 except Exception:
                     self._get_logger().warning("Failed to release slot on unexpected exception, which may lead to a leak.", exc_info=True)
             raise

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -623,17 +623,18 @@ class MoonMindProviderProfileManagerWorkflow:
             if now >= expires_at:
                 self._handoff_reservations.pop(group_id, None)
 
-    def _profile_is_reserved_for_other_group(
+    def _reserved_slot_count_for_other_groups(
         self,
         profile_id: str,
         lease_group_id: str | None,
-    ) -> bool:
+    ) -> int:
+        reserved_slots = 0
         for reserved_group_id, reservation in self._handoff_reservations.items():
             if reservation.profile_id != profile_id:
                 continue
             if reserved_group_id != lease_group_id:
-                return True
-        return False
+                reserved_slots += 1
+        return reserved_slots
 
     @staticmethod
     def _profile_matches_request(
@@ -750,9 +751,6 @@ class MoonMindProviderProfileManagerWorkflow:
         lease_group_id: str | None = None,
     ) -> Optional[ProfileSlotState]:
         """Find the best available profile matching the selector."""
-        if self._handoff_reservations:
-            now = workflow.now()
-            self._clear_expired_handoff_reservations(now)
         selector = self._normalize_selector(selector)
         exact_profile_id = str(execution_profile_ref or "").strip()
         normalized_group_id = self._normalize_optional_string(lease_group_id)
@@ -773,10 +771,10 @@ class MoonMindProviderProfileManagerWorkflow:
             exact_profile = self._profiles.get(exact_profile_id)
             if exact_profile is None or not exact_profile.is_available():
                 return None
-            if self._profile_is_reserved_for_other_group(
-                exact_profile.profile_id,
-                normalized_group_id,
-            ):
+            reserved_slots = self._reserved_slot_count_for_other_groups(
+                exact_profile.profile_id, normalized_group_id
+            )
+            if exact_profile.available_slots <= reserved_slots:
                 return None
             return (
                 exact_profile
@@ -792,10 +790,10 @@ class MoonMindProviderProfileManagerWorkflow:
         for profile in self._profiles.values():
             if not profile.is_available():
                 continue
-            if self._profile_is_reserved_for_other_group(
-                profile.profile_id,
-                normalized_group_id,
-            ):
+            reserved_slots = self._reserved_slot_count_for_other_groups(
+                profile.profile_id, normalized_group_id
+            )
+            if profile.available_slots <= reserved_slots:
                 continue
             if not self._profile_matches_request(
                 profile,

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -34,6 +34,7 @@ WORKFLOW_ID_PREFIX = "provider-profile-manager"
 # "auth-profile" spellings in identifiers until a deliberate workflow migration.
 VERIFY_LEASE_HOLDERS_PATCH = "auth-profile-manager-verify-leases-v1"
 DB_LEASE_PERSISTENCE_PATCH = "provider-profile-manager-db-lease-persistence-v1"
+SLOT_HANDOFF_RESERVATION_PATCH = "provider-profile-manager-slot-handoff-v1"
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -64,6 +65,7 @@ class ProviderProfileManagerInput(TypedDict, total=False):
     cooldowns: dict[str, str]
     lease_granted_at: dict[str, dict[str, str]]
     pending_requests: list[dict[str, str]]
+    handoff_reservations: dict[str, dict[str, str]]
 
 
 class ProviderProfileManagerOutput(TypedDict):
@@ -82,6 +84,7 @@ class SlotRequestPayload(TypedDict):
     requester_workflow_id: str
     runtime_id: str
     execution_profile_ref: str | None
+    lease_group_id: str | None
 
 
 class SlotReleasePayload(TypedDict):
@@ -89,6 +92,8 @@ class SlotReleasePayload(TypedDict):
 
     requester_workflow_id: str
     profile_id: str
+    lease_group_id: str | None
+    handoff_ttl_seconds: int | None
 
 
 class CooldownReportPayload(TypedDict):
@@ -110,6 +115,7 @@ class ProfileSyncPayload(TypedDict):
 
 
 _MAX_LEASE_DURATION_SECONDS = 5400  # 1.5 hours — safety net for leaked slots
+_MAX_HANDOFF_RESERVATION_SECONDS = 30
 
 
 @dataclass
@@ -209,6 +215,15 @@ class PendingRequest:
     runtime_id: str
     execution_profile_ref: str | None = None
     profile_selector: Optional[dict[str, Any]] = None
+    lease_group_id: str | None = None
+
+
+@dataclass
+class HandoffReservation:
+    """Short-lived profile reservation for the next step in the same run."""
+
+    profile_id: str
+    expires_at: str
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +274,7 @@ class MoonMindProviderProfileManagerWorkflow:
         self._runtime_id: Optional[str] = None
         self._profiles: dict[str, ProfileSlotState] = {}
         self._pending_requests: list[PendingRequest] = []
+        self._handoff_reservations: dict[str, HandoffReservation] = {}
         self._event_count: int = 0
         self._shutdown_requested: bool = False
         self._has_new_events: bool = False
@@ -270,14 +286,30 @@ class MoonMindProviderProfileManagerWorkflow:
         """An AgentRun requests a profile slot for this runtime family."""
         self._event_count += 1
         self._has_new_events = True
-        self._pending_requests.append(
-            PendingRequest(
-                requester_workflow_id=payload["requester_workflow_id"],
-                runtime_id=payload.get("runtime_id", self._runtime_id or ""),
-                execution_profile_ref=payload.get("execution_profile_ref"),
-                profile_selector=payload.get("profile_selector"),
+        if not workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
+            self._pending_requests.append(
+                PendingRequest(
+                    requester_workflow_id=payload["requester_workflow_id"],
+                    runtime_id=payload.get("runtime_id", self._runtime_id or ""),
+                    execution_profile_ref=payload.get("execution_profile_ref"),
+                    profile_selector=payload.get("profile_selector"),
+                )
             )
+            return
+        request = PendingRequest(
+            requester_workflow_id=payload["requester_workflow_id"],
+            runtime_id=payload.get("runtime_id", self._runtime_id or ""),
+            execution_profile_ref=payload.get("execution_profile_ref"),
+            profile_selector=payload.get("profile_selector"),
+            lease_group_id=self._normalize_optional_string(
+                payload.get("lease_group_id")
+            ),
         )
+        for index, existing in enumerate(self._pending_requests):
+            if existing.requester_workflow_id == request.requester_workflow_id:
+                self._pending_requests[index] = request
+                return
+        self._pending_requests.append(request)
 
     @workflow.signal
     async def release_slot(self, payload: dict[str, Any]) -> None:
@@ -287,8 +319,28 @@ class MoonMindProviderProfileManagerWorkflow:
         profile_id = payload["profile_id"]
         requester_id = payload["requester_workflow_id"]
         profile = self._profiles.get(profile_id)
+        released = False
         if profile:
-            profile.release(requester_id)
+            released = profile.release(requester_id)
+        if workflow.patched(SLOT_HANDOFF_RESERVATION_PATCH):
+            self._pending_requests = [
+                req
+                for req in self._pending_requests
+                if req.requester_workflow_id != requester_id
+            ]
+            lease_group_id = self._normalize_optional_string(
+                payload.get("lease_group_id")
+            )
+            handoff_ttl_seconds = self._coerce_handoff_ttl_seconds(
+                payload.get("handoff_ttl_seconds")
+            )
+            if released and lease_group_id and handoff_ttl_seconds > 0:
+                self._handoff_reservations[lease_group_id] = HandoffReservation(
+                    profile_id=profile_id,
+                    expires_at=(
+                        workflow.now() + timedelta(seconds=handoff_ttl_seconds)
+                    ).isoformat(),
+                )
         # Always remove from DB regardless of whether profile exists in memory,
         # so stale rows don't survive profile removals or disablement.
         if workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
@@ -340,9 +392,17 @@ class MoonMindProviderProfileManagerWorkflow:
                     "runtime_id": r.runtime_id,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
+                    "lease_group_id": r.lease_group_id,
                 }
                 for r in self._pending_requests
             ],
+            "handoff_reservations": {
+                group_id: {
+                    "profile_id": reservation.profile_id,
+                    "expires_at": reservation.expires_at,
+                }
+                for group_id, reservation in self._handoff_reservations.items()
+            },
             "event_count": self._event_count,
         }
 
@@ -428,6 +488,7 @@ class MoonMindProviderProfileManagerWorkflow:
         cooldowns_data = input_payload.get("cooldowns", {})
         lease_times_data = input_payload.get("lease_granted_at", {})
         pending_data = input_payload.get("pending_requests", [])
+        reservations_data = input_payload.get("handoff_reservations", {})
 
         self._pending_requests = [
             PendingRequest(
@@ -435,10 +496,32 @@ class MoonMindProviderProfileManagerWorkflow:
                 runtime_id=req.get("runtime_id", ""),
                 execution_profile_ref=req.get("execution_profile_ref"),
                 profile_selector=req.get("profile_selector"),
+                lease_group_id=self._normalize_optional_string(
+                    req.get("lease_group_id")
+                ),
             )
             for req in pending_data
             if req.get("requester_workflow_id")
         ]
+        self._handoff_reservations = {}
+        if isinstance(reservations_data, dict):
+            for group_id, reservation in reservations_data.items():
+                normalized_group_id = self._normalize_optional_string(group_id)
+                if not normalized_group_id or not isinstance(reservation, dict):
+                    continue
+                profile_id = self._normalize_optional_string(
+                    reservation.get("profile_id")
+                )
+                expires_at = self._normalize_optional_string(
+                    reservation.get("expires_at")
+                )
+                if profile_id and expires_at:
+                    self._handoff_reservations[normalized_group_id] = (
+                        HandoffReservation(
+                            profile_id=profile_id,
+                            expires_at=expires_at,
+                        )
+                    )
 
         for p in profiles_data:
             pid = p["profile_id"]
@@ -515,9 +598,82 @@ class MoonMindProviderProfileManagerWorkflow:
             if pid not in seen:
                 self._profiles[pid].enabled = False
 
+    @staticmethod
+    def _normalize_optional_string(value: object) -> str | None:
+        normalized = str(value or "").strip()
+        return normalized or None
+
+    @staticmethod
+    def _coerce_handoff_ttl_seconds(value: object) -> int:
+        try:
+            seconds = int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, min(seconds, _MAX_HANDOFF_RESERVATION_SECONDS))
+
+    def _clear_expired_handoff_reservations(self, now: datetime) -> None:
+        for group_id, reservation in list(self._handoff_reservations.items()):
+            try:
+                expires_at = datetime.fromisoformat(reservation.expires_at)
+                if expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=timezone.utc)
+            except (TypeError, ValueError):
+                self._handoff_reservations.pop(group_id, None)
+                continue
+            if now >= expires_at:
+                self._handoff_reservations.pop(group_id, None)
+
+    def _profile_is_reserved_for_other_group(
+        self,
+        profile_id: str,
+        lease_group_id: str | None,
+    ) -> bool:
+        for reserved_group_id, reservation in self._handoff_reservations.items():
+            if reservation.profile_id != profile_id:
+                continue
+            if reserved_group_id != lease_group_id:
+                return True
+        return False
+
+    @staticmethod
+    def _profile_matches_request(
+        profile: ProfileSlotState,
+        *,
+        selector: Optional[dict[str, Any]],
+        exact_profile_id: str | None,
+    ) -> bool:
+        if not profile.is_available():
+            return False
+        if exact_profile_id and profile.profile_id != exact_profile_id:
+            return False
+        if not selector:
+            return True
+        if (
+            selector.get("providerId")
+            and profile.provider_id != selector.get("providerId")
+        ):
+            return False
+        if (
+            selector.get("runtimeMaterializationMode")
+            and profile.runtime_materialization_mode
+            != selector.get("runtimeMaterializationMode")
+        ):
+            return False
+
+        tags_any = selector.get("tagsAny", [])
+        if tags_any and not set(tags_any).intersection(set(profile.tags)):
+            return False
+
+        tags_all = selector.get("tagsAll", [])
+        if tags_all and not set(tags_all).issubset(set(profile.tags)):
+            return False
+
+        return True
+
     async def _drain_queue(self) -> None:
         """Try to assign slots to pending requests in FIFO order."""
         now = workflow.now()
+        self._clear_expired_handoff_reservations(now)
         remaining: list[PendingRequest] = []
         leases_changed = False
         for req in self._pending_requests:
@@ -546,6 +702,7 @@ class MoonMindProviderProfileManagerWorkflow:
             profile = self._find_available_profile(
                 selector=req.profile_selector,
                 execution_profile_ref=req.execution_profile_ref,
+                lease_group_id=req.lease_group_id,
             )
             if profile and profile.reserve(req.requester_workflow_id, now):
                 leases_changed = True
@@ -590,52 +747,62 @@ class MoonMindProviderProfileManagerWorkflow:
         self,
         selector: Optional[dict[str, Any]] = None,
         execution_profile_ref: str | None = None,
+        lease_group_id: str | None = None,
     ) -> Optional[ProfileSlotState]:
         """Find the best available profile matching the selector."""
+        if self._handoff_reservations:
+            now = workflow.now()
+            self._clear_expired_handoff_reservations(now)
         selector = self._normalize_selector(selector)
         exact_profile_id = str(execution_profile_ref or "").strip()
+        normalized_group_id = self._normalize_optional_string(lease_group_id)
+        if normalized_group_id:
+            reservation = self._handoff_reservations.get(normalized_group_id)
+            if reservation:
+                reserved_profile = self._profiles.get(reservation.profile_id)
+                if reserved_profile and self._profile_matches_request(
+                    reserved_profile,
+                    selector=selector,
+                    exact_profile_id=exact_profile_id,
+                ):
+                    self._handoff_reservations.pop(normalized_group_id, None)
+                    return reserved_profile
+                self._handoff_reservations.pop(normalized_group_id, None)
+
         if exact_profile_id:
             exact_profile = self._profiles.get(exact_profile_id)
             if exact_profile is None or not exact_profile.is_available():
                 return None
-
-            if selector:
-                if selector.get("providerId") and exact_profile.provider_id != selector.get("providerId"):
-                    return None
-                if (
-                    selector.get("runtimeMaterializationMode")
-                    and exact_profile.runtime_materialization_mode != selector.get("runtimeMaterializationMode")
-                ):
-                    return None
-
-                tags_any = selector.get("tagsAny", [])
-                if tags_any and not set(tags_any).intersection(set(exact_profile.tags)):
-                    return None
-
-                tags_all = selector.get("tagsAll", [])
-                if tags_all and not set(tags_all).issubset(set(exact_profile.tags)):
-                    return None
-
-            return exact_profile
+            if self._profile_is_reserved_for_other_group(
+                exact_profile.profile_id,
+                normalized_group_id,
+            ):
+                return None
+            return (
+                exact_profile
+                if self._profile_matches_request(
+                    exact_profile,
+                    selector=selector,
+                    exact_profile_id=exact_profile_id,
+                )
+                else None
+            )
 
         eligible_profiles: list[ProfileSlotState] = []
         for profile in self._profiles.values():
             if not profile.is_available():
                 continue
-
-            if selector:
-                if selector.get("providerId") and profile.provider_id != selector.get("providerId"):
-                    continue
-                if selector.get("runtimeMaterializationMode") and profile.runtime_materialization_mode != selector.get("runtimeMaterializationMode"):
-                    continue
-
-                tags_any = selector.get("tagsAny", [])
-                if tags_any and not set(tags_any).intersection(set(profile.tags)):
-                    continue
-
-                tags_all = selector.get("tagsAll", [])
-                if tags_all and not set(tags_all).issubset(set(profile.tags)):
-                    continue
+            if self._profile_is_reserved_for_other_group(
+                profile.profile_id,
+                normalized_group_id,
+            ):
+                continue
+            if not self._profile_matches_request(
+                profile,
+                selector=selector,
+                exact_profile_id=None,
+            ):
+                continue
 
             eligible_profiles.append(profile)
 
@@ -797,9 +964,17 @@ class MoonMindProviderProfileManagerWorkflow:
                     "runtime_id": r.runtime_id,
                     "execution_profile_ref": r.execution_profile_ref,
                     "profile_selector": r.profile_selector,
+                    "lease_group_id": r.lease_group_id,
                 }
                 for r in self._pending_requests
             ],
+            "handoff_reservations": {
+                group_id: {
+                    "profile_id": reservation.profile_id,
+                    "expires_at": reservation.expires_at,
+                }
+                for group_id, reservation in self._handoff_reservations.items()
+            },
         }
 
     async def _load_profiles_from_db(self) -> None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import re
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Optional, TypedDict
 
@@ -159,6 +159,7 @@ DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
+RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
 _PROFILE_SYNC_RUNTIME_IDS = ("codex_cli", "claude_code", "gemini_cli")
 _MANAGED_AGENT_IDS = frozenset(
     {"gemini_cli", "gemini_cli", "claude", "claude_code", "codex", "codex_cli"}
@@ -1767,6 +1768,12 @@ class MoonMindRunWorkflow:
                                 tool_name=tool_name,
                                 resolved_skillset_ref=registry_snapshot_ref,
                             )
+                            if workflow.patched(RUN_SLOT_CONTINUITY_PATCH):
+                                self._mark_slot_continuity_for_next_step(
+                                    request=request,
+                                    ordered_nodes=ordered_nodes,
+                                    current_index=index,
+                                )
                             request = await self._maybe_bind_task_scoped_session(request)
                             child_workflow_id = (
                                 f"{workflow.info().workflow_id}:agent:{node_id}"
@@ -3171,6 +3178,95 @@ class MoonMindRunWorkflow:
             callback_policy=node_inputs.get("callbackPolicy") or {},
             profile_selector=profile_selector,
         )
+
+    @staticmethod
+    def _managed_runtime_id(agent_id: str) -> str:
+        runtime_mapping = {
+            "gemini_cli": "gemini_cli",
+            "claude": "claude_code",
+            "claude_code": "claude_code",
+            "codex": "codex_cli",
+            "codex_cli": "codex_cli",
+        }
+        normalized_agent_id = _normalize_agent_runtime_id(agent_id)
+        return runtime_mapping.get(normalized_agent_id, normalized_agent_id)
+
+    @staticmethod
+    def _plan_node_tool_mapping(node: Mapping[str, Any]) -> Mapping[str, Any] | None:
+        tool = node.get("tool")
+        skill = node.get("skill")
+        if isinstance(tool, Mapping):
+            return tool
+        if isinstance(skill, Mapping):
+            return skill
+        return None
+
+    def _agent_runtime_id_for_plan_node(
+        self,
+        node: Mapping[str, Any],
+    ) -> str | None:
+        selected_node = self._plan_node_tool_mapping(node)
+        if selected_node is None:
+            return None
+        tool_type = (
+            str(selected_node.get("type") or selected_node.get("kind") or "skill")
+            .strip()
+            .lower()
+        )
+        if tool_type != "agent_runtime":
+            return None
+        node_inputs_raw = node.get("inputs")
+        node_inputs = node_inputs_raw if isinstance(node_inputs_raw, Mapping) else {}
+        runtime_block_raw = node_inputs.get("runtime")
+        runtime_block = (
+            runtime_block_raw if isinstance(runtime_block_raw, Mapping) else {}
+        )
+        agent_id = str(
+            runtime_block.get("mode")
+            or runtime_block.get("agent_id")
+            or node_inputs.get("targetRuntime")
+            or selected_node.get("name")
+            or selected_node.get("id")
+            or ""
+        ).strip()
+        return agent_id or None
+
+    def _mark_slot_continuity_for_next_step(
+        self,
+        *,
+        request: "AgentExecutionRequest",
+        ordered_nodes: Sequence[Mapping[str, Any]],
+        current_index: int,
+    ) -> None:
+        if request.agent_kind != "managed" or current_index >= len(ordered_nodes):
+            return
+        next_agent_id = self._agent_runtime_id_for_plan_node(
+            ordered_nodes[current_index]
+        )
+        if not next_agent_id or self._agent_kind_for_id(next_agent_id) != "managed":
+            return
+        if self._managed_runtime_id(next_agent_id) != self._managed_runtime_id(
+            request.agent_id
+        ):
+            return
+
+        parameters = dict(request.parameters or {})
+        metadata = (
+            dict(parameters.get("metadata"))
+            if isinstance(parameters.get("metadata"), Mapping)
+            else {}
+        )
+        moonmind_payload = (
+            dict(metadata.get("moonmind"))
+            if isinstance(metadata.get("moonmind"), Mapping)
+            else {}
+        )
+        moonmind_payload["slotContinuity"] = {
+            "reserveForImmediateFollowup": True,
+        }
+        metadata["moonmind"] = moonmind_payload
+        parameters["metadata"] = metadata
+        request.parameters = parameters
 
     def _build_profile_selector(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3016,13 +3016,14 @@ class MoonMindRunWorkflow:
         resolved_skillset_ref: str | None = None,
     ) -> "AgentExecutionRequest":
         """Build an ``AgentExecutionRequest`` from plan-node inputs and workflow context."""
-        runtime_block = node_inputs.get("runtime") or {}
-        agent_id = str(
-            runtime_block.get("mode")
-            or runtime_block.get("agent_id")
-            or node_inputs.get("targetRuntime")
-            or tool_name
-        ).strip()
+        runtime_block_raw = node_inputs.get("runtime")
+        runtime_block = (
+            runtime_block_raw if isinstance(runtime_block_raw, Mapping) else {}
+        )
+        agent_id = self._agent_id_from_runtime_inputs(
+            node_inputs=node_inputs,
+            fallback_name=tool_name,
+        )
         if not agent_id:
             raise ValueError(
                 "agent_runtime plan node must specify an agent_id "
@@ -3201,6 +3202,24 @@ class MoonMindRunWorkflow:
             return skill
         return None
 
+    @staticmethod
+    def _agent_id_from_runtime_inputs(
+        *,
+        node_inputs: Mapping[str, Any],
+        fallback_name: str | None = None,
+    ) -> str:
+        runtime_block_raw = node_inputs.get("runtime")
+        runtime_block = (
+            runtime_block_raw if isinstance(runtime_block_raw, Mapping) else {}
+        )
+        return str(
+            runtime_block.get("mode")
+            or runtime_block.get("agent_id")
+            or node_inputs.get("targetRuntime")
+            or fallback_name
+            or ""
+        ).strip()
+
     def _agent_runtime_id_for_plan_node(
         self,
         node: Mapping[str, Any],
@@ -3217,18 +3236,10 @@ class MoonMindRunWorkflow:
             return None
         node_inputs_raw = node.get("inputs")
         node_inputs = node_inputs_raw if isinstance(node_inputs_raw, Mapping) else {}
-        runtime_block_raw = node_inputs.get("runtime")
-        runtime_block = (
-            runtime_block_raw if isinstance(runtime_block_raw, Mapping) else {}
+        agent_id = self._agent_id_from_runtime_inputs(
+            node_inputs=node_inputs,
+            fallback_name=selected_node.get("name") or selected_node.get("id"),
         )
-        agent_id = str(
-            runtime_block.get("mode")
-            or runtime_block.get("agent_id")
-            or node_inputs.get("targetRuntime")
-            or selected_node.get("name")
-            or selected_node.get("id")
-            or ""
-        ).strip()
         return agent_id or None
 
     def _mark_slot_continuity_for_next_step(

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -600,6 +600,46 @@ class TestProviderProfileManagerHelpers:
         ]
         assert "run-1" not in wf._handoff_reservations
 
+    def test_handoff_reservation_blocks_only_one_slot(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=2,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._handoff_reservations["run-1"] = HandoffReservation(
+            profile_id="p1",
+            expires_at="2026-04-15T00:00:10+00:00",
+        )
+
+        profile = wf._find_available_profile(lease_group_id="run-2")
+
+        assert profile is wf._profiles["p1"]
+
+    def test_handoff_reservation_holds_last_slot_for_reserved_group(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._handoff_reservations["run-1"] = HandoffReservation(
+            profile_id="p1",
+            expires_at="2026-04-15T00:00:10+00:00",
+        )
+
+        assert wf._find_available_profile(lease_group_id="run-2") is None
+        assert (
+            wf._find_available_profile(lease_group_id="run-1")
+            is wf._profiles["p1"]
+        )
+
     def test_clear_expired_cooldowns(self):
         wf = self._make_workflow()
         past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -9,6 +9,9 @@ from unittest.mock import patch
 import pytest
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    HandoffReservation,
+    PendingRequest,
+    SLOT_HANDOFF_RESERVATION_PATCH,
     WORKFLOW_NAME,
     MoonMindProviderProfileManagerWorkflow,
     ProfileSlotState,
@@ -466,6 +469,136 @@ class TestProviderProfileManagerHelpers:
         assert len(data["profiles"]) == 1
         assert data["leases"]["p1"] == ["wf1"]
         assert data["cooldowns"]["p1"] == "2099-01-01T00:00:00+00:00"
+
+    def test_build_continue_as_new_preserves_handoff_reservations(self):
+        wf = self._make_workflow()
+        wf._handoff_reservations["run-1"] = HandoffReservation(
+            profile_id="p1",
+            expires_at="2026-04-15T00:00:10+00:00",
+        )
+
+        data = wf._build_continue_as_new_input()
+
+        assert data["handoff_reservations"] == {
+            "run-1": {
+                "profile_id": "p1",
+                "expires_at": "2026-04-15T00:00:10+00:00",
+            }
+        }
+
+    def test_request_slot_dedupes_by_requester(self):
+        wf = self._make_workflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = True
+            wf.request_slot(
+                {
+                    "requester_workflow_id": "run-1:agent:step-1",
+                    "runtime_id": "gemini_cli",
+                    "lease_group_id": "run-1",
+                }
+            )
+            wf.request_slot(
+                {
+                    "requester_workflow_id": "run-1:agent:step-1",
+                    "runtime_id": "gemini_cli",
+                    "execution_profile_ref": "p2",
+                    "lease_group_id": "run-1",
+                }
+            )
+
+        assert len(wf._pending_requests) == 1
+        assert wf._pending_requests[0].execution_profile_ref == "p2"
+        assert wf._pending_requests[0].lease_group_id == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_release_slot_creates_short_handoff_reservation(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            current_leases=["run-1:agent:step-1"],
+            lease_granted_at={
+                "run-1:agent:step-1": "2026-04-15T00:00:00+00:00"
+            },
+        )
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = now
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == SLOT_HANDOFF_RESERVATION_PATCH
+            )
+            await wf.release_slot(
+                {
+                    "requester_workflow_id": "run-1:agent:step-1",
+                    "profile_id": "p1",
+                    "lease_group_id": "run-1",
+                    "handoff_ttl_seconds": 10,
+                }
+            )
+
+        reservation = wf._handoff_reservations["run-1"]
+        assert reservation.profile_id == "p1"
+        assert reservation.expires_at == "2026-04-15T00:00:10+00:00"
+        assert wf._profiles["p1"].current_leases == []
+
+    @pytest.mark.asyncio
+    async def test_drain_queue_prefers_reserved_same_group_over_unrelated_fifo(
+        self,
+    ):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+        wf._handoff_reservations["run-1"] = HandoffReservation(
+            profile_id="p1",
+            expires_at="2026-04-15T00:00:10+00:00",
+        )
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="run-2:agent:step-1",
+                runtime_id="gemini_cli",
+                lease_group_id="run-2",
+            ),
+            PendingRequest(
+                requester_workflow_id="run-1:agent:step-2",
+                runtime_id="gemini_cli",
+                lease_group_id="run-1",
+            ),
+        ]
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+        now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.now.return_value = now
+            mock_wf.patched.return_value = False
+            await wf._drain_queue()
+
+        assert assigned == [("run-1:agent:step-2", "p1")]
+        assert wf._profiles["p1"].current_leases == ["run-1:agent:step-2"]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "run-2:agent:step-1"
+        ]
+        assert "run-1" not in wf._handoff_reservations
 
     def test_clear_expired_cooldowns(self):
         wf = self._make_workflow()

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -44,6 +44,32 @@ def test_request_reserves_slot_for_immediate_followup_reads_moonmind_metadata() 
     assert _request_reserves_slot_for_immediate_followup(request)
 
 
+def test_request_reserves_slot_for_immediate_followup_ignores_legacy_metadata() -> None:
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="run-1",
+        idempotencyKey="run-1:step-1",
+        parameters={
+            "metadata": {
+                "moonmind": {
+                    "slotContinuity": {
+                        "hasImmediateManagedFollowup": True,
+                    }
+                }
+            }
+        },
+    )
+
+    assert not _request_reserves_slot_for_immediate_followup(request)
+
+
+def test_managed_runtime_id_normalizes_aliases() -> None:
+    assert MoonMindAgentRun._managed_runtime_id("Codex-CLI") == "codex_cli"
+    assert MoonMindAgentRun._managed_runtime_id("claude") == "claude_code"
+    assert MoonMindAgentRun._managed_runtime_id("CLAUDE_CODE") == "claude_code"
+
+
 def test_coerce_external_status_payload_maps_integration_shape() -> None:
     workflow_instance = MoonMindAgentRun()
 

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py
@@ -1,6 +1,8 @@
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.agent_run import (
     MoonMindAgentRun,
     RunStatus,
+    _request_reserves_slot_for_immediate_followup,
 )
 
 
@@ -20,6 +22,26 @@ def test_coerce_external_status_payload_accepts_canonical_shape() -> None:
     assert status.run_id == "jules-task-001"
     assert status.agent_id == "jules"
     assert status.status == RunStatus.running
+
+
+def test_request_reserves_slot_for_immediate_followup_reads_moonmind_metadata() -> None:
+    request = AgentExecutionRequest(
+        agentKind="managed",
+        agentId="codex_cli",
+        correlationId="run-1",
+        idempotencyKey="run-1:step-1",
+        parameters={
+            "metadata": {
+                "moonmind": {
+                    "slotContinuity": {
+                        "reserveForImmediateFollowup": True,
+                    }
+                }
+            }
+        },
+    )
+
+    assert _request_reserves_slot_for_immediate_followup(request)
 
 
 def test_coerce_external_status_payload_maps_integration_shape() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -10,6 +10,7 @@ import pytest
 
 pytest.importorskip("temporalio")
 
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 
@@ -39,6 +40,63 @@ class TestAgentKindForId(unittest.TestCase):
                 "managed",
                 f"{agent_id} should be managed",
             )
+
+
+class TestSlotContinuityMetadata(unittest.TestCase):
+    def test_marks_request_when_next_step_uses_same_managed_runtime(self) -> None:
+        wf = MoonMindRunWorkflow()
+        request = AgentExecutionRequest(
+            agentKind="managed",
+            agentId="codex_cli",
+            correlationId="run-1",
+            idempotencyKey="run-1:step-1",
+        )
+        ordered_nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"runtime": {"mode": "codex_cli"}},
+            },
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"runtime": {"mode": "codex_cli"}},
+            },
+        ]
+
+        wf._mark_slot_continuity_for_next_step(
+            request=request,
+            ordered_nodes=ordered_nodes,
+            current_index=1,
+        )
+
+        continuity = request.parameters["metadata"]["moonmind"]["slotContinuity"]
+        self.assertTrue(continuity["reserveForImmediateFollowup"])
+
+    def test_does_not_mark_request_when_next_step_uses_different_runtime(self) -> None:
+        wf = MoonMindRunWorkflow()
+        request = AgentExecutionRequest(
+            agentKind="managed",
+            agentId="codex_cli",
+            correlationId="run-1",
+            idempotencyKey="run-1:step-1",
+        )
+        ordered_nodes = [
+            {
+                "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                "inputs": {"runtime": {"mode": "codex_cli"}},
+            },
+            {
+                "tool": {"type": "agent_runtime", "name": "gemini_cli"},
+                "inputs": {"runtime": {"mode": "gemini_cli"}},
+            },
+        ]
+
+        wf._mark_slot_continuity_for_next_step(
+            request=request,
+            ordered_nodes=ordered_nodes,
+            current_index=1,
+        )
+
+        self.assertEqual(request.parameters, {})
 
 
 class TestJiraAgentPublishHelpers(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Preserve provider-profile slot continuity across immediate same-runtime managed steps.
- Add replay-gated slot handoff metadata from `MoonMind.Run` through `MoonMind.AgentRun` to `MoonMind.ProviderProfileManager`.
- Add regression coverage for handoff reservation, deduplication, and same-parent priority over unrelated FIFO waiters.

## Root Cause
A completed step released its provider-profile slot before the parent run could launch the next child step. The profile manager could then assign the freed slot to unrelated queued work, causing the original workflow to move back to `awaiting_slot` between consecutive steps.

## Validation
- `.venv/bin/python -m py_compile moonmind/workflows/temporal/workflows/provider_profile_manager.py moonmind/workflows/temporal/workflows/agent_run.py moonmind/workflows/temporal/workflows/run.py`
- `.venv/bin/python -m pytest tests/unit/workflows/temporal/test_provider_profile_manager.py tests/unit/workflows/temporal/workflows/test_agent_run_status_payloads.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py -q`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`