### PR TITLE
MM-336 Auth operator diagnostics

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/180-durable-task-edit-reconstruction"
+  "feature_directory": "specs/185-auth-operator-diagnostics"
 }

--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -9,6 +9,7 @@ from sqlalchemy.future import select
 from api_service.api.schemas_oauth_sessions import (
     CreateOAuthSessionRequest,
     OAuthSessionResponse,
+    ProviderProfileSummary,
 )
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
@@ -42,7 +43,30 @@ def _oauth_default(runtime_id: str, key: str) -> str | None:
     return get_provider_default(runtime_id, key)
 
 
-def _oauth_session_response(session: ManagedAgentOAuthSession) -> OAuthSessionResponse:
+def _provider_profile_summary(
+    profile: ManagedAgentProviderProfile | None,
+) -> ProviderProfileSummary | None:
+    if profile is None:
+        return None
+    return ProviderProfileSummary(
+        profile_id=profile.profile_id,
+        runtime_id=profile.runtime_id,
+        provider_id=profile.provider_id,
+        provider_label=profile.provider_label,
+        credential_source=profile.credential_source.value,
+        runtime_materialization_mode=profile.runtime_materialization_mode.value,
+        account_label=profile.account_label,
+        enabled=profile.enabled,
+        is_default=profile.is_default,
+        rate_limit_policy=profile.rate_limit_policy.value,
+    )
+
+
+def _oauth_session_response(
+    session: ManagedAgentOAuthSession,
+    *,
+    profile: ManagedAgentProviderProfile | None = None,
+) -> OAuthSessionResponse:
     return OAuthSessionResponse(
         session_id=session.session_id,
         runtime_id=session.runtime_id,
@@ -54,6 +78,7 @@ def _oauth_session_response(session: ManagedAgentOAuthSession) -> OAuthSessionRe
         session_transport=session.session_transport,
         failure_reason=redact_sensitive_text(session.failure_reason),
         created_at=session.created_at,
+        profile_summary=_provider_profile_summary(profile),
     )
 
 
@@ -178,7 +203,7 @@ async def create_oauth_session(
             detail="Failed to start OAuth session workflow. Please retry.",
         ) from exc
 
