### PR TITLE
MM-363 OAuth terminal Docker verification artifacts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/193-create-page-merge-automation"
+  "feature_directory": "specs/194-oauth-terminal-docker-verification"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-363-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-363-moonspec-orchestration-input.md
@@ -1,0 +1,91 @@
+# MM-363 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-363
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+- Labels: `MM-318`, `managed-sessions`, `oauth-terminal`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-363 from MM project
+Summary: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-363 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-363: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+
+Short Name
+oauth-terminal-docker-verification
+
+User Story
+As a MoonMind maintainer, I can run and record Docker-enabled integration evidence for OAuthTerminal managed-session auth behavior, so the remaining ADDITIONAL_WORK_NEEDED verification reports can close without relying only on unit and fake-runner evidence.
+
+Acceptance Criteria
+- Given a Docker-enabled verification environment, `./tools/test_integration.sh` passes for the OAuthTerminal-relevant managed-session coverage.
+- Given managed Codex session launch is inspected, `agent_workspaces` is mounted at `/work/agent_jobs` and the auth volume is mounted only at `MANAGED_AUTH_VOLUME_PATH` when explicitly configured.
+- Given `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`, launch fails before container creation.
+- Given runtime startup receives a valid auth-volume path, eligible auth entries seed one way into the per-run `CODEX_HOME` before Codex App Server starts.
+- Given the OAuth terminal flow runs against Docker, the auth runner and PTY bridge lifecycle are exercised end to end.
+- Verification reports are updated from ADDITIONAL_WORK_NEEDED only when the evidence above passes; otherwise they record the exact blocker.
+
+Requirements
+- Run Docker-enabled integration verification for OAuthTerminal managed-session auth behavior.
+- Ensure OAuthTerminal-relevant managed-session coverage passes through `./tools/test_integration.sh` in a Docker-enabled environment.
+- Verify managed Codex session launch mounts `agent_workspaces` at `/work/agent_jobs`.
+- Verify the auth volume is mounted only at `MANAGED_AUTH_VOLUME_PATH` when explicitly configured.
+- Verify launch fails before container creation when `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`.
+- Verify valid auth-volume startup seeds eligible auth entries one way into the per-run `CODEX_HOME` before Codex App Server starts.
+- Exercise the Docker-backed OAuth terminal auth runner and PTY bridge lifecycle end to end.
+- Update verification reports only when evidence passes; otherwise record the exact blocker.
+
+Independent Test
+Run Docker-enabled integration verification for OAuthTerminal-relevant managed-session coverage and confirm the launch, auth-volume targeting, startup seeding, auth runner, and PTY bridge lifecycle behavior match the documented contract.
+
+Source Document
+- `docs/ManagedAgents/OAuthTerminal.md`
+
+Source Sections
+- 3. Current Codex Volume Model
+- 4. Volume Targeting Rules
+- 7. Managed Codex Session Launch
+- 8. Verification
+
+Coverage IDs
+- DESIGN-REQ-004
+- DESIGN-REQ-005
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-020
+
+Current Evidence
+- `specs/175-launch-codex-auth-materialization/verification.md` has verdict ADDITIONAL_WORK_NEEDED only because Docker-backed integration could not run in the managed container.
+- `specs/180-codex-volume-targeting/verification.md` has verdict ADDITIONAL_WORK_NEEDED only because `./tools/test_integration.sh` could not run without `/var/run/docker.sock`.
+- `specs/183-oauth-terminal-flow/verification.md` also needs Docker-enabled integration evidence for the real auth runner and WebSocket bridge lifecycle.
+
+Relevant Implementation Notes
+- This story is primarily verification closure, plus any small test harness fixes needed to make the documented OAuthTerminal managed-session auth contract observable.
+- Preserve the separation between managed Codex session auth materialization and workload-container auth-volume guardrails.
+- Record exact Docker or environment blockers in verification reports if Docker-backed evidence cannot be produced.
+
+Out of Scope
+- New product behavior beyond verification and small test harness fixes needed to make the documented contract observable.
+
+Verification
+- Run `./tools/test_integration.sh` in a Docker-enabled verification environment.
+- Inspect managed Codex session launch for `agent_workspaces`, `MANAGED_AUTH_VOLUME_PATH`, and `codexHomePath` behavior.
+- Exercise the Docker-backed OAuth terminal auth runner and PTY bridge lifecycle.
+- Update the affected verification reports with passing evidence or the exact remaining blocker.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-363-report.md
+++ b/docs/tmp/jira-orchestration-reports/MM-363-report.md
@@ -1,0 +1,56 @@
+# Jira Orchestration Report: MM-363
+
+## Summary
+
+- Jira issue key: `MM-363`
+- Final Jira status: `Code Review`
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1508
+- Feature path: `specs/194-oauth-terminal-docker-verification`
+
+## Stage Outcomes
+
+| Stage | Outcome |
+| --- | --- |
+| Jira In Progress | PASS - `MM-363` was moved from `Backlog` to `In Progress` before MoonSpec work started. |
+| Jira brief loading | PASS - trusted `jira.get_issue` output was converted into `docs/tmp/jira-orchestration-inputs/MM-363-moonspec-orchestration-input.md`. |
+| Specify/Breakdown | PASS - classified as a single-story Jira preset brief; `moonspec-breakdown` was skipped and `specs/194-oauth-terminal-docker-verification/spec.md` preserves the original `MM-363` preset brief. |
+| Plan | PASS - `plan.md`, `research.md`, `quickstart.md`, `data-model.md`, and `contracts/oauth-terminal-docker-verification.md` exist with explicit unit and integration strategies. |
+| Tasks | PASS - `tasks.md` covers one story with red-first unit tests, integration tests, implementation tasks, story validation, and final `/moonspec-verify` work. |
+| Align | PASS - conservative alignment marked the completed blocker-report update task and clarified Docker-available vs Docker-unavailable dependencies; no downstream regeneration was required. |
+| Implement | BLOCKED - implementation work depends on Docker-backed integration first identifying a product or harness gap, but `/var/run/docker.sock` is unavailable in this managed-agent runtime. |
+| Verify | ADDITIONAL_WORK_NEEDED - final verification confirms Docker-backed closure evidence is missing; prior reports remain open with the exact `MM-363` blocker. |
+| PR creation | PASS - PR #1508 was created for branch `mm-363-cf9908a4`. |
+| Jira Code Review | PASS - trusted Jira transition matched `Code Review` to transition ID `51`, added a PR comment, then re-fetch confirmed final status `Code Review`. |
+
+## Files Changed
+
+- `docs/tmp/jira-orchestration-inputs/MM-363-moonspec-orchestration-input.md`
+- `.specify/feature.json`
+- `specs/175-launch-codex-auth-materialization/verification.md`
+- `specs/180-codex-volume-targeting/verification.md`
+- `specs/183-oauth-terminal-flow/verification.md`
+- `specs/194-oauth-terminal-docker-verification/spec.md`
+- `specs/194-oauth-terminal-docker-verification/checklists/requirements.md`
+- `specs/194-oauth-terminal-docker-verification/plan.md`
+- `specs/194-oauth-terminal-docker-verification/research.md`
+- `specs/194-oauth-terminal-docker-verification/data-model.md`
+- `specs/194-oauth-terminal-docker-verification/contracts/oauth-terminal-docker-verification.md`
+- `specs/194-oauth-terminal-docker-verification/quickstart.md`
+- `specs/194-oauth-terminal-docker-verification/tasks.md`
+- `specs/194-oauth-terminal-docker-verification/verification.md`
+- `docs/tmp/jira-orchestration-reports/MM-363-report.md`
+
+## Tests Run
+
+- `SPECIFY_FEATURE=194-oauth-terminal-docker-verification .specify/scripts/bash/check-prerequisites.sh --json` - PASS.
+- `SPECIFY_FEATURE=194-oauth-terminal-docker-verification .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` - PASS.
+- `test -S /var/run/docker.sock` - FAIL, Docker socket missing.
+- `docker ps --format '{{.Names}}' | head` - FAIL, cannot connect to `unix:///var/run/docker.sock`.
+- `./tools/test_integration.sh` - FAIL before tests ran because Docker could not connect to `unix:///var/run/docker.sock`.
+- Unit tests - NOT RUN; no production or unit-test code changed, and unit evidence cannot substitute for the required Docker-backed closure evidence.
+
+## Remaining Risks
+
+- Full `MM-363` closure still requires running `./tools/test_integration.sh` in a Docker-enabled environment.
+- If Docker-enabled integration fails after Docker is available, focused integration targets must isolate the product or harness gap before any runtime fix is made.
+- The PR has verification verdict `ADDITIONAL_WORK_NEEDED`; it should not be treated as fully implemented until Docker-backed evidence is recorded.

