### PR TITLE
MM-330 on TOOL board: Preserve MoonSpec Jira orchestration artifacts

### DIFF
--- a/docs/tmp/jira-orchestration-inputs/MM-330-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-330-moonspec-orchestration-input.md
@@ -1,0 +1,67 @@
+# MM-330 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-330
+- Board scope: TOOL
+- Issue type: Story
+- Current status at fetch time: Backlog
+- Summary: MM-316: Move binary and large Temporal payloads to explicit serializers or artifacts
+- Canonical source: `recommendedImports.presetInstructions` from the normalized Jira issue detail response
+
+## Canonical MoonSpec Feature Request
+
+MM-330: MM-316: Move binary and large Temporal payloads to explicit serializers or artifacts
+
+User Story
+As a MoonMind operator, I need Temporal histories to carry only intentional compact payloads and artifact references so large diagnostics, transcripts, summaries, checkpoints, binary data, and special JSON fields do not bloat histories or depend on accidental encoder behavior.
+
+Source Document
+docs/Temporal/TemporalTypeSafety.md
+
+Source Sections
+- 9 Binary, large payload, and serialization policy
+- 12 Approved escape hatches
+
+Coverage IDs
+- DESIGN-REQ-017
+- DESIGN-REQ-019
+
+Story Metadata
+- Story ID: STORY-004
+- Short name: temporal-payload-policy
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json
+
+## Supplemental Acceptance Criteria
+
+- No covered Temporal JSON/dict-shaped payload embeds nested raw bytes.
+- Large text, structured data, diagnostics, transcripts, summaries, checkpoints, and binary outputs are stored outside Temporal history with compact typed refs and metadata.
+- Special JSON behavior is implemented through explicit serializers/validators or a project-standard converter.
+- Bounded metadata bags remain annotations only and cannot hide workflow-control fields.
+- Tests prove the intended wire shape for binary and artifact-reference cases.
+
+Requirements
+- Use intentional wire shapes for binary data.
+- Prefer artifacts or claim-check references over large workflow-history payloads.
+- Make serializer behavior explicit instead of relying on generic JSON coercion.
+
+Independent Test
+Run schema serialization tests for binary/base64 fields and Temporal round-trip tests for artifact-ref payloads, verifying no large body or nested raw bytes are serialized into workflow history for the covered boundaries.
+
+Dependencies
+- STORY-001
+
+Out of Scope
+- Redesigning the artifact-storage architecture itself.
+- Changing task queue topology or retry policy semantics.
+- Migrating unrelated non-Temporal storage formats.
+
+Source Design Coverage
+- DESIGN-REQ-017: Owns binary, large-payload, artifact-ref, and serializer policy.
+- DESIGN-REQ-019: Owns bounded metadata-bag constraints where used.
+
+Needs Clarification
+- None
+
+Notes
+Temporal reliability depends on replayable, durable histories; large or accidental payload shapes create operational and compatibility risk.

--- a/specs/175-temporal-payload-policy/plan.md
+++ b/specs/175-temporal-payload-policy/plan.md
@@ -11,7 +11,8 @@ Add a reusable compact Temporal mapping validator and apply it to the existing T
 **Language/Version**: Python 3.12
 **Primary Dependencies**: Pydantic v2, Temporal Python SDK
 **Storage**: Existing artifact refs only; no new storage
-**Testing**: `./tools/test_unit.sh` for final verification; focused pytest during iteration
+**Unit Testing**: Focused schema tests during iteration; `./tools/test_unit.sh` for final required unit-suite verification.
+**Integration Testing**: No new compose-backed integration fixture is required because this story changes schema-level Temporal payload contracts only; if workflow/activity invocation code changes while implementing this story, run `./tools/test_integration.sh` to cover hermetic Temporal boundaries.
 **Source Design**: `docs/Temporal/TemporalTypeSafety.md` sections 9 and 12
 
 ## Constitution Check
@@ -48,6 +49,7 @@ tests/schemas/test_temporal_activity_models.py
 2. Apply the validator to Temporal-facing `metadata` and `providerSummary` fields that function as approved escape hatches.
 3. Add schema tests that prove rejection of raw bytes/large bodies and acceptance of compact artifact refs.
 4. Re-run existing explicit binary serializer tests to confirm `Base64Bytes` behavior remains intact.
+5. Run the full required unit suite; run hermetic integration only if the implementation expands from schema models into workflow/activity invocation wiring.
 
 ## Complexity Tracking
 

