### PR TITLE
MM-331 from TOOL board: Add Temporal type-safety gates

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/175-launch-codex-auth-materialization"
+  "feature_directory": "specs/176-temporal-type-gates"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,10 @@ Key diagnostics:
 - **Local Overlay Source**: `.agents/skills/local` is a valid *local-only input/overlay path*. It is **not** the authoritative durable storage model for MoonMind-managed skills and should not be treated as the canonical source of truth.
 - **Adapter Mappings**: `skills_active` (or its equivalent run-scoped active directory) contains the **resolved immutable active skill set for the run**. Adapters traditionally map `.agents/skills -> ../skills_active` or `.gemini/skills -> ../skills_active` to link workflows to the snapshot. Checked-in repo skills and local-only skills are merely *inputs* to this resolution.
 - **Environment Targeting**: Prefer configuring `WORKFLOW_SKILLS_WORKSPACE_ROOT` and `WORKFLOW_SKILLS_CACHE_ROOT` to point to writable paths intended specifically for storing resolved active skill snapshots and related runtime materialization artifacts (these mounts are not arbitrary mutable replacements for the canonical design).
+
+## Active Technologies
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers (176-temporal-type-gates)
+- No new persistent storage; review findings are produced as deterministic validation output and test evidence (176-temporal-type-gates)
+
+## Recent Changes
+- 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/moonmind/workflows/temporal/type_safety_gates.py
+++ b/moonmind/workflows/temporal/type_safety_gates.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+FindingStatus = Literal["pass", "fail"]
+ChangeKind = Literal["workflow", "activity", "signal", "update", "query", "continue_as_new"]
+SafetyMode = Literal["additive", "replay_tested", "in_flight_tested", "versioned_cutover"]
+AntiPattern = Literal[
+    "raw_dict_activity_payload",
+    "public_raw_dict_handler",
+    "generic_action_envelope",
+    "provider_shaped_workflow_result",
+    "untyped_status_leak",
+    "nested_raw_bytes",
+    "large_workflow_history_state",
+    "typed_request_model",
+    "compact_artifact_ref",
+    "canonical_workflow_result",
+]
+
+
+class _GateModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+
+class ReviewGateFinding(_GateModel):
+    rule_id: str = Field(alias="ruleId")
+    status: FindingStatus
+    target: str
+    message: str
+    remediation: str | None = None
+    evidence_ref: str | None = Field(default=None, alias="evidenceRef")
+
+    @field_validator("rule_id", "target", "message")
+    @classmethod
+    def _require_non_empty_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _failed_findings_require_remediation(self) -> ReviewGateFinding:
+        if self.status == "fail" and not (self.remediation and self.remediation.strip()):
+            raise ValueError("failed findings require remediation")
+        return self
+
+
+class CompatibilityEvidence(_GateModel):
+    change_kind: ChangeKind = Field(alias="changeKind")
+    safety_mode: SafetyMode | None = Field(default=None, alias="safetyMode")
+    evidence_ref: str | None = Field(default=None, alias="evidenceRef")
+    non_additive_reason: str | None = Field(default=None, alias="nonAdditiveReason")
+    callers_tolerate_unknown: bool = Field(default=False, alias="callersTolerateUnknown")
+    target: str | None = None
+
+
+class EscapeHatchJustification(_GateModel):
+    target: str
+    reason: str
+    boundary_only: bool = Field(alias="boundaryOnly")
+    transitional: bool
+    semantic_risk: bool = Field(alias="semanticRisk")
+
+
+class TemporalAntiPatternCase(_GateModel):
+    pattern: AntiPattern
+    target: str
+    expected_rule_id: str = Field(alias="expectedRuleId")
+    expected_outcome: FindingStatus = Field(alias="expectedOutcome")
+
+
+_ANTI_PATTERN_RULES: dict[str, tuple[str, str, str]] = {
+    "raw_dict_activity_payload": (
+        "TEMPORAL-ANTI-001",
+        "Raw dictionary activity payloads are not allowed at workflow call sites.",
+        "Use a named request model and typed execution boundary.",
+    ),
+    "public_raw_dict_handler": (
+        "TEMPORAL-ANTI-002",
+        "Public workflow handlers must not expose raw dictionary contracts.",
+        "Replace the handler payload with a closed request or signal model.",
+    ),
+    "generic_action_envelope": (
+        "TEMPORAL-ANTI-003",
+        "Generic action envelopes are not allowed for new public Temporal controls.",
+        "Use a specific typed command model for the public control.",
+    ),
+    "provider_shaped_workflow_result": (
+        "TEMPORAL-ANTI-004",
+        "Provider-shaped top-level activity results must not leak into workflow-facing contracts.",
+        "Normalize provider output into a canonical workflow-facing result model.",
+    ),
+    "untyped_status_leak": (
+        "TEMPORAL-ANTI-005",
+        "Untyped provider status values must not bypass a closed workflow-facing model.",
+        "Map provider statuses into the canonical status model and fail fast for unsupported values.",
+    ),
+    "nested_raw_bytes": (
+        "TEMPORAL-ANTI-006",
+        "Nested raw bytes must not be stored directly in workflow history.",
+        "Store bytes outside workflow history and pass a compact artifact or storage reference.",
+    ),
+    "large_workflow_history_state": (
+        "TEMPORAL-ANTI-007",
+        "Large conversational state must not be stored directly in workflow history.",
+        "Persist large state as artifacts or durable records and keep workflow state compact.",
+    ),
+}
+_SAFE_PATTERNS = {
+    "typed_request_model",
+    "compact_artifact_ref",
+    "canonical_workflow_result",
+}
+
+
+def evaluate_compatibility_evidence(evidence: CompatibilityEvidence) -> ReviewGateFinding:
+    target = evidence.target or f"{evidence.change_kind}:compatibility"
+
+    if evidence.safety_mode is None:
+        return ReviewGateFinding(
+            ruleId="TEMPORAL-COMPAT-001",
+            status="fail",
+            target=target,
+            message=(
+                "Compatibility-sensitive Temporal contract changes require replay, "
+                "in-flight, or cutover evidence."
+            ),
+            remediation=(
+                "Add replay or in-flight regression coverage, or document explicit "
+                "versioned cutover notes for the reviewed Temporal boundary."
+            ),
+        )
+
+    if evidence.safety_mode == "additive":
+        if evidence.evidence_ref and evidence.callers_tolerate_unknown:
+            return ReviewGateFinding(
+                ruleId="TEMPORAL-COMPAT-001",
+                status="pass",
+                target=target,
+                message="Additive Temporal contract evolution includes compatibility evidence.",
+                evidenceRef=evidence.evidence_ref,
+            )
+        return ReviewGateFinding(
+            ruleId="TEMPORAL-COMPAT-001",
+            status="fail",
+            target=target,
+            message=(
+                "Additive Temporal contract changes must include evidence and tolerate "
+                "unknown future values where applicable."
+            ),
+            remediation=(
+                "Provide a concrete evidence reference and confirm callers and handlers "
+                "tolerate optional additions or widened values."
+            ),
+            evidenceRef=evidence.evidence_ref,
+        )
+
+    if evidence.safety_mode == "versioned_cutover":
+        if not (evidence.evidence_ref and evidence.non_additive_reason):
+            return ReviewGateFinding(
+                ruleId="TEMPORAL-COMPAT-002",
+                status="fail",
+                target=target,
+                message="Unsafe non-additive Temporal changes require a cutover plan and reason.",
+                remediation=(
+                    "Document the non-additive reason and reference a migration or versioned "
+                    "cutover plan that preserves running workflow safety."
+                ),
+                evidenceRef=evidence.evidence_ref,
+            )
+        return ReviewGateFinding(
+            ruleId="TEMPORAL-COMPAT-002",
+            status="pass",
+            target=target,
+            message="Non-additive Temporal contract change includes explicit cutover evidence.",
+            evidenceRef=evidence.evidence_ref,
+        )
+
+    if not evidence.evidence_ref:
+        return ReviewGateFinding(
+            ruleId="TEMPORAL-COMPAT-001",
+            status="fail",
+            target=target,
+            message=f"{evidence.safety_mode} Temporal changes require a concrete evidence reference.",
+            remediation="Reference the replay, in-flight, schema, or boundary test evidence.",
+        )
+
+    return ReviewGateFinding(
+        ruleId="TEMPORAL-COMPAT-001",
+        status="pass",
+        target=target,
+        message=f"Temporal contract change is covered by {evidence.safety_mode} evidence.",
+        evidenceRef=evidence.evidence_ref,
+    )
+
+
+def evaluate_anti_pattern_case(case: TemporalAntiPatternCase) -> ReviewGateFinding:
+    if case.expected_outcome == "pass" or case.pattern in _SAFE_PATTERNS:
+        return ReviewGateFinding(
+            ruleId=case.expected_rule_id,
+            status="pass",
+            target=case.target,
+            message="Temporal contract shape is typed, compact, and workflow-safe.",
+        )
+
+    rule_id, message, remediation = _ANTI_PATTERN_RULES[case.pattern]
+    return ReviewGateFinding(
+        ruleId=rule_id,
+        status="fail",
+        target=case.target,
+        message=message,
+        remediation=remediation,
+    )
+
+
+def evaluate_escape_hatch(justification: EscapeHatchJustification) -> ReviewGateFinding:
+    failures: list[str] = []
+    if not justification.boundary_only:
+        failures.append("boundary-only")
+    if not justification.transitional:
+        failures.append("transitional")
+    if justification.semantic_risk:
+        failures.append("no semantic-risk")
+    if not justification.reason.strip():
+        failures.append("compatibility reason")
+
+    if failures:
+        missing = ", ".join(failures)
+        return ReviewGateFinding(
+            ruleId="TEMPORAL-ESCAPE-001",
+            status="fail",
+            target=justification.target,
+            message=f"Escape hatch is not acceptable without {missing} documentation.",
+            remediation=(
+                "Constrain the escape hatch to the public boundary, mark it transitional, "
+                "justify the replay or in-flight compatibility need, and avoid semantic risk."
+            ),
+        )
+
+    return ReviewGateFinding(
+        ruleId="TEMPORAL-ESCAPE-001",
+        status="pass",
+        target=justification.target,
+        message="Escape hatch is transitional, boundary-only, and compatibility-justified.",
+    )
+
+
+def build_self_check_findings() -> list[ReviewGateFinding]:
+    findings: list[ReviewGateFinding] = [
+        evaluate_compatibility_evidence(
+            CompatibilityEvidence(
+                changeKind="workflow",
+                safetyMode=None,
+                target="fixture:missing-compatibility-evidence",
+            )
+        ),
+        evaluate_compatibility_evidence(
+            CompatibilityEvidence(
+                changeKind="activity",
+                safetyMode="additive",
+                evidenceRef="tests/unit/workflows/temporal/test_temporal_type_safety_gates.py",
+                callersTolerateUnknown=True,
+                target="fixture:safe-additive-change",
+            )
+        ),
+    ]
+
+    for pattern in (
+        "raw_dict_activity_payload",
+        "public_raw_dict_handler",
+        "generic_action_envelope",
+        "provider_shaped_workflow_result",
+        "untyped_status_leak",
+        "nested_raw_bytes",
+        "large_workflow_history_state",
+    ):
+        rule_id = _ANTI_PATTERN_RULES[pattern][0]
+        findings.append(
+            evaluate_anti_pattern_case(
+                TemporalAntiPatternCase(
+                    pattern=pattern,
+                    target=f"fixture:{pattern}",
+                    expectedRuleId=rule_id,
+                    expectedOutcome="fail",
+                )
+            )
+        )
+
+    findings.extend(
+        [
+            evaluate_escape_hatch(
+                EscapeHatchJustification(
+                    target="fixture:invalid-escape-hatch",
+                    reason="live workflow replay compatibility",
+                    boundaryOnly=False,
+                    transitional=True,
+                    semanticRisk=False,
+                )
+            ),
+            evaluate_escape_hatch(
+                EscapeHatchJustification(
+                    target="fixture:valid-escape-hatch",
+                    reason="live workflow replay compatibility",
+                    boundaryOnly=True,
+                    transitional=True,
+                    semanticRisk=False,
+                )
+            ),
+        ]
+    )
+    return findings

