### PR TITLE
MM-360 Workload Auth-Volume Guardrails

### DIFF
--- a/docs/tmp/jira-orchestration-inputs/MM-360-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-360-moonspec-orchestration-input.md
@@ -1,0 +1,80 @@
+# MM-360 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-360
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Workload Auth-Volume Guardrails
+- Labels: `mm-318`, `moonspec-breakdown`, `oauth-terminal`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-360 from MM project
+Summary: Workload Auth-Volume Guardrails
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-360 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-360: Workload Auth-Volume Guardrails
+
+MoonSpec Story ID: STORY-006
+
+Short Name
+workload-auth-guardrails
+
+User Story
+As a security reviewer, I can verify that Docker-backed workload containers launched near managed sessions do not implicitly inherit managed-runtime auth volumes.
+
+Acceptance Criteria
+- A workload launch requested from a managed Codex session inherits no managed-runtime auth volume by default.
+- Ordinary workspace/cache workload mounts proceed without auth volumes.
+- Credential mounts without explicit approval are rejected with policy metadata.
+- Mission Control and APIs do not present workload containers as the managed Codex session identity.
+
+Requirements
+- Enforce workload profile mount allowlists.
+- Reject implicit managed-runtime auth-volume inheritance.
+- Require explicit justification/profile declaration for any credential mount.
+- Keep workload containers separate from managed session identity fields.
+
+Independent Test
+Launch workload profiles from a simulated managed-session-assisted step and assert auth-volume mounts are rejected unless explicitly declared by approved workload policy.
+
+Dependencies
+- None specified.
+
+Risks
+- Approved credential mount policy should stay narrow enough for future workload-specific exceptions.
+
+Out of Scope
+- Managed Codex session container launch itself.
+- OAuth terminal enrollment.
+- Specialized workload runner internals beyond mount policy.
+
+Source Document
+docs/ManagedAgents/OAuthTerminal.md
+
+Source Sections
+- 2. Scope
+- 4. Volume Targeting Rules
+- 9. Security Model
+- 11. Required Boundaries
+
+Coverage IDs
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-020
+
+Source Design Coverage
+- DESIGN-REQ-009: Do not make Docker workload containers inherit managed-runtime auth volumes by default.
+- DESIGN-REQ-010: Never place raw credential contents in workflow history, logs, artifacts, or UI responses.
+- DESIGN-REQ-020: Preserve ownership boundaries among OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-360-report.md
+++ b/docs/tmp/jira-orchestration-reports/MM-360-report.md
@@ -1,0 +1,47 @@
+# Jira Orchestration Report: MM-360
+
+## Summary
+
+- Jira issue key: `MM-360`
+- Final Jira status: `Code Review`
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1497
+- Feature path: `specs/184-workload-auth-guardrails`
+
+## Stage Outcomes
+
+| Stage | Outcome |
+| --- | --- |
+| Jira In Progress | PASS - `MM-360` was moved to `In Progress` before implementation work. |
+| Jira brief loading | PASS - trusted `jira.get_issue` output was converted into `docs/tmp/jira-orchestration-inputs/MM-360-moonspec-orchestration-input.md`. |
+| Specify/Breakdown | PASS - classified as a single-story Jira preset brief; existing `specs/184-workload-auth-guardrails/spec.md` was aligned instead of running breakdown. |
+| Plan | PASS - `plan.md`, `research.md`, `quickstart.md`, `data-model.md`, and `contracts/workload-auth-guardrails.md` exist and preserve `MM-360` traceability. |
+| Tasks | PASS - `tasks.md` covers one story with red-first unit tests, integration tests, implementation tasks, story validation, and final `/moonspec-verify`. |
+| Align | PASS - conservative artifact alignment added explicit `SC-002` and `SC-003` task traceability; no downstream regeneration required. |
+| Implement | PASS - implementation tasks were already complete and marked `[X]`; story scope remained `Workload Auth-Volume Guardrails`. |
+| Verify | FULLY_IMPLEMENTED - focused unit and story integration checks passed; full Docker compose integration runner was blocked by missing Docker socket. |
+| PR creation | PASS - PR #1497 was created for branch `mm-360-156e66b4`. |
+| Jira Code Review | PASS - trusted Jira transition matched `Code Review` to transition ID `51`, then re-fetch confirmed final status `Code Review`. |
+
+## Files Changed
+
+- `docs/tmp/jira-orchestration-inputs/MM-360-moonspec-orchestration-input.md`
+- `specs/184-workload-auth-guardrails/spec.md`
+- `specs/184-workload-auth-guardrails/plan.md`
+- `specs/184-workload-auth-guardrails/research.md`
+- `specs/184-workload-auth-guardrails/data-model.md`
+- `specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md`
+- `specs/184-workload-auth-guardrails/quickstart.md`
+- `specs/184-workload-auth-guardrails/tasks.md`
+- `specs/184-workload-auth-guardrails/checklists/requirements.md`
+- `specs/184-workload-auth-guardrails/verification.md`
+- `docs/tmp/jira-orchestration-reports/MM-360-report.md`
+
+## Tests Run
+
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` - PASS, 69 tests.
+- `pytest tests/integration/services/temporal/workflows/test_agent_run.py -m integration_ci -k workload_auth_volume_guardrails -q --tb=short` - PASS, 1 test.
+- `./tools/test_integration.sh` - BLOCKED, Docker socket unavailable at `/var/run/docker.sock`.
+
+## Remaining Risks
+
+- Full compose-backed integration verification still requires a Docker-enabled environment.

--- a/specs/184-workload-auth-guardrails/checklists/requirements.md
+++ b/specs/184-workload-auth-guardrails/checklists/requirements.md
@@ -37,5 +37,5 @@
 ## Notes
 
 - Runtime mode selected.
-- `MM-318` and the original preset brief are preserved in `spec.md` Input.
-- This spec covers one isolated generated story from the MM-318 breakdown.
+- `MM-360` and the original preset brief are preserved in `spec.md` Input.
+- This spec covers one isolated generated story from the MM-360 Jira preset brief.

--- a/specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md
+++ b/specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md
@@ -2,11 +2,11 @@
 
 ## Story Boundary
 
-Source story: `STORY-006` from `docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthterminal-md/stories.json`.
+Source story: `STORY-006` from Jira issue `MM-360` and source design `docs/ManagedAgents/OAuthTerminal.md`.
 
 ## Inputs
 
-- Jira traceability: `MM-318` and preset brief `MM-318: breakdown docs\ManagedAgents\OAuthTerminal.md`.
+- Jira traceability: `MM-360` and preset brief `MM-360: Workload Auth-Volume Guardrails`.
 - Source design coverage: DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-020.
 - Dependency requirements: None.
 

--- a/specs/184-workload-auth-guardrails/data-model.md
+++ b/specs/184-workload-auth-guardrails/data-model.md
@@ -23,6 +23,6 @@
 
 ## Cross-Cutting Rules
 
-- Preserve Jira issue key `MM-318` as traceability metadata in generated artifacts.
+- Preserve Jira issue key `MM-360` as traceability metadata in generated artifacts.
 - Never model raw credential contents, token values, private keys, environment dumps, or raw auth-volume listings as persisted or browser-visible fields.
 - Prefer compact refs and explicit status values over provider-shaped dictionaries.

--- a/specs/184-workload-auth-guardrails/plan.md
+++ b/specs/184-workload-auth-guardrails/plan.md
@@ -4,7 +4,7 @@
 
 ## Input
 
-Single-story feature specification from `specs/184-workload-auth-guardrails/spec.md` generated from Jira issue `MM-318` and the preserved preset brief `MM-318: breakdown docs\ManagedAgents\OAuthTerminal.md`.
+Single-story feature specification from `specs/184-workload-auth-guardrails/spec.md` generated from Jira issue `MM-360` and the preserved preset brief `MM-360: Workload Auth-Volume Guardrails`.
 
 ## Summary
 
@@ -20,7 +20,7 @@ This story implements workload mount policy and managed-session identity separat
 - Target platform: MoonMind API service, Temporal worker/runtime services, managed Codex session containers, and Mission Control where applicable.
 - Project type: backend orchestration/runtime with optional browser surface for OAuth terminal flow.
 - Performance goals: validation and serialization must be deterministic and low-overhead relative to existing workflow/API calls.
-- Constraints: preserve `MM-318` traceability; keep raw credential contents out of workflow history, browser responses, logs, and artifacts; fail fast for unsupported or unsafe runtime values.
+- Constraints: preserve `MM-360` traceability; keep raw credential contents out of workflow history, browser responses, logs, and artifacts; fail fast for unsupported or unsafe runtime values.
 - Scale/scope: one independently testable story, dependencies: None.
 
 ## Constitution Check

--- a/specs/184-workload-auth-guardrails/quickstart.md
+++ b/specs/184-workload-auth-guardrails/quickstart.md
@@ -34,7 +34,7 @@ Expected result: hermetic integration coverage passes in a Docker-enabled enviro
 
 ## End-To-End Story Check
 
-1. Confirm `spec.md` preserves `MM-318` and the original preset brief.
+1. Confirm `spec.md` preserves `MM-360` and the original preset brief.
 2. Confirm `plan.md`, `research.md`, `data-model.md`, `contracts/`, and `quickstart.md` exist.
 3. Confirm unit and integration test strategies remain separate.
 4. After implementation, run `/moonspec-verify` equivalent against `specs/184-workload-auth-guardrails/spec.md`.

--- a/specs/184-workload-auth-guardrails/research.md
+++ b/specs/184-workload-auth-guardrails/research.md
@@ -10,7 +10,7 @@ Alternatives considered: Creating new subsystems or compatibility wrappers was r
 
 Decision: Use focused pytest coverage through `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py`.
 Rationale: Unit tests can prove validation, serialization, redaction, policy, and state behavior without requiring Docker credentials or external providers.
-Alternatives considered: Provider verification tests were rejected for this planning phase because MM-318 requires deterministic local evidence first.
+Alternatives considered: Provider verification tests were rejected for this planning phase because MM-360 requires deterministic local evidence first.
 
 ## Integration Test Strategy
 
@@ -20,6 +20,6 @@ Alternatives considered: Skipping integration was rejected; only local execution
 
 ## Source Design Coverage
 
-Decision: Preserve in-scope source coverage IDs `DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-020` and keep all other MM-318 stories out of scope for this spec.
+Decision: Preserve in-scope source coverage IDs `DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-020` and keep all other OAuthTerminal stories out of scope for this spec.
 Rationale: Each generated spec must remain a single independently testable story while still preserving traceability to the broad OAuthTerminal design.
 Alternatives considered: Combining stories was rejected because it would violate the one-story MoonSpec gate.

--- a/specs/184-workload-auth-guardrails/spec.md
+++ b/specs/184-workload-auth-guardrails/spec.md
@@ -6,20 +6,71 @@
 **Input**:
 
 ```text
