### PR TITLE
MM-361 OAuth runner bootstrap PTY

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/192-edit-task-all-steps"
+  "feature_directory": "specs/192-oauth-runner-bootstrap-pty"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,8 @@ Key diagnostics:
 - Python 3.12 + Pydantic v2, existing MoonMind schema validation helpers (185-claude-policy-envelope)
 - No new persistent storage; this story defines compact runtime contracts and deterministic outputs that can later be persisted by the managed-session store (185-claude-policy-envelope)
 - No new persistent storage; this story defines compact runtime contracts and deterministic outputs that can later be persisted by the managed-session store or export sinks (191-claude-governance-telemetry)
+- Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing OAuth provider registry, existing OAuth session workflow/activity catalog, existing terminal bridge runtime helpers (192-oauth-runner-bootstrap-pty)
+- Existing OAuth session database row and workflow/activity payloads only; no new persistent storage (192-oauth-runner-bootstrap-pty)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/docs/tmp/jira-orchestration-inputs/MM-361-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-361-moonspec-orchestration-input.md
@@ -1,0 +1,88 @@
+# MM-361 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-361
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+- Labels: `MM-318`, `managed-sessions`, `oauth-terminal`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-361 from MM project
+Summary: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-361 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-361: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+
+Short Name
+oauth-runner-bootstrap-pty
+
+User Story
+As a MoonMind operator, I can start a Codex OAuth enrollment session that launches a short-lived auth runner container running the provider bootstrap command in a PTY, so credential enrollment is first-party and does not depend on placeholder container behavior.
+
+Acceptance Criteria
+- Given an authorized Codex OAuth session starts, the auth runner container mounts the selected auth volume at the provider enrollment path.
+- Given the provider registry defines a bootstrap command, the runner executes that command in a PTY owned by the OAuth enrollment session.
+- Given the session succeeds, fails, expires, or is cancelled, the runner stops and cleanup is idempotent.
+- Given the runner is active, it exposes no ordinary managed task terminal and no generic Docker exec capability.
+- Given runner startup fails because Docker or the provider CLI is unavailable, the OAuth session fails with an actionable, redacted reason.
+
+Current Evidence
+- `specs/183-oauth-terminal-flow/verification.md` has verdict `ADDITIONAL_WORK_NEEDED`.
+- `moonmind/workflows/temporal/runtime/terminal_bridge.py` currently starts a runner image with `sleep` and comments that the real specialized PTY container is not implemented.
+
+Requirements
+- Replace the placeholder auth runner lifecycle with a short-lived runner container that executes the selected provider bootstrap command in a PTY.
+- Mount the selected Codex OAuth auth volume at the provider enrollment path during enrollment.
+- Scope the runner and PTY ownership to the OAuth enrollment session.
+- Route terminal behavior through MoonMind's authenticated PTY/WebSocket bridge only.
+- Stop the runner after success, failure, expiry, or cancellation, and make cleanup idempotent.
+- Fail with actionable, redacted diagnostics when Docker, runner startup, or provider CLI execution is unavailable.
+- Preserve the boundary that OAuth terminal code is for enrollment only, not managed task execution or generic Docker exec.
+
+Independent Test
+Start a Codex OAuth session with a fake provider bootstrap command, assert the auth runner mounts the selected auth volume, executes the bootstrap command inside the session-owned PTY, exposes only authenticated terminal bridge access, and performs idempotent cleanup for success, failure, expiry, and cancellation paths with redacted failure reasons.
+
+Out of Scope
+- Managed Codex task execution changes.
+- Claude/Gemini task-scoped session parity.
+- Generic Docker exec exposure.
+- Ordinary managed task terminal attachment.
+
+Source Document
+docs/ManagedAgents/OAuthTerminal.md
+
+Source Sections
+- 5. OAuth Terminal Contract
+- 5.1 Auth runner container
+- 10. Operator Behavior
+
+Coverage IDs
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-014
+- DESIGN-REQ-020
+
+Source Design Coverage
+- DESIGN-REQ-011: Provide a first-party OAuth terminal architecture using Mission Control, OAuth Session API, MoonMind.OAuthSession, short-lived auth runner, PTY/WebSocket bridge, and xterm.js.
+- DESIGN-REQ-012: Run a short-lived auth runner container that mounts the auth volume at the provider enrollment path and tears down on success, cancellation, expiry, or failure.
+- DESIGN-REQ-014: Do not expose generic Docker exec access or ordinary task-run terminal attachment through the OAuth terminal bridge.
+- DESIGN-REQ-020: Preserve ownership boundaries among OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration.
+
+Relevant Implementation Notes
+- The auth runner container is short-lived and scoped to one OAuth session.
+- For Codex, the auth runner targets `codex_auth_volume` at `/home/app/.codex` while enrollment is happening.
+- The OAuth terminal is only for credential enrollment or repair and must not become the runtime surface for managed Codex task execution.
+- Later task-scoped Codex managed sessions target the registered provider profile and mount the auth volume separately when needed.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/activities/oauth_session_activities.py
+++ b/moonmind/workflows/temporal/activities/oauth_session_activities.py
@@ -27,7 +27,10 @@ from api_service.db.models import (
     OAuthSessionStatus,
 )
 from moonmind.schemas.agent_runtime_models import validate_codex_oauth_profile_refs
-from moonmind.workflows.temporal.runtime.providers.registry import get_provider_default
+from moonmind.workflows.temporal.runtime.providers.registry import (
+    get_provider_bootstrap_command,
+    get_provider_default,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +96,7 @@ async def oauth_session_start_auth_runner(
     if not volume_mount_path:
         raise ValueError("volume_mount_path is required")
     session_ttl = max(60, min(session_ttl, 86400))
+    bootstrap_command = get_provider_bootstrap_command(runtime_id)
 
     from moonmind.workflows.temporal.runtime.terminal_bridge import start_terminal_bridge_container
     
@@ -102,6 +106,7 @@ async def oauth_session_start_auth_runner(
         volume_ref=volume_ref,
         volume_mount_path=volume_mount_path,
         session_ttl=session_ttl,
+        bootstrap_command=bootstrap_command,
     )
     bridge_info.setdefault(
         "expires_at",

--- a/moonmind/workflows/temporal/runtime/providers/registry.py
+++ b/moonmind/workflows/temporal/runtime/providers/registry.py
@@ -31,7 +31,7 @@ OAUTH_PROVIDERS: dict[str, OAuthProviderSpec] = {
         default_mount_path_env="CODEX_VOLUME_PATH",
         provider_id="openai",
         provider_label="OpenAI",
-        bootstrap_command=["true"],
+        bootstrap_command=["codex", "login"],
         success_check="codex_config_exists",
         account_label_prefix="Codex",
     ),
@@ -86,6 +86,26 @@ def get_provider_default(runtime_id: str, key: str) -> str | None:
     if key == "session_transport":
         return spec["session_transport"]
     return None
+
+
+def get_provider_bootstrap_command(runtime_id: str) -> tuple[str, ...]:
+    """Return a validated provider bootstrap command for OAuth enrollment."""
+    spec = get_provider(runtime_id)
+    if spec is None:
+        raise ValueError(f"Unsupported OAuth runtime: {runtime_id}")
+
+    command = spec.get("bootstrap_command")
+    if not isinstance(command, list):
+        raise ValueError(
+            f"OAuth provider '{runtime_id}' bootstrap command is not configured"
+        )
+
+    normalized = tuple(str(part).strip() for part in command)
+    if not normalized or any(not part for part in normalized):
+        raise ValueError(
+            f"OAuth provider '{runtime_id}' bootstrap command is not configured"
+        )
+    return normalized
 
 
 def supported_runtime_ids() -> list[str]:

--- a/moonmind/workflows/temporal/runtime/terminal_bridge.py
+++ b/moonmind/workflows/temporal/runtime/terminal_bridge.py
@@ -5,14 +5,27 @@ from collections import deque
 from dataclasses import dataclass, field
 import logging
 import os
+import re
 from typing import Any
 
 logger = logging.getLogger(__name__)
 _MAX_RECORDED_TERMINAL_EVENTS = 256
+_MAX_STARTUP_ERROR_OUTPUT_CHARS = 600
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)(token|password|secret|api[_-]?key)=\S+"
+)
 
 
 class TerminalBridgeFrameError(ValueError):
     """Raised when a browser terminal frame is unsupported or unsafe."""
+
+
+def _redact_startup_output(output: bytes) -> str:
+    text = output.decode("utf-8", errors="replace").strip()
+    if not text:
+        return ""
+    redacted = _SECRET_ASSIGNMENT_PATTERN.sub("[REDACTED]", text)
+    return redacted[-_MAX_STARTUP_ERROR_OUTPUT_CHARS:]
 
 
 @dataclass
@@ -76,26 +89,26 @@ async def start_terminal_bridge_container(
     volume_ref: str,
     volume_mount_path: str,
     session_ttl: int,
+    bootstrap_command: tuple[str, ...] | list[str],
 ) -> dict[str, Any]:
     """Start an auth container that exposes a bridge for PTY websocket connections."""
-    
-    # In a real implementation, this would spin up a specialized docker 
-    # container that accepts a websocket connection to a PTY.
-    # For Phase 5, we satisfy the temporal workflow by returning connection metadata.
-    
+    command = tuple(str(part).strip() for part in bootstrap_command)
+    if not command or any(not part for part in command):
+        raise ValueError("provider bootstrap command is not configured")
+
     container_name = f"moonmind_auth_{session_id}"
     logger.info("Starting auth runner container %s for %s", container_name, session_id)
     
     runner_image = os.environ.get("MOONMIND_OAUTH_RUNNER_IMAGE", "alpine:3.19")
     try:
         proc = await asyncio.create_subprocess_exec(
-            "docker", "run", "-d", "--rm",
+            "docker", "run", "-d", "-i", "-t", "--rm",
             "--name", container_name,
             "--label", "moonmind.oauth_session=true",
             "--label", f"moonmind.oauth_session_id={session_id}",
             "--label", f"moonmind.runtime_id={runtime_id}",
             "-v", f"{volume_ref}:{volume_mount_path}",
-            runner_image, "sleep", str(session_ttl),
+            runner_image, *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -118,8 +131,10 @@ async def start_terminal_bridge_container(
         raise TimeoutError("Timed out while starting auth container")
 
     if proc.returncode != 0:
+        error_output = _redact_startup_output(stderr)
+        detail = f": {error_output}" if error_output else ""
         raise RuntimeError(
-            f"Failed to start auth container: {stderr.decode(errors='replace')}"
+            f"Failed to start auth container with exit code {proc.returncode}{detail}"
         )
         
     return {

--- a/moonmind/workflows/temporal/workflows/oauth_session.py
+++ b/moonmind/workflows/temporal/workflows/oauth_session.py
@@ -14,6 +14,7 @@ Design reference:
 from __future__ import annotations
 
 import logging
+import re
 from datetime import timedelta
 from typing import Any, Optional, TypedDict
 
@@ -59,6 +60,17 @@ class OAuthSessionOutput(TypedDict):
 
 # Default session TTL — sessions auto-expire after this duration.
 _DEFAULT_SESSION_TTL_SECONDS = 1800  # 30 minutes
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)(token|password|secret|api[_-]?key)=\S+"
+)
+
+
+def _redact_workflow_failure(prefix: str, error: object) -> str:
+    """Return a bounded workflow-safe failure reason."""
+    message = str(error)
+    if _SECRET_ASSIGNMENT_PATTERN.search(message):
+        return f"{prefix}: redacted provider output"
+    return f"{prefix}: {message}"
 
 
 @workflow.defn(name=WORKFLOW_NAME)
@@ -239,11 +251,17 @@ class MoonMindOAuthSessionWorkflow:
                     ),
                 )
             except Exception as exc:
