### PR TITLE
MM-330: Move binary and large Temporal payloads to explicit serializers or artifacts

### DIFF
--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any, Literal, NoReturn, get_args
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from moonmind.schemas._validation import require_non_blank
 from moonmind.schemas.managed_session_models import (
     CodexManagedSessionBinding,
     canonical_codex_managed_runtime_id,
 )
+from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 AgentKind = Literal["external", "managed"]
 ExternalExecutionStyle = Literal["polling", "streaming_gateway"]
@@ -230,6 +231,11 @@ class AgentRunHandle(BaseModel):
     poll_hint_seconds: int | None = Field(None, alias="pollHintSeconds", ge=1)
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
 
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(value, field_name="metadata")
+
     @model_validator(mode="after")
     def _normalize(self) -> "AgentRunHandle":
         self.run_id = require_non_blank(self.run_id, field_name="runId")
@@ -253,6 +259,11 @@ class AgentRunStatus(BaseModel):
     )
     poll_hint_seconds: int | None = Field(None, alias="pollHintSeconds", ge=1)
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(value, field_name="metadata")
 
     @property
     def terminal(self) -> bool:
@@ -280,6 +291,11 @@ class AgentRunResult(BaseModel):
     provider_error_code: str | None = Field(None, alias="providerErrorCode")
     retry_recommendation: str | None = Field(None, alias="retryRecommendation")
     metadata: dict[str, Any] = Field(default_factory=dict, alias="metadata")
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(value, field_name="metadata")
 
     @model_validator(mode="after")
     def _validate_payload(self) -> "AgentRunResult":

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from moonmind.schemas._validation import NonBlankStr, require_non_blank
+from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 
 ManagedSessionControlAction = Literal[
@@ -162,6 +163,11 @@ class _CodexManagedSessionRemoteContract(BaseModel):
     control_mode: ManagedSessionControlMode = Field(
         "remote_container", alias="controlMode"
     )
+
+    @field_validator("metadata", mode="after", check_fields=False)
+    @classmethod
+    def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(value, field_name="metadata")
 
 
 class CodexManagedSessionLocator(_CodexManagedSessionRemoteContract):

--- a/moonmind/schemas/managed_session_models.py
+++ b/moonmind/schemas/managed_session_models.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from moonmind.schemas._validation import NonBlankStr, require_non_blank
-from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
+from moonmind.schemas.temporal_payload_policy import (
+    MAX_TEMPORAL_METADATA_STRING_CHARS,
+    validate_compact_temporal_mapping,
+)
 
 
 ManagedSessionControlAction = Literal[
@@ -85,6 +89,61 @@ def canonical_codex_managed_runtime_id(runtime_id: str) -> str | None:
     if normalized in {"codex", "codex_cli"}:
         return "codex_cli"
     return None
+
+
+_ASSISTANT_TEXT_METADATA_KEYS = frozenset({"assistantText", "lastAssistantText"})
+_ASSISTANT_TEXT_METADATA_MAX_BYTES = 8 * 1024
+
+
+def _truncate_utf8_text(value: str, *, max_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _truncate_json_text(value: str, *, max_bytes: int) -> str:
+    if len(json.dumps(value, allow_nan=False).encode("utf-8")) <= max_bytes:
+        return value
+    low = 0
+    high = len(value)
+    while low < high:
+        midpoint = (low + high + 1) // 2
+        candidate = value[:midpoint]
+        encoded_size = len(json.dumps(candidate, allow_nan=False).encode("utf-8"))
+        if encoded_size <= max_bytes:
+            low = midpoint
+        else:
+            high = midpoint - 1
+    return value[:low]
+
+
+def _compact_managed_session_metadata(
+    value: dict[str, Any],
+) -> dict[str, Any]:
+    """Clamp provider assistant text snippets before Temporal payload validation."""
+
+    normalized = dict(value)
+    for key in _ASSISTANT_TEXT_METADATA_KEYS:
+        raw_text = normalized.get(key)
+        if not isinstance(raw_text, str):
+            continue
+        original_chars = len(raw_text)
+        compact_text = raw_text[:MAX_TEMPORAL_METADATA_STRING_CHARS]
+        compact_text = _truncate_utf8_text(
+            compact_text,
+            max_bytes=_ASSISTANT_TEXT_METADATA_MAX_BYTES,
+        )
+        compact_text = _truncate_json_text(
+            compact_text,
+            max_bytes=_ASSISTANT_TEXT_METADATA_MAX_BYTES,
+        )
+        if compact_text != raw_text:
+            normalized[key] = compact_text
+            normalized[f"{key}Truncated"] = True
+            normalized[f"{key}OriginalChars"] = original_chars
+    return normalized
+
 
 class CodexManagedSessionPlaneContract(BaseModel):
     """Frozen Phase 1 MVP contract for the Codex managed session plane."""
@@ -167,7 +226,10 @@ class _CodexManagedSessionRemoteContract(BaseModel):
     @field_validator("metadata", mode="after", check_fields=False)
     @classmethod
     def _validate_metadata(cls, value: dict[str, Any]) -> dict[str, Any]:
-        return validate_compact_temporal_mapping(value, field_name="metadata")
+        return validate_compact_temporal_mapping(
+            _compact_managed_session_metadata(value),
+            field_name="metadata",
+        )
 
 
 class CodexManagedSessionLocator(_CodexManagedSessionRemoteContract):

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 SUPPORTED_WORKFLOW_TYPES = ("MoonMind.Run", "MoonMind.ManifestIngest")
 SUPPORTED_FAILURE_POLICIES = (
@@ -218,6 +220,14 @@ class ConfigureIntegrationMonitoringRequest(BaseModel):
     )
     result_refs: list[str] = Field(default_factory=list, alias="resultRefs")
 
+    @field_validator("provider_summary", mode="after")
+    @classmethod
+    def _validate_provider_summary(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value,
+            field_name="providerSummary",
+        )
+
 
 class PollIntegrationRequest(BaseModel):
     """Request payload for polling updates while awaiting external completion."""
@@ -239,6 +249,14 @@ class PollIntegrationRequest(BaseModel):
     result_refs: list[str] = Field(default_factory=list, alias="resultRefs")
     completed_wait_cycles: int = Field(1, alias="completedWaitCycles", ge=0)
 
+    @field_validator("provider_summary", mode="after")
+    @classmethod
+    def _validate_provider_summary(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value,
+            field_name="providerSummary",
+        )
+
 
 class IntegrationCallbackRequest(BaseModel):
     """Generic provider callback payload resolved through correlation storage."""
@@ -259,6 +277,14 @@ class IntegrationCallbackRequest(BaseModel):
         default_factory=dict, alias="providerSummary"
     )
     payload_artifact_ref: Optional[str] = Field(None, alias="payloadArtifactRef")
+
+    @field_validator("provider_summary", mode="after")
+    @classmethod
+    def _validate_provider_summary(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value,
+            field_name="providerSummary",
+        )
 
 
 class IntegrationStateModel(BaseModel):
@@ -290,6 +316,14 @@ class IntegrationStateModel(BaseModel):
     provider_summary: dict[str, Any] = Field(
         default_factory=dict, alias="providerSummary"
     )
+
+    @field_validator("provider_summary", mode="after")
+    @classmethod
+    def _validate_provider_summary(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value,
+            field_name="providerSummary",
+        )
 
 
 class CancelExecutionRequest(BaseModel):

--- a/moonmind/schemas/temporal_payload_policy.py
+++ b/moonmind/schemas/temporal_payload_policy.py
@@ -28,9 +28,12 @@ def validate_compact_temporal_mapping(
 
     _validate_json_value(value, path=field_name)
     try:
-        encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode(
-            "utf-8"
-        )
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{field_name} must be JSON serializable") from exc
     if len(encoded) > MAX_TEMPORAL_METADATA_BYTES:

--- a/moonmind/schemas/temporal_payload_policy.py
+++ b/moonmind/schemas/temporal_payload_policy.py
@@ -1,0 +1,69 @@
+"""Helpers for keeping Temporal payloads compact and intentionally serialized."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+MAX_TEMPORAL_METADATA_STRING_CHARS = 8192
+MAX_TEMPORAL_METADATA_BYTES = 16 * 1024
+
+
+def validate_compact_temporal_mapping(
+    value: Any,
+    *,
+    field_name: str,
+) -> dict[str, Any]:
+    """Validate a bounded JSON mapping used inside Temporal boundary models.
+
+    Metadata/provider-summary bags are approved escape hatches only for compact
+    annotations. Large bodies, transcripts, diagnostics, checkpoints, and binary
+    payloads must move through typed artifact refs or explicit serializers.
+    """
+
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+
+    _validate_json_value(value, path=field_name)
+    try:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be JSON serializable") from exc
+    if len(encoded) > MAX_TEMPORAL_METADATA_BYTES:
+        raise ValueError(
+            f"{field_name} must serialize to <= {MAX_TEMPORAL_METADATA_BYTES} bytes; "
+            "store large payloads in artifacts and carry refs"
+        )
+    return dict(value)
+
+
+def _validate_json_value(value: Any, *, path: str) -> None:
+    if isinstance(value, bytes):
+        raise ValueError(
+            f"{path} must not contain raw bytes; use Base64Bytes or artifact refs"
+        )
+    if isinstance(value, str):
+        if len(value) > MAX_TEMPORAL_METADATA_STRING_CHARS:
+            raise ValueError(
+                f"{path} must be <= {MAX_TEMPORAL_METADATA_STRING_CHARS} characters; "
+                "store large payloads in artifacts and carry refs"
+            )
+        return
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+    if isinstance(value, dict):
+        for raw_key, nested in value.items():
+            key = str(raw_key).strip()
+            if not key:
+                raise ValueError(f"{path} contains a blank key")
+            _validate_json_value(nested, path=f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _validate_json_value(item, path=f"{path}[{index}]")
+        return
+    raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")

--- a/moonmind/schemas/temporal_signal_contracts.py
+++ b/moonmind/schemas/temporal_signal_contracts.py
@@ -3,7 +3,9 @@
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
 
 # ---------------------------------------------------------------------------
 # Public Execution Signals
@@ -28,6 +30,14 @@ class ExternalEventSignal(BaseModel):
         default_factory=dict,
         alias="providerSummary",
     )
+
+    @field_validator("provider_summary", mode="after")
+    @classmethod
+    def _validate_provider_summary(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return validate_compact_temporal_mapping(
+            value,
+            field_name="providerSummary",
+        )
 
 
 class RescheduleSignal(BaseModel):

--- a/specs/175-temporal-payload-policy/contracts/temporal-payload-policy.md
+++ b/specs/175-temporal-payload-policy/contracts/temporal-payload-policy.md
@@ -1,0 +1,15 @@
+# Contract: Temporal Payload Policy
+
+## Compact Metadata Contract
+
+Temporal-facing metadata and provider-summary fields:
+
+- MUST be JSON objects.
+- MUST NOT contain raw bytes at any nesting level.
+- MUST NOT carry large transcripts, diagnostics bodies, summaries, checkpoints, or provider response bodies inline.
+- MAY carry compact artifact refs such as `summaryRef`, `checkpointRef`, `diagnosticsRef`, `resultRef`, and `payloadArtifactRef`.
+- MAY carry compact annotation fields such as status, reason, source, attempt, and runtime identifiers.
+
+## Binary Contract
+
+Nested binary data in JSON-shaped Temporal payloads must use explicit typed serializers such as `Base64Bytes`. Larger binary outputs must be stored as artifacts and referenced by ID/ref.

--- a/specs/175-temporal-payload-policy/data-model.md
+++ b/specs/175-temporal-payload-policy/data-model.md
@@ -1,0 +1,26 @@
+# Data Model: Temporal Payload Policy
+
+## Compact Temporal Mapping
+
+- **Owner**: `moonmind/schemas/temporal_payload_policy.py`
+- **Purpose**: Shared validation for approved `metadata` and `providerSummary` escape hatches.
+- **Shape**: JSON object containing strings, numbers, booleans, nulls, arrays, and nested objects.
+- **Bounds**:
+  - raw `bytes` are rejected
+  - individual strings are capped
+  - serialized JSON mapping size is capped
+  - unsupported Python object types are rejected
+- **Large payload rule**: transcripts, diagnostics bodies, summaries, checkpoints, provider payloads, and binary outputs use artifact refs.
+
+## Affected Boundary Models
+
+- `AgentRunHandle.metadata`
+- `AgentRunStatus.metadata`
+- `AgentRunResult.metadata`
+- Codex managed-session request/response metadata fields under `_CodexManagedSessionRemoteContract`
+- Integration `providerSummary` fields in Temporal API/signal models
+
+## Explicit Binary Serializer
+
+- `Base64Bytes` remains the explicit typed serializer for binary activity fields.
+- It serializes as base64 strings on JSON dumps and accepts legacy list/int or cleartext string compatibility inputs at the typed boundary.

--- a/specs/175-temporal-payload-policy/plan.md
+++ b/specs/175-temporal-payload-policy/plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan: Temporal Payload Policy
+
+**Branch**: `175-temporal-payload-policy` | **Date**: 2026-04-15 | **Spec**: `specs/175-temporal-payload-policy/spec.md`
+
+## Summary
+
+Add a reusable compact Temporal mapping validator and apply it to the existing Temporal-facing metadata/provider-summary escape hatches used by managed-session, agent-runtime, integration signal, and integration lifecycle models. Preserve existing activity/workflow names and existing artifact-ref fields.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK
+**Storage**: Existing artifact refs only; no new storage
+**Testing**: `./tools/test_unit.sh` for final verification; focused pytest during iteration
+**Source Design**: `docs/Temporal/TemporalTypeSafety.md` sections 9 and 12
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. The change strengthens orchestration contracts without replacing agents.
+- **II. One-Click Agent Deployment**: PASS. No deployment prerequisite changes.
+- **III. Avoid Vendor Lock-In**: PASS. Artifact refs and JSON policy remain provider-neutral.
+- **IV. Own Your Data**: PASS. Large payloads remain in MoonMind artifact storage instead of Temporal history.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill runtime contract changes.
+- **VI. Evolving Scaffolds**: PASS. The policy is small and replaceable behind schema validation.
+- **VII. Powerful Runtime Configurability**: PASS. No hardcoded runtime behavior is introduced beyond schema bounds.
+- **VIII. Modular and Extensible Architecture**: PASS. Validation lives in a shared schema helper.
+- **IX. Resilient by Default**: PASS. Histories remain compact and replay-friendly; Temporal names are unchanged.
+- **X. Facilitate Continuous Improvement**: PASS. Tests provide objective verification.
+- **XI. Spec-Driven Development**: PASS. This spec/plan/tasks set tracks the runtime implementation.
+- **XII. Canonical Docs Separate Desired State From Migration Backlog**: PASS. Canonical docs are not changed.
+- **XIII. Pre-Release Compatibility Policy**: PASS. No internal compatibility alias or fallback semantic transform is added.
+
+## Project Structure
+
+```text
+moonmind/schemas/temporal_payload_policy.py
+moonmind/schemas/agent_runtime_models.py
+moonmind/schemas/managed_session_models.py
+moonmind/schemas/temporal_models.py
+moonmind/schemas/temporal_signal_contracts.py
+tests/schemas/test_temporal_payload_policy.py
+tests/schemas/test_temporal_activity_models.py
+```
+
+## Implementation Strategy
+
+1. Add a reusable validator for compact JSON mappings that rejects raw bytes, unsupported value types, large strings, and oversized serialized mappings.
+2. Apply the validator to Temporal-facing `metadata` and `providerSummary` fields that function as approved escape hatches.
+3. Add schema tests that prove rejection of raw bytes/large bodies and acceptance of compact artifact refs.
+4. Re-run existing explicit binary serializer tests to confirm `Base64Bytes` behavior remains intact.
+
+## Complexity Tracking
+
+No constitution violation or cross-module migration complexity is introduced. The only compatibility-sensitive choice is preserving existing field names and allowing compact existing metadata keys while bounding payload size and raw bytes.

--- a/specs/175-temporal-payload-policy/quickstart.md
+++ b/specs/175-temporal-payload-policy/quickstart.md
@@ -1,0 +1,15 @@
+# Quickstart: Temporal Payload Policy
+
+1. Run focused schema tests:
+
+   ```bash
+   pytest tests/schemas/test_temporal_payload_policy.py tests/schemas/test_temporal_activity_models.py -q
+   ```
+
+2. Run the required unit suite:
+
+   ```bash
+   ./tools/test_unit.sh
+   ```
+
+3. Confirm compact refs still serialize in managed-session and runtime models while raw bytes or large text in metadata/provider summaries fail validation.

--- a/specs/175-temporal-payload-policy/research.md
+++ b/specs/175-temporal-payload-policy/research.md
@@ -1,0 +1,18 @@
+# Research: Temporal Payload Policy
+
+## Decision 1: Validate Escape Hatches At Schema Boundaries
+
+- **Decision**: Enforce compact JSON mapping rules in Pydantic models for metadata/provider-summary fields.
+- **Rationale**: These models are the closest shared boundary before payloads enter Temporal histories.
+- **Rejected**: Scanning workflow history after execution. That would detect bloat too late and would not prevent accidental encoder behavior.
+
+## Decision 2: Preserve Existing Artifact Ref Fields
+
+- **Decision**: Keep summary, checkpoint, diagnostics, output, and provider payload refs as compact strings or typed artifact ref models.
+- **Rationale**: Existing models already carry refs; this story closes the gap by blocking large bodies in escape hatches.
+- **Rejected**: Redesigning the artifact storage contract. That is explicitly out of scope.
+
+## Decision 3: Keep Compatibility Names Stable
+
+- **Decision**: Do not rename Temporal activity/workflow/message types or public aliases.
+- **Rationale**: The source design and constitution require compatibility-sensitive Temporal contracts to preserve public names unless a cutover plan exists.

--- a/specs/175-temporal-payload-policy/spec.md
+++ b/specs/175-temporal-payload-policy/spec.md
@@ -1,0 +1,50 @@
+# Feature Specification: Temporal Payload Policy
+
+**Feature Branch**: `175-temporal-payload-policy`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: MM-330: Move binary and large Temporal payloads to explicit serializers or artifacts. User Story: As a MoonMind operator, I need Temporal histories to carry only intentional compact payloads and artifact references so large diagnostics, transcripts, summaries, checkpoints, binary data, and special JSON fields do not bloat histories or depend on accidental encoder behavior. Source Document: `docs/Temporal/TemporalTypeSafety.md`; Source Sections: 9 Binary, large payload, and serialization policy; 12 Approved escape hatches. Coverage IDs: DESIGN-REQ-017, DESIGN-REQ-019. Story Metadata: STORY-004, short name `temporal-payload-policy`; Breakdown JSON: `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json`.
+
+## User Story & Testing
+
+### User Story 1 - Compact Temporal Payloads (Priority: P1)
+
+Operators need Temporal histories to contain compact typed payloads, explicit artifact references, and intentional serializers so replay and history inspection are not affected by raw bytes, large transcripts, diagnostics, summaries, checkpoints, or accidental generic JSON coercion.
+
+**Independent Test**: Validate representative Temporal boundary models with nested raw bytes, overlarge metadata/provider summaries, explicit base64 bytes, and compact artifact refs. Raw bytes and large bodies must be rejected, while compact refs serialize as JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Temporal-facing result metadata bag contains nested raw bytes, **When** the model is validated, **Then** validation fails and instructs callers to use `Base64Bytes` or artifact refs.
+2. **Given** a Temporal-facing metadata or provider-summary bag contains a large transcript, diagnostics body, summary, or checkpoint text, **When** the model is validated, **Then** validation fails and directs the caller to store the body as an artifact.
+3. **Given** a managed-session response carries summary/checkpoint artifact refs, **When** the model serializes for Temporal, **Then** the JSON payload contains only the compact refs and metadata.
+4. **Given** an integration signal or callback needs provider detail, **When** the provider summary is compact, **Then** it remains accepted as annotation metadata; when it carries a large body, it is rejected in favor of `payloadArtifactRef`.
+
+## Requirements
+
+- **FR-001**: Temporal-facing binary fields MUST use explicit serializers such as `Base64Bytes` or true top-level bytes contracts; nested raw bytes in JSON/dict-shaped payloads MUST be rejected.
+- **FR-002**: Temporal-facing metadata/provider-summary escape hatches MUST be bounded JSON mappings and MUST reject values that would carry large bodies into history.
+- **FR-003**: Large diagnostics, transcripts, summaries, checkpoints, binary outputs, and provider bodies MUST move through artifact references or claim-check refs rather than inline Temporal payloads.
+- **FR-004**: Managed-session and agent-runtime response contracts MUST preserve compact artifact refs in their existing metadata/ref fields.
+- **FR-005**: Provider-summary escape hatches for integration signals and callbacks MUST remain annotation-only and compact.
+
+## Source Design Coverage
+
+| Coverage ID | Mapping |
+| --- | --- |
+| DESIGN-REQ-017 | FR-001, FR-002, FR-003, FR-004 |
+| DESIGN-REQ-019 | FR-002, FR-005 |
+
+## Out Of Scope
+
+- Redesigning artifact storage.
+- Renaming Temporal activity, workflow, signal, update, or query names.
+- Migrating unrelated non-Temporal storage formats.
+- Removing existing compatibility shims unrelated to binary/large payload policy.
+
+## Success Criteria
+
+- **SC-001**: Schema tests prove nested raw bytes are rejected in Temporal-facing metadata.
+- **SC-002**: Schema tests prove large text bodies are rejected and compact artifact refs are accepted.
+- **SC-003**: Existing Base64Bytes tests continue proving explicit binary serialization.
+- **SC-004**: Focused unit verification passes for the changed schema boundaries.

--- a/specs/175-temporal-payload-policy/speckit_analyze_report.md
+++ b/specs/175-temporal-payload-policy/speckit_analyze_report.md
@@ -1,0 +1,16 @@
+# MoonSpec Alignment Report: Temporal Payload Policy
+
+Verdict: PASS
+
+| Issue | Severity | Finding | Resolution |
+| --- | --- | --- | --- |
+| None | N/A | Spec, plan, tasks, source coverage, and implementation scope align with STORY-004 and DESIGN-REQ-017/DESIGN-REQ-019. | Proceed with verification. |
+
+## Coverage
+
+- DESIGN-REQ-017 maps to explicit binary serializers, raw-byte rejection, large-body rejection, and artifact-ref acceptance.
+- DESIGN-REQ-019 maps to bounded metadata/provider-summary escape-hatch validation.
+
+## Notes
+
+The supplied task context referenced a missing generated breakdown path. The current repository contains the same STORY-004 handoff at `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json`, which this spec uses as the source artifact.

--- a/specs/175-temporal-payload-policy/tasks.md
+++ b/specs/175-temporal-payload-policy/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Temporal Payload Policy
+
+**Input**: `specs/175-temporal-payload-policy/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/temporal-payload-policy.md`
+
+## Phase 1: Tests First
+
+- [X] T001 Add failing schema tests for nested raw bytes and large text rejection in `tests/schemas/test_temporal_payload_policy.py` (FR-001, FR-002, FR-003).
+- [X] T002 Add failing schema tests for compact managed-session artifact refs and integration provider-summary refs in `tests/schemas/test_temporal_payload_policy.py` (FR-004, FR-005).
+
+## Phase 2: Implementation
+
+- [X] T003 Add reusable compact Temporal mapping validation in `moonmind/schemas/temporal_payload_policy.py` (FR-001, FR-002, FR-003).
+- [X] T004 Apply compact metadata validation to agent-runtime models in `moonmind/schemas/agent_runtime_models.py` (FR-002, FR-003).
+- [X] T005 Apply compact metadata validation to managed-session models in `moonmind/schemas/managed_session_models.py` (FR-002, FR-004).
+- [X] T006 Apply provider-summary validation to integration Temporal models and signals in `moonmind/schemas/temporal_models.py` and `moonmind/schemas/temporal_signal_contracts.py` (FR-002, FR-005).
+
+## Phase 3: Validation
+
+- [X] T007 Run focused schema tests for payload policy and existing explicit binary serialization.
+- [X] T008 Run full required unit suite with `./tools/test_unit.sh`.
+- [X] T009 Run final `/speckit.verify` style artifact/code alignment check.

--- a/tests/schemas/test_temporal_payload_policy.py
+++ b/tests/schemas/test_temporal_payload_policy.py
@@ -1,0 +1,71 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.schemas.agent_runtime_models import AgentRunResult
+from moonmind.schemas.managed_session_models import (
+    CodexManagedSessionState,
+    CodexManagedSessionTurnResponse,
+)
+from moonmind.schemas.temporal_models import IntegrationCallbackRequest
+from moonmind.schemas.temporal_payload_policy import MAX_TEMPORAL_METADATA_STRING_CHARS
+from moonmind.schemas.temporal_signal_contracts import ExternalEventSignal
+
+
+def test_agent_run_result_metadata_rejects_nested_raw_bytes() -> None:
+    with pytest.raises(ValidationError, match="must not contain raw bytes"):
+        AgentRunResult(metadata={"diagnostics": {"payload": b"binary"}})
+
+
+def test_agent_run_result_metadata_requires_artifact_ref_for_large_text() -> None:
+    with pytest.raises(ValidationError, match="store large payloads in artifacts"):
+        AgentRunResult(
+            metadata={"transcript": "x" * (MAX_TEMPORAL_METADATA_STRING_CHARS + 1)}
+        )
+
+
+def test_managed_session_turn_response_metadata_allows_compact_artifact_refs() -> None:
+    response = CodexManagedSessionTurnResponse(
+        sessionState=CodexManagedSessionState(
+            sessionId="sess-1",
+            sessionEpoch=1,
+            containerId="container-1",
+            threadId="thread-1",
+        ),
+        turnId="turn-1",
+        status="completed",
+        outputRefs=("art-output",),
+        metadata={"summaryRef": "art-summary", "checkpointRef": "art-checkpoint"},
+    )
+
+    assert response.metadata == {
+        "summaryRef": "art-summary",
+        "checkpointRef": "art-checkpoint",
+    }
+    assert response.model_dump(mode="json", by_alias=True)["metadata"] == {
+        "summaryRef": "art-summary",
+        "checkpointRef": "art-checkpoint",
+    }
+
+
+def test_integration_provider_summary_rejects_large_provider_body() -> None:
+    with pytest.raises(ValidationError, match="store large payloads in artifacts"):
+        IntegrationCallbackRequest(
+            eventType="provider.update",
+            providerSummary={
+                "body": "x" * (MAX_TEMPORAL_METADATA_STRING_CHARS + 1),
+            },
+            payloadArtifactRef="art-provider-payload",
+        )
+
+
+def test_external_event_provider_summary_accepts_compact_refs() -> None:
+    signal = ExternalEventSignal(
+        source="jules",
+        eventType="completed",
+        observedAt=datetime.now(tz=UTC),
+        providerSummary={"resultRef": "art-result", "status": "done"},
+    )
+
+    assert signal.provider_summary == {"resultRef": "art-result", "status": "done"}

--- a/tests/unit/schemas/test_managed_session_models.py
+++ b/tests/unit/schemas/test_managed_session_models.py
@@ -262,6 +262,40 @@ def test_codex_managed_session_turn_response_requires_remote_session_state() -> 
     assert response.session_state.active_turn_id == "turn-1"
 
 
+def test_codex_managed_session_turn_response_clamps_large_assistant_text() -> None:
+    response = CodexManagedSessionTurnResponse(
+        sessionState={
+            "sessionId": "sess-123",
+            "sessionEpoch": 1,
+            "containerId": "ctr-123",
+            "threadId": "thread-1",
+        },
+        turnId="turn-1",
+        status="completed",
+        metadata={"assistantText": "x" * 12000},
+    )
+
+    assert response.metadata["assistantText"] == "x" * 8190
+    assert response.metadata["assistantTextTruncated"] is True
+    assert response.metadata["assistantTextOriginalChars"] == 12000
+
+
+def test_codex_managed_session_summary_clamps_large_last_assistant_text_bytes() -> None:
+    response = CodexManagedSessionSummary(
+        sessionState={
+            "sessionId": "sess-123",
+            "sessionEpoch": 1,
+            "containerId": "ctr-123",
+            "threadId": "thread-1",
+        },
+        metadata={"lastAssistantText": "☾" * 5000},
+    )
+
+    assert len(response.metadata["lastAssistantText"].encode("utf-8")) <= 8192
+    assert response.metadata["lastAssistantTextTruncated"] is True
+    assert response.metadata["lastAssistantTextOriginalChars"] == 5000
+
+
 def test_codex_managed_session_summary_and_publication_allow_artifact_refs() -> None:
     summary = CodexManagedSessionSummary(
         sessionState={

--- a/tests/unit/schemas/test_temporal_payload_policy.py
+++ b/tests/unit/schemas/test_temporal_payload_policy.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from moonmind.schemas.temporal_payload_policy import validate_compact_temporal_mapping
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_validate_compact_temporal_mapping_rejects_non_standard_floats(
+    value: float,
+) -> None:
+    with pytest.raises(ValueError, match="JSON serializable"):
+        validate_compact_temporal_mapping(
+            {"providerScore": value},
+            field_name="metadata",
+        )
+


### PR DESCRIPTION
MM-330: Move binary and large Temporal payloads to explicit serializers or artifacts

User Story
As a MoonMind operator, I need Temporal histories to carry only intentional compact payloads and artifact references so large diagnostics, transcripts, summaries, checkpoints, binary data, and special JSON fields do not bloat histories or depend on accidental encoder behavior.
Source Document
docs/Temporal/TemporalTypeSafety.md
Source Sections
- 9 Binary, large payload, and serialization policy
- 12 Approved escape hatches
Coverage IDs
- DESIGN-REQ-017
- DESIGN-REQ-019
Story Metadata
- Story ID: STORY-004
- Short name: temporal-payload-policy
- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json