### PR TITLE
MM-328: Enforce typed Temporal payload conversion and activity calls

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/172-typed-activity-calls"
+}

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -16,11 +16,17 @@ from __future__ import annotations
 
 import base64
 import binascii
-from typing import Annotated
+from typing import Annotated, Any, Literal
 
-from typing import Any
-
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, PlainValidator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    PlainValidator,
+    model_validator,
+)
 
 from .temporal_artifact_models import ArtifactRefModel
 
@@ -162,3 +168,122 @@ class DependencyStatusSnapshotInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     workflow_ids: list[str] = Field(default_factory=list, alias="workflowIds")
+
+
+class ExternalAgentRunInput(BaseModel):
+    """Public input for external provider run status/fetch/cancel activities."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    run_id: str = Field(
+        ...,
+        alias="runId",
+        validation_alias=AliasChoices("runId", "run_id", "externalId", "external_id"),
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "ExternalAgentRunInput":
+        self.run_id = self.run_id.strip()
+        if not self.run_id:
+            raise ValueError("runId must be nonblank")
+        return self
+
+
+class AgentRuntimeStatusInput(BaseModel):
+    """Public input for agent_runtime.status."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    run_id: str = Field(
+        ...,
+        alias="runId",
+        validation_alias=AliasChoices("runId", "run_id"),
+        min_length=1,
+    )
+    agent_id: str = Field(
+        default="managed",
+        alias="agentId",
+        validation_alias=AliasChoices("agentId", "agent_id", "agent"),
+        min_length=1,
+    )
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "AgentRuntimeStatusInput":
+        self.run_id = self.run_id.strip()
+        self.agent_id = self.agent_id.strip() or "managed"
+        if not self.run_id:
+            raise ValueError("runId must be nonblank")
+        return self
+
+
+class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
+    """Public input for agent_runtime.fetch_result."""
+
+    publish_mode: Literal["none", "pr", "branch"] = Field(
+        default="none",
+        alias="publishMode",
+        validation_alias=AliasChoices("publishMode", "publish_mode"),
+    )
+    commit_message: str | None = Field(
+        default=None,
+        alias="commitMessage",
+        validation_alias=AliasChoices("commitMessage", "commit_message"),
+    )
+    target_branch: str | None = Field(
+        default=None,
+        alias="targetBranch",
+        validation_alias=AliasChoices("targetBranch", "target_branch"),
+    )
+    head_branch: str | None = Field(
+        default=None,
+        alias="headBranch",
+        validation_alias=AliasChoices("headBranch", "head_branch"),
+    )
+    pr_resolver_expected: bool = Field(
+        default=False,
+        alias="prResolverExpected",
+        validation_alias=AliasChoices("prResolverExpected", "pr_resolver_expected"),
+    )
+
+    @model_validator(mode="after")
+    def _normalize_fetch(self) -> "AgentRuntimeFetchResultInput":
+        super()._normalize()
+        for field_name in ("commit_message", "target_branch", "head_branch"):
+            value = getattr(self, field_name)
+            if value is not None:
+                normalized = value.strip()
+                setattr(self, field_name, normalized or None)
+        return self
+
+
+class AgentRuntimeCancelInput(BaseModel):
+    """Public input for agent_runtime.cancel."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    run_id: str = Field(
+        ...,
+        alias="runId",
+        validation_alias=AliasChoices("runId", "run_id"),
+        min_length=1,
+    )
+    agent_kind: Literal["managed", "external", "unknown"] = Field(
+        default="unknown",
+        alias="agentKind",
+        validation_alias=AliasChoices("agentKind", "agent_kind"),
+    )
+    agent_id: str | None = Field(
+        default=None,
+        alias="agentId",
+        validation_alias=AliasChoices("agentId", "agent_id", "agent"),
+    )
+
+    @model_validator(mode="after")
+    def _normalize_cancel(self) -> "AgentRuntimeCancelInput":
+        self.run_id = self.run_id.strip()
+        if not self.run_id:
+            raise ValueError("runId must be nonblank")
+        if self.agent_id is not None:
+            self.agent_id = self.agent_id.strip() or None
+        return self

--- a/moonmind/schemas/temporal_activity_models.py
+++ b/moonmind/schemas/temporal_activity_models.py
@@ -248,7 +248,6 @@ class AgentRuntimeFetchResultInput(AgentRuntimeStatusInput):
 
     @model_validator(mode="after")
     def _normalize_fetch(self) -> "AgentRuntimeFetchResultInput":
-        super()._normalize()
         for field_name in ("commit_message", "target_branch", "head_branch"):
             value = getattr(self, field_name)
             if value is not None:

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -19,12 +19,16 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar, get_type_hints
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from moonmind.config.settings import settings
 from moonmind.jules.status import JulesStatusSnapshot, normalize_jules_status
 from moonmind.schemas.manifest_ingest_models import CompiledManifestPlanModel
 from moonmind.schemas.temporal_activity_models import (
+    AgentRuntimeCancelInput,
+    AgentRuntimeFetchResultInput,
+    AgentRuntimeStatusInput,
+    ExternalAgentRunInput,
     PlanGenerateInput,
 )
 from moonmind.workflows.tasks.routing import _coerce_bool
@@ -892,6 +896,59 @@ def _coerce_activity_request(
             f"{activity_type} payload must be a JSON object"
         )
     return dict(request)
+
+
+def _validate_external_agent_run_input(payload: Any) -> ExternalAgentRunInput:
+    """Validate external activity input, including scalar legacy histories."""
+
+    if isinstance(payload, str):
+        payload = {"runId": payload}
+    try:
+        return ExternalAgentRunInput.model_validate(payload)
+    except ValidationError as exc:
+        raise TemporalActivityRuntimeError(
+            f"external agent run payload is invalid: {exc}"
+        ) from exc
+
+
+def _validate_agent_runtime_status_input(payload: Any) -> AgentRuntimeStatusInput:
+    if isinstance(payload, AgentRuntimeStatusInput):
+        return payload
+    try:
+        return AgentRuntimeStatusInput.model_validate(payload)
+    except ValidationError as exc:
+        raise TemporalActivityRuntimeError(
+            f"agent_runtime.status payload is invalid: {exc}"
+        ) from exc
+
+
+def _validate_agent_runtime_fetch_result_input(
+    payload: Any,
+) -> AgentRuntimeFetchResultInput:
+    if isinstance(payload, AgentRuntimeFetchResultInput):
+        return payload
+    if isinstance(payload, AgentRuntimeStatusInput):
+        return AgentRuntimeFetchResultInput(
+            runId=payload.run_id,
+            agentId=payload.agent_id,
+        )
+    try:
+        return AgentRuntimeFetchResultInput.model_validate(payload)
+    except ValidationError as exc:
+        raise TemporalActivityRuntimeError(
+            f"agent_runtime.fetch_result payload is invalid: {exc}"
+        ) from exc
+
+
+def _validate_agent_runtime_cancel_input(payload: Any) -> AgentRuntimeCancelInput:
+    if isinstance(payload, AgentRuntimeCancelInput):
+        return payload
+    try:
+        return AgentRuntimeCancelInput.model_validate(payload)
+    except ValidationError as exc:
+        raise TemporalActivityRuntimeError(
+            f"agent_runtime.cancel payload is invalid: {exc}"
+        ) from exc
 
 
 async def _maybe_call_heartbeat(
@@ -1874,30 +1931,18 @@ class TemporalIntegrationActivities:
 
     async def integration_jules_status(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.jules_activities import jules_status_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.jules.status requires a non-empty run_id string")
-        return await jules_status_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await jules_status_activity(request.run_id)
 
     async def integration_jules_fetch_result(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.jules_activities import jules_fetch_result_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.jules.fetch_result requires a non-empty run_id string")
-        return await jules_fetch_result_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await jules_fetch_result_activity(request.run_id)
 
     async def integration_jules_cancel(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.jules_activities import jules_cancel_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.jules.cancel requires a non-empty run_id string")
-        return await jules_cancel_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await jules_cancel_activity(request.run_id)
 
     async def repo_create_pr(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.jules_activities import repo_create_pr_activity
@@ -1947,30 +1992,18 @@ class TemporalIntegrationActivities:
 
     async def integration_codex_cloud_status(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.codex_cloud_activities import codex_cloud_status_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.codex_cloud.status requires a non-empty run_id string")
-        return await codex_cloud_status_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await codex_cloud_status_activity(request.run_id)
 
     async def integration_codex_cloud_fetch_result(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.codex_cloud_activities import codex_cloud_fetch_result_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.codex_cloud.fetch_result requires a non-empty run_id string")
-        return await codex_cloud_fetch_result_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await codex_cloud_fetch_result_activity(request.run_id)
 
     async def integration_codex_cloud_cancel(self, payload, /, **kwargs):
         from moonmind.workflows.temporal.activities.codex_cloud_activities import codex_cloud_cancel_activity
-        run_id = payload
-        if isinstance(payload, Mapping):
-            run_id = payload.get("external_id") or payload.get("externalId") or payload.get("run_id") or payload.get("runId")
-        if not run_id or not isinstance(run_id, str):
-            raise TemporalActivityRuntimeError("integration.codex_cloud.cancel requires a non-empty run_id string")
-        return await codex_cloud_cancel_activity(run_id.strip())
+        request = _validate_external_agent_run_input(payload)
+        return await codex_cloud_cancel_activity(request.run_id)
 
     async def integration_openclaw_execute(self, request, /, **kwargs):
         from moonmind.workflows.temporal.activities.openclaw_activities import openclaw_execute_activity
@@ -3372,23 +3405,11 @@ class TemporalAgentRuntimeActivities:
         request: Any,
     ) -> tuple[str, str]:
         """Extract ``run_id`` and ``agent_id`` from a flexible request shape."""
+        if isinstance(request, (AgentRuntimeStatusInput, AgentRuntimeFetchResultInput)):
+            return request.run_id, request.agent_id
         if isinstance(request, Mapping):
-            run_id = str(
-                request.get("run_id")
-                or request.get("runId")
-                or ""
-            ).strip()
-            agent_id = str(
-                request.get("agent_id")
-                or request.get("agentId")
-                or request.get("agent")
-                or "managed"
-            ).strip() or "managed"
-            if not run_id:
-                raise TemporalActivityRuntimeError(
-                    "agent_runtime request requires run_id"
-                )
-            return run_id, agent_id
+            validated = _validate_agent_runtime_status_input(request)
+            return validated.run_id, validated.agent_id
         if isinstance(request, str):
             run_id = request.strip()
             if not run_id:
@@ -3443,6 +3464,8 @@ class TemporalAgentRuntimeActivities:
             raise TemporalActivityRuntimeError(
                 "run_store is required for agent_runtime.status"
             )
+        if isinstance(request, Mapping):
+            request = _validate_agent_runtime_status_input(request)
         run_id, agent_id = self._agent_runtime_request_identifiers(request)
 
         from temporalio import activity
@@ -3484,36 +3507,33 @@ class TemporalAgentRuntimeActivities:
             raise TemporalActivityRuntimeError(
                 "run_store is required for agent_runtime.fetch_result"
             )
-        run_id, _agent_id = self._agent_runtime_request_identifiers(request)
         if isinstance(request, Mapping):
-            raw_publish_mode = (
-                request.get("publish_mode")
-                or request.get("publishMode")
-                or "none"
+            request = _validate_agent_runtime_fetch_result_input(request)
+        elif isinstance(request, AgentRuntimeStatusInput) and not isinstance(
+            request, AgentRuntimeFetchResultInput
+        ):
+            request = AgentRuntimeFetchResultInput(
+                runId=request.run_id,
+                agentId=request.agent_id,
             )
-        else:
-            raw_publish_mode = "none"
+        run_id, _agent_id = self._agent_runtime_request_identifiers(request)
 
-        publish_mode = str(raw_publish_mode).strip().lower()
-        _ALLOWED_PUBLISH_MODES = {"none", "pr", "branch"}
-        if publish_mode not in _ALLOWED_PUBLISH_MODES:
-            logger.warning(
-                "Received invalid publish_mode %r for run_id %s; defaulting to 'none'",
-                raw_publish_mode,
-                run_id,
-            )
-            publish_mode = "none"
+        publish_mode = (
+            request.publish_mode
+            if isinstance(request, AgentRuntimeFetchResultInput)
+            else "none"
+        )
 
         target_branch = (
-            request.get("target_branch")
-            or request.get("targetBranch")
-            or request.get("publish_base_branch")
-            or request.get("publishBaseBranch")
-        ) if isinstance(request, Mapping) else None
+            request.target_branch
+            if isinstance(request, AgentRuntimeFetchResultInput)
+            else None
+        )
         head_branch = (
-            request.get("head_branch")
-            or request.get("headBranch")
-        ) if isinstance(request, Mapping) else None
+            request.head_branch
+            if isinstance(request, AgentRuntimeFetchResultInput)
+            else None
+        )
 
         async def _unused_profile_fetcher(**_kwargs: Any) -> dict[str, Any]:
             return {"profiles": []}
@@ -3521,15 +3541,10 @@ class TemporalAgentRuntimeActivities:
         async def _unused_slot_signal(**_kwargs: Any) -> None:
             return None
 
-        if isinstance(request, Mapping):
-            raw_pr_resolver_expected = (
-                request.get("pr_resolver_expected")
-                or request.get("prResolverExpected")
-            )
-        else:
-            raw_pr_resolver_expected = None
-        pr_resolver_expected = _coerce_bool(
-            raw_pr_resolver_expected, default=False
+        pr_resolver_expected = (
+            request.pr_resolver_expected
+            if isinstance(request, AgentRuntimeFetchResultInput)
+            else False
         )
 
         adapter = ManagedAgentAdapter(
@@ -3577,12 +3592,11 @@ class TemporalAgentRuntimeActivities:
             # Push the agent's work branch if publish_mode requires it and the
             # agent completed without failure.
             if result.failure_class is None and publish_mode != "none":
-                raw_commit_message = None
-                if isinstance(request, Mapping):
-                    raw_commit_message = (
-                        request.get("commit_message")
-                        or request.get("commitMessage")
-                    )
+                raw_commit_message = (
+                    request.commit_message
+                    if isinstance(request, AgentRuntimeFetchResultInput)
+                    else None
+                )
                 push_kwargs: dict[str, Any] = {
                     "target_branch": target_branch,
                 }
@@ -4606,15 +4620,23 @@ class TemporalAgentRuntimeActivities:
         terminate the subprocess.  For external runs, logs the request
         (external cancel must go through the provider adapter).
         """