-                await self._mark_failed(f"Failed to start auth runner: {exc}")
+                failure_reason = _redact_workflow_failure(
+                    "Failed to start auth runner", exc
+                )
+                output_reason = _redact_workflow_failure(
+                    "Auth runner launch failed", exc
+                )
+                await self._mark_failed(failure_reason)
                 return OAuthSessionOutput(
                     session_id=self._session_id,
                     status="failed",
-                    failure_reason=f"Auth runner launch failed: {exc}",
+                    failure_reason=output_reason,
                 )
 
         # Step 4: Transition to bridge_ready then awaiting_user

--- a/specs/192-oauth-runner-bootstrap-pty/checklists/requirements.md
+++ b/specs/192-oauth-runner-bootstrap-pty/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: OAuth Runner Bootstrap PTY
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated against the MM-361 canonical Jira preset brief and `docs/ManagedAgents/OAuthTerminal.md` source sections 5, 5.1, 5.2, 10, and 11.
+- The spec intentionally preserves product terms from the source design such as auth runner, provider bootstrap command, terminal bridge, generic Docker exec, and managed task terminal attachment because they define operator-visible boundaries for this story.

--- a/specs/192-oauth-runner-bootstrap-pty/contracts/oauth-runner-bootstrap-pty.md
+++ b/specs/192-oauth-runner-bootstrap-pty/contracts/oauth-runner-bootstrap-pty.md
@@ -1,0 +1,70 @@
+# Contract: OAuth Runner Bootstrap PTY
+
+## Story Boundary
+
+Source story: MM-361 Jira preset brief for replacing placeholder Codex OAuth auth runner behavior with provider bootstrap PTY lifecycle.
+
+## Inputs
+
+- Jira traceability: `MM-361` and preset brief `MM-361: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle`.
+- Source design coverage: `DESIGN-REQ-011`, `DESIGN-REQ-012`, `DESIGN-REQ-014`, `DESIGN-REQ-020`.
+- OAuth session activity request shape:
+
+```json
+{
+  "session_id": "oas_example",
+  "runtime_id": "codex_cli",
+  "volume_ref": "codex_auth_volume",
+  "volume_mount_path": "/home/app/.codex",
+  "session_ttl": 1800
+}
+```
+
+- Provider registry fields required by runner startup: `runtime_id`, `session_transport`, `default_volume_name`, `default_mount_path`, and non-empty `bootstrap_command`.
+
+## Required Behavior
+
+- `oauth_session.start_auth_runner` resolves the provider bootstrap command from the provider registry using `runtime_id`.
+- Runner startup mounts `volume_ref` at `volume_mount_path` for the provider enrollment command.
+- Runner startup executes the provider bootstrap command as the session-owned terminal process instead of placeholder sleep behavior.
+- Runner terminal access is represented only through the OAuth terminal bridge metadata.
+- Generic Docker exec and ordinary managed task terminal attachment are rejected or omitted for OAuth runner sessions.
+- Success, failure, expiry, cancellation, and API-finalize paths stop the runner through idempotent cleanup.
+- Startup, command, and cleanup failures return bounded redacted reasons.
+
+## Outputs
+
+Successful auth runner startup returns secret-free metadata:
+
+```json
+{
+  "container_name": "moonmind_auth_oas_example",
+  "terminal_session_id": "term_oas_example",
+  "terminal_bridge_id": "br_oas_example",
+  "session_transport": "moonmind_pty_ws",
+  "expires_at": "2026-04-16T18:30:00+00:00"
+}
+```
+
+Runner cleanup returns a secret-free idempotent outcome:
+
+```json
+{
+  "session_id": "oas_example",
+  "container_name": "moonmind_auth_oas_example",
+  "stopped": true
+}
+```
+
+## Failure Behavior
+
+- Missing `session_id`, `runtime_id`, `volume_ref`, `volume_mount_path`, or provider bootstrap command fails before externally visible runner side effects.
+- Missing Docker, mount failure, runner startup timeout, runner command failure, and provider command rejection produce actionable redacted reasons.
+- Failure payloads must not contain raw credential contents, token values, private keys, environment dumps, or raw auth-volume listings.
+- Integration blockers such as an unavailable Docker socket are recorded as blockers, not treated as passing evidence.
+
+## Compatibility And Boundary Requirements
+
+- The workflow-bound `oauth_session.start_auth_runner` request shape remains compatible with existing worker invocation; provider command resolution happens inside the activity/runtime boundary.
+- OAuth terminal runner evidence remains separate from managed Codex task execution evidence.
+- No compatibility aliases or hidden fallback commands are introduced for unsupported runtime values.

