### PR TITLE
[codex] Fix Jira agent skill selection

### DIFF
--- a/moonmind/workflows/adapters/codex_session_adapter.py
+++ b/moonmind/workflows/adapters/codex_session_adapter.py
@@ -49,6 +49,7 @@ from moonmind.workflows.adapters.managed_agent_adapter import (
     build_managed_profile_launch_context,
     default_credential_source_for_runtime,
 )
+from moonmind.workflows.agent_skills.selection import selected_agent_skill
 from moonmind.workflows.codex_session_timeouts import (
     MAX_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS,
 )
@@ -127,18 +128,12 @@ def _clamp_agent_run_result_summary(summary: Any, *, default: str) -> str:
     return truncated or normalized[:_MAX_AGENT_RUN_RESULT_SUMMARY_CHARS]
 
 
-def _selected_agent_skill(parameters: Mapping[str, Any] | None) -> str:
-    if not isinstance(parameters, Mapping):
-        return ""
-    return str(parameters.get("selectedSkill") or "").strip().lower()
-
-
 def _jira_issue_creator_blocker_summary(
     *,
     parameters: Mapping[str, Any] | None,
     assistant_text: str,
 ) -> str | None:
-    if _selected_agent_skill(parameters) != "jira-issue-creator":
+    if selected_agent_skill(parameters) != "jira-issue-creator":
         return None
     normalized = " ".join(str(assistant_text or "").lower().split())
     if not normalized:

--- a/moonmind/workflows/agent_skills/selection.py
+++ b/moonmind/workflows/agent_skills/selection.py
@@ -1,0 +1,26 @@
+"""Helpers for reading selected agent-skill metadata from runtime payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def selected_agent_skill(parameters: Mapping[str, Any] | None) -> str:
+    """Return the selected agent skill from supported request metadata shapes."""
+
+    if not isinstance(parameters, Mapping):
+        return ""
+
+    metadata = parameters.get("metadata")
+    metadata_map = metadata if isinstance(metadata, Mapping) else {}
+    moonmind = metadata_map.get("moonmind")
+    moonmind_map = moonmind if isinstance(moonmind, Mapping) else {}
+
+    selected = (
+        moonmind_map.get("selectedSkill")
+        or metadata_map.get("selectedSkill")
+        or parameters.get("selectedSkill")
+        or ""
+    )
+    return str(selected).strip().lower()

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -44,6 +44,7 @@ from moonmind.workflows.adapters.codex_cloud_agent_adapter import CodexCloudAgen
 from moonmind.workflows.adapters.codex_cloud_client import CodexCloudClient as CodexCloudHttpClient
 from moonmind.codex_cloud.settings import build_codex_cloud_gate, CODEX_CLOUD_DISABLED_MESSAGE
 from moonmind.workflows.adapters.jules_client import JulesClient
+from moonmind.workflows.agent_skills.selection import selected_agent_skill
 
 
 from moonmind.schemas.agent_runtime_models import (
@@ -3295,8 +3296,7 @@ class TemporalAgentRuntimeActivities:
         parameters: Mapping[str, Any] | None,
     ) -> str:
         params = parameters if isinstance(parameters, Mapping) else {}
-        selected_skill = str(params.get("selectedSkill") or "").strip().lower()
-        if selected_skill != "jira-issue-creator":
+        if selected_agent_skill(params) != "jira-issue-creator":
             return instructions
         if "MoonMind trusted Jira tools" in instructions:
             return instructions

--- a/tests/unit/workflows/adapters/test_codex_session_adapter.py
+++ b/tests/unit/workflows/adapters/test_codex_session_adapter.py
@@ -730,7 +730,16 @@ async def test_start_fails_jira_issue_creator_when_no_issues_created(
         session_image_ref="ghcr.io/moonladderstudios/moonmind:latest",
     )
     request = _request(binding, workspace_path=str(workspace_path))
-    request.parameters["selectedSkill"] = "jira-issue-creator"
+    request.parameters["metadata"] = {
+        "moonmind": {
+            "selectedSkill": "jira-issue-creator",
+            "stepLedger": {
+                "logicalStepId": "tpl:jira-breakdown:1.0.0:02:demo",
+                "attempt": 1,
+                "scope": "step",
+            },
+        },
+    }
 
     with pytest.raises(CodexSessionRunFailedError) as exc_info:
         await adapter.start(request)

--- a/tests/unit/workflows/temporal/test_agent_runtime_activities.py
+++ b/tests/unit/workflows/temporal/test_agent_runtime_activities.py
@@ -1727,7 +1727,24 @@ async def test_agent_runtime_prepare_turn_instructions_injects_context(
 
 
 @pytest.mark.asyncio
-async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint() -> None:
+@pytest.mark.parametrize(
+    "skill_parameters",
+    [
+        {
+            "selectedSkill": "jira-issue-creator",
+        },
+        {
+            "metadata": {
+                "moonmind": {
+                    "selectedSkill": "jira-issue-creator",
+                },
+            },
+        },
+    ],
+)
+async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint(
+    skill_parameters: dict[str, Any],
+) -> None:
     activities = TemporalAgentRuntimeActivities()
 
     result = await activities.agent_runtime_prepare_turn_instructions(
@@ -1739,9 +1756,9 @@ async def test_agent_runtime_prepare_turn_instructions_adds_jira_tool_hint() -> 
                 "idempotencyKey": "idem-1",
                 "parameters": {
                     "instructions": "Create Jira stories from the breakdown.",
-                    "selectedSkill": "jira-issue-creator",
                     "publishMode": "none",
                     "storyBreakdownPath": "docs/tmp/story-breakdowns/demo/stories.json",
+                    **skill_parameters,
                 },
             },
         }


### PR DESCRIPTION
## Summary

Fixes the Jira agent-runtime path so `jira-issue-creator` is detected from the canonical step metadata shape under `metadata.moonmind.selectedSkill`, while preserving support for the older top-level `selectedSkill` shape.

## Root Cause

The workflow carried the selected skill under `parameters.metadata.moonmind.selectedSkill`, but the Codex session adapter and prepare-turn activity only checked `parameters.selectedSkill`. As a result, Jira runs missed the trusted Jira tool instructions and blocked Jira output was not classified as an execution failure.

## Changes

- Add a shared `selected_agent_skill` helper for supported runtime payload shapes.
- Use that helper when appending trusted Jira tool instructions.
- Use that helper when classifying blocked Jira issue creation as `execution_error`.
- Extend unit coverage for both selected-skill payload shapes.

## Validation

- `./tools/test_unit.sh`
  - Python: `3243 passed, 1 xpassed`
  - Frontend: `10 passed`, `221 tests`

## Operational Follow-up

The five missing Jira stories from workflow `mm:04fea70d-d1e9-473d-b101-5d86ad2bc7c2` were manually created as `MM-350` through `MM-354`.