### PR TITLE
MM-334: Launch managed Codex sessions with explicit auth materialization

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/174-typed-workflow-messages"
+  "feature_directory": "specs/175-launch-codex-auth-materialization"
 }

--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -382,6 +382,14 @@ class CodexManagedSessionRuntime:
         if self._auth_volume_path is None:
             return
         source_root = self._auth_volume_path
+        if (
+            source_root.expanduser().resolve()
+            == self._codex_home_path.expanduser().resolve()
+        ):
+            raise RuntimeError(
+                "MANAGED_AUTH_VOLUME_PATH must not equal "
+                "MOONMIND_SESSION_CODEX_HOME_PATH"
+            )
         if not source_root.exists():
             raise RuntimeError(
                 f"MANAGED_AUTH_VOLUME_PATH does not exist: {source_root}"

--- a/specs/175-launch-codex-auth-materialization/checklists/requirements.md
+++ b/specs/175-launch-codex-auth-materialization/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Launch Codex Auth Materialization
+
+**Purpose**: Validate specification completeness and quality before planning  
+**Created**: 2026-04-15  
+**Feature**: `specs/175-launch-codex-auth-materialization/spec.md`
+
+## Content Quality
+
+- [X] No implementation details leak into stakeholder requirements beyond named source-contract terms
+- [X] Focused on task-operator value and credential isolation
+- [X] Written for non-technical stakeholders where possible
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No `[NEEDS CLARIFICATION]` markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes end-to-end validation
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] Specification is ready for implementation planning
+
+## Notes
+
+- The supplied breakdown JSON path is not present in this checkout; the spec preserves it in `Input` and uses the canonical source document sections as the requirement source.

--- a/specs/175-launch-codex-auth-materialization/contracts/managed-codex-auth-materialization.md
+++ b/specs/175-launch-codex-auth-materialization/contracts/managed-codex-auth-materialization.md
@@ -1,0 +1,33 @@
+# Contract: Managed Codex Auth Materialization
+
+## Launch Payload
+
+The adapter sends `agent_runtime.launch_session` a payload with:
+
+- `request.codexHomePath`: per-run task workspace Codex home
+- `request.environment.MANAGED_AUTH_VOLUME_PATH`: explicit auth target when the selected OAuth-backed profile has a durable auth volume target
+- `profile.profileId`: selected Provider Profile ID
+- `profile.credentialSource`: `oauth_volume`
+- `profile.runtimeMaterializationMode`: `oauth_home`
+
+Raw credential contents are forbidden in both `request` and `profile`.
+
+## Launcher Boundary
+
+The managed session controller must:
+
+- mount the shared workspace volume at the configured workspace root
+- mount the durable auth volume only when `MANAGED_AUTH_VOLUME_PATH` is present
+- mount the durable auth volume at exactly `MANAGED_AUTH_VOLUME_PATH`
+- reject `MANAGED_AUTH_VOLUME_PATH == codexHomePath`
+- pass reserved session path/control environment values into the container
+
+## Runtime Boundary
+
+The in-container Codex session runtime must:
+
+- require workspace, session state, artifact spool, image, and Codex home environment values
+- create the per-run Codex home when needed
+- reject an auth volume path equal to the per-run Codex home
+- copy eligible auth entries one way from `MANAGED_AUTH_VOLUME_PATH` into the per-run Codex home
+- start Codex App Server with `CODEX_HOME` set to the per-run Codex home

