### PR TITLE
[codex] Use deterministic Jira breakdown export

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1420,7 +1420,7 @@ def _normalize_story_output_payload(raw_story_output: Any) -> dict[str, Any]:
     jira_payload = _coerce_mapping(story_output.get("jira"))
     if jira_payload:
         normalized_jira: dict[str, Any] = {}
-        for key in ("projectKey", "issueTypeId"):
+        for key in ("projectKey", "issueTypeId", "issueTypeName", "dependencyMode"):
             value = jira_payload.get(key)
             if isinstance(value, str) and value.strip():
                 normalized_jira[key] = value.strip()

--- a/api_service/data/task_step_templates/jira-breakdown.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown.yaml
@@ -30,9 +30,12 @@ inputs:
     default: Story
   - name: jira_dependency_mode
     label: Jira Dependency Mode
-    type: text
+    type: enum
     required: true
-    default: none
+    default: linear_blocker_chain
+    options:
+      - linear_blocker_chain
+      - none
 steps:
   - title: Break down declarative design
     instructions: |-
@@ -57,6 +60,12 @@ steps:
       If dependency mode is linear_blocker_chain, create an ordered blocker chain so each later story is blocked by the immediately preceding story.
       If dependency mode is none, create the Jira issues without dependency links.
       Return the created Jira issue keys, URLs, dependency mode, and created/reused/failed link results.
+    storyOutput:
+      mode: jira
+      jira:
+        projectKey: "{{ inputs.jira_project_key }}"
+        issueTypeName: "{{ inputs.jira_issue_type }}"
+        dependencyMode: "{{ inputs.jira_dependency_mode }}"
     skill:
-      id: jira-issue-creator
+      id: story.create_jira_issues
       args: {}

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -53,6 +53,9 @@ _JIRA_BREAKDOWN_SLUG = "jira-breakdown"
 _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
+_STEP_RESERVED_KEYS = frozenset(
+    {"id", "title", "slug", "instructions", "skill", "skills", "annotations"}
+)
 logger = logging.getLogger(__name__)
 
 
@@ -762,6 +765,11 @@ class TaskTemplateCatalogService:
                         f"Step {index} annotations must be an object when provided."
                     )
                 step_payload["annotations"] = dict(annotations)
+            for key, value in raw_step.items():
+                normalized_key = str(key).strip()
+                if not normalized_key or normalized_key in _STEP_RESERVED_KEYS:
+                    continue
+                step_payload[normalized_key] = value
             validated.append(step_payload)
         return validated
 
@@ -853,6 +861,11 @@ class TaskTemplateCatalogService:
                 step_payload["title"] = title
             if isinstance(rendered.get("skill"), dict):
                 step_payload["skill"] = rendered["skill"]
+            for key, value in rendered.items():
+                normalized_key = str(key).strip()
+                if not normalized_key or normalized_key in _STEP_RESERVED_KEYS:
+                    continue
+                step_payload[normalized_key] = value
             resolved_steps.append(step_payload)
 
         template_caps = _normalize_capabilities(

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -765,11 +765,14 @@ class TaskTemplateCatalogService:
                         f"Step {index} annotations must be an object when provided."
                     )
                 step_payload["annotations"] = dict(annotations)
-            for key, value in raw_step.items():
-                normalized_key = str(key).strip()
-                if not normalized_key or normalized_key in _STEP_RESERVED_KEYS:
-                    continue
-                step_payload[normalized_key] = value
+            step_payload.update(
+                {
+                    str(key).strip(): value
+                    for key, value in raw_step.items()
+                    if str(key).strip()
+                    and str(key).strip() not in _STEP_RESERVED_KEYS
+                }
+            )
             validated.append(step_payload)
         return validated
 
@@ -861,11 +864,14 @@ class TaskTemplateCatalogService:
                 step_payload["title"] = title
             if isinstance(rendered.get("skill"), dict):
                 step_payload["skill"] = rendered["skill"]