--- a/moonmind/workflows/temporal/type_safety_gates.py
+++ b/moonmind/workflows/temporal/type_safety_gates.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 FindingStatus = Literal["pass", "fail"]
 ChangeKind = Literal["workflow", "activity", "signal", "update", "query", "continue_as_new"]
 SafetyMode = Literal["additive", "replay_tested", "in_flight_tested", "versioned_cutover"]
-AntiPattern = Literal[
+TemporalPatternKind = Literal[
     "raw_dict_activity_payload",
     "public_raw_dict_handler",
     "generic_action_envelope",
@@ -33,10 +33,10 @@ class ReviewGateFinding(_GateModel):
     remediation: str | None = None
     evidence_ref: str | None = Field(default=None, alias="evidenceRef")
 
-    @field_validator("rule_id", "target", "message")
+    @field_validator("rule_id", "target", "message", "remediation", "evidence_ref")
     @classmethod
-    def _require_non_empty_text(cls, value: str) -> str:
-        if not value.strip():
+    def _require_non_empty_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
             raise ValueError("must not be empty")
         return value
 
@@ -55,6 +55,13 @@ class CompatibilityEvidence(_GateModel):
     callers_tolerate_unknown: bool = Field(default=False, alias="callersTolerateUnknown")
     target: str | None = None
 
+    @field_validator("evidence_ref", "non_additive_reason", "target")
+    @classmethod
+    def _require_non_empty_optional_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("must not be empty")
+        return value
+
 
 class EscapeHatchJustification(_GateModel):
     target: str
@@ -63,12 +70,25 @@ class EscapeHatchJustification(_GateModel):
     transitional: bool
     semantic_risk: bool = Field(alias="semanticRisk")
 
+    @field_validator("target", "reason")
+    @classmethod
+    def _require_non_empty_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("must not be empty")
+        return value
 
-class TemporalAntiPatternCase(_GateModel):
-    pattern: AntiPattern
+
+class TemporalPatternCase(_GateModel):
+    pattern: TemporalPatternKind
     target: str
     expected_rule_id: str = Field(alias="expectedRuleId")
-    expected_outcome: FindingStatus = Field(alias="expectedOutcome")
+
+    @field_validator("target", "expected_rule_id")
+    @classmethod
+    def _require_non_empty_text(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("must not be empty")
+        return value
 
 
 _ANTI_PATTERN_RULES: dict[str, tuple[str, str, str]] = {
@@ -196,8 +216,8 @@ def evaluate_compatibility_evidence(evidence: CompatibilityEvidence) -> ReviewGa
     )
 
 
-def evaluate_anti_pattern_case(case: TemporalAntiPatternCase) -> ReviewGateFinding:
-    if case.expected_outcome == "pass" or case.pattern in _SAFE_PATTERNS:
+def evaluate_temporal_pattern_case(case: TemporalPatternCase) -> ReviewGateFinding:
+    if case.pattern in _SAFE_PATTERNS:
         return ReviewGateFinding(
             ruleId=case.expected_rule_id,
             status="pass",
@@ -278,12 +298,11 @@ def build_self_check_findings() -> list[ReviewGateFinding]:
     ):
         rule_id = _ANTI_PATTERN_RULES[pattern][0]
         findings.append(
-            evaluate_anti_pattern_case(
-                TemporalAntiPatternCase(
+            evaluate_temporal_pattern_case(
+                TemporalPatternCase(
                     pattern=pattern,
                     target=f"fixture:{pattern}",
                     expectedRuleId=rule_id,
-                    expectedOutcome="fail",
                 )
             )
         )

--- a/specs/176-temporal-type-gates/checklists/requirements.md
+++ b/specs/176-temporal-type-gates/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Temporal Type-Safety Gates
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-15  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Source design mapping covers DESIGN-REQ-005, DESIGN-REQ-018, DESIGN-REQ-019, and DESIGN-REQ-020.
+- The original Jira preset brief for MM-331 from TOOL board is preserved verbatim in `spec.md`.

--- a/specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md
+++ b/specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md
@@ -1,0 +1,57 @@
+# Contract: Temporal Type-Safety Gates
+
+## Purpose
+
+Define the review-gate surface for MM-331 from TOOL board. The gate evaluates Temporal type-safety migration evidence and returns deterministic findings that can be asserted in tests and read by reviewers.
+
+## Rule Categories
+
+| Rule ID Prefix | Category | Source Mapping |
+| --- | --- | --- |
+| `TEMPORAL-COMPAT-*` | Compatibility and evolution safety | DESIGN-REQ-005 |
+| `TEMPORAL-TEST-*` | Schema, boundary, replay, and static-analysis evidence | DESIGN-REQ-018 |
+| `TEMPORAL-ESCAPE-*` | Transitional escape-hatch constraints | DESIGN-REQ-019 |
+| `TEMPORAL-ANTI-*` | Known unsafe Temporal anti-patterns | DESIGN-REQ-020 |
+
+## Finding Shape
+
+```json
+{
+  "ruleId": "TEMPORAL-ANTI-001",
+  "status": "fail",
+  "target": "workflow.execute_activity raw dictionary payload fixture",
+  "message": "Raw dictionary activity payloads are not allowed at workflow call sites.",
+  "remediation": "Use a named request model and typed execution boundary, or document a boundary-only compatibility shim.",
+  "evidenceRef": null
+}
+```
+
+## Required Behavior
+
+- A compatibility-sensitive change without replay, in-flight, or cutover evidence returns a failed `TEMPORAL-COMPAT-*` or `TEMPORAL-TEST-*` finding.
+- A safe additive change with evidence returns passing findings.
+- A non-additive change without an explicit migration or cutover plan returns a failed compatibility finding.
+- A raw dictionary activity payload returns a failed `TEMPORAL-ANTI-*` finding.
+- A public workflow handler whose canonical interface is a raw dictionary returns a failed `TEMPORAL-ANTI-*` finding.
+- A generic action envelope for new public controls returns a failed `TEMPORAL-ANTI-*` finding.
+- A provider-shaped top-level workflow-facing result returns a failed `TEMPORAL-ANTI-*` finding.
+- An unnecessary untyped status or value leak where a closed model exists returns a failed `TEMPORAL-ANTI-*` finding.
+- Nested raw bytes or large conversational state in workflow history returns a failed `TEMPORAL-ANTI-*` finding unless represented through an intentional compact reference or approved serialized boundary.
+- An escape hatch without transitional, boundary-only, compatibility-justified documentation returns a failed `TEMPORAL-ESCAPE-*` finding.
+
+## Evidence Requirements
+
+Accepted evidence may be one of:
+
+- unit test name proving schema or gate behavior
+- workflow-boundary test name proving typed round trip behavior
+- replay or replay-style fixture name
+- explicit cutover or migration note for an unsafe non-additive change
+
+Evidence must identify the reviewed target. Generic statements such as "tested manually" do not satisfy the gate.
+
+## Non-Goals
+
+- This contract does not define a full inventory of every Temporal boundary.
+- This contract does not rename any Temporal workflow, activity, signal, update, or query.
+- This contract does not permit compatibility aliases that change execution semantics or billing-relevant values.

--- a/specs/176-temporal-type-gates/data-model.md
+++ b/specs/176-temporal-type-gates/data-model.md
@@ -1,0 +1,79 @@
+# Data Model: Temporal Type-Safety Gates
+
+## Review Gate Rule
+
+- **Purpose**: Defines one compatibility, testing, escape-hatch, or anti-pattern requirement.
+- **Fields**:
+  - `id`: stable rule identifier, for example `TEMPORAL-COMPAT-001`
+  - `category`: one of `compatibility`, `testing`, `escape_hatch`, `anti_pattern`
+  - `description`: reviewer-facing rule summary
+  - `severity`: `error` for merge-blocking violations, `warning` for non-blocking advisory findings
+  - `sourceDesignRequirement`: mapped `DESIGN-REQ-*` identifier
+- **Validation rules**:
+  - `id`, `category`, `description`, and `severity` are required.
+  - Every in-scope source design requirement must map to at least one rule.
+
+## Review Gate Finding
+
+- **Purpose**: Deterministic output emitted when a rule evaluates one target.
+- **Fields**:
+  - `ruleId`: matching review gate rule identifier
+  - `status`: `pass` or `fail`
+  - `target`: workflow, activity, message, fixture, or evidence item under review
+  - `message`: concise result
+  - `remediation`: required when `status` is `fail`
+  - `evidenceRef`: optional reference to replay, in-flight, schema, or boundary test evidence
+- **Validation rules**:
+  - Failed findings must include remediation.
+  - Passing compatibility-sensitive findings must include either an evidence reference or a reason the change is not compatibility-sensitive.
+
+## Compatibility Evidence
+
+- **Purpose**: Proves a Temporal contract change is safe for live or replayed histories.
+- **Fields**:
+  - `changeKind`: workflow, activity, signal, update, query, or Continue-As-New contract change
+  - `safetyMode`: `additive`, `replay_tested`, `in_flight_tested`, or `versioned_cutover`
+  - `evidenceRef`: test name, fixture name, or cutover note reference
+  - `nonAdditiveReason`: required for non-additive changes
+- **Validation rules**:
+  - Additive changes may pass when callers and handlers tolerate new optional fields or widened values.
+  - Non-additive changes require explicit replay/in-flight evidence or cutover notes.
+  - Activity, workflow, signal, update, and query names remain stable unless a cutover plan exists.
+
+## Escape Hatch Justification
+
+- **Purpose**: Documents why a temporary compatibility shape remains allowed.
+- **Fields**:
+  - `target`: boundary method, model field, or message shape
+  - `reason`: compatibility need
+  - `boundaryOnly`: true when the escape hatch is constrained to public entry validation
+  - `transitional`: true when explicitly marked as temporary
+  - `semanticRisk`: whether it can affect execution, billing, routing, or provider behavior
+- **Validation rules**:
+  - `boundaryOnly` and `transitional` must be true.
+  - `semanticRisk` must be false for accepted escape hatches.
+  - Hidden business logic behind an escape hatch fails the gate.
+
+## Temporal Anti-Pattern Case
+
+- **Purpose**: Representative fixture used to prove a known unsafe pattern is rejected.
+- **Fields**:
+  - `pattern`: raw dictionary activity payload, public raw dictionary handler, generic action envelope, provider-shaped workflow-facing result, untyped status leak, nested raw bytes, or large workflow-history state
+  - `target`: fixture or source target being checked
+  - `expectedRuleId`: rule that must fail the case
+  - `expectedOutcome`: pass or fail
+- **Validation rules**:
+  - Every anti-pattern listed in the source brief must have at least one failing fixture.
+  - Safe alternatives must pass so the gate does not merely reject all Temporal changes.
+
+## State Transitions
+
+```text
+unchecked -> evaluated_pass
+unchecked -> evaluated_fail
+evaluated_fail -> remediated -> evaluated_pass
+evaluated_fail -> accepted_cutover -> evaluated_pass
+```
+
+- `accepted_cutover` is allowed only for non-additive compatibility changes with explicit migration or cutover notes.
+- Escape hatches cannot transition to pass unless transitional and boundary-only constraints are documented.

--- a/specs/176-temporal-type-gates/data-model.md
+++ b/specs/176-temporal-type-gates/data-model.md
@@ -54,15 +54,15 @@
   - `semanticRisk` must be false for accepted escape hatches.
   - Hidden business logic behind an escape hatch fails the gate.
 
-## Temporal Anti-Pattern Case
+## Temporal Pattern Case
 
-- **Purpose**: Representative fixture used to prove a known unsafe pattern is rejected.
+- **Purpose**: Representative fixture used to prove known unsafe patterns are rejected and approved alternatives are accepted.
 - **Fields**:
-  - `pattern`: raw dictionary activity payload, public raw dictionary handler, generic action envelope, provider-shaped workflow-facing result, untyped status leak, nested raw bytes, or large workflow-history state
+  - `pattern`: raw dictionary activity payload, public raw dictionary handler, generic action envelope, provider-shaped workflow-facing result, untyped status leak, nested raw bytes, large workflow-history state, or an approved safe alternative
   - `target`: fixture or source target being checked
-  - `expectedRuleId`: rule that must fail the case
-  - `expectedOutcome`: pass or fail
+  - `expectedRuleId`: associated rule identifier for the evaluated case
 - **Validation rules**:
+  - The evaluator determines pass or fail from the pattern registry, not caller-provided outcome metadata.
   - Every anti-pattern listed in the source brief must have at least one failing fixture.
   - Safe alternatives must pass so the gate does not merely reject all Temporal changes.
 

--- a/specs/176-temporal-type-gates/plan.md
+++ b/specs/176-temporal-type-gates/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Temporal Type-Safety Gates
+
+**Branch**: `mm-331-from-tool-board-39bd254c` | **Date**: 2026-04-15 | **Spec**: [spec.md](./spec.md)  
+**Input**: Single-story feature specification from `/specs/176-temporal-type-gates/spec.md`
+
+## Summary
+
+Add enforceable Temporal type-safety review gates for Jira issue MM-331 from TOOL board. The implementation will codify compatibility evidence, escape-hatch justification, and known anti-pattern checks so unsafe Temporal contract changes fail before they can affect live or replayed workflow histories. The test strategy is TDD-first: focused unit tests for rule evaluation and finding output, plus workflow-boundary or replay-style coverage for representative Temporal contract changes.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers  
+**Storage**: No new persistent storage; review findings are produced as deterministic validation output and test evidence  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`; targeted pytest for Temporal gate/rule, schema, and workflow unit tests during iteration  
+**Integration Testing**: `./tools/test_integration.sh` for the required hermetic `integration_ci` suite when Docker is available; targeted Temporal workflow-boundary or replay-style tests for compatibility-sensitive cases  
+**Target Platform**: MoonMind backend Temporal workflow runtime and repository review/test surface  
+**Project Type**: Backend Python service and Temporal workflow runtime in a single repository  
+**Performance Goals**: Review-gate checks complete within normal unit-test runtime and add no network calls or workflow runtime polling  
+**Constraints**: Preserve Temporal workflow/activity/message names; keep compatibility handling at public boundaries; do not introduce compatibility aliases that change billing-relevant or execution semantics; keep source-design migration notes out of canonical docs  
+**Scale/Scope**: Representative high-risk Temporal boundaries covered by existing schema, managed-session, activity, typed-execution, and workflow tests; no full boundary inventory implementation in this story
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The change strengthens orchestration safety gates without replacing agent behavior.
+- **II. One-Click Agent Deployment**: PASS. No new service, secret, cloud dependency, or startup prerequisite is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The gates target MoonMind Temporal contracts and provider-neutral workflow-facing shapes.
+- **IV. Own Your Data**: PASS. The story keeps large and provider-specific bodies out of workflow histories and favors compact refs/evidence.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Skill runtime behavior is not changed.
+- **VI. The Bittersweet Lesson**: PASS. The gates are thin, test-backed policy checks that can evolve as Temporal boundaries become fully typed.
+- **VII. Powerful Runtime Configurability**: PASS. No runtime configuration semantics are changed.
+- **VIII. Modular and Extensible Architecture**: PASS. Gate logic, rule definitions, and tests stay in existing Temporal/schema/tooling boundaries.
+- **IX. Resilient by Default**: PASS. Replay and in-flight safety evidence is required for compatibility-sensitive changes.
+- **X. Facilitate Continuous Improvement**: PASS. Failures produce actionable review findings that improve future migrations.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This plan derives from the single-story spec for MM-331.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Canonical docs are treated as source requirements; implementation tracking remains in spec artifacts or docs/tmp.
+- **XIII. Pre-Release Compatibility Policy**: PASS. The plan rejects hidden compatibility aliases and preserves stable Temporal-facing names unless an explicit cutover plan exists.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/176-temporal-type-gates/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   └── temporal-type-safety-gates.md
+└── tasks.md             # Phase 2 output; not created by /speckit.plan
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── schemas/
+│   ├── temporal_activity_models.py
+│   ├── temporal_payload_policy.py
+│   ├── temporal_signal_contracts.py
+│   └── managed_session_models.py
+└── workflows/
+    └── temporal/
+        ├── activity_catalog.py
+        ├── typed_execution.py
+        └── workflows/
+            └── agent_session.py
+
+tools/
+└── validate_temporal_type_safety.py
+
+tests/
+└── unit/
+    ├── schemas/
+    │   ├── test_temporal_activity_models.py
+    │   ├── test_temporal_payload_policy.py
+    │   ├── test_temporal_signal_contracts.py
+    │   └── test_managed_session_models.py
+    └── workflows/
+        └── temporal/
+            ├── test_activity_catalog.py
+            ├── test_typed_activity_boundaries.py
+            └── workflows/
+                └── test_agent_session.py
+```
+
+**Structure Decision**: Use the existing Temporal schema, payload policy, activity catalog, typed execution, and workflow test layout. Add a narrowly scoped validation entry point only if implementation needs a reusable review gate outside normal pytest assertions.
+
+## Phase 0: Research Summary
+
+Research is captured in [research.md](./research.md). Key decisions:
+
+1. Model review gate output as deterministic rule findings so failures are actionable and testable.
+2. Keep compatibility evidence requirements close to Temporal boundary tests and replay-style fixtures rather than in canonical docs.
+3. Treat static anti-pattern checks as focused repository validation with explicit rule IDs.
+4. Keep escape-hatch acceptance narrow: public boundary only, transitional, bounded, and compatibility-justified.
+5. Use required unit verification first, then run hermetic integration when Docker is available.
+
+## Phase 1: Design Outputs
+
+- [data-model.md](./data-model.md): Defines compatibility evidence, review gate findings, escape-hatch justifications, rule definitions, and anti-pattern cases.
+- [contracts/temporal-type-safety-gates.md](./contracts/temporal-type-safety-gates.md): Captures rule IDs, finding output shape, pass/fail behavior, and required evidence.
+- [quickstart.md](./quickstart.md): Lists targeted TDD commands, full unit verification, and integration strategy.
+
+## Implementation Strategy
+
+1. Add failing unit tests for compatibility-evidence requirements, anti-pattern fixtures, and escape-hatch justification rules before production changes.
+2. Introduce a small rule/finding layer that evaluates representative Temporal type-safety migration inputs and reports actionable failures.
+3. Add or update focused checks for raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, provider-shaped top-level workflow-facing results, unnecessary untyped status leaks, nested raw bytes, and large workflow-history state.
+4. Add replay-style or workflow-boundary tests for at least one compatibility-sensitive Temporal change requiring evidence and at least one safe additive change.
+5. Preserve existing Temporal activity, workflow, update, signal, and query names; require explicit migration or cutover notes for unsafe non-additive contract changes.
+6. Run targeted unit tests first, then `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`; run `./tools/test_integration.sh` when Docker is available or record Docker socket unavailability as the blocker.
+
+## Post-Design Constitution Re-Check
+
+- **I. Orchestrate, Don't Recreate**: PASS.
+- **II. One-Click Agent Deployment**: PASS.
+- **III. Avoid Vendor Lock-In**: PASS.
+- **IV. Own Your Data**: PASS.
+- **V. Skills Are First-Class and Easy to Add**: PASS.
+- **VI. The Bittersweet Lesson**: PASS.
+- **VII. Powerful Runtime Configurability**: PASS.
+- **VIII. Modular and Extensible Architecture**: PASS.
+- **IX. Resilient by Default**: PASS.
+- **X. Facilitate Continuous Improvement**: PASS.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS.
+- **XIII. Pre-Release Compatibility Policy**: PASS.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions.

--- a/specs/176-temporal-type-gates/plan.md
+++ b/specs/176-temporal-type-gates/plan.md
@@ -76,18 +76,21 @@ tools/
 └── validate_temporal_type_safety.py
 
 tests/
-└── unit/
-    ├── schemas/
-    │   ├── test_temporal_activity_models.py
-    │   ├── test_temporal_payload_policy.py
-    │   ├── test_temporal_signal_contracts.py
-    │   └── test_managed_session_models.py
-    └── workflows/
-        └── temporal/
-            ├── test_activity_catalog.py
-            ├── test_typed_activity_boundaries.py
-            └── workflows/
-                └── test_agent_session.py
+├── unit/
+│   ├── schemas/
+│   │   ├── test_temporal_activity_models.py
+│   │   ├── test_temporal_payload_policy.py
+│   │   ├── test_temporal_signal_contracts.py
+│   │   └── test_managed_session_models.py
+│   └── workflows/
+│       └── temporal/
+│           ├── test_activity_catalog.py
+│           ├── test_temporal_type_safety_gates.py
+│           └── workflows/
+│               └── test_agent_session.py
+└── integration/
+    └── temporal/
+        └── test_temporal_type_safety_gates.py
 ```
 
 **Structure Decision**: Use the existing Temporal schema, payload policy, activity catalog, typed execution, and workflow test layout. Add a narrowly scoped validation entry point only if implementation needs a reusable review gate outside normal pytest assertions.

--- a/specs/176-temporal-type-gates/quickstart.md
+++ b/specs/176-temporal-type-gates/quickstart.md
@@ -1,0 +1,47 @@
+# Quickstart: Temporal Type-Safety Gates
+
+## Targeted TDD Loop
+
+Start by writing failing tests for the gate contract:
+
+```bash
+pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q
+```
+
+Add schema or payload-policy fixtures as needed:
+
+```bash
+pytest tests/unit/schemas/test_temporal_payload_policy.py \
+  tests/unit/schemas/test_temporal_activity_models.py \
+  tests/unit/schemas/test_temporal_signal_contracts.py \
+  tests/unit/schemas/test_managed_session_models.py -q
+```
+
+Add workflow-boundary or replay-style coverage for compatibility-sensitive cases:
+
+```bash
+pytest tests/unit/workflows/temporal/workflows/test_agent_session.py \
+  tests/unit/workflows/temporal/test_typed_activity_boundaries.py \
+  tests/unit/workflows/temporal/test_activity_catalog.py -q
+```
+
+## Full Unit Verification
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Hermetic Integration Verification
+
+```bash
+./tools/test_integration.sh
+```
+
+Run this when Docker is available. In managed agent workspaces where the Docker socket is unavailable, record that exact blocker and rely on targeted unit and workflow-boundary evidence for this planning stage.
+
+## Expected Evidence
+
+- Gate rule tests prove missing compatibility evidence, unsafe non-additive changes, and known anti-patterns fail with actionable findings.
+- Safe additive compatibility fixtures pass with evidence.
+- Escape-hatch tests prove only transitional, boundary-only, compatibility-justified shapes are accepted.
+- Workflow-boundary or replay-style tests prove representative Temporal contract changes are covered before implementation proceeds.

--- a/specs/176-temporal-type-gates/quickstart.md
+++ b/specs/176-temporal-type-gates/quickstart.md
@@ -20,10 +20,10 @@ pytest tests/unit/schemas/test_temporal_payload_policy.py \
 Add workflow-boundary or replay-style coverage for compatibility-sensitive cases:
 
 ```bash
-pytest tests/unit/workflows/temporal/workflows/test_agent_session.py \
-  tests/unit/workflows/temporal/test_typed_activity_boundaries.py \
-  tests/unit/workflows/temporal/test_activity_catalog.py -q
+pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q
 ```
+
+The integration test module should use the repo's hermetic integration markers, including `integration` and `integration_ci`, unless implementation discovers a concrete reason the fixture cannot run in required CI.
 
 ## Full Unit Verification
 

--- a/specs/176-temporal-type-gates/quickstart.md
+++ b/specs/176-temporal-type-gates/quickstart.md
@@ -12,7 +12,6 @@ Add schema or payload-policy fixtures as needed:
 
 ```bash
 pytest tests/unit/schemas/test_temporal_payload_policy.py \
-  tests/unit/schemas/test_temporal_activity_models.py \
   tests/unit/schemas/test_temporal_signal_contracts.py \
   tests/unit/schemas/test_managed_session_models.py -q
 ```

--- a/specs/176-temporal-type-gates/research.md
+++ b/specs/176-temporal-type-gates/research.md
@@ -1,0 +1,41 @@
+# Research: Temporal Type-Safety Gates
+
+## Gate Output Model
+
+Decision: Represent each gate result as a deterministic finding with a rule ID, severity, status, target, message, and remediation.
+
+Rationale: The spec requires every failure to produce an actionable reason. A structured finding model lets unit tests assert exact pass/fail behavior and gives reviewers stable output to interpret.
+
+Alternatives considered: Plain assertion failures in scattered tests. Rejected because they do not provide a shared review-gate contract or consistent remediation details.
+
+## Compatibility Evidence
+
+Decision: Require compatibility-sensitive changes to provide replay or in-flight regression evidence, or explicit versioned cutover notes, before the gate passes.
+
+Rationale: The source design states compatibility outranks model tidiness, and the constitution requires workflow/activity/update/signal payload changes to be safe for in-flight executions or have a cutover plan.
+
+Alternatives considered: Allowing reviewer discretion without evidence. Rejected because it would make gate outcomes non-deterministic and hard to verify.
+
+## Anti-Pattern Checks
+
+Decision: Cover the known anti-patterns with focused repository validation and representative fixtures: raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, provider-shaped top-level workflow-facing results, unnecessary untyped status leaks, nested raw bytes, and large workflow-history state.
+
+Rationale: The story is a review-gate story, not a full boundary inventory. Representative fixtures can prove each rule catches regressions without expanding scope into every Temporal module.
+
+Alternatives considered: Full static analysis of every possible Python type smell. Rejected as too broad for STORY-005 and likely to create noisy false positives.
+
+## Escape Hatch Policy
+
+Decision: Accept an escape hatch only when it is explicitly marked transitional, bounded to the public boundary, and justified by replay or live in-flight compatibility.
+
+Rationale: The source design permits escape hatches only as transitional mechanisms. The gate should preserve compatibility while preventing the escape hatch from becoming permanent business logic.
+
+Alternatives considered: Reject all `Mapping[str, Any]` and metadata bags. Rejected because the source design explicitly permits bounded compatibility exceptions.
+
+## Test Strategy
+
+Decision: Use targeted unit tests for gate rules and finding output, schema tests for payload/escape-hatch behavior, and workflow-boundary or replay-style tests for compatibility-sensitive cases. Use `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification and `./tools/test_integration.sh` for hermetic integration when Docker is available.
+
+Rationale: The repo’s required test taxonomy separates unit verification from compose-backed integration. This story needs both rule-level determinism and Temporal boundary confidence.
+
+Alternatives considered: Running only static checks. Rejected because the source design requires schema, boundary round-trip, replay/in-flight, and static-analysis coverage.

--- a/specs/176-temporal-type-gates/spec.md
+++ b/specs/176-temporal-type-gates/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Temporal Type-Safety Gates
+
+**Feature Branch**: `176-temporal-type-gates`  
+**Created**: 2026-04-15  
+**Status**: Draft  
+**Input**:
+
+```text
+Jira issue: MM-331 from TOOL board
+Summary: MM-316: Add Temporal type-safety compatibility, replay, and review gates
+Issue type: Story
+Current Jira status: Backlog
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-331 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+User Story
+As a reviewer of Temporal changes, I need compatibility rules, replay/in-flight tests, static analysis, and anti-pattern checks to fail unsafe type-safety migrations before they can break running workflows or reintroduce raw dictionary contracts.
+
+Source Document
+docs/Temporal/TemporalTypeSafety.md
+
+Source Sections
+- 3.5 Compatibility outranks tidiness; 10 Compatibility and evolution rules
+- 11 Testing and tooling requirements
+- 12 Approved escape hatches
+- 13 Anti-patterns
+
+Coverage IDs
+- DESIGN-REQ-005
+- DESIGN-REQ-018
+- DESIGN-REQ-019
+- DESIGN-REQ-020
+
+Story Metadata
+- Story ID: STORY-005
+- Short name: temporal-type-gates
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-316-breakdown-docs-temporal-temporaltypesafet-c8c0a38c/stories.json
+
+Acceptance Criteria
+- Compatibility-sensitive workflow, message, activity, or Continue-As-New changes include replay/in-flight regression coverage or explicit versioned cutover notes.
+- Static analysis, lint, or targeted tests catch raw dict activity payloads and public raw dict handlers in covered Temporal modules.
+- Review gates reject unnecessary Any leaks, provider-shaped top-level workflow-facing activity results, nested raw bytes, and large conversational state in workflow history where practical.
+- Escape hatches are documented as transitional and bounded.
+- Additive-first evolution is the default and unsafe non-additive changes require an explicit migration plan.
+
+Requirements
+- Preserve replay and in-flight safety during contract evolution.
+- Test schemas, Temporal boundary round trips, replay/in-flight compatibility, and static analysis coverage.
+- Block documented anti-patterns and constrain approved escape hatches.
+
+Independent Test
+Run tests that intentionally exercise disallowed raw dict activity calls, public raw dict handlers, unknown provider-shaped status leakage, and an in-flight/replay compatibility fixture, then verify the checks fail or pass exactly as policy requires.
+
+Dependencies
+- STORY-001
+- STORY-002
+- STORY-003
+- STORY-004
+
+Out of Scope
+- Implementing the boundary model inventory itself.
+- Changing Temporal task queue topology or retry policy semantics.
+- Using compatibility aliases that change billing-relevant or execution semantics.
+
+Source Design Coverage
+- DESIGN-REQ-005: Owns additive-first compatibility, replay safety, and migration planning.
+- DESIGN-REQ-018: Owns the four-layer testing and tooling gate.
+- DESIGN-REQ-019: Owns escape-hatch documentation and transitional status.
+- DESIGN-REQ-020: Owns anti-pattern blocking and removal.
+
+Needs Clarification
+- None
+
+Notes
+Without enforcement, the target-state models can drift back to raw dicts, unsafe Any, generic messages, and replay-breaking changes.
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.
+
+## User Story - Temporal Type-Safety Gates
+
+**Summary**: As a reviewer of Temporal changes, I want compatibility evidence, replay or in-flight safety checks, and anti-pattern gates to catch unsafe type-safety migrations before they can affect running workflows.
+
+**Goal**: Reviewers can rely on repeatable safety gates to confirm Temporal contract changes preserve replay compatibility, keep escape hatches bounded, and prevent raw dictionary contracts or provider-shaped payloads from returning to workflow-facing boundaries.
+
+**Independent Test**: Submit representative safe and unsafe Temporal contract changes to the review gates, including raw dictionary activity calls, public raw dictionary handlers, provider-shaped status leakage, nested raw bytes, large workflow-history state, bounded escape hatches, and replay or in-flight compatibility evidence. The unsafe cases must be rejected with actionable reasons and the safe compatibility-reviewed cases must pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** a compatibility-sensitive workflow, message, activity, or Continue-As-New contract change, **When** it lacks replay or in-flight regression coverage and lacks explicit versioned cutover notes, **Then** the review gates reject it with the missing safety evidence identified.
+2. **Given** a contract change evolves an existing Temporal boundary additively, **When** it includes the required compatibility evidence, **Then** the review gates allow it without requiring a non-additive migration plan.
+3. **Given** a change introduces a raw dictionary activity payload, a public raw dictionary handler, a generic action envelope, or a provider-shaped top-level workflow-facing result, **When** the review gates evaluate the change, **Then** they reject the unsafe contract shape and identify the violated rule.
+4. **Given** a change introduces nested raw bytes or large conversational state into workflow history, **When** the review gates evaluate the change, **Then** they reject it unless the payload is represented through an intentional compact reference or approved serialized boundary.
+5. **Given** a retained compatibility escape hatch is necessary for live or replayed histories, **When** the review gates evaluate it, **Then** it is accepted only if it is documented as transitional, bounded, and justified by compatibility needs.
+
+### Edge Cases
+
+- Non-additive contract changes must be rejected unless they include an explicit migration or cutover plan that protects running histories.
+- Additive enum or status expansion must be treated as safe only when callers and handlers tolerate unknown future values.
+- Compatibility logic must remain at public Temporal boundaries and cannot become hidden business logic.
+- Escape hatches cannot change execution semantics, billing-relevant values, or workflow routing behavior.
+- Large or binary payload findings must distinguish intentional compact references from bodies stored directly in workflow history.
+
+## Assumptions
+
+- The active story is Jira issue MM-331 from the TOOL board, mapped to STORY-005 and short name `temporal-type-gates`.
+- The existing breakdown handoff in `docs/tmp/story-breakdowns/breakdown-docs-temporal-temporaltypesafety-md-in-9e0bd9a2/stories.json` is the available source for the referenced MM-316 breakdown.
+- Existing specs for STORY-002, STORY-003, and STORY-004 may satisfy some dependencies, while no matching STORY-001 spec was found during targeted inspection.
+- The review gates may combine automated checks and documented reviewer evidence, as long as the observable outcome is deterministic pass or fail with actionable reasons.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-005**: Source `docs/Temporal/TemporalTypeSafety.md` sections 3.5 and 10 require compatibility to outrank model tidiness, additive-first evolution to be preferred, and unsafe non-additive workflow-visible changes to include deployment safety, compatibility handling, replay testing, or an explicit cutover plan. Scope: in scope. Maps to FR-001, FR-002, FR-003.
+- **DESIGN-REQ-018**: Source `docs/Temporal/TemporalTypeSafety.md` section 11 requires schema tests, Temporal boundary round-trip tests, replay or in-flight compatibility tests where compatibility is a concern, and static analysis that catches raw dictionary payloads, untyped leaks, or provider-shaped workflow-facing data. Scope: in scope. Maps to FR-001, FR-004, FR-005, FR-006.
+- **DESIGN-REQ-019**: Source `docs/Temporal/TemporalTypeSafety.md` section 12 allows escape hatches only when they are explicit, transitional, bounded, and justified by compatibility needs. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-020**: Source `docs/Temporal/TemporalTypeSafety.md` section 13 discourages raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, nested raw bytes, provider-specific top-level activity results, unnecessary `Any`, and large conversational workflow-history state. Scope: in scope. Maps to FR-004, FR-005, FR-006.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Compatibility-sensitive Temporal contract changes MUST include replay or in-flight regression evidence, or explicit versioned cutover notes, before the review gates can pass them.
+- **FR-002**: Temporal contract evolution MUST default to additive changes, and non-additive changes MUST be rejected unless they include a migration or cutover plan that preserves running workflow safety.
+- **FR-003**: Review outcomes MUST distinguish safe additive evolution from unsafe field removal, field renaming, semantic field changes, replay-visible message ordering changes, and in-place activity or workflow type changes.
+- **FR-004**: Review gates MUST reject raw dictionary activity payloads, public raw dictionary workflow handlers, generic action envelopes for new public controls, and provider-shaped top-level workflow-facing activity results.
+- **FR-005**: Review gates MUST reject unnecessary untyped values where a closed model or status is expected, including unknown provider-shaped statuses that would leak into workflow-facing contracts.
+- **FR-006**: Review gates MUST reject nested raw bytes and large conversational state stored directly in workflow history unless the payload is represented through an intentional compact reference or approved serialized boundary.
+- **FR-007**: Compatibility escape hatches MUST be accepted only when documented as transitional, bounded to the public boundary, and justified by replay or in-flight compatibility needs.
+- **FR-008**: Every gate failure MUST produce an actionable reason that identifies the violated compatibility, testing, escape-hatch, or anti-pattern rule.
+
+### Key Entities
+
+- **Compatibility Evidence**: Reviewer-visible proof that a Temporal contract change preserves live or replayed workflow safety through regression coverage, replay or in-flight fixtures, or explicit cutover notes.
+- **Review Gate Finding**: A pass or fail result for one compatibility, testing, escape-hatch, or anti-pattern rule, including the violated rule and actionable remediation when failing.
+- **Escape Hatch Justification**: A bounded record explaining why a temporary compatibility shape is retained and how it is constrained to the public boundary.
+- **Temporal Anti-Pattern Case**: A representative unsafe contract shape, such as raw dictionary payloads, public raw dictionary handlers, provider-shaped workflow-facing data, nested raw bytes, or large workflow-history state.
+
+## Success Criteria
+
+- **SC-001**: 100% of compatibility-sensitive test fixtures without replay, in-flight, or cutover evidence fail the review gates with a missing-evidence reason.
+- **SC-002**: 100% of representative anti-pattern fixtures listed in the source brief fail with a rule-specific reason.
+- **SC-003**: 100% of retained escape-hatch fixtures without transitional, bounded, compatibility-focused justification fail the review gates.
+- **SC-004**: At least one safe additive compatibility fixture passes while at least one unsafe non-additive fixture fails, proving the gates distinguish allowed evolution from unsafe migration.
+- **SC-005**: Final verification can trace every in-scope source design requirement and Jira issue MM-331 from TOOL board to at least one functional requirement and acceptance scenario.

--- a/specs/176-temporal-type-gates/tasks.md
+++ b/specs/176-temporal-type-gates/tasks.md
@@ -23,7 +23,7 @@
 
 ## Source Traceability Summary
 
-- **Original Jira input**: T001, T020
+- **Original Jira input**: T001, T020, T025
 - **FR-001**: T004, T007, T010, T011, T018
 - **FR-002**: T004, T010, T012, T018
 - **FR-003**: T004, T010, T018
@@ -32,12 +32,12 @@
 - **FR-006**: T005, T007, T012, T013, T018
 - **FR-007**: T006, T011, T014, T018
 - **FR-008**: T004, T005, T006, T010, T014, T018
-- **Acceptance Scenarios 1-5**: T007, T009, T018
+- **Acceptance Scenarios 1-5**: T007, T009, T018, T025
 - **SC-001**: T004, T007, T010, T018
 - **SC-002**: T005, T007, T012, T013, T018
 - **SC-003**: T006, T014, T018
 - **SC-004**: T004, T007, T010, T018
-- **SC-005**: T001, T020
+- **SC-005**: T001, T020, T025
 - **DESIGN-REQ-005**: T004, T010, T011, T018
 - **DESIGN-REQ-018**: T007, T008, T009, T018, T019
 - **DESIGN-REQ-019**: T006, T014, T018
@@ -88,7 +88,7 @@ No separate foundational code task is required before the story phase. Existing 
 
 ### Integration Tests (write first)
 
-- [ ] T007 Add failing integration or workflow-boundary tests for acceptance scenarios 1-5 in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-004, FR-006, SC-001, SC-002, SC-004, DESIGN-REQ-018]
+- [ ] T007 Add failing integration or workflow-boundary tests for acceptance scenarios 1-5 with `integration` and `integration_ci` markers in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-004, FR-006, SC-001, SC-002, SC-004, DESIGN-REQ-018]
 
 ### Red-First Confirmation
 

--- a/specs/176-temporal-type-gates/tasks.md
+++ b/specs/176-temporal-type-gates/tasks.md
@@ -1,0 +1,187 @@
+# Tasks: Temporal Type-Safety Gates
+
+**Input**: Design documents from `/specs/176-temporal-type-gates/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/temporal-type-safety-gates.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped around the single MM-331 story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: Each task references the relevant `FR-*`, acceptance scenario, success criterion, or `DESIGN-REQ-*` source mapping from `spec.md`.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Integration tests: `./tools/test_integration.sh` when Docker is available; targeted Temporal workflow-boundary or replay-style tests are required for this story.
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because it touches different files and does not depend on incomplete tasks.
+- Every task includes exact file paths.
+- This task list covers exactly one story: `MM-331` / `STORY-005` / `temporal-type-gates`.
+
+## Source Traceability Summary
+
+- **Original Jira input**: T001, T020
+- **FR-001**: T004, T007, T010, T011, T018
+- **FR-002**: T004, T010, T012, T018
+- **FR-003**: T004, T010, T018
+- **FR-004**: T005, T007, T012, T013, T018
+- **FR-005**: T005, T012, T013, T018
+- **FR-006**: T005, T007, T012, T013, T018
+- **FR-007**: T006, T011, T014, T018
+- **FR-008**: T004, T005, T006, T010, T014, T018
+- **Acceptance Scenarios 1-5**: T007, T009, T018
+- **SC-001**: T004, T007, T010, T018
+- **SC-002**: T005, T007, T012, T013, T018
+- **SC-003**: T006, T014, T018
+- **SC-004**: T004, T007, T010, T018
+- **SC-005**: T001, T020
+- **DESIGN-REQ-005**: T004, T010, T011, T018
+- **DESIGN-REQ-018**: T007, T008, T009, T018, T019
+- **DESIGN-REQ-019**: T006, T014, T018
+- **DESIGN-REQ-020**: T005, T012, T013, T018
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm feature artifacts and test targets are ready before TDD work starts.
+
+- [ ] T001 Confirm MM-331 from TOOL board, source design mappings, and single-story scope remain preserved in `specs/176-temporal-type-gates/spec.md`. [SC-005]
+- [ ] T002 [P] Create the planned gate test placeholder path in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-008]
+- [ ] T003 [P] Create the planned workflow-boundary test placeholder path in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [DESIGN-REQ-018]
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish the shared gate surface that the story tests and implementation will target.
+
+**CRITICAL**: No production implementation work begins until this phase and the red-first test authoring tasks are complete.
+
+No separate foundational code task is required before the story phase. Existing plan artifacts define the gate surface, data model, and contract; the next executable work is red-first story test authoring.
+
+**Checkpoint**: Foundation ready. Story test authoring may begin.
+
+---
+
+## Phase 3: Story - Temporal Type-Safety Gates
+
+**Summary**: As a reviewer of Temporal changes, I want compatibility evidence, replay or in-flight safety checks, and anti-pattern gates to catch unsafe type-safety migrations before they can affect running workflows.
+
+**Independent Test**: Submit representative safe and unsafe Temporal contract changes to the review gates. Unsafe cases must be rejected with actionable reasons, safe compatibility-reviewed cases must pass, and final verification must trace the behavior back to MM-331 from TOOL board.
+
+**Traceability**: FR-001 through FR-008, SC-001 through SC-005, DESIGN-REQ-005, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-020.
+
+**Test Plan**:
+
+- Unit: rule models, finding output, compatibility evidence decisions, anti-pattern detection, escape-hatch validation, and failure remediation messages.
+- Integration: acceptance scenarios across representative Temporal contract fixtures, including workflow-boundary or replay-style compatibility evidence.
+
+### Unit Tests (write first)
+
+- [ ] T004 Add failing unit tests for compatibility evidence, additive evolution, unsafe non-additive changes, and actionable compatibility findings in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, SC-001, SC-004, DESIGN-REQ-005]
+- [ ] T005 Add failing unit tests for raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, FR-008, SC-002, DESIGN-REQ-020]
+- [ ] T006 Add failing unit tests for transitional, boundary-only, compatibility-justified escape hatch acceptance and rejection in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-007, FR-008, SC-003, DESIGN-REQ-019]
+
+### Integration Tests (write first)
+
+- [ ] T007 Add failing integration or workflow-boundary tests for acceptance scenarios 1-5 in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-004, FR-006, SC-001, SC-002, SC-004, DESIGN-REQ-018]
+
+### Red-First Confirmation
+
+- [ ] T008 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q` and confirm T004-T006 fail for the expected missing gate implementation. [DESIGN-REQ-018]
+- [ ] T009 Run `pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q` and confirm T007 fails for the expected missing gate implementation or fixture support. [DESIGN-REQ-018]
+
+**Checkpoint**: Red-first evidence exists. Production implementation may begin after T008 and T009 record expected failures.
+
+### Implementation
+
+- [ ] T010 Create review gate rule, finding, compatibility evidence, and anti-pattern fixture models in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, DESIGN-REQ-005]
+- [ ] T011 Implement compatibility evidence evaluation and non-additive migration/cutover rejection in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, DESIGN-REQ-005]
+- [ ] T012 Implement anti-pattern rule evaluation for raw dictionary payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-004, FR-005, FR-006, DESIGN-REQ-020]
+- [ ] T013 Wire representative Temporal contract fixtures into the gate tests in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, SC-002]
+- [ ] T014 Implement escape-hatch justification evaluation in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-007, FR-008, DESIGN-REQ-019]
+- [ ] T015 Add a reusable CLI/repository validation entry point in `tools/validate_temporal_type_safety.py` only for the gate contract defined in `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md`. [FR-008]
+- [ ] T016 Wire the CLI validation entry point to the gate implementation without adding network calls, runtime polling, or persistent storage in `tools/validate_temporal_type_safety.py`. [FR-008]
+- [ ] T017 Update package exports only if needed for test imports in `moonmind/workflows/temporal/__init__.py`. [FR-008]
+- [ ] T018 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py tests/integration/temporal/test_temporal_type_safety_gates.py -q` and fix failures until the single story passes independently. [FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004]
+- [ ] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and record PASS or exact blocker in `specs/176-temporal-type-gates/verification.md`. [DESIGN-REQ-018]
+- [ ] T020 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker and targeted workflow-boundary evidence in `specs/176-temporal-type-gates/verification.md`. [SC-005, DESIGN-REQ-018]
+
+**Checkpoint**: The story is fully functional, covered by unit and integration or documented integration-blocker evidence, and testable independently.
+
+---
+
+## Phase 4: Polish And Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T021 [P] Update `specs/176-temporal-type-gates/quickstart.md` if implementation changes the targeted validation commands. [SC-005]
+- [ ] T022 [P] Update `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md` if the final finding shape or rule IDs change during implementation. [FR-008]
+- [ ] T023 Review `moonmind/workflows/temporal/type_safety_gates.py` and `tools/validate_temporal_type_safety.py` for scope drift, hidden compatibility aliases, network calls, runtime polling, or persistent storage. [DESIGN-REQ-005, DESIGN-REQ-019]
+- [ ] T024 Run the quickstart validation commands from `specs/176-temporal-type-gates/quickstart.md` and update `specs/176-temporal-type-gates/verification.md` with command results. [SC-001, SC-002, SC-003, SC-004]
+- [ ] T025 Run `/speckit.verify` for `specs/176-temporal-type-gates` after implementation and tests pass, then record the verdict in `specs/176-temporal-type-gates/verification.md`. [SC-005]
+
+---
+
+## Dependencies And Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Starts immediately.
+- **Foundational (Phase 2)**: Depends on T001-T003 and confirms no extra blocking setup is needed.
+- **Story (Phase 3)**: Depends on Phase 2 and includes T004-T009 red-first confirmation before implementation.
+- **Polish And Verification (Phase 4)**: Depends on T018 story validation and required verification evidence.
+
+### Within The Story
+
+- Unit tests T004-T006 must be written before implementation tasks T010-T017.
+- Integration/workflow-boundary test T007 must be written before implementation tasks T010-T017.
+- Red-first confirmation T008-T009 must complete before implementation tasks T010-T017.
+- Gate models T010 come before compatibility, anti-pattern, and escape-hatch logic T011-T014.
+- Validation entry point T015-T016 depends on the gate implementation T010-T014.
+- Story validation T018 precedes full unit and integration verification T019-T020.
+- Final `/speckit.verify` T025 runs only after implementation and tests pass.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel because they touch different test files.
+- T004, T005, and T006 can be authored in parallel within the same test file only if one worker owns merge coordination; otherwise do them serially.
+- T021 and T022 can run in parallel because they touch different design artifacts.
+
+---
+
+## Parallel Example
+
+```bash
+# Safe setup parallelism:
+Task: "T002 Create tests/unit/workflows/temporal/test_temporal_type_safety_gates.py"
+Task: "T003 Create tests/integration/temporal/test_temporal_type_safety_gates.py"
+
+# Safe polish parallelism:
+Task: "T021 Update specs/176-temporal-type-gates/quickstart.md"
+Task: "T022 Update specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md"
+```
+
+---
+
+## Implementation Strategy
+
+1. Preserve the MM-331 single-story scope and source-design mappings.
+2. Create failing unit and integration/workflow-boundary tests before any production code.
+3. Confirm the failures are caused by missing gate implementation, not broken setup.
+4. Implement the smallest gate model and evaluator needed to satisfy FR-001 through FR-008.
+5. Keep the gate deterministic: no network calls, no runtime polling, no persistent storage.
+6. Preserve stable Temporal-facing names and reject hidden compatibility aliases.
+7. Run targeted story tests, full unit verification, integration verification or exact Docker blocker documentation, quickstart validation, and final `/speckit.verify`.
+
+---
+
+## Notes
+
+- This task list covers one story only: `MM-331` / `STORY-005` / `temporal-type-gates`.
+- The story is not complete until both red-first evidence and final verification evidence are recorded.
+- Integration testing is required; if Docker is unavailable, record the exact blocker and the targeted workflow-boundary evidence that was run locally.