--- a/specs/192-oauth-runner-bootstrap-pty/data-model.md
+++ b/specs/192-oauth-runner-bootstrap-pty/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: OAuth Runner Bootstrap PTY
+
+## OAuth Enrollment Session
+
+- Purpose: Operator-started Codex OAuth enrollment flow that owns the auth runner lifecycle, target auth volume, terminal state, and terminal outcome.
+- Key fields: `session_id`, `runtime_id`, `profile_id`, `volume_ref`, `volume_mount_path`, `session_transport`, `terminal_session_id`, `terminal_bridge_id`, `container_name`, `status`, `failure_reason`, `expires_at`.
+- Validation rules:
+  - `session_id` and `runtime_id` are required before workflow side effects.
+  - Codex OAuth sessions require nonblank `volume_ref` and `volume_mount_path`.
+  - Failure reasons must be bounded and redacted before reaching workflow outputs, browser responses, logs, or artifacts.
+- State transitions:
+  - Startup path: `pending` -> `starting` -> `bridge_ready` -> `awaiting_user`.
+  - Terminal paths: `awaiting_user` -> `verifying` -> `registering_profile` -> `succeeded`; `awaiting_user` -> `cancelled`; `awaiting_user` -> `expired`; any startup or verification failure -> `failed`.
+
+## OAuth Provider Spec
+
+- Purpose: Runtime-owned provider defaults used to provision OAuth enrollment without embedding provider command details in workflow input.
+- Key fields: `runtime_id`, `auth_mode`, `session_transport`, `default_volume_name`, `default_mount_path`, `provider_id`, `provider_label`, `bootstrap_command`, `success_check`, `account_label_prefix`.
+- Validation rules:
+  - `bootstrap_command` must be a non-empty ordered list of nonblank strings for supported OAuth runtimes.
+  - Unsupported runtime IDs fail fast before runner startup.
+  - Command values are configuration metadata; credential values must never appear in provider spec fields.
+- Relationships:
+  - `OAuth Enrollment Session.runtime_id` resolves one provider spec.
+  - The activity/runtime boundary uses the provider spec to build the `Auth Runner Launch` request.
+
+## Auth Runner Launch
+
+- Purpose: Short-lived runner startup request for one OAuth enrollment session.
+- Key fields: `session_id`, `runtime_id`, `volume_ref`, `volume_mount_path`, `session_ttl`, `runner_image`, `bootstrap_command`.
+- Validation rules:
+  - `session_id`, `runtime_id`, `volume_ref`, `volume_mount_path`, and `bootstrap_command` are required.
+  - `session_ttl` is clamped to the existing safe session range.
+  - Runner image and command values must not expose generic Docker exec or ordinary task terminal behavior.
+- State transitions:
+  - `requested` -> `started` when the runner process/container is created and terminal metadata is available.
+  - `requested` -> `failed` for missing Docker, invalid mount, missing provider command, startup failure, command failure, or startup timeout.
+
+## Auth Runner Result
+
+- Purpose: Secret-free startup result persisted to the OAuth session row and returned to the workflow.
+- Key fields: `container_name`, `terminal_session_id`, `terminal_bridge_id`, `session_transport`, `expires_at`, `failure_reason`.
+- Validation rules:
+  - Successful results include nonblank terminal and container identifiers.
+  - Failed results expose only bounded redacted failure categories.
+  - Raw command output, credential files, token values, environment dumps, and raw auth-volume listings are forbidden.
+
+## Runner Cleanup Result
+
+- Purpose: Idempotent cleanup summary for success, failure, expiry, cancellation, API-finalize, and repeated cleanup paths.
+- Key fields: `session_id`, `container_name`, `stopped`, `reason`.
+- Validation rules:
+  - Missing or already-stopped containers return secret-free no-op outcomes.
+  - Cleanup failures are logged as bounded metadata and do not expose raw credential material.
+
+## Cross-Cutting Rules
+
+- Preserve Jira issue key `MM-361` as traceability metadata in generated artifacts, verification output, commit text, and pull request metadata.
+- Keep OAuth runner terminal evidence separate from managed Codex task execution evidence.
+- Prefer compact refs and explicit status values over provider-shaped dictionaries.

--- a/specs/192-oauth-runner-bootstrap-pty/plan.md
+++ b/specs/192-oauth-runner-bootstrap-pty/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: OAuth Runner Bootstrap PTY
+
+**Branch**: `192-oauth-runner-bootstrap-pty` | **Date**: 2026-04-16 | **Spec**: `specs/192-oauth-runner-bootstrap-pty/spec.md`
+**Input**: Single-story feature specification from `specs/192-oauth-runner-bootstrap-pty/spec.md`
+
+**Note**: The standard setup script initially rejected the managed branch name `mm-361-9a0dffbf`; it succeeded with `SPECIFY_FEATURE=192-oauth-runner-bootstrap-pty` and created this plan.
+
+## Summary
+
+MM-361 replaces the placeholder Codex OAuth auth runner with a short-lived, session-owned runner that executes the provider registry bootstrap command in a PTY-backed terminal lifecycle. The implementation should stay within the existing OAuth session workflow, activity, provider registry, and terminal bridge boundaries; avoid new persistent storage; keep OAuth terminal evidence separate from managed task execution; and prove behavior through red-first unit tests plus hermetic Temporal boundary coverage when Docker-backed integration is available.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, pytest, existing OAuth provider registry, existing OAuth session workflow/activity catalog, existing terminal bridge runtime helpers  
+**Storage**: Existing OAuth session database row and workflow/activity payloads only; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` with focused pytest targets for OAuth activities, terminal bridge runtime, provider registry, and OAuth session workflow behavior  
+**Integration Testing**: `./tools/test_integration.sh` for compose-backed `integration_ci` coverage, with focused Temporal OAuth session coverage in `tests/integration/temporal/test_oauth_session.py` when Docker is available  
+**Target Platform**: MoonMind API service and Temporal worker/runtime containers on Linux with Docker-controlled workload boundaries  
+**Project Type**: Backend orchestration/runtime feature with Temporal workflow and activity boundaries  
+**Performance Goals**: Auth runner startup remains bounded by the existing OAuth runner activity timeout; cleanup remains idempotent and retry-safe; failure reporting remains compact and secret-free  
+**Constraints**: Preserve `MM-361` traceability; do not expose generic Docker exec or ordinary managed task terminal access; do not leak raw credential contents into workflow history, browser responses, logs, or artifacts; avoid compatibility aliases for internal pre-release contracts  
+**Scale/Scope**: One independently testable story focused on Codex OAuth auth runner bootstrap PTY lifecycle; managed Codex task execution and Claude/Gemini parity remain out of scope
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I Orchestrate, Don't Recreate: PASS. The plan orchestrates provider bootstrap execution through existing runtime boundaries instead of rebuilding provider auth behavior.
+- II One-Click Agent Deployment: PASS. Uses existing local-first Docker and managed-agent test tooling with no new mandatory external service.
+- III Avoid Vendor Lock-In: PASS. Provider command selection remains behind the existing OAuth provider registry and runtime IDs.
+- IV Own Your Data: PASS. Credentials stay in operator-controlled auth volumes; workflow and artifacts carry refs and redacted metadata only.
+- V Skills Are First-Class: PASS. No executable skill contracts or skill materialization behavior are changed.
+- VI Bittersweet Lesson: PASS. The work tightens thin runtime contracts and tests around volatile OAuth runner mechanics.
+- VII Runtime Configurability: PASS. Runner image and provider bootstrap command behavior remain driven by runtime/provider configuration.
+- VIII Modular Architecture: PASS. Changes stay in existing provider registry, OAuth activity, workflow, terminal bridge, and runner helper modules.
+- IX Resilient by Default: PASS. Cleanup is idempotent, failures are explicit, and activity retries remain bounded.
+- X Continuous Improvement: PASS. MoonSpec artifacts and verification will record outcomes and blocked integration evidence when applicable.
+- XI Spec-Driven Development: PASS. MM-361 has isolated spec and planning artifacts before implementation.
+- XII Canonical Docs Separation: PASS. Implementation planning remains under `specs/` and `docs/tmp`; canonical docs are source requirements, not migration logs.
+- XIII Pre-Release Compatibility: PASS. No compatibility aliases are planned; unsupported internal runtime values should fail fast. Existing Temporal activity invocation compatibility is preserved by keeping the worker-bound request shape compatible and resolving provider bootstrap data at the activity/runtime boundary.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/192-oauth-runner-bootstrap-pty/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── oauth-runner-bootstrap-pty.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/runtime/
+├── providers/
+│   ├── base.py
+│   └── registry.py
+└── terminal_bridge.py
+
+moonmind/workflows/temporal/activities/
+└── oauth_session_activities.py
+
+moonmind/workflows/temporal/workflows/
+└── oauth_session.py
+
+api_service/services/
+└── oauth_auth_runner.py
+
+tests/unit/auth/
+├── test_oauth_provider_registry.py
+└── test_oauth_session_activities.py
+
+tests/unit/services/temporal/runtime/
+└── test_terminal_bridge.py
+
+tests/integration/temporal/
+└── test_oauth_session.py
+```
+
+**Structure Decision**: Use the existing backend orchestration/runtime layout. MM-361 does not require a new package, router, database table, or frontend surface; the work belongs at the OAuth session activity and terminal bridge runtime boundary, with workflow and integration tests proving the existing Temporal invocation shape still works.
+
+## Test Strategy
+
+- Unit strategy: add red-first tests in `tests/unit/auth/test_oauth_provider_registry.py`, `tests/unit/auth/test_oauth_session_activities.py`, and `tests/unit/services/temporal/runtime/test_terminal_bridge.py` to prove provider bootstrap commands are non-empty, `oauth_session.start_auth_runner` supplies the provider bootstrap command to the terminal bridge, the bridge starts the runner without placeholder sleep behavior, startup failures are redacted, and stop/cleanup remains idempotent. Use `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` during focused iteration and `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` before final verification.
+- Integration strategy: add or update hermetic Temporal OAuth session coverage in `tests/integration/temporal/test_oauth_session.py` to prove the workflow still invokes `oauth_session.start_auth_runner` with the worker-bound payload shape and that success, failure, cancellation, expiry, and API-finalize paths stop the runner consistently. Run `./tools/test_integration.sh` when Docker is available; if the managed container lacks `/var/run/docker.sock`, record the exact blocker in verification output rather than treating integration as passed.
+
+## Complexity Tracking
+
+None.