--- a/specs/175-launch-codex-auth-materialization/data-model.md
+++ b/specs/175-launch-codex-auth-materialization/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Launch Codex Auth Materialization
+
+## Provider Profile
+
+- `profile_id`: selected profile identifier
+- `runtime_id`: managed runtime identifier, expected `codex_cli` for this story
+- `credential_source`: `oauth_volume` for OAuth-backed profiles
+- `runtime_materialization_mode`: `oauth_home` for Codex OAuth home materialization
+- `volume_ref`: durable auth volume reference
+- `volume_mount_path`: explicit auth target exposed as `MANAGED_AUTH_VOLUME_PATH`
+
+Validation:
+
+- Profile launch metadata must not include credential file contents.
+- Auth target metadata is compact path metadata only.
+
+## Managed Session Launch Request
+
+- `taskRunId`
+- `sessionId`
+- `workspacePath`
+- `sessionWorkspacePath`
+- `artifactSpoolPath`
+- `codexHomePath`
+- `imageRef`
+- `environment.MANAGED_AUTH_VOLUME_PATH` when a selected profile requires a durable auth source
+
+Validation:
+
+- Workspace, session state, artifact spool, and Codex home paths are absolute task-scoped paths.
+- Reserved session environment values are set by the launcher, not overridden by profile environment.
+- `MANAGED_AUTH_VOLUME_PATH` must be absolute and must not equal `codexHomePath`.
+
+## Per-Run Codex Home
+
+- Directory under the task workspace, conventionally `.moonmind/codex-home`
+- Receives eligible auth entries from the durable auth source
+- Used as `CODEX_HOME` for Codex App Server
+
+Validation:
+
+- Directory must be writable.
+- Durable auth source is copied one way into this directory.
+- Generated config and runtime logs are not overwritten or copied from the durable auth source.

--- a/specs/175-launch-codex-auth-materialization/plan.md
+++ b/specs/175-launch-codex-auth-materialization/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Launch Codex Auth Materialization
+
+**Branch**: `175-launch-codex-auth-materialization` | **Date**: 2026-04-15 | **Spec**: `specs/175-launch-codex-auth-materialization/spec.md`
+
+## Summary
+
+Managed Codex sessions must launch with task-scoped runtime state while using OAuth-backed Provider Profiles as credential sources. The existing adapter and controller already pass compact profile metadata, conditionally mount the auth volume at `MANAGED_AUTH_VOLUME_PATH`, seed eligible auth entries into the per-run Codex home, and start Codex App Server with that home. This implementation closes the remaining in-container validation gap by rejecting auth-target and Codex-home path equality at the runtime materialization boundary and adds focused tests around the adapter and runtime boundaries.
+
+## Technical Context
+
+- Language/version: Python 3.12
+- Primary dependencies: Pydantic managed-session models, Temporal activity/adapter boundary, Docker-backed managed session controller, Codex App Server runtime client
+- Storage: shared `agent_workspaces` volume for per-run workspace/session/artifact/Codex home paths; durable Codex auth volume as source-only credential store
+- Unit testing: `./tools/test_unit.sh` with pytest
+- Integration testing: `./tools/test_integration.sh` for compose-backed `integration_ci` suite when Docker is available
+- Target platform: MoonMind managed-agent worker and managed Codex session container
+- Constraints: no raw credentials in workflow payloads/logs/artifacts; auth volume target must be explicit and distinct; runtime must fail fast on unsafe path shape
+- Scale/scope: one managed Codex session launch path and session runtime materialization boundary
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. Keeps Codex App Server as provider runtime and only controls launch/materialization boundaries.
+- II One-Click Agent Deployment: PASS. Uses existing compose-backed volumes and local test runner.
+- III Avoid Vendor Lock-In: PASS. Codex-specific behavior remains in Codex adapter/runtime boundaries.
+- IV Own Your Data: PASS. Credentials remain in operator-controlled volumes and task workspaces.
+- V Skills Are First-Class: PASS. No executable skill contract changes.
+- VI Bittersweet Lesson: PASS. Thin validation added at runtime boundary with tests.
+- VII Runtime Configurability: PASS. Uses Provider Profile metadata and configured volume mount target.
+- VIII Modular Architecture: PASS. Changes stay in adapter tests and Codex session runtime.
+- IX Resilient by Default: PASS. Unsafe launch state fails fast before session startup.
+- X Continuous Improvement: PASS. Verification evidence is recorded in tasks and final report.
+- XI Spec-Driven Development: PASS. This feature directory tracks spec, plan, tasks, implementation, and verification.
+- XII Canonical Docs Separation: PASS. No migration checklist is added to canonical docs.
+- XIII Pre-Release Compatibility: PASS. No compatibility alias or fallback is introduced.
+
+## Project Structure
+
+- `moonmind/workflows/adapters/codex_session_adapter.py`: builds launch payload from selected Provider Profile
+- `moonmind/workflows/temporal/runtime/managed_session_controller.py`: validates launch request and mounts workspace/auth volumes
+- `moonmind/workflows/temporal/runtime/codex_session_runtime.py`: validates in-container runtime paths, seeds auth entries, starts Codex App Server
+- `tests/unit/workflows/adapters/test_codex_session_adapter.py`: adapter boundary tests
+- `tests/unit/services/temporal/runtime/test_managed_session_controller.py`: launcher boundary tests
+- `tests/unit/services/temporal/runtime/test_codex_session_runtime.py`: in-container runtime tests
+
+## Research
+
+See `research.md`.
+
+## Data Model
+
+See `data-model.md`.
+
+## Contracts
+
+See `contracts/managed-codex-auth-materialization.md`.
+
+## Test Strategy
+
+- Unit: verify adapter launch payload for OAuth-backed profile, controller auth mount separation, session runtime path rejection, one-way credential seeding, and `CODEX_HOME` app-server environment.
+- Integration: use existing compose-backed managed Codex session launch tests when Docker is available; no new credentialed provider verification is required.
+
+## Complexity Tracking
+
+None.