-Jira issue: MM-318 from MM board
-Summary: breakdown docs\ManagedAgents\OAuthTerminal.md
+Jira issue: MM-360 from MM project
+Summary: Workload Auth-Volume Guardrails
 Issue type: Story
 Current Jira status: In Progress
 Jira project key: MM
 
-Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-318 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-360 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
 
-MM-318: breakdown docs\ManagedAgents\OAuthTerminal.md
+MM-360: Workload Auth-Volume Guardrails
 
-Selected generated story: STORY-006 Workload Auth-Volume Guardrails
-Dependencies: None
-Breakdown JSON: docs/tmp/story-breakdowns/mm-318-breakdown-docs-managedagents-oauthterminal-md/stories.json
-Source design: docs/ManagedAgents/OAuthTerminal.md
+MoonSpec Story ID: STORY-006
+
+Short Name
+workload-auth-guardrails
+
+User Story
+As a security reviewer, I can verify that Docker-backed workload containers launched near managed sessions do not implicitly inherit managed-runtime auth volumes.
+
+Acceptance Criteria
+- A workload launch requested from a managed Codex session inherits no managed-runtime auth volume by default.
+- Ordinary workspace/cache workload mounts proceed without auth volumes.
+- Credential mounts without explicit approval are rejected with policy metadata.
+- Mission Control and APIs do not present workload containers as the managed Codex session identity.
+
+Requirements
+- Enforce workload profile mount allowlists.
+- Reject implicit managed-runtime auth-volume inheritance.
+- Require explicit justification/profile declaration for any credential mount.
+- Keep workload containers separate from managed session identity fields.
+
+Independent Test
+Launch workload profiles from a simulated managed-session-assisted step and assert auth-volume mounts are rejected unless explicitly declared by approved workload policy.
+
+Dependencies
+- None specified.
+
+Risks
+- Approved credential mount policy should stay narrow enough for future workload-specific exceptions.
+
+Out of Scope
+- Managed Codex session container launch itself.
+- OAuth terminal enrollment.
+- Specialized workload runner internals beyond mount policy.
+
+Source Document
+docs/ManagedAgents/OAuthTerminal.md
+
+Source Sections
+- 2. Scope
+- 4. Volume Targeting Rules
+- 9. Security Model
+- 11. Required Boundaries
+
+Coverage IDs
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-020
+
+Source Design Coverage
+- DESIGN-REQ-009: Do not make Docker workload containers inherit managed-runtime auth volumes by default.
+- DESIGN-REQ-010: Never place raw credential contents in workflow history, logs, artifacts, or UI responses.
+- DESIGN-REQ-020: Preserve ownership boundaries among OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration.
+
+Needs Clarification
+- None
 ```
 
 ## User Story - Workload Auth-Volume Guardrails
@@ -56,7 +107,7 @@ Launch workload profiles from a simulated managed-session-assisted step and asse
 - **FR-002**: The system MUST reject implicit managed-runtime auth-volume inheritance.
 - **FR-003**: The system MUST require explicit justification/profile declaration for any credential mount.
 - **FR-004**: The system MUST keep workload containers separate from managed session identity fields.
-- **FR-005**: The spec artifacts MUST retain Jira issue key MM-318 and the original preset brief so final verification can compare against the originating Jira request.
+- **FR-005**: The spec artifacts MUST retain Jira issue key MM-360 and the original preset brief so final verification can compare against the originating Jira request.
 
 ## Source Design Requirements
 

--- a/specs/184-workload-auth-guardrails/tasks.md
+++ b/specs/184-workload-auth-guardrails/tasks.md
@@ -10,13 +10,13 @@
 
 ## Source Traceability
 
-- Story: `STORY-006` from MM-318 breakdown
+- Story: `STORY-006` from MM-360 Jira preset brief
 - Coverage: FR-001 through FR-005; DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-020
-- Original preset brief: `MM-318: breakdown docs\ManagedAgents\OAuthTerminal.md`
+- Original preset brief: `MM-360: Workload Auth-Volume Guardrails`
 
 ## Phase 1: Setup
 
-- [X] T001 Confirm active story artifacts and MM-318 traceability in specs/184-workload-auth-guardrails/spec.md, specs/184-workload-auth-guardrails/plan.md, specs/184-workload-auth-guardrails/research.md, specs/184-workload-auth-guardrails/data-model.md, and specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md (STORY-006)
+- [X] T001 Confirm active story artifacts and MM-360 traceability in specs/184-workload-auth-guardrails/spec.md, specs/184-workload-auth-guardrails/plan.md, specs/184-workload-auth-guardrails/research.md, specs/184-workload-auth-guardrails/data-model.md, and specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md (STORY-006)
 - [X] T002 Confirm focused unit and integration commands from specs/184-workload-auth-guardrails/quickstart.md are runnable or have exact environment blockers recorded (STORY-006)
 
 ## Phase 2: Foundational
@@ -46,7 +46,7 @@ Integration test plan: write red-first hermetic integration tests for the real A
 - [X] T012 Implement workload identity separation and secret-free result metadata for FR-004 FR-005 in moonmind/workloads/docker_launcher.py
 - [X] T013 Run focused unit tests until green with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` and update task evidence in specs/184-workload-auth-guardrails/tasks.md
 - [X] T014 Run integration verification with `./tools/test_integration.sh` when Docker is available; required coverage target: `tests/integration/services/temporal/workflows/test_agent_run.py`; update task evidence in specs/184-workload-auth-guardrails/tasks.md