-        if isinstance(request, Mapping):
-            agent_kind = request.get("agent_kind", "unknown")
-            run_id = request.get("run_id", "unknown")
+        if isinstance(request, AgentRuntimeCancelInput):
+            cancel_input = request
+        elif isinstance(request, Mapping):
+            cancel_input = _validate_agent_runtime_cancel_input(request)
         elif isinstance(request, (list, tuple)) and len(request) >= 2:
-            agent_kind, run_id = request[0], request[1]
+            cancel_input = AgentRuntimeCancelInput(
+                agentKind=str(request[0] or "unknown"),
+                runId=str(request[1] or ""),
+            )
         else:
-            agent_kind, run_id = "unknown", str(request)
+            cancel_input = AgentRuntimeCancelInput(
+                agentKind="unknown",
+                runId=str(request or "unknown"),
+            )
 
-        run_id_str = str(run_id)
+        agent_kind = cancel_input.agent_kind
+        run_id_str = cancel_input.run_id
 
         if agent_kind == "managed":
             try:

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Protocol
 
 from temporalio.client import Client, WorkflowExecutionDescription
-from temporalio.contrib.pydantic import pydantic_data_converter
 from temporalio.common import SearchAttributeKey, SearchAttributePair, TypedSearchAttributes
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
@@ -22,6 +21,7 @@ from moonmind.workflows.temporal.workers import (
     TemporalWorkerTopology,
     describe_configured_worker,
 )
+from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
 
 if TYPE_CHECKING:
     from moonmind.workflows.temporal.service import TemporalExecutionService
@@ -124,7 +124,7 @@ async def get_temporal_client(address: str, namespace: str) -> Client:
     return await Client.connect(
         address,
         namespace=namespace,
-        data_converter=pydantic_data_converter,
+        data_converter=MOONMIND_TEMPORAL_DATA_CONVERTER,
     )
 
 
@@ -169,7 +169,7 @@ class TemporalClientAdapter:
                 self._client = await Client.connect(
                     settings.temporal.address,
                     namespace=settings.temporal.namespace,
-                    data_converter=pydantic_data_converter,
+                    data_converter=MOONMIND_TEMPORAL_DATA_CONVERTER,
                 )
             return self._client
 

--- a/moonmind/workflows/temporal/data_converter.py
+++ b/moonmind/workflows/temporal/data_converter.py
@@ -1,0 +1,9 @@
+"""Shared Temporal payload conversion contract for MoonMind runtimes."""
+
+from __future__ import annotations
+
+from temporalio.contrib.pydantic import pydantic_data_converter
+
+MOONMIND_TEMPORAL_DATA_CONVERTER = pydantic_data_converter
+
+__all__ = ["MOONMIND_TEMPORAL_DATA_CONVERTER"]