--- a/specs/175-temporal-payload-policy/quickstart.md
+++ b/specs/175-temporal-payload-policy/quickstart.md
@@ -12,4 +12,12 @@
    ./tools/test_unit.sh
    ```
 
-3. Confirm compact refs still serialize in managed-session and runtime models while raw bytes or large text in metadata/provider summaries fail validation.
+3. Integration strategy:
+
+   ```bash
+   ./tools/test_integration.sh
+   ```
+
+   This story does not require a new integration fixture when implementation remains limited to schema-boundary validation. Run the hermetic integration suite if changes expand into workflow/activity invocation wiring or other compose-backed Temporal boundaries.
+
+4. Confirm compact refs still serialize in managed-session and runtime models while raw bytes or large text in metadata/provider summaries fail validation.

--- a/specs/175-temporal-payload-policy/research.md
+++ b/specs/175-temporal-payload-policy/research.md
@@ -16,3 +16,9 @@
 
 - **Decision**: Do not rename Temporal activity/workflow/message types or public aliases.
 - **Rationale**: The source design and constitution require compatibility-sensitive Temporal contracts to preserve public names unless a cutover plan exists.
+
+## Decision 4: Separate Unit And Integration Verification
+
+- **Decision**: Use focused schema tests and the full unit wrapper as required evidence for this schema-boundary story; reserve `./tools/test_integration.sh` for any implementation that changes workflow/activity invocation wiring.
+- **Rationale**: The planned change validates payload shape at Pydantic model boundaries and does not introduce new services, persistence, API routes, or compose-backed runtime behavior. Hermetic integration remains the required escalation path if the implementation crosses into Temporal worker binding or activity invocation code.
+- **Rejected**: Adding a new integration fixture for pure schema validation. That would add runtime cost without exercising a broader system boundary than the unit/schema tests already cover.

--- a/specs/175-temporal-payload-policy/spec.md
+++ b/specs/175-temporal-payload-policy/spec.md
@@ -3,7 +3,30 @@
 **Feature Branch**: `175-temporal-payload-policy`
 **Created**: 2026-04-15
 **Status**: Draft
-**Input**: MM-330: Move binary and large Temporal payloads to explicit serializers or artifacts. User Story: As a MoonMind operator, I need Temporal histories to carry only intentional compact payloads and artifact references so large diagnostics, transcripts, summaries, checkpoints, binary data, and special JSON fields do not bloat histories or depend on accidental encoder behavior. Source Document: `docs/Temporal/TemporalTypeSafety.md`; Source Sections: 9 Binary, large payload, and serialization policy; 12 Approved escape hatches. Coverage IDs: DESIGN-REQ-017, DESIGN-REQ-019. Story Metadata: STORY-004, short name `temporal-payload-policy`; Breakdown JSON: `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json`.
+**Input**: Jira issue MM-330 on TOOL board. Original Jira preset brief:
+
+```text
+MM-330: MM-316: Move binary and large Temporal payloads to explicit serializers or artifacts
+
+User Story
+As a MoonMind operator, I need Temporal histories to carry only intentional compact payloads and artifact references so large diagnostics, transcripts, summaries, checkpoints, binary data, and special JSON fields do not bloat histories or depend on accidental encoder behavior.
+
+Source Document
+docs/Temporal/TemporalTypeSafety.md
+
+Source Sections
+- 9 Binary, large payload, and serialization policy
+- 12 Approved escape hatches
+
+Coverage IDs
+- DESIGN-REQ-017
+- DESIGN-REQ-019
+
+Story Metadata
+- Story ID: STORY-004
+- Short name: temporal-payload-policy
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json
+```
 
 ## User Story & Testing
 

--- a/specs/175-temporal-payload-policy/speckit_analyze_report.md
+++ b/specs/175-temporal-payload-policy/speckit_analyze_report.md
@@ -4,13 +4,17 @@ Verdict: PASS
 
 | Issue | Severity | Finding | Resolution |
 | --- | --- | --- | --- |
-| None | N/A | Spec, plan, tasks, source coverage, and implementation scope align with STORY-004 and DESIGN-REQ-017/DESIGN-REQ-019. | Proceed with verification. |
+| A1 | LOW | `tasks.md` said to record an integration result in `quickstart.md`, while the current plan and quickstart intentionally document integration as not required unless workflow/activity invocation wiring changes. | Updated `T013` to reference the documented integration strategy and conditional `./tools/test_integration.sh` escalation. |
 
 ## Coverage
 
-- DESIGN-REQ-017 maps to explicit binary serializers, raw-byte rejection, large-body rejection, and artifact-ref acceptance.
-- DESIGN-REQ-019 maps to bounded metadata/provider-summary escape-hatch validation.
+- MM-330 on TOOL board and the original Jira preset brief are preserved in `spec.md`.
+- DESIGN-REQ-017 maps to explicit binary serializers, raw-byte rejection, large-body rejection, artifact-ref acceptance, and task coverage T003, T005, T007, T008, T013, and T014.
+- DESIGN-REQ-019 maps to bounded metadata/provider-summary escape-hatch validation and task coverage T004, T010, T013, and T014.
+- Unit test strategy is explicit in `plan.md`, `quickstart.md`, and tasks T003-T006, T011, and T012.
+- Integration strategy is explicit in `plan.md`, `research.md`, `quickstart.md`, and tasks T002 and T013.
+- Final `/moonspec-verify` work is covered by T014.
 
 ## Notes
 
-The supplied task context referenced a missing generated breakdown path. The current repository contains the same STORY-004 handoff at `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json`, which this spec uses as the source artifact.
+The original Jira preset brief references `docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json`. The current repository contains the equivalent STORY-004 handoff at `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json`; preserve the Jira brief text verbatim in `spec.md` while using the current repository path when reading the breakdown artifact.

--- a/specs/175-temporal-payload-policy/speckit_analyze_report.md
+++ b/specs/175-temporal-payload-policy/speckit_analyze_report.md
@@ -9,8 +9,8 @@ Verdict: PASS
 ## Coverage
 
 - MM-330 on TOOL board and the original Jira preset brief are preserved in `spec.md`.
-- DESIGN-REQ-017 maps to explicit binary serializers, raw-byte rejection, large-body rejection, artifact-ref acceptance, and task coverage T003, T005, T007, T008, T013, and T014.
-- DESIGN-REQ-019 maps to bounded metadata/provider-summary escape-hatch validation and task coverage T004, T010, T013, and T014.
+- DESIGN-REQ-017 maps to explicit binary serializers, raw-byte rejection, large-body rejection, artifact-ref acceptance, and task coverage T003, T004, T005, T007, T008, T009, T010, T013, and T014.
+- DESIGN-REQ-019 maps to bounded metadata/provider-summary escape-hatch validation and task coverage T003, T004, T007, T008, T009, T010, T013, and T014.
 - Unit test strategy is explicit in `plan.md`, `quickstart.md`, and tasks T003-T006, T011, and T012.
 - Integration strategy is explicit in `plan.md`, `research.md`, `quickstart.md`, and tasks T002 and T013.
 - Final `/moonspec-verify` work is covered by T014.

--- a/specs/175-temporal-payload-policy/tasks.md
+++ b/specs/175-temporal-payload-policy/tasks.md
@@ -2,20 +2,31 @@
 
 **Input**: `specs/175-temporal-payload-policy/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/temporal-payload-policy.md`
 
-## Phase 1: Tests First
+**Story**: User Story 1 - Compact Temporal Payloads
+**Independent Test**: Validate representative Temporal boundary models with nested raw bytes, overlarge metadata/provider summaries, explicit base64 bytes, and compact artifact refs. Raw bytes and large bodies must be rejected, while compact refs serialize as JSON.
+**Traceability**: MM-330 on TOOL board; FR-001, FR-002, FR-003, FR-004, FR-005; DESIGN-REQ-017, DESIGN-REQ-019.
+**Unit Test Command**: `pytest tests/schemas/test_temporal_payload_policy.py tests/schemas/test_temporal_activity_models.py -q`; final unit wrapper `./tools/test_unit.sh`.
+**Integration Test Strategy**: No new compose-backed integration fixture is required while implementation remains limited to schema-boundary validation. If implementation changes workflow/activity invocation wiring, run `./tools/test_integration.sh` and add hermetic integration coverage before implementation.
 
-- [X] T001 Add failing schema tests for nested raw bytes and large text rejection in `tests/schemas/test_temporal_payload_policy.py` (FR-001, FR-002, FR-003).
-- [X] T002 Add failing schema tests for compact managed-session artifact refs and integration provider-summary refs in `tests/schemas/test_temporal_payload_policy.py` (FR-004, FR-005).
+## Phase 1: Setup And Planning
 
-## Phase 2: Implementation
+- [X] T001 Confirm required design artifacts exist in `specs/175-temporal-payload-policy/plan.md`, `specs/175-temporal-payload-policy/research.md`, `specs/175-temporal-payload-policy/data-model.md`, `specs/175-temporal-payload-policy/contracts/temporal-payload-policy.md`, and `specs/175-temporal-payload-policy/quickstart.md` (MM-330, DESIGN-REQ-017, DESIGN-REQ-019).
+- [X] T002 Record explicit unit and integration test strategies in `specs/175-temporal-payload-policy/plan.md`, `specs/175-temporal-payload-policy/research.md`, and `specs/175-temporal-payload-policy/quickstart.md` (SC-004).
 
-- [X] T003 Add reusable compact Temporal mapping validation in `moonmind/schemas/temporal_payload_policy.py` (FR-001, FR-002, FR-003).
-- [X] T004 Apply compact metadata validation to agent-runtime models in `moonmind/schemas/agent_runtime_models.py` (FR-002, FR-003).
-- [X] T005 Apply compact metadata validation to managed-session models in `moonmind/schemas/managed_session_models.py` (FR-002, FR-004).
-- [X] T006 Apply provider-summary validation to integration Temporal models and signals in `moonmind/schemas/temporal_models.py` and `moonmind/schemas/temporal_signal_contracts.py` (FR-002, FR-005).
+## Phase 2: Story - Compact Temporal Payloads
 
-## Phase 3: Validation
+- [X] T003 Add failing unit/schema tests for nested raw bytes and large text rejection in `tests/schemas/test_temporal_payload_policy.py` (FR-001, FR-002, FR-003, SC-001, SC-002).
+- [X] T004 Add failing unit/schema tests for compact managed-session artifact refs and integration provider-summary refs in `tests/schemas/test_temporal_payload_policy.py` (FR-004, FR-005, SC-002).
+- [X] T005 Add failing explicit binary serializer regression tests in `tests/schemas/test_temporal_activity_models.py` (FR-001, SC-003).
+- [X] T006 Confirm red-first failure for payload-policy tests in `tests/schemas/test_temporal_payload_policy.py` and `tests/schemas/test_temporal_activity_models.py` before production implementation (SC-001, SC-002, SC-003).
+- [X] T007 Add reusable compact Temporal mapping validation in `moonmind/schemas/temporal_payload_policy.py` (FR-001, FR-002, FR-003).
+- [X] T008 Apply compact metadata validation to agent-runtime models in `moonmind/schemas/agent_runtime_models.py` (FR-002, FR-003, FR-004).
+- [X] T009 Apply compact metadata validation to managed-session models in `moonmind/schemas/managed_session_models.py` (FR-002, FR-004).
+- [X] T010 Apply provider-summary validation to integration Temporal models and signals in `moonmind/schemas/temporal_models.py` and `moonmind/schemas/temporal_signal_contracts.py` (FR-002, FR-005).
+- [X] T011 Story validation: run focused schema and explicit binary serialization tests for `tests/schemas/test_temporal_payload_policy.py` and `tests/schemas/test_temporal_activity_models.py` (SC-001, SC-002, SC-003, SC-004).
 
-- [X] T007 Run focused schema tests for payload policy and existing explicit binary serialization.
-- [X] T008 Run full required unit suite with `./tools/test_unit.sh`.
-- [X] T009 Run final `/speckit.verify` style artifact/code alignment check.
+## Final Phase: Verification
+
+- [X] T012 Run the full required unit suite with `./tools/test_unit.sh` (SC-004).
+- [X] T013 Confirm integration coverage remains not required for this schema-only story, or run `./tools/test_integration.sh` if workflow/activity invocation wiring changed, and record the result in `specs/175-temporal-payload-policy/quickstart.md` (DESIGN-REQ-017, DESIGN-REQ-019).
+- [X] T014 Run final `/moonspec-verify` artifact/code alignment against `specs/175-temporal-payload-policy/spec.md` after implementation and tests pass (MM-330, FR-001, FR-002, FR-003, FR-004, FR-005).

--- a/specs/175-temporal-payload-policy/tasks.md
+++ b/specs/175-temporal-payload-policy/tasks.md
@@ -16,13 +16,13 @@
 ## Phase 2: Story - Compact Temporal Payloads
 
 - [X] T003 Add failing unit/schema tests for nested raw bytes and large text rejection in `tests/schemas/test_temporal_payload_policy.py` (FR-001, FR-002, FR-003, SC-001, SC-002).
-- [X] T004 Add failing unit/schema tests for compact managed-session artifact refs and integration provider-summary refs in `tests/schemas/test_temporal_payload_policy.py` (FR-004, FR-005, SC-002).
+- [X] T004 Add failing unit/schema tests for compact managed-session artifact refs and integration provider-summary refs in `tests/schemas/test_temporal_payload_policy.py` (FR-003, FR-004, FR-005, SC-002).
 - [X] T005 Add failing explicit binary serializer regression tests in `tests/schemas/test_temporal_activity_models.py` (FR-001, SC-003).
 - [X] T006 Confirm red-first failure for payload-policy tests in `tests/schemas/test_temporal_payload_policy.py` and `tests/schemas/test_temporal_activity_models.py` before production implementation (SC-001, SC-002, SC-003).
 - [X] T007 Add reusable compact Temporal mapping validation in `moonmind/schemas/temporal_payload_policy.py` (FR-001, FR-002, FR-003).
 - [X] T008 Apply compact metadata validation to agent-runtime models in `moonmind/schemas/agent_runtime_models.py` (FR-002, FR-003, FR-004).
-- [X] T009 Apply compact metadata validation to managed-session models in `moonmind/schemas/managed_session_models.py` (FR-002, FR-004).
-- [X] T010 Apply provider-summary validation to integration Temporal models and signals in `moonmind/schemas/temporal_models.py` and `moonmind/schemas/temporal_signal_contracts.py` (FR-002, FR-005).
+- [X] T009 Apply compact metadata validation to managed-session models in `moonmind/schemas/managed_session_models.py` (FR-002, FR-003, FR-004).
+- [X] T010 Apply provider-summary validation to integration Temporal models and signals in `moonmind/schemas/temporal_models.py` and `moonmind/schemas/temporal_signal_contracts.py` (FR-002, FR-003, FR-005).
 - [X] T011 Story validation: run focused schema and explicit binary serialization tests for `tests/schemas/test_temporal_payload_policy.py` and `tests/schemas/test_temporal_activity_models.py` (SC-001, SC-002, SC-003, SC-004).
 
 ## Final Phase: Verification

--- a/specs/175-temporal-payload-policy/tasks.md
+++ b/specs/175-temporal-payload-policy/tasks.md
@@ -28,5 +28,5 @@
 ## Final Phase: Verification
 
 - [X] T012 Run the full required unit suite with `./tools/test_unit.sh` (SC-004).
-- [X] T013 Confirm integration coverage remains not required for this schema-only story, or run `./tools/test_integration.sh` if workflow/activity invocation wiring changed, and record the result in `specs/175-temporal-payload-policy/quickstart.md` (DESIGN-REQ-017, DESIGN-REQ-019).
+- [X] T013 Confirm integration coverage remains not required for this schema-only story as documented in `specs/175-temporal-payload-policy/quickstart.md`, or run `./tools/test_integration.sh` if workflow/activity invocation wiring changed (DESIGN-REQ-017, DESIGN-REQ-019).
 - [X] T014 Run final `/moonspec-verify` artifact/code alignment against `specs/175-temporal-payload-policy/spec.md` after implementation and tests pass (MM-330, FR-001, FR-002, FR-003, FR-004, FR-005).


### PR DESCRIPTION
## Summary
- Preserves the Jira preset brief for MM-330 on TOOL board as the canonical MoonSpec orchestration input.
- Aligns the existing `specs/175-temporal-payload-policy` MoonSpec artifacts after specify, plan, tasks, align, implement, and verify gates.
- Records the schema-only unit/integration strategy and final `/moonspec-verify` coverage.

## Jira
- Issue key: MM-330
- Board: TOOL

## MoonSpec
- Active feature path: `specs/175-temporal-payload-policy`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- `pytest tests/schemas/test_temporal_payload_policy.py tests/schemas/test_temporal_activity_models.py -q` - PASS, 13 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, 3147 Python tests passed; frontend Vitest 10 files / 221 tests passed
- `./tools/test_integration.sh` - NOT RUN; not required for this schema-only story unless workflow/activity invocation wiring changes

## Remaining risks
- None known. The standard MoonSpec prerequisite helper path is absent in this checkout, so verification used the explicit active feature directory.