-    return _oauth_session_response(new_session)
+    return _oauth_session_response(new_session, profile=existing_profile)
 
 @router.get("/{session_id}", response_model=OAuthSessionResponse)
 async def get_oauth_session(
@@ -195,8 +220,14 @@ async def get_oauth_session(
     session = result.scalars().first()
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
-        
-    return _oauth_session_response(session)
+
+    profile_result = await db.execute(
+        select(ManagedAgentProviderProfile).where(
+            ManagedAgentProviderProfile.profile_id == session.profile_id
+        )
+    )
+    profile = profile_result.scalars().first()
+    return _oauth_session_response(session, profile=profile)
 
 @router.post("/{session_id}/cancel")
 async def cancel_oauth_session(
@@ -490,4 +521,10 @@ async def reconnect_oauth_session(
             new_session_id,
         )
 
-    return _oauth_session_response(new_session)
+    profile_result = await db.execute(
+        select(ManagedAgentProviderProfile).where(
+            ManagedAgentProviderProfile.profile_id == new_session.profile_id
+        )
+    )
+    profile = profile_result.scalars().first()
+    return _oauth_session_response(new_session, profile=profile)

--- a/api_service/api/routers/oauth_sessions.py
+++ b/api_service/api/routers/oauth_sessions.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
@@ -80,6 +81,30 @@ def _oauth_session_response(
         created_at=session.created_at,
         profile_summary=_provider_profile_summary(profile),
     )
+
+
+async def _get_profile_for_session(
+    db: AsyncSession,
+    session: ManagedAgentOAuthSession,
+    *,
+    current_user: User,
+) -> ManagedAgentProviderProfile | None:
+    if not session.profile_id:
+        return None
+    user_id = getattr(current_user, "id", None)
+    visibility_clause = ManagedAgentProviderProfile.owner_user_id.is_(None)
+    if user_id is not None:
+        visibility_clause = or_(
+            visibility_clause,
+            ManagedAgentProviderProfile.owner_user_id == user_id,
+        )
+    result = await db.execute(
+        select(ManagedAgentProviderProfile).where(
+            ManagedAgentProviderProfile.profile_id == session.profile_id,
+            visibility_clause,
+        )
+    )
+    return result.scalars().first()
 
 
 async def _expire_stale_active_sessions(
@@ -221,12 +246,7 @@ async def get_oauth_session(
     if not session:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
 
-    profile_result = await db.execute(
-        select(ManagedAgentProviderProfile).where(
-            ManagedAgentProviderProfile.profile_id == session.profile_id
-        )
-    )
-    profile = profile_result.scalars().first()
+    profile = await _get_profile_for_session(db, session, current_user=current_user)
     return _oauth_session_response(session, profile=profile)
 
 @router.post("/{session_id}/cancel")
@@ -521,10 +541,9 @@ async def reconnect_oauth_session(
             new_session_id,
         )
 
-    profile_result = await db.execute(
-        select(ManagedAgentProviderProfile).where(
-            ManagedAgentProviderProfile.profile_id == new_session.profile_id
-        )
+    profile = await _get_profile_for_session(
+        db,
+        new_session,
+        current_user=current_user,
     )
-    profile = profile_result.scalars().first()
     return _oauth_session_response(new_session, profile=profile)

--- a/api_service/api/schemas_oauth_sessions.py
+++ b/api_service/api/schemas_oauth_sessions.py
@@ -6,6 +6,19 @@ from pydantic import BaseModel
 from api_service.db.models import ManagedAgentRateLimitPolicy, OAuthSessionStatus
 
 
+class ProviderProfileSummary(BaseModel):
+    profile_id: str
+    runtime_id: str
+    provider_id: str
+    provider_label: Optional[str] = None
+    credential_source: str
+    runtime_materialization_mode: str
+    account_label: Optional[str] = None
+    enabled: bool
+    is_default: bool
+    rate_limit_policy: str
+
+
 class CreateOAuthSessionRequest(BaseModel):
     runtime_id: str
     profile_id: str
@@ -30,3 +43,4 @@ class OAuthSessionResponse(BaseModel):
     session_transport: Optional[str] = None
     failure_reason: Optional[str] = None
     created_at: Optional[datetime] = None
+    profile_summary: Optional[ProviderProfileSummary] = None

--- a/docs/tmp/jira-orchestration-inputs/MM-336-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-336-moonspec-orchestration-input.md
@@ -1,0 +1,68 @@
+# MM-336 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-336
+- Board scope: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: [MM-318] Project operator-visible managed auth diagnostics
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: Synthesized from the trusted `jira.get_issue` MCP response because the response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, or `presetBrief`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-336 from MM board
+Summary: [MM-318] Project operator-visible managed auth diagnostics
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-336 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-336: [MM-318] Project operator-visible managed auth diagnostics
+
+User Story
+As an operator, I can understand OAuth enrollment, Provider Profile registration, managed Codex auth materialization, and ordinary task execution through safe statuses, summaries, diagnostics, logs, artifacts, and session metadata without inspecting auth volumes, runtime homes, or terminal scrollback as execution records.
+
+Source Document
+- Path: docs/ManagedAgents/OAuthTerminal.md
+- Sections: 1. Purpose, 8. Verification, 10. Operator Behavior, 11. Required Boundaries
+- Coverage IDs: DESIGN-REQ-004, DESIGN-REQ-016, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+- Breakdown Story ID: STORY-005
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json
+
+Acceptance Criteria
+- OAuth enrollment surfaces show session status, timestamps, failure reason, and registered profile summary where applicable.
+- Managed Codex session metadata records selected profile refs, volume refs, auth mount target, workspace Codex home path, readiness, and validation failure reasons without credential contents.
+- Ordinary task execution views direct operators to Live Logs, artifacts, summaries, diagnostics, and reset/control-boundary artifacts.
+- Runtime home directories and auth volumes are not exposed as presentation artifacts.
+- Enrollment terminal scrollback is not treated as the durable execution record for managed task runs.
+- Diagnostic events make it clear which component owns enrollment, profile metadata, session mounts, runtime seeding, or workload container behavior.
+
+Requirements
+- Publish safe OAuth/profile/session status and diagnostics metadata for operator use.
+- Record managed-session readiness and auth materialization validation failures in session metadata or diagnostics artifacts.
+- Avoid presenting auth volumes, runtime homes, and terminal scrollback as task artifacts.
+- Keep operator-visible diagnostics aligned with the component ownership boundaries in the design.
+
+Independent Test
+Simulate successful and failed enrollment plus successful and failed managed Codex session launch, then assert Mission Control/API projections show safe statuses, profile summaries, validation failures, diagnostics refs, and artifact/log pointers while omitting raw credentials, auth-volume listings, runtime-home contents, and terminal scrollback from ordinary task records.
+
+Notes
+- Short name: auth-operator-diagnostics
+- Dependencies: STORY-001, STORY-003
+- Needs clarification: None
+
+Out Of Scope
+- Displaying credential files or raw volume listings
+- Making runtime home directories browseable artifacts
+- Using OAuth terminal scrollback as the durable task execution record
+- Building Live Logs transport
+
+Source Design Coverage
+- DESIGN-REQ-004: Owns operator-facing distinction between credentials, workspaces, and artifacts.
+- DESIGN-REQ-016: Owns projection of startup validation and readiness diagnostics.
+- DESIGN-REQ-020: Owns durable execution record expectations.
+- DESIGN-REQ-021: Owns diagnostics that preserve component responsibility boundaries.
+- DESIGN-REQ-022: Owns non-goals around Live Logs transport and task-run PTY attach in operator docs/projections.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4245,6 +4245,7 @@ export interface components {
             failure_reason?: string | null;
             /** Created At */
             created_at?: string | null;
+            profile_summary?: components["schemas"]["ProviderProfileSummary"] | null;
         };
         /**
          * OAuthSessionStatus
@@ -4490,6 +4491,29 @@ export interface components {
             created_at: string | null;
             /** Updated At */
             updated_at: string | null;
+        };
+        /** ProviderProfileSummary */
+        ProviderProfileSummary: {
+            /** Profile Id */
+            profile_id: string;
+            /** Runtime Id */
+            runtime_id: string;
+            /** Provider Id */
+            provider_id: string;
+            /** Provider Label */
+            provider_label?: string | null;
+            /** Credential Source */
+            credential_source: string;
+            /** Runtime Materialization Mode */
+            runtime_materialization_mode: string;
+            /** Account Label */
+            account_label?: string | null;
+            /** Enabled */
+            enabled: boolean;
+            /** Is Default */
+            is_default: boolean;
+            /** Rate Limit Policy */
+            rate_limit_policy: string;
         };
         /** ProviderProfileUpdate */
         ProviderProfileUpdate: {

--- a/moonmind/schemas/agent_runtime_models.py
+++ b/moonmind/schemas/agent_runtime_models.py
@@ -483,6 +483,8 @@ class ManagedRuntimeProfile(BaseModel):
     passthrough_env_keys: list[str] = Field(default_factory=list, alias="passthroughEnvKeys")
     clear_env_keys: list[str] = Field(default_factory=list, alias="clearEnvKeys")
     secret_refs: dict[str, str | dict[str, str]] = Field(default_factory=dict, alias="secretRefs")
+    volume_ref: str | None = Field(None, alias="volumeRef")
+    volume_mount_path: str | None = Field(None, alias="volumeMountPath")
 
     @model_validator(mode="before")
     @classmethod
@@ -524,6 +526,16 @@ class ManagedRuntimeProfile(BaseModel):
             allowed_sensitive_keys=_ALLOWED_MANAGED_LAUNCH_METADATA_KEYS,
         ):
             raise ValueError("envOverrides must not contain raw credential keys")
+        if self.volume_ref is not None:
+            self.volume_ref = require_non_blank(
+                self.volume_ref,
+                field_name="volumeRef",
+            )
+        if self.volume_mount_path is not None:
+            self.volume_mount_path = require_non_blank(
+                self.volume_mount_path,
+                field_name="volumeMountPath",
+            )
 
         normalized_passthrough: list[str] = []
         seen: set[str] = set()

--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -963,6 +963,8 @@ class CodexSessionAdapter(ManagedAgentAdapter):
             passthroughEnvKeys=launch_context.passthrough_env_keys,
             clearEnvKeys=profile.get("clear_env_keys") or [],
             secretRefs=profile.get("secret_refs") or {},
+            volumeRef=profile.get("volume_ref"),
+            volumeMountPath=profile.get("volume_mount_path"),
         )
 
     async def _current_locator(

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3165,6 +3165,42 @@ class TemporalAgentRuntimeActivities:
         )
         return request.model_copy(update={"environment": environment})
 
+    @staticmethod
+    def _managed_session_auth_diagnostics(
+        *,
+        request: LaunchCodexManagedSessionRequest,
+        profile: ManagedRuntimeProfile | None,
+        readiness: str,
+        validation_failure_reason: str | None = None,
+    ) -> dict[str, str]:
+        diagnostics: dict[str, str] = {
+            "component": "managed_session_controller",
+            "readiness": readiness,
+            "codexHomePath": request.codex_home_path,
+        }
+        if profile is not None:
+            optional_profile_fields = {
+                "profileRef": profile.profile_id,
+                "runtimeId": profile.runtime_id,
+                "providerId": profile.provider_id,
+                "credentialSource": profile.credential_source,
+                "runtimeMaterializationMode": profile.runtime_materialization_mode,
+                "volumeRef": profile.volume_ref,
+            }
+            for key, value in optional_profile_fields.items():
+                if value is not None and str(value).strip():
+                    diagnostics[key] = str(value).strip()
+        auth_mount_target = str(
+            request.environment.get("MANAGED_AUTH_VOLUME_PATH") or ""
+        ).strip()
+        if not auth_mount_target and profile is not None and profile.volume_mount_path:
+            auth_mount_target = str(profile.volume_mount_path).strip()
+        if auth_mount_target:
+            diagnostics["authMountTarget"] = auth_mount_target
+        if validation_failure_reason:
+            diagnostics["validationFailureReason"] = validation_failure_reason
+        return diagnostics
+
     async def agent_runtime_launch_session(
         self,
         request: Mapping[str, Any] | LaunchCodexManagedSessionRequest | None = None,
@@ -3183,10 +3219,33 @@ class TemporalAgentRuntimeActivities:
         try:
             response = await controller.launch_session(validated)
         except Exception as exc:
-            detail = self._sanitize_operator_summary(str(exc)) or "managed session launch failed"
+            from moonmind.utils.logging import redact_sensitive_text
+
+            detail = (
+                self._sanitize_operator_summary(redact_sensitive_text(str(exc)))
+                or "managed session launch failed"
+            )
+            detail = redact_sensitive_text(detail)
             raise TemporalActivityRuntimeError(
-                f"agent_runtime.launch_session failed: {detail}"
+                "agent_runtime.launch_session failed: "
+                f"component=managed_session_controller reason={detail}"
             ) from exc
+        response = response.model_copy(
+            update={
+                "metadata": {
+                    **response.metadata,
+                    "authDiagnostics": self._managed_session_auth_diagnostics(
+                        request=validated,
+                        profile=profile,
+                        readiness=(
+                            response.status
+                            if response.status != "failed"
+                            else "failed"
+                        ),
+                    ),
+                }
+            }
+        )
         return self._validate_session_response(
             response,
             activity_type="agent_runtime.launch_session",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -3225,11 +3225,15 @@ class TemporalAgentRuntimeActivities:
                 self._sanitize_operator_summary(redact_sensitive_text(str(exc)))
                 or "managed session launch failed"
             )
-            detail = redact_sensitive_text(detail)
             raise TemporalActivityRuntimeError(
                 "agent_runtime.launch_session failed: "
                 f"component=managed_session_controller reason={detail}"
             ) from exc
+        response = self._validate_session_response(
+            response,
+            activity_type="agent_runtime.launch_session",
+            model_type=CodexManagedSessionHandle,
+        )
         response = response.model_copy(
             update={
                 "metadata": {
@@ -3246,11 +3250,7 @@ class TemporalAgentRuntimeActivities:
                 }
             }
         )
-        return self._validate_session_response(
-            response,
-            activity_type="agent_runtime.launch_session",
-            model_type=CodexManagedSessionHandle,
-        )
+        return response
 
     async def agent_runtime_load_session_snapshot(
         self,

--- a/specs/185-auth-operator-diagnostics/checklists/requirements.md
+++ b/specs/185-auth-operator-diagnostics/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Auth Operator Diagnostics
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- PASS: The spec preserves the MM-336 Jira preset brief and maps every in-scope source design coverage ID to functional requirements.

--- a/specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md
+++ b/specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md
@@ -1,0 +1,73 @@
+# Contract: Auth Operator Diagnostics
+
+## OAuth Session Response
+
+`GET /api/v1/oauth-sessions/{session_id}` returns the existing session fields plus optional `profile_summary`:
+
+```json
+{
+  "session_id": "oas_abc123",
+  "runtime_id": "codex_cli",
+  "profile_id": "codex-oauth",
+  "status": "failed",
+  "expires_at": "2026-04-16T12:00:00Z",
+  "terminal_session_id": "term_oas_abc123",
+  "terminal_bridge_id": "br_oas_abc123",
+  "session_transport": "moonmind_pty_ws",
+  "failure_reason": "token=[REDACTED] in [REDACTED_AUTH_PATH]",
+  "created_at": "2026-04-16T11:00:00Z",
+  "profile_summary": {
+    "profile_id": "codex-oauth",
+    "runtime_id": "codex_cli",
+    "provider_id": "openai",
+    "provider_label": "OpenAI",
+    "credential_source": "oauth_volume",
+    "runtime_materialization_mode": "oauth_home",
+    "account_label": "work account",
+    "enabled": true,
+    "is_default": false,
+    "rate_limit_policy": "backoff"
+  }
+}
+```
+
+Forbidden response content:
+- credential file contents
+- token values
+- raw auth-volume listings
+- runtime-home directory contents
+- environment dumps
+
+## Managed Session Launch Metadata
+
+`agent_runtime.launch_session` returns a `CodexManagedSessionHandle` whose metadata may include:
+
+```json
+{
+  "authDiagnostics": {
+    "component": "managed_session_controller",
+    "readiness": "ready",
+    "profileRef": "codex-oauth",
+    "runtimeId": "codex_cli",
+    "credentialSource": "oauth_volume",
+    "runtimeMaterializationMode": "oauth_home",
+    "volumeRef": "codex_auth_volume",
+    "authMountTarget": "/home/app/.codex-auth",
+    "codexHomePath": "/work/agent_jobs/run-1/.moonmind/codex-home"
+  }
+}
+```
+
+On failure, the activity error message includes a sanitized reason and owner classification:
+
+```text
+agent_runtime.launch_session failed: component=managed_session_controller reason=token=[REDACTED] in [REDACTED_AUTH_PATH]
+```
+
+Forbidden metadata content:
+- credential file contents
+- token values
+- raw environment dumps
+- raw auth-volume listings
+- runtime-home directory contents
+- OAuth terminal scrollback

--- a/specs/185-auth-operator-diagnostics/data-model.md
+++ b/specs/185-auth-operator-diagnostics/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: Auth Operator Diagnostics
+
+## OAuthSessionProjection
+
+- `session_id`: OAuth enrollment session identifier.
+- `runtime_id`: Runtime family identifier.
+- `profile_id`: Provider Profile identifier selected for enrollment.
+- `status`: Current OAuth enrollment state.
+- `created_at`: Session creation timestamp.
+- `expires_at`: Optional expiration timestamp.
+- `terminal_session_id`: Optional terminal transport identifier.
+- `terminal_bridge_id`: Optional terminal bridge identifier.
+- `session_transport`: Optional transport kind.
+- `failure_reason`: Redacted failure reason.
+- `profile_summary`: Optional `ProviderProfileSummary`.
+
+Validation rules:
+- Failure reason must be redacted before serialization.
+- Projection must not include credential file contents, raw auth-volume listings, environment dumps, or runtime-home directory contents.
+
+## ProviderProfileSummary
+
+- `profile_id`: Provider Profile identifier.
+- `runtime_id`: Runtime family identifier.
+- `provider_id`: Provider identifier.
+- `provider_label`: Optional human-readable provider label.
+- `credential_source`: Credential source enum.
+- `runtime_materialization_mode`: Materialization mode enum.
+- `account_label`: Optional account label.
+- `enabled`: Whether the profile can be selected.
+- `is_default`: Whether it is the default profile.
+- `rate_limit_policy`: Rate limit behavior.
+
+Validation rules:
+- Summary excludes `secret_refs`, `env_template`, `file_templates`, `home_path_overrides`, and raw command behavior.
+- Summary may include volume refs only through managed-session diagnostics, not as raw file listings.
+
+## AuthMaterializationDiagnostics
+
+- `component`: Owning component for the diagnostic state.
+- `readiness`: `ready` or `failed`.
+- `profile_ref`: Optional selected Provider Profile identifier.
+- `runtime_id`: Optional runtime family identifier.
+- `credential_source`: Optional credential source.
+- `runtime_materialization_mode`: Optional materialization mode.
+- `volume_ref`: Optional provider profile volume ref.
+- `auth_mount_target`: Optional managed-session auth mount target.
+- `codex_home_path`: Workspace-scoped Codex home path.
+- `validation_failure_reason`: Optional sanitized failure reason.
+
+Validation rules:
+- Values must be compact strings safe for workflow/activity metadata.
+- Secret-like values, raw credential contents, environment dumps, raw volume listings, runtime-home contents, and terminal scrollback are forbidden.
+
+## DurableExecutionEvidence
+
+- `live_logs_ref`: Existing live log surface or stream metadata.
+- `artifact_refs`: Existing artifact refs for outputs, diagnostics, summaries, and reset/control boundaries.
+- `diagnostics_ref`: Existing diagnostics artifact ref.
+- `summary_ref`: Existing summary artifact ref.
+- `reset_boundary_ref`: Existing reset/control-boundary artifact ref.
+
+Validation rules:
+- Evidence points to durable refs and summaries, not auth volumes, runtime homes, or terminal scrollback.

--- a/specs/185-auth-operator-diagnostics/plan.md
+++ b/specs/185-auth-operator-diagnostics/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan: Auth Operator Diagnostics
+
+**Branch**: `185-auth-operator-diagnostics` | **Date**: 2026-04-16 | **Spec**: `specs/185-auth-operator-diagnostics/spec.md`
+
+## Input
+
+Single-story feature specification from `specs/185-auth-operator-diagnostics/spec.md` generated from Jira issue `MM-336` and the preserved preset brief in `docs/tmp/jira-orchestration-inputs/MM-336-moonspec-orchestration-input.md`.
+
+## Summary
+
+This story adds safe operator diagnostics to existing OAuth session and managed Codex launch projections. The implementation stays inside established API schema/router and Temporal activity/controller boundaries: OAuth APIs return a compact provider profile summary, and managed session launch returns non-secret auth diagnostics for successful and failed materialization. Unit tests cover redaction and schema behavior; integration-style boundary tests cover the activity/controller launch path.
+
+## Technical Context
+
+- Language/version: Python 3.12.
+- Primary dependencies: Pydantic v2, FastAPI routers, Temporal activity runtime contracts, pytest, existing managed-session controller and provider profile materializer.
+- Storage: existing OAuth session, provider profile, managed-session records, and artifact/log refs only; no new persistent storage.
+- Unit testing: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification; focused Python tests through `./tools/test_unit.sh --python-only ...`.
+- Integration testing: `./tools/test_integration.sh` for compose-backed `integration_ci` when Docker is available; focused boundary coverage can run in unit files when Docker is mocked.
+- Target platform: MoonMind API service, Temporal worker activity runtime, managed Codex session launch boundary, and Mission Control consumers of those projections.
+- Project type: backend API and orchestration runtime.
+- Performance goals: diagnostics are derived from already-available request/profile/session metadata and add no network calls on the launch hot path.
+- Constraints: preserve MM-336 traceability; do not expose credentials, raw auth-volume listings, runtime-home contents, terminal scrollback, or environment dumps; keep large content out of workflow history.
+- Scale/scope: one independently testable story; dependencies: STORY-001 and STORY-003.
+
+## Constitution Check
+
+- I Orchestrate, Don't Recreate: PASS. The plan projects MoonMind-managed metadata without reimplementing provider auth runtimes.
+- II One-Click Agent Deployment: PASS. Uses existing local-first API/runtime behavior and test tooling.
+- III Avoid Vendor Lock-In: PASS. Diagnostics use provider profile and managed-session abstractions rather than provider-specific secrets.
+- IV Own Your Data: PASS. Operator-visible evidence stays in local API/runtime/artifact surfaces.
+- V Skills Are First-Class: PASS. No executable skill contract changes.
+- VI Bittersweet Lesson: PASS. Adds thin projections over existing runtime boundaries.
+- VII Runtime Configurability: PASS. Diagnostics reflect runtime/profile/request metadata and existing configuration.
+- VIII Modular Architecture: PASS. Work stays in API schemas/router helpers, Temporal activity runtime, and managed-session controller tests.
+- IX Resilient by Default: PASS. Failure diagnostics are sanitized and classified without hiding failure state.
+- X Continuous Improvement: PASS. Verification evidence is captured in spec artifacts.
+- XI Spec-Driven Development: PASS. Implementation follows this single-story MoonSpec.
+- XII Canonical Docs Separation: PASS. Work tracking remains under specs/docs/tmp.
+- XIII Pre-Release Compatibility: PASS. Internal contracts are updated directly without compatibility aliases.
+
+## Project Structure
+
+- Spec: `specs/185-auth-operator-diagnostics/spec.md`
+- Plan: `specs/185-auth-operator-diagnostics/plan.md`
+- Research: `specs/185-auth-operator-diagnostics/research.md`
+- Data model: `specs/185-auth-operator-diagnostics/data-model.md`
+- Contract: `specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md`
+- Quickstart: `specs/185-auth-operator-diagnostics/quickstart.md`
+- Likely production touchpoints: `api_service/api/schemas_oauth_sessions.py`, `api_service/api/routers/oauth_sessions.py`, `moonmind/workflows/temporal/activity_runtime.py`, `moonmind/workflows/temporal/runtime/managed_session_controller.py`
+- Unit test targets: `tests/unit/api_service/api/routers/test_oauth_sessions.py`, `tests/unit/workflows/temporal/test_agent_runtime_activities.py`, `tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+
+## Test Strategy
+
+- Unit strategy: add red-first tests for OAuth session profile summaries, secret/path redaction, auth diagnostics on managed session launch success, and sanitized launch failure classification. Run focused tests during iteration and the full unit suite before final verification when feasible.
+- Integration strategy: use mocked controller/activity boundary tests for deterministic launch coverage; run `./tools/test_integration.sh` only if Docker is available, otherwise record the exact Docker socket blocker.
+
+## Complexity Tracking
+
+None.

--- a/specs/185-auth-operator-diagnostics/quickstart.md
+++ b/specs/185-auth-operator-diagnostics/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Auth Operator Diagnostics
+
+## Focused Validation
+
+1. Run OAuth session API tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py
+```
+
+2. Run managed session activity/controller tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py
+```
+
+3. If Docker is available, run required hermetic integration coverage:
+
+```bash
+./tools/test_integration.sh
+```
+
+## End-To-End Story Check
+
+1. Create or fetch an OAuth session that references a registered Provider Profile.
+2. Confirm the OAuth session response includes status, timestamps, redacted failure reason, and a compact profile summary.
+3. Launch a managed Codex session with an OAuth-backed profile.
+4. Confirm launch/session metadata includes selected profile ref, credential source, volume ref, auth mount target, Codex home path, readiness, and component ownership.
+5. Confirm responses and metadata do not contain credential contents, token values, raw auth-volume listings, runtime-home contents, environment dumps, or terminal scrollback.
+
+## Final Verification
+
+Run the full unit suite before final MoonSpec verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```

--- a/specs/185-auth-operator-diagnostics/research.md
+++ b/specs/185-auth-operator-diagnostics/research.md
@@ -1,0 +1,33 @@
+# Research: Auth Operator Diagnostics
+
+## OAuth Session Projection
+
+Decision: Extend the existing OAuth session response with a compact `profile_summary` when the referenced Provider Profile exists.
+
+Rationale: The OAuth session API already owns enrollment status, timestamps, terminal transport refs, and failure redaction. Joining the selected profile in the existing request path gives operators the registered profile summary without exposing credential files or raw auth volumes.
+
+Alternatives considered: Add a new diagnostics endpoint; rejected because it would duplicate the existing session fetch surface for this single-story projection.
+
+## Managed Codex Launch Diagnostics
+
+Decision: Attach `authDiagnostics` metadata to the managed session launch handle in the Temporal activity boundary after materialization and after controller launch succeeds.
+
+Rationale: The activity receives both the selected profile payload and the shaped launch request. This boundary can report selected profile refs, auth mount target, Codex home path, readiness, and ownership without adding persistent storage or raw credential data to workflow history.
+
+Alternatives considered: Persist diagnostics in `CodexManagedSessionRecord`; deferred because this story only requires operator-visible launch/session metadata and artifact/log refs already exist for durable evidence.
+
+## Failure Classification
+
+Decision: Sanitize launch/materialization failure text through the existing operator-summary sanitizer and expose component ownership in the raised activity error.
+
+Rationale: Failed launches currently propagate a sanitized activity error. Adding owner classification preserves the design boundary and avoids leaking token-like values or auth paths.
+
+Alternatives considered: Return a failed handle instead of raising; rejected because the current activity contract uses exceptions for launch failures.
+
+## Task Execution Evidence
+
+Decision: Reuse existing session artifact/log/summary/diagnostics refs as the durable execution evidence model and avoid exposing auth volumes or runtime homes as artifacts.
+
+Rationale: The source design explicitly treats logs, summaries, diagnostics, and continuity artifacts as the audit truth. Existing managed-session records already contain refs for those surfaces.
+
+Alternatives considered: Add new artifact types for auth homes; rejected as out of scope and explicitly disallowed by the source design.

--- a/specs/185-auth-operator-diagnostics/spec.md
+++ b/specs/185-auth-operator-diagnostics/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Auth Operator Diagnostics
+
+**Feature Branch**: `185-auth-operator-diagnostics`
+**Created**: 2026-04-16
+**Status**: Draft
+**Input**: MM-336: [MM-318] Project operator-visible managed auth diagnostics
+
+## Original Jira Preset Brief
+
+```text
+MM-336: [MM-318] Project operator-visible managed auth diagnostics
+
+User Story
+As an operator, I can understand OAuth enrollment, Provider Profile registration, managed Codex auth materialization, and ordinary task execution through safe statuses, summaries, diagnostics, logs, artifacts, and session metadata without inspecting auth volumes, runtime homes, or terminal scrollback as execution records.
+
+Source Document
+- Path: docs/ManagedAgents/OAuthTerminal.md
+- Sections: 1. Purpose, 8. Verification, 10. Operator Behavior, 11. Required Boundaries
+- Coverage IDs: DESIGN-REQ-004, DESIGN-REQ-016, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+- Breakdown Story ID: STORY-005
+- Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthtermina-74125184/stories.json
+
+Acceptance Criteria
+- OAuth enrollment surfaces show session status, timestamps, failure reason, and registered profile summary where applicable.
+- Managed Codex session metadata records selected profile refs, volume refs, auth mount target, workspace Codex home path, readiness, and validation failure reasons without credential contents.
+- Ordinary task execution views direct operators to Live Logs, artifacts, summaries, diagnostics, and reset/control-boundary artifacts.
+- Runtime home directories and auth volumes are not exposed as presentation artifacts.
+- Enrollment terminal scrollback is not treated as the durable execution record for managed task runs.
+- Diagnostic events make it clear which component owns enrollment, profile metadata, session mounts, runtime seeding, or workload container behavior.
+
+Requirements
+- Publish safe OAuth/profile/session status and diagnostics metadata for operator use.
+- Record managed-session readiness and auth materialization validation failures in session metadata or diagnostics artifacts.
+- Avoid presenting auth volumes, runtime homes, and terminal scrollback as task artifacts.
+- Keep operator-visible diagnostics aligned with the component ownership boundaries in the design.
+
+Independent Test
+Simulate successful and failed enrollment plus successful and failed managed Codex session launch, then assert Mission Control/API projections show safe statuses, profile summaries, validation failures, diagnostics refs, and artifact/log pointers while omitting raw credentials, auth-volume listings, runtime-home contents, and terminal scrollback from ordinary task records.
+
+Notes
+- Short name: auth-operator-diagnostics
+- Dependencies: STORY-001, STORY-003
+- Needs clarification: None
+
+Out Of Scope
+- Displaying credential files or raw volume listings
+- Making runtime home directories browseable artifacts
+- Using OAuth terminal scrollback as the durable task execution record
+- Building Live Logs transport
+
+Source Design Coverage
+- DESIGN-REQ-004: Owns operator-facing distinction between credentials, workspaces, and artifacts.
+- DESIGN-REQ-016: Owns projection of startup validation and readiness diagnostics.
+- DESIGN-REQ-020: Owns durable execution record expectations.
+- DESIGN-REQ-021: Owns diagnostics that preserve component responsibility boundaries.
+- DESIGN-REQ-022: Owns non-goals around Live Logs transport and task-run PTY attach in operator docs/projections.
+```
+
+## User Story - View Safe Auth Diagnostics
+
+**Summary**: As an operator, I want OAuth enrollment, Provider Profile registration, managed Codex auth materialization, and task execution surfaces to expose safe statuses and diagnostics so I can understand auth-related state without inspecting credential volumes, runtime homes, or terminal scrollback.
+
+**Goal**: Provide safe operator-visible projections for OAuth sessions and managed Codex session launches that identify status, selected profile refs, mount refs, readiness, validation failures, and durable artifact/log pointers while keeping credential contents and raw runtime homes out of ordinary task records.
+
+**Independent Test**: Simulate successful and failed OAuth enrollment plus successful and failed managed Codex session launch; the story passes only when API/runtime projections expose safe status, profile summary, readiness, validation failure, diagnostics refs, and artifact/log pointers and omit raw credentials, auth-volume listings, runtime-home contents, and terminal scrollback.
+
+**Acceptance Scenarios**:
+
+1. **Given** an OAuth enrollment session has current status, timestamps, and profile metadata, **when** an operator fetches the session through the API, **then** the response includes sanitized status, timestamps, failure reason when present, and a registered profile summary where available.
+2. **Given** a managed Codex session launch uses an OAuth-backed provider profile, **when** the launch succeeds, **then** session metadata records the selected profile ref, credential source, volume ref, auth mount target, workspace Codex home path, readiness state, and component ownership without credential contents or raw listings.
+3. **Given** managed Codex auth materialization or launch validation fails, **when** the failure is surfaced to the operator, **then** metadata includes a sanitized validation failure reason and component ownership while omitting credential contents, environment dumps, raw auth-volume listings, runtime-home contents, and terminal scrollback.
+4. **Given** an ordinary managed task run is inspected, **when** its execution records are presented, **then** durable logs, artifacts, summaries, diagnostics, and reset/control-boundary refs are the operator-visible execution record rather than auth volumes, runtime homes, or OAuth terminal scrollback.
+
+### Edge Cases
+
+- OAuth enrollment has not yet registered a provider profile.
+- OAuth enrollment failed with a secret-like failure reason or auth path.
+- Managed Codex launch has no selected provider profile.
+- Managed Codex launch uses an OAuth profile with a volume ref but no auth mount target.
+- Runtime materialization failure text contains token-like values, auth paths, or raw environment values.
+
+## Assumptions
+
+- STORY-001 and STORY-003 provide Provider Profile metadata and managed Codex auth materialization inputs that this story can project safely.
+- Live Logs and artifact transport already exist; this story references their safe refs and does not build new transport.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-004**: Operators must be able to distinguish credentials, workspaces, and artifacts without treating auth volumes or runtime homes as presentation artifacts. Source: `docs/ManagedAgents/OAuthTerminal.md` sections 1 and 10. Scope: in scope. Maps to FR-001, FR-004, FR-006, and FR-007.
+- **DESIGN-REQ-016**: Startup validation and readiness diagnostics must be projected for managed Codex auth materialization. Source: section 8. Scope: in scope. Maps to FR-003 and FR-005.
+- **DESIGN-REQ-020**: Logs, summaries, diagnostics, and continuity artifacts remain the durable operator/audit truth for ordinary task execution. Source: sections 1 and 10. Scope: in scope. Maps to FR-006 and FR-007.
+- **DESIGN-REQ-021**: Diagnostic events must preserve ownership boundaries between OAuth terminal, Provider Profile, managed-session controller, Codex runtime, and workload orchestration. Source: section 11. Scope: in scope. Maps to FR-002, FR-003, and FR-005.
+- **DESIGN-REQ-022**: OAuth terminal scrollback and raw auth/runtime homes must not become the ordinary managed task execution record. Source: sections 10 and 11. Scope: in scope. Maps to FR-006 and FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: OAuth session API responses MUST expose sanitized session status, creation/expiration timestamps, terminal transport refs, and redacted failure reason without credential contents, token values, raw auth-volume listings, or raw runtime-home contents.
+- **FR-002**: OAuth session API responses SHOULD include a registered provider profile summary when the profile exists, limited to profile ID, runtime ID, provider ID/label, credential source, materialization mode, account label, enabled/default flags, and rate-limit policy.
+- **FR-003**: Managed Codex launch metadata MUST expose safe auth materialization diagnostics including selected provider profile ref when present, credential source, volume ref, auth mount target, workspace Codex home path, readiness state, and owning component.
+- **FR-004**: Managed Codex launch metadata MUST NOT expose credential file contents, token values, environment dumps, raw auth-volume listings, runtime-home directory contents, or OAuth terminal scrollback.
+- **FR-005**: Managed Codex launch failures caused by auth materialization or startup validation MUST surface a sanitized validation failure reason and owning component without leaking secret-like values or auth paths.
+- **FR-006**: Ordinary managed task execution records MUST direct operators to Live Logs, artifacts, summaries, diagnostics, and reset/control-boundary refs as durable evidence, not auth volumes, runtime homes, or OAuth terminal scrollback.
+- **FR-007**: Diagnostic metadata MUST identify whether OAuth enrollment, Provider Profile metadata, managed-session container mounts, Codex runtime seeding, or workload orchestration owns the reported state.
+
+### Key Entities
+
+- **OAuth Session Projection**: Browser/API-safe view of an OAuth enrollment session.
+- **Provider Profile Summary**: Compact non-secret profile metadata suitable for operator display.
+- **Auth Materialization Diagnostics**: Non-secret managed-session launch metadata describing selected profile refs, mount refs, readiness, validation failures, and owning component.
+- **Durable Execution Evidence**: Live log refs, artifact refs, summaries, diagnostics, and reset/control-boundary refs for ordinary managed task runs.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: OAuth session API tests prove responses include status, timestamps, redacted failure reason, and profile summary when available, with zero secret-like values or raw auth paths.
+- **SC-002**: Managed Codex launch tests prove success metadata includes selected profile ref, credential source, volume ref, auth mount target, workspace Codex home path, readiness, and owning component.
+- **SC-003**: Managed Codex launch failure tests prove validation failure details are sanitized and classified by owning component.
+- **SC-004**: Projection tests prove task execution metadata references logs, artifacts, summaries, diagnostics, and reset/control-boundary refs without presenting auth volumes, runtime homes, or terminal scrollback as artifacts.
+- **SC-005**: Source design coverage for DESIGN-REQ-004, DESIGN-REQ-016, DESIGN-REQ-020, DESIGN-REQ-021, and DESIGN-REQ-022 is mapped to passing verification evidence.

--- a/specs/185-auth-operator-diagnostics/tasks.md
+++ b/specs/185-auth-operator-diagnostics/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Auth Operator Diagnostics
+
+**Input**: `specs/185-auth-operator-diagnostics/spec.md`, `specs/185-auth-operator-diagnostics/plan.md`, `specs/185-auth-operator-diagnostics/research.md`, `specs/185-auth-operator-diagnostics/data-model.md`, `specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md`
+
+## Prerequisites
+
+- Unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
+- Integration command: `./tools/test_integration.sh` when Docker is available
+- Full unit command before verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+
+## Source Traceability
+
+- Jira issue: `MM-336`
+- Story: `STORY-005` from MM-318 breakdown
+- Coverage: FR-001 through FR-007; SC-001 through SC-005; DESIGN-REQ-004, DESIGN-REQ-016, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+- Original preset brief: `docs/tmp/jira-orchestration-inputs/MM-336-moonspec-orchestration-input.md`
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active story artifacts and MM-336 traceability in specs/185-auth-operator-diagnostics/spec.md, specs/185-auth-operator-diagnostics/plan.md, specs/185-auth-operator-diagnostics/research.md, specs/185-auth-operator-diagnostics/data-model.md, and specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md (STORY-005)
+- [X] T002 Confirm focused unit and integration commands from specs/185-auth-operator-diagnostics/quickstart.md are runnable or have exact environment blockers recorded (STORY-005)
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect existing OAuth session, provider profile, managed session activity, and controller projections before writing tests in api_service/api/routers/oauth_sessions.py, api_service/api/schemas_oauth_sessions.py, moonmind/workflows/temporal/activity_runtime.py, and moonmind/workflows/temporal/runtime/managed_session_controller.py (FR-001 through FR-007)
+- [X] T004 Prepare shared test fixtures for sanitized provider profile summaries and auth diagnostics in tests/unit/api_service/api/routers/test_oauth_sessions.py and tests/unit/workflows/temporal/test_agent_runtime_activities.py (SC-001 through SC-003)
+
+## Phase 3: View Safe Auth Diagnostics
+
+Story summary: Project OAuth enrollment, Provider Profile, managed Codex auth materialization, and ordinary task execution diagnostics through safe operator-visible metadata.
+
+Independent test: Simulate successful and failed OAuth enrollment plus successful and failed managed Codex session launch; assert safe status, profile summary, readiness, validation failure, diagnostics refs, and artifact/log pointers are exposed while raw credentials, auth-volume listings, runtime-home contents, and terminal scrollback are omitted.
+
+Traceability IDs: FR-001 through FR-007; SC-001 through SC-005; DESIGN-REQ-004, DESIGN-REQ-016, DESIGN-REQ-020, DESIGN-REQ-021, DESIGN-REQ-022
+
+Unit test plan: write red-first tests for OAuth profile summary projection and managed session auth diagnostics metadata before production code.
+
+Integration test plan: use the real activity/controller boundary with mocked Docker/controller dependencies for deterministic hermetic coverage; run Docker-backed integration runner if available.
+
+- [X] T005 [P] Add failing OAuth session response test for sanitized profile summary and redacted failure fields covering FR-001 FR-002 SC-001 DESIGN-REQ-004 in tests/unit/api_service/api/routers/test_oauth_sessions.py
+- [X] T006 [P] Add failing managed session launch activity test for authDiagnostics success metadata covering FR-003 FR-004 SC-002 DESIGN-REQ-016 DESIGN-REQ-021 in tests/unit/workflows/temporal/test_agent_runtime_activities.py
+- [X] T007 [P] Add failing managed session launch activity test for sanitized validation failure diagnostics covering FR-005 SC-003 DESIGN-REQ-016 DESIGN-REQ-021 in tests/unit/workflows/temporal/test_agent_runtime_activities.py
+- [X] T008 [P] Add managed session controller test asserting durable record/artifact refs remain the execution evidence and auth/runtime homes are not published as artifacts covering FR-006 FR-007 SC-004 DESIGN-REQ-020 DESIGN-REQ-022 in tests/unit/services/temporal/runtime/test_managed_session_controller.py
+- [X] T009 Run red-first focused tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` and record expected failures in specs/185-auth-operator-diagnostics/tasks.md (STORY-005)
+- [X] T010 Implement ProviderProfileSummary schema and OAuth session profile summary projection for FR-001 FR-002 in api_service/api/schemas_oauth_sessions.py and api_service/api/routers/oauth_sessions.py
+- [X] T011 Implement authDiagnostics metadata construction for managed Codex launch success for FR-003 FR-004 in moonmind/workflows/temporal/activity_runtime.py
+- [X] T012 Implement sanitized auth diagnostics failure classification for managed Codex launch failures for FR-005 in moonmind/workflows/temporal/activity_runtime.py
+- [X] T013 Confirm managed-session records/artifact publication continue to expose only logs, summaries, diagnostics, reset/control-boundary refs, and never auth homes as artifacts for FR-006 FR-007 in moonmind/workflows/temporal/runtime/managed_session_controller.py
+- [X] T014 Run focused tests until green with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` and update task evidence in specs/185-auth-operator-diagnostics/tasks.md
+- [X] T015 Run integration verification with `./tools/test_integration.sh` when Docker is available; otherwise record `/var/run/docker.sock` blocker in specs/185-auth-operator-diagnostics/tasks.md
+- [X] T016 Validate MM-336 traceability and source design coverage against specs/185-auth-operator-diagnostics/spec.md and specs/185-auth-operator-diagnostics/contracts/auth-operator-diagnostics.md
+
+## Final Phase: Polish And Verification
+
+- [X] T017 Refactor only story-local code and tests after green validation in files named by specs/185-auth-operator-diagnostics/plan.md
+- [X] T018 Run full unit suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` before final verification for STORY-005
+- [X] T019 Run quickstart validation from specs/185-auth-operator-diagnostics/quickstart.md and record any Docker integration blocker
+- [X] T020 Run final `/moonspec-verify` equivalent for specs/185-auth-operator-diagnostics/spec.md and write verification result in specs/185-auth-operator-diagnostics/verification.md
+
+## Dependencies And Order
+
+- Complete Phase 1 and Phase 2 before red-first story tests.
+- Write and confirm unit/boundary tests fail before implementation tasks.
+- Complete implementation tasks before green validation and final verification.
+- Keep this task list scoped to MM-336 STORY-005.
+
+## Parallel Examples
+
+- T005, T006, T007, and T008 may be authored in parallel because they touch different test concerns.
+- T010 can proceed after T005 red confirmation; T011 and T012 can proceed after T006 and T007 red confirmation.
+
+## Implementation Strategy
+
+- Follow TDD: red unit/boundary tests, production implementation, focused green tests, full unit suite, final `/moonspec-verify`.
+- Preserve `MM-336` and the preset brief in all verification evidence.
+- Treat missing Docker socket as a blocker to record, not a passing integration result.
+
+## Implementation Evidence
+
+- Red unit evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` failed before production changes on missing `profile_summary`, `volumeRef`/`volumeMountPath` profile fields, and missing managed-session `authDiagnostics`.
+- Focused unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` passed with 123 tests.
+- Full unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3247 Python tests, 16 subtests, and 222 frontend tests.
+- Required integration runner blocker: `/var/run/docker.sock` is not present in this managed-agent environment, so `./tools/test_integration.sh` cannot run here.

--- a/specs/185-auth-operator-diagnostics/verification.md
+++ b/specs/185-auth-operator-diagnostics/verification.md
@@ -1,0 +1,39 @@
+# Verification: Auth Operator Diagnostics
+
+Verdict: FULLY_IMPLEMENTED
+
+## Scope
+
+- Jira issue: MM-336
+- Feature spec: `specs/185-auth-operator-diagnostics/spec.md`
+- Preserved source brief: `docs/tmp/jira-orchestration-inputs/MM-336-moonspec-orchestration-input.md`
+- Runtime mode: runtime
+
+## Requirement Coverage
+
+- FR-001 VERIFIED: OAuth session responses expose safe session status, timestamps, terminal transport refs, and redacted failure reason through `OAuthSessionResponse` and `_oauth_session_response`.
+- FR-002 VERIFIED: OAuth session responses include a compact `profile_summary` when a matching Provider Profile exists, excluding secret refs, env templates, file templates, raw volume refs, and raw mount paths.
+- FR-003 VERIFIED: Managed Codex launch activity metadata includes `authDiagnostics` with selected profile ref, runtime/provider IDs, credential source, materialization mode, volume ref, auth mount target, Codex home path, readiness, and owning component.
+- FR-004 VERIFIED: Launch diagnostics tests assert token-like values and raw auth file paths do not appear in metadata.
+- FR-005 VERIFIED: Launch failure handling reports `component=managed_session_controller` and a sanitized reason that redacts token-like values and auth paths.
+- FR-006 VERIFIED: Managed-session controller record tests confirm durable evidence stays in artifact/log/summary/diagnostics refs and does not publish auth homes as artifact refs.
+- FR-007 VERIFIED: OAuth/profile and managed-session diagnostics identify ownership through profile summaries and `component` metadata.
+
+## Source Design Coverage
+
+- DESIGN-REQ-004 VERIFIED through OAuth projection tests and managed-session evidence tests.
+- DESIGN-REQ-016 VERIFIED through managed-session launch success/failure diagnostics tests.
+- DESIGN-REQ-020 VERIFIED through controller record evidence assertions.
+- DESIGN-REQ-021 VERIFIED through `component=managed_session_controller` diagnostics and profile summary ownership.
+- DESIGN-REQ-022 VERIFIED through assertions that auth/runtime homes and OAuth terminal scrollback are not ordinary execution artifact refs.
+
+## Test Evidence
+
+- Red-first focused unit run failed before production changes on missing `profile_summary`, unsupported `volumeRef`/`volumeMountPath` profile fields, and missing `authDiagnostics`.
+- Focused green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` passed with 123 tests.
+- Full unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3247 Python tests, 16 subtests, and 222 frontend tests.
+- Integration runner: NOT RUN. `/var/run/docker.sock` is unavailable in this managed-agent environment, so `./tools/test_integration.sh` cannot start compose-backed integration tests.
+
+## Residual Risk
+
+- Docker-backed integration verification was blocked by the missing Docker socket, but the story's required boundary behavior is covered by focused API/activity/controller unit tests with mocked Docker/controller boundaries.

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -273,6 +273,50 @@ async def test_oauth_session_response_includes_safe_provider_profile_summary(
 
 
 @pytest.mark.asyncio
+async def test_oauth_session_response_omits_profile_summary_for_other_owner(
+    client_app: AsyncClient, _module_db
+) -> None:
+    session_id = "oas_profilesummary2"
+    profile_id = "codex-cli-profile-other-owner"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                provider_label="Other Owner",
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                account_label="other owner account",
+                owner_user_id=uuid.uuid4(),
+            )
+        )
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                status=OAuthSessionStatus.SUCCEEDED,
+                requested_by_user_id="None",
+            )
+        )
+        await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/oauth-sessions/{session_id}")
+
+    assert response.status_code == 200
+    assert response.json()["profile_summary"] is None
+    assert "Other Owner" not in response.text
+    assert "other owner account" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_create_codex_oauth_session_uses_configured_volume_defaults(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/api_service/api/routers/test_oauth_sessions.py
+++ b/tests/unit/api_service/api/routers/test_oauth_sessions.py
@@ -206,6 +206,73 @@ async def test_oauth_session_response_redacts_secret_like_failure_reason(
 
 
 @pytest.mark.asyncio
+async def test_oauth_session_response_includes_safe_provider_profile_summary(
+    client_app: AsyncClient, _module_db
+) -> None:
+    session_id = "oas_profilesummary1"
+    profile_id = "codex-cli-profile-summary"
+    raw_secret = "sk-test-profile-summary-secret"
+
+    async with db_base.async_session_maker() as session:
+        session.add(
+            ManagedAgentProviderProfile(
+                profile_id=profile_id,
+                runtime_id="codex_cli",
+                provider_id="openai",
+                provider_label="OpenAI",
+                credential_source=ProviderCredentialSource.OAUTH_VOLUME,
+                runtime_materialization_mode=RuntimeMaterializationMode.OAUTH_HOME,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                account_label="codex account",
+                secret_refs={"provider_api_key": "env://OPENAI_API_KEY"},
+                env_template={"OPENAI_API_KEY": raw_secret},
+                enabled=True,
+                is_default=True,
+            )
+        )
+        session.add(
+            ManagedAgentOAuthSession(
+                session_id=session_id,
+                runtime_id="codex_cli",
+                profile_id=profile_id,
+                volume_ref="codex_auth_volume",
+                volume_mount_path="/home/app/.codex",
+                account_label="codex account",
+                status=OAuthSessionStatus.FAILED,
+                requested_by_user_id="None",
+                failure_reason=f"token={raw_secret} in /home/app/.codex/auth.json",
+            )
+        )
+        await session.commit()
+
+    async with client_app as client:
+        response = await client.get(f"/api/v1/oauth-sessions/{session_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert raw_secret not in response.text
+    assert "/home/app/.codex/auth.json" not in response.text
+    assert payload["failure_reason"] == "token=[REDACTED] in [REDACTED_AUTH_PATH]"
+    assert payload["profile_summary"] == {
+        "profile_id": profile_id,
+        "runtime_id": "codex_cli",
+        "provider_id": "openai",
+        "provider_label": "OpenAI",
+        "credential_source": "oauth_volume",
+        "runtime_materialization_mode": "oauth_home",
+        "account_label": "codex account",
+        "enabled": True,
+        "is_default": True,
+        "rate_limit_policy": "backoff",
+    }
+    assert "secret_refs" not in payload["profile_summary"]
+    assert "env_template" not in payload["profile_summary"]
+    assert "volume_ref" not in payload["profile_summary"]
+    assert "volume_mount_path" not in payload["profile_summary"]
+
+
+@pytest.mark.asyncio
 async def test_create_codex_oauth_session_uses_configured_volume_defaults(
     client_app: AsyncClient, _module_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -190,6 +190,82 @@ async def test_controller_launches_container_and_returns_typed_handle(
 
 
 @pytest.mark.asyncio
+async def test_controller_record_keeps_auth_and_runtime_homes_out_of_artifact_refs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_NETWORK", raising=False)
+    monkeypatch.delenv("MOONMIND_DOCKER_NETWORK", raising=False)
+    workspace_root = tmp_path / "agent_jobs"
+    session_store = ManagedSessionStore(tmp_path / "session-store")
+    session_supervisor = AsyncMock()
+    session_supervisor.emit_session_event = Mock()
+    request = LaunchCodexManagedSessionRequest(
+        taskRunId="task-auth-evidence",
+        sessionId="sess-auth-evidence",
+        threadId="logical-thread-1",
+        workspacePath=str(workspace_root / "task-auth-evidence" / "repo"),
+        sessionWorkspacePath=str(workspace_root / "task-auth-evidence" / "session"),
+        artifactSpoolPath=str(workspace_root / "task-auth-evidence" / "artifacts"),
+        codexHomePath=str(
+            workspace_root / "task-auth-evidence" / ".moonmind" / "codex-home"
+        ),
+        imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+        environment={"MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth"},
+    )
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            return 0, "ctr-auth-evidence\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": request.session_id,
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-auth-evidence",
+                    "threadId": request.thread_id,
+                },
+                "status": "ready",
+                "imageRef": request.image_ref,
+                "controlUrl": "docker-exec://mm-codex-session-sess-auth-evidence",
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        session_store=session_store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    await controller.launch_session(request)
+
+    stored = session_store.load("sess-auth-evidence")
+    assert stored is not None
+    assert stored.published_artifact_refs() == ()
+    record_payload = stored.model_dump(mode="json", by_alias=True)
+    assert record_payload["artifactSpoolPath"].endswith(
+        "task-auth-evidence/artifacts"
+    )
+    assert "MANAGED_AUTH_VOLUME_PATH" not in json.dumps(record_payload)
+    assert ".codex-auth" not in json.dumps(record_payload)
+    assert "codex-home" not in json.dumps(stored.published_artifact_refs())
+
+
+@pytest.mark.asyncio
 async def test_controller_uses_request_moonmind_url_for_docker_network(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -730,6 +730,56 @@ async def test_launch_session_returns_safe_auth_diagnostics_metadata(
     assert "token=" not in str(result.metadata)
 
 
+async def test_launch_session_accepts_mapping_response_before_auth_diagnostics(
+    tmp_path: Path,
+) -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value={
+            "sessionState": {
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            "status": "ready",
+            "imageRef": "moonmind:latest",
+            "metadata": {"vendorThreadId": "vendor-thread-1"},
+        }
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+    codex_home_path = tmp_path / "task-1" / ".moonmind" / "codex-home"
+
+    result = await activities.agent_runtime_launch_session(
+        {
+            "request": {
+                "taskRunId": "task-1",
+                "sessionId": "sess-1",
+                "threadId": "thread-1",
+                "workspacePath": str(tmp_path / "task-1" / "repo"),
+                "sessionWorkspacePath": str(tmp_path / "task-1" / "session"),
+                "artifactSpoolPath": str(tmp_path / "task-1" / "artifacts"),
+                "codexHomePath": str(codex_home_path),
+                "imageRef": "moonmind:latest",
+            },
+            "profile": {
+                "runtimeId": "codex_cli",
+                "profileId": "codex-oauth",
+                "providerId": "openai",
+                "credentialSource": "oauth_volume",
+                "runtimeMaterializationMode": "oauth_home",
+                "volumeRef": "codex_auth_volume",
+                "volumeMountPath": "/home/app/.codex-auth",
+            },
+        }
+    )
+
+    assert isinstance(result, CodexManagedSessionHandle)
+    assert result.metadata["vendorThreadId"] == "vendor-thread-1"
+    assert result.metadata["authDiagnostics"]["profileRef"] == "codex-oauth"
+    assert result.metadata["authDiagnostics"]["readiness"] == "ready"
+
+
 async def test_launch_session_failure_reports_sanitized_auth_diagnostics(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -667,6 +667,118 @@ async def test_launch_session_materializes_profile_into_request_environment(
     )
 
 
+async def test_launch_session_returns_safe_auth_diagnostics_metadata(
+    tmp_path: Path,
+) -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        return_value=CodexManagedSessionHandle(
+            sessionState={
+                "sessionId": "sess-1",
+                "sessionEpoch": 1,
+                "containerId": "ctr-1",
+                "threadId": "thread-1",
+            },
+            status="ready",
+            imageRef="moonmind:latest",
+            metadata={"vendorThreadId": "vendor-thread-1"},
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+    codex_home_path = tmp_path / "task-1" / ".moonmind" / "codex-home"
+
+    result = await activities.agent_runtime_launch_session(
+        {
+            "request": {
+                "taskRunId": "task-1",
+                "sessionId": "sess-1",
+                "threadId": "thread-1",
+                "workspacePath": str(tmp_path / "task-1" / "repo"),
+                "sessionWorkspacePath": str(tmp_path / "task-1" / "session"),
+                "artifactSpoolPath": str(tmp_path / "task-1" / "artifacts"),
+                "codexHomePath": str(codex_home_path),
+                "imageRef": "moonmind:latest",
+                "environment": {"MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth"},
+            },
+            "profile": {
+                "runtimeId": "codex_cli",
+                "profileId": "codex-oauth",
+                "providerId": "openai",
+                "credentialSource": "oauth_volume",
+                "runtimeMaterializationMode": "oauth_home",
+                "volumeRef": "codex_auth_volume",
+                "volumeMountPath": "/home/app/.codex-auth",
+            },
+        }
+    )
+
+    diagnostics = result.metadata["authDiagnostics"]
+    assert result.metadata["vendorThreadId"] == "vendor-thread-1"
+    assert diagnostics == {
+        "component": "managed_session_controller",
+        "readiness": "ready",
+        "profileRef": "codex-oauth",
+        "runtimeId": "codex_cli",
+        "providerId": "openai",
+        "credentialSource": "oauth_volume",
+        "runtimeMaterializationMode": "oauth_home",
+        "volumeRef": "codex_auth_volume",
+        "authMountTarget": "/home/app/.codex-auth",
+        "codexHomePath": str(codex_home_path),
+    }
+    assert "auth.json" not in str(result.metadata)
+    assert "token=" not in str(result.metadata)
+
+
+async def test_launch_session_failure_reports_sanitized_auth_diagnostics(
+    tmp_path: Path,
+) -> None:
+    controller = AsyncMock()
+    controller.launch_session = AsyncMock(
+        side_effect=RuntimeError(
+            "MANAGED_AUTH_VOLUME_PATH /home/app/.codex-auth/auth.json token=sk-test-secret failed"
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(session_controller=controller)
+
+    with pytest.raises(
+        TemporalActivityRuntimeError,
+        match="component=managed_session_controller",
+    ) as exc_info:
+        await activities.agent_runtime_launch_session(
+            {
+                "request": {
+                    "taskRunId": "task-1",
+                    "sessionId": "sess-1",
+                    "threadId": "thread-1",
+                    "workspacePath": str(tmp_path / "task-1" / "repo"),
+                    "sessionWorkspacePath": str(tmp_path / "task-1" / "session"),
+                    "artifactSpoolPath": str(tmp_path / "task-1" / "artifacts"),
+                    "codexHomePath": str(
+                        tmp_path / "task-1" / ".moonmind" / "codex-home"
+                    ),
+                    "imageRef": "moonmind:latest",
+                    "environment": {"MANAGED_AUTH_VOLUME_PATH": "/home/app/.codex-auth"},
+                },
+                "profile": {
+                    "runtimeId": "codex_cli",
+                    "profileId": "codex-oauth",
+                    "providerId": "openai",
+                    "credentialSource": "oauth_volume",
+                    "runtimeMaterializationMode": "oauth_home",
+                    "volumeRef": "codex_auth_volume",
+                    "volumeMountPath": "/home/app/.codex-auth",
+                },
+            }
+        )
+
+    message = str(exc_info.value)
+    assert "sk-test-secret" not in message
+    assert "/home/app/.codex-auth/auth.json" not in message
+    assert "[REDACTED]" in message
+    assert "[REDACTED_AUTH_PATH]" in message
+
+
 async def test_launch_session_rejects_structured_secret_ref_values(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Jira Issue
MM-336

## Active MoonSpec Feature Path
specs/185-auth-operator-diagnostics

## Verification Verdict
FULLY_IMPLEMENTED

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api_service/api/routers/test_oauth_sessions.py tests/unit/workflows/temporal/test_agent_runtime_activities.py tests/unit/services/temporal/runtime/test_managed_session_controller.py` - passed, 123 tests.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - passed, 3247 Python tests, 16 subtests, and 222 frontend tests.
- `./tools/test_integration.sh` - not run because `/var/run/docker.sock` is unavailable in this managed runtime.

## Remaining Risks
Docker-backed hermetic integration tests were blocked by the missing Docker socket in the agent container. The changed API, activity, and controller boundaries are covered by focused unit tests and the full unit suite.