--- a/specs/176-temporal-type-gates/tasks.md
+++ b/specs/176-temporal-type-gates/tasks.md
@@ -49,9 +49,9 @@
 
 **Purpose**: Confirm feature artifacts and test targets are ready before TDD work starts.
 
-- [ ] T001 Confirm MM-331 from TOOL board, source design mappings, and single-story scope remain preserved in `specs/176-temporal-type-gates/spec.md`. [SC-005]
-- [ ] T002 [P] Create the planned gate test placeholder path in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-008]
-- [ ] T003 [P] Create the planned workflow-boundary test placeholder path in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [DESIGN-REQ-018]
+- [X] T001 Confirm MM-331 from TOOL board, source design mappings, and single-story scope remain preserved in `specs/176-temporal-type-gates/spec.md`. [SC-005]
+- [X] T002 [P] Create the planned gate test placeholder path in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-008]
+- [X] T003 [P] Create the planned workflow-boundary test placeholder path in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [DESIGN-REQ-018]
 
 ---
 
@@ -82,34 +82,34 @@ No separate foundational code task is required before the story phase. Existing 
 
 ### Unit Tests (write first)
 
-- [ ] T004 Add failing unit tests for compatibility evidence, additive evolution, unsafe non-additive changes, and actionable compatibility findings in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, SC-001, SC-004, DESIGN-REQ-005]
-- [ ] T005 Add failing unit tests for raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, FR-008, SC-002, DESIGN-REQ-020]
-- [ ] T006 Add failing unit tests for transitional, boundary-only, compatibility-justified escape hatch acceptance and rejection in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-007, FR-008, SC-003, DESIGN-REQ-019]
+- [X] T004 Add failing unit tests for compatibility evidence, additive evolution, unsafe non-additive changes, and actionable compatibility findings in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, SC-001, SC-004, DESIGN-REQ-005]
+- [X] T005 Add failing unit tests for raw dictionary activity payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, FR-008, SC-002, DESIGN-REQ-020]
+- [X] T006 Add failing unit tests for transitional, boundary-only, compatibility-justified escape hatch acceptance and rejection in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-007, FR-008, SC-003, DESIGN-REQ-019]
 
 ### Integration Tests (write first)
 
