### PR TITLE
Create a Jira Orchestrate preset. This preset should take a Jira issue identifier as input (e.g. MM-328), change the issue's status to In Progress, re

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -134,6 +134,8 @@ steps:
     instructions: |-
       Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
 
+      This preset owns pull request creation before the Jira Code Review transition. It must be run with task.publish.mode=none so the pull request is created in this step, not by a later MoonMind publish stage. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
+
       First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a pull request with the available authenticated GitHub tooling.
 
       The pull request title must include {{ inputs.jira_issue_key }}. The pull request body must include:
@@ -143,7 +145,7 @@ steps:
       - tests run
       - remaining risks
 
-      If authentication, remote configuration, branch protection, or repository permissions prevent PR creation, stop before changing Jira to Code Review and report the exact blocker.
+      After creation, record the confirmed pull request URL in the step result and in a local handoff artifact at artifacts/jira-orchestrate-pr.json with keys jira_issue_key and pull_request_url. Do not continue unless the pull_request_url is a GitHub pull request URL for the current work branch.
     skill:
       id: auto
       args: {}
@@ -152,6 +154,8 @@ steps:
   - title: Move Jira issue to Code Review
     instructions: |-
       Change Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists.
+
+      Before using any Jira transition tool, read the previous pull request creation result or artifacts/jira-orchestrate-pr.json and verify it contains a non-empty pull_request_url for {{ inputs.jira_issue_key }}. If no confirmed pull request URL is available, stop without changing Jira and report that Code Review is blocked until PR creation succeeds.
 
       Use the trusted Jira issue updater workflow and Jira transition tools. Match Code Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
     skill:

--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -1,0 +1,172 @@
+slug: jira-orchestrate
+title: Jira Orchestrate
+description: Move a Jira issue through implementation by using its preset brief as the MoonSpec orchestration input, creating a PR, and advancing the issue to Code Review.
+scope: global
+version: 1.0.0
+tags:
+  - jira
+  - moonspec
+  - orchestration
+  - pull-request
+requiredCapabilities:
+  - git
+annotations:
+  sourceSkill: moonspec-orchestrate
+  jiraWorkflow: implementation-to-code-review
+  output: pull-request
+inputs:
+  - name: jira_issue_key
+    label: Jira Issue Key
+    type: text
+    required: true
+  - name: orchestration_mode
+    label: Orchestration Mode
+    type: enum
+    required: true
+    default: runtime
+    options:
+      - runtime
+      - docs
+  - name: source_design_path
+    label: Source Design Path
+    type: text
+    required: false
+    default: ""
+  - name: constraints
+    label: Constraints
+    type: textarea
+    required: false
+    default: ""
+steps:
+  - title: Move Jira issue to In Progress
+    instructions: |-
+      Change Jira issue {{ inputs.jira_issue_key }} to status In Progress before implementation starts.
+
+      Use the trusted Jira issue updater workflow and Jira transition tools. Match In Progress against the issue's available transitions or target statuses; do not guess transition IDs. Re-fetch the issue when possible and report the confirmed status.
+    skill:
+      id: jira-issue-updater
+      args: {}
+  - title: Load Jira preset brief
+    instructions: |-
+      Fetch Jira issue {{ inputs.jira_issue_key }} through the trusted Jira tool surface.
+
+      Build the canonical MoonSpec orchestration input from the issue's Jira preset brief. Prefer a normalized preset brief or recommended preset instructions when the Jira issue response exposes one. If that field is unavailable, synthesize the brief from the issue key, summary, description, acceptance criteria, and relevant implementation notes.
+
+      Preserve the issue key in the brief so downstream spec artifacts and the pull request can reference {{ inputs.jira_issue_key }}.
+    skill:
+      id: auto
+      args: {}
+  - title: Classify request and resume point
+    instructions: |-
+      Use the Jira preset brief for {{ inputs.jira_issue_key }} as the canonical Moon Spec orchestration input.
+
+      Additional constraints:
+      {{ inputs.constraints }}
+
+      Selected mode: {{ inputs.orchestration_mode }}.
+      Default to runtime mode and only use docs mode when explicitly requested.
+      If the brief points at an implementation document, treat it as runtime source requirements.
+      Source design path (optional): {{ inputs.source_design_path }}.
+
+      Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+      Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+    skill:
+      id: auto
+      args: {}
+  - title: Create or select Moon Spec
+    instructions: |-
+      For a single-story Jira preset brief, run moonspec-specify unless an active spec.md already passes the specify gate.
+      For a broad technical or declarative design, run moonspec-breakdown first, then select the recommended first generated spec unless the issue brief explicitly requires processing all specs.
+      Preserve Jira issue {{ inputs.jira_issue_key }} and the original preset brief in spec.md so final verification can compare against them.
+    skill:
+      id: moonspec-specify
+      args: {}
+  - title: Split broad designs when needed
+    instructions: |-
+      Run moonspec-breakdown only when the Jira preset brief is a broad technical or declarative design with multiple independently testable stories.
+      Keep each generated spec isolated and process specs in dependency order when multiple specs are required by {{ inputs.jira_issue_key }}.
+    skill:
+      id: auto
+      args: {}
+  - title: Plan selected spec
+    instructions: |-
+      Run moonspec-plan when plan.md or required design artifacts are missing or stale.
+      Verify that plan.md, research.md, quickstart.md, and any required data model or contracts exist before continuing.
+      Keep unit and integration test strategies explicit.
+    skill:
+      id: moonspec-plan
+      args: {}
+  - title: Generate TDD task breakdown
+    instructions: |-
+      Run moonspec-tasks when tasks.md is missing or upstream artifacts changed.
+      Verify tasks.md covers exactly one story and includes red-first unit tests, integration tests, implementation tasks, story validation, and final /moonspec-verify work.
+    skill:
+      id: moonspec-tasks
+      args: {}
+  - title: Align Moon Spec artifacts
+    instructions: |-
+      Run moonspec-align after task generation.
+      Let moonspec-align analyze and remediate artifact drift conservatively without manual analyze prompts, scripted user approvals, or extra Prompt A/Prompt B loops.
+      If alignment changes spec.md, plan.md, design artifacts, or tasks.md, re-check the downstream gates and regenerate only artifacts that are now stale.
+    skill:
+      id: moonspec-align
+      args: {}
+  - title: Implement the task breakdown
+    instructions: |-
+      Run moonspec-implement when implementation work remains.
+      Require TDD evidence: unit and integration tests are written and confirmed failing before production code.
+      Mark completed tasks [X] in tasks.md and preserve the selected story scope.
+    skill:
+      id: moonspec-implement
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Verify completion
+    instructions: |-
+      Run moonspec-verify as the final read-only gate unless an up-to-date verification report already covers the current code and artifacts.
+      If the verdict is ADDITIONAL_WORK_NEEDED, use the report as the remaining-work list and run at most two bounded implementation and verification cycles.
+      If the verdict is NO_DETERMINATION, stop and report the missing evidence, commands, or context.
+      Continue to pull request creation only when the verdict is FULLY_IMPLEMENTED.
+    skill:
+      id: moonspec-verify
+      args: {}
+  - title: Create pull request
+    instructions: |-
+      Create a pull request for the completed work for Jira issue {{ inputs.jira_issue_key }}.
+
+      First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a pull request with the available authenticated GitHub tooling.
+
+      The pull request title must include {{ inputs.jira_issue_key }}. The pull request body must include:
+      - the Jira issue key
+      - the active MoonSpec feature path
+      - verification verdict
+      - tests run
+      - remaining risks
+
+      If authentication, remote configuration, branch protection, or repository permissions prevent PR creation, stop before changing Jira to Code Review and report the exact blocker.
+    skill:
+      id: auto
+      args: {}
+      requiredCapabilities:
+        - git
+  - title: Move Jira issue to Code Review
+    instructions: |-
+      Change Jira issue {{ inputs.jira_issue_key }} to status Code Review only after the pull request exists.
+
+      Use the trusted Jira issue updater workflow and Jira transition tools. Match Code Review against the issue's available transitions or target statuses; do not guess transition IDs. Add or preserve a Jira-visible reference to the pull request when supported by the trusted tools. Re-fetch the issue when possible and report the confirmed status.
+    skill:
+      id: jira-issue-updater
+      args: {}
+  - title: Return Jira orchestration report
+    instructions: |-
+      Return a concise Jira Orchestration report with:
+      - Jira issue key and final Jira status
+      - Pull request URL
+      - Feature path or generated spec list
+      - Stage outcomes for Jira In Progress, Jira brief loading, Specify/Breakdown, Plan, Tasks, Align, Implement, Verify, PR creation, and Jira Code Review
+      - Files changed
+      - Tests run and status
+      - Remaining risks
+    skill:
+      id: auto
+      args: {}