-            for key, value in rendered.items():
-                normalized_key = str(key).strip()
-                if not normalized_key or normalized_key in _STEP_RESERVED_KEYS:
-                    continue
-                step_payload[normalized_key] = value
+            step_payload.update(
+                {
+                    str(key).strip(): value
+                    for key, value in rendered.items()
+                    if str(key).strip()
+                    and str(key).strip() not in _STEP_RESERVED_KEYS
+                }
+            )
             resolved_steps.append(step_payload)
 
         template_caps = _normalize_capabilities(

--- a/docs/Tasks/SkillAndPlanContracts.md
+++ b/docs/Tasks/SkillAndPlanContracts.md
@@ -486,7 +486,8 @@ When a task requests Jira issue creation from ambiguous user intent, the planner
 
 Pure Jira issue creation does not require branch or PR publishing. A PR is required only when the agent produces repository changes that need to be published.
 
-When a task already has fully structured story JSON and an exact Jira target, the planner may use the narrower deterministic batch tool:
+When a task already has fully structured story JSON and a concrete Jira target,
+the planner may use the narrower deterministic batch tool:
 
 ```json
 {
@@ -500,7 +501,8 @@ When a task already has fully structured story JSON and an exact Jira target, th
       "mode": "jira",
       "jira": {
         "projectKey": "MM",
-        "issueTypeId": "10001"
+        "issueTypeName": "Story",
+        "dependencyMode": "linear_blocker_chain"
       }
     },
     "storyBreakdownPath": "docs/tmp/story-breakdowns/example/stories.json"
@@ -508,7 +510,12 @@ When a task already has fully structured story JSON and an exact Jira target, th
 }
 ```
 
-`story.create_jira_issues` is backed by `mm.tool.execute` and requires `integration:jira`. It creates one Jira issue per story from inline `stories` or from `storyBreakdownPath`; it is not the default path for ambiguous Jira requests.
+`story.create_jira_issues` is backed by `mm.tool.execute` and requires
+`integration:jira`. It creates one Jira issue per story from inline `stories` or
+from `storyBreakdownPath`, resolves `issueTypeName` through the trusted Jira
+metadata surface when `issueTypeId` is not supplied, and creates dependency
+links when `dependencyMode = linear_blocker_chain`. It is not the default path
+for ambiguous Jira requests.
 
 If Jira output succeeds, workflow PR output is skipped because Jira is the requested output. If Jira output cannot run or fails and fallback is enabled, the tool returns fallback metadata pointing to the existing `docs/tmp/story-breakdowns/...` handoff so normal branch/PR publishing can expose that docs output.
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -14,6 +14,7 @@ from moonmind.integrations.jira.models import (
     CreateIssueRequest,
     CreateIssueLinkRequest,
     CreateSubtaskRequest,
+    ListCreateIssueTypesRequest,
     SearchIssuesRequest,
 )
 from moonmind.integrations.jira.tool import JiraToolService
@@ -105,6 +106,83 @@ def _story_description(story: Mapping[str, Any]) -> str:
         ),
     ]
     return (description + "".join(sections)).strip() or _story_summary(story, index=1)