-- [ ] T007 Add failing integration or workflow-boundary tests for acceptance scenarios 1-5 with `integration` and `integration_ci` markers in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-004, FR-006, SC-001, SC-002, SC-004, DESIGN-REQ-018]
+- [X] T007 Add failing integration or workflow-boundary tests for acceptance scenarios 1-5 with `integration` and `integration_ci` markers in `tests/integration/temporal/test_temporal_type_safety_gates.py`. [FR-001, FR-004, FR-006, SC-001, SC-002, SC-004, DESIGN-REQ-018]
 
 ### Red-First Confirmation
 
-- [ ] T008 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q` and confirm T004-T006 fail for the expected missing gate implementation. [DESIGN-REQ-018]
-- [ ] T009 Run `pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q` and confirm T007 fails for the expected missing gate implementation or fixture support. [DESIGN-REQ-018]
+- [X] T008 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q` and confirm T004-T006 fail for the expected missing gate implementation. [DESIGN-REQ-018]
+- [X] T009 Run `pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q` and confirm T007 fails for the expected missing gate implementation or fixture support. [DESIGN-REQ-018]
 
 **Checkpoint**: Red-first evidence exists. Production implementation may begin after T008 and T009 record expected failures.
 
 ### Implementation
 
-- [ ] T010 Create review gate rule, finding, compatibility evidence, and anti-pattern fixture models in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, DESIGN-REQ-005]
-- [ ] T011 Implement compatibility evidence evaluation and non-additive migration/cutover rejection in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, DESIGN-REQ-005]
-- [ ] T012 Implement anti-pattern rule evaluation for raw dictionary payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-004, FR-005, FR-006, DESIGN-REQ-020]
-- [ ] T013 Wire representative Temporal contract fixtures into the gate tests in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, SC-002]
-- [ ] T014 Implement escape-hatch justification evaluation in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-007, FR-008, DESIGN-REQ-019]
-- [ ] T015 Add a reusable CLI/repository validation entry point in `tools/validate_temporal_type_safety.py` only for the gate contract defined in `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md`. [FR-008]
-- [ ] T016 Wire the CLI validation entry point to the gate implementation without adding network calls, runtime polling, or persistent storage in `tools/validate_temporal_type_safety.py`. [FR-008]
-- [ ] T017 Update package exports only if needed for test imports in `moonmind/workflows/temporal/__init__.py`. [FR-008]
-- [ ] T018 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py tests/integration/temporal/test_temporal_type_safety_gates.py -q` and fix failures until the single story passes independently. [FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004]
-- [ ] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and record PASS or exact blocker in `specs/176-temporal-type-gates/verification.md`. [DESIGN-REQ-018]
-- [ ] T020 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker and targeted workflow-boundary evidence in `specs/176-temporal-type-gates/verification.md`. [SC-005, DESIGN-REQ-018]
+- [X] T010 Create review gate rule, finding, compatibility evidence, and anti-pattern fixture models in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, FR-008, DESIGN-REQ-005]
+- [X] T011 Implement compatibility evidence evaluation and non-additive migration/cutover rejection in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-001, FR-002, FR-003, DESIGN-REQ-005]
+- [X] T012 Implement anti-pattern rule evaluation for raw dictionary payloads, public raw dictionary handlers, generic action envelopes, provider-shaped workflow-facing results, untyped status leaks, nested raw bytes, and large workflow-history state in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-004, FR-005, FR-006, DESIGN-REQ-020]
+- [X] T013 Wire representative Temporal contract fixtures into the gate tests in `tests/unit/workflows/temporal/test_temporal_type_safety_gates.py`. [FR-004, FR-005, FR-006, SC-002]
+- [X] T014 Implement escape-hatch justification evaluation in `moonmind/workflows/temporal/type_safety_gates.py`. [FR-007, FR-008, DESIGN-REQ-019]
+- [X] T015 Add a reusable CLI/repository validation entry point in `tools/validate_temporal_type_safety.py` only for the gate contract defined in `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md`. [FR-008]
+- [X] T016 Wire the CLI validation entry point to the gate implementation without adding network calls, runtime polling, or persistent storage in `tools/validate_temporal_type_safety.py`. [FR-008]
+- [X] T017 Update package exports only if needed for test imports in `moonmind/workflows/temporal/__init__.py`. [FR-008]
+- [X] T018 Run `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py tests/integration/temporal/test_temporal_type_safety_gates.py -q` and fix failures until the single story passes independently. [FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, SC-001, SC-002, SC-003, SC-004]
+- [X] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and record PASS or exact blocker in `specs/176-temporal-type-gates/verification.md`. [DESIGN-REQ-018]
+- [X] T020 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker and targeted workflow-boundary evidence in `specs/176-temporal-type-gates/verification.md`. [SC-005, DESIGN-REQ-018]
 
 **Checkpoint**: The story is fully functional, covered by unit and integration or documented integration-blocker evidence, and testable independently.
 
@@ -119,11 +119,11 @@ No separate foundational code task is required before the story phase. Existing 
 
 **Purpose**: Strengthen the completed story without adding hidden scope.
 
-- [ ] T021 [P] Update `specs/176-temporal-type-gates/quickstart.md` if implementation changes the targeted validation commands. [SC-005]
-- [ ] T022 [P] Update `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md` if the final finding shape or rule IDs change during implementation. [FR-008]
-- [ ] T023 Review `moonmind/workflows/temporal/type_safety_gates.py` and `tools/validate_temporal_type_safety.py` for scope drift, hidden compatibility aliases, network calls, runtime polling, or persistent storage. [DESIGN-REQ-005, DESIGN-REQ-019]
-- [ ] T024 Run the quickstart validation commands from `specs/176-temporal-type-gates/quickstart.md` and update `specs/176-temporal-type-gates/verification.md` with command results. [SC-001, SC-002, SC-003, SC-004]
-- [ ] T025 Run `/speckit.verify` for `specs/176-temporal-type-gates` after implementation and tests pass, then record the verdict in `specs/176-temporal-type-gates/verification.md`. [SC-005]
+- [X] T021 [P] Update `specs/176-temporal-type-gates/quickstart.md` if implementation changes the targeted validation commands. [SC-005]
+- [X] T022 [P] Update `specs/176-temporal-type-gates/contracts/temporal-type-safety-gates.md` if the final finding shape or rule IDs change during implementation. [FR-008]
+- [X] T023 Review `moonmind/workflows/temporal/type_safety_gates.py` and `tools/validate_temporal_type_safety.py` for scope drift, hidden compatibility aliases, network calls, runtime polling, or persistent storage. [DESIGN-REQ-005, DESIGN-REQ-019]
+- [X] T024 Run the quickstart validation commands from `specs/176-temporal-type-gates/quickstart.md` and update `specs/176-temporal-type-gates/verification.md` with command results. [SC-001, SC-002, SC-003, SC-004]
+- [X] T025 Run `/speckit.verify` for `specs/176-temporal-type-gates` after implementation and tests pass, then record the verdict in `specs/176-temporal-type-gates/verification.md`. [SC-005]
 
 ---
 

--- a/specs/176-temporal-type-gates/verification.md
+++ b/specs/176-temporal-type-gates/verification.md
@@ -1,0 +1,80 @@
+# Verification: Temporal Type-Safety Gates
+
+## Jira Status
+
+- `MM-331` transition to `In Progress`: BLOCKED before implementation by trusted Jira policy. `jira.search_issues` with `projectKey=TOOL` returned the issue in `Backlog`; `jira.get_issue`, `jira.get_transitions`, and update/transition operations for issue key `MM-331` were denied by project policy because project key `MM` is not allowed in the current Jira tool surface.
+
+## Red-First Evidence
+
+- `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q`: FAIL before production implementation with `ModuleNotFoundError: No module named 'moonmind.workflows.temporal.type_safety_gates'`.
+- `pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q`: FAIL before production implementation because `tools/validate_temporal_type_safety.py` did not exist.
+
+## Targeted Story Validation
+
+- `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py tests/integration/temporal/test_temporal_type_safety_gates.py -q`: PASS, 15 tests.
+
+## Full Verification Commands
+
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 3161 Python tests, 1 xpassed, 101 warnings, 16 subtests, and 221 frontend tests.
+- `./tools/test_integration.sh`: BLOCKED by unavailable Docker socket: `failed to connect to the docker API at unix:///var/run/docker.sock ... no such file or directory`.
+- `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py -q`: PASS, 14 tests.
+- `pytest tests/unit/schemas/test_temporal_payload_policy.py tests/unit/schemas/test_temporal_signal_contracts.py tests/unit/schemas/test_managed_session_models.py -q`: PASS, 46 tests.
+- `pytest tests/integration/temporal/test_temporal_type_safety_gates.py -q`: PASS, 1 test.
+- `python tools/validate_temporal_type_safety.py --self-check --json`: PASS, 11 deterministic self-check findings.
+
+## MoonSpec Verification Report
+
+**Feature**: Temporal Type-Safety Gates  
+**Spec**: `/work/agent_jobs/mm:1d421ae1-f92a-43ef-8f5c-1da22a5c6e71/repo/specs/176-temporal-type-gates/spec.md`  
+**Original Request Source**: `spec.md` Input for Jira `MM-331` from TOOL board  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+### Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/workflows/temporal/type_safety_gates.py`, `test_compatibility_sensitive_change_requires_evidence`, CLI self-check target `fixture:missing-compatibility-evidence` | VERIFIED | Missing replay, in-flight, or cutover evidence fails with remediation. |
+| FR-002 | `evaluate_compatibility_evidence`, `test_safe_additive_change_passes_with_evidence`, `test_non_additive_change_requires_cutover_reason` | VERIFIED | Additive evidence passes; unsafe non-additive cutover evidence gaps fail. |
+| FR-003 | `evaluate_compatibility_evidence` safety modes and compatibility unit tests | VERIFIED | The gate distinguishes additive evidence, replay/in-flight evidence, and versioned cutover evidence. |
+| FR-004 | anti-pattern rule table and parametrized anti-pattern unit test | VERIFIED | Raw dictionaries, public raw dict handlers, generic envelopes, and provider-shaped results fail with rule-specific findings. |
+| FR-005 | anti-pattern rule `TEMPORAL-ANTI-005` and parametrized unit test | VERIFIED | Untyped provider status/value leaks fail with remediation. |
+| FR-006 | anti-pattern rules `TEMPORAL-ANTI-006` and `TEMPORAL-ANTI-007`, unit and integration self-check tests | VERIFIED | Nested raw bytes and large workflow-history state fail unless represented by safe compact patterns. |
+| FR-007 | `evaluate_escape_hatch`, escape-hatch unit tests, CLI self-check targets | VERIFIED | Escape hatches pass only when transitional, boundary-only, compatibility-justified, and non-semantic-risky. |
+| FR-008 | `ReviewGateFinding` validation, unit remediation assertion, CLI JSON output | VERIFIED | Failed findings require actionable remediation and stable rule IDs. |
+
+### Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| AS-1 | `fixture:missing-compatibility-evidence`, compatibility unit test | VERIFIED | Compatibility-sensitive changes without evidence fail. |
+| AS-2 | `fixture:safe-additive-change`, additive compatibility unit test | VERIFIED | Safe additive evolution with evidence passes. |
+| AS-3 | parametrized anti-pattern unit tests and CLI self-check findings | VERIFIED | Unsafe raw/generic/provider-shaped contract shapes fail. |
+| AS-4 | nested raw bytes and large workflow-history anti-pattern tests | VERIFIED | Large or binary workflow-history payloads fail; safe alternatives pass. |
+| AS-5 | valid and invalid escape-hatch unit/integration fixtures | VERIFIED | Escape hatches are accepted only with transitional boundary-only justification. |
+
+### Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-005 / Constitution IX | compatibility evaluator and tests | VERIFIED | Compatibility-sensitive changes require regression evidence or cutover evidence. |
+| DESIGN-REQ-018 / Constitution VI | red-first evidence, unit tests, targeted integration CLI self-check | VERIFIED | Schema/rule behavior and workflow-boundary style CLI validation are covered. Full Docker integration runner was blocked by missing socket, but targeted `integration_ci` test passed locally. |
+| DESIGN-REQ-019 | escape-hatch evaluator and tests | VERIFIED | Escape hatches are explicit, transitional, and boundary-only. |
+| DESIGN-REQ-020 | anti-pattern evaluator and tests | VERIFIED | Known unsafe Temporal anti-patterns are blocked with rule-specific findings. |
+| Constitution XI | `spec.md`, `plan.md`, `tasks.md`, and verification evidence | VERIFIED | Spec-driven artifacts exist and remain traceable to `MM-331`. |
+| Constitution XIII | code review for aliases and scope drift | VERIFIED | No hidden compatibility aliases, network calls, runtime polling, or persistent storage were introduced. |
+
+### Original Request Alignment
+
+- The implementation preserves Jira issue `MM-331` in the spec artifacts and verification evidence.
+- The produced gate surface is deterministic, runtime-oriented, and scoped to compatibility evidence, anti-pattern findings, escape-hatch validation, and CLI self-check fixtures.
+- The original Jira status transition request remains blocked by trusted Jira policy, not by local implementation.
+
+### Gaps
+
+- No implementation gap remains.
+- Environment gap: full Docker-backed `./tools/test_integration.sh` could not run because `/var/run/docker.sock` is unavailable in this managed workspace.
+
+### Decision
+
+- FULLY_IMPLEMENTED for the single `MM-331` story, with Docker integration runner evidence recorded as an environment blocker and targeted `integration_ci` workflow-boundary validation passing locally.

