### PR TITLE
[codex] Use allowed Jira project for breakdown preset

### DIFF
--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -30,6 +30,7 @@ from api_service.db.models import (
     TaskTemplateReleaseStatus,
     TaskTemplateScopeType,
 )
+from moonmind.config.settings import settings
 
 _FORBIDDEN_STEP_KEYS = frozenset(
     {
@@ -48,6 +49,8 @@ _FORBIDDEN_STEP_KEYS = frozenset(
 _SUPPORTED_INPUT_TYPES = frozenset(
     {"text", "textarea", "markdown", "enum", "boolean", "user", "team", "repo_path"}
 )
+_JIRA_BREAKDOWN_SLUG = "jira-breakdown"
+_JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
 logger = logging.getLogger(__name__)
@@ -246,6 +249,37 @@ def _render_value(
     return value
 
 
+def _first_allowed_jira_project_key() -> str | None:
+    raw_projects = str(settings.atlassian.jira.jira_allowed_projects or "").strip()
+    if not raw_projects:
+        return None
+    for raw_project in raw_projects.split(","):
+        project_key = raw_project.strip().upper()
+        if project_key:
+            return project_key
+    return None
+
+
+def _effective_inputs_schema(
+    *, slug: str, inputs_schema: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Apply runtime-derived defaults without mutating stored template versions."""
+
+    effective_schema = [dict(definition) for definition in inputs_schema]
+    if slug != _JIRA_BREAKDOWN_SLUG:
+        return effective_schema
+
+    project_key = _first_allowed_jira_project_key()
+    if not project_key:
+        return effective_schema
+
+    for definition in effective_schema:
+        if str(definition.get("name") or "").strip() == _JIRA_BREAKDOWN_PROJECT_INPUT:
+            definition["default"] = project_key
+            break
+    return effective_schema
+
+
 def _serialize_template(
     *,
     template: TaskStepTemplate,
@@ -266,7 +300,10 @@ def _serialize_template(
             if template.latest_version
             else version.version
         ),
-        "inputs": list(version.inputs_schema or []),
+        "inputs": _effective_inputs_schema(
+            slug=template.slug,
+            inputs_schema=list(version.inputs_schema or []),
+        ),
         "steps": list(version.steps or []),
         "annotations": dict(version.annotations or {}),
         "requiredCapabilities": _normalize_capabilities(
@@ -760,7 +797,10 @@ class TaskTemplateCatalogService:
             raise TaskTemplateNotFoundError("Template version not found.")
 
         validated_inputs = self._resolve_inputs(
-            schema=list(selected_version.inputs_schema or []),
+            schema=_effective_inputs_schema(
+                slug=template.slug,
+                inputs_schema=list(selected_version.inputs_schema or []),
+            ),
             submitted=dict(inputs or {}),
         )
         variables = {

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -250,14 +250,10 @@ def _render_value(
 
 
 def _first_allowed_jira_project_key() -> str | None:
-    raw_projects = str(settings.atlassian.jira.jira_allowed_projects or "").strip()
-    if not raw_projects:
+    projects = settings.atlassian.jira.jira_allowed_projects
+    if not projects:
         return None
-    for raw_project in raw_projects.split(","):
-        project_key = raw_project.strip().upper()
-        if project_key:
-            return project_key
-    return None
+    return projects.split(",")[0]
 
 
 def _effective_inputs_schema(
@@ -265,16 +261,16 @@ def _effective_inputs_schema(
 ) -> list[dict[str, Any]]:
     """Apply runtime-derived defaults without mutating stored template versions."""
 
-    effective_schema = [dict(definition) for definition in inputs_schema]
     if slug != _JIRA_BREAKDOWN_SLUG:
-        return effective_schema
+        return inputs_schema
 
     project_key = _first_allowed_jira_project_key()
     if not project_key:
-        return effective_schema
+        return inputs_schema
 
+    effective_schema = [dict(definition) for definition in inputs_schema]
     for definition in effective_schema:
-        if str(definition.get("name") or "").strip() == _JIRA_BREAKDOWN_PROJECT_INPUT:
+        if definition.get("name") == _JIRA_BREAKDOWN_PROJECT_INPUT:
             definition["default"] = project_key
             break
     return effective_schema
@@ -302,7 +298,7 @@ def _serialize_template(
         ),
         "inputs": _effective_inputs_schema(
             slug=template.slug,
-            inputs_schema=list(version.inputs_schema or []),
+            inputs_schema=version.inputs_schema or [],
         ),
         "steps": list(version.steps or []),
         "annotations": dict(version.annotations or {}),
@@ -799,7 +795,7 @@ class TaskTemplateCatalogService:
         validated_inputs = self._resolve_inputs(
             schema=_effective_inputs_schema(
                 slug=template.slug,
-                inputs_schema=list(selected_version.inputs_schema or []),
+                inputs_schema=selected_version.inputs_schema or [],
             ),
             submitted=dict(inputs or {}),
         )

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3172,7 +3172,7 @@ class TemporalAgentRuntimeActivities:
             + "- List available tools with `GET $MOONMIND_URL/mcp/tools`.\n"
             + "- Invoke Jira tools with `POST $MOONMIND_URL/mcp/tools/call` and "
             + "JSON like `{\"tool\":\"jira.list_create_issue_types\","
-            + "\"arguments\":{\"projectKey\":\"TOOL\"}}`.\n"
+            + "\"arguments\":{\"projectKey\":\"<PROJECT_KEY>\"}}`.\n"
             + "- Resolve the Story issue type through `jira.list_create_issue_types` "
             + "and create issues through `jira.create_issue`.\n"
             + "- Treat the task as blocked if Jira tool calls are unavailable or no "

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -24,6 +24,7 @@ from api_service.services.task_templates.catalog import (
     TaskTemplateNotFoundError,
 )
 from api_service.services.task_templates.save import TaskTemplateSaveService
+from moonmind.config.settings import settings
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -465,6 +466,55 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
             assert "linear_blocker_chain" in expanded["steps"][1]["instructions"]
             assert "ordered blocker chain" in expanded["steps"][1]["instructions"]
             assert "Source Document path" in expanded["steps"][1]["instructions"]
+
+
+async def test_jira_breakdown_uses_first_allowed_project_as_runtime_default(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings.atlassian.jira, "jira_allowed_projects", "MM,OPS")
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service.get_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+            )
+            project_input = next(
+                item
+                for item in template["inputs"]
+                if item["name"] == "jira_project_key"
+            )
+            assert project_input["default"] == "MM"
+
+            expanded = await service.expand_template(
+                slug="jira-breakdown",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_issue_type": "Story",
+                    "jira_dependency_mode": "none",
+                },
+                context={},
+            )
+
+            assert "Jira Story issue in project MM" in expanded["steps"][1][
+                "instructions"
+            ]
+            assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
 
 
 async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):


### PR DESCRIPTION
## Summary

- Use the first configured `ATLASSIAN_JIRA_ALLOWED_PROJECTS` value as the runtime default for the Jira Breakdown preset project key.
- Keep stored seed template versions static while applying the effective default at template read and expansion time.
- Replace the hardcoded `TOOL` Jira tool hint example with a neutral `<PROJECT_KEY>` placeholder.

## Impact

New Jira Breakdown preset applications will default to the operator-configured allowed Jira project when no explicit project key is supplied. Existing already-rendered workflows are unchanged.

## Validation

- `./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py::test_jira_breakdown_uses_first_allowed_project_as_runtime_default tests/unit/api/test_task_step_templates_service.py::test_seed_catalog_includes_jira_breakdown_preset tests/unit/workflows/temporal/test_agent_runtime_activities.py::test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint`
- `git diff --check -- api_service/services/task_templates/catalog.py moonmind/workflows/temporal/activity_runtime.py tests/unit/api/test_task_step_templates_service.py`