### PR TITLE
[codex] Document image input task contracts

### DIFF
--- a/docs/Tasks/ImageSystem.md
+++ b/docs/Tasks/ImageSystem.md
@@ -1,133 +1,469 @@
-# Task Image Input System (Temporal Execution)
+# Task Image Input System
 
-**Implementation tracking:** [`docs/tmp/remaining-work/Tasks-ImageSystem.md`](../tmp/remaining-work/Tasks-ImageSystem.md)
+Status: Proposed
+Owners: MoonMind Engineering
+Last updated: 2026-04-16
 
-## Summary
+## 1. Purpose
 
-This design defines how **image attachments** are processed within MoonMind tasks using the new Temporal-based execution and Artifact storage architecture.
+This document defines the canonical desired-state contract for image inputs in MoonMind task executions.
 
-The goals of this subsystem:
-1. Allow users to **upload images** from the Mission Control UI.
-2. Store the uploaded bytes securely in the **Artifact Store** (MinIO).
-3. Pass lightweight, secure `ArtifactRef` pointers into the **Temporal Workflow** (`MoonMind.Run`).
-4. Execute a deterministic **Vision Processing Activity** to extract useful text context (captions, OCR) for downstream LLM prompts.
-5. Provide a deterministic path for sandbox activities to access raw image bytes when needed.
+The system exists to let users:
+
+- attach images to the task objective target or to individual steps from the Create page
+- store uploaded bytes securely in the Artifact Store
+- submit lightweight artifact references into `MoonMind.Run`
+- preserve attachment targeting through create, edit, and rerun flows
+- generate deterministic image-derived context for text-first runtimes
+- materialize raw image bytes into the workspace when a runtime or step requires direct file access
+- preview and download task images through MoonMind-owned APIs
+
+This document is declarative. It defines the target system contract. It is not a rollout log.
 
 ---
 
-## Architecture Overview
+## 2. Related docs
 