+
+
+def _breakdown_source_path(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    source = value.get("source")
+    if isinstance(source, Mapping):
+        path = _string(source.get("referencePath") or source.get("path"))
+        if path:
+            return path
+    return ""
+
+
+def _story_source_reference(
+    story: Mapping[str, Any],
+    *,
+    fallback_path: str = "",
+) -> dict[str, Any]:
+    source_ref = story.get("sourceReference") or story.get("source_reference")
+    if isinstance(source_ref, Mapping):
+        reference = dict(source_ref)
+    else:
+        reference = {}
+    path = _string(reference.get("path") or fallback_path)
+    if path:
+        reference["path"] = path
+    return reference
+
+
+def _missing_source_reference_story_ids(
+    stories: Sequence[Mapping[str, Any]],
+    *,
+    fallback_path: str,
+) -> list[str]:
+    missing: list[str] = []
+    for index, story in enumerate(stories, start=1):
+        reference = _story_source_reference(story, fallback_path=fallback_path)
+        if not _string(reference.get("path")):
+            missing.append(_story_id(story, index=index))
+    return missing
+
+
+def _story_description_with_source(
+    story: Mapping[str, Any],
+    *,
+    fallback_source_path: str,
+) -> str:
+    description = _story_description(story)
+    reference = _story_source_reference(story, fallback_path=fallback_source_path)
+    source_path = _string(reference.get("path"))
+    source_lines: list[str] = []
+    if source_path:
+        source_lines.append(f"Source Document: {source_path}")
+    title = _string(reference.get("title"))
+    if title:
+        source_lines.append(f"Source Title: {title}")
+    sections = [
+        _string(item)
+        for item in _list(reference.get("sections"))
+        if _string(item)
+    ]
+    if sections:
+        source_lines.append(
+            "Source Sections:\n" + "\n".join(f"- {item}" for item in sections)
+        )
+    coverage_ids = [
+        _string(item)
+        for item in _list(reference.get("coverageIds") or reference.get("coverage_ids"))
+        if _string(item)
+    ]
+    if coverage_ids:
+        source_lines.append(
+            "Coverage IDs:\n" + "\n".join(f"- {item}" for item in coverage_ids)
+        )
+    if not source_lines:
+        return description
+    return (description + "\n\nSource Document\n" + "\n".join(source_lines)).strip()
 
 
 def _truncate_jira_description(description: str) -> str:
@@ -375,7 +453,10 @@ async def _create_dependency_links(
                 {
                     **base_result,
                     "status": "failed",
-                    "errorCode": _string(getattr(exc, "code", "")) or exc.__class__.__name__,
+                    "errorCode": (
+                        _string(getattr(exc, "code", ""))
+                        or exc.__class__.__name__
+                    ),
                     "message": "Jira dependency link creation failed.",
                 }
             )
@@ -383,8 +464,45 @@ async def _create_dependency_links(
         status = "existing" if result.get("existing") else "created"
         link_results.append({**base_result, "status": status})
 
-    chain_complete = all(item.get("status") in {"created", "existing"} for item in link_results)
+    chain_complete = all(
+        item.get("status") in {"created", "existing"} for item in link_results
+    )
     return link_results, chain_complete
+
+
+def _extract_issue_type_items(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, Mapping):
+        candidates = (
+            payload.get("issueTypes")
+            or payload.get("issuetypes")
+            or payload.get("values")
+            or payload.get("items")
+            or []
+        )
+    else:
+        candidates = payload
+    return [dict(item) for item in _list(candidates) if isinstance(item, Mapping)]
+
+
+async def _resolve_issue_type_id(
+    *,
+    service: JiraToolService,
+    project_key: str,
+    issue_type_id: str,
+    issue_type_name: str,
+) -> str:
+    if issue_type_id:
+        return issue_type_id
+    if not issue_type_name:
+        return ""
+    payload = await service.list_create_issue_types(
+        ListCreateIssueTypesRequest(projectKey=project_key)
+    )
+    normalized_name = issue_type_name.strip().lower()
+    for item in _extract_issue_type_items(payload):
+        if _string(item.get("name")).lower() == normalized_name:
+            return _string(item.get("id"))
+    return ""
 
 
 async def create_jira_issues_from_stories(
@@ -410,6 +528,16 @@ async def create_jira_issues_from_stories(
         or inputs.get("issueTypeId")
         or inputs.get("issue_type_id")
     )
+    issue_type_name = _string(
+        jira_payload.get("issueTypeName")
+        or jira_payload.get("issue_type_name")
+        or jira_payload.get("issueType")
+        or jira_payload.get("issue_type")
+        or inputs.get("issueTypeName")
+        or inputs.get("issue_type_name")
+        or inputs.get("issueType")
+        or inputs.get("issue_type")
+    )
     fallback_on_failure = str(
         story_output.get("fallback")
         or story_output.get("onFailure")
@@ -430,12 +558,14 @@ async def create_jira_issues_from_stories(
             )
         raise ValueError(dependency_mode_error)
 
-    stories = _coerce_story_payload(
+    raw_story_payload = (
         inputs.get("stories")
         or inputs.get("storyBreakdown")
         or inputs.get("story_breakdown")
         or inputs.get("storyBreakdownJson")
     )
+    breakdown_source_path = _breakdown_source_path(raw_story_payload)
+    stories = _coerce_story_payload(raw_story_payload)
     if not stories:
         repo = _string(inputs.get("repository") or inputs.get("repo"))
         ref = _string(
@@ -452,6 +582,13 @@ async def create_jira_issues_from_stories(
                 fetched = story_fetcher(repo, ref, path)
                 if inspect.isawaitable(fetched):
                     fetched = await fetched  # type: ignore[assignment]
+                fetched_payload: Any = fetched
+                if isinstance(fetched, str) and fetched.strip():
+                    try:
+                        fetched_payload = json.loads(fetched)
+                    except json.JSONDecodeError:
+                        fetched_payload = fetched
+                breakdown_source_path = _breakdown_source_path(fetched_payload)
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
                 if fallback_on_failure:
@@ -470,17 +607,75 @@ async def create_jira_issues_from_stories(
                 dependency_mode=dependency_mode,
             )
         raise ValueError("No stories were available for Jira issue creation.")
-    if not project_key or not issue_type_id:
+    if not project_key:
+        reason = (
+            "Jira projectKey and issueTypeId are required."
+            if not (issue_type_id or issue_type_name)
+            else "Jira projectKey is required."
+        )
         if fallback_on_failure:
             return _fallback_result(
-                reason="Jira projectKey and issueTypeId are required.",
+                reason=reason,
                 inputs=inputs,
                 story_count=len(stories),
                 dependency_mode=dependency_mode,
             )
-        raise ValueError("Jira projectKey and issueTypeId are required.")
+        raise ValueError(reason)
+
+    story_breakdown_path = _string(
+        inputs.get("storyBreakdownPath") or story_output.get("storyBreakdownPath")
+    )
+    if story_breakdown_path:
+        missing_source_ids = _missing_source_reference_story_ids(
+            stories,
+            fallback_path=breakdown_source_path,
+        )
+        if missing_source_ids:
+            reason = (
+                "Jira story creation requires sourceReference.path or breakdown "
+                "source.referencePath for every story. Missing: "
+                + ", ".join(missing_source_ids)
+            )
+            if fallback_on_failure:
+                return _fallback_result(
+                    reason=reason,
+                    inputs=inputs,
+                    story_count=len(stories),
+                    dependency_mode=dependency_mode,
+                )
+            raise ValueError(reason)
 
     service = jira_service_factory()
+    try:
+        issue_type_id = await _resolve_issue_type_id(
+            service=service,
+            project_key=project_key,
+            issue_type_id=issue_type_id,
+            issue_type_name=issue_type_name,
+        )
+    except Exception as exc:
+        if fallback_on_failure:
+            return _fallback_result(
+                reason=f"Unable to resolve Jira issue type: {exc}",
+                inputs=inputs,
+                story_count=len(stories),
+                dependency_mode=dependency_mode,
+            )
+        raise
+    if not issue_type_id:
+        reason = (
+            "Jira issueTypeId is required or issueTypeName must resolve to a "
+            "creatable issue type."
+        )
+        if fallback_on_failure:
+            return _fallback_result(
+                reason=reason,
+                inputs=inputs,
+                story_count=len(stories),
+                dependency_mode=dependency_mode,
+            )
+        raise ValueError(reason)
+
     created: list[dict[str, Any]] = []
     issue_mappings: list[dict[str, Any]] = []
     marker_label = _workflow_marker_label(inputs=inputs, context=_context)
@@ -510,7 +705,12 @@ async def create_jira_issues_from_stories(
                 jira_payload=jira_payload,
                 marker_label=marker_label,
             )
-            description = _truncate_jira_description(_story_description(story))
+            description = _truncate_jira_description(
+                _story_description_with_source(
+                    story,
+                    fallback_source_path=breakdown_source_path,
+                )
+            )
             parent_issue_key = _parent_issue_key(
                 story=story,
                 jira_payload=jira_payload,

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -182,7 +182,10 @@ def _story_description_with_source(
         )
     if not source_lines:
         return description
-    return (description + "\n\nSource Document\n" + "\n".join(source_lines)).strip()
+    source_block = "Source Reference\n" + "\n".join(source_lines)
+    if not description:
+        return source_block
+    return (source_block + "\n\n" + description).strip()
 
 
 def _truncate_jira_description(description: str) -> str:

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -605,6 +605,21 @@ def _build_runtime_planner():
                 for step in raw_steps
                 if isinstance(step, Mapping)
             }
+            if not story_output_payload:
+                for step in raw_steps:
+                    if not isinstance(step, Mapping):
+                        continue
+                    step_story_output = _coerce_mapping(
+                        step.get("storyOutput") or step.get("story_output")
+                    )
+                    if step_story_output:
+                        story_output_payload = dict(step_story_output)
+                        story_output_mode = str(
+                            story_output_payload.get("mode")
+                            or story_output_payload.get("target")
+                            or ""
+                        ).strip().lower()
+                        break
             should_prepare_story_breakdown = should_prepare_story_breakdown or bool(
                 step_tool_names & (_JIRA_STORY_OUTPUT_TOOLS | _MOONSPEC_BREAKDOWN_TOOLS)
             )

--- a/specs/177-jira-chain-blockers/contracts/story-output-contract.md
+++ b/specs/177-jira-chain-blockers/contracts/story-output-contract.md
@@ -7,6 +7,8 @@
 - `stories`, `storyBreakdown`, `story_breakdown`, or `storyBreakdownJson`
 - `storyOutput.jira.projectKey` or `projectKey`
 - `storyOutput.jira.issueTypeId` or `issueTypeId`
+- `storyOutput.jira.issueTypeName` or `issueTypeName` when the issue type id
+  should be resolved through the trusted Jira metadata surface
 - optional `storyBreakdownPath`
 - optional `workflowId` or equivalent marker source
 
@@ -22,6 +24,14 @@ Supported values:
 
 - `none`
 - `linear_blocker_chain`
+
+Source references:
+
+- When `storyBreakdownPath` is present, every story must have
+  `sourceReference.path`, or the breakdown payload must provide
+  `source.referencePath` / `source.path`.
+- Missing source references fail before Jira mutation and return fallback
+  metadata when fallback is enabled.
 
 Validation:
 

--- a/tests/integration/test_startup_task_template_seeding.py
+++ b/tests/integration/test_startup_task_template_seeding.py
@@ -76,7 +76,7 @@ async def test_startup_seeds_default_task_templates(disabled_env_keys, tmp_path)
         assert jira_template.latest_version is not None
         assert [
             step["skill"]["id"] for step in jira_template.latest_version.steps
-        ] == ["moonspec-breakdown", "jira-issue-creator"]
+        ] == ["moonspec-breakdown", "story.create_jira_issues"]
 
         result = await session.execute(
             select(TaskStepTemplate)

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -735,6 +735,8 @@ def test_create_task_shaped_execution_preserves_story_output_contract(
                         "jira": {
                             "projectKey": "MM",
                             "issueTypeId": "10001",
+                            "issueTypeName": "Story",
+                            "dependencyMode": "linear_blocker_chain",
                             "labels": ["moonmind"],
                         },
                     },
@@ -750,6 +752,8 @@ def test_create_task_shaped_execution_preserves_story_output_contract(
         "jira": {
             "projectKey": "MM",
             "issueTypeId": "10001",
+            "issueTypeName": "Story",
+            "dependencyMode": "linear_blocker_chain",
             "labels": ["moonmind"],
         },
     }

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -441,7 +441,7 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
             assert template.latest_version is not None
             assert [step["skill"]["id"] for step in template.latest_version.steps] == [
                 "moonspec-breakdown",
-                "jira-issue-creator",
+                "story.create_jira_issues",
             ]
 
             expanded = await service.expand_template(
@@ -453,7 +453,6 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
                     "feature_request": "docs/Designs/RuntimeTypes.md",
                     "jira_project_key": "TOOL",
                     "jira_issue_type": "Story",
-                    "jira_dependency_mode": "linear_blocker_chain",
                 },
                 context={},
             )
@@ -461,11 +460,22 @@ async def test_seed_catalog_includes_jira_breakdown_preset(tmp_path):
             assert len(expanded["steps"]) == 2
             assert expanded["steps"][0]["skill"]["id"] == "moonspec-breakdown"
             assert "docs/Designs/RuntimeTypes.md" in expanded["steps"][0]["instructions"]
-            assert expanded["steps"][1]["skill"]["id"] == "jira-issue-creator"
+            assert expanded["steps"][1]["skill"]["id"] == "story.create_jira_issues"
             assert "Jira Story issue in project TOOL" in expanded["steps"][1]["instructions"]
             assert "linear_blocker_chain" in expanded["steps"][1]["instructions"]
             assert "ordered blocker chain" in expanded["steps"][1]["instructions"]
             assert "Source Document path" in expanded["steps"][1]["instructions"]
+            assert expanded["steps"][1]["storyOutput"] == {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "TOOL",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            }
+            assert expanded["appliedTemplate"]["inputs"]["jira_dependency_mode"] == (
+                "linear_blocker_chain"
+            )
 
 
 async def test_jira_breakdown_uses_first_allowed_project_as_runtime_default(
@@ -514,6 +524,12 @@ async def test_jira_breakdown_uses_first_allowed_project_as_runtime_default(
             assert "Jira Story issue in project MM" in expanded["steps"][1][
                 "instructions"
             ]
+            assert "Dependency mode: none." in expanded["steps"][1]["instructions"]
+            assert expanded["steps"][1]["storyOutput"]["jira"] == {
+                "projectKey": "MM",
+                "issueTypeName": "Story",
+                "dependencyMode": "none",
+            }
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
 
 

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -155,9 +155,53 @@ async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_
     assert result.outputs["storyOutput"]["status"] == "jira_created"
     request = service.requests[0]
     assert request.issue_type_id == "10005"
+    assert request.description.startswith(
+        "Source Reference\nSource Document: docs/Designs/RuntimeTypes.md"
+    )
     assert "Source Document: docs/Designs/RuntimeTypes.md" in request.description
     assert "Section 1" in request.description
     assert "DESIGN-REQ-001" in request.description
+
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_preserves_source_reference_when_description_truncates():
+    service = _FakeJiraService()
+    long_description = "x" * 40000
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "none",
+                },
+            },
+            "stories": [
+                {
+                    "summary": "Create a traced story",
+                    "description": long_description,
+                    "sourceReference": {
+                        "path": "docs/Designs/RuntimeTypes.md",
+                        "sections": ["Section 1"],
+                        "coverageIds": ["DESIGN-REQ-001"],
+                    },
+                }
+            ],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    request = service.requests[0]
+    assert len(request.description) == 32767
+    assert request.description.startswith(
+        "Source Reference\nSource Document: docs/Designs/RuntimeTypes.md"
+    )
+    assert "Section 1" in request.description
+    assert "DESIGN-REQ-001" in request.description
+    assert request.description.endswith("[Truncated by MoonMind before Jira export]")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -41,6 +41,14 @@ class _FakeJiraService:
         self.search_requests.append(request)
         return self.search_response
 
+    async def list_create_issue_types(self, request):
+        return {
+            "issueTypes": [
+                {"id": "10005", "name": "Story"},
+                {"id": "10006", "name": "Task"},
+            ]
+        }
+
     async def create_issue_link(self, request):
         self.link_requests.append(request)
         if self.fail_link_after is not None and len(self.link_requests) > self.fail_link_after:
@@ -98,6 +106,84 @@ async def test_create_jira_issues_from_inline_story_breakdown():
     assert request.summary == "Create proposal intent records"
     assert request.fields["labels"] == ["moonmind"]
     assert "Intent is visible" in request.description
+
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_resolves_issue_type_name_from_story_breakdown_source():
+    service = _FakeJiraService()
+    breakdown = {
+        "source": {
+            "referencePath": "docs/Designs/RuntimeTypes.md",
+            "title": "Runtime Types",
+        },
+        "stories": [
+            {
+                "id": "STORY-001",
+                "summary": "Create proposal intent records",
+                "description": "As an operator, I can track proposal intent.",
+                "sourceReference": {
+                    "sections": ["Section 1"],
+                    "coverageIds": ["DESIGN-REQ-001"],
+                },
+            }
+        ],
+    }
+
+    async def fetcher(_repo: str, _ref: str, _path: str) -> str:
+        import json
+
+        return json.dumps(breakdown)
+
+    result = await create_jira_issues_from_stories(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "targetBranch": "breakdown-branch",
+            "storyBreakdownPath": "docs/tmp/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "none",
+                },
+            },
+        },
+        jira_service_factory=lambda: service,
+        story_fetcher=fetcher,
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "jira_created"
+    request = service.requests[0]
+    assert request.issue_type_id == "10005"
+    assert "Source Document: docs/Designs/RuntimeTypes.md" in request.description
+    assert "Section 1" in request.description
+    assert "DESIGN-REQ-001" in request.description
+
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_blocks_story_breakdown_without_source_reference():
+    service = _FakeJiraService()
+
+    result = await create_jira_issues_from_stories(
+        {
+            "storyBreakdownPath": "docs/tmp/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            },
+            "stories": [{"id": "STORY-001", "summary": "No source"}],
+        },
+        jira_service_factory=lambda: service,
+    )
+
+    assert service.requests == []
+    assert result.outputs["storyOutput"]["status"] == "fallback"
+    assert "requires sourceReference.path" in result.outputs["storyOutput"]["reason"]
+    assert "STORY-001" in result.outputs["storyOutput"]["reason"]
 
 
 @pytest.mark.asyncio
@@ -210,7 +296,16 @@ async def test_create_jira_issues_fallback_reports_partial_success():
                 "mode": "jira",
                 "jira": {"projectKey": "MM", "issueTypeId": "10001"},
             },
-            "stories": [{"summary": "First"}, {"summary": "Second"}],
+            "stories": [
+                {
+                    "summary": "First",
+                    "sourceReference": {"path": "docs/Designs/RuntimeTypes.md"},
+                },
+                {
+                    "summary": "Second",
+                    "sourceReference": {"path": "docs/Designs/RuntimeTypes.md"},
+                },
+            ],
         },
         jira_service_factory=lambda: service,
     )

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -315,8 +315,16 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
                     },
                     {
                         "id": "jira",
-                        "tool": {"type": "skill", "name": "jira-issue-creator"},
+                        "tool": {"type": "skill", "name": "story.create_jira_issues"},
                         "instructions": "Create Jira issues from the generated breakdown.",
+                        "storyOutput": {
+                            "mode": "jira",
+                            "jira": {
+                                "projectKey": "MM",
+                                "issueTypeName": "Story",
+                                "dependencyMode": "linear_blocker_chain",
+                            },
+                        },
                     },
                 ],
             }