--- a/specs/173-jira-orchestrate-preset/plan.md
+++ b/specs/173-jira-orchestrate-preset/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: Jira Orchestrate Preset
+
+**Branch**: `173-jira-orchestrate-preset` | **Date**: 2026-04-15 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add a seeded global task preset at `api_service/data/task_step_templates/jira-orchestrate.yaml`. The preset uses the existing Jira updater skill for workflow transitions and copies the MoonSpec Orchestrate stage structure for the implementation lifecycle. The preset remains within the existing task template schema, so no database or runtime contract changes are required.
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The preset composes existing Jira and MoonSpec skills instead of implementing new agent behavior.
+- **II. One-Click Agent Deployment**: PASS. The preset is optional seeded catalog data and introduces no mandatory dependency.
+- **III. Avoid Vendor Lock-In**: PASS. Jira-specific behavior stays in the existing optional Jira integration and trusted tool surface.
+- **IV. Own Your Data**: PASS. The workflow operates through MoonMind-managed task and Jira surfaces.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The change adds a skill-composed preset with explicit inputs, outputs, and side effects.
+- **VI. Evolving Scaffolds**: PASS. The preset is data and can be replaced without runtime refactoring.
+- **VII. Runtime Configurability**: PASS. Preset expansion remains parameterized by inputs; runtime/publish settings remain task-level configuration.
+- **VIII. Modular Architecture**: PASS. Changes are isolated to seeded preset data and tests.
+- **IX. Resilient by Default**: PASS. Jira transitions require trusted tools and PR creation blockers stop before Code Review.
+- **X. Continuous Improvement**: PASS. Final report captures outcomes, tests, risks, PR URL, and Jira status.
+- **XI. Spec-Driven Development**: PASS. This spec, plan, and task list track the change.
+- **XII. Canonical Documentation Separation**: PASS. No migration backlog is added to canonical docs.
+- **XIII. Pre-Release Compatibility**: PASS. No compatibility aliases or fallback contracts are introduced.
+
+## Implementation Scope
+
+- Add `jira-orchestrate.yaml` to the seeded task template directory.
+- Add unit coverage for catalog seed synchronization and template expansion.
+- Add startup seeding integration coverage proving the preset is synchronized with the default catalog.
+
+## Validation
+
+- `pytest tests/unit/api/test_task_step_templates_service.py -q`
+- `pytest tests/integration/test_startup_task_template_seeding.py -q`
+- `./tools/test_unit.sh`

--- a/specs/173-jira-orchestrate-preset/spec.md
+++ b/specs/173-jira-orchestrate-preset/spec.md
@@ -1,0 +1,36 @@
+# Feature Specification: Jira Orchestrate Preset
+
+**Feature Branch**: `173-jira-orchestrate-preset`
+**Created**: 2026-04-15
+**Input**: User description: "Create a Jira Orchestrate preset. This preset should take a Jira issue identifier as input (e.g. MM-328), change the issue's status to In Progress, reproduce all the steps of moonspec-orchestrate with the issue's Jira preset brief as input, create a PR, and then change the status of the Jira issue to Code Review."
+
+## User Story 1 - Run MoonSpec From A Jira Issue (Priority: P1)
+
+As an operator, I can select a Jira Orchestrate preset, enter a Jira issue key, and get an expanded task flow that moves the issue to In Progress, uses the issue's Jira preset brief as the MoonSpec input, creates a pull request, and then moves the issue to Code Review.
+
+**Independent Test**: Expand the seeded preset with `MM-328` and verify the generated steps include Jira status transitions, MoonSpec orchestration stages, PR creation, and final Code Review transition in the required order.
+
+### Acceptance Scenarios
+
+1. **Given** the seeded preset catalog is synchronized, **When** the Jira Orchestrate preset is loaded, **Then** it is available as a global active preset.
+2. **Given** a Jira issue key input, **When** the preset is expanded, **Then** the first step changes that issue to In Progress through the Jira updater skill.
+3. **Given** the same expansion, **When** the MoonSpec stages are inspected, **Then** they mirror the existing MoonSpec Orchestrate lifecycle while using the Jira preset brief as the canonical input.
+4. **Given** verification succeeds, **When** the PR stage runs, **Then** the workflow requires a pull request whose title includes the Jira issue key.
+5. **Given** the PR exists, **When** the final Jira transition runs, **Then** the issue is moved to Code Review through the Jira updater skill.
+
+## Requirements
+
+- **FR-001**: The system MUST seed a global `jira-orchestrate` task preset.
+- **FR-002**: The preset MUST require a Jira issue key input.
+- **FR-003**: The preset MUST transition the Jira issue to In Progress before implementation work.
+- **FR-004**: The preset MUST instruct the runtime to use the issue's Jira preset brief as the canonical MoonSpec orchestration input.
+- **FR-005**: The preset MUST include the MoonSpec Orchestrate lifecycle stages: classify/resume, specify, optional breakdown, plan, tasks, align, implement, and verify.
+- **FR-006**: The preset MUST include a pull request creation stage after successful verification.
+- **FR-007**: The preset MUST transition the Jira issue to Code Review only after the pull request exists.
+- **FR-008**: Automated tests MUST validate seed synchronization and expansion behavior for the new preset.
+
+## Success Criteria
+
+- **SC-001**: Startup seed synchronization creates the `jira-orchestrate` preset.
+- **SC-002**: Expansion with `MM-328` produces the expected Jira, MoonSpec, PR, and report steps with the issue key rendered.
+- **SC-003**: Existing seeded presets continue to pass their catalog tests.

