### PR TITLE
[codex] Optimize Docker publish cache usage

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,16 +43,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
+        if: matrix.platform == 'linux/amd64'
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install system dependencies
+        if: matrix.platform == 'linux/amd64'
         run: |
           sudo apt-get update
           sudo apt-get install -y libcairo2-dev pkg-config
 
       - name: Cache pip dependencies
+        if: matrix.platform == 'linux/amd64'
         uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -61,16 +64,19 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install Python dependencies
+        if: matrix.platform == 'linux/amd64'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
 
       - name: Setup Node.js
+        if: matrix.platform == 'linux/amd64'
         uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Check frontend and generated contracts
+        if: matrix.platform == 'linux/amd64'
         run: |
           npm ci
           npm run frontend:ci

--- a/api_service/Dockerfile
+++ b/api_service/Dockerfile
@@ -220,10 +220,6 @@ ENV CODEX_CLI_VERSION=${CODEX_CLI_VERSION} \
 
 WORKDIR /app
 
-RUN build_id="${MOONMIND_BUILD_ID:-}" \
-    && if [ -z "${build_id}" ]; then build_id="$(date -u +%Y%m%d.%H%M)"; fi \
-    && printf '%s\n' "${build_id}" > /app/.moonmind-build-id
-
 # Copy Codex and Gemini/Claude artifacts from the tooling builder so the runtime
 # image retains only the compiled CLIs and minimal Node runtime needed to
 # execute them.
@@ -338,6 +334,10 @@ COPY --from=frontend-builder /build/api_service/static/task_dashboard/ /opt/moon
 
 RUN chmod +x /app/api_service/entrypoint.sh && \
     sed -i 's/\r$//' /app/api_service/entrypoint.sh
+
+RUN build_id="${MOONMIND_BUILD_ID:-}" \
+    && if [ -z "${build_id}" ]; then build_id="$(date -u +%Y%m%d.%H%M)"; fi \
+    && printf '%s\n' "${build_id}" > /app/.moonmind-build-id
 
 EXPOSE 5000
 


### PR DESCRIPTION
## Summary

- Move the MoonMind build ID write to the final Docker image layer so per-run build IDs do not invalidate dependency-heavy runtime layers.
- Run the Docker publish frontend/contracts preflight only on the amd64 matrix leg while keeping both amd64 and arm64 image builds.

## Impact

This should reduce Docker publish wall time by restoring cache reuse for runtime package installs and by skipping duplicate validation setup on the arm64 runner.

## Validation

- Parsed `.github/workflows/docker-publish.yml` with `python3` and verified the amd64 gates.
- Ran `docker buildx build --check --file ./api_service/Dockerfile .`.
- Ran `git diff --check -- .github/workflows/docker-publish.yml api_service/Dockerfile`.