--- a/specs/175-launch-codex-auth-materialization/quickstart.md
+++ b/specs/175-launch-codex-auth-materialization/quickstart.md
@@ -1,0 +1,24 @@
+# Quickstart: Launch Codex Auth Materialization
+
+## Focused Unit Verification
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py -k 'oauth_profile_auth_target'
+./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py -k 'auth_volume_equal_to_codex_home or seeds_auth_volume'
+```
+
+## Broader Unit Verification
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+```
+
+## Integration Verification
+
+When Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+Provider OAuth verification with real credentials is not required for this story.

--- a/specs/175-launch-codex-auth-materialization/research.md
+++ b/specs/175-launch-codex-auth-materialization/research.md
@@ -1,0 +1,33 @@
+# Research: Launch Codex Auth Materialization
+
+## Resume And Existing Implementation
+
+Decision: Reuse the existing managed Codex adapter, managed session controller, and Codex session runtime boundaries.
+
+Rationale: The current code already carries selected Provider Profile metadata into the launch request, conditionally mounts an auth volume at `MANAGED_AUTH_VOLUME_PATH`, seeds eligible auth files into a task-scoped Codex home, and starts Codex App Server with `CODEX_HOME` set to that path.
+
+Alternatives considered: Introduce a new launch contract or profile materializer. Rejected because the existing boundaries match the source design and only need a targeted validation hardening.
+
+## Auth Target Validation
+
+Decision: Validate auth-target and Codex-home separation both at the launcher boundary and inside the session runtime before seeding credentials.
+
+Rationale: The controller can reject unsafe launch requests before Docker starts, but the source design also requires the session runtime to validate the optional auth-volume path before materialization. Runtime validation protects direct module invocation and future launcher variants.
+
+Alternatives considered: Rely only on controller validation. Rejected because it leaves the in-container materialization boundary weaker than the design.
+
+## Credential Seeding
+
+Decision: Keep one-way copy semantics and preserve the existing exclusion behavior for generated config, sessions, and runtime log databases.
+
+Rationale: Durable OAuth credentials should seed the per-run home, while generated session state must not become the provider-profile source of truth or overwrite profile/materialized config.
+
+Alternatives considered: Bind-mount the durable auth volume as `CODEX_HOME`. Rejected because it violates task-scoped runtime state isolation.
+
+## Test Scope
+
+Decision: Add focused unit coverage for adapter profile-to-launch payload and runtime validation; rely on existing controller and runtime seeding tests for the remaining source requirements.
+
+Rationale: The changed behavior is local and testable without Docker credentials. Compose-backed integration can be run separately when Docker is available.
+
+Alternatives considered: Add provider verification tests using real OAuth credentials. Rejected because provider verification is explicitly outside required PR verification.