--- a/specs/173-jira-orchestrate-preset/spec.md
+++ b/specs/173-jira-orchestrate-preset/spec.md
@@ -26,11 +26,13 @@ As an operator, I can select a Jira Orchestrate preset, enter a Jira issue key, 
 - **FR-004**: The preset MUST instruct the runtime to use the issue's Jira preset brief as the canonical MoonSpec orchestration input.
 - **FR-005**: The preset MUST include the MoonSpec Orchestrate lifecycle stages: classify/resume, specify, optional breakdown, plan, tasks, align, implement, and verify.
 - **FR-006**: The preset MUST include a pull request creation stage after successful verification.
-- **FR-007**: The preset MUST transition the Jira issue to Code Review only after the pull request exists.
-- **FR-008**: Automated tests MUST validate seed synchronization and expansion behavior for the new preset.
+- **FR-007**: The preset MUST transition the Jira issue to Code Review only after the pull request exists and a confirmed pull request URL is available from the PR creation step.
+- **FR-008**: The preset MUST stop before the Code Review transition when PR creation is blocked or no confirmed pull request URL is available.
+- **FR-009**: Automated tests MUST validate seed synchronization and expansion behavior for the new preset.
 
 ## Success Criteria
 
 - **SC-001**: Startup seed synchronization creates the `jira-orchestrate` preset.
 - **SC-002**: Expansion with `MM-328` produces the expected Jira, MoonSpec, PR, and report steps with the issue key rendered.
-- **SC-003**: Existing seeded presets continue to pass their catalog tests.
+- **SC-003**: Expansion with `MM-328` makes the PR creation step require `task.publish.mode=none` and makes the Code Review step verify a concrete PR URL handoff before changing Jira.
+- **SC-004**: Existing seeded presets continue to pass their catalog tests.

--- a/specs/173-jira-orchestrate-preset/tasks.md
+++ b/specs/173-jira-orchestrate-preset/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Jira Orchestrate Preset
+
+**Input**: Design documents from `/specs/173-jira-orchestrate-preset/`
+
+## Phase 1: Preset Data
+
+- [X] T001 Add global seeded `jira-orchestrate` preset in `api_service/data/task_step_templates/jira-orchestrate.yaml`
+- [X] T002 Include required Jira issue key input and optional MoonSpec orchestration inputs
+- [X] T003 Compose Jira In Progress, Jira preset brief loading, MoonSpec lifecycle, PR creation, Jira Code Review, and final report steps
+
+## Phase 2: Tests
+
+- [X] T004 Add catalog unit coverage for seed synchronization and expansion in `tests/unit/api/test_task_step_templates_service.py`
+- [X] T005 Add startup seed coverage in `tests/integration/test_startup_task_template_seeding.py`
+
+## Phase 3: Validation
+
+- [X] T006 Run `pytest tests/unit/api/test_task_step_templates_service.py -q`
+- [X] T007 Run `pytest tests/integration/test_startup_task_template_seeding.py -q`
+- [X] T008 Run `./tools/test_unit.sh`

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -77,3 +77,36 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert [
             step["skill"]["id"] for step in jira_template.latest_version.steps
         ] == ["moonspec-breakdown", "jira-issue-creator"]
