### PR TITLE
[codex] Fix Jira story output handoff

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1798,6 +1798,14 @@ describe("Task Create Entrypoint", () => {
               id: "step-second",
               title: "Second",
               instructions: "Second step instructions.",
+              storyOutput: {
+                mode: "jira",
+                jira: {
+                  projectKey: "MM",
+                  issueTypeName: "Story",
+                  dependencyMode: "linear_blocker_chain",
+                },
+              },
               tool: {
                 name: "pr-resolver",
                 inputs: { merge: false },
@@ -1828,6 +1836,14 @@ describe("Task Create Entrypoint", () => {
         skillRequiredCapabilities: [],
         templateStepId: "",
         templateInstructions: "",
+        storyOutput: {
+          mode: "jira",
+          jira: {
+            projectKey: "MM",
+            issueTypeName: "Story",
+            dependencyMode: "linear_blocker_chain",
+          },
+        },
       },
     ]);
   });
@@ -4017,6 +4033,52 @@ describe("Task Create Entrypoint", () => {
   });
 
   it("applies a preset into task steps and submits them", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:speckit-demo:1.2.3:01",
+                title: "Clarify spec",
+                instructions: "Clarify the {{ inputs.feature_name }} scope.",
+                skill: {
+                  id: "speckit-clarify",
+                  args: { feature: "Task Create" },
+                },
+              },
+              {
+                id: "tpl:speckit-demo:1.2.3:02",
+                title: "Plan implementation",
+                instructions: "Write a plan for the task builder recovery.",
+                storyOutput: {
+                  mode: "jira",
+                  jira: {
+                    projectKey: "MM",
+                    issueTypeName: "Story",
+                    dependencyMode: "linear_blocker_chain",
+                  },
+                },
+              },
+            ],
+            appliedTemplate: {
+              slug: "speckit-demo",
+              version: "1.2.3",
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     const presetSelect = await screen.findByLabelText("Preset");
@@ -4093,6 +4155,14 @@ describe("Task Create Entrypoint", () => {
         id: "tpl:speckit-demo:1.2.3:02",
         title: "Plan implementation",
         instructions: "Write a plan for the task builder recovery.",
+        storyOutput: {
+          mode: "jira",
+          jira: {
+            projectKey: "MM",
+            issueTypeName: "Story",
+            dependencyMode: "linear_blocker_chain",
+          },
+        },
       },
     ]);
     expect(request.payload.task.appliedStepTemplates).toEqual([

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -368,6 +368,8 @@ interface ExpandedStepPayload {
   instructions?: string;
   skill?: TaskTemplateStepSkill;
   tool?: TaskTemplateStepSkill;
+  storyOutput?: Record<string, unknown>;
+  story_output?: Record<string, unknown>;
 }
 
 interface TaskTemplateExpandResponse {
@@ -416,6 +418,7 @@ interface StepState {
   skillRequiredCapabilities: string;
   templateStepId: string;
   templateInstructions: string;
+  storyOutput?: Record<string, unknown>;
 }
 
 interface AppliedTemplateState {
@@ -802,6 +805,9 @@ function createStepStateEntriesFromTemporalDraft(
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
+      ...(step.storyOutput && Object.keys(step.storyOutput).length > 0
+        ? { storyOutput: step.storyOutput }
+        : {}),
     });
   });
 }
@@ -1099,6 +1105,12 @@ function mapExpandedStepToState(
         : {};
   const stepId = String(step.id || "").trim();
   const instructions = String(step.instructions || "").trim();
+  const storyOutput =
+    step.storyOutput && typeof step.storyOutput === "object"
+      ? step.storyOutput
+      : step.story_output && typeof step.story_output === "object"
+        ? step.story_output
+        : undefined;
   return createStepStateEntry(index, {
     id: stepId,
     title: String(step.title || "").trim(),
@@ -1108,6 +1120,7 @@ function mapExpandedStepToState(
     skillRequiredCapabilities: extractCapabilityCsv(tool.requiredCapabilities),
     templateStepId: stepId,
     templateInstructions: instructions,
+    ...(storyOutput ? { storyOutput } : {}),
   });
 }
 
@@ -3969,6 +3982,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             ...(sourceStep.id.trim() ? { id: sourceStep.id.trim() } : {}),
             ...(sourceStep.title.trim()
               ? { title: sourceStep.title.trim() }
+              : {}),
+            ...(sourceStep.storyOutput
+              ? { storyOutput: sourceStep.storyOutput }
               : {}),
             ...entry.payload,
           };

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -64,6 +64,7 @@ export type TemporalSubmissionDraft = {
     skillRequiredCapabilities: string[];
     templateStepId: string;
     templateInstructions: string;
+    storyOutput?: Record<string, unknown>;
   }>;
   appliedTemplates: Array<{
     slug: string;
@@ -259,6 +260,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     step.template_step_id,
     id.startsWith('tpl:') ? id : '',
   );