--- a/specs/192-oauth-runner-bootstrap-pty/quickstart.md
+++ b/specs/192-oauth-runner-bootstrap-pty/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: OAuth Runner Bootstrap PTY
+
+## Prerequisites
+
+- Work from repository root.
+- Use managed-agent local test mode for unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1`.
+- Docker is required only for compose-backed hermetic integration verification.
+- The active feature directory is `specs/192-oauth-runner-bootstrap-pty`.
+
+## Focused Unit Verification
+
+Run the red-first unit targets for the MM-361 runner lifecycle:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py
+```
+
+Expected pre-implementation result: newly added MM-361 tests fail because the runner still uses placeholder sleep behavior or does not route provider bootstrap command ownership through the terminal bridge.
+
+Expected post-implementation result: focused tests pass and prove provider bootstrap command validation, activity-to-runtime runner startup, terminal bridge command ownership, redacted startup failures, generic exec rejection, and idempotent cleanup.
+
+## Workflow Boundary Verification
+
+Run focused Temporal OAuth session tests when iterating on workflow/activity boundaries:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_session_activities.py
+```
+
+Expected result: workflow-bound activity payload expectations remain compatible while runner startup and cleanup behavior reflect the MM-361 contract.
+
+## Full Unit Verification
+
+Before final verification, run:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Expected result: full required unit suite passes.
+
+## Integration Verification
+
+When Docker is available, run:
+
+```bash
+./tools/test_integration.sh
+```
+
+Coverage target: `tests/integration/temporal/test_oauth_session.py` must include or retain hermetic coverage for OAuth session success, failure, cancellation, expiry, API-finalize, and runner stop paths.
+
+Expected result: hermetic integration coverage passes in a Docker-enabled environment. If `/var/run/docker.sock` is unavailable in a managed-agent container, record the exact blocker in verification output.
+
+## End-To-End Story Check
+
+1. Confirm `spec.md` preserves `MM-361` and the original Jira preset brief.
+2. Confirm `plan.md`, `research.md`, `data-model.md`, `contracts/oauth-runner-bootstrap-pty.md`, and `quickstart.md` exist.
+3. Confirm unit and integration test strategies remain separate.
+4. Confirm runner startup no longer uses placeholder sleep behavior for provider bootstrap terminal ownership.
+5. After implementation, run `/moonspec-verify` equivalent against `specs/192-oauth-runner-bootstrap-pty/spec.md`.
+
+## Validation Results - 2026-04-16
+
+- Red-first focused unit evidence: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` failed before production changes for the expected MM-361 reasons: missing provider bootstrap command resolver, activity not passing `bootstrap_command`, terminal bridge not accepting `bootstrap_command`, and placeholder runner startup behavior.
+- Focused unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/test_oauth_terminal_websocket.py tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` passed with 46 Python tests and 225 dashboard tests.
+- Focused Temporal integration verification: `pytest tests/integration/temporal/test_oauth_session.py -q --tb=short` passed with 9 tests.
+- Compose-backed integration verification: `./tools/test_integration.sh` did not run because `/var/run/docker.sock` is unavailable in this managed container (`dial unix /var/run/docker.sock: connect: no such file or directory`).
+- Full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3448 Python tests, 1 xpass, 16 subtests, and 225 dashboard tests.

--- a/specs/192-oauth-runner-bootstrap-pty/research.md
+++ b/specs/192-oauth-runner-bootstrap-pty/research.md
@@ -1,0 +1,43 @@
+# Research: OAuth Runner Bootstrap PTY
+
+## Auth Runner Boundary
+
+Decision: Implement MM-361 at the existing OAuth session activity/runtime boundary by having `oauth_session.start_auth_runner` resolve the provider bootstrap command from the OAuth provider registry and pass it into the terminal bridge startup helper.
+Rationale: The existing workflow already invokes `oauth_session.start_auth_runner` with `session_id`, `runtime_id`, volume refs, and TTL. Resolving bootstrap details inside the activity keeps workflow history compact and preserves the worker-bound invocation shape for in-flight compatibility while still replacing placeholder runner behavior.
+Alternatives considered: Adding bootstrap command fields to the workflow input or Temporal activity payload was rejected because it would spread provider configuration through workflow history and create unnecessary compatibility-sensitive payload churn.
+
+## Provider Bootstrap Command Source
+
+Decision: Treat the OAuth provider registry as the source of provider bootstrap commands for this story, and fail fast when a supported runtime has no non-empty bootstrap command.
+Rationale: The registry already contains provider defaults such as runtime ID, session transport, auth volume name, mount path, and `bootstrap_command`; keeping command selection there preserves provider ownership boundaries and avoids hard-coded command behavior in the workflow.
+Alternatives considered: Reading commands from environment variables or per-request fields was rejected for this story because it would introduce unvalidated runtime input and obscure the provider boundary that the source design requires.
+
+## PTY Runner Startup
+
+Decision: Replace placeholder `sleep` runner startup with a runner command path that starts the configured runner image with the selected auth volume mounted and the provider bootstrap command as the terminal-owned process.
+Rationale: MM-361 specifically exists because the current runner starts an image with `sleep`, which does not exercise provider login behavior or own the terminal session. The planned boundary should make command execution explicit and testable without exposing generic exec.
+Alternatives considered: Keeping `sleep` plus separate exec into the container was rejected because generic exec is explicitly out of scope and forbidden by the OAuth terminal boundary.
+
+## Failure Redaction
+
+Decision: Normalize runner startup and bootstrap failures into actionable, redacted reasons that identify missing Docker, mount/startup failure, missing provider command, command failure, or timeout without echoing full command output or credential-like values.
+Rationale: The constitution and OAuth terminal design both prohibit raw credentials in workflow history, logs, artifacts, or browser responses. Startup errors still need operator value, so the reason must be categorical and bounded.
+Alternatives considered: Returning raw stderr was rejected because provider login output can contain credential-like strings or environment details.
+
+## Cleanup Semantics
+
+Decision: Keep cleanup best-effort and idempotent through the existing stop/remove helper, while adding tests for no-container, already-stopped, partial-start, and failure cases.
+Rationale: OAuth sessions can finish through success, failure, cancellation, expiry, or API-finalize paths; cleanup must be retry-safe and should not turn an already-finished terminal session into a hard failure.
+Alternatives considered: Making stop failures terminal workflow errors was rejected because cleanup retry noise should not obscure the final OAuth session outcome.
+
+## Unit Test Strategy
+
+Decision: Use focused Python unit tests for provider registry validation, activity-to-runtime payload construction, terminal bridge runner startup command construction, failure redaction, generic exec rejection, and cleanup idempotency.
+Rationale: These tests can be deterministic with mocked process creation and do not require real credentials, live providers, or Docker socket access.
+Alternatives considered: Provider verification tests were rejected for this planning phase because MM-361 requires hermetic evidence first.
+
+## Integration Test Strategy
+
+Decision: Use `tests/integration/temporal/test_oauth_session.py` for hermetic Temporal boundary coverage of the existing OAuth workflow invocation shape and runner lifecycle terminal paths.
+Rationale: MM-361 touches Temporal workflow/activity boundaries and must prove the workflow can still start, finalize, fail, cancel, expire, and stop the runner through the real worker-bound activity names.
+Alternatives considered: Relying only on unit tests was rejected because the workflow/activity boundary is compatibility-sensitive and requires boundary evidence.

--- a/specs/192-oauth-runner-bootstrap-pty/spec.md
+++ b/specs/192-oauth-runner-bootstrap-pty/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: OAuth Runner Bootstrap PTY
+
+**Feature Branch**: `192-oauth-runner-bootstrap-pty`  
+**Created**: 2026-04-16  
+**Status**: Draft  
+**Input**:
+
+```text
+# MM-361 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-361
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+- Labels: `MM-318`, `managed-sessions`, `oauth-terminal`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-361 from MM project
+Summary: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-361 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-361: [OAuthTerminal] Replace placeholder auth runner with provider bootstrap PTY lifecycle
+
+Short Name
+oauth-runner-bootstrap-pty
+
+User Story
+As a MoonMind operator, I can start a Codex OAuth enrollment session that launches a short-lived auth runner container running the provider bootstrap command in a PTY, so credential enrollment is first-party and does not depend on placeholder container behavior.
+
+Acceptance Criteria
+- Given an authorized Codex OAuth session starts, the auth runner container mounts the selected auth volume at the provider enrollment path.
+- Given the provider registry defines a bootstrap command, the runner executes that command in a PTY owned by the OAuth enrollment session.
+- Given the session succeeds, fails, expires, or is cancelled, the runner stops and cleanup is idempotent.
+- Given the runner is active, it exposes no ordinary managed task terminal and no generic Docker exec capability.
+- Given runner startup fails because Docker or the provider CLI is unavailable, the OAuth session fails with an actionable, redacted reason.
+
+Current Evidence
+- `specs/183-oauth-terminal-flow/verification.md` has verdict `ADDITIONAL_WORK_NEEDED`.
+- `moonmind/workflows/temporal/runtime/terminal_bridge.py` currently starts a runner image with `sleep` and comments that the real specialized PTY container is not implemented.
+
+Requirements
+- Replace the placeholder auth runner lifecycle with a short-lived runner container that executes the selected provider bootstrap command in a PTY.
+- Mount the selected Codex OAuth auth volume at the provider enrollment path during enrollment.
+- Scope the runner and PTY ownership to the OAuth enrollment session.
+- Route terminal behavior through MoonMind's authenticated PTY/WebSocket bridge only.
+- Stop the runner after success, failure, expiry, or cancellation, and make cleanup idempotent.
+- Fail with actionable, redacted diagnostics when Docker, runner startup, or provider CLI execution is unavailable.
+- Preserve the boundary that OAuth terminal code is for enrollment only, not managed task execution or generic Docker exec.
+
+Independent Test
+Start a Codex OAuth session with a fake provider bootstrap command, assert the auth runner mounts the selected auth volume, executes the bootstrap command inside the session-owned PTY, exposes only authenticated terminal bridge access, and performs idempotent cleanup for success, failure, expiry, and cancellation paths with redacted failure reasons.
+
+Out of Scope
+- Managed Codex task execution changes.
+- Claude/Gemini task-scoped session parity.
+- Generic Docker exec exposure.
+- Ordinary managed task terminal attachment.
+
+Source Document
+docs/ManagedAgents/OAuthTerminal.md
+
+Source Sections
+- 5. OAuth Terminal Contract
+- 5.1 Auth runner container
+- 10. Operator Behavior
+
+Coverage IDs
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-014
+- DESIGN-REQ-020
+
+Source Design Coverage
+- DESIGN-REQ-011: Provide a first-party OAuth terminal architecture using Mission Control, OAuth Session API, MoonMind.OAuthSession, short-lived auth runner, PTY/WebSocket bridge, and xterm.js.
+- DESIGN-REQ-012: Run a short-lived auth runner container that mounts the auth volume at the provider enrollment path and tears down on success, cancellation, expiry, or failure.
+- DESIGN-REQ-014: Do not expose generic Docker exec access or ordinary task-run terminal attachment through the OAuth terminal bridge.
+- DESIGN-REQ-020: Preserve ownership boundaries among OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration.
+
+Relevant Implementation Notes
+- The auth runner container is short-lived and scoped to one OAuth session.
+- For Codex, the auth runner targets `codex_auth_volume` at `/home/app/.codex` while enrollment is happening.
+- The OAuth terminal is only for credential enrollment or repair and must not become the runtime surface for managed Codex task execution.
+- Later task-scoped Codex managed sessions target the registered provider profile and mount the auth volume separately when needed.
+
+Needs Clarification
+- None
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.
+
+## User Story - OAuth Runner Bootstrap PTY
+
+**Summary**: As a MoonMind operator, I want Codex OAuth enrollment to launch a short-lived, session-owned auth runner that executes the provider bootstrap command in an interactive terminal so that credential enrollment is first-party and no longer depends on placeholder container behavior.
+
+**Goal**: Operators can start Codex OAuth enrollment and observe that the selected auth volume is mounted for enrollment, the provider bootstrap command owns the interactive terminal session, cleanup is reliable across terminal outcomes, and failures are actionable without exposing secrets.
+
+**Independent Test**: Start a Codex OAuth session using a fake provider bootstrap command, complete or terminate the session through success, failure, expiry, and cancellation paths, and verify volume targeting, command execution ownership, bridge-only access, idempotent cleanup, and redacted failure reporting.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized operator starts a Codex OAuth enrollment session, **when** the auth runner starts, **then** the selected auth volume is mounted at the provider enrollment path for that session.
+2. **Given** the selected provider profile defines a bootstrap command, **when** the auth runner becomes interactive, **then** the command runs in a terminal session owned by the OAuth enrollment session.
+3. **Given** the auth runner is active, **when** terminal access is requested, **then** access is available only through MoonMind's authenticated terminal bridge and not through ordinary task terminal attachment or generic Docker exec.
+4. **Given** the session succeeds, fails, expires, or is cancelled, **when** cleanup runs once or multiple times, **then** the runner stops and cleanup leaves a consistent terminal state.
+5. **Given** the runner cannot start or the provider bootstrap command cannot run, **when** the OAuth session reports failure, **then** the operator receives an actionable, redacted reason.
+
+### Edge Cases
+
+- The selected auth volume is missing, unavailable, or cannot be mounted at the enrollment path.
+- The provider registry has no bootstrap command or has a command that exits before terminal readiness.
+- Runner startup succeeds but terminal bridge readiness never occurs before the session expires.
+- The operator cancels while bootstrap command startup, terminal readiness, or credential verification is in progress.
+- Cleanup is retried after partial runner startup, failed runner startup, or an already-stopped runner.
+- Failure details include credential-like output that must not appear in workflow history, logs, artifacts, or browser responses.
+
+## Assumptions
+
+- MM-361 is a follow-up to the MM-358 OAuth terminal story and narrows scope to replacing the placeholder auth runner lifecycle with real provider bootstrap terminal ownership.
+- Existing OAuth session authorization, profile registration, credential verification, and managed Codex task execution behavior remain in place unless needed to validate this runner lifecycle.
+- Runtime validation can use deterministic fake provider bootstrap commands before live provider enrollment is exercised.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-011**: Source section 5 requires first-party OAuth terminal enrollment to connect Mission Control, OAuth session control, a short-lived auth runner, a terminal bridge, provider login, mounted auth volume verification, and profile registration. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, and FR-011.
+- **DESIGN-REQ-012**: Source section 5.1 requires the auth runner to be short-lived, scoped to one OAuth session, mounted to the provider enrollment path, connected only through the authenticated bridge, stopped after terminal outcomes, and leave credentials in the durable auth volume for later verification. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-006, FR-007, FR-008, FR-009, and FR-010.
+- **DESIGN-REQ-014**: Source sections 5.2 and 11 forbid generic Docker exec access and ordinary task-run terminal attachment through the OAuth terminal bridge. Scope: in scope. Maps to FR-004, FR-005, and FR-010.
+- **DESIGN-REQ-020**: Source section 11 requires OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration to keep their ownership boundaries separate. Scope: in scope. Maps to FR-010, FR-011, FR-012, and FR-013.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST start a short-lived auth runner for an authorized Codex OAuth enrollment session.
+- **FR-002**: The auth runner MUST mount the selected auth volume at the provider enrollment path for the duration of enrollment.
+- **FR-003**: The auth runner MUST execute the selected provider bootstrap command in a terminal session owned by the OAuth enrollment session.
+- **FR-004**: Terminal input and output for the runner MUST be reachable only through MoonMind's authenticated OAuth terminal bridge.
+- **FR-005**: System MUST reject or omit ordinary managed task terminal attachment for OAuth runner sessions.
+- **FR-006**: System MUST stop the auth runner after success, failure, expiry, or cancellation.
+- **FR-007**: Runner cleanup MUST be idempotent across repeated cleanup requests and partially-started runner states.
+- **FR-008**: Runner startup failures MUST produce actionable, redacted failure reasons for operators.
+- **FR-009**: Provider bootstrap command failures MUST produce actionable, redacted failure reasons for operators.
+- **FR-010**: System MUST NOT expose generic Docker exec access through the OAuth terminal bridge.
+- **FR-011**: Runtime records MUST keep OAuth enrollment terminal evidence separate from managed Codex task execution evidence.
+- **FR-012**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key MM-361 and the original preset brief as traceability evidence.
+- **FR-013**: System MUST keep raw credential contents out of workflow history, logs, artifacts, and browser-visible failure responses during runner startup, execution, and cleanup.
+
+### Key Entities
+
+- **OAuth Enrollment Session**: Operator-started credential enrollment flow scoped to an auth volume, provider profile target, runner lifecycle, terminal state, and terminal outcome.
+- **Auth Runner**: Short-lived enrollment runner scoped to one OAuth session that mounts the selected auth volume, runs the provider bootstrap command, and stops after a terminal outcome.
+- **Provider Bootstrap Command**: Provider-defined enrollment command that creates or repairs credentials in the selected auth volume.
+- **OAuth Terminal Bridge**: Authenticated terminal transport that mediates browser input and output for the runner without exposing generic exec or ordinary task terminal access.
+- **Runner Outcome**: Secret-free terminal result describing success, failure, expiry, cancellation, cleanup status, and redacted operator-facing reason when needed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit tests prove authorized Codex OAuth enrollment starts exactly one session-scoped auth runner with the selected auth volume mounted at the provider enrollment path.
+- **SC-002**: Unit tests prove provider bootstrap command execution is represented as session-owned terminal behavior rather than placeholder sleep behavior.
+- **SC-003**: Unit tests prove success, failure, expiry, and cancellation each stop the auth runner and repeated cleanup leaves the same terminal runner state.
+- **SC-004**: Unit tests prove missing runner dependencies, mount failures, startup failures, and bootstrap command failures return actionable redacted reasons.
+- **SC-005**: Boundary tests prove OAuth runner terminal access is only available through the authenticated OAuth terminal bridge and not through ordinary managed task terminal attachment or generic Docker exec.
+- **SC-006**: Verification evidence confirms MM-361 and the original preset brief are preserved in the active Moon Spec artifacts and delivery metadata.