--- a/tests/integration/temporal/test_temporal_type_safety_gates.py
+++ b/tests/integration/temporal/test_temporal_type_safety_gates.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci]
+
+
+def test_temporal_type_safety_gate_self_check_covers_acceptance_scenarios() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "tools" / "validate_temporal_type_safety.py"),
+            "--self-check",
+            "--json",
+        ],
+        cwd=repo_root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    payload = json.loads(result.stdout)
+    findings = payload["findings"]
+    by_target = {finding["target"]: finding for finding in findings}
+
+    assert by_target["fixture:missing-compatibility-evidence"]["status"] == "fail"
+    assert by_target["fixture:safe-additive-change"]["status"] == "pass"
+    assert by_target["fixture:raw_dict_activity_payload"]["status"] == "fail"
+    assert by_target["fixture:provider_shaped_workflow_result"]["status"] == "fail"
+    assert by_target["fixture:nested_raw_bytes"]["status"] == "fail"
+    assert by_target["fixture:large_workflow_history_state"]["status"] == "fail"
+    assert by_target["fixture:invalid-escape-hatch"]["status"] == "fail"
+    assert by_target["fixture:valid-escape-hatch"]["status"] == "pass"
+    assert all(
+        finding["message"] and (finding["status"] == "pass" or finding["remediation"])
+        for finding in findings
+    )