+  const storyOutput = firstObjectValue(step.storyOutput, step.story_output);
   const result = {
     id,
     title: stringValue(step.title),
@@ -275,6 +277,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
       step.template_instructions,
       templateStepId ? instructions : '',
     ),
+    ...(Object.keys(storyOutput).length > 0 ? { storyOutput } : {}),
   };
 
   const hasContent =
@@ -285,7 +288,8 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     Object.keys(result.skillArgs).length > 0 ||
     result.skillRequiredCapabilities.length > 0 ||
     result.templateStepId ||
-    result.templateInstructions;
+    result.templateInstructions ||
+    Object.keys(storyOutput).length > 0;
   return hasContent ? result : null;
 }
 

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -518,6 +518,9 @@ async def create_jira_issues_from_stories(
     """Create one Jira issue per story, or report docs/tmp fallback metadata."""
 
     story_output = _mapping(inputs.get("storyOutput") or inputs.get("story_output"))
+    story_output_mode = str(
+        story_output.get("mode") or story_output.get("target") or ""
+    ).strip().lower()
     jira_payload = _mapping(story_output.get("jira") or inputs.get("jira"))
     project_key = _string(
         jira_payload.get("projectKey")
@@ -541,12 +544,21 @@ async def create_jira_issues_from_stories(
         or inputs.get("issueType")
         or inputs.get("issue_type")
     )
+    fallback_keys = ("fallback", "onFailure", "on_failure")
+    fallback_configured = any(key in story_output for key in fallback_keys)
     fallback_on_failure = str(
-        story_output.get("fallback")
-        or story_output.get("onFailure")
-        or story_output.get("on_failure")
-        or "docs_tmp"
+        next(
+            (
+                story_output.get(key)
+                for key in fallback_keys
+                if key in story_output
+            ),
+            "docs_tmp",
+        )
     ).strip().lower() not in {"fail", "none", "false"}
+    fallback_for_missing_stories = fallback_on_failure and (
+        story_output_mode != "jira" or fallback_configured
+    )
     dependency_mode, dependency_mode_error = _dependency_mode(
         inputs=inputs,
         story_output=story_output,
@@ -594,7 +606,7 @@ async def create_jira_issues_from_stories(
                 breakdown_source_path = _breakdown_source_path(fetched_payload)
                 stories = _coerce_story_payload(fetched)
             except Exception as exc:
-                if fallback_on_failure:
+                if fallback_for_missing_stories:
                     return _fallback_result(
                         reason=f"Unable to read story breakdown for Jira output: {exc}",
                         inputs=inputs,
@@ -603,7 +615,7 @@ async def create_jira_issues_from_stories(
                 raise
 
     if not stories:
-        if fallback_on_failure:
+        if fallback_for_missing_stories:
             return _fallback_result(
                 reason="No stories were available for Jira issue creation.",
                 inputs=inputs,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -235,6 +235,10 @@ _JIRA_STORY_OUTPUT_TOOLS = frozenset({"story.create_jira_issues"})
 _MOONSPEC_BREAKDOWN_TOOLS = frozenset({"moonspec-breakdown"})
 
 
+def _requires_branch_publish_for_story_output(value: Any) -> bool:
+    return str(value or "").strip().lower() not in {"branch", "pr"}
+
+
 def _slug_for_story_breakdown(value: Any) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
     return slug[:48] or "story-breakdown"
@@ -699,8 +703,11 @@ def _build_runtime_planner():
                         selected_skill=effective_step_skill_name,
                     )
                 if step_tool_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
-                    if story_output_mode == "jira" and not step_node_inputs.get(
-                        "publishMode"
+                    if (
+                        story_output_mode == "jira"
+                        and _requires_branch_publish_for_story_output(
+                            step_node_inputs.get("publishMode")
+                        )
                     ):
                         step_node_inputs["publishMode"] = "branch"
                     step_node_inputs["instructions"] = (
@@ -737,8 +744,11 @@ def _build_runtime_planner():
             for idx in range(effective_step_count):
                 expanded_inputs = dict(node_inputs)
                 if selected_skill_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
-                    if story_output_mode == "jira" and not expanded_inputs.get(
-                        "publishMode"
+                    if (
+                        story_output_mode == "jira"
+                        and _requires_branch_publish_for_story_output(
+                            expanded_inputs.get("publishMode")
+                        )
                     ):
                         expanded_inputs["publishMode"] = "branch"
                     expanded_inputs["instructions"] = (
@@ -775,7 +785,12 @@ def _build_runtime_planner():
         else:
             node_id = str(task_payload.get("id") or "node-1").strip() or "node-1"
             if selected_skill_name.lower() in _MOONSPEC_BREAKDOWN_TOOLS:
-                if story_output_mode == "jira" and not node_inputs.get("publishMode"):
+                if (
+                    story_output_mode == "jira"
+                    and _requires_branch_publish_for_story_output(
+                        node_inputs.get("publishMode")
+                    )
+                ):
                     node_inputs["publishMode"] = "branch"
                 node_inputs["instructions"] = _append_story_breakdown_instructions(
                     str(node_inputs.get("instructions") or ""),
@@ -839,8 +854,11 @@ def _build_runtime_planner():
                 and not _jira_agent_skill_selected(publish_selected_skill)
             ):
                 publish_inputs = publish_node["inputs"]
-                if story_output_mode == "jira" and not publish_inputs.get(
-                    "publishMode"
+                if (
+                    story_output_mode == "jira"
+                    and _requires_branch_publish_for_story_output(
+                        publish_inputs.get("publishMode")
+                    )
                 ):
                     publish_inputs["publishMode"] = "branch"
                 commit_suffix = (

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -256,6 +256,48 @@ async def test_create_jira_issues_falls_back_to_docs_tmp_when_jira_target_missin
 
 
 @pytest.mark.asyncio
+async def test_create_jira_issues_fails_when_jira_mode_has_no_story_payload():
+    with pytest.raises(ValueError, match="No stories were available"):
+        await create_jira_issues_from_stories(
+            {
+                "storyBreakdownPath": "docs/tmp/story-breakdowns/example/stories.json",
+                "storyOutput": {
+                    "mode": "jira",
+                    "jira": {
+                        "projectKey": "MM",
+                        "issueTypeId": "10001",
+                        "dependencyMode": "linear_blocker_chain",
+                    },
+                },
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_jira_issues_allows_explicit_fallback_when_jira_mode_has_no_story_payload():
+    result = await create_jira_issues_from_stories(
+        {
+            "storyBreakdownPath": "docs/tmp/story-breakdowns/example/stories.json",
+            "storyOutput": {
+                "mode": "jira",
+                "fallback": "docs_tmp",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeId": "10001",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            },
+        }
+    )
+
+    assert result.outputs["storyOutput"]["status"] == "fallback"
+    assert (
+        result.outputs["storyOutput"]["reason"]
+        == "No stories were available for Jira issue creation."
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_jira_issues_truncates_description_and_creates_subtasks():
     service = _FakeJiraService()
     long_description = "x" * 40000

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -357,6 +357,58 @@ def test_runtime_planner_shares_story_breakdown_path_for_jira_breakdown_preset()
     )
 
 
+def test_runtime_planner_uses_branch_handoff_for_jira_output_when_task_publish_none():
+    planner = _build_runtime_planner()
+    snapshot = SimpleNamespace(
+        digest="reg:sha256:test",
+        artifact_ref="art_registry_123",
+    )
+
+    plan = planner(
+        inputs={
+            "task": {
+                "title": "Jira Breakdown",
+                "instructions": "Break down docs/Design.md into Jira stories.",
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "none"},
+                "steps": [
+                    {
+                        "id": "breakdown",
+                        "tool": {"type": "skill", "name": "moonspec-breakdown"},
+                        "instructions": "Extract MoonSpec stories.",
+                    },
+                    {
+                        "id": "jira",
+                        "tool": {"type": "skill", "name": "story.create_jira_issues"},
+                        "instructions": "Create Jira issues from the generated breakdown.",
+                        "storyOutput": {
+                            "mode": "jira",
+                            "jira": {
+                                "projectKey": "MM",
+                                "issueTypeName": "Story",
+                                "dependencyMode": "linear_blocker_chain",
+                            },
+                        },
+                    },
+                ],
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    breakdown = plan["nodes"][0]
+    jira = plan["nodes"][1]
+
+    assert breakdown["inputs"]["storyOutput"]["mode"] == "jira"
+    assert breakdown["inputs"]["publishMode"] == "branch"
+    assert breakdown["inputs"]["targetBranch"].startswith("jira-breakdown-")
+    assert "commit your work" in breakdown["inputs"]["instructions"]
+    assert jira["inputs"]["publishMode"] == "none"
+    assert jira["inputs"]["storyOutput"]["mode"] == "jira"
+    assert jira["inputs"]["targetBranch"] == breakdown["inputs"]["targetBranch"]
+
+
 def test_runtime_planner_does_not_require_pr_branch_for_jira_issue_creator():
     planner = _build_runtime_planner()
     snapshot = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Preserve per-step `storyOutput` metadata from template expansion through Create page submission and edit/rerun draft reconstruction.
- Force Jira story-output breakdowns to use a branch handoff so `story.create_jira_issues` can fetch generated stories from a pushed ref instead of a job-local workspace path.
- Fail fast when deterministic Jira story creation is requested but no story payload can be read, unless fallback is explicitly configured.

## Root Cause

The Jira Breakdown preset produced structured Jira export metadata, but the Create page submission path dropped hidden per-step `storyOutput`. The planner then treated the generated breakdown as docs output and the Jira step had no accessible story payload, returning a successful fallback with `storyCount: 0`.

## Validation

- `./tools/test_unit.sh tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx -t "closes stream and shows Stream ended when task transitions to terminal"`
- `git diff --check`