--- a/specs/175-launch-codex-auth-materialization/verification.md
+++ b/specs/175-launch-codex-auth-materialization/verification.md
@@ -60,6 +60,13 @@
 
 - Run `./tools/test_integration.sh` in a Docker-enabled environment and record the result.
 
+## MM-363 Docker Verification Attempt
+
+- Attempted under `specs/194-oauth-terminal-docker-verification` on 2026-04-16.
+- Command: `./tools/test_integration.sh`
+- Result: BLOCKED before tests ran because Docker could not connect to `unix:///var/run/docker.sock`; the socket is absent in this managed-agent container.
+- Decision: Preserve ADDITIONAL_WORK_NEEDED. No Docker-backed closure evidence was produced.
+
 ## Decision
 
 - Keep the feature at `ADDITIONAL_WORK_NEEDED` until Docker-backed integration verification passes. No implementation gap was found in the inspected code or unit evidence.

--- a/specs/180-codex-volume-targeting/verification.md
+++ b/specs/180-codex-volume-targeting/verification.md
@@ -59,6 +59,13 @@
 
 1. Run `./tools/test_integration.sh` in a Docker-enabled environment and record the result.
 
+## MM-363 Docker Verification Attempt
+
+- Attempted under `specs/194-oauth-terminal-docker-verification` on 2026-04-16.
+- Command: `./tools/test_integration.sh`
+- Result: BLOCKED before tests ran because Docker could not connect to `unix:///var/run/docker.sock`; the socket is absent in this managed-agent container.
+- Decision: Preserve ADDITIONAL_WORK_NEEDED. No compose-backed closure evidence was produced.
+
 ## Decision
 
 - Code, unit coverage, and direct integration boundary evidence satisfy the story.

--- a/specs/183-oauth-terminal-flow/verification.md
+++ b/specs/183-oauth-terminal-flow/verification.md
@@ -42,3 +42,10 @@
 ## Remaining Work
 
 - Run `./tools/test_integration.sh` in a Docker-enabled environment and confirm `tests/integration/temporal/test_oauth_session.py` coverage for the OAuth workflow plus terminal bridge lifecycle.
+
+## MM-363 Docker Verification Attempt
+
+- Attempted under `specs/194-oauth-terminal-docker-verification` on 2026-04-16.
+- Command: `./tools/test_integration.sh`
+- Result: BLOCKED before tests ran because Docker could not connect to `unix:///var/run/docker.sock`; the socket is absent in this managed-agent container.
+- Decision: Preserve ADDITIONAL_WORK_NEEDED. No Docker-backed auth runner or PTY bridge lifecycle evidence was produced.

--- a/specs/194-oauth-terminal-docker-verification/checklists/requirements.md
+++ b/specs/194-oauth-terminal-docker-verification/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: OAuth Terminal Docker Verification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-16  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details beyond source traceability and observable verification commands
+- [x] Focused on user value and operational needs
+- [x] Written for stakeholders and maintainers
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic except for required source command names
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into stakeholder-facing requirements beyond verification evidence requirements
+
+## Notes
+
+- The story is intentionally verification-focused. Docker availability is acceptance-critical and may remain a blocker in managed-agent containers without `/var/run/docker.sock`.

--- a/specs/194-oauth-terminal-docker-verification/contracts/oauth-terminal-docker-verification.md
+++ b/specs/194-oauth-terminal-docker-verification/contracts/oauth-terminal-docker-verification.md
@@ -1,0 +1,44 @@
+# Contract: OAuth Terminal Docker Verification
+
+## Verification Command Contract
+
+Command:
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected behavior:
+- Runs the repo's hermetic integration suite marked `integration_ci`.
+- Requires Docker access and the compose-backed test environment.
+- Produces enough evidence to evaluate OAuthTerminal-relevant managed-session coverage.
+
+Blocked behavior:
+- If `/var/run/docker.sock` is unavailable or the Docker daemon cannot be reached, the story remains ADDITIONAL_WORK_NEEDED and reports record the exact blocker.
+
+## Evidence Contract
+
+Evidence used for closure must include:
+- Managed Codex session launch mounting `agent_workspaces` at `/work/agent_jobs`.
+- Conditional auth volume mount only at `MANAGED_AUTH_VOLUME_PATH`.
+- Pre-container rejection when `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`.
+- Runtime startup one-way seeding from valid auth-volume path into per-run `CODEX_HOME`.
+- Docker-backed OAuth terminal auth runner and PTY bridge lifecycle behavior.
+
+Evidence must not include:
+- Raw credential files or token values.
+- Full environment dumps.
+- Full Docker Compose logs pasted into reports.
+- Auth headers, private keys, cookies, or session IDs.
+
+## Report Update Contract
+
+Affected reports:
+- `specs/175-launch-codex-auth-materialization/verification.md`
+- `specs/180-codex-volume-targeting/verification.md`
+- `specs/183-oauth-terminal-flow/verification.md`
+
+Update rules:
+- Change a verdict from ADDITIONAL_WORK_NEEDED only when the specific Docker-backed gap in that report is covered by passing evidence.
+- If Docker is unavailable, preserve the blocker and reference `MM-363`.
+- If integration fails for a product or harness defect, record the failing command and a concise redacted failure summary.