--- a/tests/unit/workflows/temporal/test_temporal_type_safety_gates.py
+++ b/tests/unit/workflows/temporal/test_temporal_type_safety_gates.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from moonmind.workflows.temporal.type_safety_gates import (
+    CompatibilityEvidence,
+    EscapeHatchJustification,
+    ReviewGateFinding,
+    TemporalAntiPatternCase,
+    evaluate_anti_pattern_case,
+    evaluate_compatibility_evidence,
+    evaluate_escape_hatch,
+)
+
+
+def test_compatibility_sensitive_change_requires_evidence() -> None:
+    finding = evaluate_compatibility_evidence(
+        CompatibilityEvidence(changeKind="workflow", safetyMode=None)
+    )
+
+    assert finding.status == "fail"
+    assert finding.rule_id == "TEMPORAL-COMPAT-001"
+    assert "replay, in-flight, or cutover evidence" in finding.message
+    assert finding.remediation
+
+
+def test_safe_additive_change_passes_with_evidence() -> None:
+    finding = evaluate_compatibility_evidence(
+        CompatibilityEvidence(
+            changeKind="activity",
+            safetyMode="additive",
+            evidenceRef="tests/unit/workflows/temporal/test_activity_catalog.py",
+            callersTolerateUnknown=True,
+        )
+    )
+
+    assert finding.status == "pass"
+    assert finding.evidence_ref == "tests/unit/workflows/temporal/test_activity_catalog.py"
+
+
+def test_non_additive_change_requires_cutover_reason() -> None:
+    finding = evaluate_compatibility_evidence(
+        CompatibilityEvidence(
+            changeKind="signal",
+            safetyMode="versioned_cutover",
+            evidenceRef="cutover-plan.md",
+        )
+    )
+
+    assert finding.status == "fail"
+    assert finding.rule_id == "TEMPORAL-COMPAT-002"
+    assert "non-additive" in finding.message
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected_rule"),
+    [
+        ("raw_dict_activity_payload", "TEMPORAL-ANTI-001"),
+        ("public_raw_dict_handler", "TEMPORAL-ANTI-002"),
+        ("generic_action_envelope", "TEMPORAL-ANTI-003"),
+        ("provider_shaped_workflow_result", "TEMPORAL-ANTI-004"),
+        ("untyped_status_leak", "TEMPORAL-ANTI-005"),
+        ("nested_raw_bytes", "TEMPORAL-ANTI-006"),
+        ("large_workflow_history_state", "TEMPORAL-ANTI-007"),
+    ],
+)
+def test_known_temporal_anti_patterns_fail_with_rule_specific_findings(
+    pattern: str, expected_rule: str
+) -> None:
+    finding = evaluate_anti_pattern_case(
+        TemporalAntiPatternCase(
+            pattern=pattern,
+            target=f"fixture:{pattern}",
+            expectedRuleId=expected_rule,
+            expectedOutcome="fail",
+        )
+    )
+
+    assert finding.status == "fail"
+    assert finding.rule_id == expected_rule
+    assert finding.remediation
+
+
+def test_safe_temporal_contract_case_passes() -> None:
+    finding = evaluate_anti_pattern_case(
+        TemporalAntiPatternCase(
+            pattern="typed_request_model",
+            target="fixture:typed-request",
+            expectedRuleId="TEMPORAL-ANTI-SAFE",
+            expectedOutcome="pass",
+        )
+    )
+
+    assert finding.status == "pass"
+    assert finding.rule_id == "TEMPORAL-ANTI-SAFE"
+
+
+def test_escape_hatch_requires_transitional_boundary_only_justification() -> None:
+    finding = evaluate_escape_hatch(
+        EscapeHatchJustification(
+            target="legacy-control-signal",
+            reason="live workflow replay compatibility",
+            boundaryOnly=False,
+            transitional=True,
+            semanticRisk=False,
+        )
+    )
+
+    assert finding.status == "fail"
+    assert finding.rule_id == "TEMPORAL-ESCAPE-001"
+    assert "boundary-only" in finding.message
+
+
+def test_valid_escape_hatch_passes() -> None:
+    finding = evaluate_escape_hatch(
+        EscapeHatchJustification(
+            target="legacy-control-signal",
+            reason="live workflow replay compatibility",
+            boundaryOnly=True,
+            transitional=True,
+            semanticRisk=False,
+        )
+    )
+
+    assert finding.status == "pass"
+    assert finding.rule_id == "TEMPORAL-ESCAPE-001"
+
+
+def test_failed_finding_requires_remediation() -> None:
+    with pytest.raises(ValidationError, match="remediation"):
+        ReviewGateFinding(
+            ruleId="TEMPORAL-ANTI-001",
+            status="fail",
+            target="fixture",
+            message="failed",
+        )