@@ -331,12 +339,22 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     assert breakdown["inputs"]["storyBreakdownPath"].startswith(
         "docs/tmp/story-breakdowns/"
     )
+    assert breakdown["inputs"]["storyOutput"]["mode"] == "jira"
+    assert breakdown["inputs"]["targetBranch"].startswith("jira-breakdown-")
     assert (
         jira["inputs"]["storyBreakdownPath"]
         == breakdown["inputs"]["storyBreakdownPath"]
     )
-    assert jira["inputs"]["selectedSkill"] == "jira-issue-creator"
-    assert jira["inputs"]["publishMode"] == "none"
+    assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
+    assert jira["tool"] == {
+        "type": "skill",
+        "name": "story.create_jira_issues",
+        "version": "1.0",
+    }
+    assert jira["inputs"]["selectedSkill"] == "story.create_jira_issues"
+    assert jira["inputs"]["storyOutput"]["jira"]["dependencyMode"] == (
+        "linear_blocker_chain"
+    )
 
 
 def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():


### PR DESCRIPTION
## Summary
- route the Jira Breakdown preset through deterministic `story.create_jira_issues` instead of the managed `$jira-issue-creator` agent step
- carry structured Jira output inputs through template expansion and runtime planning, including `issueTypeName` and `dependencyMode`
- resolve Jira issue type names through the trusted Jira metadata path and enforce source references before mutating Jira story output

## Why
The preset could ask for blocker-chain behavior in prompt text while still relying on the agent skill to decide whether to call Jira link tools. This makes blocker links less deterministic. The preset now passes structured inputs to the first-party Jira story output tool so issue creation, dependency linking, and partial-failure reporting happen at the backend tool boundary.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/api/routers/test_executions.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/integration/test_startup_task_template_seeding.py -q --tb=short`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py`