-- [X] T015 Validate the single-story acceptance scenarios and MM-318 traceability against specs/184-workload-auth-guardrails/spec.md and specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md
+- [X] T015 Validate the single-story acceptance scenarios and MM-360 traceability against specs/184-workload-auth-guardrails/spec.md and specs/184-workload-auth-guardrails/contracts/workload-auth-guardrails.md
 
 ## Final Phase: Polish And Verification
 
@@ -60,7 +60,7 @@ Integration test plan: write red-first hermetic integration tests for the real A
 - Complete Phase 1 and Phase 2 before writing red-first story tests.
 - Write and confirm unit and integration tests fail before implementation tasks.
 - Complete implementation tasks before green validation and final verification.
-- Keep this task list scoped to exactly one story; do not implement other MM-318 generated specs here.
+- Keep this task list scoped to exactly one story; do not implement other OAuthTerminal-generated specs here.
 
 ## Parallel Examples
 
@@ -70,14 +70,14 @@ Integration test plan: write red-first hermetic integration tests for the real A
 ## Implementation Strategy
 
 - Follow TDD: red unit tests, red integration tests, production implementation, focused green tests, full unit suite, final `/moonspec-verify`.
-- Preserve `MM-318` and the preset brief in all verification evidence.
+- Preserve `MM-360` and the preset brief in all verification evidence.
 - Treat missing Docker socket as a blocker to record, not a passing integration result.
 
 ## Implementation Evidence
 
 - Red unit evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` failed before production changes on missing `credentialMounts` support and missing workload `identityKind` metadata.
 - Red integration evidence: `pytest tests/integration/services/temporal/workflows/test_agent_run.py -k workload_auth_volume_guardrails -q --tb=short` failed before production changes on missing `credentialMounts` support.
-- Focused unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` passed with 68 tests.
+- Focused unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` passed with 69 tests after MM-360 traceability alignment.
 - Focused integration green: `pytest tests/integration/services/temporal/workflows/test_agent_run.py -m integration_ci -k workload_auth_volume_guardrails -q --tb=short` passed with 1 test.
 - Full unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3202 Python tests, 16 subtests, and 221 frontend tests.
 - Required integration runner blocker: `./tools/test_integration.sh` could not connect to `/var/run/docker.sock`; Docker-backed compose verification was not available in this managed-agent environment.

--- a/specs/184-workload-auth-guardrails/tasks.md
+++ b/specs/184-workload-auth-guardrails/tasks.md
@@ -36,7 +36,7 @@ Unit test plan: write red-first unit tests for validation, serialization, redact
 
 Integration test plan: write red-first hermetic integration tests for the real API/workflow/runtime/container/UI boundary before production code when Docker/browser services are available.
 
-- [X] T005 [P] Add failing unit test for mount allowlist and credential mount declaration validation for FR-001 FR-002 FR-003 SC-005 DESIGN-REQ-009 in tests/unit/workloads/test_workload_contract.py
+- [X] T005 [P] Add failing unit test for mount allowlist and credential mount declaration validation for FR-001 FR-002 FR-003 SC-002 SC-003 SC-005 DESIGN-REQ-009 in tests/unit/workloads/test_workload_contract.py
 - [X] T006 [P] Add failing unit test for secret redaction and workload identity separation for FR-004 FR-005 DESIGN-REQ-010 DESIGN-REQ-020 in tests/unit/workloads/test_docker_workload_launcher.py
 - [X] T007 [P] Add failing integration test for workflow-to-workload launch boundary without implicit auth inheritance for SC-001 through SC-004 DESIGN-REQ-009 DESIGN-REQ-020 in tests/integration/services/temporal/workflows/test_agent_run.py
 - [X] T008 Run red-first focused unit tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` and record expected failures in specs/184-workload-auth-guardrails/tasks.md (STORY-006)