--- a/specs/194-oauth-terminal-docker-verification/data-model.md
+++ b/specs/194-oauth-terminal-docker-verification/data-model.md
@@ -1,0 +1,39 @@
+# Data Model: OAuth Terminal Docker Verification
+
+## Docker Verification Attempt
+
+- `command`: the exact verification command, normally `./tools/test_integration.sh`
+- `environment_status`: whether Docker socket and daemon access are available
+- `started_at`: timestamp when verification was attempted
+- `result`: `pass`, `fail`, or `blocked`
+- `summary`: short secret-free result summary
+- `blocker`: exact blocker when result is `blocked`
+
+Validation rules:
+- A `pass` result requires Docker-backed integration execution, not unit-only evidence.
+- A `blocked` result must include the exact missing prerequisite or environment failure.
+- Summaries must not include tokens, credential file contents, auth headers, private keys, or raw environment dumps.
+
+## Runtime Evidence Item
+
+- `area`: managed Codex launch, Codex runtime startup, OAuth terminal runner, or PTY bridge
+- `requirement_ids`: related `FR-*` and `DESIGN-REQ-*` IDs
+- `evidence_source`: test name, command, or inspected runtime boundary
+- `status`: `verified`, `partial`, `missing`, or `blocked`
+- `notes`: secret-free explanation
+
+Validation rules:
+- Each in-scope source requirement must map to at least one evidence item.
+- Evidence for report closure must include integration coverage where the acceptance scenario crosses Docker or Temporal runtime boundaries.
+
+## Verification Report Update
+
+- `report_path`: affected verification report
+- `previous_verdict`: existing report verdict
+- `new_verdict`: updated verdict after evidence review
+- `evidence_refs`: related Docker verification attempts and runtime evidence items
+- `remaining_work`: exact remaining work when verdict is not fully closed
+
+Validation rules:
+- `new_verdict` must remain ADDITIONAL_WORK_NEEDED unless Docker-backed evidence covers the report's stated gap.
+- Report updates must preserve Jira issue key `MM-363` when referencing this closure attempt.

--- a/specs/194-oauth-terminal-docker-verification/plan.md
+++ b/specs/194-oauth-terminal-docker-verification/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: OAuth Terminal Docker Verification
+
+**Branch**: `194-oauth-terminal-docker-verification` | **Date**: 2026-04-16 | **Spec**: `specs/194-oauth-terminal-docker-verification/spec.md`  
+**Input**: Single-story feature specification from `specs/194-oauth-terminal-docker-verification/spec.md`
+
+## Summary
+
+MM-363 is a runtime verification-closure story for OAuthTerminal managed-session auth behavior. The primary work is to run Docker-backed hermetic integration evidence for managed Codex launch volume targeting, per-run Codex home seeding, and OAuth terminal auth runner/PTY bridge lifecycle, then update prior verification reports only when passing evidence exists. If the active runtime lacks Docker, the implementation must record the exact blocker and leave closure incomplete.
+
+**Note**: The standard prerequisite script rejects the managed branch name `mm-363-cf9908a4`; use `SPECIFY_FEATURE=194-oauth-terminal-docker-verification` when running Moon Spec helper scripts in this workspace.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, pytest, Docker Compose, existing OAuth session workflow/activity catalog, managed Codex session controller/runtime helpers  
+**Storage**: Existing workflow artifacts and verification reports only; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` with focused OAuthTerminal and managed Codex targets when harness fixes are needed  
+**Integration Testing**: `./tools/test_integration.sh` for compose-backed `integration_ci` coverage; focused direct integration targets may be used during diagnosis before the full script  
+**Target Platform**: MoonMind API and Temporal worker/runtime containers on Linux with Docker available for hermetic integration  
+**Project Type**: Backend/runtime verification story with Temporal, Docker, and artifact/report boundaries  
+**Performance Goals**: Integration verification should complete within the existing hermetic suite timeout budget; no new long-running workflow boundary tests should be added to required CI  
+**Constraints**: Preserve `MM-363` traceability; do not claim report closure without Docker-backed evidence; do not copy credentials, tokens, auth volume listings, or sensitive environment dumps into reports; preserve existing runtime ownership boundaries  
+**Scale/Scope**: One independently testable verification story covering OAuthTerminal managed-session auth behavior and the existing verification reports for specs 175, 180, and 183
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I Orchestrate, Don't Recreate: PASS. The story verifies existing managed runtime and OAuth terminal orchestration rather than replacing provider behavior.
+- II One-Click Agent Deployment: PASS. The required path uses the repo's existing Docker Compose-backed integration runner.
+- III Avoid Vendor Lock-In: PASS. Codex is the current concrete managed-session target, with provider-specific behavior behind existing runtime/provider boundaries.
+- IV Own Your Data: PASS. Evidence remains in repo artifacts and reports; credentials stay in auth volumes and are not copied into reports.
+- V Skills Are First-Class: PASS. No executable skill contracts or skill materialization behavior are changed.
+- VI Bittersweet Lesson: PASS. The work verifies contracts and records evidence so obsolete blockers can be removed only when proven.
+- VII Runtime Configurability: PASS. Docker, volume names, and auth mount paths remain governed by existing environment/configuration.
+- VIII Modular Architecture: PASS. Any harness fixes must stay within existing OAuth session, managed-session controller/runtime, or integration test boundaries.
+- IX Resilient by Default: PASS. Verification records exact blockers and avoids false closure when required evidence is unavailable.
+- X Continuous Improvement: PASS. Prior ADDITIONAL_WORK_NEEDED reports are updated only with evidence or precise blockers.
+- XI Spec-Driven Development: PASS. MM-363 has isolated spec and planning artifacts before runtime verification closure.
+- XII Canonical Docs Separation: PASS. Canonical docs remain source requirements; migration/run evidence stays under `specs/` and `docs/tmp`.
+- XIII Pre-Release Compatibility: PASS. No compatibility aliases are planned; existing internal contract behavior is verified as-is.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/194-oauth-terminal-docker-verification/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── oauth-terminal-docker-verification.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/temporal/runtime/
+├── managed_session_controller.py
+├── codex_session_runtime.py
+└── terminal_bridge.py
+
+moonmind/workflows/temporal/activities/
+└── oauth_session_activities.py
+
+tests/integration/services/temporal/
+├── test_codex_session_runtime.py
+└── test_codex_session_task_creation.py
+
+tests/integration/temporal/
+└── test_oauth_session.py
+
+specs/
+├── 175-launch-codex-auth-materialization/verification.md
+├── 180-codex-volume-targeting/verification.md
+└── 183-oauth-terminal-flow/verification.md
+```
+
+**Structure Decision**: Use the existing runtime and integration test layout. This story should not add new runtime packages, APIs, database tables, or frontend surfaces unless a small test harness fix is required to observe the documented contract.
+
+## Test Strategy
+
+- Unit strategy: run focused unit tests only if diagnosis identifies a harness or runtime behavior gap that can be validated without Docker. Candidate commands are `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py`.
+- Integration strategy: run `./tools/test_integration.sh` in a Docker-enabled environment. If it fails because `/var/run/docker.sock` is missing, record that blocker and do not update prior verification reports to closure. If Docker is available and failures are specific to OAuthTerminal managed-session auth behavior, make the smallest runtime or test harness fix and rerun.
+
+## Complexity Tracking
+
+None.

