### PR TITLE
[codex] Compact agent run result metadata

### DIFF
--- a/moonmind/schemas/temporal_payload_policy.py
+++ b/moonmind/schemas/temporal_payload_policy.py
@@ -2,11 +2,44 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import Any
 
 MAX_TEMPORAL_METADATA_STRING_CHARS = 8192
 MAX_TEMPORAL_METADATA_BYTES = 16 * 1024
+MAX_TEMPORAL_METADATA_REF_CHARS = 1024
+
+
+def compact_temporal_ref_metadata(
+    field_name: str,
+    value: Any,
+    *,
+    max_chars: int = MAX_TEMPORAL_METADATA_REF_CHARS,
+) -> dict[str, Any]:
+    """Return compact metadata for a value that should be a reference.
+
+    Runtime request fields sometimes carry inline user content even when the
+    contract name says "ref". Workflow result metadata must not echo those large
+    values back into history, so non-compact values are represented by stable
+    diagnostics instead of the original text.
+    """
+
+    normalized = str(value or "").strip()
+    if not normalized:
+        return {}
+    if (
+        len(normalized) <= max_chars
+        and "\n" not in normalized
+        and "\r" not in normalized
+    ):
+        return {field_name: normalized}
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return {
+        f"{field_name}Omitted": True,
+        f"{field_name}Sha256": digest,
+        f"{field_name}LengthChars": len(normalized),
+    }
 
 
 def validate_compact_temporal_mapping(

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -38,6 +38,7 @@ from moonmind.schemas.managed_session_models import (
     TerminateCodexManagedSessionRequest,
     canonical_codex_managed_runtime_id,
 )
+from moonmind.schemas.temporal_payload_policy import compact_temporal_ref_metadata
 from moonmind.workflows.adapters.managed_agent_adapter import (
     ManagedAgentAdapter,
     ManagedProfileLaunchContext,
@@ -103,6 +104,19 @@ _JIRA_CREATED_ISSUE_KEYS_PATTERN = re.compile(
     re.IGNORECASE,
 )
 logger = logging.getLogger(__name__)
+
+
+def _result_ref_metadata(
+    *,
+    instruction_ref: str | None,
+    resolved_skillset_ref: str | None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    metadata.update(compact_temporal_ref_metadata("instructionRef", instruction_ref))
+    metadata.update(
+        compact_temporal_ref_metadata("resolvedSkillsetRef", resolved_skillset_ref)
+    )
+    return metadata
 
 
 def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
@@ -280,10 +294,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
         initial_result = AgentRunResult(
             outputRefs=[],
             summary=None,
-            metadata={
-                "instructionRef": original_instruction_ref,
-                "resolvedSkillsetRef": original_skillset_ref,
-            },
+            metadata=_result_ref_metadata(
+                instruction_ref=original_instruction_ref,
+                resolved_skillset_ref=original_skillset_ref,
+            ),
         )
         self._save_run_state(
             run_id=run_id,
@@ -415,8 +429,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
                     outputRefs=output_refs,
                     summary=assistant_text,
                     metadata={
-                        "instructionRef": original_instruction_ref,
-                        "resolvedSkillsetRef": original_skillset_ref,
+                        **_result_ref_metadata(
+                            instruction_ref=original_instruction_ref,
+                            resolved_skillset_ref=original_skillset_ref,
+                        ),
                         "sessionSummary": summary.model_dump(mode="json", by_alias=True),
                         "sessionArtifacts": publication.model_dump(mode="json", by_alias=True),
                         "turnId": turn_id,
@@ -1231,10 +1247,10 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             summary,
             default=default_summary,
         )
-        metadata: dict[str, Any] = {
-            "instructionRef": instruction_ref,
-            "resolvedSkillsetRef": resolved_skillset_ref,
-        }
+        metadata = _result_ref_metadata(
+            instruction_ref=instruction_ref,
+            resolved_skillset_ref=resolved_skillset_ref,
+        )
         if profile_id:
             metadata["profileId"] = profile_id
         if turn_id:

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -23,6 +23,7 @@ with workflow.unsafe.imports_passed_through():
         AgentRuntimeStatusInput,
         ExternalAgentRunInput,
     )
+    from moonmind.schemas.temporal_payload_policy import compact_temporal_ref_metadata
     from moonmind.workflows.adapters.agent_adapter import AgentAdapter
     from moonmind.workflows.adapters.managed_agent_adapter import (
         ManagedAgentAdapter,
@@ -98,6 +99,16 @@ _EXTERNAL_STATUS_TO_RUN_STATUS: dict[str, str] = {
     "timed-out": RunStatus.timed_out,
     "unknown": RunStatus.awaiting_callback,
 }
+
+
+def _setdefault_compact_ref_metadata(
+    metadata: dict[str, Any],
+    field_name: str,
+    value: Any,
+) -> None:
+    for key, compact_value in compact_temporal_ref_metadata(field_name, value).items():
+        metadata.setdefault(key, compact_value)
+
 
 # Default workflow-level execution timeouts
 DEFAULT_MANAGED_TIMEOUT_SECONDS = 3600      # 1 hour
@@ -416,9 +427,17 @@ class MoonMindAgentRun:
                 by_alias=True,
             )
             if request.instruction_ref:
-                metadata.setdefault("instructionRef", request.instruction_ref)
+                _setdefault_compact_ref_metadata(
+                    metadata,
+                    "instructionRef",
+                    request.instruction_ref,
+                )
             if request.resolved_skillset_ref:
-                metadata.setdefault("resolvedSkillsetRef", request.resolved_skillset_ref)
+                _setdefault_compact_ref_metadata(
+                    metadata,
+                    "resolvedSkillsetRef",
+                    request.resolved_skillset_ref,
+                )
         elif request.agent_kind == "managed":
             task_run_id = str(self.run_id or "").strip()
 

--- a/tests/schemas/test_temporal_payload_policy.py
+++ b/tests/schemas/test_temporal_payload_policy.py
@@ -9,7 +9,10 @@ from moonmind.schemas.managed_session_models import (
     CodexManagedSessionTurnResponse,
 )
 from moonmind.schemas.temporal_models import IntegrationCallbackRequest
-from moonmind.schemas.temporal_payload_policy import MAX_TEMPORAL_METADATA_STRING_CHARS
+from moonmind.schemas.temporal_payload_policy import (
+    MAX_TEMPORAL_METADATA_STRING_CHARS,
+    compact_temporal_ref_metadata,
+)
 from moonmind.schemas.temporal_signal_contracts import ExternalEventSignal
 
 
@@ -23,6 +26,19 @@ def test_agent_run_result_metadata_requires_artifact_ref_for_large_text() -> Non
         AgentRunResult(
             metadata={"transcript": "x" * (MAX_TEMPORAL_METADATA_STRING_CHARS + 1)}
         )
+
+
+def test_compact_temporal_ref_metadata_replaces_inline_content_with_diagnostics() -> None:
+    metadata = compact_temporal_ref_metadata(
+        "instructionRef",
+        "Implement this feature\n" + ("details " * 2000),
+    )
+
+    assert metadata["instructionRefOmitted"] is True
+    assert metadata["instructionRefLengthChars"] > MAX_TEMPORAL_METADATA_STRING_CHARS
+    assert len(metadata["instructionRefSha256"]) == 64
+    assert "instructionRef" not in metadata
+    AgentRunResult(metadata=metadata)
 
 
 def test_managed_session_turn_response_metadata_allows_compact_artifact_refs() -> None:

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -100,6 +100,7 @@ def _request(
     *,
     workspace_path: str | None = None,
     timeout_seconds: Any | None = None,
+    instruction_ref: str = "artifact:instructions",
 ) -> AgentExecutionRequest:
     workspace_spec = {}
     if workspace_path is not None:
@@ -113,7 +114,7 @@ def _request(
         executionProfileRef="codex-default",
         correlationId="corr-1",
         idempotencyKey="idem-1",
-        instructionRef="artifact:instructions",
+        instructionRef=instruction_ref,
         managedSession=binding,
         workspaceSpec=workspace_spec,
         parameters={"publishMode": "none"},
@@ -372,6 +373,81 @@ async def test_start_launches_missing_task_scoped_session_and_persists_result(
     assert control_calls[-1]["action"] == "send_turn"
     assert control_calls[-1]["containerId"] == "container-1"
     assert control_calls[-1]["threadId"] == "thread-1"
+
+
+async def test_start_omits_large_inline_instruction_from_result_metadata(
+    tmp_path: Path,
+) -> None:
+    binding = _binding()
+    large_instruction = "Use this request as the canonical input:\n" + (
+        "Implement the workflow cleanup. " * 400
+    )
+
+    async def _load_snapshot(_workflow_id: str) -> CodexManagedSessionSnapshot:
+        return _snapshot(binding=binding)
+
+    async def _launch_session(_request: Any) -> CodexManagedSessionHandle:
+        return _session_handle(
+            session_id=binding.session_id,
+            session_epoch=binding.session_epoch,
+            container_id="container-1",
+            thread_id="thread-1",
+        )
+
+    adapter = CodexSessionAdapter(
+        profile_fetcher=_fake_profiles(
+            [{"profile_id": "codex-default", "credential_source": "oauth_volume"}]
+        ),
+        slot_requester=_async_noop,
+        slot_releaser=_async_noop,
+        cooldown_reporter=_async_noop,
+        workflow_id="wf-agent-run-1",
+        runtime_id="codex_cli",
+        run_store=ManagedRunStore(tmp_path / "managed_runs"),
+        load_session_snapshot=_load_snapshot,
+        launch_session=_launch_session,
+        session_status=AsyncMock(),
+        prepare_turn_instructions=_prepare_turn_instructions,
+        send_turn=AsyncMock(
+            return_value=_turn_response(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        interrupt_turn=_async_noop,
+        clear_remote_session=_async_noop,
+        terminate_remote_session=_async_noop,
+        fetch_remote_summary=AsyncMock(
+            return_value=_summary(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        publish_remote_artifacts=AsyncMock(
+            return_value=_publication(
+                session_id=binding.session_id,
+                session_epoch=binding.session_epoch,
+                container_id="container-1",
+                thread_id="thread-1",
+            )
+        ),
+        attach_runtime_handles=_async_noop,
+        apply_session_control_action=_async_noop,
+        workspace_root=str(tmp_path / "agent_jobs"),
+        session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
+    )
+
+    handle = await adapter.start(_request(binding, instruction_ref=large_instruction))
+    result = await adapter.fetch_result(handle.run_id)
+
+    assert result.metadata["instructionRefOmitted"] is True
+    assert result.metadata["instructionRefLengthChars"] == len(large_instruction.strip())
+    assert len(result.metadata["instructionRefSha256"]) == 64
+    assert "instructionRef" not in result.metadata
 
 
 async def test_start_passes_oauth_profile_auth_target_to_launch_session(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -56,6 +56,7 @@ def _managed_session_request(
     *,
     parameters: dict[str, Any] | None = None,
     workspace_spec: dict[str, Any] | None = None,
+    instruction_ref: str = "artifact:instructions",
 ) -> AgentExecutionRequest:
     return AgentExecutionRequest(
         agentKind="managed",
@@ -63,7 +64,7 @@ def _managed_session_request(
         executionProfileRef="codex-default",
         correlationId="corr-managed-1",
         idempotencyKey="idem-managed-1",
-        instructionRef="artifact:instructions",
+        instructionRef=instruction_ref,
         managedSession={
             "workflowId": "wf-task-1:session:codex_cli",
             "taskRunId": "wf-task-1",
@@ -96,6 +97,29 @@ async def test_managed_fetch_result_input_ignores_legacy_workspace_branch_for_he
     assert isinstance(activity_input, AgentRuntimeFetchResultInput)
     assert activity_input.target_branch == "main"
     assert activity_input.head_branch is None
+
+
+async def test_managed_session_result_enrichment_omits_large_inline_instruction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_workflow_runtime(monkeypatch)
+    run = MoonMindAgentRun()
+    large_instruction = "Use this request as the canonical input:\n" + (
+        "Implement the workflow cleanup. " * 400
+    )
+    request = _managed_session_request(instruction_ref=large_instruction)
+
+    result = run._enrich_result_metadata(
+        request=request,
+        result=AgentRunResult(summary="done", metadata={}),
+    )
+
+    assert result is not None
+    assert result.metadata["instructionRefOmitted"] is True
+    assert result.metadata["instructionRefLengthChars"] == len(large_instruction.strip())
+    assert len(result.metadata["instructionRefSha256"]) == 64
+    assert "instructionRef" not in result.metadata
+    assert result.metadata["managedSession"]["taskRunId"] == "wf-task-1"
 
 
 async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(


### PR DESCRIPTION
## Summary

- Add compact reference metadata for request fields that may accidentally carry inline user content.
- Stop managed Codex session results from echoing oversized `instructionRef` / `resolvedSkillsetRef` values into `AgentRunResult.metadata`.
- Cover the payload-policy helper, Codex session adapter result construction, and AgentRun managed-session enrichment paths with regression tests.

## Root Cause

A managed Codex run could pass a full prompt body through `instructionRef`. The adapter then copied that value into `AgentRunResult.metadata`, which violates MoonMind's Temporal payload policy and caused workflow-task validation failures before step 1 could advance.

## Validation

- `./tools/test_unit.sh tests/schemas/test_temporal_payload_policy.py tests/unit/workflows/adapters/test_codex_session_adapter.py tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py`
- `PYTHONPYCACHEPREFIX=/tmp/moonmind-pycache python3 -m compileall moonmind/schemas/temporal_payload_policy.py moonmind/workflows/adapters/codex_session_adapter.py moonmind/workflows/temporal/workflows/agent_run.py`
- `./tools/test_unit.sh`
- `git diff --check`