--- a/tests/unit/workflows/temporal/test_temporal_type_safety_gates.py
+++ b/tests/unit/workflows/temporal/test_temporal_type_safety_gates.py
@@ -7,10 +7,10 @@ from moonmind.workflows.temporal.type_safety_gates import (
     CompatibilityEvidence,
     EscapeHatchJustification,
     ReviewGateFinding,
-    TemporalAntiPatternCase,
-    evaluate_anti_pattern_case,
+    TemporalPatternCase,
     evaluate_compatibility_evidence,
     evaluate_escape_hatch,
+    evaluate_temporal_pattern_case,
 )
 
 
@@ -68,12 +68,11 @@ def test_non_additive_change_requires_cutover_reason() -> None:
 def test_known_temporal_anti_patterns_fail_with_rule_specific_findings(
     pattern: str, expected_rule: str
 ) -> None:
-    finding = evaluate_anti_pattern_case(
-        TemporalAntiPatternCase(
+    finding = evaluate_temporal_pattern_case(
+        TemporalPatternCase(
             pattern=pattern,
             target=f"fixture:{pattern}",
             expectedRuleId=expected_rule,
-            expectedOutcome="fail",
         )
     )
 
@@ -83,12 +82,11 @@ def test_known_temporal_anti_patterns_fail_with_rule_specific_findings(
 
 
 def test_safe_temporal_contract_case_passes() -> None:
-    finding = evaluate_anti_pattern_case(
-        TemporalAntiPatternCase(
+    finding = evaluate_temporal_pattern_case(
+        TemporalPatternCase(
             pattern="typed_request_model",
             target="fixture:typed-request",
             expectedRuleId="TEMPORAL-ANTI-SAFE",
-            expectedOutcome="pass",
         )
     )
 
@@ -134,4 +132,59 @@ def test_failed_finding_requires_remediation() -> None:
             status="fail",
             target="fixture",
             message="failed",
+        )
+
+
+def test_temporal_pattern_evaluation_ignores_fixture_outcome_metadata() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        TemporalPatternCase(
+            pattern="raw_dict_activity_payload",
+            target="fixture:unsafe",
+            expectedRuleId="TEMPORAL-ANTI-001",
+            expectedOutcome="pass",
+        )
+
+    finding = evaluate_temporal_pattern_case(
+        TemporalPatternCase(
+            pattern="raw_dict_activity_payload",
+            target="fixture:unsafe",
+            expectedRuleId="TEMPORAL-ANTI-001",
+        )
+    )
+
+    assert finding.status == "fail"
+    assert finding.rule_id == "TEMPORAL-ANTI-001"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "ruleId": "TEMPORAL-COMPAT-001",
+            "status": "pass",
+            "target": "fixture",
+            "message": "ok",
+            "evidenceRef": "   ",
+        },
+        {
+            "ruleId": "TEMPORAL-COMPAT-001",
+            "status": "fail",
+            "target": "fixture",
+            "message": "failed",
+            "remediation": "   ",
+        },
+    ],
+)
+def test_finding_rejects_blank_optional_text(payload: dict[str, object]) -> None:
+    with pytest.raises(ValidationError, match="must not be empty"):
+        ReviewGateFinding(**payload)
+
+
+def test_compatibility_evidence_rejects_blank_evidence_reference() -> None:
+    with pytest.raises(ValidationError, match="must not be empty"):
+        CompatibilityEvidence(
+            changeKind="activity",
+            safetyMode="additive",
+            evidenceRef="   ",
+            callersTolerateUnknown=True,
         )

--- a/tools/validate_temporal_type_safety.py
+++ b/tools/validate_temporal_type_safety.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from moonmind.workflows.temporal.type_safety_gates import build_self_check_findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate deterministic Temporal type-safety review gates."
+    )
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="Evaluate representative safe and unsafe fixtures from MM-331.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    args = parser.parse_args(argv)
+
+    if not args.self_check:
+        parser.error("--self-check is required until repository scanning fixtures are added")
+
+    findings = build_self_check_findings()
+    payload = {"findings": [finding.model_dump(by_alias=True) for finding in findings]}
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        for finding in findings:
+            print(
+                f"{finding.status.upper()} {finding.rule_id} {finding.target}: "
+                f"{finding.message}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add deterministic Temporal type-safety gate models and evaluators for compatibility evidence, anti-pattern detection, and escape-hatch validation.
- Add a `tools/validate_temporal_type_safety.py` self-check CLI and targeted unit/integration coverage.
- Add MoonSpec artifacts and verification evidence for MM-331 from TOOL board.

## Required PR Metadata
- Jira issue key: `MM-331`
- Jira board: `TOOL`
- Active MoonSpec feature path: `specs/176-temporal-type-gates`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests Run
- `pytest tests/unit/workflows/temporal/test_temporal_type_safety_gates.py tests/integration/temporal/test_temporal_type_safety_gates.py -q` PASS, 15 tests.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS, 3161 Python tests, 16 subtests, 221 frontend tests.
- `pytest tests/unit/schemas/test_temporal_payload_policy.py tests/unit/schemas/test_temporal_signal_contracts.py tests/unit/schemas/test_managed_session_models.py -q` PASS, 46 tests.
- `python tools/validate_temporal_type_safety.py --self-check --json` PASS, 11 deterministic self-check findings.
- `./tools/test_integration.sh` not run to completion in the managed workspace because `/var/run/docker.sock` is unavailable; targeted `integration_ci` module passed locally.

## Remaining Risks
- Full Docker-backed integration runner was blocked in this managed workspace by the unavailable Docker socket.
- Jira transition for MM-331 to In Progress was blocked by the trusted Jira tool policy for project key `MM`; this is recorded in the spec verification artifact.