--- a/specs/184-workload-auth-guardrails/verification.md
+++ b/specs/184-workload-auth-guardrails/verification.md
@@ -2,8 +2,8 @@
 
 ## Scope
 
-- Jira issue: MM-318
-- Preserved preset brief: `MM-318: breakdown docs\ManagedAgents\OAuthTerminal.md`
+- Jira issue: MM-360
+- Preserved preset brief: `MM-360: Workload Auth-Volume Guardrails`
 - Story: STORY-006 Workload Auth-Volume Guardrails
 - Source design: `docs/ManagedAgents/OAuthTerminal.md`
 
@@ -11,7 +11,7 @@
 
 - FR-001, FR-002, FR-003: `RunnerProfile.credentialMounts` is the only approved path for auth-like workload volumes. Normal `requiredMounts` and `optionalMounts` still reject auth, credential, and secret volume names.
 - FR-004: workload Docker labels and result metadata expose `identityKind=workload` for workload containers, keeping workload identity separate from managed-session identity.
-- FR-005: MM-318 and the original preset brief remain present in `spec.md`, `tasks.md`, and this verification record.
+- FR-005: MM-360 and the original preset brief remain present in `spec.md`, `tasks.md`, and this verification record.
 - DESIGN-REQ-009: workloads do not inherit managed-runtime auth volumes by default; auth-like volumes require explicit credential mount declaration.
 - DESIGN-REQ-010: credential mount justification and approval metadata are not emitted into Docker run args; existing output and metadata redaction remains in force.
 - DESIGN-REQ-020: changes stay inside workload schema and Docker workload launcher boundaries.