--- a/specs/175-launch-codex-auth-materialization/spec.md
+++ b/specs/175-launch-codex-auth-materialization/spec.md
@@ -1,0 +1,76 @@
+# Feature Specification: Launch Codex Auth Materialization
+
+**Feature Branch**: `175-launch-codex-auth-materialization`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**: MM-334: Launch managed Codex sessions with explicit auth materialization
+
+User Story
+As a task operator, I can launch a managed Codex session using a selected OAuth-backed Provider Profile, with the durable auth volume mounted only at an explicit auth target and eligible credentials copied one way into the per-run CODEX_HOME under the task workspace before Codex App Server starts.
+Source Document
+- Path: docs/ManagedAgents/OAuthTerminal.md
+- Sections: 3.2 Shared task workspace volume, 3.3 Explicit auth-volume target, 4. Volume Targeting Rules, 7. Managed Codex Session Launch, 8. Verification
+- Coverage IDs: DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017
+- Breakdown Story ID: STORY-003
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json
+
+## User Story - Managed Codex OAuth Auth Materialization
+
+### Summary
+
+A task operator launches a managed Codex session with an OAuth-backed Provider Profile, and MoonMind materializes credentials into the task-scoped runtime home without using the durable auth volume as the live Codex home.
+
+### Goal
+
+Allow selected OAuth-backed Codex provider credentials to be used by managed Codex sessions while keeping durable auth storage separate from per-run session state.
+
+### Independent Test
+
+Start a managed Codex session with a selected OAuth-backed profile and verify that the launch request uses the task workspace for the per-run Codex home, mounts the durable auth volume only at an explicit auth target, rejects an auth target equal to the Codex home, copies only eligible auth entries into the per-run Codex home, and starts Codex App Server with that per-run home.
+
+### Acceptance Scenarios
+
+1. **Given** a task operator selects an OAuth-backed Codex Provider Profile, **when** MoonMind launches the managed Codex session, **then** the session receives the shared task workspace volume and the per-run `CODEX_HOME` path is under that task workspace.
+2. **Given** the selected profile requires a durable auth volume, **when** the session container is launched, **then** the auth volume is mounted only at an explicit auth target separate from the per-run Codex home.
+3. **Given** the session runtime starts inside the container, **when** an explicit auth target is present, **then** it validates that the auth target is not the per-run Codex home, copies eligible auth entries one way into the per-run Codex home, and starts Codex App Server with `CODEX_HOME` set to the per-run path.
+4. **Given** an invalid launch attempts to use the same path for the auth target and per-run Codex home, **when** the launcher or session runtime validates the request, **then** the session fails fast before using that path as live runtime state.
+
+### Edge Cases
+
+- The selected profile has no auth-volume target; the session still uses the per-run Codex home and does not mount the durable auth volume.
+- The durable auth source contains session logs or materialized runtime config; those entries are not copied over generated per-run config.
+- Workspace, artifact, session state, or Codex home paths are missing, non-writable, or outside the managed workspace boundary.
+- Credential contents must not be included in workflow history, logs, artifacts, or UI-visible responses.
+
+## Requirements
+
+- **FR-001**: Managed Codex session launches MUST use the shared task workspace volume for task repo, session state, artifact spool, and per-run Codex home paths. Maps to DESIGN-REQ-005 and DESIGN-REQ-015.
+- **FR-002**: OAuth-backed Provider Profile selection MUST pass compact profile metadata and an explicit auth target to the launch boundary without passing raw credential contents. Maps to DESIGN-REQ-006 and DESIGN-REQ-017.
+- **FR-003**: The managed-session launcher MUST mount the durable Codex auth volume only when an explicit auth target is present, and the target MUST be separate from the per-run Codex home. Maps to DESIGN-REQ-006, DESIGN-REQ-007, and DESIGN-REQ-015.
+- **FR-004**: The session runtime MUST independently validate that `MANAGED_AUTH_VOLUME_PATH` is an absolute auth source separate from the per-run `CODEX_HOME` before credential materialization. Maps to DESIGN-REQ-006 and DESIGN-REQ-015.
+- **FR-005**: The session runtime MUST copy eligible auth entries one way from the durable auth source into the per-run Codex home before Codex App Server starts, without treating session-local state as provider-profile source of truth. Maps to DESIGN-REQ-016.
+- **FR-006**: Codex App Server MUST start with `CODEX_HOME` set to the per-run Codex home under the task workspace. Maps to DESIGN-REQ-015 and DESIGN-REQ-016.
+- **FR-007**: Verification MUST cover both the profile-to-launch boundary and the in-container runtime materialization boundary without exposing credential contents. Maps to DESIGN-REQ-017.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-005**: Managed Codex sessions receive the shared `agent_workspaces` volume and per-task layout under `/work/agent_jobs`. Source: `docs/ManagedAgents/OAuthTerminal.md` section 3.2. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-006**: Durable auth volume mounts are explicit through `MANAGED_AUTH_VOLUME_PATH` and separate from the live Codex home. Source: section 3.3. Scope: in scope. Maps to FR-002, FR-003, FR-004.
+- **DESIGN-REQ-007**: Credential copying is one-way from durable auth volume to per-run Codex home; workload containers do not inherit auth volumes by default. Source: section 4. Scope: in scope for managed session launch; workload container propagation is out of scope for this story. Maps to FR-003 and FR-005.
+- **DESIGN-REQ-015**: Managed Codex launch passes reserved workspace, state, artifact, Codex home, and control URL environment values. Source: section 7. Scope: in scope. Maps to FR-001, FR-003, FR-004, FR-006.
+- **DESIGN-REQ-016**: Session runtime validates workspace paths, creates the per-run Codex home, seeds eligible auth entries, and starts Codex App Server with `CODEX_HOME = codexHomePath`. Source: section 7. Scope: in scope. Maps to FR-005 and FR-006.
+- **DESIGN-REQ-017**: Verification happens at OAuth/profile and managed-session launch boundaries without copying credential contents into workflow payloads, artifacts, logs, or UI responses. Source: section 8. Scope: in scope. Maps to FR-002 and FR-007.
+
+## Key Entities
+
+- **Provider Profile**: Selected runtime profile carrying compact credential source metadata, volume reference, explicit auth target, and materialization mode.
+- **Durable Auth Volume**: Provider-profile credential store mounted only at the explicit auth target when required.
+- **Per-Run Codex Home**: Task-scoped Codex home under the shared workspace that receives one-way credential seeds and is used as `CODEX_HOME`.
+- **Managed Session Launch Request**: Boundary payload containing workspace paths, per-run Codex home path, image, control URL, profile metadata, and sanitized environment values.
+
+## Success Criteria
+
+- **SC-001**: Unit tests verify OAuth-backed Provider Profile launch passes an explicit auth target while keeping the per-run Codex home under the task workspace.
+- **SC-002**: Unit tests verify launcher/runtime validation rejects an auth target equal to the per-run Codex home.
+- **SC-003**: Unit tests verify eligible auth entries are copied into the per-run Codex home without overwriting materialized config or copying excluded runtime logs.
+- **SC-004**: Unit tests verify Codex App Server receives `CODEX_HOME` as the per-run task workspace home.

