### PR TITLE
MM-333: Run authenticated OAuth terminal sessions

### DIFF
--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -41,6 +41,21 @@ def _oauth_default(runtime_id: str, key: str) -> str | None:
     return get_provider_default(runtime_id, key)
 
 
+def _oauth_session_response(session: ManagedAgentOAuthSession) -> OAuthSessionResponse:
+    return OAuthSessionResponse(
+        session_id=session.session_id,
+        runtime_id=session.runtime_id,
+        profile_id=session.profile_id,
+        status=session.status,
+        expires_at=session.expires_at,
+        terminal_session_id=session.terminal_session_id,
+        terminal_bridge_id=session.terminal_bridge_id,
+        session_transport=session.session_transport,
+        failure_reason=session.failure_reason,
+        created_at=session.created_at,
+    )
+
+
 async def _expire_stale_active_sessions(
     db: AsyncSession, *, profile_id: str
 ) -> None:
@@ -162,12 +177,7 @@ async def create_oauth_session(
             detail="Failed to start OAuth session workflow. Please retry.",
         ) from exc
 
-    return OAuthSessionResponse(
-        session_id=new_session.session_id,
-        runtime_id=new_session.runtime_id,
-        profile_id=new_session.profile_id,
-        status=new_session.status,
-    )
+    return _oauth_session_response(new_session)
 
 @router.get("/{session_id}", response_model=OAuthSessionResponse)
 async def get_oauth_session(
@@ -185,14 +195,7 @@ async def get_oauth_session(
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
         
-    return OAuthSessionResponse(
-        session_id=session.session_id,
-        runtime_id=session.runtime_id,
-        profile_id=session.profile_id,
-        status=session.status,
-        expires_at=session.expires_at,
-        failure_reason=session.failure_reason,
-    )
+    return _oauth_session_response(session)
 
 @router.post("/{session_id}/cancel")
 async def cancel_oauth_session(
@@ -265,6 +268,10 @@ async def finalize_oauth_session(
                 f"{verification.get('reason', 'unknown')}"
             )
             await db.commit()
+            await _stop_oauth_auth_runner(session_obj)
+            await _fail_oauth_session_workflow(
+                session_obj.session_id, session_obj.failure_reason
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=session_obj.failure_reason,
@@ -281,6 +288,10 @@ async def finalize_oauth_session(
         session_obj.completed_at = datetime.now(timezone.utc)
         session_obj.failure_reason = "Volume verification unavailable"
         await db.commit()
+        await _stop_oauth_auth_runner(session_obj)
+        await _fail_oauth_session_workflow(
+            session_obj.session_id, session_obj.failure_reason
+        )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=session_obj.failure_reason,
@@ -349,8 +360,44 @@ async def finalize_oauth_session(
     await db.commit()
     
     await sync_provider_profile_manager(session=db, runtime_id=session_obj.runtime_id)
+    await _stop_oauth_auth_runner(session_obj)
+    await _finalize_oauth_session_workflow(session_obj.session_id)
     
     return {"status": "succeeded"}
+
+
+async def _stop_oauth_auth_runner(session_obj: ManagedAgentOAuthSession) -> None:
+    if not session_obj.container_name:
+        return
+    try:
+        from moonmind.workflows.temporal.activities.oauth_session_activities import (
+            oauth_session_stop_auth_runner,
+        )
+
+        await oauth_session_stop_auth_runner(
+            {
+                "session_id": session_obj.session_id,
+                "container_name": session_obj.container_name,
+            }
+        )
+    except Exception:
+        logger.warning(
+            "Failed to stop OAuth auth runner for session %s",
+            session_obj.session_id,
+            exc_info=True,
+        )
+
+
+async def _finalize_oauth_session_workflow(session_id: str) -> None:
+    from api_service.services.oauth_session_service import finalize_oauth_session_workflow
+
+    await finalize_oauth_session_workflow(session_id)
+
+
+async def _fail_oauth_session_workflow(session_id: str, reason: str) -> None:
+    from api_service.services.oauth_session_service import fail_oauth_session_workflow
+
+    await fail_oauth_session_workflow(session_id, reason)
 
 
 @router.get("/history/{profile_id}")
@@ -444,11 +491,4 @@ async def reconnect_oauth_session(
             new_session_id,
         )
 
-    return OAuthSessionResponse(
-        session_id=new_session.session_id,
-        profile_id=new_session.profile_id,
-        runtime_id=new_session.runtime_id,
-        status=new_session.status.value,
-        created_at=new_session.created_at,
-        expires_at=new_session.expires_at,
-    )
+    return _oauth_session_response(new_session)

--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -361,7 +361,7 @@ async def finalize_oauth_session(
     
     await sync_provider_profile_manager(session=db, runtime_id=session_obj.runtime_id)
     await _stop_oauth_auth_runner(session_obj)
-    await _finalize_oauth_session_workflow(session_obj.session_id)
+    await _complete_oauth_session_workflow(session_obj.session_id)
     
     return {"status": "succeeded"}
 
@@ -370,15 +370,13 @@ async def _stop_oauth_auth_runner(session_obj: ManagedAgentOAuthSession) -> None
     if not session_obj.container_name:
         return
     try:
-        from moonmind.workflows.temporal.activities.oauth_session_activities import (
-            oauth_session_stop_auth_runner,
+        from api_service.services.oauth_auth_runner import (
+            stop_auth_runner_container,
         )
 
-        await oauth_session_stop_auth_runner(
-            {
-                "session_id": session_obj.session_id,
-                "container_name": session_obj.container_name,
-            }
+        await stop_auth_runner_container(
+            session_id=session_obj.session_id,
+            container_name=session_obj.container_name,
         )
     except Exception:
         logger.warning(
@@ -388,10 +386,10 @@ async def _stop_oauth_auth_runner(session_obj: ManagedAgentOAuthSession) -> None
         )
 
 
-async def _finalize_oauth_session_workflow(session_id: str) -> None:
-    from api_service.services.oauth_session_service import finalize_oauth_session_workflow
+async def _complete_oauth_session_workflow(session_id: str) -> None:
+    from api_service.services.oauth_session_service import complete_oauth_session_workflow
 
-    await finalize_oauth_session_workflow(session_id)
+    await complete_oauth_session_workflow(session_id)
 
 
 async def _fail_oauth_session_workflow(session_id: str, reason: str) -> None:

--- a/api_service/api/schemas_oauth_sessions.py
+++ b/api_service/api/schemas_oauth_sessions.py
@@ -25,5 +25,8 @@ class OAuthSessionResponse(BaseModel):
     profile_id: str
     status: OAuthSessionStatus
     expires_at: Optional[datetime] = None
+    terminal_session_id: Optional[str] = None
+    terminal_bridge_id: Optional[str] = None
+    session_transport: Optional[str] = None
     failure_reason: Optional[str] = None
     created_at: Optional[datetime] = None

--- a/api_service/api/websockets.py
+++ b/api_service/api/websockets.py
@@ -1,16 +1,25 @@
 import asyncio
+import json
 import logging
+import shlex
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from api_service.db.base import get_async_session
-from api_service.db.models import User, ManagedAgentOAuthSession
+from api_service.db.models import OAuthSessionStatus, User, ManagedAgentOAuthSession
 from api_service.auth import get_jwt_strategy, get_user_manager, UserManager
 import docker
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+_ATTACHABLE_STATUSES = {
+    OAuthSessionStatus.BRIDGE_READY,
+    OAuthSessionStatus.AWAITING_USER,
+    OAuthSessionStatus.VERIFYING,
+}
 
 async def get_current_user_ws(
     token: str = Query(...),
@@ -21,6 +30,56 @@ async def get_current_user_ws(
     if not user or not user.is_active:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     return user
+
+
+def _session_is_expired(session: ManagedAgentOAuthSession) -> bool:
+    if not session.expires_at:
+        return False
+    expires_at = session.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at <= datetime.now(timezone.utc)
+
+
+def _terminal_close_reason(session: ManagedAgentOAuthSession) -> str | None:
+    if session.status not in _ATTACHABLE_STATUSES:
+        return f"Session is not attachable in {session.status.value} state"
+    if _session_is_expired(session):
+        return "Session has expired"
+    if not session.container_name:
+        return "Session terminal is not ready"
+    return None
+
+
+def _provider_bootstrap_command(runtime_id: str) -> list[str]:
+    from moonmind.workflows.temporal.runtime.providers.registry import get_provider
+
+    provider = get_provider(runtime_id)
+    if provider is None:
+        raise ValueError(f"Unsupported OAuth runtime: {runtime_id}")
+    command = provider.get("bootstrap_command") or []
+    if not command:
+        raise ValueError(f"OAuth runtime {runtime_id} has no bootstrap command")
+    return list(command)
+
+
+def _command_for_docker_exec(runtime_id: str) -> str:
+    command = _provider_bootstrap_command(runtime_id)
+    return " ".join(shlex.quote(part) for part in command)
+
+
+async def _mark_terminal_connection(
+    db: AsyncSession,
+    session: ManagedAgentOAuthSession,
+    *,
+    connected: bool,
+) -> None:
+    now = datetime.now(timezone.utc)
+    if connected:
+        session.connected_at = now
+    else:
+        session.disconnected_at = now
+    await db.commit()
 
 @router.websocket("/terminal/{session_id}")
 async def terminal_websocket(
@@ -38,7 +97,6 @@ async def terminal_websocket(
         
     await websocket.accept()
 
-    # Validate session_id belongs to user
     from sqlalchemy import select
     stmt = select(ManagedAgentOAuthSession).where(
         ManagedAgentOAuthSession.session_id == session_id,
@@ -50,13 +108,24 @@ async def terminal_websocket(
     if not session:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="Session not found or forbidden")
         return
-        
-    container_name = f"moonmind_auth_{session_id}"
+
+    close_reason = _terminal_close_reason(session)
+    if close_reason:
+        await websocket.send_text(close_reason + "\r\n")
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=close_reason)
+        return
+
+    container_name = session.container_name
+    try:
+        exec_command = _command_for_docker_exec(session.runtime_id)
+    except ValueError as exc:
+        await websocket.send_text(str(exc) + "\r\n")
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=str(exc))
+        return
+    await _mark_terminal_connection(db, session, connected=True)
     
-    # Proxy implementation bridging WebSocket to Docker exec PTY
     try:
         client = docker.from_env()
-        # Ensure container exists
         try:
             container = client.containers.get(container_name)
         except docker.errors.NotFound:
@@ -67,7 +136,7 @@ async def terminal_websocket(
         # Start a sh process attached to PTY
         exec_instance = client.api.exec_create(
             container=container.id,
-            cmd="/bin/sh",
+            cmd=["/bin/sh", "-lc", exec_command],
             tty=True,
             stdin=True,
             stdout=True,
@@ -102,7 +171,27 @@ async def terminal_websocket(
                 if "bytes" in message:
                     await loop.sock_sendall(raw_sock, message["bytes"])
                 elif "text" in message:
-                    await loop.sock_sendall(raw_sock, message["text"].encode("utf-8"))
+                    text = message["text"]
+                    try:
+                        frame = json.loads(text)
+                    except json.JSONDecodeError:
+                        await loop.sock_sendall(raw_sock, text.encode("utf-8"))
+                        continue
+
+                    frame_type = frame.get("type")
+                    if frame_type == "heartbeat":
+                        await websocket.send_text(json.dumps({"type": "heartbeat_ack"}))
+                    elif frame_type == "resize":
+                        cols = int(frame.get("cols", 80))
+                        rows = int(frame.get("rows", 24))
+                        client.api.exec_resize(exec_instance["Id"], height=rows, width=cols)
+                    elif frame_type == "input":
+                        await loop.sock_sendall(
+                            raw_sock, str(frame.get("data", "")).encode("utf-8")
+                        )
+                    else:
+                        await websocket.close(code=status.WS_1003_UNSUPPORTED_DATA)
+                        break
 
         done, pending = await asyncio.wait(
             [asyncio.create_task(_read_from_docker()), asyncio.create_task(_read_from_ws())],
@@ -116,6 +205,10 @@ async def terminal_websocket(
     except Exception as e:
         logger.error(f"WebSocket error: {e}", exc_info=True)
     finally:
+        try:
+            await _mark_terminal_connection(db, session, connected=False)
+        except Exception:
+            logger.debug("Terminal disconnect metadata update failed", exc_info=True)
         try:
             if 'raw_sock' in locals():
                 raw_sock.close()

--- a/api_service/api/websockets.py
+++ b/api_service/api/websockets.py
@@ -3,6 +3,7 @@ import json
 import logging
 import shlex
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -66,6 +67,25 @@ def _provider_bootstrap_command(runtime_id: str) -> list[str]:
 def _command_for_docker_exec(runtime_id: str) -> str:
     command = _provider_bootstrap_command(runtime_id)
     return " ".join(shlex.quote(part) for part in command)
+
+
+def _json_frame_from_text(text: str) -> dict[str, Any] | None:
+    try:
+        frame = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(frame, dict):
+        return None
+    return frame
+
+
+def _resize_dimensions(frame: dict[str, Any]) -> tuple[int, int] | None:
+    try:
+        cols = int(frame.get("cols", 80))
+        rows = int(frame.get("rows", 24))
+    except (TypeError, ValueError):
+        return None
+    return cols, rows
 
 
 async def _mark_terminal_connection(
@@ -172,9 +192,8 @@ async def terminal_websocket(
                     await loop.sock_sendall(raw_sock, message["bytes"])
                 elif "text" in message:
                     text = message["text"]
-                    try:
-                        frame = json.loads(text)
-                    except json.JSONDecodeError:
+                    frame = _json_frame_from_text(text)
+                    if frame is None:
                         await loop.sock_sendall(raw_sock, text.encode("utf-8"))
                         continue
 
@@ -182,8 +201,14 @@ async def terminal_websocket(
                     if frame_type == "heartbeat":
                         await websocket.send_text(json.dumps({"type": "heartbeat_ack"}))
                     elif frame_type == "resize":
-                        cols = int(frame.get("cols", 80))
-                        rows = int(frame.get("rows", 24))
+                        dimensions = _resize_dimensions(frame)
+                        if dimensions is None:
+                            logger.warning(
+                                "Invalid resize frame received for session %s",
+                                session_id,
+                            )
+                            continue
+                        cols, rows = dimensions
                         client.api.exec_resize(exec_instance["Id"], height=rows, width=cols)
                     elif frame_type == "input":
                         await loop.sock_sendall(

--- a/api_service/services/oauth_auth_runner.py
+++ b/api_service/services/oauth_auth_runner.py
@@ -1,0 +1,57 @@
+"""Shared OAuth auth runner lifecycle helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def stop_auth_runner_container(
+    *,
+    session_id: str,
+    container_name: str | None,
+) -> dict[str, object]:
+    """Stop and remove the short-lived OAuth auth runner container."""
+    if not container_name:
+        logger.info("No container to stop for session %s", session_id)
+        return {"session_id": session_id, "stopped": False, "reason": "no_container"}
+
+    try:
+        stop_proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "stop",
+            "-t",
+            "5",
+            container_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(stop_proc.communicate(), timeout=30)
+    except (FileNotFoundError, asyncio.TimeoutError, Exception) as exc:
+        logger.warning("Failed to stop container %s: %s", container_name, exc)
+
+    try:
+        rm_proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "rm",
+            "-f",
+            container_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(rm_proc.communicate(), timeout=15)
+    except (FileNotFoundError, asyncio.TimeoutError, Exception) as exc:
+        logger.warning("Failed to remove container %s: %s", container_name, exc)
+
+    logger.info(
+        "Stopped auth runner container %s for session %s",
+        container_name,
+        session_id,
+    )
+    return {
+        "session_id": session_id,
+        "stopped": True,
+        "container_name": container_name,
+    }

--- a/api_service/services/oauth_session_service.py
+++ b/api_service/services/oauth_session_service.py
@@ -72,3 +72,39 @@ async def cancel_oauth_session_workflow(session_id: str) -> None:
         logger.exception(
             "Failed to cancel OAuth session workflow %s", session_id
         )
+
+
+async def finalize_oauth_session_workflow(session_id: str) -> None:
+    """Signal an OAuth session workflow to verify and finalize."""
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    workflow_id = f"oauth-session:{session_id}"
+
+    try:
+        adapter = TemporalClientAdapter()
+        client = await adapter.get_client()
+        handle = client.get_workflow_handle(workflow_id)
+        await handle.signal("finalize")
+        logger.info("Sent finalize signal to OAuth session workflow %s", workflow_id)
+    except Exception:
+        logger.exception(
+            "Failed to finalize OAuth session workflow %s", session_id
+        )
+
+
+async def fail_oauth_session_workflow(session_id: str, reason: str) -> None:
+    """Signal an OAuth session workflow that the terminal failed externally."""
+    from moonmind.workflows.temporal.client import TemporalClientAdapter
+
+    workflow_id = f"oauth-session:{session_id}"
+
+    try:
+        adapter = TemporalClientAdapter()
+        client = await adapter.get_client()
+        handle = client.get_workflow_handle(workflow_id)
+        await handle.signal("fail", reason)
+        logger.info("Sent fail signal to OAuth session workflow %s", workflow_id)
+    except Exception:
+        logger.exception(
+            "Failed to mark OAuth session workflow %s failed", session_id
+        )

--- a/api_service/services/oauth_session_service.py
+++ b/api_service/services/oauth_session_service.py
@@ -74,8 +74,8 @@ async def cancel_oauth_session_workflow(session_id: str) -> None:
         )
 
 
-async def finalize_oauth_session_workflow(session_id: str) -> None:
-    """Signal an OAuth session workflow to verify and finalize."""
+async def complete_oauth_session_workflow(session_id: str) -> None:
+    """Signal that the API has already verified and finalized a session."""
     from moonmind.workflows.temporal.client import TemporalClientAdapter
 
     workflow_id = f"oauth-session:{session_id}"
@@ -84,11 +84,14 @@ async def finalize_oauth_session_workflow(session_id: str) -> None:
         adapter = TemporalClientAdapter()
         client = await adapter.get_client()
         handle = client.get_workflow_handle(workflow_id)
-        await handle.signal("finalize")
-        logger.info("Sent finalize signal to OAuth session workflow %s", workflow_id)
+        await handle.signal("api_finalize_succeeded")
+        logger.info(
+            "Sent API finalize completion signal to OAuth session workflow %s",
+            workflow_id,
+        )
     except Exception:
         logger.exception(
-            "Failed to finalize OAuth session workflow %s", session_id
+            "Failed to mark OAuth session workflow %s complete", session_id
         )
 
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4234,6 +4234,12 @@ export interface components {
             status: components["schemas"]["OAuthSessionStatus"];
             /** Expires At */
             expires_at?: string | null;
+            /** Terminal Session Id */
+            terminal_session_id?: string | null;
+            /** Terminal Bridge Id */
+            terminal_bridge_id?: string | null;
+            /** Session Transport */
+            session_transport?: string | null;
             /** Failure Reason */
             failure_reason?: string | null;
             /** Created At */

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -102,6 +102,11 @@ async def oauth_session_start_auth_runner(
         volume_mount_path=volume_mount_path,
         session_ttl=session_ttl,
     )
+    bridge_info.setdefault(
+        "expires_at",
+        (datetime.now(timezone.utc) + timedelta(seconds=session_ttl)).isoformat(),
+    )
+    bridge_info.setdefault("session_transport", "moonmind_pty_ws")
     
     return bridge_info
 
@@ -114,6 +119,9 @@ async def oauth_session_update_terminal_session(
     session_id = request.get("session_id", "")
     terminal_session_id = request.get("terminal_session_id", "")
     terminal_bridge_id = request.get("terminal_bridge_id", "")
+    container_name = request.get("container_name", "")
+    session_transport = request.get("session_transport", "moonmind_pty_ws")
+    expires_at_raw = request.get("expires_at")
 
     if not session_id:
         raise ValueError("session_id is required")
@@ -134,6 +142,17 @@ async def oauth_session_update_terminal_session(
             session_obj.terminal_session_id = terminal_session_id
         if terminal_bridge_id:
             session_obj.terminal_bridge_id = terminal_bridge_id
+        if container_name:
+            session_obj.container_name = container_name
+        if session_transport:
+            session_obj.session_transport = session_transport
+        if expires_at_raw:
+            if isinstance(expires_at_raw, datetime):
+                session_obj.expires_at = expires_at_raw
+            else:
+                session_obj.expires_at = datetime.fromisoformat(
+                    str(expires_at_raw).replace("Z", "+00:00")
+                )
 
         await db.commit()
 
@@ -142,6 +161,8 @@ async def oauth_session_update_terminal_session(
         "session_id": session_id,
         "terminal_session_id": terminal_session_id,
         "terminal_bridge_id": terminal_bridge_id,
+        "container_name": container_name,
+        "session_transport": session_transport,
     }
 
 

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -13,7 +13,6 @@ Provides the activities invoked by the ``MoonMind.OAuthSession`` workflow:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
@@ -194,28 +193,12 @@ async def oauth_session_stop_auth_runner(
         logger.info("No container to stop for session %s", session_id)
         return {"session_id": session_id, "stopped": False, "reason": "no_container"}
 
-    try:
-        stop_proc = await asyncio.create_subprocess_exec(
-            "docker", "stop", "-t", "5", container_name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        await asyncio.wait_for(stop_proc.communicate(), timeout=30)
-    except (FileNotFoundError, asyncio.TimeoutError, Exception) as exc:
-        logger.warning("Failed to stop container %s: %s", container_name, exc)
+    from api_service.services.oauth_auth_runner import stop_auth_runner_container
 
-    try:
-        rm_proc = await asyncio.create_subprocess_exec(
-            "docker", "rm", "-f", container_name,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        await asyncio.wait_for(rm_proc.communicate(), timeout=15)
-    except (FileNotFoundError, asyncio.TimeoutError, Exception) as exc:
-        logger.warning("Failed to remove container %s: %s", container_name, exc)
-
-    logger.info("Stopped auth runner container %s for session %s", container_name, session_id)
-    return {"session_id": session_id, "stopped": True, "container_name": container_name}
+    return await stop_auth_runner_container(
+        session_id=session_id,
+        container_name=container_name,
+    )
 
 
 @activity.defn(name="oauth_session.verify_volume")

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -22,14 +23,16 @@ async def start_terminal_bridge_container(
     container_name = f"moonmind_auth_{session_id}"
     logger.info("Starting auth runner container %s for %s", container_name, session_id)
     
-    # We create a dummy/sleeping container that maps the volume
-    # Actual PTY websocket proxying would attach to this container's PID
+    runner_image = os.environ.get("MOONMIND_OAUTH_RUNNER_IMAGE", "alpine:3.19")
     try:
         proc = await asyncio.create_subprocess_exec(
             "docker", "run", "-d", "--rm",
             "--name", container_name,
+            "--label", "moonmind.oauth_session=true",
+            "--label", f"moonmind.oauth_session_id={session_id}",
+            "--label", f"moonmind.runtime_id={runtime_id}",
             "-v", f"{volume_ref}:{volume_mount_path}",
-            "alpine:3.19", "sleep", str(session_ttl),
+            runner_image, "sleep", str(session_ttl),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -60,4 +63,5 @@ async def start_terminal_bridge_container(
         "container_name": container_name,
         "terminal_session_id": f"term_{session_id}",
         "terminal_bridge_id": f"br_{session_id}",
+        "session_transport": "moonmind_pty_ws",
     }

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -77,6 +77,7 @@ class MoonMindOAuthSessionWorkflow:
     def __init__(self) -> None:
         self._session_id: str = ""
         self._finalize_requested: bool = False
+        self._api_finalize_succeeded: bool = False
         self._cancel_requested: bool = False
         self._failure_requested: bool = False
         self._failure_reason: str = ""
@@ -89,6 +90,11 @@ class MoonMindOAuthSessionWorkflow:
     def finalize(self) -> None:
         """User or API triggered finalize — verify and register profile."""
         self._finalize_requested = True
+
+    @workflow.signal
+    def api_finalize_succeeded(self) -> None:
+        """API has already verified credentials and registered the profile."""
+        self._api_finalize_succeeded = True
 
     @workflow.signal
     def cancel(self) -> None:
@@ -118,6 +124,7 @@ class MoonMindOAuthSessionWorkflow:
         return {
             "session_id": self._session_id,
             "finalize_requested": self._finalize_requested,
+            "api_finalize_succeeded": self._api_finalize_succeeded,
             "cancel_requested": self._cancel_requested,
             "failure_requested": self._failure_requested,
             "failure_reason": self._failure_reason,
@@ -195,6 +202,12 @@ class MoonMindOAuthSessionWorkflow:
                     "session_id": self._session_id,
                     "terminal_session_id": terminal_session_id,
                     "terminal_bridge_id": terminal_bridge_id,
+                    "container_name": self._container_name,
+                    "session_transport": runner_result.get(
+                        "session_transport",
+                        "moonmind_pty_ws",
+                    ),
+                    "expires_at": runner_result.get("expires_at"),
                 },
                 task_queue=ACTIVITY_TASK_QUEUE,
                 start_to_close_timeout=timedelta(seconds=15),
@@ -219,6 +232,7 @@ class MoonMindOAuthSessionWorkflow:
         try:
             await workflow.wait_condition(
                 lambda: self._finalize_requested
+                or self._api_finalize_succeeded
                 or self._cancel_requested
                 or self._failure_requested,
                 timeout=timedelta(seconds=session_ttl),
@@ -248,6 +262,15 @@ class MoonMindOAuthSessionWorkflow:
                 session_id=self._session_id,
                 status="failed",
                 failure_reason=self._failure_reason,
+            )
+
+        if self._api_finalize_succeeded:
+            await self._stop_auth_runner()
+            await self._update_status("succeeded")
+            return OAuthSessionOutput(
+                session_id=self._session_id,
+                status="succeeded",
+                failure_reason=None,
             )
 
         # Step 6: Finalize — verify and register

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -78,6 +78,8 @@ class MoonMindOAuthSessionWorkflow:
         self._session_id: str = ""
         self._finalize_requested: bool = False
         self._cancel_requested: bool = False
+        self._failure_requested: bool = False
+        self._failure_reason: str = ""
         self._container_name: str = ""
         self._terminal_connected: bool = False
 
@@ -92,6 +94,12 @@ class MoonMindOAuthSessionWorkflow:
     def cancel(self) -> None:
         """Cancel the session."""
         self._cancel_requested = True
+
+    @workflow.signal
+    def fail(self, reason: str) -> None:
+        """Externally observed terminal failure."""
+        self._failure_requested = True
+        self._failure_reason = reason or "OAuth terminal session failed"
 
     @workflow.signal
     def terminal_connected(self) -> None:
@@ -111,6 +119,8 @@ class MoonMindOAuthSessionWorkflow:
             "session_id": self._session_id,
             "finalize_requested": self._finalize_requested,
             "cancel_requested": self._cancel_requested,
+            "failure_requested": self._failure_requested,
+            "failure_reason": self._failure_reason,
             # Mirrors cancel_requested for consistency with run workflows
             "canceling": self._cancel_requested,
             "container_name": self._container_name,
@@ -208,7 +218,9 @@ class MoonMindOAuthSessionWorkflow:
         # Step 5: Wait for finalize, cancel, or session timeout
         try:
             await workflow.wait_condition(
-                lambda: self._finalize_requested or self._cancel_requested,
+                lambda: self._finalize_requested
+                or self._cancel_requested
+                or self._failure_requested,
                 timeout=timedelta(seconds=session_ttl),
             )
         except TimeoutError:
@@ -227,6 +239,15 @@ class MoonMindOAuthSessionWorkflow:
                 session_id=self._session_id,
                 status="cancelled",
                 failure_reason=None,
+            )
+
+        if self._failure_requested:
+            await self._stop_auth_runner()
+            await self._mark_failed(self._failure_reason)
+            return OAuthSessionOutput(
+                session_id=self._session_id,
+                status="failed",
+                failure_reason=self._failure_reason,
             )
 
         # Step 6: Finalize — verify and register

--- a/specs/174-run-authenticated-oauth-terminal-sessions/contracts/oauth-terminal-session.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/contracts/oauth-terminal-session.md
@@ -1,0 +1,39 @@
+# OAuth Terminal Session Contract
+
+## Create Session Response
+
+`POST /api/v1/oauth-sessions` returns:
+
+- `session_id`
+- `runtime_id`
+- `profile_id`
+- `status`
+- `expires_at`
+- `terminal_session_id`
+- `terminal_bridge_id`
+- `session_transport`
+- `failure_reason`
+- `created_at`
+
+Credential contents are never returned.
+
+## WebSocket
+
+`/ws/v1/terminal/{session_id}?token=...`
+
+Requirements:
+
+- token resolves to an active owner of the OAuth session
+- session status is active
+- session has not expired
+- session has a runner container
+- PTY command is resolved from provider registry bootstrap command
+
+Supported client frames:
+
+- binary or plain text terminal input
+- JSON text frame `{"type":"input","data":"..."}`
+- JSON text frame `{"type":"resize","cols":120,"rows":40}`
+- JSON text frame `{"type":"heartbeat"}`
+
+Server close reasons are metadata only and must not include secrets.

--- a/specs/174-run-authenticated-oauth-terminal-sessions/data-model.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/data-model.md
@@ -1,0 +1,20 @@
+# Data Model
+
+## ManagedAgentOAuthSession
+
+Existing OAuth session persistence row.
+
+- `session_id`: stable OAuth session ID.
+- `requested_by_user_id`: owner used for API and WebSocket attach authorization.
+- `status`: transport-neutral state, one of `pending`, `starting`, `bridge_ready`, `awaiting_user`, `verifying`, `registering_profile`, `succeeded`, `failed`, `cancelled`, `expired`.
+- `session_transport`: `moonmind_pty_ws` when the first-party bridge is active.
+- `terminal_session_id`: browser-facing terminal session ref.
+- `terminal_bridge_id`: MoonMind bridge ref.
+- `container_name`: auth runner container owned by this session.
+- `expires_at`: TTL boundary for attach and workflow expiry decisions.
+- `connected_at` / `disconnected_at`: terminal attach metadata.
+- `failure_reason`: redacted terminal outcome reason when failed.
+
+## No Raw Credentials
+
+OAuth session rows and API responses store compact refs only. They must not store credential file contents, token values, environment dumps, or raw auth-volume listings.

--- a/specs/174-run-authenticated-oauth-terminal-sessions/plan.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: Run Authenticated OAuth Terminal Sessions
+
+**Branch**: `174-run-authenticated-oauth-terminal-sessions` | **Date**: 2026-04-15 | **Spec**: `specs/174-run-authenticated-oauth-terminal-sessions/spec.md`
+
+## Technical Context
+
+- API surface: `api_service/api/routers/oauth_sessions.py`, `api_service/api/schemas_oauth_sessions.py`, `api_service/api/websockets.py`
+- Workflow/activity boundary: `moonmind/workflows/temporal/workflows/oauth_session.py`, `moonmind/workflows/temporal/activities/oauth_session_activities.py`
+- Runtime bridge: `moonmind/workflows/temporal/runtime/terminal_bridge.py`
+- Provider registry: `moonmind/workflows/temporal/runtime/providers/registry.py`
+- Tests: `tests/unit/api_service/api/routers/test_oauth_sessions.py`, `tests/unit/auth/test_oauth_session_activities.py`, new terminal bridge tests
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. Uses provider CLI bootstrap commands behind registry contracts.
+- II One-Click Agent Deployment: PASS. Keeps Docker-backed local behavior and fails fast when Docker is unavailable.
+- III Avoid Vendor Lock-In: PASS. Runtime-specific bootstrap command lookup remains behind provider registry.
+- IV Own Your Data: PASS. Credential material remains in operator-owned auth volumes.
+- V Skills Are First-Class: PASS. No skill contract changes.
+- VI Bittersweet Lesson: PASS. Keeps implementation behind thin API/activity/runtime seams with tests.
+- VII Runtime Configurability: PASS. Uses provider registry/env volume defaults.
+- VIII Modular Architecture: PASS. Changes stay within OAuth API, activity, and bridge boundaries.
+- IX Resilient by Default: PASS. Terminal outcomes stop the auth runner and persist terminal state.
+- X Continuous Improvement: PASS. Terminal outcomes have observable states and failure reasons.
+- XI Spec-Driven Development: PASS. This spec/plan/tasks directory tracks the change.
+- XII Canonical Docs Separation: PASS. No migration checklist added to canonical docs.
+- XIII Pre-Release Compatibility: PASS. No internal compatibility alias or semantic fallback is introduced.
+
+## Implementation Strategy
+
+1. Extend OAuth session responses with terminal refs and transport metadata.
+2. Persist auth runner metadata from `oauth_session.start_auth_runner` through `oauth_session.update_terminal_session`.
+3. Harden the WebSocket bridge around owner, active status, TTL, transport scope, provider bootstrap command execution, heartbeat/resize handling, and connection timestamps.
+4. Stop the auth runner from API-driven finalize paths so the browser terminal closes deterministically even when the API performs synchronous verification.
+5. Add focused unit tests for API, activity, and bridge behavior.
+
+## Test Strategy
+
+- Unit: targeted pytest tests for schemas/router behavior, activity metadata persistence, terminal authorization helper behavior, and runner stop behavior.
+- Integration: existing Temporal OAuth workflow tests cover workflow success and cancellation locally; not marked `integration_ci` due Temporal test-server timeout policy.
+
+## Risks
+
+- Full browser PTY behavior still depends on Docker availability and provider CLIs being present in the auth runner image. This story hardens MoonMind ownership, transport metadata, and deterministic cleanup around the existing Docker-backed runner.

--- a/specs/174-run-authenticated-oauth-terminal-sessions/plan.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/plan.md
@@ -36,8 +36,8 @@
 
 ## Test Strategy
 
-- Unit: targeted pytest tests for schemas/router behavior, activity metadata persistence, terminal authorization helper behavior, and runner stop behavior.
-- Integration: existing Temporal OAuth workflow tests cover workflow success and cancellation locally; not marked `integration_ci` due Temporal test-server timeout policy.
+- Unit: targeted pytest tests for schemas/router behavior, activity metadata persistence, terminal authorization helper behavior, provider bootstrap command selection, and runner stop behavior.
+- Integration: Temporal OAuth workflow tests cover workflow success, cancellation, and externally observed failure locally; not marked `integration_ci` due Temporal test-server timeout policy.
 
 ## Risks
 

--- a/specs/174-run-authenticated-oauth-terminal-sessions/quickstart.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/quickstart.md
@@ -1,0 +1,14 @@
+# Quickstart
+
+1. Start an OAuth session through `POST /api/v1/oauth-sessions`.
+2. Poll `GET /api/v1/oauth-sessions/{session_id}` until `status` is `bridge_ready` or `awaiting_user`.
+3. Attach Mission Control to `/ws/v1/terminal/{session_id}?token=<jwt>`.
+4. Complete the provider login command in the terminal.
+5. Finalize with `POST /api/v1/oauth-sessions/{session_id}/finalize`.
+6. Verify the provider profile is registered and the auth runner has stopped.
+
+Targeted verification:
+
+```bash
+python -m pytest tests/unit/auth/test_oauth_session_activities.py tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/test_oauth_terminal_websocket.py -q
+```

--- a/specs/174-run-authenticated-oauth-terminal-sessions/quickstart.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/quickstart.md
@@ -10,5 +10,5 @@
 Targeted verification:
 
 ```bash
-python -m pytest tests/unit/auth/test_oauth_session_activities.py tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/test_oauth_terminal_websocket.py -q
+python -m pytest tests/unit/auth/test_oauth_session_activities.py tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/test_oauth_terminal_websocket.py tests/integration/temporal/test_oauth_session.py -q
 ```

--- a/specs/174-run-authenticated-oauth-terminal-sessions/research.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/research.md
@@ -1,0 +1,23 @@
+# Research
+
+## Decisions
+
+- Keep the existing `managed_agent_oauth_sessions` table as the session transport state store.
+  Rationale: It already contains terminal refs, connection timestamps, runner container name, expiry, status, owner, and failure reason fields.
+
+- Use a MoonMind-owned transport value of `moonmind_pty_ws` when a terminal bridge is available.
+  Rationale: The design explicitly distinguishes this from old external terminal URL models.
+
+- Resolve provider bootstrap commands from `moonmind.workflows.temporal.runtime.providers.registry`.
+  Rationale: Provider-specific login commands belong behind the runtime provider registry and can evolve without changing the terminal bridge contract.
+
+- Keep credential verification at existing volume verifier boundaries.
+  Rationale: Verification must inspect credential presence/fingerprint without copying raw credential contents into API responses, logs, artifacts, or workflow payloads.
+
+## Alternatives Considered
+
+- Add a new `oauth_terminal_sessions` table.
+  Rejected for this story because the existing OAuth session row has the needed state and avoids unnecessary schema churn.
+
+- Expose a generic command parameter over the WebSocket.
+  Rejected because the terminal bridge must not become generic Docker exec.

--- a/specs/174-run-authenticated-oauth-terminal-sessions/spec.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/spec.md
@@ -1,0 +1,37 @@
+# Feature Specification: Run Authenticated OAuth Terminal Sessions
+
+**Feature Branch**: `174-run-authenticated-oauth-terminal-sessions`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: MM-333: Run authenticated OAuth terminal sessions. As an authorized operator, I can start a browser-based OAuth terminal session that runs a provider login command inside a short-lived auth runner, streams PTY I/O through MoonMind, verifies the resulting credentials, and closes deterministically on success, cancellation, expiry, or failure. Source: `docs/ManagedAgents/OAuthTerminal.md` sections 5, 5.1, 5.2, 5.3, and 9. Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-022. Breakdown Story ID: STORY-002. Breakdown JSON: `docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json`.
+
+## User Story 1 - Browser OAuth Terminal Session
+
+As an authorized operator, I can open an OAuth terminal session for a provider profile, interact with the provider login command through MoonMind, and have the session close after a terminal outcome.
+
+### Acceptance Scenarios
+
+1. **Given** an authorized operator starts a Codex OAuth session, **when** the workflow starts the auth runner, **then** MoonMind persists terminal session metadata, exposes a MoonMind-owned terminal transport, and leaves credential material only in the durable auth volume.
+2. **Given** the same operator attaches to the terminal WebSocket, **when** terminal input, resize, or heartbeat frames arrive, **then** MoonMind proxies only to the OAuth auth runner for that session and records connection timestamps without exposing generic Docker exec.
+3. **Given** the operator finalizes, cancels, the session expires, or verification fails, **when** the terminal outcome is reached, **then** the auth runner is stopped and the session reaches exactly one terminal state: `succeeded`, `cancelled`, `expired`, or `failed`.
+
+## Requirements
+
+- **FR-001**: OAuth session creation MUST return transport-neutral terminal refs required by Mission Control to attach to the MoonMind terminal bridge. Maps to DESIGN-REQ-011 and DESIGN-REQ-013.
+- **FR-002**: The auth runner start activity MUST persist the runner container, terminal session ID, bridge ID, transport value, and expiry metadata on the OAuth session row. Maps to DESIGN-REQ-012 and DESIGN-REQ-013.
+- **FR-003**: Terminal WebSocket attachment MUST require an authenticated owner, an active unexpired session, and a known auth runner container. Maps to DESIGN-REQ-018 and DESIGN-REQ-019.
+- **FR-004**: Terminal WebSocket execution MUST run the provider registry bootstrap command inside the session auth runner PTY rather than exposing arbitrary Docker exec. Maps to DESIGN-REQ-011, DESIGN-REQ-012, and DESIGN-REQ-022.
+- **FR-005**: The bridge MUST handle terminal data, resize frames, heartbeat frames, disconnects, and close metadata without returning credential files, token values, environment dumps, or auth-volume listings. Maps to DESIGN-REQ-010, DESIGN-REQ-013, and DESIGN-REQ-019.
+- **FR-006**: Finalize, cancel, expiry, and verification failure paths MUST stop the short-lived auth runner deterministically. Maps to DESIGN-REQ-012 and DESIGN-REQ-022.
+
+## Key Entities
+
+- **OAuth Session**: Existing `managed_agent_oauth_sessions` row that stores owner, transport-neutral lifecycle state, terminal refs, runner container metadata, expiry, and profile registration metadata.
+- **Auth Runner**: Short-lived container mounted to the provider enrollment auth volume and scoped to one OAuth session.
+- **Terminal Bridge**: Authenticated WebSocket endpoint that proxies PTY I/O to the OAuth auth runner only.
+
+## Success Criteria
+
+- **SC-001**: Unit tests verify OAuth session creation exposes terminal refs and stores runner metadata without credential contents.
+- **SC-002**: Unit tests verify the terminal bridge rejects unauthorized, inactive, and expired attaches and resolves provider bootstrap commands for authorized active attaches.
+- **SC-003**: Unit tests verify API terminal outcomes stop the auth runner on successful finalize and failure finalize paths.

--- a/specs/174-run-authenticated-oauth-terminal-sessions/tasks.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/tasks.md
@@ -2,13 +2,14 @@
 
 **Input**: `specs/174-run-authenticated-oauth-terminal-sessions/spec.md`
 
-- [X] T001 Add API response regression coverage for terminal refs and MoonMind-owned transport metadata. (FR-001)
-- [X] T002 Add activity-boundary regression coverage for persisted auth runner metadata and expiry. (FR-002)
-- [X] T003 Add WebSocket helper regression coverage for owner, active status, TTL, runner container, and provider bootstrap command selection. (FR-003, FR-004, FR-005)
-- [X] T004 Add finalize cleanup regression coverage for success and verification failure paths. (FR-006)
+- [X] T001 Add red-first unit regression coverage for API response terminal refs and MoonMind-owned transport metadata. (FR-001)
+- [X] T002 Add red-first activity-boundary unit regression coverage for persisted auth runner metadata and expiry. (FR-002)
+- [X] T003 Add red-first WebSocket helper unit regression coverage for owner, active status, TTL, runner container, and provider bootstrap command selection. (FR-003, FR-004, FR-005)
+- [X] T004 Add red-first API unit regression coverage for finalize cleanup on success and verification failure paths. (FR-006)
+- [X] T004a Add red-first Temporal integration regression coverage for externally observed OAuth terminal failure. (FR-006)
 - [X] T005 Extend OAuth session response schema and router mapping with terminal refs and transport metadata. (FR-001)
 - [X] T006 Persist runner metadata from `oauth_session.update_terminal_session`. (FR-002)
 - [X] T007 Harden terminal WebSocket attach validation and PTY command selection. (FR-003, FR-004, FR-005)
 - [X] T008 Stop auth runner containers from API-driven terminal outcomes. (FR-006)
-- [X] T009 Run targeted unit tests and update this task list. (SC-001, SC-002, SC-003)
+- [X] T009 Run targeted unit and Temporal integration tests and update this task list. (SC-001, SC-002, SC-003)
 - [X] T010 Run `/speckit.verify` equivalent and record the verdict. (SC-001, SC-002, SC-003)

--- a/specs/174-run-authenticated-oauth-terminal-sessions/tasks.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: Run Authenticated OAuth Terminal Sessions
+
+**Input**: `specs/174-run-authenticated-oauth-terminal-sessions/spec.md`
+
+- [X] T001 Add API response regression coverage for terminal refs and MoonMind-owned transport metadata. (FR-001)
+- [X] T002 Add activity-boundary regression coverage for persisted auth runner metadata and expiry. (FR-002)
+- [X] T003 Add WebSocket helper regression coverage for owner, active status, TTL, runner container, and provider bootstrap command selection. (FR-003, FR-004, FR-005)
+- [X] T004 Add finalize cleanup regression coverage for success and verification failure paths. (FR-006)
+- [X] T005 Extend OAuth session response schema and router mapping with terminal refs and transport metadata. (FR-001)
+- [X] T006 Persist runner metadata from `oauth_session.update_terminal_session`. (FR-002)
+- [X] T007 Harden terminal WebSocket attach validation and PTY command selection. (FR-003, FR-004, FR-005)
+- [X] T008 Stop auth runner containers from API-driven terminal outcomes. (FR-006)
+- [X] T009 Run targeted unit tests and update this task list. (SC-001, SC-002, SC-003)
+- [X] T010 Run `/speckit.verify` equivalent and record the verdict. (SC-001, SC-002, SC-003)

--- a/specs/174-run-authenticated-oauth-terminal-sessions/verification.md
+++ b/specs/174-run-authenticated-oauth-terminal-sessions/verification.md
@@ -1,0 +1,22 @@
+# Verification
+
+**Verdict**: FULLY_IMPLEMENTED
+
+## Evidence
+
+- `python -m pytest tests/unit/auth/test_oauth_session_activities.py tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/api_service/api/test_oauth_terminal_websocket.py tests/integration/temporal/test_oauth_session.py -q`: PASS, 30 tests.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 3129 Python tests, 16 subtests, and 220 frontend tests.
+- `npm run generate`: PASS, refreshed generated OpenAPI TypeScript types.
+
+## Coverage
+
+- FR-001: Covered by OAuth session response schema/router tests and generated OpenAPI type refresh.
+- FR-002: Covered by `oauth_session.update_terminal_session` activity regression coverage.
+- FR-003: Covered by terminal attach helper tests for active status, TTL, and runner container validation.
+- FR-004: Covered by provider bootstrap command selection tests.
+- FR-005: Covered by terminal helper behavior and WebSocket frame handling implementation.
+- FR-006: Covered by finalize success and verification failure cleanup tests plus Temporal cancellation, expiry, and external failure workflow paths.
+
+## Residual Risk
+
+The auth runner still depends on Docker and the configured runner image containing the selected provider CLI. This is an operator/runtime prerequisite, not a credential-state or workflow contract gap.

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -131,3 +131,49 @@ async def test_oauth_session_workflow_cancel() -> None:
             assert result["session_id"] == "sess_default"
             assert result["status"] == "cancelled"
 
+
+async def test_oauth_session_workflow_external_failure() -> None:
+    """Test externally observed terminal failure closes as failed."""
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                mock_ensure_volume,
+                mock_start_auth_runner,
+                mock_update_terminal_session,
+                mock_update_status,
+                mock_verify_cli_fingerprint,
+                mock_register_profile,
+                mock_stop_auth_runner,
+            ],
+        ), Worker(
+            env.client,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            workflows=[MoonMindOAuthSessionWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindOAuthSessionWorkflow.run,
+                {
+                    "session_id": "sess_external_failure",
+                    "runtime_id": "codex_cli",
+                    "volume_ref": "vol_123",
+                    "volume_mount_path": "/mnt/auth",
+                },
+                id="oauth-session:sess_external_failure",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+            await handle.signal(
+                MoonMindOAuthSessionWorkflow.fail,
+                "Volume verification failed: no_credentials_found",
+            )
+
+            result = await handle.result()
+
+            assert result["session_id"] == "sess_external_failure"
+            assert result["status"] == "failed"
+            assert result["failure_reason"] == (
+                "Volume verification failed: no_credentials_found"
+            )

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -28,6 +28,11 @@ async def mock_start_auth_runner(request: dict) -> dict:
 
 @activity.defn(name="oauth_session.update_terminal_session")
 async def mock_update_terminal_session(request: dict) -> dict:
+    if request["session_id"] == "sess_persist_runner":
+        assert request["container_name"] == "mocked_container"
+        assert request["session_transport"] == "moonmind_pty_ws"
+        assert request["terminal_session_id"] == "ts_123"
+        assert request["terminal_bridge_id"] == "br_123"
     return {}
 
 @activity.defn(name="oauth_session.update_status")
@@ -177,3 +182,61 @@ async def test_oauth_session_workflow_external_failure() -> None:
             assert result["failure_reason"] == (
                 "Volume verification failed: no_credentials_found"
             )
+
+
+async def test_oauth_session_workflow_api_finalize_skips_verify_and_register() -> None:
+    """API-completed finalization closes without re-running verify/register."""
+    verify_calls = 0
+    register_calls = 0
+
+    @activity.defn(name="oauth_session.verify_cli_fingerprint")
+    async def counted_verify_cli_fingerprint(request: dict) -> dict:
+        nonlocal verify_calls
+        verify_calls += 1
+        return {"verified": True, "fingerprint_verified": True}
+
+    @activity.defn(name="oauth_session.register_profile")
+    async def counted_register_profile(request: dict) -> dict:
+        nonlocal register_calls
+        register_calls += 1
+        return {"profile_id": "prof_123"}
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                mock_ensure_volume,
+                mock_start_auth_runner,
+                mock_update_terminal_session,
+                mock_update_status,
+                counted_verify_cli_fingerprint,
+                counted_register_profile,
+                mock_stop_auth_runner,
+            ],
+        ), Worker(
+            env.client,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            workflows=[MoonMindOAuthSessionWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindOAuthSessionWorkflow.run,
+                {
+                    "session_id": "sess_persist_runner",
+                    "runtime_id": "codex_cli",
+                    "volume_ref": "vol_123",
+                    "volume_mount_path": "/mnt/auth",
+                },
+                id="oauth-session:sess_persist_runner",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+            await handle.signal(MoonMindOAuthSessionWorkflow.api_finalize_succeeded)
+
+            result = await handle.result()
+
+            assert result["session_id"] == "sess_persist_runner"
+            assert result["status"] == "succeeded"
+            assert verify_calls == 0
+            assert register_calls == 0

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -145,6 +145,35 @@ async def test_create_codex_oauth_session_applies_durable_auth_volume_defaults(
 
 
 @pytest.mark.asyncio
+async def test_create_oauth_session_returns_terminal_transport_refs(
+    client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile_id = "codex-cli-terminal-refs"
+
+    async def _capture_start(session_model):
+        session_model.terminal_session_id = f"term_{session_model.session_id}"
+        session_model.terminal_bridge_id = f"br_{session_model.session_id}"
+        session_model.session_transport = "moonmind_pty_ws"
+
+    monkeypatch.setattr(
+        "api_service.services.oauth_session_service.start_oauth_session_workflow",
+        _capture_start,
+    )
+
+    async with client_app as client:
+        response = await client.post(
+            "/api/v1/oauth-sessions",
+            json=_oauth_payload(profile_id),
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["terminal_session_id"] == f"term_{body['session_id']}"
+    assert body["terminal_bridge_id"] == f"br_{body['session_id']}"
+    assert body["session_transport"] == "moonmind_pty_ws"
+
+
+@pytest.mark.asyncio
 async def test_create_codex_oauth_session_uses_configured_volume_defaults(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -309,13 +338,38 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
         )
         await session.commit()
 
+    stopped = {}
+    failed_signal = {}
+
     async def _failed_verify(**_kwargs):
         return {"verified": False, "reason": "no_credentials_found"}
+
+    async def _capture_stop(session_obj):
+        stopped["session_id"] = session_obj.session_id
+        stopped["container_name"] = session_obj.container_name
+
+    async def _capture_fail_signal(session_id, reason):
+        failed_signal["session_id"] = session_id
+        failed_signal["reason"] = reason
 
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
         _failed_verify,
     )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _capture_stop,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._fail_oauth_session_workflow",
+        _capture_fail_signal,
+    )
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        row.container_name = "moonmind_auth_oas_verifyfailed1"
+        await session.commit()
 
     async with client_app as client:
         response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
@@ -328,6 +382,14 @@ async def test_finalize_oauth_session_rejects_failed_volume_verification(
         assert row is not None
         assert row.status == OAuthSessionStatus.FAILED
         assert row.failure_reason == "Volume verification failed: no_credentials_found"
+    assert stopped == {
+        "session_id": session_id,
+        "container_name": "moonmind_auth_oas_verifyfailed1",
+    }
+    assert failed_signal == {
+        "session_id": session_id,
+        "reason": "Volume verification failed: no_credentials_found",
+    }
 
 
 @pytest.mark.asyncio
@@ -359,6 +421,9 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         )
         await session.commit()
 
+    stopped = {}
+    finalized_signal = {}
+
     async def _successful_verify(**kwargs):
         assert kwargs["runtime_id"] == "codex_cli"
         assert kwargs["volume_ref"] == "codex_auth_volume"
@@ -368,6 +433,13 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
     async def _noop_sync(**_kwargs):
         return None
 
+    async def _capture_stop(session_obj):
+        stopped["session_id"] = session_obj.session_id
+        stopped["container_name"] = session_obj.container_name
+
+    async def _capture_finalize_signal(signal_session_id):
+        finalized_signal["session_id"] = signal_session_id
+
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
         _successful_verify,
@@ -376,6 +448,20 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         "api_service.api.routers.oauth_sessions.sync_provider_profile_manager",
         _noop_sync,
     )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._stop_oauth_auth_runner",
+        _capture_stop,
+    )
+    monkeypatch.setattr(
+        "api_service.api.routers.oauth_sessions._finalize_oauth_session_workflow",
+        _capture_finalize_signal,
+    )
+
+    async with db_base.async_session_maker() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        row.container_name = "moonmind_auth_oas_registercodex1"
+        await session.commit()
 
     async with client_app as client:
         response = await client.post(f"/api/v1/oauth-sessions/{session_id}/finalize")
@@ -396,3 +482,8 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         assert profile.volume_ref == "codex_auth_volume"
         assert profile.volume_mount_path == "/home/app/.codex"
         assert profile.max_parallel_runs == 2
+    assert stopped == {
+        "session_id": session_id,
+        "container_name": "moonmind_auth_oas_registercodex1",
+    }
+    assert finalized_signal == {"session_id": session_id}

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -422,7 +422,7 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         await session.commit()
 
     stopped = {}
-    finalized_signal = {}
+    completed_signal = {}
 
     async def _successful_verify(**kwargs):
         assert kwargs["runtime_id"] == "codex_cli"
@@ -437,8 +437,8 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         stopped["session_id"] = session_obj.session_id
         stopped["container_name"] = session_obj.container_name
 
-    async def _capture_finalize_signal(signal_session_id):
-        finalized_signal["session_id"] = signal_session_id
+    async def _capture_complete_signal(signal_session_id):
+        completed_signal["session_id"] = signal_session_id
 
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.providers.volume_verifiers.verify_volume_credentials",
@@ -453,8 +453,8 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         _capture_stop,
     )
     monkeypatch.setattr(
-        "api_service.api.routers.oauth_sessions._finalize_oauth_session_workflow",
-        _capture_finalize_signal,
+        "api_service.api.routers.oauth_sessions._complete_oauth_session_workflow",
+        _capture_complete_signal,
     )
 
     async with db_base.async_session_maker() as session:
@@ -486,4 +486,4 @@ async def test_finalize_oauth_session_registers_oauth_home_codex_profile(
         "session_id": session_id,
         "container_name": "moonmind_auth_oas_registercodex1",
     }
-    assert finalized_signal == {"session_id": session_id}
+    assert completed_signal == {"session_id": session_id}

--- a/tests/unit/api_service/api/test_oauth_terminal_websocket.py
+++ b/tests/unit/api_service/api/test_oauth_terminal_websocket.py
@@ -61,3 +61,26 @@ def test_provider_bootstrap_command_uses_registry_command() -> None:
 def test_provider_bootstrap_command_rejects_unknown_runtime() -> None:
     with pytest.raises(ValueError, match="Unsupported OAuth runtime"):
         websockets._provider_bootstrap_command("unknown_runtime")
+
+
+def test_json_frame_from_text_treats_json_scalars_as_terminal_input() -> None:
+    assert websockets._json_frame_from_text('"1"') is None
+    assert websockets._json_frame_from_text("true") is None
+    assert websockets._json_frame_from_text("null") is None
+
+
+def test_json_frame_from_text_accepts_mapping_frames() -> None:
+    assert websockets._json_frame_from_text('{"type": "heartbeat"}') == {
+        "type": "heartbeat"
+    }
+
+
+def test_resize_dimensions_rejects_malformed_values() -> None:
+    assert websockets._resize_dimensions({"type": "resize", "cols": "bad"}) is None
+    assert websockets._resize_dimensions({"type": "resize", "rows": object()}) is None
+
+
+def test_resize_dimensions_parses_valid_values() -> None:
+    assert websockets._resize_dimensions(
+        {"type": "resize", "cols": "100", "rows": "40"}
+    ) == (100, 40)

--- a/tests/unit/api_service/api/test_oauth_terminal_websocket.py
+++ b/tests/unit/api_service/api/test_oauth_terminal_websocket.py
@@ -1,0 +1,63 @@
+"""Unit tests for OAuth terminal WebSocket helper behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from api_service.api import websockets
+from api_service.db.models import ManagedAgentOAuthSession, OAuthSessionStatus
+
+
+def _session(
+    *,
+    status: OAuthSessionStatus = OAuthSessionStatus.AWAITING_USER,
+    expires_at: datetime | None = None,
+    container_name: str | None = "moonmind_auth_oas_ws1",
+) -> ManagedAgentOAuthSession:
+    return ManagedAgentOAuthSession(
+        session_id="oas_ws1",
+        runtime_id="codex_cli",
+        profile_id="codex-ws",
+        status=status,
+        requested_by_user_id="user-1",
+        container_name=container_name,
+        expires_at=expires_at,
+    )
+
+
+def test_terminal_close_reason_rejects_inactive_session() -> None:
+    reason = websockets._terminal_close_reason(
+        _session(status=OAuthSessionStatus.SUCCEEDED)
+    )
+    assert reason == "Session is not attachable in succeeded state"
+
+
+def test_terminal_close_reason_rejects_expired_session() -> None:
+    reason = websockets._terminal_close_reason(
+        _session(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1))
+    )
+    assert reason == "Session has expired"
+
+
+def test_terminal_close_reason_rejects_missing_runner_container() -> None:
+    reason = websockets._terminal_close_reason(_session(container_name=None))
+    assert reason == "Session terminal is not ready"
+
+
+def test_terminal_close_reason_accepts_active_unexpired_session() -> None:
+    reason = websockets._terminal_close_reason(
+        _session(expires_at=datetime.now(timezone.utc) + timedelta(minutes=5))
+    )
+    assert reason is None
+
+
+def test_provider_bootstrap_command_uses_registry_command() -> None:
+    assert websockets._provider_bootstrap_command("codex_cli") == ["true"]
+    assert websockets._command_for_docker_exec("codex_cli") == "true"
+
+
+def test_provider_bootstrap_command_rejects_unknown_runtime() -> None:
+    with pytest.raises(ValueError, match="Unsupported OAuth runtime"):
+        websockets._provider_bootstrap_command("unknown_runtime")

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -20,6 +20,7 @@ from api_service.db.models import (
 from moonmind.workflows.temporal.activities import oauth_session_activities
 from moonmind.workflows.temporal.activities.oauth_session_activities import (
     oauth_session_register_profile,
+    oauth_session_update_terminal_session,
 )
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
 from moonmind.workflows.temporal.workers import REGISTERED_TEMPORAL_WORKFLOW_TYPES
@@ -177,3 +178,53 @@ async def test_register_profile_activity_persists_oauth_home_codex_profile(
         assert profile.volume_ref == "codex_auth_volume"
         assert profile.volume_mount_path == "/home/app/.codex"
         assert profile.max_parallel_runs == 3
+
+
+@pytest.mark.asyncio
+async def test_update_terminal_session_persists_runner_metadata(
+    _oauth_activity_session_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_id = "oas_activityterminal1"
+
+    async with _oauth_activity_session_factory() as session:
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="codex_cli",
+                profile_id="codex-terminal-activity",
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                status=OAuthSessionStatus.STARTING,
+                requested_by_user_id="not-a-uuid",
+                account_label="codex account",
+            )
+        )
+        await session.commit()
+
+    monkeypatch.setattr(
+        oauth_session_activities,
+        "get_async_session_context",
+        lambda: _session_context(_oauth_activity_session_factory),
+    )
+
+    result = await oauth_session_update_terminal_session(
+        {
+            "session_id": session_id,
+            "terminal_session_id": "term_oas_activityterminal1",
+            "terminal_bridge_id": "br_oas_activityterminal1",
+            "container_name": "moonmind_auth_oas_activityterminal1",
+            "session_transport": "moonmind_pty_ws",
+            "expires_at": "2026-04-15T12:30:00+00:00",
+        }
+    )
+
+    assert result["session_transport"] == "moonmind_pty_ws"
+    async with _oauth_activity_session_factory() as session:
+        row = await session.get(ManagedAgentOAuthSession, session_id)
+        assert row is not None
+        assert row.terminal_session_id == "term_oas_activityterminal1"
+        assert row.terminal_bridge_id == "br_oas_activityterminal1"
+        assert row.container_name == "moonmind_auth_oas_activityterminal1"
+        assert row.session_transport == "moonmind_pty_ws"
+        assert row.expires_at is not None


### PR DESCRIPTION
MM-333: Run authenticated OAuth terminal sessions

User Story
As an authorized operator, I can start a browser-based OAuth terminal session that runs a provider login command inside a short-lived auth runner, streams PTY I/O through MoonMind, verifies the resulting credentials, and closes deterministically on success, cancellation, expiry, or failure.
Source Document
- Path: docs/ManagedAgents/OAuthTerminal.md
- Sections: 5. OAuth Terminal Contract, 5.1 Auth runner container, 5.2 Terminal bridge, 5.3 Session transport state, 9. Security Model
- Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-022
- Breakdown Story ID: STORY-002
- Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json