@@ -20,13 +20,17 @@
 
 - Red unit: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` failed before implementation on missing `credentialMounts` support and missing workload `identityKind` metadata.
 - Red integration: `pytest tests/integration/services/temporal/workflows/test_agent_run.py -k workload_auth_volume_guardrails -q --tb=short` failed before implementation on missing `credentialMounts` support.
-- Focused unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` passed with 68 tests.
+- Focused unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py` passed with 69 tests after MM-360 traceability alignment.
 - Focused integration green: `pytest tests/integration/services/temporal/workflows/test_agent_run.py -m integration_ci -k workload_auth_volume_guardrails -q --tb=short` passed with 1 test.
 - Full unit green: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3202 Python tests, 16 subtests, and 221 frontend tests.
 
 ## Integration Runner
 
 `./tools/test_integration.sh` was attempted and blocked by the managed-agent environment: Docker was unavailable at `/var/run/docker.sock`.
+
+## MoonSpec Prerequisite Script
+
+`.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` was attempted and blocked by the managed-agent branch name `mm-360-156e66b4`, which does not match the numbered Moon Spec branch pattern expected by the script. The active feature directory was resolved manually as `specs/184-workload-auth-guardrails`.
 
 ## Result
 

--- a/specs/184-workload-auth-guardrails/verification.md
+++ b/specs/184-workload-auth-guardrails/verification.md
@@ -30,7 +30,7 @@
 
 ## MoonSpec Prerequisite Script
 
-`.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` was attempted and blocked by the managed-agent branch name `mm-360-156e66b4`, which does not match the numbered Moon Spec branch pattern expected by the script. The active feature directory was resolved manually as `specs/184-workload-auth-guardrails`.
+`SPECIFY_FEATURE=184-workload-auth-guardrails .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` passed, resolving the active feature directory as `specs/184-workload-auth-guardrails` and listing `research.md`, `data-model.md`, `contracts/`, `quickstart.md`, and `tasks.md`.
 
 ## Result
 


### PR DESCRIPTION
## Summary
- Preserve MM-360 as the canonical MoonSpec Jira preset brief for Workload Auth-Volume Guardrails.
- Align the existing workload-auth-guardrails MoonSpec artifacts to the MM-360 issue key and source brief.
- Record final verification evidence for the completed single-story feature.

## Jira
- Jira issue key: MM-360

## MoonSpec
- Active feature path: specs/184-workload-auth-guardrails
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/workloads/test_workload_contract.py tests/unit/workloads/test_docker_workload_launcher.py - PASS (69 tests)
- pytest tests/integration/services/temporal/workflows/test_agent_run.py -m integration_ci -k workload_auth_volume_guardrails -q --tb=short - PASS (1 test)
- ./tools/test_integration.sh - NOT RUN/BLOCKED (Docker socket unavailable at /var/run/docker.sock)

## Remaining risks
- Full compose-backed integration verification requires a Docker-enabled environment.