### PR TITLE
MM-340 Show all steps when editing tasks

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/182-oauth-state-verify"
+  "feature_directory": "specs/192-edit-task-all-steps"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-340-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-340-moonspec-orchestration-input.md
@@ -1,0 +1,53 @@
+# MM-340 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-340
+- Board scope: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: You should see all steps from a multi-step task when you click edit
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: Synthesized from the trusted `jira.get_issue` MCP response because the response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, or `presetBrief`.
+
+## Canonical MoonSpec Feature Request
+
+MM-340: You should see all steps from a multi-step task when you click edit
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-340 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Fix the Edit Task page so editing a multi-step task shows every step in the task, not only step 1.
+
+Current behavior:
+
+When a user opens the Edit Task page for a multi-step task, the page only displays step 1.
+
+Expected behavior:
+
+When a user clicks edit for a multi-step task, the Edit Task page displays all steps from that task so the user can review and edit the complete multi-step plan.
+
+## Supplemental Acceptance Criteria
+
+- Given a task has multiple steps, when the user opens the Edit Task page for that task, then every existing step is visible in the edit form.
+- Given a task has a single step, when the user opens the Edit Task page, then the existing single-step editing behavior remains available.
+- Given the Edit Task page loads an existing multi-step task, when step data includes more than one step, then the UI must not truncate the list to the first step.
+- Given the user saves edits for a multi-step task, when the task is persisted, then unchanged steps that were loaded into the edit form are preserved unless the user explicitly changes or removes them.
+- Given the task data is missing or malformed for some steps, when the Edit Task page loads, then the UI surfaces a clear recoverable state instead of silently hiding later valid steps.
+
+## Implementation Notes
+
+Investigate the task editing data flow from the task detail/edit entrypoint through the frontend state initialization. The likely issue is that the edit form initializes from only the first step instead of mapping the task's full step collection.
+
+Touch these surfaces as needed:
+
+- Mission Control task edit page and related frontend state initialization.
+- API/read-model code that supplies task steps to the edit page, if the frontend boot payload currently omits later steps.
+- Save/update handlers that serialize edited task steps back to the backend.
+- Focused frontend tests for multi-step edit initialization and preservation.
+
+Verification:
+
+- Add or update tests proving the Edit Task page renders all steps for a multi-step task.
+- Add or update tests proving single-step edit behavior is unchanged.
+- Add or update tests proving save/update does not drop existing later steps.
+- Run the focused frontend test target during iteration, then run the required unit verification before finalizing implementation.

--- a/docs/tmp/jira-orchestration-reports/MM-340-report.md
+++ b/docs/tmp/jira-orchestration-reports/MM-340-report.md
@@ -1,0 +1,45 @@
+# Jira Orchestration Report: MM-340
+
+- Jira issue: MM-340
+- Final Jira status: Code Review
+- Pull request: https://github.com/MoonLadderStudios/MoonMind/pull/1498
+- Feature path: `specs/192-edit-task-all-steps`
+
+## Stage Outcomes
+
+- Jira In Progress: Completed; issue was transitioned from Backlog to In Progress after matching the available Jira transition.
+- Jira brief loading: Completed; trusted Jira issue data was fetched and normalized into `docs/tmp/jira-orchestration-inputs/MM-340-moonspec-orchestration-input.md`.
+- Specify/Breakdown: Completed; classified as a single-story feature request, so `moonspec-specify` was used and `moonspec-breakdown` was not required.
+- Plan: Completed; `plan.md`, `research.md`, `data-model.md`, contract, and `quickstart.md` were generated for the selected story.
+- Tasks: Completed; `tasks.md` covers exactly one story with red-first unit and integration tests, implementation work, validation, and final `/moonspec-verify`.
+- Align: Completed; artifact drift was checked and remediated conservatively.
+- Implement: Completed; multi-step edit draft reconstruction and edit-form initialization were implemented with focused frontend coverage.
+- Verify: Completed; MoonSpec verdict was FULLY_IMPLEMENTED.
+- PR creation: Completed; PR #1498 was created for branch `192-edit-task-all-steps`.
+- Jira Code Review: Completed; PR URL was verified from `artifacts/jira-orchestrate-pr.json`, a Jira-visible PR comment was added, and the issue was transitioned to Code Review.
+
+## Files Changed
+
+- `.specify/feature.json`
+- `docs/tmp/jira-orchestration-inputs/MM-340-moonspec-orchestration-input.md`
+- `frontend/src/entrypoints/task-create.test.tsx`
+- `frontend/src/entrypoints/task-create.tsx`
+- `frontend/src/lib/temporalTaskEditing.ts`
+- `specs/192-edit-task-all-steps/checklists/requirements.md`
+- `specs/192-edit-task-all-steps/contracts/edit-task-steps-ui.md`
+- `specs/192-edit-task-all-steps/data-model.md`
+- `specs/192-edit-task-all-steps/plan.md`
+- `specs/192-edit-task-all-steps/quickstart.md`
+- `specs/192-edit-task-all-steps/research.md`
+- `specs/192-edit-task-all-steps/spec.md`
+- `specs/192-edit-task-all-steps/tasks.md`
+
+## Tests Run
+
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`: failed before production changes for the new red-first tests.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`: passed after implementation, 107 tests.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: passed, 3440 Python tests, 16 subtests, and 228 frontend tests.
+
+## Remaining Risks
+
+- None identified.

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -473,6 +473,67 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Amulti-step-edit?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:multi-step-edit",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              profileId: "profile:codex-default",
+              model: "gpt-5.4",
+              effort: "medium",
+              repository: "MoonLadderStudios/MoonMind",
+              startingBranch: "main",
+              targetBranch: "mm-340-edit-task-all-steps",
+              publishMode: "pr",
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                task: {
+                  instructions: "Investigate why edit shows only step 1.",
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.4",
+                    effort: "medium",
+                    profileId: "profile:codex-default",
+                  },
+                  git: {
+                    startingBranch: "main",
+                    targetBranch: "mm-340-edit-task-all-steps",
+                  },
+                  publish: { mode: "pr" },
+                  steps: [
+                    {
+                      id: "step-primary",
+                      title: "Investigate",
+                      instructions: "Investigate why edit shows only step 1.",
+                      skill: {
+                        id: "moonspec-orchestrate",
+                        args: { mode: "runtime" },
+                        requiredCapabilities: ["git"],
+                      },
+                    },
+                    {
+                      id: "step-patch",
+                      title: "Patch",
+                      instructions: "Patch the edit reconstruction path.",
+                    },
+                    {
+                      id: "step-verify",
+                      title: "Verify",
+                      instructions: "Run the focused task-create tests.",
+                    },
+                  ],
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aartifact-edit?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -785,6 +846,17 @@ describe("Task Create Entrypoint", () => {
               applied: "immediate",
               message: "Inputs updated.",
               execution: { workflowId: "mm:edit-123" },
+            }),
+          } as Response);
+        }
+        if (url === "/api/executions/mm%3Amulti-step-edit/update") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              accepted: true,
+              applied: "immediate",
+              message: "Inputs updated.",
+              execution: { workflowId: "mm:multi-step-edit" },
             }),
           } as Response);
         }