+
+        result = await session.execute(
+            select(TaskStepTemplate)
+            .where(
+                TaskStepTemplate.slug == "jira-orchestrate",
+                TaskStepTemplate.scope_type == TaskTemplateScopeType.GLOBAL,
+                TaskStepTemplate.scope_ref.is_(None),
+            )
+            .options(selectinload(TaskStepTemplate.latest_version))
+        )
+        jira_orchestrate_template = result.scalar_one_or_none()
+        assert jira_orchestrate_template is not None
+        assert jira_orchestrate_template.latest_version is not None
+        jira_orchestrate_steps = [
+            step["skill"]["id"]
+            for step in jira_orchestrate_template.latest_version.steps
+        ]
+        assert jira_orchestrate_steps[0] == "jira-issue-updater"
+        assert "moonspec-implement" in jira_orchestrate_steps
+        assert "moonspec-verify" in jira_orchestrate_steps
+        assert jira_orchestrate_steps[-2] == "jira-issue-updater"
+        pr_step = next(
+            step
+            for step in jira_orchestrate_template.latest_version.steps
+            if step["title"] == "Create pull request"
+        )
+        assert "pull request" in pr_step["instructions"]
+        code_review_step = next(
+            step
+            for step in jira_orchestrate_template.latest_version.steps
+            if step["title"] == "Move Jira issue to Code Review"
+        )
+        assert "Code Review" in code_review_step["instructions"]

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -104,9 +104,12 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
             if step["title"] == "Create pull request"
         )
         assert "pull request" in pr_step["instructions"]
+        assert "task.publish.mode=none" in pr_step["instructions"]
+        assert "artifacts/jira-orchestrate-pr.json" in pr_step["instructions"]
         code_review_step = next(
             step
             for step in jira_orchestrate_template.latest_version.steps
             if step["title"] == "Move Jira issue to Code Review"
         )
         assert "Code Review" in code_review_step["instructions"]
+        assert "pull_request_url" in code_review_step["instructions"]

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -464,6 +464,73 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
             assert "Source Document path" in expanded["steps"][1]["instructions"]
 
 
+async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="jira-orchestrate",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            assert template.title == "Jira Orchestrate"
+            assert template.latest_version is not None
+            assert template.latest_version.annotations["jiraWorkflow"] == (
+                "implementation-to-code-review"
+            )
+            assert [step["skill"]["id"] for step in template.latest_version.steps] == [
+                "jira-issue-updater",
+                "auto",
+                "auto",
+                "moonspec-specify",
+                "auto",
+                "moonspec-plan",
+                "moonspec-tasks",
+                "moonspec-align",
+                "moonspec-implement",
+                "moonspec-verify",
+                "auto",
+                "jira-issue-updater",
+                "auto",
+            ]
+
+            expanded = await service.expand_template(
+                slug="jira-orchestrate",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "jira_issue_key": "MM-328",
+                    "orchestration_mode": "runtime",
+                    "source_design_path": "",
+                    "constraints": "Keep the scope narrow.",
+                },
+                context={},
+            )
+
+            assert len(expanded["steps"]) == 13
+            assert expanded["steps"][0]["skill"]["id"] == "jira-issue-updater"
+            assert "MM-328" in expanded["steps"][0]["instructions"]
+            assert "In Progress" in expanded["steps"][0]["instructions"]
+            assert "Jira preset brief" in expanded["steps"][1]["instructions"]
+            assert "Keep the scope narrow." in expanded["steps"][2]["instructions"]
+            assert expanded["steps"][10]["title"] == "Create pull request"
+            assert "pull request title must include MM-328" in expanded["steps"][10][
+                "instructions"
+            ]
+            assert expanded["steps"][11]["skill"]["id"] == "jira-issue-updater"
+            assert "Code Review" in expanded["steps"][11]["instructions"]
+
+
 async def test_sync_seed_templates_creates_missing_seed(tmp_path):
     seed_dir = tmp_path / "seeds"
     seed_data = {

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -527,7 +527,15 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
             assert "pull request title must include MM-328" in expanded["steps"][10][
                 "instructions"
             ]
+            assert "task.publish.mode=none" in expanded["steps"][10]["instructions"]
+            assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][10][
+                "instructions"
+            ]
             assert expanded["steps"][11]["skill"]["id"] == "jira-issue-updater"
+            assert "pull_request_url" in expanded["steps"][11]["instructions"]
+            assert "stop without changing Jira" in expanded["steps"][11][
+                "instructions"
+            ]
             assert "Code Review" in expanded["steps"][11]["instructions"]
 
 


### PR DESCRIPTION
Create a Jira Orchestrate preset. This preset should take a Jira issue identifier as input (e.g. MM-328), change the issue's status to In Progress, reproduce all the steps of moonspec-orchestrate with the issue's Jira preset brief as input, create a PR, and then change the status of the Jira issue to Code Review. Either use or copy portions of existing skills, presets, and tools as appropriate to develop the new preset.