--- a/moonmind/workflows/temporal/typed_execution.py
+++ b/moonmind/workflows/temporal/typed_execution.py
@@ -11,9 +11,19 @@ from temporalio.common import RetryPolicy
 from temporalio.workflow import ActivityCancellationType
 
 from moonmind.schemas.temporal_activity_models import (
+    AgentRuntimeCancelInput,
+    AgentRuntimeFetchResultInput,
+    AgentRuntimeStatusInput,
     ArtifactReadInput,
     ArtifactWriteCompleteInput,
+    ExternalAgentRunInput,
     PlanGenerateInput,
+)
+from moonmind.schemas.agent_runtime_models import (
+    AgentExecutionRequest,
+    AgentRunHandle,
+    AgentRunResult,
+    AgentRunStatus,
 )
 from moonmind.workflows.temporal.activity_runtime import PlanGenerateActivityResult
 from moonmind.workflows.temporal.artifacts import ArtifactRef
@@ -66,6 +76,122 @@ async def execute_typed_activity(
 
 @overload
 async def execute_typed_activity(
+    activity: Literal["integration.jules.start", "integration.codex_cloud.start"],
+    arg: AgentExecutionRequest,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunHandle:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal["integration.jules.status", "integration.codex_cloud.status"],
+    arg: ExternalAgentRunInput,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunStatus:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal[
+        "integration.jules.fetch_result",
+        "integration.codex_cloud.fetch_result",
+        "agent_runtime.publish_artifacts",
+    ],
+    arg: ExternalAgentRunInput | AgentRunResult,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunResult:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal["integration.jules.cancel", "integration.codex_cloud.cancel"],
+    arg: ExternalAgentRunInput,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunStatus:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal["agent_runtime.status"],
+    arg: AgentRuntimeStatusInput,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunStatus:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal["agent_runtime.fetch_result"],
+    arg: AgentRuntimeFetchResultInput,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunResult:
+    pass
+
+
+@overload
+async def execute_typed_activity(
+    activity: Literal["agent_runtime.cancel"],
+    arg: AgentRuntimeCancelInput,
+    *,
+    task_queue: str | None = None,
+    start_to_close_timeout: timedelta | None = None,
+    schedule_to_close_timeout: timedelta | None = None,
+    heartbeat_timeout: timedelta | None = None,
+    retry_policy: RetryPolicy | None = None,
+    cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
+) -> AgentRunStatus:
+    pass
+
+
+@overload
+async def execute_typed_activity(
     activity: str,
     arg: Any,
     *,
@@ -75,6 +201,7 @@ async def execute_typed_activity(
     heartbeat_timeout: timedelta | None = None,
     retry_policy: RetryPolicy | None = None,
     cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
 ) -> Any:
     pass
 
@@ -89,6 +216,7 @@ async def execute_typed_activity(
     heartbeat_timeout: timedelta | None = None,
     retry_policy: RetryPolicy | None = None,
     cancellation_type: ActivityCancellationType | None = None,
+    summary: str | Mapping[str, Any] | None = None,
 ) -> Any:
     """A statically typed facade for workflow.execute_activity.
 
@@ -102,6 +230,7 @@ async def execute_typed_activity(
         "heartbeat_timeout": heartbeat_timeout,
         "retry_policy": retry_policy,
         "cancellation_type": cancellation_type,
+        "summary": summary,
     }
     filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
 

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -17,6 +17,12 @@ with workflow.unsafe.imports_passed_through():
         AgentRunStatus as AgentRunStatusModel,
         _MAX_SUMMARY_CHARS,
     )
+    from moonmind.schemas.temporal_activity_models import (
+        AgentRuntimeCancelInput,
+        AgentRuntimeFetchResultInput,
+        AgentRuntimeStatusInput,
+        ExternalAgentRunInput,
+    )
     from moonmind.workflows.adapters.agent_adapter import AgentAdapter
     from moonmind.workflows.adapters.managed_agent_adapter import (
         ManagedAgentAdapter,
@@ -40,6 +46,7 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
     )
+    from moonmind.workflows.temporal.typed_execution import execute_typed_activity
     from moonmind.workflows.provider_failures import (
         classify_provider_failure,
         provider_error_requires_cooldown,
@@ -311,7 +318,7 @@ class MoonMindAgentRun:
                 "agent_runtime.session_status": "Fetch managed Codex session status",
             }.get(activity_name, activity_name),
         )
-        return await workflow.execute_activity(
+        return await execute_typed_activity(
             activity_name,
             args,
             **kwargs,
@@ -485,7 +492,7 @@ class MoonMindAgentRun:
     def _build_managed_fetch_result_activity_input(
         self,
         request: AgentExecutionRequest,
-    ) -> dict[str, Any]:
+    ) -> AgentRuntimeFetchResultInput:
         params = request.parameters if isinstance(request.parameters, Mapping) else {}
         raw_publish_mode = params.get("publishMode")
         publish_mode = (
@@ -499,15 +506,15 @@ class MoonMindAgentRun:
             run_id = str(request.managed_session.task_run_id).strip()
 
         activity_input: dict[str, Any] = {
-            "run_id": run_id,
-            "agent_id": request.agent_id,
+            "runId": run_id,
+            "agentId": request.agent_id,
         }
         if publish_mode != "none":
-            activity_input["publish_mode"] = publish_mode
+            activity_input["publishMode"] = publish_mode
 
         raw_commit_message = params.get("commitMessage")
         if isinstance(raw_commit_message, str) and raw_commit_message.strip():
-            activity_input["commit_message"] = raw_commit_message.strip()
+            activity_input["commitMessage"] = raw_commit_message.strip()
 
         target_branch = str(
             params.get("publishBaseBranch")
@@ -515,7 +522,7 @@ class MoonMindAgentRun:
             or ""
         ).strip()
         if target_branch:
-            activity_input["target_branch"] = target_branch
+            activity_input["targetBranch"] = target_branch
 
         head_branch = str(
             params.get("targetBranch")
@@ -523,11 +530,11 @@ class MoonMindAgentRun:
             or ""
         ).strip()
         if head_branch:
-            activity_input["head_branch"] = head_branch
+            activity_input["headBranch"] = head_branch
 
         if _request_selected_skill(request) == "pr-resolver":
-            activity_input["pr_resolver_expected"] = True
-        return activity_input
+            activity_input["prResolverExpected"] = True
+        return AgentRuntimeFetchResultInput.model_validate(activity_input)
 
     async def _fetch_managed_result(
         self,
@@ -1531,7 +1538,7 @@ class MoonMindAgentRun:
                                 act_name = f"integration.{self._external_agent_id}.status"
                                 status_dict = await self._execute_routed_activity(
                                     act_name,
-                                    {"external_id": self.run_id},
+                                    ExternalAgentRunInput(runId=str(self.run_id or "")),
                                     cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                                 )
@@ -1545,10 +1552,10 @@ class MoonMindAgentRun:
                                 elif use_managed_status_activity:
                                     status_payload = await self._execute_routed_activity(
                                         "agent_runtime.status",
-                                        {
-                                            "run_id": self.run_id,
-                                            "agent_id": request.agent_id,
-                                        },
+                                        AgentRuntimeStatusInput(
+                                            runId=str(self.run_id or ""),
+                                            agentId=request.agent_id,
+                                        ),
                                         cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                                     )
@@ -1661,7 +1668,7 @@ class MoonMindAgentRun:
                         act_name = f"integration.{self._external_agent_id}.fetch_result"
                         result_dict = await self._execute_routed_activity(
                             act_name,
-                            {"external_id": self.run_id},
+                            ExternalAgentRunInput(runId=str(self.run_id or "")),
                             cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                         )
@@ -1833,7 +1840,7 @@ class MoonMindAgentRun:
                 # Post-run artifact publishing via the agent_runtime activity fleet.
                 enriched_result = await self._execute_routed_activity(
                     "agent_runtime.publish_artifacts",
-                    self.final_result.model_dump(mode="json", by_alias=True) if hasattr(self.final_result, "model_dump") else self.final_result,
+                    self.final_result,
                     cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                 )
@@ -1887,14 +1894,17 @@ class MoonMindAgentRun:
                             act_name = f"integration.{self._external_agent_id}.cancel"
                             await self._execute_routed_activity(
                                 act_name,
-                                {"external_id": self.run_id},
+                                ExternalAgentRunInput(runId=str(self.run_id or "")),
                                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                             )
                         else:
                             await self._execute_routed_activity(
                                 "agent_runtime.cancel",
-                                {"agent_kind": self.agent_kind, "run_id": self.run_id},
+                                AgentRuntimeCancelInput(
+                                    agentKind=self.agent_kind,
+                                    runId=str(self.run_id or ""),
+                                ),
                                 cancellation_type=ActivityCancellationType.TRY_CANCEL,
 
                             )

--- a/specs/172-typed-activity-calls/checklists/requirements.md
+++ b/specs/172-typed-activity-calls/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Typed Temporal Activity Calls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Checklist passes for runtime implementation planning.

--- a/specs/172-typed-activity-calls/contracts/temporal-activity-boundary.md
+++ b/specs/172-typed-activity-calls/contracts/temporal-activity-boundary.md
@@ -1,0 +1,40 @@
+# Temporal Activity Boundary Contract
+
+## Shared Converter
+
+All MoonMind-owned Temporal clients use `MOONMIND_TEMPORAL_DATA_CONVERTER`. Workers inherit that converter through the connected client.
+
+## Activity Types Preserved
+
+This feature does not rename activity type strings. The migrated contract covers:
+
+- `integration.jules.start`
+- `integration.jules.status`
+- `integration.jules.fetch_result`
+- `integration.jules.cancel`
+- `integration.codex_cloud.start`
+- `integration.codex_cloud.status`
+- `integration.codex_cloud.fetch_result`
+- `integration.codex_cloud.cancel`
+- `agent_runtime.status`
+- `agent_runtime.fetch_result`
+- `agent_runtime.cancel`
+- `agent_runtime.publish_artifacts`
+
+## Workflow Call-Site Rules
+
+- Start activities receive `AgentExecutionRequest`.
+- External status/fetch/cancel activities receive `ExternalAgentRunInput`.
+- Managed status activities receive `AgentRuntimeStatusInput`.
+- Managed fetch-result activities receive `AgentRuntimeFetchResultInput`.
+- Managed cancel activities receive `AgentRuntimeCancelInput`.
+- Publish-artifacts receives `AgentRunResult` or `None`.
+- Calls go through `execute_typed_activity` so overloads document the workflow-facing response type.
+
+## Legacy Boundary Rules
+
+Legacy dict payloads are accepted only at activity entry points. Accepted aliases validate into the canonical model immediately and are not propagated as business logic payloads.
+
+## Workflow-Facing Responses
+
+Workflows consume canonical MoonMind models: `AgentRunHandle`, `AgentRunStatus`, and `AgentRunResult`. Provider-specific fields may appear only as bounded metadata after normalization.

--- a/specs/172-typed-activity-calls/data-model.md
+++ b/specs/172-typed-activity-calls/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: Typed Temporal Activity Calls
+
+## Shared Temporal Data Converter
+
+- Purpose: Single MoonMind import used by Temporal clients and workers for Pydantic-aware payload conversion.
+- Validation: Must be identical to the converter passed into `Client.connect`.
+- State transitions: None; this is a stateless contract object.
+
+## External Run Identifier Request
+
+- Purpose: Identifies one external provider run/session for status, fetch-result, and cancel activities.
+- Fields:
+  - `runId`: required nonblank canonical run/session identifier.
+- Legacy boundary aliases:
+  - `external_id`, `externalId`, and `run_id` validate into `runId` at public activity entry only.
+- Validation:
+  - Unknown fields are rejected.
+  - Blank identifiers are rejected.
+
+## Agent Runtime Status Request
+
+- Purpose: Reads managed runtime status for one run.
+- Fields:
+  - `runId`: required nonblank run identifier.
+  - `agentId`: optional agent/runtime identifier, default `managed`.
+- Validation:
+  - Unknown fields are rejected.
+  - Legacy snake-case aliases validate at activity entry only.
+
+## Agent Runtime Fetch Result Request
+
+- Purpose: Reads and optionally publishes the terminal result for one managed run.
+- Fields:
+  - `runId`: required nonblank run identifier.
+  - `agentId`: optional agent/runtime identifier, default `managed`.
+  - `publishMode`: optional, one of `none`, `pr`, or `branch`.
+  - `commitMessage`, `targetBranch`, `headBranch`: optional publish metadata.
+  - `prResolverExpected`: optional boolean.
+- Validation:
+  - Unknown fields are rejected.
+  - Unsupported publish mode fails request validation.
+
+## Agent Runtime Cancel Request
+
+- Purpose: Cancels one runtime run at the activity boundary.
+- Fields:
+  - `runId`: required nonblank run identifier.
+  - `agentKind`: required runtime kind.
+  - `agentId`: optional runtime identifier.
+- Validation:
+  - Unknown fields are rejected.
+  - Blank identifiers are rejected.
+
+## Canonical Agent Runtime Responses
+
+- Purpose: Workflow-facing return contracts.
+- Models:
+  - `AgentRunHandle`
+  - `AgentRunStatus`
+  - `AgentRunResult`
+- Validation:
+  - Provider-shaped dictionaries must be converted into these models before workflow logic stores or branches on them.

--- a/specs/172-typed-activity-calls/plan.md
+++ b/specs/172-typed-activity-calls/plan.md
@@ -12,7 +12,8 @@ Enforce typed Temporal payload conversion and typed activity calls for the high-
 **Language/Version**: Python 3.12
 **Primary Dependencies**: Temporal Python SDK, `temporalio.contrib.pydantic.pydantic_data_converter`, Pydantic v2, pytest, Temporal test worker utilities
 **Storage**: Temporal workflow histories carry compact typed payloads; no new persistence tables
-**Testing**: `./tools/test_unit.sh`; targeted `pytest` for `tests/unit/workflows/temporal/...`
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`; targeted `pytest` for `tests/unit/workflows/temporal/...` during iteration
+**Integration Testing**: Targeted Temporal test-worker unit coverage is required for this story because it proves typed request serialization through a real Temporal worker without Docker. Run `./tools/test_integration.sh` for the hermetic `integration_ci` suite when Docker is available; record Docker socket unavailability as the exact blocker when it is not.
 **Target Platform**: MoonMind Temporal client, worker fleet, and AgentRun workflow/activity runtime
 **Project Type**: Backend Python service and Temporal workflow runtime in a single repository
 **Performance Goals**: No additional network calls or polling; validation is constant-time for small activity payloads
@@ -91,7 +92,7 @@ Research is captured in [research.md](./research.md). Key decisions:
 2. Add Pydantic request models for managed runtime and external run activity inputs using `extra="forbid"`.
 3. Preserve legacy dict aliases only at public activity entry validation.
 4. Migrate AgentRun call sites to typed request models and typed execution without changing activity type strings.
-5. Prove typed serialization with unit and Temporal test-worker coverage.
+5. Prove typed serialization with unit and Temporal test-worker coverage, and run the compose-backed hermetic integration suite when Docker is available.
 
 ## Phase 1: Design Outputs
 
@@ -106,7 +107,7 @@ Research is captured in [research.md](./research.md). Key decisions:
 3. Extend `execute_typed_activity` overloads for migrated activity names and route AgentRun activity execution through that facade.
 4. Update AgentRun workflow call sites to pass typed request models for migrated external and managed runtime calls.
 5. Update activity runtime entry points to validate any retained dict payloads into the typed models before business logic.
-6. Add tests for converter identity, strict model validation, typed call-site payloads, and Temporal boundary round-trips.
+6. Add tests for converter identity, strict model validation, typed call-site payloads, and Temporal boundary round-trips. Treat `./tools/test_integration.sh` as the integration strategy for environments with Docker access.
 
 ## Post-Design Constitution Re-Check
 

--- a/specs/172-typed-activity-calls/plan.md
+++ b/specs/172-typed-activity-calls/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Typed Temporal Activity Calls
+
+**Branch**: `172-typed-activity-calls` | **Date**: 2026-04-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/172-typed-activity-calls/spec.md`
+
+## Summary
+
+Enforce typed Temporal payload conversion and typed activity calls for the high-risk managed/external agent runtime activity boundary. The implementation adds one shared MoonMind Temporal data converter contract, extends activity request models for managed runtime and external run identifiers, updates the typed execution facade, and migrates AgentRun workflow call sites to construct typed models before invoking activities. Tests cover the converter contract, request validation, workflow call-site payload types, and real Temporal boundary serialization.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Temporal Python SDK, `temporalio.contrib.pydantic.pydantic_data_converter`, Pydantic v2, pytest, Temporal test worker utilities
+**Storage**: Temporal workflow histories carry compact typed payloads; no new persistence tables
+**Testing**: `./tools/test_unit.sh`; targeted `pytest` for `tests/unit/workflows/temporal/...`
+**Target Platform**: MoonMind Temporal client, worker fleet, and AgentRun workflow/activity runtime
+**Project Type**: Backend Python service and Temporal workflow runtime in a single repository
+**Performance Goals**: No additional network calls or polling; validation is constant-time for small activity payloads
+**Constraints**: Preserve stable activity type strings; keep nondeterministic provider/file/network work in activities; retain only boundary-level legacy dict handling needed for in-flight payload safety; do not expose provider-shaped data to workflow logic
+**Scale/Scope**: Representative migrated boundary includes shared data converter, typed execution facade, AgentRun external status/fetch/cancel calls, managed status/fetch/cancel calls, publish result handoff, and boundary validation tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The change strengthens Temporal orchestration contracts without creating a new agent runtime.
+- **II. One-Click Agent Deployment**: PASS. No new service, secret, or cloud dependency is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. Provider data is normalized behind adapter/activity boundaries into MoonMind contracts.
+- **IV. Own Your Data**: PASS. Workflow history stores MoonMind-owned typed payloads rather than provider-specific bodies.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Skill behavior is not changed.
+- **VI. The Bittersweet Lesson**: PASS. The change is a thin contract layer around existing runtime behavior.
+- **VII. Powerful Runtime Configurability**: PASS. No configuration semantics are hardcoded or altered.
+- **VIII. Modular and Extensible Architecture**: PASS. Converter, schemas, typed facade, workflow call sites, and tests stay in existing module boundaries.
+- **IX. Resilient by Default**: PASS. Boundary tests and validated compatibility aliases protect in-flight invocation shapes.
+- **X. Facilitate Continuous Improvement**: PASS. Stronger contracts make failures explicit and easier to diagnose.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This plan derives from the single-story spec.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Runtime work and tracking remain in feature artifacts and docs/tmp references.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS. No new internal compatibility alias is added beyond boundary validation for existing payload shapes.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/172-typed-activity-calls/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── temporal-activity-boundary.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/
+│   └── temporal_activity_models.py
+└── workflows/
+    └── temporal/
+        ├── client.py
+        ├── data_converter.py
+        ├── typed_execution.py
+        ├── activity_runtime.py
+        └── workflows/
+            └── agent_run.py
+
+tests/
+└── unit/
+    └── workflows/
+        └── temporal/
+            ├── test_temporal_client.py
+            ├── test_typed_activity_boundaries.py
+            ├── test_agent_runtime_activities.py
+            └── workflows/
+                └── test_agent_run_jules_execution.py
+```
+
+**Structure Decision**: Use existing schema, Temporal client, typed execution, activity runtime, and AgentRun workflow modules. This keeps the feature at the Temporal boundary where the source design requires it.
+
+## Phase 0: Research Summary
+
+Research is captured in [research.md](./research.md). Key decisions:
+
+1. Create a shared data converter module and import it from client/worker-facing code.
+2. Add Pydantic request models for managed runtime and external run activity inputs using `extra="forbid"`.
+3. Preserve legacy dict aliases only at public activity entry validation.
+4. Migrate AgentRun call sites to typed request models and typed execution without changing activity type strings.
+5. Prove typed serialization with unit and Temporal test-worker coverage.
+
+## Phase 1: Design Outputs
+
+- [data-model.md](./data-model.md): Defines shared converter, request models, typed facade, canonical runtime responses, and boundary shim behavior.
+- [contracts/temporal-activity-boundary.md](./contracts/temporal-activity-boundary.md): Captures activity type strings, request/response contracts, legacy aliases, and workflow-facing guarantees.
+- [quickstart.md](./quickstart.md): Lists targeted and full validation commands.
+
+## Implementation Strategy
+
+1. Add a shared MoonMind Temporal data converter contract and replace direct converter imports in client construction.
+2. Add strict typed activity request models for external run identifiers and managed runtime status/fetch/cancel operations.
+3. Extend `execute_typed_activity` overloads for migrated activity names and route AgentRun activity execution through that facade.
+4. Update AgentRun workflow call sites to pass typed request models for migrated external and managed runtime calls.
+5. Update activity runtime entry points to validate any retained dict payloads into the typed models before business logic.
+6. Add tests for converter identity, strict model validation, typed call-site payloads, and Temporal boundary round-trips.
+
+## Post-Design Constitution Re-Check
+
+- **I. Orchestrate, Don't Recreate**: PASS.
+- **II. One-Click Agent Deployment**: PASS.
+- **III. Avoid Vendor Lock-In**: PASS.
+- **IV. Own Your Data**: PASS.
+- **V. Skills Are First-Class and Easy to Add**: PASS.
+- **VI. The Bittersweet Lesson**: PASS.
+- **VII. Powerful Runtime Configurability**: PASS.
+- **VIII. Modular and Extensible Architecture**: PASS.
+- **IX. Resilient by Default**: PASS.
+- **X. Facilitate Continuous Improvement**: PASS.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS.
+- **XIII. Pre-Release Velocity: Delete, Don't Deprecate**: PASS.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions.

--- a/specs/172-typed-activity-calls/quickstart.md
+++ b/specs/172-typed-activity-calls/quickstart.md
@@ -1,0 +1,23 @@
+# Quickstart: Typed Temporal Activity Calls
+
+## Targeted Validation
+
+```bash
+pytest tests/unit/workflows/temporal/test_temporal_client.py \
+  tests/unit/workflows/temporal/test_typed_activity_boundaries.py \
+  tests/unit/workflows/temporal/test_agent_runtime_activities.py \
+  tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py -q
+```
+
+## Full Unit Suite
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Expected Evidence
+
+- Temporal client tests prove the shared data converter contract is used.
+- Typed boundary tests prove strict request validation and real Temporal round-trip serialization.
+- AgentRun workflow tests prove migrated call sites pass typed request model instances.
+- Agent runtime activity tests prove legacy dict payloads validate at the public edge into canonical models.

--- a/specs/172-typed-activity-calls/quickstart.md
+++ b/specs/172-typed-activity-calls/quickstart.md
@@ -15,6 +15,14 @@ pytest tests/unit/workflows/temporal/test_temporal_client.py \
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
 ```
 
+## Hermetic Integration Suite
+
+```bash
+./tools/test_integration.sh
+```
+
+Run this when Docker is available. If `/var/run/docker.sock` is unavailable in a managed agent workspace, record that exact blocker and rely on the targeted Temporal test-worker unit coverage for this story's typed serialization path.
+
 ## Expected Evidence
 
 - Temporal client tests prove the shared data converter contract is used.

--- a/specs/172-typed-activity-calls/research.md
+++ b/specs/172-typed-activity-calls/research.md
@@ -1,0 +1,31 @@
+# Research: Typed Temporal Activity Calls
+
+## Shared Temporal Data Converter
+
+Decision: Add an importable MoonMind data converter constant that points to Temporal's Pydantic-aware converter and use it from Temporal client construction.
+Rationale: The source design treats converter policy as part of the contract. A named project constant makes client/worker drift testable and avoids scattered direct imports.
+Alternatives considered: Continue importing `pydantic_data_converter` directly in each module; rejected because it is harder to audit and assert as a shared contract.
+
+## Typed Activity Request Models
+
+Decision: Add strict Pydantic request models in `moonmind/schemas/temporal_activity_models.py` for managed runtime status/fetch/cancel inputs and external run identifier inputs.
+Rationale: These are high-risk workflow history payloads that currently use dicts and scalar shims. Models with `extra="forbid"` make the canonical wire shape explicit.
+Alternatives considered: Dataclasses; rejected because the project standard for Temporal boundary I/O is Pydantic v2.
+
+## Compatibility Boundary
+
+Decision: Keep legacy dict alias handling only inside activity runtime entry validation, then proceed with canonical typed models.
+Rationale: In-flight histories may still contain `external_id`, `externalId`, `run_id`, or `runId`. Accepting those at the public edge protects replay while avoiding provider-shaped data inside workflow logic.
+Alternatives considered: Remove all legacy aliases immediately; rejected because Temporal-facing contracts are compatibility-sensitive for in-flight histories.
+
+## Typed Execution Facade
+
+Decision: Extend `execute_typed_activity` overloads for migrated runtime activity names and use it from the AgentRun activity router.
+Rationale: Workflow code needs a single typed helper so static analysis sees request and response contracts while the existing route catalog still controls task queues and timeouts.
+Alternatives considered: Call `workflow.execute_activity` directly with typed models; rejected because it would not satisfy the typed facade requirement and would leave call sites inconsistent.
+
+## Provider Data Boundary
+
+Decision: Continue allowing adapters to interact with provider-shaped data inside activities, but require workflow-side code to validate responses into `AgentRunHandle`, `AgentRunStatus`, and `AgentRunResult`.
+Rationale: Workflows must store canonical MoonMind state in history. Provider details remain in bounded metadata only after normalization.
+Alternatives considered: Store raw provider responses and normalize later; rejected because it leaks provider-specific history shape into workflow replay.

--- a/specs/172-typed-activity-calls/spec.md
+++ b/specs/172-typed-activity-calls/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Typed Temporal Activity Calls
+
+**Feature Branch**: `172-typed-activity-calls`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: User description: "MM-328: Enforce typed Temporal payload conversion and activity calls
+
+User Story
+As a MoonMind workflow maintainer, I need Temporal clients, workers, and workflow activity call sites to share typed payload conversion and typed execution helpers so model annotations match the serialized wire shape and provider-specific data cannot leak into workflow histories.
+Source Document
+docs/Temporal/TemporalTypeSafety.md
+Source Sections
+- 3.4 The data converter is part of the contract
+- 3.6 Determinism remains the workflow rule
+- 5 Activities
+- 5.4 Provider-specific data stops at the activity boundary
+- 5.5 Compatibility shims are narrow and temporary
+Coverage IDs
+- DESIGN-REQ-004
+- DESIGN-REQ-006
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+Story Metadata
+- Story ID: STORY-002
+- Short name: typed-activity-calls
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the request is "Implement Docs/<path>.md", treat it as runtime intent and use the document as source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+**Implementation Intent**: Runtime implementation. Required deliverables include production runtime code changes plus validation tests.
+
+## User Story - Enforce Typed Activity Calls
+
+**Summary**: As a MoonMind workflow maintainer, I want Temporal clients, workers, and activity call sites to share typed payload conversion and typed execution helpers so workflow histories carry canonical MoonMind contracts instead of ad hoc provider-shaped dictionaries.
+
+**Goal**: Temporal-facing code validates activity inputs and structured outputs through shared typed contracts, while nondeterministic provider work remains inside activities and provider-specific payloads are normalized before workflows observe them.
+
+**Independent Test**: Run Temporal boundary and workflow unit tests that pass typed activity request models through the shared payload converter and typed execution helper, then assert workflows receive canonical MoonMind result models rather than provider-shaped dictionaries.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Temporal client or worker is created, **When** it connects to Temporal, **Then** it uses the shared MoonMind Pydantic-aware data converter policy.
+2. **Given** a workflow calls a migrated activity, **When** it constructs the activity argument, **Then** the argument is a named typed request model and the call goes through the typed execution facade.
+3. **Given** an external provider activity returns provider-shaped status or result data internally, **When** the workflow receives the activity response, **Then** the workflow-facing value is a canonical MoonMind activity/result model or is immediately validated into one.
+4. **Given** a legacy dict-shaped payload still reaches a public activity boundary for in-flight compatibility, **When** the activity starts processing it, **Then** it validates the dict into the canonical request model before business logic runs.
+
+### Edge Cases
+
+- Legacy aliases such as `external_id` or `run_id` may appear at activity entry; they must be accepted only by boundary validation and serialized from canonical models afterward.
+- Unknown fields in new typed activity request models must fail validation rather than silently entering workflow history.
+- Provider status/result dictionaries must not be returned directly from migrated activities to workflow logic.
+- Data converter configuration must be shared through one importable contract so clients and workers cannot drift.
+
+## Assumptions
+
+- This story targets representative high-risk managed and external agent runtime activity calls rather than every remaining historical Temporal boundary in one change.
+- Existing stable activity type strings are preserved.
+- Compatibility handling for already-running histories remains at public activity edges only.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-004**: Source `docs/Temporal/TemporalTypeSafety.md` section 3.4. Temporal clients and workers must share a Pydantic-aware payload conversion policy, with legacy JSON-shaped boundaries immediately validating into canonical models. Scope: in scope. Mapped to FR-001, FR-002.
+- **DESIGN-REQ-006**: Source `docs/Temporal/TemporalTypeSafety.md` section 3.6. Type-safety changes must not move network, filesystem, provider inspection, clocks, subprocesses, or mutable external reads into workflow code. Scope: in scope. Mapped to FR-007.
+- **DESIGN-REQ-009**: Source `docs/Temporal/TemporalTypeSafety.md` section 5 and 5.3. Activities expose single typed request models and named structured return models, while workflow call sites construct typed requests through typed execution facades. Scope: in scope. Mapped to FR-003, FR-004, FR-005.
+- **DESIGN-REQ-010**: Source `docs/Temporal/TemporalTypeSafety.md` section 5.4. Provider-specific payloads terminate inside activities and workflow-facing values use MoonMind canonical contracts. Scope: in scope. Mapped to FR-006.
+- **DESIGN-REQ-011**: Source `docs/Temporal/TemporalTypeSafety.md` section 5.5. Legacy dict acceptance is narrow, temporary, boundary-only, and immediately validates into canonical models. Scope: in scope. Mapped to FR-002, FR-008.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Temporal client construction MUST use a shared MoonMind Pydantic-aware data converter contract for Temporal-facing calls.
+- **FR-002**: Temporal worker construction MUST receive the same shared data converter policy through the client used to run workers.
+- **FR-003**: Migrated activity inputs MUST use named Pydantic v2 request models with unknown fields rejected by default.
+- **FR-004**: Migrated workflow activity call sites MUST construct typed request models instead of inline raw dictionaries.
+- **FR-005**: Migrated workflow activity call sites MUST use the typed execution facade for activity execution.
+- **FR-006**: Migrated provider or runtime activities MUST return canonical MoonMind response models or validate returned dictionaries into canonical MoonMind response models before workflow logic consumes them.
+- **FR-007**: Workflow code MUST keep provider inspection, environment reads, filesystem I/O, subprocesses, network calls, and other nondeterministic work inside activities.
+- **FR-008**: Any retained legacy dict-shaped activity acceptance MUST exist only at the public boundary and validate into the canonical request model before business logic runs.
+
+### Key Entities
+
+- **Shared Temporal Data Converter**: The importable MoonMind contract used by clients and workers to serialize and deserialize Temporal payloads.
+- **Typed Activity Request**: A named Pydantic v2 model representing a single public activity argument.
+- **Typed Execution Facade**: The workflow-side helper that wraps Temporal activity execution with overloads for known activity request and response types.
+- **Canonical Agent Runtime Result**: MoonMind-owned response models such as `AgentRunHandle`, `AgentRunStatus`, and `AgentRunResult` that workflows may safely store in history.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit coverage proves Temporal clients use the shared MoonMind data converter contract.
+- **SC-002**: Unit coverage proves migrated activity request models reject unknown fields and accept only documented legacy aliases at the public boundary.
+- **SC-003**: Workflow unit coverage proves external and managed runtime polling/fetch/cancel calls are made with typed request model instances.
+- **SC-004**: Temporal boundary coverage proves a typed activity request can round-trip through a real Temporal test worker and return a typed canonical model.
+- **SC-005**: Targeted tests for migrated modules pass through the repo test runner.

--- a/specs/172-typed-activity-calls/tasks.md
+++ b/specs/172-typed-activity-calls/tasks.md
@@ -42,15 +42,16 @@ Run the targeted tests in `quickstart.md` and confirm typed request models are s
 - [X] T011 Update `moonmind/workflows/temporal/activity_runtime.py` to validate retained legacy dicts into typed models at public activity edges. [FR-006, FR-008]
 - [X] T012 Update any affected existing tests/mocks to use typed request models where they inspect migrated call-site payloads. [FR-004, FR-005]
 - [X] T013 Run targeted tests from `quickstart.md` and fix regressions.
-- [X] T014 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record exact blocker.
-- [X] T015 Run `/speckit.verify` equivalent read-only verification and record verdict.
+- [X] T014 Run hermetic integration verification with `./tools/test_integration.sh` when Docker is available, or record the exact Docker blocker in verification notes.
+- [X] T015 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record exact blocker.
+- [X] T016 Run `/moonspec-verify` equivalent read-only verification and record verdict.
 
 ## Dependencies and Execution Order
 
 1. T001-T004 establish artifacts and shared contracts.
 2. T005-T009 create red-first evidence.
 3. T010-T012 implement and update tests.
-4. T013-T015 verify.
+4. T013-T016 verify.
 
 ## Parallel Examples
 

--- a/specs/172-typed-activity-calls/tasks.md
+++ b/specs/172-typed-activity-calls/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: Typed Temporal Activity Calls
+
+**Input**: `/specs/172-typed-activity-calls/spec.md`, `/specs/172-typed-activity-calls/plan.md`
+**Prerequisites**: `research.md`, `data-model.md`, `contracts/temporal-activity-boundary.md`, `quickstart.md`
+**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+**Integration Test Command**: `./tools/test_integration.sh` when Docker is available; targeted Temporal test-worker unit coverage is required for this story.
+
+## Source Traceability Summary
+
+- DESIGN-REQ-004: T001, T004, T008, T013
+- DESIGN-REQ-006: T010, T011, T014
+- DESIGN-REQ-009: T002, T003, T005, T006, T009, T012
+- DESIGN-REQ-010: T006, T010, T011, T014
+- DESIGN-REQ-011: T002, T007, T008, T012
+
+## Story Summary
+
+Enforce shared typed conversion and typed activity calls for representative managed/external agent runtime Temporal activity boundaries.
+
+## Independent Test
+
+Run the targeted tests in `quickstart.md` and confirm typed request models are serialized through Temporal and workflow call sites receive canonical MoonMind models.
+
+## Phase 1: Setup
+
+- [X] T001 Create Moon Spec feature artifacts in `specs/172-typed-activity-calls/` for MM-328 traceability.
+
+## Phase 2: Foundational
+
+- [X] T002 Add strict typed activity request models in `moonmind/schemas/temporal_activity_models.py` for external run identifiers and managed runtime status/fetch/cancel payloads. [FR-003, FR-008]
+- [X] T003 Add or update typed execution overloads in `moonmind/workflows/temporal/typed_execution.py` for migrated runtime activity names. [FR-005]
+- [X] T004 Add shared Temporal data converter contract in `moonmind/workflows/temporal/data_converter.py` and use it from `moonmind/workflows/temporal/client.py`. [FR-001, FR-002]
+
+## Phase 3: Story
+
+- [X] T005 [P] Add failing converter contract tests in `tests/unit/workflows/temporal/test_temporal_client.py`. [SC-001]
+- [X] T006 [P] Add failing typed boundary tests in `tests/unit/workflows/temporal/test_typed_activity_boundaries.py` for strict validation and Temporal round-trip. [SC-002, SC-004]
+- [X] T007 [P] Add failing activity runtime validation tests in `tests/unit/workflows/temporal/test_agent_runtime_activities.py`. [FR-008]
+- [X] T008 [P] Add failing AgentRun call-site payload tests in `tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py`. [SC-003]
+- [X] T009 Run targeted tests and confirm the new tests fail before production edits.
+- [X] T010 Update `moonmind/workflows/temporal/workflows/agent_run.py` to construct typed request models and route migrated calls through `execute_typed_activity`. [FR-004, FR-005, FR-006, FR-007]
+- [X] T011 Update `moonmind/workflows/temporal/activity_runtime.py` to validate retained legacy dicts into typed models at public activity edges. [FR-006, FR-008]
+- [X] T012 Update any affected existing tests/mocks to use typed request models where they inspect migrated call-site payloads. [FR-004, FR-005]
+- [X] T013 Run targeted tests from `quickstart.md` and fix regressions.
+- [X] T014 Run final unit verification with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record exact blocker.
+- [X] T015 Run `/speckit.verify` equivalent read-only verification and record verdict.
+
+## Dependencies and Execution Order
+
+1. T001-T004 establish artifacts and shared contracts.
+2. T005-T009 create red-first evidence.
+3. T010-T012 implement and update tests.
+4. T013-T015 verify.
+
+## Parallel Examples
+
+- T005, T006, T007, and T008 can be authored in parallel because they touch separate test files.
+
+## Implementation Strategy
+
+Keep stable Temporal activity names. Add typed models at the schema boundary, validate compatibility payloads at activity entry, and make workflow call sites construct canonical request models before invoking the typed execution facade.

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -32,6 +32,10 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionTurnResponse,
     LaunchCodexManagedSessionRequest,
 )
+from moonmind.schemas.temporal_activity_models import (
+    AgentRuntimeCancelInput,
+    AgentRuntimeStatusInput,
+)
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
 from moonmind.workflows.temporal import client as temporal_client_module
 from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
@@ -163,6 +167,58 @@ async def test_status_missing_run_id_raises_error(tmp_path: Path) -> None:
 
     with pytest.raises(TemporalActivityRuntimeError):
         await activities.agent_runtime_status({"agent_id": "codex_cli"})
+
+
+async def test_status_accepts_typed_request_model(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="typed-status-1", status="running")
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+
+    result = await activities.agent_runtime_status(
+        AgentRuntimeStatusInput(runId="typed-status-1", agentId="codex_cli")
+    )
+
+    assert isinstance(result, AgentRunStatus)
+    assert result.run_id == "typed-status-1"
+
+
+async def test_fetch_result_validates_legacy_dict_to_typed_request(
+    tmp_path: Path,
+) -> None:
+    store = _make_store(tmp_path)
+    _save_record(store, run_id="typed-fetch-1", status="completed")
+    activities = TemporalAgentRuntimeActivities(run_store=store)
+
+    result = await activities.agent_runtime_fetch_result(
+        {
+            "run_id": "typed-fetch-1",
+            "agent_id": "codex_cli",
+            "publish_mode": "none",
+            "pr_resolver_expected": True,
+        }
+    )
+
+    assert isinstance(result, AgentRunResult)
+
+
+async def test_cancel_accepts_typed_request_model() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    result = await activities.agent_runtime_cancel(
+        AgentRuntimeCancelInput(agentKind="external", runId="external-run-1")
+    )
+
+    assert isinstance(result, AgentRunStatus)
+    assert result.run_id == "external-run-1"
+
+
+async def test_external_agent_run_activity_wrapper_rejects_unknown_fields() -> None:
+    activities = TemporalAgentRuntimeActivities()
+
+    with pytest.raises(Exception):
+        await activities.integration_jules_status(
+            {"runId": "jules-1", "rawProviderPayload": {"status": "done"}}
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/temporal/test_temporal_client.py
+++ b/tests/unit/workflows/temporal/test_temporal_client.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 import pytest
 
 from moonmind.workflows.temporal.client import TemporalClientAdapter
+from moonmind.workflows.temporal import client as temporal_client_module
+from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -23,6 +25,22 @@ class _FakeWorkflowExecution:
 def adapter() -> TemporalClientAdapter:
     mock_client = AsyncMock()
     return TemporalClientAdapter(client=mock_client)
+
+
+async def test_temporal_client_uses_shared_pydantic_data_converter(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_connect(address, *, namespace, data_converter):
+        captured["address"] = address
+        captured["namespace"] = namespace
+        captured["data_converter"] = data_converter
+        return AsyncMock()
+
+    monkeypatch.setattr(temporal_client_module.Client, "connect", fake_connect)
+
+    await temporal_client_module.get_temporal_client("temporal:7233", "default")
+
+    assert captured["data_converter"] is MOONMIND_TEMPORAL_DATA_CONVERTER
 
 
 # ---- get_drain_metrics ----

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+from temporalio import activity, workflow
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from moonmind.schemas.agent_runtime_models import AgentRunStatus
+from moonmind.schemas.temporal_activity_models import (
+    AgentRuntimeFetchResultInput,
+    ExternalAgentRunInput,
+)
+from moonmind.workflows.temporal.data_converter import MOONMIND_TEMPORAL_DATA_CONVERTER
+from moonmind.workflows.temporal.typed_execution import execute_typed_activity
+
+
+def test_external_agent_run_input_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        ExternalAgentRunInput.model_validate(
+            {"runId": "run-1", "providerPayload": {"raw": True}}
+        )
+
+
+def test_external_agent_run_input_validates_legacy_alias_at_boundary() -> None:
+    request = ExternalAgentRunInput.model_validate({"external_id": "ext-1"})
+
+    assert request.run_id == "ext-1"
+    assert request.model_dump(mode="json", by_alias=True) == {"runId": "ext-1"}
+
+
+def test_agent_runtime_fetch_result_input_rejects_unsupported_publish_mode() -> None:
+    with pytest.raises(ValidationError):
+        AgentRuntimeFetchResultInput.model_validate(
+            {"runId": "managed-1", "publishMode": "side-channel"}
+        )
+
+
+@activity.defn(name="typed.boundary.status")
+async def _typed_status_activity(request: ExternalAgentRunInput) -> AgentRunStatus:
+    assert isinstance(request, ExternalAgentRunInput)
+    return AgentRunStatus(
+        runId=request.run_id,
+        agentKind="external",
+        agentId="jules",
+        status="completed",
+        observedAt=datetime.now(tz=UTC),
+    )
+
+
+@workflow.defn(name="TypedActivityBoundaryWorkflow")
+class _TypedActivityBoundaryWorkflow:
+    @workflow.run
+    async def run(self, run_id: str) -> AgentRunStatus:
+        return await execute_typed_activity(
+            "typed.boundary.status",
+            ExternalAgentRunInput(runId=run_id),
+            start_to_close_timeout=timedelta(seconds=30),
+        )
+
+
+@pytest.mark.asyncio
+async def test_typed_activity_request_round_trips_through_temporal_worker() -> None:
+    async with await WorkflowEnvironment.start_time_skipping(
+        data_converter=MOONMIND_TEMPORAL_DATA_CONVERTER
+    ) as env:
+        async with Worker(
+            env.client,
+            task_queue="typed-boundary-test",
+            workflows=[_TypedActivityBoundaryWorkflow],
+            activities=[_typed_status_activity],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                _TypedActivityBoundaryWorkflow.run,
+                "round-trip-1",
+                id="typed-boundary-round-trip",
+                task_queue="typed-boundary-test",
+            )
+
+    assert isinstance(result, AgentRunStatus)
+    assert result.run_id == "round-trip-1"
+    assert result.status == "completed"

--- a/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
+++ b/tests/unit/workflows/temporal/test_typed_activity_boundaries.py
@@ -38,6 +38,24 @@ def test_agent_runtime_fetch_result_input_rejects_unsupported_publish_mode() -> 
         )
 
 
+def test_agent_runtime_fetch_result_input_normalizes_parent_and_fetch_fields() -> None:
+    request = AgentRuntimeFetchResultInput.model_validate(
+        {
+            "runId": " managed-1 ",
+            "agentId": " codex ",
+            "commitMessage": " Use typed payloads ",
+            "targetBranch": " main ",
+            "headBranch": "   ",
+        }
+    )
+
+    assert request.run_id == "managed-1"
+    assert request.agent_id == "codex"
+    assert request.commit_message == "Use typed payloads"
+    assert request.target_branch == "main"
+    assert request.head_branch is None
+
+
 @activity.defn(name="typed.boundary.status")
 async def _typed_status_activity(request: ExternalAgentRunInput) -> AgentRunStatus:
     assert isinstance(request, ExternalAgentRunInput)

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -13,6 +13,7 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunStatus,
     _MAX_SUMMARY_CHARS,
 )
+from moonmind.schemas.temporal_activity_models import AgentRuntimeFetchResultInput
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -92,8 +93,9 @@ async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_he
 
     activity_input = run._build_managed_fetch_result_activity_input(request)
 
-    assert activity_input["target_branch"] == "main"
-    assert "head_branch" not in activity_input
+    assert isinstance(activity_input, AgentRuntimeFetchResultInput)
+    assert activity_input.target_branch == "main"
+    assert activity_input.head_branch is None
 
 
 async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
@@ -276,10 +278,9 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
     assert routed_calls[0][1]["workflowId"] == "wf-task-1:session:override"
     assert routed_calls[0][1]["taskRunId"] == "wf-task-1"
     assert routed_calls[1][1]["workspacePath"] == "/work/task/repo"
-    assert routed_calls[2][1] == {
-        "run_id": "wf-task-1",
-        "agent_id": "codex",
-    }
+    assert isinstance(routed_calls[2][1], AgentRuntimeFetchResultInput)
+    assert routed_calls[2][1].run_id == "wf-task-1"
+    assert routed_calls[2][1].agent_id == "codex"
 
 
 async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
@@ -514,9 +515,10 @@ async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_
     fetch_payload = next(
         payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
     )
-    assert fetch_payload["publish_mode"] == "pr"
-    assert fetch_payload["target_branch"] == "main"
-    assert fetch_payload["head_branch"] == "feature/recover-detached-head"
+    assert isinstance(fetch_payload, AgentRuntimeFetchResultInput)
+    assert fetch_payload.publish_mode == "pr"
+    assert fetch_payload.target_branch == "main"
+    assert fetch_payload.head_branch == "feature/recover-detached-head"
 
 
 async def test_agent_run_managed_session_start_runtime_error_returns_failed_result(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -12,6 +12,10 @@ from moonmind.schemas.agent_runtime_models import (
     AgentRunResult,
     AgentRunStatus,
 )
+from moonmind.schemas.temporal_activity_models import (
+    AgentRuntimeFetchResultInput,
+    ExternalAgentRunInput,
+)
 from moonmind.workflows.temporal.workflows import agent_run as agent_run_module
 from moonmind.workflows.temporal.workflows.agent_run import MoonMindAgentRun
 
@@ -168,6 +172,68 @@ async def test_agent_run_jules_branch_publish_failure_maps_to_non_success(
     assert result.metadata["publishOutcome"] == "publish_failed"
 
 
+async def test_agent_run_external_poll_and_fetch_use_typed_activity_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run = MoonMindAgentRun()
+    routed_calls: list[tuple[str, Any]] = []
+
+    _configure_workflow_runtime(monkeypatch)
+
+    wait_calls = 0
+
+    async def fake_wait_condition(_condition: Any, timeout: timedelta) -> None:
+        nonlocal wait_calls
+        wait_calls += 1
+        raise asyncio.TimeoutError()
+
+    async def fake_execute_routed_activity(
+        activity_name: str,
+        payload: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        routed_calls.append((activity_name, payload))
+        if activity_name == "integration.resolve_adapter_metadata":
+            return {"agent_id": payload, "execution_style": "polling"}
+        if activity_name == "integration.jules.start":
+            return {"external_id": "session-typed-1", "status": "queued"}
+        if activity_name == "integration.jules.status":
+            assert isinstance(payload, ExternalAgentRunInput)
+            return AgentRunStatus(
+                runId=payload.run_id,
+                agentKind="external",
+                agentId="jules",
+                status="completed",
+            )
+        if activity_name == "integration.jules.fetch_result":
+            assert isinstance(payload, ExternalAgentRunInput)
+            return AgentRunResult(summary="Done", metadata={})
+        if activity_name == "agent_runtime.publish_artifacts":
+            assert isinstance(payload, AgentRunResult)
+            return payload
+        raise AssertionError(f"Unexpected routed activity: {activity_name}")
+
+    monkeypatch.setattr(agent_run_module.workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(run, "_execute_routed_activity", fake_execute_routed_activity)
+
+    result = await run.run(_request())
+
+    assert wait_calls == 1
+    assert result.summary == "Done"
+    status_payload = next(
+        payload for name, payload in routed_calls if name == "integration.jules.status"
+    )
+    fetch_payload = next(
+        payload
+        for name, payload in routed_calls
+        if name == "integration.jules.fetch_result"
+    )
+    assert isinstance(status_payload, ExternalAgentRunInput)
+    assert status_payload.run_id == "session-typed-1"
+    assert isinstance(fetch_payload, ExternalAgentRunInput)
+    assert fetch_payload.run_id == "session-typed-1"
+
+
 async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -263,9 +329,10 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
     fetch_payload = next(
         payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
     )
-    assert fetch_payload["publish_mode"] == "pr"
-    assert fetch_payload["commit_message"] == "Use producer commit text"
-    assert fetch_payload["target_branch"] == "main"
+    assert isinstance(fetch_payload, AgentRuntimeFetchResultInput)
+    assert fetch_payload.publish_mode == "pr"
+    assert fetch_payload.commit_message == "Use producer commit text"
+    assert fetch_payload.target_branch == "main"
 
 
 async def test_agent_run_managed_preserves_task_scoped_session_metadata(
@@ -414,10 +481,9 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
     fetch_payload = next(
         payload for name, payload in routed_calls if name == "agent_runtime.fetch_result"
     )
-    assert fetch_payload == {
-        "run_id": "wf-run-1",
-        "agent_id": "codex_cli",
-    }
+    assert isinstance(fetch_payload, AgentRuntimeFetchResultInput)
+    assert fetch_payload.run_id == "wf-run-1"
+    assert fetch_payload.agent_id == "codex_cli"
     assert result.metadata["managedSession"] == {
         "workflowId": "wf-run-1:session:codex_cli",
         "taskRunId": "wf-run-1",


### PR DESCRIPTION
MM-328: Enforce typed Temporal payload conversion and activity calls

User Story
As a MoonMind workflow maintainer, I need Temporal clients, workers, and workflow activity call sites to share typed payload conversion and typed execution helpers so model annotations match the serialized wire shape and provider-specific data cannot leak into workflow histories.
Source Document
docs/Temporal/TemporalTypeSafety.md
Source Sections
- 3.4 The data converter is part of the contract
- 3.6 Determinism remains the workflow rule
- 5 Activities
- 5.4 Provider-specific data stops at the activity boundary
- 5.5 Compatibility shims are narrow and temporary
Coverage IDs
- DESIGN-REQ-004
- DESIGN-REQ-006
- DESIGN-REQ-009
- DESIGN-REQ-010
- DESIGN-REQ-011
Story Metadata
- Story ID: STORY-002
- Short name: typed-activity-calls
- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json