-In an artifact-centric, Temporal-orchestrated model, we never embed large binaries or multi-part uploads directly into job creation JSON or Temporal execution histories.
+- `docs/UI/CreatePage.md`
+- `docs/Tasks/TaskArchitecture.md`
+- `docs/Temporal/TemporalArchitecture.md`
+- `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
+- `docs/Temporal/ArtifactPresentationContract.md`
 
-### High-Level Flow
+---
 
+## 3. Product stance and terminology
+
+### 3.1 Product stance
+
+MoonMind is artifact-first.
+
+Rules:
+
+- uploaded image bytes must not be embedded in Temporal histories
+- uploaded image bytes must not be embedded directly in task instruction text
+- the control plane submits structured attachment references, not raw binaries
+- derived image summaries are secondary artifacts; they do not replace the source image refs
+- attachment targeting is explicit and durable
+
+### 3.2 Canonical terminology
+
+The canonical control-plane field name is `inputAttachments`.
+
+The default Create-page attachment policy currently authorizes image MIME types, so the product may label the UI as `Images` while still using the generic `inputAttachments` contract.
+
+Canonical target kinds:
+
+- **objective-scoped attachment**: a ref submitted through `task.inputAttachments`
+- **step-scoped attachment**: a ref submitted through `task.steps[n].inputAttachments`
+
+Canonical reference shape:
+
+```ts
+interface TaskInputAttachmentRef {
+  artifactId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
 ```
-Dashboard UI
-  │
-  ├─ 1) POST /artifacts (multipart or direct)
-  │     └─ returns ArtifactRef(s)
-  │
-  ├─ 2) Upload bytes directly to Artifact Store (MinIO via presigned URL)
-  │
-  └─ 3) POST /api/queue/jobs (Payload includes initialParameters.inputArtifactRefs)
-        │
-        ▼
-MoonMind.Run Workflow (Temporal)
-  │
-  ├─ 1) Initializes state with input ArtifactRefs.
-  │
-  ├─ 2) Schedules `vision.generate_context` Activity (mm.activity.llm queue):
-  │     - Activity fetches image bytes from Artifact Store.
-  │     - Activity calls Vision LLM (e.g., Gemini 1.5 Pro/Flash).
-  │     - Activity writes `image_context.md` text back to Artifact Store.
-  │     - Activity returns new ArtifactRef to the Workflow.
-  │
-  ├─ 3) Schedules `plan.generate` (if applicable) or `mm.skill.execute`:
-  │     - The generated `image_context.md` Ref is passed to the LLM for reasoning.
-  │
-  └─ 4) Evaluates Sandboxed Activity (e.g., `sandbox.run_command`):
-        - If the sandbox script needs the raw images, an `artifact.download_to_workspace`
-          activity is scheduled to materialize the bytes into `repo/.moonmind/inputs/`.
+
+Canonical prepared-manifest shape:
+
+```ts
+interface AttachmentManifestEntry {
+  artifactId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  targetKind: "task" | "step";
+  stepRef?: string;
+  stepOrdinal?: number;
+  workspacePath: string;
+  visionContextPath?: string;
+  sourceArtifactPath?: string;
+}
 ```
 
----
+Rules:
 
-## Data Model & Artifact Index
-
-Instead of implicitly storing images as `AgentJobArtifact` records prefixed with `inputs/`, images are formalized through the unified **Artifact Index**.
-
-* **Content-Type**: Must be `image/png`, `image/jpeg`, or `image/webp`.
-* **Linkage**: The `artifact_links` table connects the image to the workflow execution.
-  - `link_type`: `input.image`
-  - `label`: Original filename (e.g., `screenshot.png`)
-* **Retention Class**: Inherits the `standard` policy (e.g., 30 days) alongside other job inputs/outputs.
-* **Integrity**: Enforced via `sha256` checksums validated upon completion of the upload to the Artifact Store.
+- target meaning comes from the field that contains the ref
+- attachment identity does not depend on filename conventions
+- image context generation must preserve target meaning
 
 ---
 
-## Authorization & Security
+## 4. End-to-end desired-state flow
 
-Security applies evenly across the Artifact API as established by the `WorkflowArtifactSystemDesign.md`.
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Create Page
+    participant A as Artifact API
+    participant E as Executions API
+    participant W as MoonMind.Run
+    participant P as Prepare / Artifact Activities
+    participant V as Vision Activity
+    participant R as Runtime Step Executor
 
-* **End-User Access**:
-  - Regulated entirely by the Workflow Execution viewing permissions.
-  - Generates short-lived (e.g., 15 minute) presigned URLs for UI preview and download.
-  - No permanent direct access to the object store.
-* **Worker Access**:
-  - Activities operate using service credentials and least-privilege roles to fetch blobs from the Artifact Store.
-  - They do not rely on passing active worker-claim tokens like the legacy architecture.
-* **Content Safety**:
-  - `image/svg+xml` files remain strictly forbidden to prevent script injection.
-  - Minimum and maximum byte boundaries for chunks and total size are enforced by the Artifact API bounds.
+    U->>C: Select images on objective target or step target
+    C->>A: Create artifact upload(s)
+    C->>A: Upload image bytes
+    C->>A: Complete upload(s)
+    C->>E: Submit task-shaped request with inputAttachments refs
+    E->>E: Validate policy + persist task input snapshot
+    E->>W: Start or update MoonMind.Run with refs
+    W->>P: Download and materialize image inputs
+    P->>P: Write attachments manifest
+    W->>V: Generate target-aware image context
+    V->>P: Write context artifacts
+    W->>R: Execute planning or step runtime with attachment context
+```
+
+Rules:
+
+- upload completes before create, update, or rerun submission is accepted
+- the execution API persists the authoritative snapshot of attachment targeting
+- workflow prepare is responsible for deterministic local materialization and manifest generation
+- runtime adapters consume structured refs and derived context, not browser-local state
 
 ---
 
-## Workload Specific Behavior
+## 5. Control-plane contract
 
-### 1. Planning and Coding Skills (Text Only)
+### 5.1 Canonical submission path
 
-For capabilities acting as standard LLM prompts (such as `pr-resolver` or simple `codex exec` interactions):
-* The raw bytes never enter the `sandbox` container logic.
-* The Workflow invokes `vision.generate_context` in the `mm.activity.llm` fleet.
-* The result is a text artifact (e.g., `image_context.md`) summarising the image content.
-* `plan.generate` and text-centric tools append this image context strictly inside the system prompt:
+The canonical submit path is task-shaped execution submission through `/api/executions`.
+
+Rules:
+
+- image inputs are submitted through the task-shaped Temporal execution API
+- legacy queue-specific attachment submission routes are not the desired-state contract
+- all browser upload and download flows remain behind MoonMind-owned API endpoints
+
+### 5.2 Canonical task contract
+
+Representative task-shaped payload:
+
+```json
+{
+  "type": "task",
+  "payload": {
+    "repository": "owner/repo",
+    "task": {
+      "instructions": "Resolved task objective text.",
+      "inputAttachments": [
+        {
+          "artifactId": "art_objective_123",
+          "filename": "overview.png",
+          "contentType": "image/png",
+          "sizeBytes": 48213
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-1",
+          "instructions": "Inspect the screenshot and identify the issue.",
+          "inputAttachments": [
+            {
+              "artifactId": "art_step1_456",
+              "filename": "bug.png",
+              "contentType": "image/png",
+              "sizeBytes": 72109
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- `task.inputAttachments` is the objective-scoped attachment target
+- `task.steps[n].inputAttachments` is the step-scoped attachment target
+- the API must preserve target scoping through create, edit, and rerun
+- attachment refs are normalized before the workflow starts
+
+### 5.3 Authoritative snapshot contract
+
+The original task input snapshot is the source of truth for edit and rerun reconstruction.
+
+Rules:
+
+- the snapshot must preserve:
+  - text fields
+  - target attachment refs
+  - step identity and order
+  - runtime, publish, and repository settings
+  - applied preset metadata
+- attachment target binding is reconstructed from the snapshot, not inferred from artifact links alone
+- the system must fail explicitly rather than silently discarding attachment bindings during reconstruction
+
+---
+
+## 6. Artifact model and storage contract
+
+Image inputs are first-class artifacts.
+
+Rules:
+
+- image bytes are stored in the Artifact Store
+- each submitted image is linked to the execution with an execution-owned artifact link
+- artifact link metadata may include target diagnostics, but execution payload and snapshot remain the authoritative source of target binding
+- worker-side uploads must not overwrite or impersonate input attachments in reserved namespaces
+
+Canonical properties:
+
+- supported content types come from attachment policy, with image types as the default desired-state allowlist
+- `image/svg+xml` remains forbidden
+- integrity is enforced at artifact completion time
+- retention follows the execution’s artifact retention policy unless overridden by a more specific policy
+
+Recommended artifact metadata keys:
+
+- `source: "task-create"`
+- `attachmentKind: "input"`
+- `targetKind: "task" | "step"`
+- `stepRef`
+- `stepOrdinal`
+- `originalFilename`
+
+Rules:
+
+- metadata is helpful for observability but not the source of truth for binding
+- target binding must still be derivable from the task snapshot even if metadata is incomplete
+
+---
+
+## 7. Validation and policy contract
+
+Attachment policy is server-defined and browser-enforced, then revalidated server-side.
+
+Rules:
+
+- allowed content types are checked before upload and again when the API finalizes the artifact
+- signature sniffing must confirm the content is a supported image type
+- max count, per-file size, and total size limits are enforced
+- uploads with invalid or incomplete content are rejected before execution start
+- caption hints or other future fields that are not yet supported must fail fast rather than being silently ignored
+
+Representative policy shape:
+
+```json
+{
+  "enabled": true,
+  "maxCount": 10,
+  "maxBytes": 10485760,
+  "totalBytes": 26214400,
+  "allowedContentTypes": [
+    "image/png",
+    "image/jpeg",
+    "image/webp"
+  ]
+}
+```
+
+Rules:
+
+- if the policy is disabled, image input entry points must be hidden and no image refs may be accepted from the Create page
+- if the policy is enabled but a runtime later cannot consume images, the create path must fail explicitly rather than silently dropping them
+
+---
+
+## 8. Prepare-time materialization contract
+
+Workflow prepare owns deterministic local file materialization.
+
+Rules:
+
+- prepare downloads all declared input attachments before the relevant runtime or step executes
+- prepare writes a canonical manifest at:
 
 ```text
-INPUT ATTACHMENTS:
-[Provided text summary generated from the provided artifacts...]
+.moonmind/attachments_manifest.json
 ```
 
-### 2. Multi-modal Run-times
+- prepare writes raw files into stable target-aware locations:
 
-If MoonMind introduces a model execution path (like a direct `gemini` multimodal chat capability inside the sandbox or as a dedicated skill activity):
-* The Temporal workflow passes the `ArtifactRef` into the multimodal context array.
-* The specific activity fetching the Artifact blobs constructs a valid multimodal Provider Payload (base64 or signed platform URL) seamlessly without intermediary caching disk writes.
+```text
+.moonmind/inputs/task/<artifactId>-<sanitized-filename>
+.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>
+```
 
-### 3. Sandbox Materialisation (Optional)
+- target-aware workspace paths must be deterministic
+- the workspace path for one target must not depend on any unrelated target’s attachment ordering
 
-If a user specifically instructs: *"Crop this image using ImageMagick"*
-* The skill must dictate a requirement for raw visual assets over text captions.
-* The Temporal execution schedules the `artifact.download_to_workspace` activity to physically map the image `ArtifactRef`s into `.moonmind/inputs/<artifact_id>-<label>` inside the active Sandbox workspace before the shell command executes.
-* Standard `.git/info/exclude` rules prevent accidental commits of these ephemeral visual assets.
+Rules:
 
----
-
-## API Contract Summary
-
-Legacy routes using `POST /api/queue/jobs/with-attachments` and trailing `/worker` suffixes are deprecated.
-
-Instead, the client integrates directly with the standard REST endpoints:
-1. `POST /artifacts`
-2. upload bytes using pre-signed URL.
-3. `POST /artifacts/{artifact_id}/complete`
-4. Use standard `POST /api/queue/jobs`
-
-UI rendering consumes:
-* `GET /executions/{namespace}/{workflow_id}/{run_id}/artifacts?link_type=input.image`
-* Followed by `POST /artifacts/{artifact_id}/presign-download` for UI thumbnails.
+- objective-scoped attachments are materialized under `.moonmind/inputs/task/`
+- step-scoped attachments are materialized under `.moonmind/inputs/steps/<stepRef>/`
+- if a step has no explicit `id`, the control plane or prepare layer must assign a stable step reference for manifest and path purposes
+- partial materialization is a failure, not a best-effort success
 
 ---
 
-## Vision pipeline (target)
+## 9. Vision context generation contract
 
-Images ingest through **`POST /artifacts`** with valid image MIME types and Temporal **`ArtifactRef`s** in workflow variables. **`vision.generate_context`** (or equivalent) produces text artifacts wired into **`mm.skill.execute`** preparation. Legacy **`with-attachments`** queue ingest is retired once Temporal paths cover all cases. Progress: [`docs/tmp/remaining-work/Tasks-ImageSystem.md`](../tmp/remaining-work/Tasks-ImageSystem.md).
+Image-derived text context is generated as a deterministic secondary artifact.
+
+Rules:
+
+- context generation is target-aware
+- context generation may be enabled or disabled by runtime configuration
+- when disabled, manifest generation and raw file materialization still occur
+- generated text must remain traceable back to the source image artifact refs
+
+Desired-state output paths:
+
+```text
+.moonmind/vision/task/image_context.md
+.moonmind/vision/steps/<stepRef>/image_context.md
+.moonmind/vision/image_context_index.json
+```
+
+Rules:
+
+- objective-scoped images produce objective-scoped context
+- step-scoped images produce step-scoped context
+- the index artifact summarizes what context exists for which target
+- generated context may include OCR, captions, and safety notes, but must remain deterministic and auditable for a given source image set and model configuration
+
+---
+
+## 10. Prompt and runtime injection contract
+
+### 10.1 Text-first runtimes
+
+Text-first runtimes consume image context through an injected `INPUT ATTACHMENTS` block.
+
+Rules:
+
+- the `INPUT ATTACHMENTS` block appears before `WORKSPACE`
+- the block references:
+  - relevant workspace paths
+  - relevant manifest entries
+  - relevant generated context paths
+- step execution receives only:
+  - objective-scoped attachment context
+  - the current step’s attachment context
+- non-current step attachment context is not injected into a step unless the runtime or planner explicitly requests cross-step access
+
+### 10.2 Planning and task-level reasoning
+
+Rules:
+
+- task-level planning receives objective-scoped attachment context
+- planning may also receive a compact inventory of step-scoped attachments so the planner understands later-step inputs without flattening them into the current step context
+- planning does not need full raw bytes for attachments that belong to later steps unless a planner-specific runtime explicitly requires them
+
+### 10.3 Multimodal runtimes
+
+Rules:
+
+- multimodal adapters may choose to consume raw image refs directly
+- this does not change the control-plane contract
+- the same artifact refs, target bindings, and prepare-time manifest remain the source of truth
+- direct provider payload construction is a runtime-adapter concern, not a Create-page concern
+
+---
+
+## 11. UI preview and detail contract
+
+Task detail, edit, and rerun surfaces may preview and download image inputs.
+
+Rules:
+
+- previews and downloads go through MoonMind-owned API endpoints
+- previews are organized by target:
+  - objective-scoped
+  - step-scoped
+- the UI must not infer target binding from filenames
+- preview failure must not remove access to metadata or download actions
+- edit and rerun surfaces must distinguish persisted attachments from new local files not yet uploaded
+
+---
+
+## 12. Authorization and security contract
+
+Security boundaries are artifact-first and execution-owned.
+
+Rules:
+
+- end-user preview and download are governed by execution ownership and view permissions
+- the browser receives short-lived presigned download URLs or MoonMind proxy responses; it does not receive long-lived object-store credentials
+- worker-side access uses service credentials and execution authorization, not browser credentials
+- the system must not trust text extracted from images as executable instructions unless the authored task explicitly chooses to use it
+- images remain untrusted user input
+
+Rules:
+
+- no direct browser access to object storage
+- no direct browser access to Jira or provider-specific file endpoints
+- no scriptable image types
+- no hidden compatibility transforms that silently rewrite attachment refs or retarget them to another step
+
+---
+
+## 13. Edit and rerun durability contract
+
+Rules:
+
+- create, edit, and rerun all use the same authoritative attachment contract
+- unchanged attachment refs survive edit and rerun unchanged
+- removing an attachment is explicit
+- adding a new attachment is explicit
+- an attachment must never disappear merely because the browser reconstructed a text-only draft
+- historical source artifacts may continue to exist under retention policy even after the edited draft no longer references them
+
+---
+
+## 14. Observability and diagnostics contract
+
+The image input system must expose enough evidence to debug failures without reading raw workflow history heuristics.
+
+Recommended event classes:
+
+- attachment upload started
+- attachment upload completed
+- attachment validation failed
+- prepare download started
+- prepare download completed
+- prepare download failed
+- image context generation started
+- image context generation completed
+- image context generation failed
+
+Rules:
+
+- attachment manifest path and generated context paths should be discoverable from task diagnostics
+- task detail and debugging surfaces should expose target-aware attachment metadata
+- step-level failures must identify the affected step target
+
+---
+
+## 15. Non-goals
+
+The desired-state image system does not require:
+
+- embedding raw image bytes in execution create payloads
+- embedding images into instruction markdown as data URLs
+- implicit attachment sharing across steps
+- live Jira sync
+- generic non-image attachment types by default
+- provider-specific multimodal message formats as the control-plane contract
+
+---
+
+## 16. Summary
+
+The desired-state image system is simple in principle:
+
+1. the Create page binds images to an explicit target
+2. MoonMind stores those images as artifacts
+3. the execution API preserves the binding in the task contract and authoritative snapshot
+4. workflow prepare materializes the files and generates target-aware image context
+5. runtimes consume only the context that belongs to the objective or step they are executing
+
+That is the canonical contract.

--- a/docs/Tasks/ImageSystem.md
+++ b/docs/Tasks/ImageSystem.md
@@ -76,7 +76,7 @@ interface AttachmentManifestEntry {
   filename: string;
   contentType: string;
   sizeBytes: number;
-  targetKind: "task" | "step";
+  targetKind: "objective" | "step";
   stepRef?: string;
   stepOrdinal?: number;
   workspacePath: string;
@@ -225,7 +225,7 @@ Recommended artifact metadata keys:
 
 - `source: "task-create"`
 - `attachmentKind: "input"`
-- `targetKind: "task" | "step"`
+- `targetKind: "objective" | "step"`
 - `stepRef`
 - `stepOrdinal`
 - `originalFilename`
@@ -288,7 +288,7 @@ Rules:
 - prepare writes raw files into stable target-aware locations:
 
 ```text
-.moonmind/inputs/task/<artifactId>-<sanitized-filename>
+.moonmind/inputs/objective/<artifactId>-<sanitized-filename>
 .moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>
 ```
 
@@ -297,7 +297,7 @@ Rules:
 
 Rules:
 
-- objective-scoped attachments are materialized under `.moonmind/inputs/task/`
+- objective-scoped attachments are materialized under `.moonmind/inputs/objective/`
 - step-scoped attachments are materialized under `.moonmind/inputs/steps/<stepRef>/`
 - if a step has no explicit `id`, the control plane or prepare layer must assign a stable step reference for manifest and path purposes
 - partial materialization is a failure, not a best-effort success

--- a/docs/Tasks/TaskArchitecture.md
+++ b/docs/Tasks/TaskArchitecture.md
@@ -1,199 +1,438 @@
 # Task Architecture (Control Plane)
 
-Status: Active  
-Owners: MoonMind Engineering  
-Last Updated: 2026-04-04  
+Status: Active
+Owners: MoonMind Engineering
+Last updated: 2026-04-16
 
 ## 1. Purpose
 
-This document defines the **high-level control plane architecture** of MoonMind's task system and Mission Control dashboard. 
+This document defines the high-level desired-state control-plane architecture for MoonMind tasks.
 
-It maps how the control plane translates user intentions in the Mission Control UI—specifically task instructions, artifacts, runtime choices, and **agent skill selection intent**—into the durable execution system backed by Temporal. 
+It maps how the control plane translates user intent from Mission Control — including:
 
-Detailed UI behavior, route-level contracts, payload examples, and page interaction rules are documented natively in `docs/UI/MissionControlArchitecture.md`.
-Detailed backend workflow execution logic is defined in `docs/Temporal/TemporalArchitecture.md` and `docs/Tasks/SkillAndPlanContracts.md`.
-Detailed agent-skill storage, precedence, and workspace path rules live in `docs/Tasks/AgentSkillSystem.md`.
+- task objective text
+- step-authored instructions
+- objective-scoped and step-scoped input attachments
+- runtime and publish choices
+- agent skill selection intent
+- presets, Jira imports, and dependency declarations
 
----
+into durable execution under Temporal.
 
-## 2. Current System Snapshot
-
-MoonMind has transitioned from a raw queue/system dispatcher into a workflow-orchestrated system backed by **Temporal**. The Mission Control dashboard operates as the **Control Plane**, surfacing workflows to the user as "Tasks".
-
-The current dashboard and backend API support:
-- Workflow Executions for single commands (`MoonMind.Run`), manifest graphs (`MoonMind.ManifestIngest`), and agent lifecycle orchestration (`MoonMind.AgentRun` child workflows).
-- First-class Artifact references (pointers passed from UI to the backend vs. raw embedded payloads).
-- A task-detail model that reads execution overview plus a dedicated step-ledger surface instead of inferring step state from logs or timeline heuristics.
-- Visual Task Proposals which can be reviewed by humans before formal promotion into new Temporal executions.
-- Shared task preset/template catalogs for rapid workflow authoring.
-- Operator actions (Pause, Resume, Cancel, Approve) dispatched via API as Temporal Signals/Updates.
-- **Agent Skill Systems:** MoonMind uses a deployment-backed Agent Skill System where tasks carry explicit skill-selection intent, and the control plane resolves that intent into a run-scoped immutable skill context before execution.
+This document is architectural and declarative. Detailed page behavior belongs in `docs/UI/CreatePage.md`. Detailed image-input behavior belongs in `docs/Tasks/ImageSystem.md`.
 
 ---
 
-## 3. High-Level Architecture
+## 2. System snapshot
 
-The API Service acts as the translation layer between the Mission Control UI (Task domain) and the Execution Plane (Temporal Workflow domain). All operations (read/write/signal) pass through this API.
+MoonMind uses a Temporal-backed execution model in which Mission Control acts as the control plane.
+
+The control plane already centers on these product objects:
+
+- `MoonMind.Run` as the standard task execution workflow
+- first-class artifacts for large or binary inputs and outputs
+- step-authored tasks rather than opaque queue jobs
+- reusable task presets
+- runtime and provider selection intent
+- durable execution actions such as pause, resume, cancel, approve, and rerun
+
+Desired-state additions clarified by this document:
+
+- image inputs are first-class structured task inputs
+- attachment targeting is explicit and durable
+- create, edit, and rerun preserve attachment bindings through an authoritative task input snapshot
+- runtime preparation and prompt composition are target-aware rather than attachment-bucket-driven
+
+---
+
+## 3. Core architectural principles
+
+### 3.1 Task-first control plane
+
+The user authors tasks, not workflow internals.
+
+Rules:
+
+- the Create page defines user intent in task terms
+- the control plane translates that task intent into execution-plane contracts
+- the execution plane owns lifecycle progression, retries, waiting, and history
+
+### 3.2 Artifact-first binary handling
+
+Rules:
+
+- binary inputs are stored as artifacts
+- binary inputs are referenced in execution contracts by lightweight refs
+- binary inputs are not embedded in workflow histories or text instructions
+
+### 3.3 Explicit target binding
+
+Rules:
+
+- an input attachment must belong to an explicit target
+- the supported target kinds are:
+  - task objective target
+  - step target
+- target binding must survive create, edit, rerun, prepare, prompt composition, and detail rendering
+
+### 3.4 Durable reconstruction
+
+Rules:
+
+- task input reconstruction uses an authoritative snapshot
+- text-only reconstruction is insufficient for attachment-aware tasks
+- silent loss of attachment bindings is a contract violation
+
+### 3.5 Separation of text from structured inputs
+
+Rules:
+
+- instruction text remains text
+- images remain structured inputs
+- derived image context is a secondary artifact, not the instruction field itself
+
+---
+
+## 4. High-level architecture
 
 ```mermaid
 flowchart LR
-    U[Authenticated User] --> D[Mission Control UI]
+    U[Authenticated User] --> UI[Mission Control Create Page]
 
     subgraph Control Plane
-        D --> A[API Service]
-        A --> P[Task Proposal APIs]
-        A --> T[Task Template Catalog APIs]
-        A --> C[Artifact Metadata API]
-        A --> S[Agent Skill Catalog / Resolution API]
+        UI --> API[Executions API]
+        UI --> ART[Artifact API]
+        UI --> JIRA[Jira Browser API]
+        API --> SNAP[Authoritative Task Input Snapshot]
+        API --> PROF[Provider Profile + Runtime Defaults]
+        API --> PRESETS[Task Preset APIs]
     end
 
-    subgraph Execution Plane - Temporal Foundation
-        A -.->|Start/Signal/Query+Refs| WF[MoonMind.Run]
-        WF -->|Child Workflow| AR[MoonMind.AgentRun]
-        WF --> Q[mm.activity.* Task Queues]
-        AR --> Q_RT[mm.activity.agent_runtime]
-        AR --> Q_INT[mm.activity.integrations]
-        Q --> W_LLM[LLM Activity Fleet]
-        Q --> W_SB[Sandbox Activity Fleet]
-        Q --> W_ART[Artifact Activity Fleet]
-        Q_RT --> W_AGT[Agent Runtime Fleet]
-        Q_INT --> W_INT[Integrations Fleet]
-    end
-
-    subgraph Long-Lived Workflows
-        PPM[MoonMind.ProviderProfileManager]
-        OA[MoonMind.OAuthSession]
+    subgraph Execution Plane
+        API -.-> RUN[MoonMind.Run]
+        RUN --> PREP[Prepare / Artifact Activities]
+        RUN --> VISION[Vision Context Activity]
+        RUN --> STEP[Planner or Step Runtime]
+        RUN --> CHILD[MoonMind.AgentRun child workflow]
     end
 
     subgraph Blob Storage
-        D -.->|Direct Presigned Upload/Download| S3[(MinIO / S3 Object Store)]
-        W_ART -.-> S3
+        ART -.-> S3[(Artifact Store)]
+        PREP -.-> S3
+        VISION -.-> S3
     end
 ```
 
-### Key layers
+Key boundary:
 
-- **UI Layer (Mission Control)**: Presents "Tasks" to the user, allowing for creation, monitoring, and interaction (e.g., approval gates, pausing work).
-- **Control Plane API**: Maps UI requests to Temporal commands (Start Workflow, Send Signal) and manages domain concepts outside Temporal's scope (Proposals, Templates, Auth). This now heavily features agent skill selection, skill snapshot preparation, and passing only refs into execution.
-- **Execution Plane (Temporal)**: Owns durable states and schedules Activities under role-based fleets. `MoonMind.Run` owns task-level step truth and progress, while true agent execution steps dispatch as `MoonMind.AgentRun` child workflows rather than plain activity invocations.
-- **Blob Storage (Artifacts)**: Heavy data is stored out-of-band in an S3-compatible backend (MinIO). The UI and the Workflow exchange lightweight `ArtifactRef`s.
-
-### Control-plane boundary
-
-Task submit resolves selection intent into immutable refs. True agent lifecycle orchestration happens through `MoonMind.AgentRun` child workflows on the execution plane. The control plane does not drive agent lifecycle steps directly.
-
-Boundary responsibilities:
-
-- **Control plane** owns skill-selection intent, policy resolution, and snapshot preparation
-- **Execution plane** owns durable lifecycle orchestration and state progression
-- **Runtime adapters** own provider/runtime translation and canonical contract normalization
+- the control plane owns authoring intent, artifact refs, target binding, runtime choice, and snapshot durability
+- the execution plane owns lifecycle and step execution
+- runtime adapters own provider-specific realization details
 
 ---
 
-## 4. Control Plane Responsibilities
+## 5. Control-plane responsibilities
 
-The Mission Control provides one place to:
-- **Submit Work**: Send instructions, artifacts, runtime choices, and explicit skill-selection intent into the API, which starts a new Temporal Workflow Execution.
-- **Resolve Agent Skills**: Accept task/step skill selectors, merge built-in/deployment/repo/local sources under policy, and produce an immutable resolved skill snapshot for execution.
-- **Provide Files**: Upload images/context to the Artifact Store (`POST /artifacts`) and pass the generated `ArtifactRef` into the task input.
-- **Review Pre-Execution Plans**: Triage "Task Proposals" built by workers before they are promoted into full task runs.
-- **Monitor State**: Surface Temporal Visibility metrics, workflow statuses, and `mm_state` progression fields in a user-friendly table.
-- **Read Step Truth**: Fetch execution detail plus a step-ledger surface, using the plan artifact as the canonical planned-step source and workflow state/query as the live step-state source.
-- **Command & Control**: Pause, Resume, and Cancel executing runs by issuing commands to the API, sending Temporal Signals to the workflow.
+The control plane is responsible for all of the following.
 
-### 4.1 Agent Skill Resolution Boundary
+### 5.1 Authoring and validation
 
-The core control-plane resolution flow operates as follows:
-1. The user submits workflow intent inside Mission Control, potentially including `task.skills` and `step.skills`.
-2. The control plane resolves built-in, deployment, repo, and local skill sources using canonical precedence rules.
-3. The control plane produces a `ResolvedSkillSet` artifact.
-4. Only refs and compact metadata linking to the snapshot are passed into the execution-plane workflow/runtime path.
+- render the Create page
+- validate repository, runtime, publish mode, dependencies, and attachment policy
+- collect text fields, preset state, Jira imports, and input attachments into a coherent draft
 
-**Explicit Boundary Rule:** The *control plane* owns task-facing selection, policy, and resolution intent. The *execution plane* consumes immutable resolved refs. The *runtime adapters* materialize the snapshot for the target runtime.
+### 5.2 Artifact upload orchestration
 
-### 4.2 Task Payload and Mission Control Implications
+- create upload intents through MoonMind artifact APIs
+- upload browser-selected files before execution submission
+- finalize artifact creation and reject incomplete uploads
+- submit only structured attachment refs to the execution API
 
-Task-shaped payloads and UI surfaces now encapsulate skill-selection logic. 
-* The control plane API expects payloads including `task.skills`, `step.skills`, skill-set names, include/exclude selectors, and potentially materialization preferences.
-* The Mission Control UI provides selection mechanisms for skill sets at submit time, displays resolved skill snapshots inside task detail views, and exposes compact provenance metadata for user review.
-* Mission Control task detail should render the Steps surface from a dedicated step-ledger read, not by parsing generic artifacts or managed-run log text.
-* Task payloads and control-plane APIs should not depend on provider-shaped execution results. The control plane consumes canonical runtime contracts (`AgentRunHandle`, `AgentRunStatus`, `AgentRunResult`), not provider-native payloads.
-* For Temporal-backed task surfaces, `taskId == workflowId`.
+### 5.3 Task contract normalization
 
-*(Note on Scheduling/Reruns: When a task is rerun, the control plane reuses the original resolved skill snapshot by default. Conversely, scheduled tasks preserve the explicit skill-selection intent and resolve it according to the canonical policy at their scheduled execution time.)*
+- normalize the task-shaped payload
+- preserve `task.inputAttachments` and `task.steps[].inputAttachments`
+- preserve step identity and order
+- preserve runtime and publish intent
+- preserve preset and Jira provenance when those contracts allow it
 
----
+### 5.4 Snapshot durability
 
-## 5. Workload Types
+- persist an authoritative task input snapshot for edit and rerun
+- reconstruct from that snapshot rather than from lossy derived projections
+- preserve attachment target binding in the snapshot
 
-From the perspective of the Dashboard and the user, workloads are represented as **Tasks** or **Proposals**.
+### 5.5 User-facing reads
 
-### 5.1 Workflow Executions (Tasks)
-
-These represent actively running automation. The dashboard groups these under the "Tasks" list.
-
-| Workflow type | Purpose |
-| --- | --- |
-| `MoonMind.Run` | Standard execution container for text instructions, direct executable tool invocations, plan-driven work, and agent-runtime work that may carry resolved agent skill context |
-| `MoonMind.ManifestIngest` | Complex ingest jobs utilizing fan-out/fan-in aggregation |
-| `MoonMind.AgentRun` | Durable lifecycle wrapper for true agent execution; dispatched as a child workflow from `MoonMind.Run` per plan step when `tool.type == "agent_runtime"` |
-| `MoonMind.ProviderProfileManager` | Long-running provider-profile coordination for managed runtimes |
-| `MoonMind.OAuthSession` | OAuth dance lifecycle |
-
-The UI surfaces these by querying Temporal Visibility indices filtered securely by the user's API credentials.
-
-Important: true agent steps are executed as `MoonMind.AgentRun` child workflows, not as plain activity invocations. This gives each agent step its own durable lifecycle, cancellation boundary, and history shard.
-
-Task-detail rule:
-
-- the parent task view shows the latest/current run's step ledger by default
-- step rows may carry `childWorkflowId`, `childRunId`, and `taskRunId`
-- child runtime logs and diagnostics stay in `/api/task-runs/*` and must not be flattened into parent workflow state
-
-### 5.2 Task Proposals
-- **Control-plane only objects**. These are recommendations generated by agents or by the `proposals` stage of a `MoonMind.Run`, awaiting human review.
-- Proposals do not execute on their own. Promotion creates a new `MoonMind.Run` through the same Temporal-backed create path used by `/api/executions`; the legacy queue backend is not part of the target design.
-- Proposal payloads may need to persist explicit skill-selection intent so that promoted executions preserve the intended execution context.
+- expose previews and downloads through MoonMind APIs
+- surface attachment metadata by target in detail, edit, and rerun flows
+- expose enough diagnostics for operators to understand attachment-related failures
 
 ---
 
-## 6. System Invariants (Control Plane)
+## 6. Canonical task-shaped contract
 
-The following invariants define how the UI interacts with the execution backend:
+Representative contract:
 
-1. **Artifact Passing, Not Data Embedding**  
-   The UI will not post large text blobs or multipart image attachments directly into a task execution payload. It uses `POST /artifacts` to receive short-lived `ArtifactRef` pointers, passing only those refs down to Temporal. 
+```ts
+interface TaskInputAttachmentRef {
+  artifactId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
 
-2. **Decoupled execution capability**  
-   The UI determines **what** the intent is (Target Repository, required executable tool or runtime, selected agent skills / skill sets, Artifacts). The API and Temporal ensure the job is routed to the exact fleet (`mm.activity.sandbox`, `mm.activity.llm`, `mm.activity.agent_runtime`, `mm.activity.integrations`) equipped to fulfill that specific capability.
+interface TaskStepPayload {
+  id?: string;
+  title?: string;
+  instructions?: string;
+  inputAttachments?: TaskInputAttachmentRef[];
+  skill?: {
+    id?: string;
+    args?: Record<string, unknown>;
+    requiredCapabilities?: string[];
+  };
+  skills?: {
+    include?: Array<{ name: string }>;
+  };
+}
 
-3. **Status Polling & Observability**  
-   The UI reads state by polling the API, which interrogates Temporal Visibility and the Postgres Artifact Index. **Temporal Visibility is the source of truth for execution state.** Projection rows and adapter caches may exist for performance and compatibility, but they are not the semantic owner of query behavior. The source of truth for file outputs lives in the Artifact Index.
+interface TaskPayload {
+  instructions?: string;
+  inputAttachments?: TaskInputAttachmentRef[];
+  steps?: TaskStepPayload[];
+  runtime?: {
+    mode?: string;
+    profileId?: string;
+    model?: string;
+    effort?: string;
+  };
+  publish?: {
+    mode?: "none" | "branch" | "pr";
+  };
+  git?: {
+    startingBranch?: string;
+    targetBranch?: string;
+  };
+  appliedStepTemplates?: unknown[];
+  dependsOn?: string[];
+}
+```
 
-4. **Approval Routing via Signals**  
-   When a workflow asks for human permission (e.g. "Can I push to `main`?"), the workflow enters a paused state. The UI displays the approval button, and submitting the form delegates a Temporal `Update` or `Signal` through the Control Plane API to seamlessly unpause the execution block.
+Rules:
 
-5. **Skill Selection, Then Snapshot Resolution**  
-   The UI and API exchange skill-selection intent, not raw mutable runtime skill state. The control plane resolves that intent into an immutable skill snapshot before or as part of execution preparation.
-
-6. **Resolved Skill Context Uses Refs**  
-   The control plane must not embed full instruction bundles or skill bodies directly in task payloads when artifact-backed refs are the correct execution boundary.
-
-7. **Canonical Runtime Contracts**  
-   Task payloads and control-plane APIs must not depend on provider-shaped execution results. Canonical runtime contracts (`AgentRunHandle`, `AgentRunStatus`, `AgentRunResult`) are the interface between the execution plane and the control plane.
+- `task.inputAttachments` is the objective-scoped input target
+- `task.steps[n].inputAttachments` is the step-scoped input target
+- these fields are part of the task contract, not incidental UI metadata
+- the absence of attachments is valid
+- the presence of attachments must be preserved across create, detail, edit, and rerun
 
 ---
 
-## 7. Document Boundaries
+## 7. Snapshot and edit/rerun architecture
 
-Use this document to understand the "Big Picture" view of the Mission Control UI operating over the Execution Plane.
+The original task input snapshot is the authoritative representation of the authored draft.
 
-For implementation-level specs, see:
-- `docs/Tasks/AgentSkillSystem.md`: Canonical storage, precedence, versioning, path conventions, and `ResolvedSkillSet` semantics for agent skills.
-- `docs/UI/MissionControlArchitecture.md`: Dashboard API routes, endpoint mappings, layout structures, and live UX component behavior.
-- `docs/Tasks/SkillAndPlanContracts.md`: How executable tools and plans generated in the control plane resolve to literal executions in the execution plane.
-- `docs/Temporal/StepLedgerAndProgressModel.md`: Canonical step-ledger schema, status vocabulary, checks, attempts, and latest-run behavior.
-- `docs/Temporal/TemporalArchitecture.md`: Pure Temporal execution philosophy, queue logic, visibility tables, and worker fleet design.
-- `docs/Temporal/TaskExecutionCompatibilityModel.md`: Concrete compatibility bridge between task-oriented product surfaces and Temporal-backed workflow executions.
-- `docs/Temporal/VisibilityAndUiQueryModel.md`: Canonical query model, Search Attribute registry, status mapping, and pagination semantics for Temporal-backed list/detail surfaces.
-- `docs/Tasks/ImageSystem.md`: The specific flow of image processing from UI `ArtifactRef` generation into LLM context chunks.
+Rules:
+
+- it must preserve:
+  - task objective text
+  - objective-scoped attachment refs
+  - step text
+  - step-scoped attachment refs
+  - step order and identity
+  - runtime and publish selections
+  - preset application metadata
+  - dependency declarations that remain part of the editable contract
+- edit and rerun derive their initial browser state from this snapshot
+- fallback evidence refs may assist diagnostics, but they are not an authoritative replacement for the snapshot
+- an attachment-aware execution without a reconstructible snapshot is degraded and must be treated as such explicitly
+
+---
+
+## 8. Execution-plane responsibilities
+
+The execution plane consumes the normalized task contract.
+
+### 8.1 Workflow responsibilities
+
+`MoonMind.Run` owns:
+
+- durable state progression
+- waiting, retry, and cancel semantics
+- prepare-time attachment handling
+- image context generation orchestration
+- passing target-aware context into the relevant planner or step runtime
+
+### 8.2 Prepare responsibilities
+
+Prepare owns:
+
+- downloading objective-scoped and step-scoped attachments
+- writing a canonical attachments manifest
+- materializing raw files into stable workspace locations
+- producing target-aware image context artifacts
+- failing explicitly when attachment preparation is incomplete or invalid
+
+### 8.3 Step execution responsibilities
+
+Step execution owns:
+
+- consuming task-level objective context when relevant
+- consuming only the current step’s step-scoped image context by default
+- avoiding accidental leakage of unrelated step attachments into the wrong step execution
+
+### 8.4 Child workflow responsibilities
+
+If a step is executed through `MoonMind.AgentRun`, the parent-child boundary must preserve target-aware prepared context.
+
+Rules:
+
+- parent workflow remains the source of truth for attachment target binding
+- child workflows receive only the prepared context relevant to the child step
+- child workflow logs and diagnostics do not redefine target binding semantics
+
+---
+
+## 9. Artifact and authorization boundary
+
+The artifact system is the binary boundary of the control plane.
+
+Rules:
+
+- the browser never receives long-lived object-store credentials
+- user preview and download are authorized by execution ownership and view permissions
+- worker-side download and materialization use service credentials and execution authorization
+- artifact links are execution-scoped
+- target binding is preserved by task contract and snapshot semantics, not inferred from storage paths alone
+
+Recommended metadata may include:
+
+- target kind
+- step reference
+- original filename
+- source import path such as upload or Jira import
+
+Rules:
+
+- metadata is helpful for observability
+- metadata must not be the only place where target meaning exists
+
+---
+
+## 10. Runtime and prompt boundary
+
+The control plane does not dictate provider-native multimodal payloads.
+
+Rules:
+
+- the control plane passes normalized task intent plus artifact refs
+- text-first runtimes consume generated image context through the canonical `INPUT ATTACHMENTS` contract
+- multimodal runtimes may consume raw image refs through runtime adapters without changing the control-plane task contract
+- runtime adapters must not invent new attachment targeting rules that the Create page cannot express
+
+---
+
+## 11. Invariants
+
+The following invariants define the desired-state task system.
+
+1. **No binary payloads in Temporal history**
+   Image bytes do not belong in execution histories or inline create payload text.
+
+2. **Explicit attachment targets**
+   Every input attachment belongs either to the task objective target or to a declared step target.
+
+3. **No silent attachment loss**
+   Create, edit, rerun, and prepare must fail explicitly rather than silently dropping attachments.
+
+4. **Text remains text**
+   Instruction fields remain textual authoring surfaces. Images remain structured inputs.
+
+5. **Snapshot-based durability**
+   Attachment-aware edit and rerun require an authoritative task input snapshot.
+
+6. **Server-defined policy**
+   Attachment policy is defined by server configuration and enforced by both browser and API.
+
+7. **MoonMind-owned browser APIs**
+   The browser talks only to MoonMind APIs, not directly to Jira, object storage, or provider-specific file endpoints.
+
+8. **Target-aware runtime consumption**
+   By default, step execution receives only its own step-scoped attachment context plus relevant objective-scoped context.
+
+9. **No hidden retargeting**
+   Reordering steps, applying presets, or changing text must not silently retarget an existing attachment to another step.
+
+10. **Compatibility without semantic drift**
+   Compatibility aliases and migration layers may exist, but they must not change the canonical meaning of objective-scoped versus step-scoped attachments.
+
+---
+
+## 12. Workload-specific behavior
+
+### 12.1 `MoonMind.Run`
+
+This is the canonical attachment-aware task workflow.
+
+Rules:
+
+- attachment-aware task authoring is defined against `MoonMind.Run`
+- create, edit, rerun, and detail flows for attachment-aware tasks are all modeled in task-shaped `MoonMind.Run` terms
+
+### 12.2 `MoonMind.AgentRun`
+
+This child workflow may execute a specific step.
+
+Rules:
+
+- when used, it consumes prepared context for the step it represents
+- it must not redefine or broaden its attachment scope beyond what the parent workflow prepared
+
+### 12.3 Other workflow types
+
+Other workflow types may reuse artifact infrastructure, but they do not redefine the Create-page attachment contract.
+
+---
+
+## 13. Observability and operator surfaces
+
+The architecture must support operator understanding without requiring raw history parsing.
+
+Rules:
+
+- task detail should expose attachment metadata by target
+- diagnostics should expose manifest and generated context refs where appropriate
+- attachment failures should identify:
+  - which target failed
+  - whether the failure happened during upload, validation, materialization, or context generation
+- step-aware surfaces should identify the current step’s attachment context separately from unrelated step inputs
+
+---
+
+## 14. Boundary with page-level and subsystem docs
+
+Use this document to understand the architectural contract.
+
+Use the related docs for detailed behavior:
+
+- `docs/UI/CreatePage.md` for page sections, field behavior, Jira targeting, edit/rerun UX, and validation copy
+- `docs/Tasks/ImageSystem.md` for image-input upload, artifact storage, materialization, context generation, and preview/download behavior
+- `docs/Tasks/AgentSkillSystem.md` for skill selection and resolution
+- `docs/Temporal/TemporalArchitecture.md` for workflow lifecycle and worker topology
+
+---
+
+## 15. Summary
+
+MoonMind’s control plane is task-first, artifact-first, and target-aware.
+
+For image inputs that means:
+
+- the user authors text and image inputs in one draft
+- the control plane uploads and binds images to explicit targets
+- the task contract and authoritative snapshot preserve those bindings
+- the execution plane prepares and injects target-aware context
+- detail, edit, and rerun surfaces can round-trip the same authored intent without semantic loss
+
+That is the desired-state task architecture contract.

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -118,7 +118,7 @@ Representative browser model:
 
 ```ts
 type AttachmentTarget =
-  | { kind: "preset-objective" }
+  | { kind: "objective" }
   | { kind: "step"; stepLocalId: string };
 
 interface DraftAttachment {
@@ -145,6 +145,7 @@ interface StepDraft {
   templateStepId: string;
   templateInstructions: string;
   attachments: DraftAttachment[];
+  templateAttachments: DraftAttachment[];
 }
 
 interface TaskDraft {
@@ -252,6 +253,7 @@ Rules:
 - a template-expanded step remains template-bound only while its authored instructions and attachment set still match the template-authored step input contract
 - any manual edit to a template-bound step’s instructions detaches that step from template instruction identity
 - any manual edit to a template-bound step’s attachment set detaches that step from template input identity
+- `templateAttachments` stores the template-authored attachment set used for detachment comparisons
 - importing Jira text or Jira images into a template-bound step counts as a manual edit
 
 ---

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -2,23 +2,23 @@
 
 Status: Proposed
 Owners: MoonMind Engineering
-Last updated: 2026-04-11
+Last updated: 2026-04-16
 
 ## 1. Purpose
 
-Define the canonical desired-state design for the MoonMind Create page.
+This document defines the canonical desired-state contract for the MoonMind Create page.
 
-The Create page is the single task-composition surface for:
+The Create page is the single task-authoring surface for:
 
-- authoring manual task steps
+- composing manual task steps
+- attaching structured input images to the task objective or to individual steps
 - applying reusable task presets
+- importing Jira text and, when allowed, Jira images into declared draft targets
 - selecting run dependencies
 - configuring runtime, repository, publish, and schedule options
-- importing Jira story text into either:
-  - a step's `Instructions` field, or
-  - the preset `Feature Request / Initial Instructions` field
+- creating, editing, and rerunning task-shaped Temporal executions
 
-This document describes the page as it exists today and extends it with the Jira browsing and selection experience.
+This document is declarative. It defines the contract the product must satisfy. It is not an implementation changelog or rollout log.
 
 ---
 
@@ -27,6 +27,8 @@ This document describes the page as it exists today and extends it with the Jira
 - `docs/UI/MissionControlArchitecture.md`
 - `docs/UI/MissionControlStyleGuide.md`
 - `docs/UI/TypeScriptSystem.md`
+- `docs/Tasks/ImageSystem.md`
+- `docs/Tasks/TaskArchitecture.md`
 - `docs/Tasks/AgentSkillSystem.md`
 - `docs/Temporal/TemporalArchitecture.md`
 - `docs/Temporal/WorkflowTypeCatalogAndLifecycle.md`
@@ -43,15 +45,19 @@ Core posture:
 - steps are the canonical authored execution units
 - presets are reusable step blueprints and objective helpers, not a separate task type
 - Jira is an external instruction source, not a runtime, not an execution substrate, and not a primary task source
-- manual entry must remain first-class even when presets or Jira are unavailable
-- browser clients must only call MoonMind APIs; they must never call Jira directly
+- input images are structured task inputs, not pasted binary content and not part of the instruction text body
+- browser clients call only MoonMind APIs; they never call Jira, object storage, or model providers directly
+- manual authoring remains first-class even when presets, Jira, or image upload are unavailable
+- edit and rerun must preserve the authored task draft, including attachment targeting, unless the user explicitly changes it
 
 Important distinctions:
 
-- **primary step instructions** are the default manual task objective
-- **preset feature request / initial instructions** are the preferred objective source when present
-- **applied preset steps** are expanded step blueprints, not live links to the preset definition
-- **imported Jira text** is a one-time copy into a target field, not a live sync
+- **objective text** is resolved from existing task-authoring fields; it is still text
+- **objective-scoped images** are structured inputs attached to the task objective target
+- **step-scoped images** are structured inputs attached to a specific step target
+- **applied preset steps** are expanded step blueprints, not live bindings to a preset definition
+- **imported Jira text** is a one-time copy into a text field, not a live sync
+- **imported Jira images** are structured attachment selections, not inline embedded images
 
 ---
 
@@ -64,9 +70,11 @@ The canonical Create page route is:
 Rules:
 
 - `/tasks/new` is the canonical route
+- compatibility aliases may exist, but they must redirect to the canonical route and must not define separate product behavior
 - the page is server-hosted by FastAPI and rendered by the Mission Control React/Vite UI
-- runtime config is generated server-side and passed through the boot payload
-- all page actions must go through MoonMind REST APIs
+- runtime configuration is generated server-side and passed through the boot payload
+- all page actions go through MoonMind REST APIs
+- artifact upload, preview, and download all remain behind MoonMind-controlled API surfaces
 
 Representative implementation surfaces:
 
@@ -75,57 +83,97 @@ Representative implementation surfaces:
 
 ---
 
-## 5. Current baseline this design preserves
-
-The Create page already supports all of the following, and this design keeps them as first-class behaviors:
-
-1. a multi-step editor with:
-   - one required primary step
-   - add / remove / reorder controls
-   - per-step instructions
-   - optional per-step runtime selection from one mixed selector surface:
-     - `agent_skill`
-     - `runtime_command`
-   - optional per-step required-capability CSV
-   - optional per-step arguments JSON
-2. a task preset area with:
-   - preset selection
-   - a preset objective field labeled `Feature Request / Initial Instructions`
-   - preset expansion into steps
-   - saving the current step draft as a preset
-3. a dependency picker for existing `MoonMind.Run` prerequisites
-4. runtime and provider selection
-5. model and effort selection
-6. repository and branch configuration
-7. publish-mode selection
-8. optional policy-gated attachment selection
-9. priority and max-attempt controls
-10. a `Propose Tasks` toggle
-11. immediate, deferred, and recurring schedule modes
-12. submission through the Temporal-backed create endpoint
-13. automatic task-input artifact fallback when the inline submission payload is too large
-
-This design does not replace the current Create page mental model. It extends it.
-
----
-
-## 6. Canonical page model
+## 5. Canonical page model
 
 The page is a single composition form with these canonical sections, in this order:
 
 | Order | Section | Purpose |
 | --- | --- | --- |
-| 1 | Header | Identify the page as task creation |
-| 2 | Steps | Author the task plan directly |
-| 3 | Task Presets | Apply reusable step blueprints and define preset objective text |
-| 4 | Dependencies | Block the new task on existing runs |
-| 5 | Execution context | Runtime, provider, model, effort, repo, branches, publish mode |
-| 6 | Attachments | Optional input files when enabled by policy |
-| 7 | Execution controls | Priority, max attempts, propose tasks |
-| 8 | Schedule | Immediate, once, deferred minutes, recurring |
-| 9 | Submit | Create the task |
+| 1 | Header | Identify the page as task creation, edit, or rerun |
+| 2 | Steps | Author the execution plan directly, including step-scoped image inputs |
+| 3 | Task Presets | Apply reusable step blueprints and define preset objective text and objective-scoped image inputs |
+| 4 | Dependencies | Block the new run on existing `MoonMind.Run` executions |
+| 5 | Execution context | Runtime, provider, model, effort, repository, branches, publish mode |
+| 6 | Execution controls | Priority, max attempts, propose tasks |
+| 7 | Schedule | Immediate, once, deferred minutes, recurring |
+| 8 | Submit | Create, save changes, or rerun |
 
-The Jira browser is not its own top-level page section. It is a shared secondary instruction-source surface that can be invoked from the Steps and Task Presets sections.
+Rules:
+
+- there is no detached, page-wide “image bucket”
+- every selected attachment belongs to an explicit target
+- the shared secondary surfaces are:
+  - the Jira browser
+  - provider/profile selectors
+  - attachment preview and removal affordances
+- image selection belongs with the field it informs, not with unrelated page controls
+
+---
+
+## 6. Draft model
+
+The browser draft is step-first and target-aware.
+
+Representative browser model:
+
+```ts
+type AttachmentTarget =
+  | { kind: "preset-objective" }
+  | { kind: "step"; stepLocalId: string };
+
+interface DraftAttachment {
+  localId: string;
+  target: AttachmentTarget;
+  source: "local" | "artifact";
+  status: "selected" | "uploading" | "uploaded" | "failed";
+  artifactId?: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  previewUrl?: string | null;
+  errorMessage?: string | null;
+}
+
+interface StepDraft {
+  localId: string;
+  id: string;
+  title: string;
+  instructions: string;
+  skillId: string;
+  skillArgs: string;
+  skillRequiredCapabilities: string;
+  templateStepId: string;
+  templateInstructions: string;
+  attachments: DraftAttachment[];
+}
+
+interface TaskDraft {
+  presetObjectiveText: string;
+  presetObjectiveAttachments: DraftAttachment[];
+  steps: StepDraft[];
+  appliedTemplates: AppliedTemplateState[];
+  runtime: string;
+  providerProfile: string;
+  model: string;
+  effort: string;
+  repository: string;
+  startingBranch: string;
+  targetBranch: string;
+  publishMode: "none" | "branch" | "pr";
+  dependencies: string[];
+}
+```
+
+Rules:
+
+- attachments are structured inputs, not part of the `Instructions` text value
+- the UI may render image thumbnails directly under an instructions field so the relationship is visually clear
+- the source of truth for attachment targeting is structured state, not text conventions
+- the draft may contain both local-file selections and previously uploaded artifact-backed attachments
+- the draft must distinguish:
+  - an existing persisted attachment
+  - a newly selected local file
+  - an upload failure that has not yet been resolved
 
 ---
 
@@ -133,88 +181,78 @@ The Jira browser is not its own top-level page section. It is a shared secondary
 
 ### 7.1 Step list
 
-The step editor must render a list of step cards.
+The step editor renders a list of step cards.
 
 Rules:
 
 - the first card is always **Step 1 (Primary)**
 - users may add, remove, and reorder steps
 - reordering changes authored order only; it does not create dependency edges between steps
-- the page must always remain valid with exactly one step card present
+- the page must remain valid with exactly one step card present
+- each step card owns its own instructions and attachment state
+- moving or reordering a step moves its attachments with it
 
 ### 7.2 Step fields
 
 Each step card must expose:
 
 - `Instructions`
+- `Images` or `Input Attachments` when attachment policy is enabled
 - `Skill (optional)`
-- `Arguments (optional JSON object)` when the selected item accepts args
+- `Skill Args (optional JSON object)` when a non-empty explicit skill is selected
+- `Skill Required Capabilities (optional CSV)` in Advanced Settings
 
 Rules:
 
 - the primary step must contain instructions or an explicit skill
 - when any additional step is present, the primary step must contain instructions
 - non-primary steps may omit instructions to continue from the task objective
-- non-primary steps may omit skill to inherit the primary-step skill defaults
+- non-primary steps may omit skill to inherit primary-step skill defaults
+- step attachments are visible in the same card as the step instructions they inform
 
-### 7.2.1 Mixed selector contract
+### 7.3 Step attachment contract
 
-The existing `Skill (optional)` control is a mixed selector surface.
-
-It may present:
-
-- agent skills
-- runtime commands
-
-Representative browser model:
-
-```ts
-type StepRuntimeSelection =
-  | {
-      kind: "agent_skill";
-      name: string;
-      args?: Record<string, unknown> | null;
-    }
-  | {
-      kind: "runtime_command";
-      name: string;
-      args?: Record<string, unknown> | null;
-    };
-```
+A step may own zero or more attachments.
 
 Rules:
 
-* the browser may keep the visible label `Skill` for continuity, but the
-  submitted payload must preserve the selected item's `kind`
-* `runtime_command` items must be filtered by the currently selected runtime
-* changing runtime must revalidate the current selection and clear or mark
-  invalid any unsupported `runtime_command`
-* `agent_skill` and `runtime_command` items may share one dropdown, but they
-  must not be flattened to one undifferentiated string in the backend
-* `Arguments` applies to the selected item regardless of kind
-* selecting a `runtime_command` does not make that command part of the task's
-  resolved skill set; it is execution configuration for the `agent_runtime`
-  step
+- step attachments are submitted through `task.steps[n].inputAttachments`
+- adding or removing a step attachment is a first-class authored change to that step
+- the UI must show, per attachment:
+  - filename
+  - type
+  - size
+  - thumbnail preview when preview is supported
+  - upload or error state when relevant
+- the UI must allow removing a selected or persisted attachment before submit
+- attachment order may be displayed, but execution semantics do not rely on visual ordering
+- the same image must not become attached to another step implicitly because the user reordered steps, edited text, or applied a preset
+- if the product supports drag-and-drop or paste, those gestures must still land on an explicit target step
 
-### 7.3 Advanced settings
+### 7.4 Objective-scoped attachment target
 
-The page must expose `Skill Required Capabilities (optional CSV)` behind a collapsed Advanced Settings section outside the step-list region.
+The page also supports an objective-scoped attachment target.
+
+This target exists for the preset-owned objective field rather than for a specific step.
 
 Rules:
 
-- each step may still author optional skill required capabilities
-- required capabilities remain an advanced routing override, not part of the default visible Create Task flow
-- runtime, publish mode, selected skills, selected runtime commands, and presets derive the common capability set automatically
+- objective-scoped attachments are submitted through `task.inputAttachments`
+- they belong to the preset objective target, not to an anonymous page-wide bucket
+- if presets are disabled, this target may be hidden entirely
+- objective-scoped attachments are part of the task-level objective context
+- they are not copied down into step attachments automatically
 
-### 7.4 Template-bound steps
+### 7.5 Template-bound steps
 
 Preset-expanded steps may carry template step identity.
 
 Rules:
 
-- a template-expanded step remains template-bound only while its authored instructions still match the template-provided instructions
-- any manual edit to a template-bound step's instructions detaches that step from the template binding for instruction identity purposes
-- importing Jira text into a step counts as a manual instruction edit
+- a template-expanded step remains template-bound only while its authored instructions and attachment set still match the template-authored step input contract
+- any manual edit to a template-bound step’s instructions detaches that step from template instruction identity
+- any manual edit to a template-bound step’s attachment set detaches that step from template input identity
+- importing Jira text or Jira images into a template-bound step counts as a manual edit
 
 ---
 
@@ -222,15 +260,16 @@ Rules:
 
 ### 8.1 Preset area
 
-The preset area must remain optional.
+The preset area remains optional.
 
-It must expose:
+It exposes:
 
 - `Preset`
 - `Feature Request / Initial Instructions`
+- objective-scoped image inputs when attachment policy is enabled
 - `Apply`
 - `Save Current Steps as Preset` when preset saving is enabled
-- status text describing preset loading and apply outcomes
+- status text describing preset load and apply outcomes
 
 ### 8.2 Preset application
 
@@ -240,58 +279,53 @@ Rules:
 
 - when the form still contains only the initial empty default step, applying a preset may replace that placeholder step set
 - otherwise, applying a preset appends expanded preset steps to the existing draft
-- preset input values may be resolved from:
-  - explicit preset objective text
-  - remembered prior input values
-  - preset defaults
-  - current draft instructions
-  - repository draft values
-- applying a preset must be explicit; selecting a preset alone must not modify the step list
+- selecting a preset alone must not modify the draft
+- objective-scoped attachments are not silently generated by preset application unless the preset system explicitly defines them in a future contract
+- preset application remains an explicit action
 
-### 8.3 Preset objective text
+### 8.3 Preset objective contract
 
-`Feature Request / Initial Instructions` is the preset-owned objective source.
+`Feature Request / Initial Instructions` is the preset-owned objective text source.
 
 Rules:
 
-- when non-empty, it is preferred over the primary step instructions for task objective resolution
-- it is the correct target when the user wants Jira story text to drive a preset-oriented task flow
-- changing this field must never silently mutate already-expanded preset steps
+- when non-empty, it is preferred over primary-step instructions for objective text resolution
+- objective-scoped attachments are the matching structured input source for this field
+- changing preset objective text or objective-scoped attachments must not silently rewrite already expanded steps
 
-### 8.4 Preset reapply behavior
+### 8.4 Reapply behavior
 
-The page must distinguish between:
+The page distinguishes between:
 
-- selecting or editing preset inputs, and
+- changing preset inputs, and
 - applying or reapplying the preset
 
 Rules:
 
-- when preset inputs change after a preset has already been applied, the page must mark the preset state as **needs reapply**
-- the page must surface a clear `Reapply preset` action when the preset is dirty
-- reapplying the preset must be explicit
-- the page must not automatically overwrite expanded steps when the preset objective field changes, including when the change came from Jira import
+- when preset objective text changes after apply, the page marks the preset state as **needs reapply**
+- when objective-scoped attachments change after apply, the page also marks the preset state as **needs reapply**
+- the page surfaces a clear `Reapply preset` action when the preset is dirty
+- reapply is explicit
+- the page must not automatically overwrite expanded steps because preset inputs changed
 
 ---
 
 ## 9. Dependency contract
 
-The dependency area must remain a bounded picker for existing `MoonMind.Run` executions.
+The dependency area remains a bounded picker for existing `MoonMind.Run` executions.
 
 Rules:
 
 - users may add up to 10 direct dependencies
-- duplicate dependencies must be rejected client-side
+- duplicate dependencies are rejected client-side
 - dependency fetch failure must not block manual task creation
-- dependency selection is independent from Jira and presets
+- dependency selection is independent from image attachments, Jira, and presets
 
 ---
 
 ## 10. Execution context contract
 
-The Create page must preserve the existing execution-context controls.
-
-Required controls:
+The Create page preserves these execution-context controls:
 
 - `Runtime`
 - `Provider profile` when profiles exist for the selected runtime
@@ -304,42 +338,217 @@ Required controls:
 
 Rules:
 
-- runtime defaults come from server-provided runtime config
+- runtime defaults come from server-provided runtime configuration
+- attachment policy also comes from server-provided runtime configuration
 - provider-profile options are runtime-specific
-- available `runtime_command` items are runtime-specific and must update when
-  `Runtime` changes
-- if a runtime change invalidates an already-selected `runtime_command`, the
-  page must show an explicit validation error until the user clears or replaces
-  that selection
+- repository validation rules are unaffected by attachments or Jira
 - resolver-style skills may still force publish mode to `none`
-- repository validation rules remain unchanged by Jira integration
-- Jira import must never bypass or weaken repository validation
+- image upload must never bypass or weaken repository validation, publish validation, or runtime gating
 
 ---
 
-## 11. Attachment, execution-control, and schedule contract
+## 11. Attachment policy and UX contract
 
-This design preserves the current controls for:
+Attachment behavior is policy-gated.
 
-- attachments when enabled by policy
-- priority
-- max attempts
-- `Propose Tasks`
-- schedule mode and schedule parameters
+Representative runtime config shape:
+
+```json
+{
+  "system": {
+    "attachmentPolicy": {
+      "enabled": true,
+      "maxCount": 10,
+      "maxBytes": 10485760,
+      "totalBytes": 26214400,
+      "allowedContentTypes": [
+        "image/png",
+        "image/jpeg",
+        "image/webp"
+      ]
+    }
+  }
+}
+```
 
 Rules:
 
-- Jira integration must not change attachment policy
-- Jira integration must not change schedule semantics
-- if attachment selection is visible but submission support is still unavailable for the current backend path, the page must fail fast with the current explicit message rather than silently dropping files
+- when policy is disabled, all attachment entry points are hidden
+- when policy permits only image MIME types, the UI should use an image-specific label such as `Images`
+- validation must happen both before upload and at submit time
+- the browser must fail fast and visibly when:
+  - count limit is exceeded
+  - single-file size limit is exceeded
+  - total size limit is exceeded
+  - content type is unsupported
+  - upload fails
+- the browser must not silently drop a selected image
+- the user must be able to remove a failed or invalid image without losing unrelated draft state
+- previews are advisory UI affordances; preview failure must not corrupt the draft
+
+Desired-state UX affordances:
+
+- file picker
+- drag-and-drop where supported
+- paste-from-clipboard where supported
+- thumbnail preview for supported images
+- keyboard-accessible remove and retry actions
+- a concise per-target attachment summary
 
 ---
 
-## 12. Objective resolution and title derivation
+## 12. Jira integration contract
 
-The Create page must preserve a single canonical objective-resolution rule.
+### 12.1 Product role
 
-The resolved task objective is determined in this order:
+Jira exists to source task inputs into the Create page.
+
+It is not intended to:
+
+- create MoonMind tasks automatically on issue selection
+- replace the step editor
+- replace presets
+- change the task submission API shape into a Jira-native workflow type
+- make the browser talk directly to Jira
+
+### 12.2 Supported targets
+
+The Jira browser supports these targets:
+
+- preset objective text
+- preset objective attachments
+- any step’s instructions
+- any step’s attachments
+
+Representative target model:
+
+```ts
+type JiraImportTarget =
+  | { kind: "preset-objective-text" }
+  | { kind: "preset-objective-attachments" }
+  | { kind: "step-text"; stepLocalId: string }
+  | { kind: "step-attachments"; stepLocalId: string };
+```
+
+Rules:
+
+- opening the browser from a field preselects its matching target
+- the browser must display the current target explicitly
+- switching targets inside the browser must not clear the selected issue
+
+### 12.3 Text and image import semantics
+
+Rules:
+
+- selecting a Jira issue never mutates the draft automatically
+- text import remains explicit and supports `Replace target text` and `Append to target text`
+- image import remains explicit and supports selecting which supported images to add
+- imported Jira images become structured attachments on the selected target
+- imported Jira images are not injected into instruction text as markdown, HTML, or inline data
+- when importing into a template-bound step, text and attachment imports both count as manual customization
+
+### 12.4 Preset interaction
+
+Rules:
+
+- importing Jira text or images into the preset objective target marks an already-applied preset as needing reapply
+- importing into a step target does not mutate preset objective state
+
+---
+
+## 13. Edit and rerun contract
+
+The Create page also serves as the edit and rerun surface for `MoonMind.Run` executions.
+
+Rules:
+
+- edit and rerun reconstruct the draft from the authoritative task input snapshot
+- reconstructed draft state includes:
+  - objective text
+  - objective-scoped attachments
+  - step instructions
+  - step-scoped attachments
+  - runtime and publish settings
+  - applied templates and their dirty state
+  - dependencies that remain part of the editable contract
+- existing persisted attachments must be rendered distinctly from newly selected local files
+- the user must be able to:
+  - keep an existing attachment
+  - remove an existing attachment
+  - add a new attachment
+  - replace one attachment by removing the old and adding the new
+- rerun preserves original attachment refs by default unless the user edits them
+- untouched attachments must survive round-trips through edit and rerun without being silently dropped or duplicated
+
+---
+
+## 14. Submission contract
+
+The Create page submit flow remains artifact-first.
+
+Rules:
+
+- local images upload to the artifact system before create, edit, or rerun is submitted
+- the browser submits structured attachment refs, not raw binary payloads, to the execution create/update API
+- the control plane stores an authoritative task input snapshot that preserves attachment targeting
+- oversized task text continues to use existing artifact fallback behavior for text payloads
+- attachment upload completion is required before the execution becomes eligible to start
+- attachment selection alone does not create a task; submit remains explicit
+
+Representative task-shaped payload:
+
+```json
+{
+  "type": "task",
+  "payload": {
+    "repository": "owner/repo",
+    "task": {
+      "instructions": "Resolved task objective text.",
+      "inputAttachments": [
+        {
+          "artifactId": "art_objective_123",
+          "filename": "overview.png",
+          "contentType": "image/png",
+          "sizeBytes": 48213
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-1",
+          "instructions": "Inspect the screenshot and identify the bug.",
+          "inputAttachments": [
+            {
+              "artifactId": "art_step1_456",
+              "filename": "bug.png",
+              "contentType": "image/png",
+              "sizeBytes": 72109
+            }
+          ]
+        },
+        {
+          "id": "step-2",
+          "instructions": "Implement the fix and verify the result."
+        }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- `task.inputAttachments` is the objective-scoped target
+- `task.steps[n].inputAttachments` is the step-scoped target
+- absence of attachments is valid
+- the meaning of an attachment is defined by its target, not by filename conventions
+
+---
+
+## 15. Objective resolution and title derivation
+
+The page preserves a canonical objective-resolution rule for text.
+
+The resolved objective text is determined in this order:
 
 1. preset `Feature Request / Initial Instructions`
 2. primary step `Instructions`
@@ -347,403 +556,83 @@ The resolved task objective is determined in this order:
 
 Rules:
 
-- importing Jira text into the preset objective field overrides the primary step for objective resolution
-- importing Jira text into the primary step affects the resolved objective only when the preset objective field is empty
-- importing Jira text into a non-primary step does not change the resolved task objective
-- explicit task title derivation should continue to use the first non-empty line of the resolved objective text
+- importing Jira text into the preset objective field overrides primary-step text for objective text resolution
+- importing Jira text into the primary step affects resolved objective text only when preset objective text is empty
+- importing Jira text into a non-primary step does not change resolved objective text
+- explicit task title derivation continues to use the first non-empty line of the resolved objective text
+
+Attachment rules:
+
+- objective-scoped attachments are always part of the task-level objective input context
+- primary-step attachments may also participate in task-level objective input context because the primary step is the default authored task objective
+- non-primary step attachments do not affect task title derivation
+- non-primary step attachments do not become task-level objective inputs unless the planner or runtime explicitly promotes them for a derived purpose
 
 ---
 
-## 13. Jira integration: product role
-
-Jira integration exists to source instruction text into the Create page.
-
-It is not intended to:
-
-- create MoonMind tasks automatically on issue selection
-- replace the step editor
-- replace presets
-- change the submission API shape into a Jira-native workflow type
-- make the browser talk directly to Jira
-
-Primary Jira use cases:
-
-1. browse a Jira board by column while composing a task
-2. inspect a story before importing it
-3. copy normalized story text into a chosen target field
-4. use a Jira story to seed preset objective text
-5. use a Jira story to seed the primary step or any secondary step instructions
-
----
-
-## 14. Jira integration: runtime config contract
-
-The Create page may expose Jira only when runtime config explicitly enables it.
-
-Representative desired-state config shape:
-
-```json
-{
-  "sources": {
-    "jira": {
-      "connections": "/api/jira/connections",
-      "projects": "/api/jira/projects",
-      "boards": "/api/jira/boards",
-      "columns": "/api/jira/boards/{boardId}/columns",
-      "issues": "/api/jira/boards/{boardId}/issues",
-      "issue": "/api/jira/issues/{issueKey}"
-    }
-  },
-  "system": {
-    "jiraIntegration": {
-      "enabled": true,
-      "defaultProjectKey": "",
-      "defaultBoardId": "",
-      "rememberLastBoardInSession": true
-    }
-  }
-}
-```
+## 16. Failure and empty-state rules
 
 Rules:
 
-- the presence of `sources.jira` alone is not sufficient; Jira entry points should only render when `system.jiraIntegration.enabled` is true
-- all Jira URLs must remain MoonMind API endpoints
-- browser clients must not embed Jira credentials or Jira-domain knowledge beyond the documented response shapes
+- if attachment policy is disabled, the page hides attachment entry points and remains fully usable
+- if an upload fails, the failure remains local to the affected target and the rest of the draft remains intact
+- if attachment preview fails, metadata remains visible and the user can still remove the attachment
+- if edit or rerun cannot reconstruct attachments, the page must fail explicitly rather than silently dropping them
+- if Jira is unavailable, the user can close the Jira browser and continue manual authoring without losing draft state
+- if the selected Jira issue cannot be fetched, the page must not mutate the draft
+- create, edit, and rerun must never proceed with silently discarded attachments
+
+Representative copy:
+
+- `Image upload failed. Remove the image or retry before submitting.`
+- `This runtime does not currently allow image inputs.`
+- `The task draft could not be reconstructed because one or more attachment bindings were missing.`
+- `Failed to load Jira issue. You can continue creating the task manually.`
 
 ---
 
-## 15. Jira integration: server API contract
-
-The browser-facing API should return Create-page-ready data.
-
-### 15.1 Column contract
-
-Jira columns are board-specific.
+## 17. Accessibility and interaction rules
 
 Rules:
 
-- the MoonMind API must resolve columns from Jira board configuration
-- the MoonMind API, not the browser, is responsible for translating Jira status-to-column mapping into a board-column model
-- the browser must render board columns in board order
-- board-scoped column requests may include the selected `projectKey` query parameter; when present, the API verifies the board is listed for that project instead of relying only on Jira board location metadata
-
-Representative column response:
-
-```json
-{
-  "board": {
-    "id": "42",
-    "name": "MoonMind Delivery",
-    "projectKey": "MM"
-  },
-  "columns": [
-    { "id": "todo", "name": "To Do", "count": 12 },
-    { "id": "doing", "name": "Doing", "count": 4 },
-    { "id": "done", "name": "Done", "count": 30 }
-  ]
-}
-```
-
-### 15.2 Issue-list contract
-
-The issue-list endpoint must support board browsing by column.
-
-Representative response:
-
-```json
-{
-  "boardId": "42",
-  "columns": [
-    { "id": "todo", "name": "To Do" },
-    { "id": "doing", "name": "Doing" },
-    { "id": "done", "name": "Done" }
-  ],
-  "itemsByColumn": {
-    "todo": [
-      {
-        "issueKey": "MM-123",
-        "summary": "Add Jira import to Create page",
-        "issueType": "Story",
-        "statusName": "Selected for Development",
-        "assignee": "Ada",
-        "updatedAt": "2026-04-10T19:30:00Z"
-      }
-    ]
-  }
-}
-```
-
-Rules:
-
-- the browser must not infer column membership from raw issue status text
-- the issue list may optionally support `q=` filtering by issue key or summary
-- the issue list may include the selected `projectKey` query parameter, and the server filters returned stories to that selected project and configured project allowlist
-- empty columns must still be renderable
-
-### 15.3 Issue-detail contract
-
-The issue-detail endpoint must return normalized story content suitable for preview and import.
-When a board context is present, the browser may send both `boardId` and selected
-`projectKey` query parameters so the server can preserve project policy context
-while resolving the story's board column.
-
-Representative response:
-
-```json
-{
-  "issueKey": "MM-123",
-  "url": "https://jira.example.com/browse/MM-123",
-  "summary": "Add Jira import to Create page",
-  "issueType": "Story",
-  "column": { "id": "doing", "name": "Doing" },
-  "status": { "id": "10001", "name": "In Progress" },
-  "descriptionText": "As a user, I want to browse Jira stories by column...",
-  "acceptanceCriteriaText": "Given a board... When I choose a column... Then I can import the story into a task field.",
-  "recommendedImports": {
-    "presetInstructions": "MM-123: Add Jira import to Create page\n\nAs a user, I want to browse Jira stories by column...",
-    "stepInstructions": "Complete Jira story MM-123: Add Jira import to Create page\n\nDescription\nAs a user, I want to browse Jira stories by column...\n\nAcceptance criteria\nGiven a board..."
-  }
-}
-```
-
-Rules:
-
-- MoonMind must normalize Jira rich text before returning it to the browser
-- the browser must consume normalized text, not parse Jira rich-text formats itself
-- the response should include target-specific recommended import text so the client can stay simple and consistent
+- all open, close, target, upload, remove, retry, and import actions must be keyboard accessible
+- image preview controls must expose meaningful labels to assistive technology
+- step cards must clearly identify when attachments are present
+- the Jira browser title must identify the current import target
+- after importing text or images from Jira, focus must return predictably to the updated field or to an explicit success notice
+- validation errors must be associated with the specific target that failed
 
 ---
 
-## 16. Jira integration: shared browser surface
+## 18. Testing requirements
 
-The Jira experience must be implemented as one shared instruction-source surface.
+The Create page test suite should cover:
 
-Canonical posture:
-
-- one shared Jira browser may be open at a time
-- it opens from a target field, but it is not permanently embedded inside every field
-- it must preserve the rest of the draft while open
-
-Preferred UI form:
-
-- a modal or side drawer titled `Browse Jira story`
-
-The Jira browser must show:
-
-1. current import target
-2. Jira connection selector when more than one connection exists
-3. project selector when needed
-4. board selector
-5. column tabs or a segmented column control
-6. issue list for the active column
-7. an issue preview panel
-8. import-mode selector
-9. explicit import actions
-
-Rules:
-
-- opening the browser from a field preselects that field as the target
-- the browser may allow target switching while open
-- selecting an issue must not write into the draft automatically
-- import requires an explicit user action
+1. attachment entry points are hidden when policy is disabled
+2. image validation enforces count, per-file size, total size, and content type
+3. selecting images does not create hidden draft mutations on other targets
+4. step-scoped images remain attached to the correct step through reorder operations
+5. importing Jira text does not mutate the draft until import is confirmed
+6. importing Jira images creates structured attachments on the selected target
+7. importing into a template-bound step detaches that step when appropriate
+8. changing preset objective text or objective-scoped attachments after apply marks the preset as needing reapply
+9. create submission uploads images before execution create
+10. edit reconstructs persisted attachments correctly
+11. rerun preserves untouched attachments by default
+12. preview failure or upload failure does not corrupt unrelated draft state
+13. submit fails explicitly when attachments are invalid or incomplete
 
 ---
 
-## 17. Jira integration: target model
-
-Jira import must support these targets:
-
-- preset objective field: `Feature Request / Initial Instructions`
-- any step's `Instructions` field, including the primary step
-
-Representative UI target model:
-
-```ts
-type JiraImportTarget =
-  | { kind: "preset-objective" }
-  | { kind: "step-instructions"; stepLocalId: string };
-```
-
-Rules:
-
-- the target selected at browser-open time is the default target
-- the browser should display the target explicitly so the user always knows where the import will land
-- switching the target inside the browser must not clear the selected Jira issue
-
----
-
-## 18. Jira integration: import modes
-
-The browser must support target-aware import modes.
-
-Minimum modes:
-
-- `Preset brief` — summary plus description
-- `Execution brief` — summary plus description plus acceptance criteria
-- `Description only`
-- `Acceptance criteria only`
-
-Default mode by target:
-
-- preset objective target defaults to `Preset brief`
-- step-instructions target defaults to `Execution brief`
-
-Rules:
-
-- the import preview must update live as the user changes mode
-- the user must be able to override the default mode before import
-- import mode affects only the copied text, not the selected issue identity
-
----
-
-## 19. Jira integration: write semantics
-
-### 19.1 Preset-objective target
-
-When the target is the preset objective field:
-
-- importing must update `Feature Request / Initial Instructions`
-- importing must not directly rewrite the step list
-- if a preset has already been applied, the page must mark the preset as needing reapply
-
-### 19.2 Step-instructions target
-
-When the target is a step instructions field:
-
-- importing must write directly into that step's `Instructions`
-- importing into the primary step may satisfy the primary-step instruction requirement
-- importing into a template-bound step detaches the step from template instruction identity if the imported text differs from the template instructions
-
-### 19.3 Replace and append
-
-The browser must support two explicit write actions:
-
-- `Replace target`
-- `Append to target`
-
-Rules:
-
-- `Replace target` is the default action
-- `Append to target` must preserve the existing field text and add a clear separator before the imported Jira text
-- neither action may run automatically on issue selection
-
----
-
-## 20. Jira integration: provenance and affordances
-
-The Create page should retain lightweight, field-level source provenance after import.
-
-Representative desired-state provenance model:
-
-```ts
-interface JiraImportProvenance {
-  source: "jira";
-  issueKey: string;
-  boardId: string;
-  columnId: string;
-  importedAt: string;
-  mode: "preset-brief" | "execution-brief" | "description-only" | "acceptance-only";
-}
-```
-
-Rules:
-
-- provenance is advisory UI metadata, not a live binding
-- the page should render a subtle chip such as `Jira: MM-123` near an imported field
-- reopening the Jira browser from an imported field should prefer the prior issue selection when possible
-- clearing a field does not require a Jira call
-
-Submission behavior:
-
-- Jira provenance may be carried as advisory metadata if and when the backend accepts it
-- absence of submitted provenance must not block create
-- create must remain compatible with the existing task payload shape
-
----
-
-## 21. Failure and empty-state rules
-
-Jira must be an additive capability only.
-
-Rules:
-
-- if Jira integration is disabled, the page must hide Jira entry points and remain fully usable
-- if Jira fetch fails, the failure must remain local to the Jira browser and must not corrupt the draft
-- the user must be able to close the Jira browser and continue manual authoring without losing form state
-- empty project, board, column, or issue states must be rendered explicitly
-- if the selected issue cannot be fetched, the page must keep the current draft untouched
-
-Representative empty and failure copy:
-
-- `No Jira boards available.`
-- `This board has no columns.`
-- `No issues found in this column.`
-- `Failed to load Jira stories. You can continue creating the task manually.`
-
----
-
-## 22. Submission invariants
-
-The Create page submit flow must remain fundamentally unchanged.
-
-Rules:
-
-- Jira import changes authored field content only
-- the task is still submitted through the existing Temporal-backed create endpoint
-- objective resolution order remains unchanged except for the fact that Jira can now populate either of the existing objective sources
-- oversized task input must still use the existing artifact fallback flow
-- Jira must not introduce a separate create endpoint or a separate task type
-
-Practical consequence:
-
-- importing Jira into the preset objective field feeds the existing preset-objective path
-- importing Jira into the primary step feeds the existing manual-step path
-- importing Jira into a secondary step affects only that step unless the same text is also placed into the preset objective or primary step
-
----
-
-## 23. Accessibility and interaction rules
-
-The Jira browser and new field affordances must meet the same accessibility bar as the rest of Mission Control.
-
-Rules:
-
-- all open, close, target, and import actions must be keyboard accessible
-- the browser title must identify the current target context
-- column controls must be navigable by keyboard and expose active state clearly
-- issue rows must expose key plus summary for screen-reader scanning
-- importing must move focus predictably back to the updated field or to an explicit success notice
-
----
-
-## 24. Testing requirements
-
-The Create page test suite should cover the following behaviors:
-
-1. Jira entry points are hidden when integration is disabled
-2. board columns load and render in board order
-3. issue lists switch correctly by column
-4. selecting an issue does not mutate the draft until import is confirmed
-5. importing into the preset objective field updates only that field
-6. importing into the primary step updates that step and satisfies instruction validation
-7. importing into a secondary step updates only that step
-8. importing into a template-bound step detaches template instruction identity when appropriate
-9. changing the preset objective through Jira after preset apply marks the preset as needing reapply
-10. Jira API failures do not block manual task creation
-11. create submission still uses the existing endpoint and objective resolution order
-
----
-
-## 25. Summary of desired-state posture
+## 19. Summary
 
 The Create page remains a single, task-first composition form.
 
-Jira is added as a reusable instruction-source browser that can target either:
+Images are supported as explicit structured inputs attached either to:
 
-- a step's `Instructions`, or
-- the preset `Feature Request / Initial Instructions`
+- the preset objective target, or
+- a specific step target
 
-That is the entire product posture.
+That is the desired-state contract.
 
-The page does **not** become Jira-native. It stays MoonMind-native, while letting Jira provide high-value source text exactly where users already compose work.
+The page does not become an image editor, a Jira-native surface, or a binary transport layer. It remains MoonMind-native and task-first while allowing users to author text and image inputs together in the same draft.


### PR DESCRIPTION
## Summary

- Rewrites the task image input design as the canonical desired-state contract for target-aware image attachments.
- Updates the high-level task architecture doc to make task input snapshots, artifact-first binary handling, and attachment target binding explicit.
- Updates the Create page contract for objective-scoped and step-scoped image inputs, Jira image imports, edit/rerun durability, and attachment validation behavior.

## Impact

Docs-only change. This clarifies the intended product and architecture contracts for image inputs without changing runtime code or APIs.

## Validation

- `git diff --check origin/main...HEAD`