--- a/specs/175-launch-codex-auth-materialization/tasks.md
+++ b/specs/175-launch-codex-auth-materialization/tasks.md
@@ -9,12 +9,12 @@
 
 ## Source Traceability
 
-- DESIGN-REQ-005: T001, T004, T007
-- DESIGN-REQ-006: T001, T002, T005, T006
-- DESIGN-REQ-007: T002, T005, T006
-- DESIGN-REQ-015: T001, T004, T006, T007
-- DESIGN-REQ-016: T002, T005, T006, T007
-- DESIGN-REQ-017: T001, T002, T006, T008
+- DESIGN-REQ-005: T001, T003, T007, T008, T009
+- DESIGN-REQ-006: T001, T003, T004, T005, T006, T007, T008, T009
+- DESIGN-REQ-007: T002, T003, T007, T008, T009
+- DESIGN-REQ-015: T001, T004, T005, T006, T007, T008, T009
+- DESIGN-REQ-016: T002, T004, T006, T007, T008, T009
+- DESIGN-REQ-017: T003, T007, T008, T009, T010
 
 ## Phase 1: Setup
 
@@ -37,4 +37,4 @@ Independent test: Verify selected profile metadata produces an explicit auth tar
 - [X] T007 Run targeted adapter and runtime unit tests for OAuth launch metadata, auth seeding, auth path rejection, and app-server `CODEX_HOME`. (FR-001 through FR-007, SC-001 through SC-004)
 - [X] T008 Run broader unit test coverage for the three managed-session launch/runtime test files. (FR-001 through FR-007)
 - [X] T009 Run integration verification or record exact local blocker. Blocked locally because `/var/run/docker.sock` is unavailable to `./tools/test_integration.sh`. (FR-007)
