### PR TITLE
The scheduled field should use the same value as created if the task is NOT scheduled in the future, i.e. "Immediate" schedule mode

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -616,6 +616,9 @@ def _serialize_execution(
         else None
     )
 
+    created_at = getattr(record, "created_at", None) or record.started_at
+    scheduled_for = getattr(record, "scheduled_for", None) or created_at
+
     return ExecutionModel(
         task_id=record.workflow_id,
         task_run_id=task_run_id,
@@ -686,8 +689,8 @@ def _serialize_execution(
         paused=_manifest_attr(manifest_status, "paused"),
         counts=_manifest_attr(manifest_status, "counts"),
         artifacts_count=len(record.artifact_refs or []),
-        scheduled_for=getattr(record, "scheduled_for", None),
-        created_at=getattr(record, "created_at", None) or record.started_at,
+        scheduled_for=scheduled_for,
+        created_at=created_at,
         steps_href=steps_href,
         actions=actions,
         debug_fields=debug_fields,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -616,7 +616,8 @@ def _serialize_execution(
         else None
     )
 
-    created_at = getattr(record, "created_at", None) or record.started_at
+    started_at = getattr(record, "started_at", None)
+    created_at = getattr(record, "created_at", None) or started_at or record.updated_at
     scheduled_for = getattr(record, "scheduled_for", None) or created_at
 
     return ExecutionModel(
@@ -708,7 +709,7 @@ def _serialize_execution(
         failed_dependency_id=failed_dependency_id,
         blocked_on_dependencies=raw_state == "waiting_on_dependencies",
         dependency_outcomes=dependency_outcomes,
-        started_at=record.started_at,
+        started_at=started_at,
         updated_at=record.updated_at,
         closed_at=record.closed_at,
         detail_href=f"/tasks/{record.workflow_id}",
@@ -2349,7 +2350,11 @@ async def list_executions(
                             if item.state == MoonMindWorkflowState.SCHEDULED.value
                             else 1
                         ),
-                        item.scheduled_for or datetime.max.replace(tzinfo=UTC),
+                        (
+                            item.scheduled_for
+                            if item.state == MoonMindWorkflowState.SCHEDULED.value
+                            else datetime.max.replace(tzinfo=UTC)
+                        ),
                         -(item.updated_at.timestamp() if item.updated_at else 0),
                         item.workflow_id,
                     )

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1309,6 +1309,34 @@ def test_serialize_execution_treats_system_owner_id_as_system_owner_type() -> No
     assert payload.owner_id == "system"
 
 
+def test_serialize_execution_uses_created_at_for_immediate_schedule() -> None:
+    created_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
+    record = SimpleNamespace(
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={},
+        owner_id="user-1",
+        entry="run",
+        workflow_type=SimpleNamespace(value="MoonMind.Run"),
+        state=MoonMindWorkflowState.EXECUTING,
+        workflow_id="wf-1",
+        namespace="moonmind",
+        run_id="run-1",
+        artifact_refs=[],
+        scheduled_for=None,
+        created_at=created_at,
+        started_at=created_at,
+        updated_at=created_at,
+        closed_at=None,
+        integration_state=None,
+    )
+
+    payload = _serialize_execution(record)
+
+    assert payload.scheduled_for == created_at
+    assert payload.created_at == created_at
+
+
 def test_serialize_execution_surfaces_runtime_model_effort_from_parameters() -> None:
     """Ensure runtime/model/effort stored in record.parameters are surfaced."""
     record = SimpleNamespace(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1337,6 +1337,33 @@ def test_serialize_execution_uses_created_at_for_immediate_schedule() -> None:
     assert payload.created_at == created_at
 
 
+def test_serialize_execution_falls_back_to_updated_at_for_created_at() -> None:
+    updated_at = datetime(2026, 3, 6, 0, 0, tzinfo=UTC)
+    record = SimpleNamespace(
+        close_status=None,
+        search_attributes={"mm_entry": "run"},
+        memo={},
+        owner_id="user-1",
+        entry="run",
+        workflow_type=SimpleNamespace(value="MoonMind.Run"),
+        state=MoonMindWorkflowState.EXECUTING,
+        workflow_id="wf-1",
+        namespace="moonmind",
+        run_id="run-1",
+        artifact_refs=[],
+        scheduled_for=None,
+        created_at=None,
+        updated_at=updated_at,
+        closed_at=None,
+        integration_state=None,
+    )
+
+    payload = _serialize_execution(record)
+
+    assert payload.created_at == updated_at
+    assert payload.scheduled_for == updated_at
+
+
 def test_serialize_execution_surfaces_runtime_model_effort_from_parameters() -> None:
     """Ensure runtime/model/effort stored in record.parameters are surfaced."""
     record = SimpleNamespace(

--- a/tests/unit/api/test_executions_temporal.py
+++ b/tests/unit/api/test_executions_temporal.py
@@ -284,6 +284,95 @@ def test_list_executions_source_temporal_orders_scheduled_runs_by_scheduled_time
     assert items[1]["startedAt"] is None
 
 
+def test_list_executions_source_temporal_orders_immediate_runs_by_updated_at(
+    client,
+) -> None:
+    from datetime import UTC, datetime
+    from types import SimpleNamespace
+
+    test_client, _service, _user, _mock_session = client
+
+    executions_module.get_temporal_client_adapter.cache_clear()
+
+    older_created = datetime(2026, 4, 15, 9, 0, tzinfo=UTC)
+    newer_created = datetime(2026, 4, 15, 10, 0, tzinfo=UTC)
+    older_updated = datetime(2026, 4, 15, 11, 0, tzinfo=UTC)
+    newer_updated = datetime(2026, 4, 15, 12, 0, tzinfo=UTC)
+
+    async def _memo():
+        return {}
+
+    def _datetime_bytes(value: datetime) -> bytes:
+        return f'"{value.isoformat().replace("+00:00", "Z")}"'.encode("utf-8")
+
+    def _workflow(
+        workflow_id: str,
+        *,
+        created_at: datetime,
+        updated_at: datetime,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=workflow_id,
+            run_id=f"run-{workflow_id}",
+            namespace="moonmind",
+            workflow_type="MoonMind.Run",
+            status=1,
+            memo=_memo,
+            search_attributes={
+                "mm_state": b'"executing"',
+                "mm_entry": b'["run"]',
+                "mm_updated_at": _datetime_bytes(updated_at),
+            },
+            start_time=created_at,
+            execution_time=None,
+            close_time=None,
+        )
+
+    with patch(
+        "api_service.api.routers.executions.TemporalClientAdapter"
+    ) as mock_adapter_cls:
+        mock_adapter = mock_adapter_cls.return_value
+        mock_client = AsyncMock()
+        mock_adapter.get_client = AsyncMock(return_value=mock_client)
+
+        mock_iterator = AsyncMock()
+        mock_iterator.current_page = [
+            _workflow(
+                "mm:wf-older-created-newer-updated",
+                created_at=older_created,
+                updated_at=newer_updated,
+            ),
+            _workflow(
+                "mm:wf-newer-created-older-updated",
+                created_at=newer_created,
+                updated_at=older_updated,
+            ),
+        ]
+        mock_iterator.next_page_token = None
+        mock_client.list_workflows = lambda **kwargs: mock_iterator
+        mock_client.count_workflows = AsyncMock(return_value=SimpleNamespace(count=2))
+
+        response = test_client.get(
+            "/api/executions",
+            params={"source": "temporal", "workflowType": "MoonMind.Run"},
+        )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["workflowId"] for item in items] == [
+        "mm:wf-older-created-newer-updated",
+        "mm:wf-newer-created-older-updated",
+    ]
+    assert (
+        datetime.fromisoformat(items[0]["scheduledFor"].replace("Z", "+00:00"))
+        == older_created
+    )
+    assert (
+        datetime.fromisoformat(items[1]["scheduledFor"].replace("Z", "+00:00"))
+        == newer_created
+    )
+
+
 def test_describe_execution_source_temporal_syncs_projection(client) -> None:
     test_client, service, user, _mock_session = client
 


### PR DESCRIPTION
The scheduled field should use the same value as created if the task is NOT scheduled in the future, i.e. "Immediate" schedule mode