--- a/specs/194-oauth-terminal-docker-verification/quickstart.md
+++ b/specs/194-oauth-terminal-docker-verification/quickstart.md
@@ -1,0 +1,65 @@
+# Quickstart: OAuth Terminal Docker Verification
+
+## 1. Confirm Docker Availability
+
+```bash
+test -S /var/run/docker.sock
+docker ps
+```
+
+Expected: Docker socket exists and the daemon responds.
+
+Current managed-agent result for this run:
+
+```text
+/var/run/docker.sock is unavailable; docker ps cannot connect to the daemon.
+```
+
+## 2. Run Required Integration Verification
+
+```bash
+./tools/test_integration.sh
+```
+
+Expected in a Docker-enabled environment: the hermetic `integration_ci` suite passes, including OAuthTerminal-relevant managed-session coverage.
+
+If blocked: record the exact Docker or compose prerequisite failure and do not close prior ADDITIONAL_WORK_NEEDED reports.
+
+Current managed-agent result for this run:
+
+```text
+./tools/test_integration.sh exited with code 1 after creating .env from .env-template.
+The command failed before tests ran because Docker could not connect to unix:///var/run/docker.sock:
+dial unix /var/run/docker.sock: connect: no such file or directory.
+```
+
+## 3. Diagnose Focused Runtime Boundaries When Needed
+
+Use focused targets only after the required command identifies a specific failing area:
+
+```bash
+python -m pytest tests/integration/services/temporal/test_codex_session_task_creation.py -q --tb=short
+python -m pytest tests/integration/services/temporal/test_codex_session_runtime.py -q --tb=short
+python -m pytest tests/integration/temporal/test_oauth_session.py -q --tb=short
+```
+
+## 4. Run Unit Checks If Harness Fixes Are Needed
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py
+```
+
+Use this command only to validate non-Docker runtime or harness fixes. It cannot replace Docker-backed closure evidence.
+
+## 5. Update Reports
+
+Update these reports only after evidence review:
+
+- `specs/175-launch-codex-auth-materialization/verification.md`
+- `specs/180-codex-volume-targeting/verification.md`
+- `specs/183-oauth-terminal-flow/verification.md`
+
+Rules:
+- Passing Docker evidence may close the matching gap.
+- Missing Docker access keeps ADDITIONAL_WORK_NEEDED with the exact blocker.
+- Redact secrets and summarize logs.

--- a/specs/194-oauth-terminal-docker-verification/research.md
+++ b/specs/194-oauth-terminal-docker-verification/research.md
@@ -1,0 +1,33 @@
+# Research: OAuth Terminal Docker Verification
+
+## Input Classification
+
+Decision: Treat `MM-363` as a single-story runtime feature request.
+
+Rationale: The preset brief contains one user story focused on producing Docker-backed integration evidence for OAuthTerminal managed-session auth behavior. It references `docs/ManagedAgents/OAuthTerminal.md` as runtime source requirements, and the user explicitly selected runtime mode.
+
+Alternatives considered: A broad design breakdown was rejected because the brief already names one independently testable story. Documentation-only mode was rejected because the request requires runtime verification evidence.
+
+## Docker Evidence Source
+
+Decision: Use `./tools/test_integration.sh` as the required integration command and treat Docker socket absence as a blocking environment condition.
+
+Rationale: Repo instructions define this script as the hermetic integration runner for `integration_ci`; prior verification reports identify lack of `/var/run/docker.sock` as the remaining blocker. MM-363 explicitly asks for Docker-enabled integration evidence.
+
+Alternatives considered: Unit-only verification and fake-runner integration evidence were rejected because the story exists specifically to close gaps left by those weaker evidence classes.
+
+## Report Closure Policy
+
+Decision: Update prior verification reports from ADDITIONAL_WORK_NEEDED only after passing Docker-backed evidence exists; otherwise record the exact blocker.
+
+Rationale: The Jira brief makes false closure a requirement violation. This also aligns with the constitution's verification and continuous-improvement principles.
+
+Alternatives considered: Marking reports complete based on existing unit evidence was rejected because it contradicts the original request and current report gaps.
+
+## Secret Handling
+
+Decision: Summarize Docker and integration output and redact any credential-like content before writing reports.
+
+Rationale: Source design section 8 and security guardrails prohibit credential contents in workflow payloads, artifacts, logs, UI responses, and published summaries.
+
+Alternatives considered: Copying full compose output into verification reports was rejected because it can expose environment details and is explicitly discouraged by repo security guardrails.

--- a/specs/194-oauth-terminal-docker-verification/spec.md
+++ b/specs/194-oauth-terminal-docker-verification/spec.md
@@ -1,0 +1,175 @@
+# Feature Specification: OAuth Terminal Docker Verification
+
+**Feature Branch**: `194-oauth-terminal-docker-verification`  
+**Created**: 2026-04-16  
+**Status**: Draft  
+**Input**:
+
+```text
+# MM-363 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-363
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+- Labels: `MM-318`, `managed-sessions`, `oauth-terminal`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-363 from MM project
+Summary: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-363 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-363: [OAuthTerminal] Close Docker-backed integration verification for managed auth volumes
+
+Short Name
+oauth-terminal-docker-verification
+
+User Story
+As a MoonMind maintainer, I can run and record Docker-enabled integration evidence for OAuthTerminal managed-session auth behavior, so the remaining ADDITIONAL_WORK_NEEDED verification reports can close without relying only on unit and fake-runner evidence.
+
+Acceptance Criteria
+- Given a Docker-enabled verification environment, `./tools/test_integration.sh` passes for the OAuthTerminal-relevant managed-session coverage.
+- Given managed Codex session launch is inspected, `agent_workspaces` is mounted at `/work/agent_jobs` and the auth volume is mounted only at `MANAGED_AUTH_VOLUME_PATH` when explicitly configured.
+- Given `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`, launch fails before container creation.
+- Given runtime startup receives a valid auth-volume path, eligible auth entries seed one way into the per-run `CODEX_HOME` before Codex App Server starts.
+- Given the OAuth terminal flow runs against Docker, the auth runner and PTY bridge lifecycle are exercised end to end.
+- Verification reports are updated from ADDITIONAL_WORK_NEEDED only when the evidence above passes; otherwise they record the exact blocker.
+
+Requirements
+- Run Docker-enabled integration verification for OAuthTerminal managed-session auth behavior.
+- Ensure OAuthTerminal-relevant managed-session coverage passes through `./tools/test_integration.sh` in a Docker-enabled environment.
+- Verify managed Codex session launch mounts `agent_workspaces` at `/work/agent_jobs`.
+- Verify the auth volume is mounted only at `MANAGED_AUTH_VOLUME_PATH` when explicitly configured.
+- Verify launch fails before container creation when `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`.
+- Verify valid auth-volume startup seeds eligible auth entries one way into the per-run `CODEX_HOME` before Codex App Server starts.
+- Exercise the Docker-backed OAuth terminal auth runner and PTY bridge lifecycle end to end.
+- Update verification reports only when evidence passes; otherwise record the exact blocker.
+
+Independent Test
+Run Docker-enabled integration verification for OAuthTerminal-relevant managed-session coverage and confirm the launch, auth-volume targeting, startup seeding, auth runner, and PTY bridge lifecycle behavior match the documented contract.
+
+Source Document
+- `docs/ManagedAgents/OAuthTerminal.md`
+
+Source Sections
+- 3. Current Codex Volume Model
+- 4. Volume Targeting Rules
+- 7. Managed Codex Session Launch
+- 8. Verification
+
+Coverage IDs
+- DESIGN-REQ-004
+- DESIGN-REQ-005
+- DESIGN-REQ-006
+- DESIGN-REQ-007
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-020
+
+Current Evidence
+- `specs/175-launch-codex-auth-materialization/verification.md` has verdict ADDITIONAL_WORK_NEEDED only because Docker-backed integration could not run in the managed container.
+- `specs/180-codex-volume-targeting/verification.md` has verdict ADDITIONAL_WORK_NEEDED only because `./tools/test_integration.sh` could not run without `/var/run/docker.sock`.
+- `specs/183-oauth-terminal-flow/verification.md` also needs Docker-enabled integration evidence for the real auth runner and WebSocket bridge lifecycle.
+
+Relevant Implementation Notes
+- This story is primarily verification closure, plus any small test harness fixes needed to make the documented OAuthTerminal managed-session auth contract observable.
+- Preserve the separation between managed Codex session auth materialization and workload-container auth-volume guardrails.
+- Record exact Docker or environment blockers in verification reports if Docker-backed evidence cannot be produced.
+
+Out of Scope
+- New product behavior beyond verification and small test harness fixes needed to make the documented contract observable.
+
+Verification
+- Run `./tools/test_integration.sh` in a Docker-enabled verification environment.
+- Inspect managed Codex session launch for `agent_workspaces`, `MANAGED_AUTH_VOLUME_PATH`, and `codexHomePath` behavior.
+- Exercise the Docker-backed OAuth terminal auth runner and PTY bridge lifecycle.
+- Update the affected verification reports with passing evidence or the exact remaining blocker.
+
+Needs Clarification
+- None
+```
+
+**Implementation Intent**: Runtime verification closure. Required deliverables include Docker-backed integration evidence when available, plus any small runtime or test harness fixes needed to make the documented OAuthTerminal managed-session auth contract observable.
+
+## User Story - OAuth Terminal Docker Verification
+
+**Summary**: As a MoonMind maintainer, I want Docker-enabled integration evidence for OAuthTerminal managed-session auth behavior so that prior ADDITIONAL_WORK_NEEDED reports can be closed with real runtime proof.
+
+**Goal**: Maintainers can run the required Docker-backed integration checks, inspect the managed Codex launch and OAuth terminal runtime boundaries, and update verification reports only with passing evidence or an exact blocker.
+
+**Independent Test**: Run `./tools/test_integration.sh` in a Docker-enabled environment and confirm that OAuthTerminal-relevant managed-session coverage proves workspace mounting, explicit auth-volume targeting, auth target validation, one-way auth seeding, and Docker-backed auth runner/PTY bridge lifecycle behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Docker-enabled verification environment, **when** `./tools/test_integration.sh` runs, **then** OAuthTerminal-relevant managed-session integration coverage passes.
+2. **Given** managed Codex session launch is inspected, **when** the launch command is built, **then** `agent_workspaces` is mounted at `/work/agent_jobs`.
+3. **Given** an auth volume is explicitly configured, **when** the managed Codex session launch command is built, **then** the auth volume is mounted only at `MANAGED_AUTH_VOLUME_PATH` and not at `codexHomePath`.
+4. **Given** `MANAGED_AUTH_VOLUME_PATH` equals `codexHomePath`, **when** launch validation runs, **then** the session fails before container creation.
+5. **Given** runtime startup receives a valid auth-volume path, **when** Codex App Server startup begins, **then** eligible auth entries are seeded one way into per-run `CODEX_HOME`.
+6. **Given** the OAuth terminal flow runs against Docker, **when** the flow completes, fails, expires, or is cancelled, **then** the auth runner and PTY bridge lifecycle is exercised end to end with secret-free evidence.
+7. **Given** Docker-backed evidence is unavailable or fails, **when** verification reports are updated, **then** they record the exact blocker instead of claiming closure.
+
+### Edge Cases
+
+- Docker socket or daemon is unavailable in the verification environment.
+- Compose-backed integration tests fail before OAuthTerminal-relevant coverage runs.
+- Runtime evidence proves launch behavior but not OAuth terminal runner behavior, or the reverse.
+- Integration output includes credential-like text that must not be copied into artifacts or reports.
+- A small test harness defect prevents observing behavior that unit and fake-runner evidence already covered.
+
+## Assumptions
+
+- MM-363 is a verification-closure story for already implemented OAuthTerminal and managed Codex auth-volume behavior, not a request for new product semantics.
+- Small test harness fixes are in scope only when they are necessary to observe the documented contract in Docker-backed integration.
+- Verification reports may remain ADDITIONAL_WORK_NEEDED if Docker-backed evidence cannot be produced in the active runtime.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-004**: Source section 3.2 requires every managed Codex session container to receive the shared `agent_workspaces` volume mounted at `/work/agent_jobs`. Scope: in scope. Maps to FR-001, FR-002, and FR-009.
+- **DESIGN-REQ-005**: Source section 3.2 requires per-task paths, including repo, session state, artifacts, and per-run Codex home, to live under `agent_workspaces`. Scope: in scope. Maps to FR-001, FR-002, FR-005, and FR-009.
+- **DESIGN-REQ-006**: Source sections 3.3 and 4 require auth volumes to mount into managed Codex sessions only through an explicit `MANAGED_AUTH_VOLUME_PATH` separate from `codexHomePath`. Scope: in scope. Maps to FR-003, FR-004, and FR-009.
+- **DESIGN-REQ-007**: Source section 4 requires credential copying from durable auth volume to per-run Codex home to be one-way during session startup. Scope: in scope. Maps to FR-005 and FR-009.
+- **DESIGN-REQ-017**: Source section 7 requires managed Codex session launch to pass reserved workspace, state, artifact, Codex home, and control URL values and to mount workspace and conditional auth volumes correctly. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005, and FR-009.
+- **DESIGN-REQ-018**: Source section 8 requires verification at the OAuth/Profile boundary and managed-session launch boundary without copying credential contents into workflow payloads, artifacts, logs, or UI responses. Scope: in scope. Maps to FR-006, FR-007, FR-008, and FR-009.
+- **DESIGN-REQ-020**: Source section 11 requires OAuth terminal code, Provider Profile code, managed-session controller code, Codex session runtime code, and Docker workload orchestration to keep ownership boundaries separate. Scope: in scope. Maps to FR-006, FR-007, FR-008, and FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The verification flow MUST run or attempt the Docker-backed integration command required for OAuthTerminal-relevant managed-session coverage.
+- **FR-002**: The evidence MUST verify that managed Codex sessions mount `agent_workspaces` at `/work/agent_jobs`.
+- **FR-003**: The evidence MUST verify that configured auth volumes are mounted only at `MANAGED_AUTH_VOLUME_PATH`.
+- **FR-004**: The evidence MUST verify that `MANAGED_AUTH_VOLUME_PATH` equal to `codexHomePath` fails before container creation.
+- **FR-005**: The evidence MUST verify that valid auth-volume startup seeds eligible auth entries one way into the per-run `CODEX_HOME` before Codex App Server starts.
+- **FR-006**: The evidence MUST verify Docker-backed OAuth terminal auth runner and PTY bridge lifecycle behavior end to end.
+- **FR-007**: Verification reports MUST change from ADDITIONAL_WORK_NEEDED only when passing Docker-backed evidence exists.
+- **FR-008**: If Docker-backed evidence cannot be produced, verification reports MUST record the exact blocker without copying raw credentials, tokens, or sensitive environment dumps.
+- **FR-009**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key MM-363 and the original preset brief as traceability evidence.
+
+### Key Entities
+
+- **Docker-Enabled Verification Environment**: Runtime with Docker socket, compose dependencies, and local services needed to run the hermetic integration suite.
+- **Managed Codex Session Launch Evidence**: Secret-free proof of workspace mount, auth-volume target, reserved environment, and pre-container validation behavior.
+- **OAuth Terminal Runtime Evidence**: Secret-free proof that the auth runner and PTY/WebSocket bridge lifecycle runs against Docker.
+- **Verification Report Update**: Changes to prior MoonSpec verification reports that either close ADDITIONAL_WORK_NEEDED with passing evidence or preserve it with an exact blocker.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `./tools/test_integration.sh` passes in a Docker-enabled environment or fails with a documented environment blocker before any closure is claimed.
+- **SC-002**: Verification evidence covers workspace mounting, explicit auth-volume targeting, equality rejection, and one-way `CODEX_HOME` seeding.
+- **SC-003**: Verification evidence covers Docker-backed OAuth terminal auth runner and PTY bridge lifecycle behavior.
+- **SC-004**: Prior verification reports for specs 175, 180, and 183 are updated only with passing Docker-backed evidence or an exact blocker.
+- **SC-005**: Verification output preserves `MM-363` and contains no raw credentials, token values, auth headers, private keys, or sensitive environment dumps.

--- a/specs/194-oauth-terminal-docker-verification/tasks.md
+++ b/specs/194-oauth-terminal-docker-verification/tasks.md
@@ -82,7 +82,7 @@
 - [ ] T015 Apply the smallest runtime or test harness fix needed for a Docker-backed managed Codex launch evidence gap in `moonmind/workflows/temporal/runtime/managed_session_controller.py`, `moonmind/workflows/temporal/runtime/codex_session_runtime.py`, or integration tests (FR-002 through FR-005)
 - [ ] T016 Apply the smallest runtime or test harness fix needed for a Docker-backed OAuth terminal runner/PTY bridge evidence gap in `moonmind/workflows/temporal/activities/oauth_session_activities.py`, `moonmind/workflows/temporal/runtime/terminal_bridge.py`, or integration tests (FR-006)
 - [ ] T017 Rerun focused unit and integration checks after any fix until the story evidence passes or a precise blocker remains (SC-001 through SC-003)
-- [ ] T018 Update `specs/175-launch-codex-auth-materialization/verification.md`, `specs/180-codex-volume-targeting/verification.md`, and `specs/183-oauth-terminal-flow/verification.md` only with passing Docker-backed evidence or the exact remaining blocker, preserving MM-363 traceability (FR-007, FR-008, FR-009, SC-004, SC-005)
+- [X] T018 Update `specs/175-launch-codex-auth-materialization/verification.md`, `specs/180-codex-volume-targeting/verification.md`, and `specs/183-oauth-terminal-flow/verification.md` only with passing Docker-backed evidence or the exact remaining blocker, preserving MM-363 traceability (FR-007, FR-008, FR-009, SC-004, SC-005)
 
 **Checkpoint**: The MM-363 story is complete only when Docker-backed evidence passes and affected verification reports are updated accordingly. In this managed-agent runtime, implementation is blocked by missing Docker socket access.
 
@@ -108,7 +108,7 @@
 
 ### Within The Story
 
-- T010 must run before report closure tasks T018.
+- T010 must run before report closure tasks T018 when Docker is available; T012 is the prerequisite for blocker-only report updates when Docker is unavailable.
 - T007-T009 are needed only when Docker-backed evidence identifies a unit-testable gap.
 - T015-T016 are needed only when integration evidence identifies product or harness gaps.
 - T018 must not change prior report verdicts without passing Docker-backed evidence.

--- a/specs/194-oauth-terminal-docker-verification/tasks.md
+++ b/specs/194-oauth-terminal-docker-verification/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: OAuth Terminal Docker Verification
+
+**Input**: Design documents from `/specs/194-oauth-terminal-docker-verification/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/oauth-terminal-docker-verification.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write or adjust tests first only if a product or harness gap is found; the primary required evidence is Docker-backed integration verification.
+
+**Organization**: Tasks are grouped by phase around the single MM-363 story so verification closure stays focused and traceable.
+
+**Source Traceability**: The original MM-363 Jira preset brief is preserved in `specs/194-oauth-terminal-docker-verification/spec.md`. Tasks cover FR-001 through FR-009, acceptance scenarios 1-7, SC-001 through SC-005, and DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-017, DESIGN-REQ-018, and DESIGN-REQ-020.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/runtime/test_managed_session_controller.py tests/unit/services/temporal/runtime/test_codex_session_runtime.py tests/unit/auth/test_oauth_session_activities.py tests/unit/services/temporal/runtime/test_terminal_bridge.py`
+- Integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify` (`/speckit.verify` equivalent)
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm active MM-363 artifacts and the verification environment before changing reports or code.
+
+- [X] T001 Confirm `.specify/feature.json` points to `specs/194-oauth-terminal-docker-verification` and MM-363 traceability is present in `specs/194-oauth-terminal-docker-verification/spec.md` (FR-009, SC-005)
+- [X] T002 [P] Confirm no existing feature directory already owns MM-363 using `rg -n "MM-363" specs docs/tmp` (FR-009)
+- [X] T003 [P] Inspect `specs/175-launch-codex-auth-materialization/verification.md`, `specs/180-codex-volume-targeting/verification.md`, and `specs/183-oauth-terminal-flow/verification.md` for current Docker-backed evidence gaps (FR-007, SC-004)
+- [X] T004 Check Docker availability with `test -S /var/run/docker.sock` and `docker ps`, recording the result in `specs/194-oauth-terminal-docker-verification/quickstart.md` (FR-001, SC-001)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish whether runtime verification can proceed in this environment.
+
+**CRITICAL**: Report closure and code changes are blocked until Docker-backed verification can run or a precise blocker is recorded.
+
+- [X] T005 Confirm `./tools/test_integration.sh` is the required hermetic integration command from repo instructions and `specs/194-oauth-terminal-docker-verification/quickstart.md` (FR-001, SC-001)
+- [X] T006 Confirm the active runtime lacks Docker socket access and therefore cannot produce closure evidence in this managed-agent container (FR-001, FR-008, SC-001)
+
+**Checkpoint**: Foundation complete; implementation is blocked in this runtime by missing Docker access.
+
+---
+
+## Phase 3: Story - OAuth Terminal Docker Verification
+
+**Summary**: As a MoonMind maintainer, I want Docker-enabled integration evidence for OAuthTerminal managed-session auth behavior so prior ADDITIONAL_WORK_NEEDED reports can be closed with real runtime proof.
+
+**Independent Test**: Run `./tools/test_integration.sh` in a Docker-enabled environment and confirm managed Codex launch, auth-volume targeting, one-way seeding, and OAuth terminal auth runner/PTY bridge lifecycle behavior.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009; acceptance scenarios 1-7; SC-001 through SC-005; DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-020
+
+**Test Plan**:
+
+- Unit: run focused unit targets only when a non-Docker runtime or harness fix is needed.
+- Integration: run `./tools/test_integration.sh`; use focused integration targets only to diagnose failures after Docker is available.
+
+### Unit Tests (write first) ⚠️
+
+> **NOTE: This story is verification-first. Add or adjust unit tests only after Docker-backed integration identifies a product or harness gap that unit coverage can isolate.**
+
+- [ ] T007 [P] Add failing unit coverage for any managed-session launch validation gap identified by Docker-backed verification in `tests/unit/services/temporal/runtime/test_managed_session_controller.py` or `tests/unit/services/temporal/runtime/test_codex_session_runtime.py` (FR-002, FR-003, FR-004, FR-005)
+- [ ] T008 [P] Add failing unit coverage for any OAuth terminal runner or PTY bridge gap identified by Docker-backed verification in `tests/unit/auth/test_oauth_session_activities.py` or `tests/unit/services/temporal/runtime/test_terminal_bridge.py` (FR-006, DESIGN-REQ-018)
+- [ ] T009 Run the focused unit command from `specs/194-oauth-terminal-docker-verification/quickstart.md` if T007 or T008 changes tests, and confirm failures before production fixes (SC-002, SC-003)
+
+### Integration Tests (write first) ⚠️
+
+- [ ] T010 Run `./tools/test_integration.sh` in a Docker-enabled environment and capture a secret-free summary in `specs/194-oauth-terminal-docker-verification/quickstart.md` (FR-001, SC-001)
+- [ ] T011 If the full integration suite fails, run focused integration targets in `tests/integration/services/temporal/test_codex_session_task_creation.py`, `tests/integration/services/temporal/test_codex_session_runtime.py`, and `tests/integration/temporal/test_oauth_session.py` to isolate OAuthTerminal-relevant failures (FR-002 through FR-006)
+- [X] T012 If Docker is unavailable, record the exact blocker in `specs/194-oauth-terminal-docker-verification/quickstart.md` and do not close prior reports (FR-008, SC-001)
+
+### Red-First Confirmation ⚠️
+
+- [ ] T013 Confirm any new unit or integration test failure identifies the intended MM-363 behavior gap before editing production code (SC-002, SC-003)
+- [X] T014 Confirm missing Docker socket blocks red-first integration execution in this managed-agent runtime (FR-001, FR-008, SC-001)
+
+### Implementation
+
+- [ ] T015 Apply the smallest runtime or test harness fix needed for a Docker-backed managed Codex launch evidence gap in `moonmind/workflows/temporal/runtime/managed_session_controller.py`, `moonmind/workflows/temporal/runtime/codex_session_runtime.py`, or integration tests (FR-002 through FR-005)
+- [ ] T016 Apply the smallest runtime or test harness fix needed for a Docker-backed OAuth terminal runner/PTY bridge evidence gap in `moonmind/workflows/temporal/activities/oauth_session_activities.py`, `moonmind/workflows/temporal/runtime/terminal_bridge.py`, or integration tests (FR-006)
+- [ ] T017 Rerun focused unit and integration checks after any fix until the story evidence passes or a precise blocker remains (SC-001 through SC-003)
+- [ ] T018 Update `specs/175-launch-codex-auth-materialization/verification.md`, `specs/180-codex-volume-targeting/verification.md`, and `specs/183-oauth-terminal-flow/verification.md` only with passing Docker-backed evidence or the exact remaining blocker, preserving MM-363 traceability (FR-007, FR-008, FR-009, SC-004, SC-005)
+
+**Checkpoint**: The MM-363 story is complete only when Docker-backed evidence passes and affected verification reports are updated accordingly. In this managed-agent runtime, implementation is blocked by missing Docker socket access.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Finalize evidence without adding hidden scope.
+
+- [ ] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` if any code or unit-test files changed (SC-005)
+- [X] T020 Run `/moonspec-verify` (`/speckit.verify` equivalent) against `specs/194-oauth-terminal-docker-verification/spec.md`, preserving MM-363 in verification output (FR-009, SC-005)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on setup and blocks report closure.
+- **Story (Phase 3)**: Depends on Docker-backed integration availability or exact blocker recording.
+- **Polish & Verification (Phase 4)**: Depends on implementation evidence or blocker classification.
+
+### Within The Story
+
+- T010 must run before report closure tasks T018.
+- T007-T009 are needed only when Docker-backed evidence identifies a unit-testable gap.
+- T015-T016 are needed only when integration evidence identifies product or harness gaps.
+- T018 must not change prior report verdicts without passing Docker-backed evidence.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel during setup.
+- T007 and T008 can be authored in parallel if Docker-backed verification identifies independent managed-session and OAuth-terminal gaps.
+- T015 and T016 can proceed independently only if failures are isolated to disjoint files.
+
+## Implementation Strategy
+
+1. Confirm active spec artifacts and Docker availability.
+2. Run `./tools/test_integration.sh` in a Docker-enabled environment.
+3. If Docker is unavailable, record the exact blocker and stop without claiming closure.
+4. If Docker is available and integration fails, isolate failures with focused integration targets.
+5. Add failing unit or integration tests for any concrete product/harness gaps.
+6. Apply the smallest runtime or harness fix.
+7. Rerun focused and full integration verification.
+8. Update prior verification reports only with passing evidence or exact blockers.
+9. Run final MoonSpec verification.
+
+## Notes
+
+- This task list covers exactly one story: MM-363 OAuth Terminal Docker Verification.
+- Existing unit and fake-runner evidence cannot substitute for Docker-backed closure evidence.
+- Preserve `MM-363` and the original Jira preset brief in implementation notes, verification output, commit text, and pull request metadata.
+- Do not paste full Docker Compose output, credential listings, tokens, or environment dumps into reports.

--- a/specs/194-oauth-terminal-docker-verification/verification.md
+++ b/specs/194-oauth-terminal-docker-verification/verification.md
@@ -1,0 +1,73 @@
+# MoonSpec Verification Report
+
+**Feature**: OAuth Terminal Docker Verification  
+**Spec**: `/work/agent_jobs/mm:5ec614d3-3b4c-48ac-a12e-52d3053c19d4/repo/specs/194-oauth-terminal-docker-verification/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving Jira issue `MM-363` and `docs/tmp/jira-orchestration-inputs/MM-363-moonspec-orchestration-input.md`  
+**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Confidence**: HIGH for blocker classification; LOW for runtime closure because Docker-backed tests could not run.
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Docker availability | `test -S /var/run/docker.sock` | FAIL | Docker socket is absent in this managed-agent container. |
+| Docker daemon | `docker ps --format '{{.Names}}' \| head` | FAIL | Docker CLI cannot connect to `unix:///var/run/docker.sock`. |
+| Moon Spec prerequisites | `SPECIFY_FEATURE=194-oauth-terminal-docker-verification .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | PASS | Artifacts resolve when the managed branch name is bypassed with explicit feature selection. |
+| Integration | `./tools/test_integration.sh` | FAIL | Exited before tests ran because Docker could not connect to `unix:///var/run/docker.sock`. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh ...` | NOT RUN | No production or unit-test code changed; unit evidence cannot substitute for the required Docker-backed closure evidence. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `./tools/test_integration.sh` attempted and failed at Docker connection | PARTIAL | The required command was attempted, but no Docker-backed tests ran. |
+| FR-002 | Prior unit and fake-runner evidence in specs 175/180; no new Docker evidence | PARTIAL | Workspace mount behavior remains unit-verified, not closed by Docker evidence. |
+| FR-003 | Prior unit and fake-runner evidence in specs 175/180; no new Docker evidence | PARTIAL | Explicit auth target behavior remains unit-verified, not closed by Docker evidence. |
+| FR-004 | Prior unit evidence in specs 175/180; no new Docker evidence | PARTIAL | Equality rejection remains unit-verified, not closed by Docker evidence. |
+| FR-005 | Prior unit evidence in spec 175; no new Docker evidence | PARTIAL | One-way seeding remains unit-verified, not closed by Docker evidence. |
+| FR-006 | Prior unit evidence in spec 183; no new Docker evidence | PARTIAL | Docker-backed auth runner and PTY bridge lifecycle could not be exercised. |
+| FR-007 | Verification reports for specs 175, 180, and 183 updated with MM-363 attempt | VERIFIED | Reports preserve ADDITIONAL_WORK_NEEDED because no passing Docker evidence exists. |
+| FR-008 | `quickstart.md`, this report, and affected reports record the exact Docker blocker | VERIFIED | Blocker is precise and secret-free. |
+| FR-009 | `spec.md`, `tasks.md`, affected reports, and this report preserve MM-363 | VERIFIED | Traceability is preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| Docker-enabled integration suite passes | `./tools/test_integration.sh` | MISSING | Docker is unavailable, so the suite did not run. |
+| Managed Codex session mounts `agent_workspaces` | Existing unit/fake-runner reports | PARTIAL | No new Docker-backed evidence. |
+| Auth volume mounts only at `MANAGED_AUTH_VOLUME_PATH` | Existing unit/fake-runner reports | PARTIAL | No new Docker-backed evidence. |
+| Equal auth target and Codex home fails before container creation | Existing unit reports | PARTIAL | No new Docker-backed evidence. |
+| Valid auth volume seeds per-run `CODEX_HOME` | Existing unit reports | PARTIAL | No new Docker-backed evidence. |
+| OAuth terminal runs against Docker end to end | Docker command blocked | MISSING | No auth runner or PTY bridge Docker lifecycle evidence was produced. |
+| Reports record exact blocker when evidence is unavailable | Updated reports and `quickstart.md` | VERIFIED | Reports preserve ADDITIONAL_WORK_NEEDED and cite the missing Docker socket. |
+
+## Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-004 | Existing unit/fake-runner evidence; no new Docker evidence | PARTIAL | Still blocked on compose-backed verification. |
+| DESIGN-REQ-005 | Existing unit/fake-runner evidence; no new Docker evidence | PARTIAL | Still blocked on compose-backed verification. |
+| DESIGN-REQ-006 | Existing unit/fake-runner evidence; no new Docker evidence | PARTIAL | Still blocked on compose-backed verification. |
+| DESIGN-REQ-007 | Existing unit evidence; no new Docker evidence | PARTIAL | Still blocked on compose-backed verification. |
+| DESIGN-REQ-017 | Existing unit/fake-runner evidence; no new Docker evidence | PARTIAL | Still blocked on compose-backed verification. |
+| DESIGN-REQ-018 | Blocker recorded without secrets | PARTIAL | Secret-free blocker reporting is satisfied; runtime verification remains blocked. |
+| DESIGN-REQ-020 | Existing boundary evidence; no new Docker evidence | PARTIAL | No new boundary violation found, but Docker verification did not run. |
+
+## Original Request Alignment
+
+- The input was classified as a single-story runtime feature request.
+- Existing artifacts were inspected; no prior MM-363 feature directory existed.
+- Moon Spec artifacts were created under `specs/194-oauth-terminal-docker-verification`.
+- The required Docker-backed command was attempted and failed before test execution because Docker is unavailable in this managed-agent container.
+- Prior reports were not closed; they now record the MM-363 attempt and the exact blocker.
+
+## Remaining Work
+
+1. Run `./tools/test_integration.sh` in a Docker-enabled environment.
+2. If it passes, update specs 175, 180, and 183 verification reports with passing Docker-backed evidence and close matching gaps.
+3. If it fails after Docker starts, isolate OAuthTerminal-relevant failures with focused integration targets and apply the smallest runtime or harness fix.
+
+## Decision
+
+MM-363 remains ADDITIONAL_WORK_NEEDED. The blocker is environmental, concrete, and reproducible in this managed-agent runtime: `/var/run/docker.sock` is absent, so Docker-backed closure evidence cannot be produced here.