@@ -1621,6 +1693,63 @@ describe("Task Create Entrypoint", () => {
     );
   });
 
+  it("reconstructs ordered editable steps from Temporal execution fields", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:ordered-steps",
+      workflowType: "MoonMind.Run",
+      inputParameters: {
+        task: {
+          instructions: "Primary operator objective.",
+          steps: [
+            {
+              id: "step-primary",
+              title: "Primary",
+              instructions: "Primary operator objective.",
+              skill: {
+                id: "moonspec-orchestrate",
+                args: { mode: "runtime" },
+                requiredCapabilities: ["git"],
+              },
+            },
+            {},
+            {
+              id: "step-second",
+              title: "Second",
+              instructions: "Second step instructions.",
+              tool: {
+                name: "pr-resolver",
+                inputs: { merge: false },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps).toEqual([
+      {
+        id: "step-primary",
+        title: "Primary",
+        instructions: "Primary operator objective.",
+        skillId: "moonspec-orchestrate",
+        skillArgs: { mode: "runtime" },
+        skillRequiredCapabilities: ["git"],
+        templateStepId: "",
+        templateInstructions: "",
+      },
+      {
+        id: "step-second",
+        title: "Second",
+        instructions: "Second step instructions.",
+        skillId: "pr-resolver",
+        skillArgs: { merge: false },
+        skillRequiredCapabilities: [],
+        templateStepId: "",
+        templateInstructions: "",
+      },
+    ]);
+  });
+
   it("uses null for optional draft fields that cannot be reconstructed", () => {
     const draft = buildTemporalSubmissionDraftFromExecution({
       workflowId: "mm:minimal",
@@ -1711,6 +1840,77 @@ describe("Task Create Entrypoint", () => {
     });
     expect(screen.queryByText("Schedule (optional)")).toBeNull();
     expect(screen.getByRole("button", { name: "Save Changes" })).toBeTruthy();
+  });
+
+  it("loads every step when editing a multi-step Temporal execution", async () => {
+    renderForEdit("mm:multi-step-edit");
+
+    expect(await screen.findByRole("heading", { name: "Edit Task" })).toBeTruthy();
+    await waitFor(() => {
+      const instructions = screen.getAllByLabelText(
+        "Instructions",
+      ) as HTMLTextAreaElement[];
+      expect(instructions.map((item) => item.value)).toEqual([
+        "Investigate why edit shows only step 1.",
+        "Patch the edit reconstruction path.",
+        "Run the focused task-create tests.",
+      ]);
+      expect(screen.getByText("Step 1 (Primary)")).toBeTruthy();
+      expect(screen.getByText("Step 2")).toBeTruthy();
+      expect(screen.getByText("Step 3")).toBeTruthy();
+    });
+  });
+
+  it("preserves unchanged later steps when saving a multi-step edit", async () => {
+    renderForEdit("mm:multi-step-edit");
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Instructions")).toHaveLength(3);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Amulti-step-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) => String(url) === "/api/executions/mm%3Amulti-step-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+    expect(request).toMatchObject({
+      updateName: "UpdateInputs",
+      parametersPatch: {
+        task: {
+          instructions: "Investigate why edit shows only step 1.",
+          steps: [
+            {
+              id: "step-primary",
+              title: "Investigate",
+              instructions: "Investigate why edit shows only step 1.",
+              skill: {
+                id: "moonspec-orchestrate",
+                args: { mode: "runtime" },
+                requiredCapabilities: ["git"],
+              },
+            },
+            {
+              id: "step-patch",
+              title: "Patch",
+              instructions: "Patch the edit reconstruction path.",
+            },
+            {
+              id: "step-verify",
+              title: "Verify",
+              instructions: "Run the focused task-create tests.",
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("loads rerun mode instructions from an input artifact when inline instructions are absent", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -534,6 +534,33 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Aauto-primary-skill?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:auto-primary-skill",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              targetSkill: "moonspec-orchestrate",
+              inputParameters: {
+                task: {
+                  instructions: "Preserve the target skill.",
+                  steps: [
+                    {
+                      instructions: "Preserve the target skill.",
+                      skill: { id: "auto" },
+                    },
+                  ],
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Aartifact-edit?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -1750,6 +1777,74 @@ describe("Task Create Entrypoint", () => {
     ]);
   });
 
+  it("does not synthesize a task objective into an editable step", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:objective-differs",
+      workflowType: "MoonMind.Run",
+      inputParameters: {
+        task: {
+          instructions: "Preset-level objective text.",
+          steps: [
+            {
+              id: "step-1",
+              title: "Execute preset",
+              instructions: "Run the first explicit preset step.",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps).toEqual([
+      expect.objectContaining({
+        id: "step-1",
+        title: "Execute preset",
+        instructions: "Run the first explicit preset step.",
+      }),
+    ]);
+  });
+
+  it("uses artifact steps when inline execution steps are partial", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:partial-inline-steps",
+        workflowType: "MoonMind.Run",
+        inputArtifactRef: "full-input",
+        inputParameters: {
+          task: {
+            instructions: "Run the artifact-backed plan.",
+            steps: [
+              {
+                id: "placeholder",
+                instructions: "Inline placeholder step.",
+              },
+            ],
+          },
+        },
+      },
+      {
+        task: {
+          instructions: "Run the artifact-backed plan.",
+          steps: [
+            {
+              id: "artifact-1",
+              instructions: "Hydrated artifact step one.",
+            },
+            {
+              id: "artifact-2",
+              instructions: "Hydrated artifact step two.",
+            },
+          ],
+        },
+      },
+    );
+
+    expect(draft.steps.map((step) => step.id)).toEqual([
+      "artifact-1",
+      "artifact-2",
+    ]);
+  });
+
   it("uses null for optional draft fields that cannot be reconstructed", () => {
     const draft = buildTemporalSubmissionDraftFromExecution({
       workflowId: "mm:minimal",
@@ -1858,6 +1953,17 @@ describe("Task Create Entrypoint", () => {
       expect(screen.getByText("Step 1 (Primary)")).toBeTruthy();
       expect(screen.getByText("Step 2")).toBeTruthy();
       expect(screen.getByText("Step 3")).toBeTruthy();
+    });
+  });
+
+  it("uses the target skill when the first reconstructed step is auto", async () => {
+    renderForEdit("mm:auto-primary-skill");
+
+    expect(await screen.findByRole("heading", { name: "Edit Task" })).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText(/Skill \(optional\)/) as HTMLInputElement).value,
+      ).toBe("moonspec-orchestrate");
     });
   });
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -774,6 +774,32 @@ function createStepStateEntry(
   };
 }
 
+function createStepStateEntriesFromTemporalDraft(
+  draft: ReturnType<typeof buildTemporalSubmissionDraftFromExecution>,
+): StepState[] {
+  if (draft.steps.length === 0) {
+    return [
+      createStepStateEntry(1, {
+        instructions: draft.taskInstructions,
+        ...(draft.primarySkill ? { skillId: draft.primarySkill } : {}),
+      }),
+    ];
+  }
+
+  return draft.steps.map((step, index) =>
+    createStepStateEntry(index + 1, {
+      id: step.id,
+      title: step.title,
+      instructions: step.instructions,
+      skillId: step.skillId || (index === 0 ? draft.primarySkill || "" : ""),
+      skillArgs: stringifySkillArgs(step.skillArgs),
+      skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
+      templateStepId: step.templateStepId,
+      templateInstructions: step.templateInstructions,
+    }),
+  );
+}
+
 function hasExplicitSkillSelection(skillId: string): boolean {
   const normalized = skillId.trim().toLowerCase();
   return normalized !== "" && normalized !== "auto";
@@ -2088,13 +2114,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (draft.publishMode) {
       setPublishMode(draft.publishMode);
     }
-    setSteps([
-      createStepStateEntry(1, {
-        instructions: draft.taskInstructions,
-        ...(draft.primarySkill ? { skillId: draft.primarySkill } : {}),
-      }),
-    ]);
-    setNextStepNumber(2);
+    const reconstructedSteps = createStepStateEntriesFromTemporalDraft(draft);
+    setSteps(reconstructedSteps);
+    setNextStepNumber(reconstructedSteps.length + 1);
     setAppliedTemplates(draft.appliedTemplates);
     setAppliedTemplateFeatureRequest("");
     setScheduleMode("immediate");

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -786,18 +786,24 @@ function createStepStateEntriesFromTemporalDraft(
     ];
   }
 
-  return draft.steps.map((step, index) =>
-    createStepStateEntry(index + 1, {
+  return draft.steps.map((step, index) => {
+    const primarySkill = draft.primarySkill || "";
+    const shouldUsePrimarySkill =
+      index === 0 &&
+      primarySkill !== "" &&
+      !hasExplicitSkillSelection(step.skillId);
+
+    return createStepStateEntry(index + 1, {
       id: step.id,
       title: step.title,
       instructions: step.instructions,
-      skillId: step.skillId || (index === 0 ? draft.primarySkill || "" : ""),
+      skillId: shouldUsePrimarySkill ? primarySkill : step.skillId,
       skillArgs: stringifySkillArgs(step.skillArgs),
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
-    }),
-  );
+    });
+  });
 }
 
 function hasExplicitSkillSelection(skillId: string): boolean {

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -302,23 +302,17 @@ function draftStepsFromTask(
     return [];
   }
 
-  const taskInstructions = stringValue(task.instructions);
-  if (taskInstructions && taskInstructions !== steps[0]?.instructions) {
-    return [
-      {
-        id: '',
-        title: '',
-        instructions: taskInstructions,
-        skillId: '',
-        skillArgs: {},
-        skillRequiredCapabilities: [],
-        templateStepId: '',
-        templateInstructions: '',
-      },
-      ...steps,
-    ];
-  }
   return steps;
+}
+
+function selectDraftSteps(
+  taskSteps: TemporalSubmissionDraft['steps'],
+  artifactTaskSteps: TemporalSubmissionDraft['steps'],
+): TemporalSubmissionDraft['steps'] {
+  if (artifactTaskSteps.length > taskSteps.length) {
+    return artifactTaskSteps;
+  }
+  return taskSteps.length > 0 ? taskSteps : artifactTaskSteps;
 }
 
 function nullableStringValue(...values: unknown[]): string | null {
@@ -532,7 +526,7 @@ export function buildTemporalSubmissionDraftFromExecution(
       artifactSkill.name,
       artifactTaskSkills[0],
     ),
-    steps: taskSteps.length > 0 ? taskSteps : artifactTaskSteps,
+    steps: selectDraftSteps(taskSteps, artifactTaskSteps),
     appliedTemplates: normalizeAppliedTemplates(
       task.appliedStepTemplates || artifactTask.appliedStepTemplates,
     ),

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -55,6 +55,16 @@ export type TemporalSubmissionDraft = {
   publishMode: string | null;
   taskInstructions: string;
   primarySkill: string | null;
+  steps: Array<{
+    id: string;
+    title: string;
+    instructions: string;
+    skillId: string;
+    skillArgs: Record<string, unknown>;
+    skillRequiredCapabilities: string[];
+    templateStepId: string;
+    templateInstructions: string;
+  }>;
   appliedTemplates: Array<{
     slug: string;
     version: string;
@@ -196,6 +206,31 @@ function stepInstructions(value: unknown): string[] {
     .filter(Boolean);
 }
 
+function stringArrayValue(...values: unknown[]): string[] {
+  for (const value of values) {
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    const normalized = value
+      .map((item) => String(item ?? '').trim())
+      .filter(Boolean);
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return [];
+}
+
+function firstObjectValue(...values: unknown[]): Record<string, unknown> {
+  for (const value of values) {
+    const normalized = objectValue(value);
+    if (Object.keys(normalized).length > 0) {
+      return normalized;
+    }
+  }
+  return {};
+}
+
 function taskInstructionsFrom(...tasks: Record<string, unknown>[]): string {
   for (const task of tasks) {
     const instructions = [
@@ -207,6 +242,83 @@ function taskInstructionsFrom(...tasks: Record<string, unknown>[]): string {
     }
   }
   return '';
+}
+
+function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number] | null {
+  const step = objectValue(value);
+  if (Object.keys(step).length === 0) {
+    return null;
+  }
+
+  const tool = objectValue(step.tool);
+  const skill = objectValue(step.skill);
+  const instructions = stringValue(step.instructions);
+  const id = stringValue(step.id);
+  const templateStepId = stringValue(
+    step.templateStepId,
+    step.template_step_id,
+    id.startsWith('tpl:') ? id : '',
+  );
+  const result = {
+    id,
+    title: stringValue(step.title),
+    instructions,
+    skillId: stringValue(tool.name, tool.id, skill.id, skill.name),
+    skillArgs: firstObjectValue(tool.inputs, tool.args, skill.inputs, skill.args),
+    skillRequiredCapabilities: stringArrayValue(
+      tool.requiredCapabilities,
+      skill.requiredCapabilities,
+    ),
+    templateStepId,
+    templateInstructions: stringValue(
+      step.templateInstructions,
+      step.template_instructions,
+      templateStepId ? instructions : '',
+    ),
+  };
+
+  const hasContent =
+    result.id ||
+    result.title ||
+    result.instructions ||
+    result.skillId ||
+    Object.keys(result.skillArgs).length > 0 ||
+    result.skillRequiredCapabilities.length > 0 ||
+    result.templateStepId ||
+    result.templateInstructions;
+  return hasContent ? result : null;
+}
+
+function draftStepsFromTask(
+  task: Record<string, unknown>,
+): TemporalSubmissionDraft['steps'] {
+  const rawSteps = Array.isArray(task.steps) ? task.steps : [];
+  const steps = rawSteps
+    .map((entry) => draftStepFrom(entry))
+    .filter((entry): entry is TemporalSubmissionDraft['steps'][number] =>
+      Boolean(entry),
+    );
+  if (steps.length === 0) {
+    return [];
+  }
+
+  const taskInstructions = stringValue(task.instructions);
+  if (taskInstructions && taskInstructions !== steps[0]?.instructions) {
+    return [
+      {
+        id: '',
+        title: '',
+        instructions: taskInstructions,
+        skillId: '',
+        skillArgs: {},
+        skillRequiredCapabilities: [],
+        templateStepId: '',
+        templateInstructions: '',
+      },
+      ...steps,
+    ];
+  }
+  return steps;
 }
 
 function nullableStringValue(...values: unknown[]): string | null {
@@ -331,6 +443,8 @@ export function buildTemporalSubmissionDraftFromExecution(
   const skill = objectValue(task.skill);
   const artifactTool = objectValue(artifactTask.tool);
   const artifactSkill = objectValue(artifactTask.skill);
+  const taskSteps = draftStepsFromTask(task);
+  const artifactTaskSteps = draftStepsFromTask(artifactTask);
 
   const artifactRepository = stringValue(artifactParams.repository);
   const taskSkills = skillSelectorNames(task.skills);
@@ -418,12 +532,16 @@ export function buildTemporalSubmissionDraftFromExecution(
       artifactSkill.name,
       artifactTaskSkills[0],
     ),
+    steps: taskSteps.length > 0 ? taskSteps : artifactTaskSteps,
     appliedTemplates: normalizeAppliedTemplates(
       task.appliedStepTemplates || artifactTask.appliedStepTemplates,
     ),
   };
 
-  if (!draft.taskInstructions && !draft.primarySkill) {
+  const hasStepContent = draft.steps.some(
+    (step) => step.instructions || step.skillId,
+  );
+  if (!draft.taskInstructions && !draft.primarySkill && !hasStepContent) {
     throw new Error(
       'Task instructions could not be reconstructed from this execution.',
     );

--- a/specs/192-edit-task-all-steps/checklists/requirements.md
+++ b/specs/192-edit-task-all-steps/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Edit Task Shows All Steps
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The preserved input contains implementation notes for downstream planning, but the specification requirements remain behavior-focused.

--- a/specs/192-edit-task-all-steps/contracts/edit-task-steps-ui.md
+++ b/specs/192-edit-task-all-steps/contracts/edit-task-steps-ui.md
@@ -1,0 +1,35 @@
+# UI Contract: Edit Task Step Reconstruction
+
+## Boundary
+
+The shared `/tasks/new` page in edit or rerun mode consumes a `TemporalSubmissionDraft` from `buildTemporalSubmissionDraftFromExecution`.
+
+## Inputs
+
+- Execution detail for a supported `MoonMind.Run`.
+- Optional input artifact or task input snapshot.
+- Task data may include:
+  - `task.instructions`
+  - `task.steps[]`
+  - `step.id`
+  - `step.title`
+  - `step.instructions`
+  - `step.skill` or `step.tool`
+  - `step.skill.args` / `step.skill.inputs` / `step.tool.inputs`
+  - `step.skill.requiredCapabilities` / `step.tool.requiredCapabilities`
+
+## Required Behavior
+
+- If explicit valid steps exist, the draft exposes an ordered `steps` array.
+- The edit form renders every draft step as a distinct form section.
+- If no explicit valid steps exist, the form keeps the current single primary step behavior.
+- Saving an unchanged loaded draft serializes later steps back into `task.steps`.
+
+## Error Behavior
+
+- Missing all task instructions, step content, and primary skill still fails reconstruction with the existing error.
+- Malformed empty step entries are skipped instead of causing valid later steps to be dropped.
+
+## Traceability
+
+This contract implements MM-340 and maps to FR-001 through FR-006.

--- a/specs/192-edit-task-all-steps/data-model.md
+++ b/specs/192-edit-task-all-steps/data-model.md
@@ -1,0 +1,51 @@
+# Data Model: Edit Task Shows All Steps
+
+## TemporalSubmissionDraft
+
+Represents the create/edit/rerun form state reconstructed from execution detail and optional input artifacts.
+
+Fields added or clarified:
+
+- `steps`: ordered list of reconstructed editable task steps. Optional for compatibility with current single-step paths.
+- `taskInstructions`: existing primary instruction string used for legacy single-step fallback and objective-level instructions.
+
+Validation rules:
+
+- `steps` preserves source order.
+- Empty or non-object step entries are ignored.
+- At least one of `taskInstructions`, `primarySkill`, or a reconstructed step with meaningful instructions or skill metadata must exist.
+
+## EditableTaskStep
+
+Represents one task step in the shared task form.
+
+Fields:
+
+- `id`: optional durable/template step id.
+- `title`: optional display title.
+- `instructions`: step instructions.
+- `skillId`: explicit skill or tool name/id.
+- `skillArgs`: serialized JSON input for the skill.
+- `skillRequiredCapabilities`: comma-separated capabilities already used by submit serialization.
+- `templateStepId`: optional original template step id when the step is template-bound.
+- `templateInstructions`: optional template instruction baseline.
+
+Validation rules:
+
+- Step entries with all fields empty may be omitted during reconstruction.
+- Object-shaped skill inputs must serialize to JSON for display in the skill-args field.
+- Valid later steps must remain valid even if earlier entries are empty.
+
+## TaskEditUpdatePayload
+
+Existing submit/update payload generated from `StepState[]`.
+
+State transition:
+
+1. Execution detail/input artifact -> `TemporalSubmissionDraft`.
+2. `TemporalSubmissionDraft.steps` -> `StepState[]`.
+3. `StepState[]` -> task create/edit payload.
+
+Invariant:
+
+- Unchanged reconstructed later steps remain present in the submitted payload unless removed by the operator.

--- a/specs/192-edit-task-all-steps/plan.md
+++ b/specs/192-edit-task-all-steps/plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Edit Task Shows All Steps
+
+**Branch**: `192-edit-task-all-steps` | **Date**: 2026-04-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/specs/192-edit-task-all-steps/spec.md`
+
+## Summary
+
+Fix MM-340 by preserving ordered task step data in the Temporal edit/rerun draft model and applying that step array to the shared `/tasks/new` form. The implementation will extend the existing frontend reconstruction helper and edit-mode form initialization, with focused Vitest coverage proving multi-step rendering and payload preservation while keeping existing single-step behavior intact.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React frontend plus Python 3.12 backend context  
+**Primary Dependencies**: React, TanStack Query, Vitest, Testing Library, existing Temporal task editing helpers  
+**Storage**: Existing execution detail and input artifact contracts; no new persistent storage  
+**Unit Testing**: Vitest through `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` for focused iteration and `./tools/test_unit.sh` for final verification  
+**Integration Testing**: Frontend component integration tests in Vitest/Testing Library for edit-form load and submit behavior; required project integration suite remains `./tools/test_integration.sh` when backend/compose boundaries change  
+**Target Platform**: Mission Control web UI served by FastAPI  
+**Project Type**: Web application frontend with existing API contracts  
+**Performance Goals**: Reconstruct and render typical multi-step task drafts without extra network calls beyond existing execution/artifact fetches  
+**Constraints**: Preserve MM-340 traceability; do not mutate historical artifacts; do not drop user-authored steps; keep compatibility-sensitive Temporal/backend payloads unchanged unless proven necessary  
+**Scale/Scope**: One user-facing edit/rerun reconstruction path for supported `MoonMind.Run` tasks
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The change stays inside MoonMind's orchestration UI and does not add agent behavior.
+- II. One-Click Agent Deployment: PASS. No deployment prerequisites or new services are introduced.
+- III. Avoid Vendor Lock-In: PASS. The behavior is provider-neutral and applies to existing task data.
+- IV. Own Your Data: PASS. Existing locally stored execution/input data remains the source.
+- V. Skills Are First-Class and Easy to Add: PASS. Step-level skill selections are preserved when present.
+- VI. Scientific Method/Test Anchor: PASS. The plan uses failing focused frontend tests before production changes.
+- VII. Runtime Configurability: PASS. No hardcoded operator config is added.
+- VIII. Modular and Extensible Architecture: PASS. The fix extends existing reconstruction helpers and form state mapping.
+- IX. Resilient by Default: PASS. The update preserves existing steps rather than silently truncating them.
+- X. Facilitate Continuous Improvement: PASS. Verification evidence will identify MM-340 and test coverage.
+- XI. Spec-Driven Development: PASS. Spec, plan, tasks, and verification are part of the change.
+- XII. Canonical Documentation Separation: PASS. Implementation notes remain under `specs/` and `docs/tmp`; no canonical docs are rewritten.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility aliases or hidden transforms are added.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/192-edit-task-all-steps/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── edit-task-steps-ui.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── lib/
+│   └── temporalTaskEditing.ts
+└── entrypoints/
+    ├── task-create.tsx
+    └── task-create.test.tsx
+```
+
+**Structure Decision**: Use the existing Mission Control frontend task-editing modules. Backend files are not planned unless tests show execution detail lacks step data.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/192-edit-task-all-steps/quickstart.md
+++ b/specs/192-edit-task-all-steps/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart: Edit Task Shows All Steps
+
+## Focused Validation
+
+1. Prepare frontend dependencies if needed:
+
+```bash
+npm ci --no-fund --no-audit
+```
+
+2. Run the focused task-create tests:
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx
+```
+
+3. Run the project unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Manual Scenario
+
+1. Open an editable `MoonMind.Run` that has at least three task steps.
+2. Click Edit from the task detail page.
+3. Confirm the Edit Task page shows Step 1, Step 2, and Step 3 separately.
+4. Save without modifying Step 2 or Step 3.
+5. Confirm the update request still includes later step payloads.

--- a/specs/192-edit-task-all-steps/research.md
+++ b/specs/192-edit-task-all-steps/research.md
@@ -1,0 +1,25 @@
+# Research: Edit Task Shows All Steps
+
+## Draft Reconstruction Source
+
+Decision: Preserve explicit step records in `TemporalSubmissionDraft` in addition to the existing flattened `taskInstructions` string.
+Rationale: The current helper already reads `task.steps`, but it merges instructions into a single string. Keeping ordered step records lets the form render all steps without changing backend contracts.
+Alternatives considered: Backend reconstruction endpoint. Rejected because the issue is reproducible in frontend draft application and existing execution detail already carries task step data.
+
+## Form Initialization
+
+Decision: Apply reconstructed draft steps to `StepState[]` when present, and fall back to the existing single-step initialization when no step array is available.
+Rationale: This preserves single-step behavior and fixes multi-step truncation without changing create-mode defaults.
+Alternatives considered: Split the flattened instruction string on blank lines. Rejected because that would guess user intent and lose step metadata.
+
+## Step Metadata Preservation
+
+Decision: Map known step fields into existing `StepState`: `id`, `title`, `instructions`, skill/tool name, skill inputs/args, required capabilities, and template instruction identity.
+Rationale: These fields already participate in submit serialization, so preserving them prevents unchanged steps from being dropped or merged.
+Alternatives considered: Preserve raw step payloads separately. Rejected because submit already serializes from `StepState` and a second raw payload path would create conflicting sources of truth.
+
+## Test Strategy
+
+Decision: Add focused Vitest coverage in `frontend/src/entrypoints/task-create.test.tsx` for helper reconstruction, edit-page rendering, and unchanged save payload preservation.
+Rationale: This is the highest-risk UI path and is already covered by adjacent edit/rerun tests using mocked execution detail responses.
+Alternatives considered: Compose-backed integration tests. Rejected for this slice because no backend/service boundary changes are planned.

--- a/specs/192-edit-task-all-steps/spec.md
+++ b/specs/192-edit-task-all-steps/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification: Edit Task Shows All Steps
+
+**Feature Branch**: `192-edit-task-all-steps`
+**Created**: 2026-04-16
+**Status**: Draft
+**Input**:
+
+```text
+# MM-340 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-340
+- Board scope: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: You should see all steps from a multi-step task when you click edit
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: Synthesized from the trusted `jira.get_issue` MCP response because the response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, or `presetBrief`.
+
+## Canonical MoonSpec Feature Request
+
+MM-340: You should see all steps from a multi-step task when you click edit
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-340 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Fix the Edit Task page so editing a multi-step task shows every step in the task, not only step 1.
+
+Current behavior:
+
+When a user opens the Edit Task page for a multi-step task, the page only displays step 1.
+
+Expected behavior:
+
+When a user clicks edit for a multi-step task, the Edit Task page displays all steps from that task so the user can review and edit the complete multi-step plan.
+
+## Supplemental Acceptance Criteria
+
+- Given a task has multiple steps, when the user opens the Edit Task page for that task, then every existing step is visible in the edit form.
+- Given a task has a single step, when the user opens the Edit Task page, then the existing single-step editing behavior remains available.
+- Given the Edit Task page loads an existing multi-step task, when step data includes more than one step, then the UI must not truncate the list to the first step.
+- Given the user saves edits for a multi-step task, when the task is persisted, then unchanged steps that were loaded into the edit form are preserved unless the user explicitly changes or removes them.
+- Given the task data is missing or malformed for some steps, when the Edit Task page loads, then the UI surfaces a clear recoverable state instead of silently hiding later valid steps.
+
+## Implementation Notes
+
+Investigate the task editing data flow from the task detail/edit entrypoint through the frontend state initialization. The likely issue is that the edit form initializes from only the first step instead of mapping the task's full step collection.
+
+Touch these surfaces as needed:
+
+- Mission Control task edit page and related frontend state initialization.
+- API/read-model code that supplies task steps to the edit page, if the frontend boot payload currently omits later steps.
+- Save/update handlers that serialize edited task steps back to the backend.
+- Focused frontend tests for multi-step edit initialization and preservation.
+
+Verification:
+
+- Add or update tests proving the Edit Task page renders all steps for a multi-step task.
+- Add or update tests proving single-step edit behavior is unchanged.
+- Add or update tests proving save/update does not drop existing later steps.
+- Run the focused frontend test target during iteration, then run the required unit verification before finalizing implementation.
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.
+
+## User Story - Edit Multi-Step Task
+
+**Summary**: As a MoonMind operator, I want the Edit Task form to load every step from a multi-step task so that I can review and update the complete task plan.
+
+**Goal**: Opening Edit Task for a multi-step `MoonMind.Run` task reconstructs the full ordered step list into the shared task form instead of flattening or truncating later steps.
+
+**Independent Test**: Load the Edit Task page with a supported `MoonMind.Run` execution whose input contains multiple task steps, then verify each step appears in order with its instructions and saving the unchanged draft preserves the later steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** an editable `MoonMind.Run` execution has multiple task steps, **when** the operator opens `/tasks/new?editExecutionId=<workflowId>`, **then** the Edit Task form displays every step in the original order.
+2. **Given** an editable `MoonMind.Run` execution has a single-step task, **when** the operator opens Edit Task, **then** the existing single-step form behavior is preserved.
+3. **Given** an editable multi-step task is loaded and the operator saves without removing later steps, **when** the update payload is built, **then** the later steps remain present in the submitted task parameters.
+4. **Given** a reconstructed task step has optional title, skill, skill inputs, or template binding metadata, **when** the Edit Task form loads, **then** those fields remain associated with the same step instead of being merged into step 1.
+5. **Given** some step entries are malformed or empty, **when** the Edit Task form loads, **then** valid later steps still appear and invalid empty entries do not cause a silent fallback to only step 1.
+
+### Edge Cases
+
+- Task-level objective instructions may exist alongside explicit step entries; the primary form step should preserve the objective while later explicit steps remain separate.
+- A first explicit step may be absent or empty while later steps contain valid instructions.
+- Step-level skill inputs may be object-shaped and must remain serializable in the edit form.
+- Template-bound step identifiers and titles must not be dropped during draft reconstruction.
+
+## Assumptions
+
+- MM-340 targets the existing Temporal task editing path for `MoonMind.Run` executions.
+- The issue is observable in the frontend reconstruction and form initialization path; backend changes are only needed if execution detail omits step data.
+- Attachments are out of scope unless they already appear as step metadata in the existing contract.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST reconstruct an ordered edit-form step list from available task step data for supported `MoonMind.Run` edit and rerun drafts.
+- **FR-002**: The system MUST display every valid reconstructed step in the Edit Task form instead of flattening all step instructions into step 1.
+- **FR-003**: The system MUST preserve single-step reconstruction behavior when only one step or only task-level instructions are available.
+- **FR-004**: The system MUST preserve each reconstructed step's instructions, title, explicit skill selection, skill inputs, required capabilities, and template binding metadata when those values are present.
+- **FR-005**: The system MUST preserve valid later steps when earlier step entries are empty or partially malformed.
+- **FR-006**: The edit update payload MUST retain unchanged later steps unless the operator explicitly removes or edits them.
+- **FR-007**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key MM-340.
+
+### Key Entities
+
+- **Temporal Submission Draft**: Frontend draft reconstructed from execution detail and optional input artifact data.
+- **Editable Task Step**: Ordered form step containing instructions, title, skill selection, skill inputs, required capabilities, and template binding metadata when available.
+- **Task Edit Update Payload**: Parameters patch submitted through `UpdateInputs` or `RequestRerun` after the operator saves the reconstructed draft.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit-level reconstruction tests prove a multi-step execution produces a draft containing every valid step in order.
+- **SC-002**: Frontend integration tests prove Edit Task renders all reconstructed steps for a multi-step execution.
+- **SC-003**: Frontend integration tests prove saving an unchanged multi-step edit payload preserves later step instructions.
+- **SC-004**: Existing single-step edit reconstruction tests continue to pass.
+- **SC-005**: Verification evidence preserves MM-340 as the source Jira issue for the feature.

--- a/specs/192-edit-task-all-steps/tasks.md
+++ b/specs/192-edit-task-all-steps/tasks.md
@@ -9,7 +9,7 @@
 
 - Unit tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
 - Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Phase 1: Setup
 
@@ -45,7 +45,7 @@
 ## Phase 4: Polish And Verification
 
 - [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for required unit verification.
-- [X] T013 Run `/speckit.verify` against `specs/192-edit-task-all-steps/spec.md` and record the verdict: FULLY_IMPLEMENTED.
+- [X] T013 Run `/moonspec-verify` against `specs/192-edit-task-all-steps/spec.md` and record the verdict: FULLY_IMPLEMENTED.
 
 ## Dependencies & Execution Order
 

--- a/specs/192-edit-task-all-steps/tasks.md
+++ b/specs/192-edit-task-all-steps/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Edit Task Shows All Steps
+
+**Input**: Design documents from `/specs/192-edit-task-all-steps/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Test Commands**:
+
+- Unit tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature artifacts exist under `specs/192-edit-task-all-steps/` for MM-340 traceability.
+- [X] T002 Confirm implementation files and tests are localized to `frontend/src/lib/temporalTaskEditing.ts`, `frontend/src/entrypoints/task-create.tsx`, and `frontend/src/entrypoints/task-create.test.tsx`.
+
+## Phase 2: Foundational
+
+- [X] T003 Verify existing frontend test harness and mocked execution-detail responses in `frontend/src/entrypoints/task-create.test.tsx`.
+
+## Phase 3: Story - Edit Multi-Step Task
+
+**Summary**: As a MoonMind operator, I want the Edit Task form to load every step from a multi-step task so that I can review and update the complete task plan.
+
+**Independent Test**: Load the Edit Task page with a supported `MoonMind.Run` execution whose input contains multiple task steps, then verify each step appears in order with its instructions and saving the unchanged draft preserves the later steps.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, SC-001, SC-002, SC-003, SC-004, SC-005, MM-340
+
+### Unit Tests
+
+- [X] T004 Add failing draft reconstruction test for ordered multi-step output in `frontend/src/entrypoints/task-create.test.tsx` covering FR-001, FR-004, FR-005, SC-001.
+- [X] T005 Add failing edit-page rendering test for all multi-step sections in `frontend/src/entrypoints/task-create.test.tsx` covering FR-002, FR-003, SC-002, SC-004.
+- [X] T006 Add failing save-payload preservation test for unchanged later steps in `frontend/src/entrypoints/task-create.test.tsx` covering FR-006, SC-003.
+- [X] T007 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and confirm T004-T006 fail for the expected truncation reason.
+
+### Implementation
+
+- [X] T008 Extend `TemporalSubmissionDraft` and reconstruction helpers in `frontend/src/lib/temporalTaskEditing.ts` to expose ordered editable steps for FR-001, FR-004, FR-005.
+- [X] T009 Update edit/rerun draft application in `frontend/src/entrypoints/task-create.tsx` to initialize `StepState[]` from reconstructed steps for FR-002 and FR-003.
+- [X] T010 Preserve unchanged later steps in submitted edit/rerun payloads through the existing `StepState[]` serialization in `frontend/src/entrypoints/task-create.tsx` for FR-006.
+- [X] T011 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and confirm the focused tests pass.
+
+## Phase 4: Polish And Verification
+
+- [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for required unit verification.
+- [X] T013 Run `/speckit.verify` against `specs/192-edit-task-all-steps/spec.md` and record the verdict: FULLY_IMPLEMENTED.
+
+## Dependencies & Execution Order
+
+- T004-T006 must be written before T008-T010.
+- T007 must run before production implementation.
+- T011 must pass before T012.
+- T013 is final after tests pass.
+
+## Implementation Strategy
+
+Keep the change narrow: preserve step records during reconstruction, apply those records to form state, and rely on the existing submit serialization to preserve later steps.


### PR DESCRIPTION
## Summary
- Preserve ordered task step data during Temporal edit/rerun draft reconstruction.
- Initialize the Edit Task form with every reconstructed step instead of flattening everything into Step 1.
- Add MM-340 MoonSpec artifacts and focused frontend coverage for multi-step rendering and unchanged-step preservation.

## Jira
- Issue: MM-340

## MoonSpec
- Active feature: `specs/192-edit-task-all-steps`
- Verification verdict: FULLY_IMPLEMENTED

## Tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS: 3440 Python tests, 16 subtests, 228 frontend tests.

## Remaining Risks
- None identified.