--- a/specs/192-oauth-runner-bootstrap-pty/tasks.md
+++ b/specs/192-oauth-runner-bootstrap-pty/tasks.md
@@ -1,0 +1,176 @@
+# Tasks: OAuth Runner Bootstrap PTY
+
+**Input**: Design documents from `/specs/192-oauth-runner-bootstrap-pty/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/oauth-runner-bootstrap-pty.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around a single MM-361 story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: The original MM-361 Jira preset brief is preserved in `specs/192-oauth-runner-bootstrap-pty/spec.md`. Tasks cover FR-001 through FR-013, acceptance scenarios 1-5, edge cases, SC-001 through SC-006, and DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-014, and DESIGN-REQ-020.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active MM-361 artifacts and local test targets before writing failing tests.
+
+- [X] T001 Confirm `.specify/feature.json` points to `specs/192-oauth-runner-bootstrap-pty` and MM-361 traceability is present in `specs/192-oauth-runner-bootstrap-pty/spec.md` (FR-012, SC-006)
+- [X] T002 Confirm the planned unit and integration commands in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` match the repo test taxonomy in `AGENTS.md` (SC-001, SC-005)
+- [X] T003 [P] Review provider registry bootstrap command fields in `moonmind/workflows/temporal/runtime/providers/registry.py` against `specs/192-oauth-runner-bootstrap-pty/contracts/oauth-runner-bootstrap-pty.md` (FR-003, DESIGN-REQ-011)
+- [X] T004 [P] Review current placeholder runner startup in `moonmind/workflows/temporal/runtime/terminal_bridge.py` and record the expected red-first failure target in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` (FR-003, SC-002)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish test fixtures and boundary assumptions required before story implementation starts.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T005 Add or adjust process-spawn monkeypatch fixtures for terminal bridge runner startup in `tests/unit/services/temporal/runtime/test_terminal_bridge.py` (FR-002, FR-003, FR-008, FR-009)
+- [X] T006 Add or adjust activity monkeypatch fixtures for provider lookup and terminal bridge startup in `tests/unit/auth/test_oauth_session_activities.py` (FR-001, FR-003, DESIGN-REQ-012)
+- [X] T007 [P] Add or adjust provider registry fixture coverage helpers in `tests/unit/auth/test_oauth_provider_registry.py` (FR-003, DESIGN-REQ-011)
+- [X] T008 [P] Add or adjust Temporal OAuth session integration activity stubs in `tests/integration/temporal/test_oauth_session.py` to record start and stop runner calls without live provider credentials (FR-006, FR-007, DESIGN-REQ-012)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - OAuth Runner Bootstrap PTY
+
+**Summary**: As a MoonMind operator, I want Codex OAuth enrollment to launch a short-lived, session-owned auth runner that executes the provider bootstrap command in an interactive terminal so that credential enrollment is first-party and no longer depends on placeholder container behavior.
+
+**Independent Test**: Start a Codex OAuth session using a fake provider bootstrap command, complete or terminate the session through success, failure, expiry, and cancellation paths, and verify volume targeting, command execution ownership, bridge-only access, idempotent cleanup, and redacted failure reporting.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-014, DESIGN-REQ-020
+
+**Test Plan**:
+
+- Unit: provider registry bootstrap command validation, activity-to-runtime command resolution, terminal bridge command startup, redacted failures, generic exec rejection, and idempotent cleanup.
+- Integration: Temporal OAuth session success, failure, cancellation, expiry, API-finalize, and runner stop paths through the existing workflow/activity boundary.
+
+### Unit Tests (write first) ⚠️
+
+> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
+
+- [X] T009 [P] Add failing unit tests proving OAuth provider specs expose non-empty provider bootstrap commands and Codex no longer uses placeholder-only behavior in `tests/unit/auth/test_oauth_provider_registry.py` (FR-003, SC-002, DESIGN-REQ-011)
+- [X] T010 [P] Add failing unit tests proving `oauth_session.start_auth_runner` resolves the provider bootstrap command and passes it to terminal bridge startup in `tests/unit/auth/test_oauth_session_activities.py` (FR-001, FR-003, DESIGN-REQ-012)
+- [X] T011 [P] Add failing unit tests proving missing or unsupported provider bootstrap command values fail fast with redacted reasons in `tests/unit/auth/test_oauth_session_activities.py` (FR-008, FR-009, FR-013)
+- [X] T012 [P] Add failing unit tests proving terminal bridge runner startup uses the selected auth volume mount and provider bootstrap command instead of `sleep` in `tests/unit/services/temporal/runtime/test_terminal_bridge.py` (FR-002, FR-003, SC-001, SC-002)
+- [X] T013 [P] Add failing unit tests proving terminal bridge startup redacts Docker, mount, timeout, and command failure details in `tests/unit/services/temporal/runtime/test_terminal_bridge.py` (FR-008, FR-009, FR-013)
+- [X] T014 [P] Add failing unit tests proving OAuth terminal bridge rejects generic Docker exec and ordinary task terminal frames while preserving authenticated bridge-only behavior in `tests/unit/services/temporal/runtime/test_terminal_bridge.py` (FR-004, FR-005, FR-010, DESIGN-REQ-014)
+- [X] T015 [P] Add failing unit tests proving auth runner cleanup is idempotent for missing, already-stopped, and remove-failed containers in `tests/unit/auth/test_oauth_session_activities.py` (FR-006, FR-007, SC-003)
+- [X] T016 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` to confirm T009-T015 fail for the expected MM-361 reasons in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` (SC-001, SC-002, SC-003, SC-004)
+
+### Integration Tests (write first) ⚠️
+
+- [X] T017 [P] Add failing Temporal integration coverage proving OAuth session success starts and stops the session-owned runner through `oauth_session.start_auth_runner` and `oauth_session.stop_auth_runner` in `tests/integration/temporal/test_oauth_session.py` (acceptance scenarios 1, 2, and 4; FR-001, FR-002, FR-003, FR-006)
+- [X] T018 [P] Add failing Temporal integration coverage proving cancellation, expiry, failure signal, and API-finalize paths stop the auth runner consistently in `tests/integration/temporal/test_oauth_session.py` (acceptance scenario 4; FR-006, FR-007, SC-003)
+- [X] T019 [P] Add failing Temporal integration coverage proving workflow activity payload shape remains compatible, bridge-only terminal metadata is preserved, and provider bootstrap command resolution stays inside the activity/runtime boundary in `tests/integration/temporal/test_oauth_session.py` (acceptance scenario 3; FR-003, FR-004, FR-005, FR-011, DESIGN-REQ-014, DESIGN-REQ-020)
+- [X] T020 [P] Add failing Temporal integration coverage proving auth runner launch failure returns an actionable redacted failure reason in `tests/integration/temporal/test_oauth_session.py` (acceptance scenario 5; FR-008, FR-009, FR-013)
+- [X] T021 Run `./tools/test_integration.sh` or record the Docker socket blocker in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` to confirm T017-T020 fail for the expected MM-361 reasons before production changes (SC-005, DESIGN-REQ-012)
+
+### Red-First Confirmation ⚠️
+
+- [X] T022 Confirm unit failures from T016 identify placeholder sleep behavior, missing provider command resolution, or missing redaction in `tests/unit/services/temporal/runtime/test_terminal_bridge.py` and `tests/unit/auth/test_oauth_session_activities.py` before editing production code (SC-001, SC-002, SC-004)
+- [X] T023 Confirm integration failures from T021 identify missing MM-361 runner lifecycle behavior or document the unavailable Docker blocker in `tests/integration/temporal/test_oauth_session.py` before editing production code (SC-005)
+
+### Implementation
+
+- [X] T024 Replace placeholder OAuth provider bootstrap command values with validated runtime provider bootstrap commands in `moonmind/workflows/temporal/runtime/providers/registry.py` (FR-003, DESIGN-REQ-011)
+- [X] T025 Add provider bootstrap command validation helpers in `moonmind/workflows/temporal/runtime/providers/registry.py` (FR-003, FR-008, FR-009)
+- [X] T026 Update `oauth_session.start_auth_runner` to resolve provider bootstrap commands by `runtime_id`, fail fast for missing commands, and pass commands to terminal bridge startup in `moonmind/workflows/temporal/activities/oauth_session_activities.py` (FR-001, FR-003, FR-008, FR-009, DESIGN-REQ-012)
+- [X] T027 Update terminal bridge runner startup to accept a provider bootstrap command, mount the selected auth volume, and start the command as the session-owned terminal process instead of placeholder sleep behavior in `moonmind/workflows/temporal/runtime/terminal_bridge.py` (FR-002, FR-003, SC-001, SC-002)
+- [X] T028 Add bounded redaction for runner startup, Docker, mount, timeout, and command failures in `moonmind/workflows/temporal/runtime/terminal_bridge.py` (FR-008, FR-009, FR-013)
+- [X] T029 Ensure auth runner cleanup remains idempotent and returns stable secret-free outcomes in `api_service/services/oauth_auth_runner.py` and `moonmind/workflows/temporal/activities/oauth_session_activities.py` (FR-006, FR-007, SC-003)
+- [X] T030 Confirm OAuth workflow failure and stop paths continue to call existing activities with compatible payloads in `moonmind/workflows/temporal/workflows/oauth_session.py` (FR-006, FR-007, FR-011, DESIGN-REQ-020)
+- [X] T031 Confirm generic Docker exec and ordinary task terminal attachment remain rejected or omitted through terminal bridge frame handling in `moonmind/workflows/temporal/runtime/terminal_bridge.py` (FR-004, FR-005, FR-010, DESIGN-REQ-014)
+- [X] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` and fix failures in touched production files until the focused unit suite passes (SC-001, SC-002, SC-003, SC-004)
+- [X] T033 Run `./tools/test_integration.sh` when Docker is available or record the exact Docker blocker in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` (SC-005)
+
+**Checkpoint**: The MM-361 story is fully functional, covered by unit and integration strategy, and testable independently.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T034 [P] Update `specs/192-oauth-runner-bootstrap-pty/contracts/oauth-runner-bootstrap-pty.md` if implementation evidence changes the runner startup or failure contract without changing story scope (FR-012, SC-006)
+- [X] T035 [P] Update `specs/192-oauth-runner-bootstrap-pty/quickstart.md` with final focused unit, full unit, and integration command results or blockers (FR-012, SC-006)
+- [X] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification and record the result in `specs/192-oauth-runner-bootstrap-pty/quickstart.md` (SC-006)
+- [X] T037 Run `/moonspec-verify` (`/speckit.verify` equivalent) against `specs/192-oauth-runner-bootstrap-pty/spec.md` after implementation and tests pass, preserving MM-361 and the original preset brief in verification output (FR-012, SC-006)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish & Verification (Phase 4)**: Depends on story implementation and focused validation passing.
+
+### Within The Story
+
+- Unit tests T009-T015 must be written before implementation tasks T024-T031.
+- Integration tests T017-T020 must be written before implementation tasks T024-T031.
+- Red-first confirmation tasks T022-T023 must complete before production code tasks T024-T031.
+- Provider registry validation T024-T025 precedes activity resolution T026.
+- Activity resolution T026 precedes terminal bridge command startup T027-T028.
+- Cleanup and workflow compatibility tasks T029-T030 follow the runner startup contract.
+- Focused validation T032-T033 follows all production code tasks.
+- Final verification T037 follows full unit verification T036.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel during setup.
+- T007 and T008 can run in parallel with T005-T006 because they touch different test files.
+- T009, T012, T014, and T017 can be authored in parallel after foundational fixtures are ready because they touch different files.
+- T034 and T035 can run in parallel after implementation validation because they update separate MoonSpec artifacts.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent red-first test authoring together:
+Task: "T009 Add failing provider registry bootstrap tests in tests/unit/auth/test_oauth_provider_registry.py"
+Task: "T012 Add failing terminal bridge startup command tests in tests/unit/services/temporal/runtime/test_terminal_bridge.py"
+Task: "T017 Add failing Temporal success lifecycle coverage in tests/integration/temporal/test_oauth_session.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 setup checks and Phase 2 fixtures.
+2. Write unit tests T009-T015 and confirm focused unit failures with T016.
+3. Write integration tests T017-T020 and confirm failures or Docker blocker with T021.
+4. Complete red-first confirmation T022-T023.
+5. Implement provider registry validation, activity command resolution, terminal bridge runner startup, failure redaction, cleanup idempotency, and workflow compatibility through T024-T031.
+6. Run focused unit and integration validation with T032-T033.
+7. Complete polish, full unit verification, and `/moonspec-verify` through T034-T037.
+
+---
+
+## Notes
+
+- This task list covers exactly one story: MM-361 OAuth Runner Bootstrap PTY.
+- Do not add managed Codex task execution changes, Claude/Gemini parity work, generic Docker exec exposure, or ordinary managed task terminal attachment.
+- Preserve `MM-361` and the original Jira preset brief in implementation notes, verification output, commit text, and pull request metadata.
+- Integration tests may be blocked inside managed-agent containers without Docker socket access; record that blocker explicitly instead of treating integration as passed.