-- [X] T010 Run `/speckit.verify` equivalent and record final verdict: `ADDITIONAL_WORK_NEEDED` only for unavailable Docker-backed integration execution; implementation and unit evidence are complete. (SC-001 through SC-004)
+- [X] T010 Run `/moonspec-verify` equivalent and record final verdict: `ADDITIONAL_WORK_NEEDED` only for unavailable Docker-backed integration execution; implementation and unit evidence are complete. (SC-001 through SC-004)

--- a/specs/175-launch-codex-auth-materialization/tasks.md
+++ b/specs/175-launch-codex-auth-materialization/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Launch Codex Auth Materialization
+
+**Input**: `specs/175-launch-codex-auth-materialization/spec.md`
+
+## Prerequisites
+
+- Unit command: `./tools/test_unit.sh`
+- Integration command: `./tools/test_integration.sh` when Docker is available
+
+## Source Traceability
+
+- DESIGN-REQ-005: T001, T004, T007
+- DESIGN-REQ-006: T001, T002, T005, T006
+- DESIGN-REQ-007: T002, T005, T006
+- DESIGN-REQ-015: T001, T004, T006, T007
+- DESIGN-REQ-016: T002, T005, T006, T007
+- DESIGN-REQ-017: T001, T002, T006, T008
+
+## Phase 1: Setup
+
+- [X] T001 Inspect existing managed Codex adapter, controller, runtime, and tests for profile launch, explicit auth target, workspace volume, and Codex home behavior in `moonmind/workflows/adapters/codex_session_adapter.py`, `moonmind/workflows/temporal/runtime/managed_session_controller.py`, and `moonmind/workflows/temporal/runtime/codex_session_runtime.py`. (FR-001, FR-002, DESIGN-REQ-005, DESIGN-REQ-006)
+
+## Phase 2: Foundational
+
+- [X] T002 Confirm existing runtime seeding coverage for one-way auth copy and excluded entries in `tests/unit/services/temporal/runtime/test_codex_session_runtime.py`. (FR-005, DESIGN-REQ-007, DESIGN-REQ-016)
+
+## Phase 3: Managed Codex OAuth Auth Materialization
+
+Story summary: Launch a managed Codex session using a selected OAuth-backed Provider Profile while keeping durable auth storage separate from per-run Codex runtime state.
+
+Independent test: Verify selected profile metadata produces an explicit auth target at launch, runtime rejects an auth target equal to Codex home, eligible auth entries seed one way, and Codex App Server uses the per-run `CODEX_HOME`.
+
+- [X] T003 Add red-first adapter unit regression coverage for OAuth-backed Provider Profile launch metadata in `tests/unit/workflows/adapters/test_codex_session_adapter.py`. (FR-002, FR-003, SC-001)
+- [X] T004 Add red-first runtime unit regression coverage rejecting `MANAGED_AUTH_VOLUME_PATH` equal to per-run Codex home in `tests/unit/services/temporal/runtime/test_codex_session_runtime.py`. (FR-004, SC-002)
+- [X] T005 Confirm red-first failure for runtime equality validation before production change with targeted `./tools/test_unit.sh`. (FR-004, SC-002)
+- [X] T006 Implement runtime boundary validation before auth seeding in `moonmind/workflows/temporal/runtime/codex_session_runtime.py`. (FR-004, DESIGN-REQ-006, DESIGN-REQ-015)
+- [X] T007 Run targeted adapter and runtime unit tests for OAuth launch metadata, auth seeding, auth path rejection, and app-server `CODEX_HOME`. (FR-001 through FR-007, SC-001 through SC-004)
+- [X] T008 Run broader unit test coverage for the three managed-session launch/runtime test files. (FR-001 through FR-007)
+- [X] T009 Run integration verification or record exact local blocker. Blocked locally because `/var/run/docker.sock` is unavailable to `./tools/test_integration.sh`. (FR-007)
+- [X] T010 Run `/speckit.verify` equivalent and record final verdict: `ADDITIONAL_WORK_NEEDED` only for unavailable Docker-backed integration execution; implementation and unit evidence are complete. (SC-001 through SC-004)

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2189,6 +2189,31 @@ def test_runtime_launch_session_seeds_auth_volume_without_overwriting_materializ
     assert not Path(request.codex_home_path, "logs_1.sqlite").exists()
 
 