### PR DESCRIPTION
## Summary

- Jira issue key: MM-363
- Active MoonSpec feature path: `specs/194-oauth-terminal-docker-verification`
- Added the canonical Jira orchestration input for MM-363.
- Added MoonSpec runtime verification artifacts for OAuthTerminal Docker-backed evidence closure.
- Updated prior verification reports for specs 175, 180, and 183 with the MM-363 Docker verification attempt and exact blocker.

## Verification verdict

ADDITIONAL_WORK_NEEDED

Docker-backed closure evidence could not be produced in the managed-agent runtime because `/var/run/docker.sock` is unavailable. Prior reports remain open until `./tools/test_integration.sh` runs in a Docker-enabled environment.

## Tests run

- `SPECIFY_FEATURE=194-oauth-terminal-docker-verification .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` - PASS
- `test -S /var/run/docker.sock` - FAIL, Docker socket missing
- `docker ps --format '{{.Names}}' | head` - FAIL, cannot connect to Docker daemon
- `./tools/test_integration.sh` - FAIL before tests ran because Docker could not connect to `unix:///var/run/docker.sock`

## Remaining risks

- Docker-backed integration evidence is still required before MM-363 can be marked fully implemented.
- If Docker-enabled integration fails after the daemon is available, focused integration targets must isolate the product or harness gap before any runtime fix is made.

## Notes

This preset owns pull request creation before any Jira Code Review transition. Jira was not transitioned to Code Review in this step.