--- a/tests/integration/temporal/test_oauth_session.py
+++ b/tests/integration/temporal/test_oauth_session.py
@@ -188,6 +188,61 @@ async def test_oauth_session_workflow_external_failure() -> None:
             )
 
 
+async def test_oauth_session_workflow_start_failure_is_redacted() -> None:
+    """Auth runner launch failures return actionable reasons without raw secrets."""
+    failures: list[str] = []
+
+    @activity.defn(name="oauth_session.start_auth_runner")
+    async def failing_start_auth_runner(request: dict) -> dict:
+        raise RuntimeError("failed token=super-secret password=hunter2")
+
+    @activity.defn(name="oauth_session.mark_failed")
+    async def record_mark_failed(request: dict) -> dict:
+        failures.append(request["reason"])
+        return {}
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                mock_ensure_volume,
+                failing_start_auth_runner,
+                mock_update_terminal_session,
+                mock_update_status,
+                mock_verify_cli_fingerprint,
+                mock_register_profile,
+                mock_stop_auth_runner,
+                record_mark_failed,
+            ],
+        ), Worker(
+            env.client,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            workflows=[MoonMindOAuthSessionWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                MoonMindOAuthSessionWorkflow.run,
+                {
+                    "session_id": "sess_start_failure",
+                    "runtime_id": "codex_cli",
+                    "volume_ref": "vol_123",
+                    "volume_mount_path": "/mnt/auth",
+                },
+                id="oauth-session:sess_start_failure",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+    assert result["session_id"] == "sess_start_failure"
+    assert result["status"] == "failed"
+    assert "Auth runner launch failed" in result["failure_reason"]
+    assert "token=" not in result["failure_reason"]
+    assert "password=" not in result["failure_reason"]
+    assert failures
+    assert "token=" not in failures[0]
+    assert "password=" not in failures[0]
+
+
 async def test_oauth_session_workflow_api_finalize_skips_verify_and_register() -> None:
     """API-completed finalization closes without re-running verify/register."""
     verify_calls = 0
@@ -311,6 +366,86 @@ async def test_oauth_session_workflow_missing_transport_uses_legacy_bridge_defau
         }
     ]
     assert terminal_payloads[0]["session_transport"] == "moonmind_pty_ws"