+def test_runtime_launch_session_rejects_auth_volume_equal_to_codex_home(
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=request.codex_home_path,
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="MANAGED_AUTH_VOLUME_PATH must not equal MOONMIND_SESSION_CODEX_HOME_PATH",
+    ):
+        runtime.launch_session(request)
+
+
 def test_run_ready_requires_runtime_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     workspace_path = tmp_path / "repo"
     workspace_path.mkdir()

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -374,6 +374,103 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["threadId"] == "thread-1"
 
 
+async def test_start_passes_oauth_profile_auth_target_to_launch_session(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    launch_calls: list[Any] = []
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(request: Any) -> CodexManagedSessionHandle:
+        launch_calls.append(request)
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [
+                {
+                    "profile_id": "codex-oauth",
+                    "runtime_id": "codex_cli",
+                    "provider_id": "openai",
+                    "credential_source": "oauth_volume",
+                    "runtime_materialization_mode": "oauth_home",
+                    "volume_ref": "codex_auth_volume",
+                    "volume_mount_path": "/home/app/.codex-auth",
+                }
+            ]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed-runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(
+            return_value=_turn_response(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    await adapter.start(
+        _request(binding).model_copy(update={"execution_profile_ref": "codex-oauth"})
+    )
+
+    assert len(launch_calls) == 1
+    launch_payload = launch_calls[0]
+    launch_request = launch_payload["request"]
+    assert launch_request["environment"]["MANAGED_AUTH_VOLUME_PATH"] == (
+        "/home/app/.codex-auth"
+    )
+    assert launch_request["environment"]["MOONMIND_EXECUTION_PROFILE_REF"] == (
+        "codex-oauth"
+    )
+    assert launch_request["codexHomePath"].endswith(
+        f"{binding.task_run_id}/.moonmind/codex-home"
+    )
+    assert launch_request["codexHomePath"] != (
+        launch_request["environment"]["MANAGED_AUTH_VOLUME_PATH"]
+    )
+    assert launch_payload["profile"]["credentialSource"] == "oauth_volume"
+
+
 async def test_start_persists_running_live_capable_record_before_send_turn_completes(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
MM-334: Launch managed Codex sessions with explicit auth materialization

User Story
As a task operator, I can launch a managed Codex session using a selected OAuth-backed Provider Profile, with the durable auth volume mounted only at an explicit auth target and eligible credentials copied one way into the per-run CODEX_HOME under the task workspace before Codex App Server starts.
Source Document
- Path: docs/ManagedAgents/OAuthTerminal.md
- Sections: 3.2 Shared task workspace volume, 3.3 Explicit auth-volume target, 4. Volume Targeting Rules, 7. Managed Codex Session Launch, 8. Verification
- Coverage IDs: DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-015, DESIGN-REQ-016, DESIGN-REQ-017
- Breakdown Story ID: STORY-003
- Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json