+
+
+async def test_oauth_session_workflow_success_starts_and_stops_runner() -> None:
+    """Successful OAuth session owns runner startup and cleanup metadata."""
+    start_payloads: list[dict] = []
+    stop_payloads: list[dict] = []
+    terminal_payloads: list[dict] = []
+
+    @activity.defn(name="oauth_session.start_auth_runner")
+    async def record_start_auth_runner(request: dict) -> dict:
+        start_payloads.append(request)
+        return {
+            "container_name": "mocked_container",
+            "terminal_session_id": "ts_123",
+            "terminal_bridge_id": "br_123",
+            "session_transport": "moonmind_pty_ws",
+        }
+
+    @activity.defn(name="oauth_session.update_terminal_session")
+    async def record_update_terminal_session(request: dict) -> dict:
+        terminal_payloads.append(request)
+        return {}
+
+    @activity.defn(name="oauth_session.stop_auth_runner")
+    async def record_stop_auth_runner(request: dict) -> dict:
+        stop_payloads.append(request)
+        return {"stopped": True}
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=ACTIVITY_TASK_QUEUE,
+            activities=[
+                mock_ensure_volume,
+                record_start_auth_runner,
+                record_update_terminal_session,
+                mock_update_status,
+                mock_verify_cli_fingerprint,
+                mock_register_profile,
+                record_stop_auth_runner,
+            ],
+        ), Worker(
+            env.client,
+            task_queue=WORKFLOW_TASK_QUEUE,
+            workflows=[MoonMindOAuthSessionWorkflow],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                MoonMindOAuthSessionWorkflow.run,
+                {
+                    "session_id": "sess_runner_lifecycle",
+                    "runtime_id": "codex_cli",
+                    "volume_ref": "vol_123",
+                    "volume_mount_path": "/mnt/auth",
+                },
+                id="oauth-session:sess_runner_lifecycle",
+                task_queue=WORKFLOW_TASK_QUEUE,
+            )
+
+            await handle.signal(MoonMindOAuthSessionWorkflow.finalize)
+            result = await handle.result()
+
+    assert result["status"] == "succeeded"
+    assert start_payloads == [
+        {
+            "session_id": "sess_runner_lifecycle",
+            "runtime_id": "codex_cli",
+            "volume_ref": "vol_123",
+            "volume_mount_path": "/mnt/auth",
+            "session_ttl": 1800,
+        }
+    ]
+    assert terminal_payloads[0]["terminal_bridge_id"] == "br_123"
+    assert terminal_payloads[0]["session_transport"] == "moonmind_pty_ws"
+    assert stop_payloads == [
+        {
+            "session_id": "sess_runner_lifecycle",
+            "container_name": "mocked_container",
+        }
+    ]
 
 
 async def test_oauth_session_workflow_rejects_codex_oauth_input_without_refs() -> None:

--- a/tests/unit/api_service/api/test_oauth_terminal_websocket.py
+++ b/tests/unit/api_service/api/test_oauth_terminal_websocket.py
@@ -54,8 +54,8 @@ def test_terminal_close_reason_accepts_active_unexpired_session() -> None:
 
 
 def test_provider_bootstrap_command_uses_registry_command() -> None:
-    assert websockets._provider_bootstrap_command("codex_cli") == ["true"]
-    assert websockets._command_for_docker_exec("codex_cli") == "true"
+    assert websockets._provider_bootstrap_command("codex_cli") == ["codex", "login"]
+    assert websockets._command_for_docker_exec("codex_cli") == "codex login"
 
 
 def test_provider_bootstrap_command_rejects_unknown_runtime() -> None:

--- a/tests/unit/auth/test_oauth_provider_registry.py
+++ b/tests/unit/auth/test_oauth_provider_registry.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from moonmind.workflows.temporal.runtime.providers.registry import (
     OAUTH_PROVIDERS,
+    get_provider_bootstrap_command,
     get_provider,
     get_provider_default,
     supported_runtime_ids,
@@ -90,3 +93,23 @@ class TestOAuthProviderRegistry:
             assert len(spec["bootstrap_command"]) > 0, (
                 f"Provider '{runtime_id}' bootstrap_command should not be empty"
             )
+
+    def test_codex_bootstrap_command_is_not_placeholder(self) -> None:
+        assert get_provider_bootstrap_command("codex_cli") == ("codex", "login")
+
+    def test_bootstrap_command_rejects_unknown_runtime(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported OAuth runtime"):
+            get_provider_bootstrap_command("unknown_runtime")
+
+    def test_bootstrap_command_rejects_blank_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        providers = dict(OAUTH_PROVIDERS)
+        providers["codex_cli"] = dict(providers["codex_cli"], bootstrap_command=[" "])
+        monkeypatch.setattr(
+            "moonmind.workflows.temporal.runtime.providers.registry.OAUTH_PROVIDERS",
+            providers,
+        )
+
+        with pytest.raises(ValueError, match="bootstrap command is not configured"):
+            get_provider_bootstrap_command("codex_cli")

--- a/tests/unit/auth/test_oauth_session_activities.py
+++ b/tests/unit/auth/test_oauth_session_activities.py
@@ -21,9 +21,12 @@ from api_service.db.models import (
 from moonmind.workflows.temporal.activities import oauth_session_activities
 from moonmind.workflows.temporal.activities.oauth_session_activities import (
     oauth_session_register_profile,
+    oauth_session_start_auth_runner,
+    oauth_session_stop_auth_runner,
     oauth_session_update_terminal_session,
 )
 from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
+from moonmind.workflows.temporal.runtime.providers import registry as provider_registry
 from moonmind.workflows.temporal.workers import REGISTERED_TEMPORAL_WORKFLOW_TYPES
 
 
@@ -326,3 +329,80 @@ async def test_update_terminal_session_persists_runner_metadata(
         assert row.container_name == "moonmind_auth_oas_activityterminal1"
         assert row.session_transport == "moonmind_pty_ws"
         assert row.expires_at is not None
+
+
+@pytest.mark.asyncio
+async def test_start_auth_runner_resolves_provider_bootstrap_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    async def fake_start_terminal_bridge_container(**kwargs):
+        observed.update(kwargs)
+        return {
+            "container_name": "moonmind_auth_oas_activityrunner1",
+            "terminal_session_id": "term_oas_activityrunner1",
+            "terminal_bridge_id": "br_oas_activityrunner1",
+            "session_transport": "moonmind_pty_ws",
+        }
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.terminal_bridge.start_terminal_bridge_container",
+        fake_start_terminal_bridge_container,
+    )
+
+    result = await oauth_session_start_auth_runner(
+        {
+            "session_id": "oas_activityrunner1",
+            "runtime_id": "codex_cli",
+            "volume_ref": "codex_auth_volume",
+            "volume_mount_path": "/home/app/.codex",
+            "session_ttl": 120,
+        }
+    )
+
+    assert result["container_name"] == "moonmind_auth_oas_activityrunner1"
+    assert observed["bootstrap_command"] == ("codex", "login")
+    assert observed["volume_ref"] == "codex_auth_volume"
+    assert observed["volume_mount_path"] == "/home/app/.codex"
+
+
+@pytest.mark.asyncio
+async def test_start_auth_runner_rejects_missing_provider_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    providers = dict(provider_registry.OAUTH_PROVIDERS)
+    providers["codex_cli"] = dict(providers["codex_cli"], bootstrap_command=[])
+    monkeypatch.setattr(provider_registry, "OAUTH_PROVIDERS", providers)
+
+    with pytest.raises(ValueError, match="bootstrap command is not configured"):
+        await oauth_session_start_auth_runner(
+            {
+                "session_id": "oas_activityrunner_missing_command",
+                "runtime_id": "codex_cli",
+                "volume_ref": "codex_auth_volume",
+                "volume_mount_path": "/home/app/.codex",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_stop_auth_runner_without_container_is_idempotent(
+    _oauth_activity_session_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oauth_session_activities,
+        "get_async_session_context",
+        lambda: _session_context(_oauth_activity_session_factory),
+    )
+
+    result = await oauth_session_stop_auth_runner(
+        {"session_id": "oas_activityrunner_no_container"}
+    )
+
+    assert result == {
+        "session_id": "oas_activityrunner_no_container",
+        "stopped": False,
+        "reason": "no_container",
+    }

--- a/tests/unit/services/temporal/runtime/test_terminal_bridge.py
+++ b/tests/unit/services/temporal/runtime/test_terminal_bridge.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+from moonmind.workflows.temporal.runtime import terminal_bridge
 from moonmind.workflows.temporal.runtime.terminal_bridge import (
     TerminalBridgeConnection,
     TerminalBridgeFrameError,
+    start_terminal_bridge_container,
 )
 
 
@@ -72,3 +74,86 @@ def test_terminal_bridge_rejects_generic_exec_frames() -> None:
 
     with pytest.raises(TerminalBridgeFrameError, match="generic Docker exec"):
         bridge.handle_frame({"type": "docker_exec", "command": "sh"})
+
+    with pytest.raises(TerminalBridgeFrameError, match="generic Docker exec"):
+        bridge.handle_frame({"type": "task_terminal", "session": "managed"})
+
+
+class _FakeProcess:
+    def __init__(self, returncode: int = 0, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self._stderr = stderr
+        self.killed = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return b"container-id\n", self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+@pytest.mark.asyncio
+async def test_start_terminal_bridge_container_uses_provider_bootstrap_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[str] = []
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        observed.extend(args)
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        terminal_bridge.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    result = await start_terminal_bridge_container(
+        session_id="oas_terminal_runner",
+        runtime_id="codex_cli",
+        volume_ref="codex_auth_volume",
+        volume_mount_path="/home/app/.codex",
+        session_ttl=1800,
+        bootstrap_command=("codex", "login"),
+    )
+
+    assert result["container_name"] == "moonmind_auth_oas_terminal_runner"
+    assert "-v" in observed
+    assert "codex_auth_volume:/home/app/.codex" in observed
+    assert observed[-2:] == ["codex", "login"]
+    assert "sleep" not in observed
+
+
+@pytest.mark.asyncio
+async def test_start_terminal_bridge_container_redacts_startup_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_create_subprocess_exec(*_args, **_kwargs):
+        return _FakeProcess(
+            returncode=1,
+            stderr=b"failed token=super-secret password=hunter2",
+        )
+
+    monkeypatch.setattr(
+        terminal_bridge.asyncio,
+        "create_subprocess_exec",
+        fake_create_subprocess_exec,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await start_terminal_bridge_container(
+            session_id="oas_terminal_runner_failed",
+            runtime_id="codex_cli",
+            volume_ref="codex_auth_volume",
+            volume_mount_path="/home/app/.codex",
+            session_ttl=1800,
+            bootstrap_command=("codex", "login"),
+        )
+
+    message = str(exc_info.value)
+    assert "token=" not in message
+    assert "password=" not in message
+    assert "super-secret" not in message
+    assert "hunter2" not in message
+    assert "failed" in message
+    assert "exit code 1" in message


### PR DESCRIPTION
## Summary
- Jira issue: MM-361
- Active MoonSpec feature path: `specs/192-oauth-runner-bootstrap-pty`
- Replaces the placeholder Codex OAuth auth runner lifecycle with a provider bootstrap PTY path owned by the OAuth enrollment session.
- Adds provider bootstrap command validation, activity-to-runtime command resolution, terminal bridge runner startup, bounded failure redaction, and focused unit/Temporal boundary coverage.

## Verification Verdict
- Final MoonSpec verification verdict: `NO_DETERMINATION`
- Reason: implementation and focused boundary evidence passed, but compose-backed integration verification could not run in the managed container because the Docker socket was unavailable at `/var/run/docker.sock`.

## Tests Run
- Red-first focused unit command failed before production changes for the expected MM-361 reasons and is recorded in `specs/192-oauth-runner-bootstrap-pty/quickstart.md`.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` passed after implementation.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api_service/api/test_oauth_terminal_websocket.py tests/unit/auth/test_oauth_provider_registry.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py` passed after updating stale expectations.
- `pytest tests/integration/temporal/test_oauth_session.py -q --tb=short` passed: 9 tests.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed: 3448 Python tests, 1 xpass, 16 subtests, and 225 dashboard tests.
- `git diff --check` passed.
- `./tools/test_integration.sh` was attempted but could not run because Docker was unavailable in this managed container.

## Remaining Risks
- Compose-backed hermetic integration must be run in a Docker-enabled environment before the integration gate can be treated as complete.
- The PR was created directly from this step with task publish mode treated as none; no later MoonMind publish stage is expected to create the PR.
