### PR TITLE
MM-368 Enforce image artifact storage and policy

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/194-oauth-terminal-docker-verification"
+  "feature_directory": "specs/195-enforce-image-artifact-policy"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,8 @@ Key diagnostics:
 - No new persistent storage; this story defines compact runtime contracts and deterministic outputs that can later be persisted by the managed-session store or export sinks (191-claude-governance-telemetry)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing OAuth provider registry, existing OAuth session workflow/activity catalog, existing terminal bridge runtime helpers (192-oauth-runner-bootstrap-pty)
 - Existing OAuth session database row and workflow/activity payloads only; no new persistent storage (192-oauth-runner-bootstrap-pty)
+- Python 3.12; TypeScript/React for existing Create-page behavior + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, existing React Create page (195-enforce-image-artifact-policy)
+- Existing Temporal artifact metadata tables and configured artifact store; no new persistent storage (195-enforce-image-artifact-policy)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1410,8 +1410,18 @@ async def _validate_and_collect_task_input_attachments(
         )
 
     if session is not None:
+        artifact_ids = list(unique)
+        artifact_result = await session.execute(
+            select(TemporalArtifact).where(
+                TemporalArtifact.artifact_id.in_(artifact_ids)
+            )
+        )
+        artifacts_by_id = {
+            artifact.artifact_id: artifact
+            for artifact in artifact_result.scalars().all()
+        }
         for ref in unique.values():
-            artifact = await session.get(TemporalArtifact, ref["artifactId"])
+            artifact = artifacts_by_id.get(ref["artifactId"])
             if artifact is None:
                 raise _invalid_task_request(
                     f"input attachment artifact was not found: {ref['artifactId']}."

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 from urllib.parse import urlsplit
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,9 @@ from api_service.db.models import (
     TemporalExecutionCanonicalRecord,
     TemporalExecutionCloseStatus,
     TemporalExecutionRecord,
+    TemporalArtifact,
+    TemporalArtifactLink,
+    TemporalArtifactStatus,
     TemporalArtifactRetentionClass,
     User,
 )
@@ -1250,6 +1254,190 @@ def _coerce_step_count(value: Any) -> int:
     return len(value)
 
 
+_ATTACHMENT_REF_KEYS = frozenset(
+    {"artifactId", "filename", "contentType", "sizeBytes"}
+)
+_FORBIDDEN_ATTACHMENT_CONTENT_TYPES = frozenset({"image/svg+xml"})
+
+
+def _normalized_attachment_content_type(value: object) -> str:
+    return str(value or "").split(";", 1)[0].strip().lower()
+
+
+def _allowed_attachment_content_types() -> set[str]:
+    configured = {
+        _normalized_attachment_content_type(item)
+        for item in settings.workflow.agent_job_attachment_allowed_content_types
+    }
+    configured.discard("")
+    configured.difference_update(_FORBIDDEN_ATTACHMENT_CONTENT_TYPES)
+    return configured or {"image/png", "image/jpeg", "image/webp"}
+
+
+def _normalize_attachment_ref(raw: Any, *, field_name: str) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise _invalid_task_request(f"{field_name} must be an object.")
+    unsupported = sorted(str(key) for key in raw.keys() if key not in _ATTACHMENT_REF_KEYS)
+    if unsupported:
+        raise _invalid_task_request(
+            f"{field_name} contains unsupported fields: {', '.join(unsupported)}."
+        )
+    artifact_id = str(raw.get("artifactId") or "").strip()
+    if not artifact_id:
+        raise _invalid_task_request(f"{field_name}.artifactId is required.")
+    if not artifact_id.startswith("art_"):
+        raise _invalid_task_request(f"{field_name}.artifactId must be a MoonMind artifact id.")
+    filename = str(raw.get("filename") or "").strip()
+    if not filename:
+        raise _invalid_task_request(f"{field_name}.filename is required.")
+    content_type = _normalized_attachment_content_type(raw.get("contentType"))
+    if not content_type:
+        raise _invalid_task_request(f"{field_name}.contentType is required.")
+    if content_type in _FORBIDDEN_ATTACHMENT_CONTENT_TYPES:
+        raise _invalid_task_request(f"{content_type} is not supported for input attachments.")
+    allowed = _allowed_attachment_content_types()
+    if content_type not in allowed:
+        supported = ", ".join(sorted(allowed))
+        raise _invalid_task_request(
+            f"{field_name}.contentType must be one of: {supported}."
+        )
+    size_value = raw.get("sizeBytes")
+    if isinstance(size_value, bool):
+        raise _invalid_task_request(f"{field_name}.sizeBytes must be a non-negative integer.")
+    try:
+        size_bytes = int(size_value)
+    except (TypeError, ValueError) as exc:
+        raise _invalid_task_request(
+            f"{field_name}.sizeBytes must be a non-negative integer."
+        ) from exc
+    if size_bytes < 0:
+        raise _invalid_task_request(f"{field_name}.sizeBytes must be a non-negative integer.")
+    return {
+        "artifactId": artifact_id,
+        "filename": filename,
+        "contentType": content_type,
+        "sizeBytes": size_bytes,
+    }
+
+
+def _normalize_attachment_ref_list(raw: Any, *, field_name: str) -> list[dict[str, Any]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise _invalid_task_request(f"{field_name} must be a JSON array.")
+    return [
+        _normalize_attachment_ref(item, field_name=f"{field_name}[{index}]")
+        for index, item in enumerate(raw)
+    ]
+
+
+async def _validate_and_collect_task_input_attachments(
+    *,
+    task_payload: Mapping[str, Any],
+    session: AsyncSession | None,
+) -> tuple[list[dict[str, Any]], dict[int, list[dict[str, Any]]], list[dict[str, Any]]]:
+    objective_refs = _normalize_attachment_ref_list(
+        task_payload.get("inputAttachments"),
+        field_name="payload.task.inputAttachments",
+    )
+    step_refs: dict[int, list[dict[str, Any]]] = {}
+    raw_steps = task_payload.get("steps")
+    if isinstance(raw_steps, list):
+        for index, step in enumerate(raw_steps):
+            if not isinstance(step, Mapping):
+                continue
+            refs = _normalize_attachment_ref_list(
+                step.get("inputAttachments"),
+                field_name=f"payload.task.steps[{index}].inputAttachments",
+            )
+            if refs:
+                step_refs[index] = refs
+
+    attachment_index: list[dict[str, Any]] = []
+    for ref in objective_refs:
+        attachment_index.append({**ref, "targetKind": "objective"})
+    for index, refs in step_refs.items():
+        step = raw_steps[index] if isinstance(raw_steps, list) else {}
+        step_ref = ""
+        if isinstance(step, Mapping):
+            step_ref = str(step.get("id") or "").strip()
+        for ref in refs:
+            attachment_index.append(
+                {
+                    **ref,
+                    "targetKind": "step",
+                    "stepOrdinal": index,
+                    **({"stepRef": step_ref} if step_ref else {}),
+                }
+            )
+
+    if not attachment_index:
+        return objective_refs, step_refs, []
+    if not settings.workflow.agent_job_attachment_enabled:
+        raise _invalid_task_request("input attachment policy is disabled.")
+
+    unique: dict[str, dict[str, Any]] = {}
+    for ref in attachment_index:
+        artifact_id = ref["artifactId"]
+        existing = unique.get(artifact_id)
+        if existing is not None and (
+            existing["contentType"] != ref["contentType"]
+            or existing["sizeBytes"] != ref["sizeBytes"]
+        ):
+            raise _invalid_task_request(
+                f"input attachment {artifact_id} has conflicting declarations."
+            )
+        unique.setdefault(artifact_id, ref)
+
+    if len(unique) > settings.workflow.agent_job_attachment_max_count:
+        raise _invalid_task_request(
+            "too many input attachments "
+            f"({len(unique)}/{settings.workflow.agent_job_attachment_max_count})."
+        )
+    max_bytes = int(settings.workflow.agent_job_attachment_max_bytes)
+    total_bytes = 0
+    for ref in unique.values():
+        size_bytes = int(ref["sizeBytes"])
+        if size_bytes > max_bytes:
+            raise _invalid_task_request(
+                f"input attachment {ref['artifactId']} exceeds max bytes ({max_bytes})."
+            )
+        total_bytes += size_bytes
+    total_limit = int(settings.workflow.agent_job_attachment_total_bytes)
+    if total_bytes > total_limit:
+        raise _invalid_task_request(
+            f"input attachments exceed total bytes ({total_limit})."
+        )
+
+    if session is not None:
+        for ref in unique.values():
+            artifact = await session.get(TemporalArtifact, ref["artifactId"])
+            if artifact is None:
+                raise _invalid_task_request(
+                    f"input attachment artifact was not found: {ref['artifactId']}."
+                )
+            if artifact.status is not TemporalArtifactStatus.COMPLETE:
+                raise _invalid_task_request(
+                    "input attachment artifact must be complete before execution start: "
+                    f"{ref['artifactId']} is {artifact.status.value}."
+                )
+            artifact_content_type = _normalized_attachment_content_type(
+                artifact.content_type
+            )
+            if artifact_content_type and artifact_content_type != ref["contentType"]:
+                raise _invalid_task_request(
+                    f"input attachment {ref['artifactId']} content type mismatch."
+                )
+            if artifact.size_bytes is not None and int(artifact.size_bytes) != int(
+                ref["sizeBytes"]
+            ):
+                raise _invalid_task_request(
+                    f"input attachment {ref['artifactId']} size mismatch."
+                )
+
+    return objective_refs, step_refs, attachment_index
+
+
 def _normalize_task_skill_selectors(
     raw: Any, *, field_name: str
 ) -> dict[str, Any] | None:
@@ -1664,6 +1852,7 @@ def _build_original_task_input_snapshot_payload(
     source_kind: str,
     payload: Mapping[str, Any],
     task_payload: Mapping[str, Any],
+    attachment_refs: list[dict[str, Any]] | None = None,
     source_workflow_id: str | None = None,
     source_run_id: str | None = None,
 ) -> dict[str, Any]:
@@ -1683,7 +1872,7 @@ def _build_original_task_input_snapshot_payload(
         },
         "draft": draft,
         "largeContentRefs": {},
-        "attachmentRefs": [],
+        "attachmentRefs": list(attachment_refs or []),
         "lineage": {},
         "excluded": {
             "schedule": (
@@ -1740,6 +1929,7 @@ async def _persist_original_task_input_snapshot(
     user: User,
     payload: Mapping[str, Any],
     task_payload: Mapping[str, Any],
+    attachment_refs: list[dict[str, Any]] | None = None,
     source_kind: str,
     source_workflow_id: str | None = None,
     source_run_id: str | None = None,
@@ -1759,6 +1949,7 @@ async def _persist_original_task_input_snapshot(
         source_kind=source_kind,
         payload=payload,
         task_payload=task_payload,
+        attachment_refs=attachment_refs,
         source_workflow_id=source_workflow_id,
         source_run_id=source_run_id,
     )
@@ -1787,6 +1978,7 @@ async def _persist_original_task_input_snapshot(
             "draft_shape": snapshot_payload["draft"]["taskShape"],
             "schema_name": "OriginalTaskInputSnapshot",
             "created_by": principal,
+            "attachment_refs": list(attachment_refs or []),
         },
     )
     completed = await artifact_service.write_complete(
@@ -1806,10 +1998,63 @@ async def _persist_original_task_input_snapshot(
         memo["task_input_snapshot_source_kind"] = source_kind
         target_record.memo = memo
         refs = list(target_record.artifact_refs or [])
+        for attachment_ref in attachment_refs or []:
+            attachment_id = str(attachment_ref.get("artifactId") or "").strip()
+            if attachment_id and attachment_id not in refs:
+                refs.append(attachment_id)
         if completed.artifact_id not in refs:
             refs.append(completed.artifact_id)
             target_record.artifact_refs = refs
+        else:
+            target_record.artifact_refs = refs
     return completed.artifact_id
+
+
+async def _attach_input_attachment_artifacts_to_execution(
+    *,
+    session: AsyncSession | None,
+    record,
+    attachment_refs: list[dict[str, Any]],
+) -> None:
+    if session is None or not attachment_refs:
+        return
+    if not isinstance(
+        record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)
+    ):
+        return
+    unique_ids = list(dict.fromkeys(str(ref.get("artifactId") or "") for ref in attachment_refs))
+    unique_ids = [artifact_id for artifact_id in unique_ids if artifact_id]
+    if not unique_ids:
+        return
+
+    existing_refs = list(record.artifact_refs or [])
+    changed_refs = False
+    for artifact_id in unique_ids:
+        if artifact_id not in existing_refs:
+            existing_refs.append(artifact_id)
+            changed_refs = True
+        session.add(
+            TemporalArtifactLink(
+                id=uuid4(),
+                artifact_id=artifact_id,
+                namespace=record.namespace,
+                workflow_id=record.workflow_id,
+                run_id=record.run_id,
+                link_type="input.attachment",
+                label=next(
+                    (
+                        str(ref.get("filename") or "").strip()
+                        for ref in attachment_refs
+                        if ref.get("artifactId") == artifact_id
+                    ),
+                    None,
+                )
+                or None,
+            )
+        )
+    if changed_refs:
+        record.artifact_refs = existing_refs
+    await session.flush()
 
 
 async def _create_execution_from_task_request(
@@ -1872,8 +2117,20 @@ async def _create_execution_from_task_request(
 
     if len(depends_on) > 10:
         raise _invalid_task_request(f"{field_name} can have a maximum of 10 items.")
+    (
+        objective_attachment_refs,
+        step_attachment_refs,
+        attachment_index,
+    ) = await _validate_and_collect_task_input_attachments(
+        task_payload=task_payload,
+        session=session,
+    )
     step_count = _coerce_step_count(task_payload.get("steps"))
     normalized_steps = _normalize_task_steps(task_payload)
+    if step_attachment_refs:
+        for index, refs in step_attachment_refs.items():
+            if index < len(normalized_steps):
+                normalized_steps[index]["inputAttachments"] = refs
 
     repository = str(payload.get("repository") or "").strip() or None
     integration = (
@@ -1933,6 +2190,8 @@ async def _create_execution_from_task_request(
             normalized_task_for_planner["inputs"] = dict(normalized_tool["inputs"])
     if isinstance(task_payload.get("inputs"), dict):
         normalized_task_for_planner["inputs"] = dict(task_payload["inputs"])
+    if objective_attachment_refs:
+        normalized_task_for_planner["inputAttachments"] = objective_attachment_refs
     if runtime_payload:
         normalized_task_for_planner["runtime"] = dict(runtime_payload)
     if normalized_steps:
@@ -2083,17 +2342,26 @@ async def _create_execution_from_task_request(
             },
         ) from exc
 
+    await _attach_input_attachment_artifacts_to_execution(
+        session=session,
+        record=record,
+        attachment_refs=attachment_index,
+    )
+
     snapshot_ref = await _persist_original_task_input_snapshot(
         session=session,
         record=record,
         user=user,
         payload=payload,
         task_payload=task_payload,
+        attachment_refs=attachment_index,
         source_kind="create",
     )
-    execution = _serialize_execution(record, user=user)
     if snapshot_ref:
         await session.commit()
+    if isinstance(record, (TemporalExecutionRecord, TemporalExecutionCanonicalRecord)):
+        await session.refresh(record)
+    execution = _serialize_execution(record, user=user)
     return execution
 
 

--- a/docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md
@@ -1,0 +1,101 @@
+# MM-368 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-368
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Enforce image artifact storage and policy
+- Labels: `moonmind-workflow-mm-710b9b03-7ff6-4c87-ac25-ddef82bbf280`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-368 from MM project
+Summary: Enforce image artifact storage and policy
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-368 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-368: Enforce image artifact storage and policy
+
+Source Reference
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 6. Artifact model and storage contract
+  - 7. Validation and policy contract
+  - 12. Authorization and security contract
+- Coverage IDs:
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-017
+
+User Story
+As an operator, I need uploaded image bytes stored as first-class execution artifacts and governed by server-defined attachment policy so invalid or unsupported image inputs never start an execution.
+
+Acceptance Criteria
+- Image bytes are stored in the Artifact Store and linked to the execution as input attachments.
+- Allowed content types default to `image/png`, `image/jpeg`, and `image/webp`; `image/svg+xml` is rejected.
+- Browser checks are repeated server-side before artifact completion or execution start.
+- Max count, per-file size, total size, and integrity constraints are enforced.
+- Worker-side uploads cannot overwrite or impersonate reserved input attachment namespaces.
+- Disabled policy hides Create-page entry points and rejects submitted image refs.
+- Unsupported future fields and incompatible runtimes fail explicitly rather than being ignored or dropped.
+
+Requirements
+- Persist uploaded image bytes as artifacts rather than execution payload data.
+- Attach execution-owned artifact links for submitted images.
+- Treat artifact metadata as observability, not as binding source of truth.
+- Revalidate content type, signature, counts, sizes, and completion integrity server-side.
+- Reject scriptable image content types and other untrusted image risks.
+- Keep the task snapshot as the authoritative source for attachment target binding.
+- Prevent worker-side uploads from overwriting or impersonating reserved input attachment namespaces.
+- Enforce server-defined attachment policy even when browser-side checks have already run.
+- Fail explicitly when image attachments are disabled, unsupported by the selected runtime, incomplete, invalid, or include unsupported future fields.
+
+Relevant Implementation Notes
+- Canonical image input field: `inputAttachments`.
+- Objective-scoped attachments are submitted through `task.inputAttachments`.
+- Step-scoped attachments are submitted through `task.steps[n].inputAttachments`.
+- Image bytes must not be embedded in Temporal histories or task instruction text.
+- The control plane submits structured attachment references, not raw binaries.
+- The execution API persists the authoritative snapshot of attachment targeting.
+- Image artifacts should be linked to the execution with execution-owned artifact links.
+- Artifact metadata may include target diagnostics such as `source`, `attachmentKind`, `targetKind`, `stepRef`, `stepOrdinal`, and `originalFilename`, but metadata is not the binding source of truth.
+- Integrity must be enforced at artifact completion time before execution start.
+- Policy defaults should include `enabled=true`, max count, per-file size, total size, and allowed content types of `image/png`, `image/jpeg`, and `image/webp`.
+- The Create page may label the feature as images, but the implementation should preserve the generic `inputAttachments` contract.
+- Security boundaries are artifact-first and execution-owned: no direct browser access to object storage, no direct browser access to Jira or provider file endpoints, no scriptable image types, and no silent compatibility transforms that rewrite attachment refs or retarget them to another step.
+
+Suggested Implementation Areas
+- Artifact upload creation, completion, and validation paths.
+- Execution submission validation and task snapshot persistence.
+- Create-page image entry point visibility and browser-side policy checks.
+- Server-side attachment policy enforcement before artifact completion or execution start.
+- Worker artifact upload namespace protections.
+- Tests covering artifact storage, policy rejection, execution linkage, disabled policy behavior, and unsupported runtime or future-field failure.
+
+Validation
+- Verify uploaded image bytes are persisted as artifacts and linked to the execution as input attachments.
+- Verify `image/png`, `image/jpeg`, and `image/webp` are accepted by default and `image/svg+xml` is rejected.
+- Verify server-side validation repeats browser checks for content type, signature, max count, per-file size, total size, and completion integrity.
+- Verify invalid, incomplete, over-limit, or scriptable image uploads are rejected before execution start.
+- Verify disabled attachment policy hides Create-page entry points and rejects submitted image refs.
+- Verify worker-side uploads cannot overwrite or impersonate reserved input attachment namespaces.
+- Verify unsupported future fields and incompatible runtimes fail explicitly instead of being ignored or dropped.
+
+Non-Goals
+- Embedding raw image bytes in Temporal histories, workflow payloads, or task instruction text.
+- Treating artifact metadata as the authoritative attachment binding source.
+- Allowing `image/svg+xml` or other scriptable image content types.
+- Adding hidden compatibility transforms that silently rewrite attachment refs or retarget them to another step.
+- Redesigning the broader artifact store, retention model, or runtime adapter architecture beyond the storage and policy enforcement needed for this story.
+
+Needs Clarification
+- None

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -46,6 +46,7 @@ _RESERVED_INPUT_ATTACHMENT_PREFIXES = (
     ".moonmind/inputs/",
     "/.moonmind/inputs/",
 )
+_NORMALIZED_RESERVED_INPUT_ATTACHMENT_PREFIXES: frozenset[str]
 
 
 class TemporalArtifactError(Exception):
@@ -220,6 +221,32 @@ def _is_task_input_attachment_metadata(metadata: Mapping[str, Any]) -> bool:
     return source in _TASK_INPUT_ATTACHMENT_SOURCES or attachment_kind == "input"
 
 
+def _normalize_reserved_input_attachment_path(raw_path: str) -> str:
+    path = raw_path.strip().replace("\\", "/").lower()
+    is_absolute = path.startswith("/")
+    parts: list[str] = []
+    for part in path.split("/"):
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(part)
+    normalized = "/".join(parts)
+    if is_absolute:
+        normalized = f"/{normalized}" if normalized else "/"
+    if normalized and not normalized.endswith("/"):
+        normalized = f"{normalized}/"
+    return normalized
+
+
+_NORMALIZED_RESERVED_INPUT_ATTACHMENT_PREFIXES = frozenset(
+    _normalize_reserved_input_attachment_path(prefix)
+    for prefix in _RESERVED_INPUT_ATTACHMENT_PREFIXES
+)
+
+
 def _assert_not_reserved_input_attachment_metadata(
     metadata: Mapping[str, Any] | None,
 ) -> None:
@@ -237,12 +264,12 @@ def _assert_not_reserved_input_attachment_metadata(
         raw_value = source.get(key)
         if not isinstance(raw_value, str):
             continue
-        candidate = raw_value.strip().replace("\\", "/").lower().lstrip("./")
+        candidate = _normalize_reserved_input_attachment_path(raw_value)
         if not candidate:
             continue
         if any(
-            candidate.startswith(prefix.lstrip("/").lstrip("./"))
-            for prefix in _RESERVED_INPUT_ATTACHMENT_PREFIXES
+            candidate.startswith(prefix)
+            for prefix in _NORMALIZED_RESERVED_INPUT_ATTACHMENT_PREFIXES
         ):
             raise TemporalArtifactValidationError(
                 "worker artifact uploads may not target the reserved input attachment namespace"
@@ -272,6 +299,15 @@ def _validate_image_attachment_payload(
         len(payload) < 12 or not payload.startswith(b"RIFF") or payload[8:12] != b"WEBP"
     ):
         raise TemporalArtifactValidationError("image/webp signature validation failed")
+
+
+def _requires_image_payload_validation(
+    *, content_type: str | None, metadata: Mapping[str, Any] | None
+) -> bool:
+    normalized = _normalized_content_type(content_type)
+    return _is_task_input_attachment_metadata(metadata or {}) or normalized.startswith(
+        "image/"
+    )
 
 
 def _expires_at_for_retention(
@@ -1334,7 +1370,10 @@ class TemporalArtifactService:
             artifact.status = db_models.TemporalArtifactStatus.FAILED
             await self._repository.commit()
             raise
-        if _is_task_input_attachment_metadata(artifact.metadata_json or {}):
+        if _requires_image_payload_validation(
+            content_type=content_type or artifact.content_type,
+            metadata=artifact.metadata_json,
+        ):
             try:
                 _validate_image_attachment_payload(
                     content_type=content_type or artifact.content_type,
@@ -1477,7 +1516,10 @@ class TemporalArtifactService:
             artifact.status = db_models.TemporalArtifactStatus.FAILED
             await self._repository.commit()
             raise
-        if _is_task_input_attachment_metadata(artifact.metadata_json or {}):
+        if _requires_image_payload_validation(
+            content_type=artifact.content_type,
+            metadata=artifact.metadata_json,
+        ):
             try:
                 _validate_image_attachment_payload(
                     content_type=artifact.content_type,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -37,6 +37,15 @@ _PREVIEW_MAX_BYTES = 16 * 1024
 _STREAM_CHUNK_BYTES = 64 * 1024
 _SINGLE_PUT_READ_RETRY_DELAYS_SECONDS = (0.1, 0.2, 0.4, 0.8, 1.6)
 _SINGLE_PUT_READ_RETRYABLE_S3_ERROR_CODES = {"404", "NoSuchKey", "NotFound"}
+_TASK_INPUT_ATTACHMENT_SOURCES = frozenset(
+    {"task-dashboard-step-attachment", "task-create"}
+)
+_RESERVED_INPUT_ATTACHMENT_PREFIXES = (
+    "inputs/",
+    "/inputs/",
+    ".moonmind/inputs/",
+    "/.moonmind/inputs/",
+)
 
 
 class TemporalArtifactError(Exception):
@@ -189,6 +198,80 @@ def _derive_retention(
     if link in {"output.primary", "output.patch", "output.summary"}:
         return db_models.TemporalArtifactRetentionClass.STANDARD
     return db_models.TemporalArtifactRetentionClass.STANDARD
+
+
+def _normalized_content_type(value: object | None) -> str:
+    return str(value or "").split(";", 1)[0].strip().lower()
+
+
+def _allowed_input_attachment_content_types() -> set[str]:
+    configured = {
+        _normalized_content_type(item)
+        for item in settings.workflow.agent_job_attachment_allowed_content_types
+    }
+    configured.discard("")
+    configured.discard("image/svg+xml")
+    return configured or {"image/png", "image/jpeg", "image/webp"}
+
+
+def _is_task_input_attachment_metadata(metadata: Mapping[str, Any]) -> bool:
+    source = str(metadata.get("source") or "").strip().lower()
+    attachment_kind = str(metadata.get("attachmentKind") or "").strip().lower()
+    return source in _TASK_INPUT_ATTACHMENT_SOURCES or attachment_kind == "input"
+
+
+def _assert_not_reserved_input_attachment_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> None:
+    source = dict(metadata or {})
+    for key in (
+        "artifact_path",
+        "artifactPath",
+        "path",
+        "relative_path",
+        "relativePath",
+        "workspacePath",
+        "workspace_path",
+        "name",
+    ):
+        raw_value = source.get(key)
+        if not isinstance(raw_value, str):
+            continue
+        candidate = raw_value.strip().replace("\\", "/").lower().lstrip("./")
+        if not candidate:
+            continue
+        if any(
+            candidate.startswith(prefix.lstrip("/").lstrip("./"))
+            for prefix in _RESERVED_INPUT_ATTACHMENT_PREFIXES
+        ):
+            raise TemporalArtifactValidationError(
+                "worker artifact uploads may not target the reserved input attachment namespace"
+            )
+
+
+def _validate_image_attachment_payload(
+    *,
+    content_type: str | None,
+    payload: bytes,
+) -> None:
+    normalized = _normalized_content_type(content_type)
+    if normalized == "image/svg+xml":
+        raise TemporalArtifactValidationError("image/svg+xml is not supported")
+    allowed = _allowed_input_attachment_content_types()
+    if normalized not in allowed:
+        supported = ", ".join(sorted(allowed))
+        raise TemporalArtifactValidationError(
+            f"unsupported image attachment content type {normalized or '<missing>'}; "
+            f"supported types: {supported}"
+        )
+    if normalized == "image/png" and not payload.startswith(b"\x89PNG\r\n\x1a\n"):
+        raise TemporalArtifactValidationError("image/png signature validation failed")
+    if normalized == "image/jpeg" and not payload.startswith(b"\xff\xd8\xff"):
+        raise TemporalArtifactValidationError("image/jpeg signature validation failed")
+    if normalized == "image/webp" and (
+        len(payload) < 12 or not payload.startswith(b"RIFF") or payload[8:12] != b"WEBP"
+    ):
+        raise TemporalArtifactValidationError("image/webp signature validation failed")
 
 
 def _expires_at_for_retention(
@@ -1119,6 +1202,7 @@ class TemporalArtifactService:
         redaction_level: db_models.TemporalArtifactRedactionLevel = db_models.TemporalArtifactRedactionLevel.NONE,
     ) -> tuple[db_models.TemporalArtifact, ArtifactUploadDescriptor]:
         now = datetime.now(UTC)
+        _assert_not_reserved_input_attachment_metadata(metadata_json)
         declared_size: int | None = None
         if size_bytes is not None:
             declared_size = int(size_bytes)
@@ -1250,6 +1334,16 @@ class TemporalArtifactService:
             artifact.status = db_models.TemporalArtifactStatus.FAILED
             await self._repository.commit()
             raise
+        if _is_task_input_attachment_metadata(artifact.metadata_json or {}):
+            try:
+                _validate_image_attachment_payload(
+                    content_type=content_type or artifact.content_type,
+                    payload=payload,
+                )
+            except TemporalArtifactValidationError:
+                artifact.status = db_models.TemporalArtifactStatus.FAILED
+                await self._repository.commit()
+                raise
 
         await asyncio.get_running_loop().run_in_executor(
             None,
@@ -1383,6 +1477,16 @@ class TemporalArtifactService:
             artifact.status = db_models.TemporalArtifactStatus.FAILED
             await self._repository.commit()
             raise
+        if _is_task_input_attachment_metadata(artifact.metadata_json or {}):
+            try:
+                _validate_image_attachment_payload(
+                    content_type=artifact.content_type,
+                    payload=payload,
+                )
+            except TemporalArtifactValidationError:
+                artifact.status = db_models.TemporalArtifactStatus.FAILED
+                await self._repository.commit()
+                raise
 
         artifact.sha256 = digest
         artifact.size_bytes = actual_size

--- a/specs/195-enforce-image-artifact-policy/checklists/requirements.md
+++ b/specs/195-enforce-image-artifact-policy/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Enforce Image Artifact Storage and Policy
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request from the MM-368 Jira preset brief.
+- Existing Moon Spec artifacts were inspected; no MM-368 feature directory existed, so orchestration resumed from Specify.

--- a/specs/195-enforce-image-artifact-policy/checklists/requirements.md
+++ b/specs/195-enforce-image-artifact-policy/checklists/requirements.md
@@ -38,3 +38,4 @@
 
 - Input classified as a single-story runtime feature request from the MM-368 Jira preset brief.
 - Existing Moon Spec artifacts were inspected; no MM-368 feature directory existed, so orchestration resumed from Specify.
+- Active `spec.md` passes the specify gate and embeds the original MM-368 Jira preset brief for final verification comparison.

--- a/specs/195-enforce-image-artifact-policy/contracts/image-attachment-policy.md
+++ b/specs/195-enforce-image-artifact-policy/contracts/image-attachment-policy.md
@@ -1,0 +1,84 @@
+# Contract: Image Attachment Policy
+
+## Task Submission Contract
+
+Task-shaped execution payloads may include:
+
+```json
+{
+  "payload": {
+    "task": {
+      "inputAttachments": [
+        {
+          "artifactId": "art_...",
+          "filename": "diagram.png",
+          "contentType": "image/png",
+          "sizeBytes": 1234
+        }
+      ],
+      "steps": [
+        {
+          "inputAttachments": [
+            {
+              "artifactId": "art_...",
+              "filename": "step.webp",
+              "contentType": "image/webp",
+              "sizeBytes": 2048
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+Validation errors:
+- Attachment policy disabled: reject with `invalid_execution_request`.
+- Unknown attachment ref field: reject with `invalid_execution_request`.
+- Incomplete, missing, deleted, or unreadable artifact: reject with `invalid_execution_request`.
+- Unsupported content type or `image/svg+xml`: reject with `invalid_execution_request`.
+- Max count, per-file size, or total-size violation: reject with `invalid_execution_request`.
+
+## Artifact Completion Contract
+
+Artifacts created by the Create-page attachment flow are identified by metadata:
+
+```json
+{
+  "metadata": {
+    "source": "task-dashboard-step-attachment"
+  }
+}
+```
+
+Completion rules:
+- Completed bytes must satisfy declared size/hash.
+- Declared and actual content type must be allowed by policy.
+- PNG bytes must start with the PNG signature.
+- JPEG bytes must start with the JPEG SOI marker.
+- WebP bytes must use RIFF/WEBP framing.
+- SVG and unknown image types are rejected.
+
+## Snapshot Contract
+
+Original task input snapshots include:
+
+```json
+{
+  "attachmentRefs": [
+    {
+      "artifactId": "art_...",
+      "filename": "diagram.png",
+      "contentType": "image/png",
+      "sizeBytes": 1234,
+      "targetKind": "objective"
+    }
+  ]
+}
+```
+
+Rules:
+- The snapshot task body preserves canonical `inputAttachments` fields.
+- `attachmentRefs` is a compact index for reconstruction and visibility.
+- Artifact metadata cannot override target kind.

--- a/specs/195-enforce-image-artifact-policy/data-model.md
+++ b/specs/195-enforce-image-artifact-policy/data-model.md
@@ -1,0 +1,73 @@
+# Data Model: Enforce Image Artifact Storage and Policy
+
+## Input Attachment Ref
+
+Represents one structured attachment target in a task-shaped execution payload.
+
+Fields:
+- `artifactId`: Artifact identifier for previously uploaded image bytes.
+- `filename`: Operator-visible original filename.
+- `contentType`: Declared image content type.
+- `sizeBytes`: Declared byte size.
+
+Validation:
+- No unknown fields are accepted.
+- `artifactId`, `filename`, and `contentType` must be non-empty strings.
+- `sizeBytes` must be a non-negative integer.
+- `contentType` must be server-allowed and must not be `image/svg+xml`.
+
+## Attachment Policy
+
+Server-defined policy exposed to the Create page and enforced by API boundaries.
+
+Fields:
+- `enabled`
+- `maxCount`
+- `maxBytes`
+- `totalBytes`
+- `allowedContentTypes`
+
+Validation:
+- Disabled policy rejects any submitted image refs.
+- Allowed types default to `image/png`, `image/jpeg`, and `image/webp`.
+- `image/svg+xml` is rejected even if a caller attempts to configure it.
+
+## Attachment Artifact
+
+Existing Temporal artifact row containing uploaded image bytes and metadata.
+
+Relevant fields:
+- `artifact_id`
+- `content_type`
+- `size_bytes`
+- `sha256`
+- `status`
+- `metadata_json`
+- `storage_key`
+
+Validation:
+- Status must be `COMPLETE` before execution start.
+- Metadata is used for diagnostics, not target binding.
+- Actual completed bytes must match declared size/hash when declarations exist.
+- Magic bytes must match the accepted content type for image attachment artifacts.
+
+## Task Snapshot
+
+Existing original task input snapshot artifact.
+
+Relevant fields:
+- `draft.task.inputAttachments`
+- `draft.task.steps[n].inputAttachments`
+- `attachmentRefs`
+
+Validation:
+- Target binding comes from the task fields, not artifact metadata.
+- `attachmentRefs` records normalized refs for visibility and reconstruction.
+
+## Execution Artifact Visibility
+
+Existing execution record artifact refs and artifact links.
+
+Rules:
+- Submitted attachment artifact IDs are attached to execution artifact refs after workflow creation.
+- Link metadata remains secondary observability and must not retarget attachments.

--- a/specs/195-enforce-image-artifact-policy/plan.md
+++ b/specs/195-enforce-image-artifact-policy/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Enforce Image Artifact Storage and Policy
+
+**Branch**: `195-enforce-image-artifact-policy` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/195-enforce-image-artifact-policy/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+MM-368 requires task image inputs to stay artifact-backed and server-governed. The implementation will extend the existing Temporal artifact and task-shaped execution paths so attachment artifacts are validated by server policy at completion and execution submission, canonical `inputAttachments` refs are preserved in task parameters and snapshots, reserved input attachment namespaces are protected from worker impersonation, and disabled policy blocks image refs. Validation will use focused pytest unit coverage plus contract-style API coverage against the existing FastAPI/SQLAlchemy Temporal execution path.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for existing Create-page behavior  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, existing React Create page  
+**Storage**: Existing Temporal artifact metadata tables and configured artifact store; no new persistent storage  
+**Unit Testing**: pytest via `./tools/test_unit.sh`, with focused pytest targets for iteration  
+**Integration Testing**: pytest contract coverage against FastAPI app + sqlite-backed metadata, plus existing hermetic integration tier when needed  
+**Target Platform**: MoonMind API service and managed-agent runtime containers  
+**Project Type**: Web service with frontend submission client and Temporal workflow orchestration backend  
+**Performance Goals**: Attachment validation should be linear in submitted attachment count and use compact metadata/signature checks before workflow start  
+**Constraints**: Do not embed image bytes in payloads or Temporal history; do not introduce new storage tables; preserve pre-release compatibility policy by failing unsupported attachment shapes explicitly  
+**Scale/Scope**: One task execution submit request with up to configured attachment count and total bytes; objective and step attachment refs only
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing Temporal artifact and execution orchestration surfaces.
+- II. One-Click Agent Deployment: PASS. No new external service dependency.
+- III. Avoid Vendor Lock-In: PASS. Uses generic artifact refs and task attachment contracts, not provider file APIs.
+- IV. Own Your Data: PASS. Image bytes remain in MoonMind-owned artifact storage.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill runtime mutation; task refs remain adapter-visible structured inputs.
+- VI. Replaceability and Scientific Method: PASS. Behavior is contract-tested at API/service boundaries.
+- VII. Runtime Configurability: PASS. Attachment policy uses existing server settings.
+- VIII. Modular and Extensible Architecture: PASS. Validation lives at API/service boundaries.
+- IX. Resilient by Default: PASS. Invalid inputs fail before workflow start.
+- X. Facilitate Continuous Improvement: PASS. Validation errors are explicit and operator-visible.
+- XI. Spec-Driven Development: PASS. This plan follows a one-story spec with tests.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Implementation notes stay in spec artifacts; canonical docs are not converted to migration logs.
+- XIII. Pre-release Compatibility Policy: PASS. Unsupported shapes fail explicitly instead of compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/195-enforce-image-artifact-policy/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── image-attachment-policy.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/routers/
+    ├── executions.py
+    └── temporal_artifacts.py
+
+moonmind/
+├── config/settings.py
+└── workflows/temporal/artifacts.py
+
+frontend/
+└── src/entrypoints/
+    ├── task-create.tsx
+    └── task-create.test.tsx
+
+tests/
+├── contract/
+│   └── test_temporal_execution_api.py
+└── unit/
+    ├── api/routers/test_executions.py
+    ├── api/routers/test_temporal_artifacts.py
+    └── workflows/temporal/test_artifacts.py
+```
+
+**Structure Decision**: Keep attachment validation in the existing artifact service and execution router boundaries. Preserve Create-page policy behavior unless tests reveal missing disabled-policy visibility.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/195-enforce-image-artifact-policy/quickstart.md
+++ b/specs/195-enforce-image-artifact-policy/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Enforce Image Artifact Storage and Policy
+
+## Focused Test Commands
+
+Unit/API iteration:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py -q
+MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/workflows/temporal/test_artifacts.py -q
+MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_temporal_artifacts.py -q
+```
+
+Contract/API iteration:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/contract/test_temporal_execution_api.py -q
+```
+
+Final unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## End-to-End Story Checks
+
+1. Create a completed PNG/JPEG/WebP artifact through `/api/artifacts`, then submit a task-shaped execution with that artifact in `task.inputAttachments`.
+2. Confirm the execution starts only after the artifact is complete and the task snapshot preserves the attachment ref.
+3. Submit refs for `image/svg+xml`, incomplete artifacts, too many artifacts, over-limit artifacts, unknown fields, and disabled policy.
+4. Confirm each invalid case returns a validation error before workflow start.
+5. Attempt a worker-style upload into a reserved input attachment namespace and confirm it is rejected.
+
+## Source Coverage
+
+- DESIGN-REQ-008: artifact-backed image storage and execution linkage.
+- DESIGN-REQ-009: default allowed content types and SVG rejection.
+- DESIGN-REQ-010: repeated server-side validation before completion/start.
+- DESIGN-REQ-017: artifact-first authorization and reserved namespace protection.

--- a/specs/195-enforce-image-artifact-policy/research.md
+++ b/specs/195-enforce-image-artifact-policy/research.md
@@ -1,0 +1,49 @@
+# Research: Enforce Image Artifact Storage and Policy
+
+## Input Classification
+
+Decision: Treat the MM-368 Jira preset brief as a single-story runtime feature request.
+Rationale: The brief contains one operator story centered on image artifact storage and policy enforcement, with one acceptance set and one source design path.
+Alternatives considered: Treating `docs/Tasks/ImageSystem.md` as a broad design would require `moonspec-breakdown`, but MM-368 already selected the storage/policy/security subset.
+
+## Attachment Storage Surface
+
+Decision: Reuse the existing Temporal artifact service and metadata tables for image bytes.
+Rationale: The source design requires artifact-first storage and the repo already has `/api/artifacts` creation, upload, completion, metadata, and execution-link endpoints.
+Alternatives considered: Adding a dedicated attachment table was rejected because the story requires no new durable storage and the artifact service already provides lifecycle and ownership.
+
+## Server-Side Policy Enforcement
+
+Decision: Enforce image policy both at artifact completion for Create-page attachment artifacts and at task-shaped execution submission for submitted `inputAttachments` refs.
+Rationale: Completion catches invalid bytes as early as possible; execution submission catches disabled policy, incomplete refs, mismatched metadata, unsupported future fields, and clients that bypass browser checks.
+Alternatives considered: Browser-only validation was rejected because MM-368 explicitly requires repeated server-side checks.
+
+## Image Type Validation
+
+Decision: Validate declared content type against the server allowlist and sniff compact magic bytes for PNG, JPEG, and WebP; always reject `image/svg+xml`.
+Rationale: The source design names the default allowed image types and forbids scriptable image content. Magic-byte checks are deterministic and cheap.
+Alternatives considered: Full image decoding was rejected as unnecessary for policy enforcement and would add dependency/CPU cost.
+
+## Attachment Ref Shape
+
+Decision: Accept only canonical ref fields: `artifactId`, `filename`, `contentType`, and `sizeBytes`.
+Rationale: The story requires unsupported future fields to fail explicitly rather than being ignored.
+Alternatives considered: Allowing unknown fields was rejected because it would silently drop unsupported attachment semantics.
+
+## Execution Artifact Linkage
+
+Decision: Preserve refs in the task parameters and original task input snapshot, and add submitted attachment IDs to execution artifact refs after execution creation.
+Rationale: The task snapshot is the authoritative target-binding source, while execution artifact refs improve operator visibility without making metadata authoritative.
+Alternatives considered: Relying only on client-side post-create link calls was rejected because non-browser API clients could otherwise start executions with unlinked attachment refs.
+
+## Runtime Compatibility
+
+Decision: Treat current task runtimes as compatible with artifact-backed attachment refs because prepare-time materialization and text context are the default desired state.
+Rationale: No repo setting currently declares a runtime-specific incompatibility matrix. This story still fails explicitly for unsupported attachment fields and invalid policy states.
+Alternatives considered: Blocking delegated runtimes such as Jules or Codex Cloud was rejected because no canonical repo requirement identifies them as incompatible for this story.
+
+## Test Strategy
+
+Decision: Add focused unit tests for validation helpers/service behavior and contract API tests for task-shaped execution submission.
+Rationale: The highest-risk boundaries are artifact completion and execution request normalization.
+Alternatives considered: Full compose-backed integration was deferred unless focused tests reveal service wiring gaps.

--- a/specs/195-enforce-image-artifact-policy/spec.md
+++ b/specs/195-enforce-image-artifact-policy/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Enforce Image Artifact Storage and Policy
+
+**Feature Branch**: `195-enforce-image-artifact-policy`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-368 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md`
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Enforce Image Artifact Storage and Policy
+
+**Summary**: As an operator, I need uploaded image bytes stored as first-class execution artifacts and governed by server-defined attachment policy so invalid or unsupported image inputs never start an execution.
+
+**Goal**: Image task inputs are accepted only when the server can prove that the uploaded artifacts satisfy the configured image policy, are complete, are linked as execution-owned input attachments, and cannot be impersonated by worker artifact uploads.
+
+**Independent Test**: Submit task-shaped execution requests with valid and invalid image attachment refs and verify that valid images remain artifact-backed input attachments while disabled, incomplete, oversized, unsupported, scriptable, future-field, incompatible-runtime, and reserved-namespace attempts fail before execution starts.
+
+**Acceptance Scenarios**:
+
+1. **Given** attachment policy is enabled and completed image artifacts use allowed content types, **When** a task-shaped execution is submitted with objective-scoped and step-scoped `inputAttachments`, **Then** the execution is accepted with artifact-backed input attachment refs preserved in the task snapshot.
+2. **Given** an attachment ref points to an incomplete artifact, an unsupported content type, a scriptable image type, an over-limit size/count/total, or a mismatched integrity signal, **When** execution submission or artifact completion is attempted, **Then** the request is rejected before execution starts.
+3. **Given** attachment policy is disabled, **When** the Create page loads or a task-shaped execution request submits image refs, **Then** image entry points are not offered and submitted refs are rejected.
+4. **Given** a worker-side artifact upload targets a reserved input attachment namespace, **When** the upload is requested, **Then** the upload is rejected and cannot overwrite or impersonate input attachments.
+5. **Given** an attachment ref includes unsupported future fields or the selected runtime cannot consume image attachments, **When** execution submission is attempted, **Then** the system fails explicitly instead of silently ignoring or dropping attachment refs.
+
+### Edge Cases
+
+- The browser reports an allowed image type, but the server-side content type or signature validation does not confirm a supported image.
+- The selected files are individually valid but exceed configured max count or total-size policy.
+- An artifact upload was created but not completed before task submission.
+- A user attempts to submit `image/svg+xml` or another scriptable content type.
+- A worker upload uses a path or namespace reserved for input attachments.
+- A task edit or rerun reconstructs a draft containing existing attachment refs while attachment policy is now disabled.
+- A request contains fields not yet supported by the attachment contract.
+
+## Assumptions
+
+- The story is runtime implementation work, not documentation-only work.
+- `docs/Tasks/ImageSystem.md` is treated as source requirements for runtime behavior.
+- The canonical control-plane field name remains `inputAttachments`.
+- Objective-scoped attachments are represented by `task.inputAttachments`; step-scoped attachments are represented by `task.steps[n].inputAttachments`.
+- Existing artifact APIs remain the storage surface for uploaded image bytes.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-008** (Source: `docs/Tasks/ImageSystem.md`, section 6; MM-368 brief): Image bytes MUST be stored in the Artifact Store and linked to the execution as input attachments. Scope: in scope. Maps to FR-001, FR-002, FR-008.
+- **DESIGN-REQ-009** (Source: `docs/Tasks/ImageSystem.md`, section 6; MM-368 brief): Allowed content types MUST default to `image/png`, `image/jpeg`, and `image/webp`; `image/svg+xml` MUST be rejected. Scope: in scope. Maps to FR-003, FR-004.
+- **DESIGN-REQ-010** (Source: `docs/Tasks/ImageSystem.md`, section 7; MM-368 brief): Browser checks MUST be repeated server-side before artifact completion or execution start, including content type, signature, count, size, total size, and integrity constraints. Scope: in scope. Maps to FR-004, FR-005, FR-006.
+- **DESIGN-REQ-017** (Source: `docs/Tasks/ImageSystem.md`, section 12; MM-368 brief): Authorization and security boundaries MUST prevent direct browser storage access, worker-side input namespace impersonation, scriptable image types, and hidden compatibility transforms that silently rewrite attachment refs. Scope: in scope. Maps to FR-007, FR-009, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST persist uploaded image bytes as artifacts rather than embedding image bytes in execution payloads, workflow histories, or task instruction text.
+- **FR-002**: System MUST preserve objective-scoped and step-scoped `inputAttachments` as execution-owned artifact links in the authoritative task snapshot.
+- **FR-003**: System MUST default image attachment policy to allow `image/png`, `image/jpeg`, and `image/webp`.
+- **FR-004**: System MUST reject `image/svg+xml`, scriptable image types, and any image content type outside the configured allowlist.
+- **FR-005**: System MUST revalidate browser-side attachment checks server-side before artifact completion or execution start.
+- **FR-006**: System MUST enforce configured max count, per-file size, total size, upload completion, and integrity constraints before execution starts.
+- **FR-007**: System MUST reject worker-side artifact uploads that attempt to overwrite or impersonate reserved input attachment namespaces.
+- **FR-008**: System MUST reject submitted image refs when attachment policy is disabled, and Create-page image entry points MUST be unavailable when policy is disabled.
+- **FR-009**: System MUST fail explicitly for unsupported future attachment fields and incompatible runtimes instead of silently ignoring, dropping, rewriting, or retargeting attachment refs.
+- **FR-010**: System MUST treat artifact metadata as observability only; authoritative target binding MUST come from the task snapshot.
+
+### Key Entities
+
+- **Input Attachment Ref**: A lightweight task payload reference to an artifact-backed image, including artifact identity, filename, content type, and byte size.
+- **Attachment Policy**: Server-defined rules controlling enablement, allowed image content types, max count, per-file size, and total size.
+- **Execution-Owned Artifact Link**: The relationship between a submitted task execution and an input attachment artifact.
+- **Task Snapshot**: The authoritative persisted task input state that preserves objective and step attachment target binding.
+- **Reserved Input Namespace**: Artifact storage locations reserved for user-submitted input attachments and unavailable to worker-side artifact uploads.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Valid objective-scoped and step-scoped image attachments are accepted only as artifact-backed refs and remain present in the task snapshot in automated coverage.
+- **SC-002**: Unsupported, scriptable, incomplete, over-count, oversized, over-total, or integrity-invalid image attachments are rejected before execution start in automated coverage.
+- **SC-003**: Disabled attachment policy prevents Create-page image entry points and rejects submitted image refs in automated coverage.
+- **SC-004**: Worker-side uploads to reserved input namespaces are rejected in automated coverage.
+- **SC-005**: Unsupported future fields and incompatible-runtime inputs produce explicit validation failures without silently dropping attachment refs in automated coverage.

--- a/specs/195-enforce-image-artifact-policy/spec.md
+++ b/specs/195-enforce-image-artifact-policy/spec.md
@@ -18,6 +18,95 @@ Inspect existing Moon Spec artifacts and resume from the first incomplete stage 
 
 **Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md`
 
+## Original Jira Preset Brief
+
+Jira issue: MM-368 from MM project
+Summary: Enforce image artifact storage and policy
+Issue type: Story
+Current Jira status at trusted fetch time: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-368 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-368: Enforce image artifact storage and policy
+
+Source Reference:
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 6. Artifact model and storage contract
+  - 7. Validation and policy contract
+  - 12. Authorization and security contract
+- Coverage IDs:
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-017
+
+User Story:
+As an operator, I need uploaded image bytes stored as first-class execution artifacts and governed by server-defined attachment policy so invalid or unsupported image inputs never start an execution.
+
+Acceptance Criteria:
+- Image bytes are stored in the Artifact Store and linked to the execution as input attachments.
+- Allowed content types default to `image/png`, `image/jpeg`, and `image/webp`; `image/svg+xml` is rejected.
+- Browser checks are repeated server-side before artifact completion or execution start.
+- Max count, per-file size, total size, and integrity constraints are enforced.
+- Worker-side uploads cannot overwrite or impersonate reserved input attachment namespaces.
+- Disabled policy hides Create-page entry points and rejects submitted image refs.
+- Unsupported future fields and incompatible runtimes fail explicitly rather than being ignored or dropped.
+
+Requirements:
+- Persist uploaded image bytes as artifacts rather than execution payload data.
+- Attach execution-owned artifact links for submitted images.
+- Treat artifact metadata as observability, not as binding source of truth.
+- Revalidate content type, signature, counts, sizes, and completion integrity server-side.
+- Reject scriptable image content types and other untrusted image risks.
+- Keep the task snapshot as the authoritative source for attachment target binding.
+- Prevent worker-side uploads from overwriting or impersonating reserved input attachment namespaces.
+- Enforce server-defined attachment policy even when browser-side checks have already run.
+- Fail explicitly when image attachments are disabled, unsupported by the selected runtime, incomplete, invalid, or include unsupported future fields.
+
+Relevant Implementation Notes:
+- Canonical image input field: `inputAttachments`.
+- Objective-scoped attachments are submitted through `task.inputAttachments`.
+- Step-scoped attachments are submitted through `task.steps[n].inputAttachments`.
+- Image bytes must not be embedded in Temporal histories or task instruction text.
+- The control plane submits structured attachment references, not raw binaries.
+- The execution API persists the authoritative snapshot of attachment targeting.
+- Image artifacts should be linked to the execution with execution-owned artifact links.
+- Artifact metadata may include target diagnostics such as `source`, `attachmentKind`, `targetKind`, `stepRef`, `stepOrdinal`, and `originalFilename`, but metadata is not the binding source of truth.
+- Integrity must be enforced at artifact completion time before execution start.
+- Policy defaults should include `enabled=true`, max count, per-file size, total size, and allowed content types of `image/png`, `image/jpeg`, and `image/webp`.
+- The Create page may label the feature as images, but the implementation should preserve the generic `inputAttachments` contract.
+- Security boundaries are artifact-first and execution-owned: no direct browser access to object storage, no direct browser access to Jira or provider file endpoints, no scriptable image types, and no silent compatibility transforms that rewrite attachment refs or retarget them to another step.
+
+Suggested Implementation Areas:
+- Artifact upload creation, completion, and validation paths.
+- Execution submission validation and task snapshot persistence.
+- Create-page image entry point visibility and browser-side policy checks.
+- Server-side attachment policy enforcement before artifact completion or execution start.
+- Worker artifact upload namespace protections.
+- Tests covering artifact storage, policy rejection, execution linkage, disabled policy behavior, and unsupported runtime or future-field failure.
+
+Validation:
+- Verify uploaded image bytes are persisted as artifacts and linked to the execution as input attachments.
+- Verify `image/png`, `image/jpeg`, and `image/webp` are accepted by default and `image/svg+xml` is rejected.
+- Verify server-side validation repeats browser checks for content type, signature, max count, per-file size, total size, and completion integrity.
+- Verify invalid, incomplete, over-limit, or scriptable image uploads are rejected before execution start.
+- Verify disabled attachment policy hides Create-page entry points and rejects submitted image refs.
+- Verify worker-side uploads cannot overwrite or impersonate reserved input attachment namespaces.
+- Verify unsupported future fields and incompatible runtimes fail explicitly instead of being ignored or dropped.
+
+Non-Goals:
+- Embedding raw image bytes in Temporal histories, workflow payloads, or task instruction text.
+- Treating artifact metadata as the authoritative attachment binding source.
+- Allowing `image/svg+xml` or other scriptable image content types.
+- Adding hidden compatibility transforms that silently rewrite attachment refs or retarget them to another step.
+- Redesigning the broader artifact store, retention model, or runtime adapter architecture beyond the storage and policy enforcement needed for this story.
+
+Needs Clarification:
+- None
+
 <!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
 
 ## User Story - Enforce Image Artifact Storage and Policy

--- a/specs/195-enforce-image-artifact-policy/speckit_analyze_report.md
+++ b/specs/195-enforce-image-artifact-policy/speckit_analyze_report.md
@@ -1,0 +1,25 @@
+# MoonSpec Alignment Report: Enforce Image Artifact Storage and Policy
+
+**Date**: 2026-04-17  
+**Feature**: `specs/195-enforce-image-artifact-policy`  
+**Mode**: Automated conservative alignment after task generation
+
+## Findings
+
+| Finding | Severity | Remediation |
+| --- | --- | --- |
+| `spec.md` and `verification.md` state that unsupported runtimes fail explicitly for image attachments, but `tasks.md` only named unsupported future fields for the FR-009/SC-005 unit-test task. | Medium | Updated T006 to name unsupported target runtime coverage and added a focused unit regression for a task submission that combines `inputAttachments` with an unsupported `targetRuntime`. |
+
+## Gate Re-Check
+
+- Specify gate: PASS. The active spec remains a single-story runtime feature and preserves the original MM-368 Jira preset brief.
+- Plan gate: PASS. Required planning artifacts remain present and unchanged: `plan.md`, `research.md`, `data-model.md`, `contracts/image-attachment-policy.md`, and `quickstart.md`.
+- Task gate: PASS. `tasks.md` covers exactly one story, red-first unit tests, integration/contract tests, implementation tasks, story validation, and final `/moonspec-verify` work.
+- Constitution gate: PASS. No new dependencies, storage, compatibility aliases, or architecture exceptions were introduced.
+
+## Validation
+
+- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachments -q`: PASS.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py -q`: PASS, 80 passed and 12 warnings.
+- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks`: PASS.
+- `git diff --check`: PASS.

--- a/specs/195-enforce-image-artifact-policy/tasks.md
+++ b/specs/195-enforce-image-artifact-policy/tasks.md
@@ -3,7 +3,14 @@
 **Input**: `/work/agent_jobs/mm:230435a6-2451-4a5d-9736-19e4bdb70014/repo/specs/195-enforce-image-artifact-policy/spec.md`  
 **Plan**: `/work/agent_jobs/mm:230435a6-2451-4a5d-9736-19e4bdb70014/repo/specs/195-enforce-image-artifact-policy/plan.md`  
 **Unit test command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration test command**: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/contract/test_temporal_execution_api.py -q`
 **Focused iteration commands**: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py tests/contract/test_temporal_execution_api.py -q`
+
+## Story Scope
+
+This task list covers exactly one independently testable story from MM-368: uploaded image bytes are stored as first-class execution artifacts and governed by server-defined attachment policy so invalid or unsupported image inputs never start an execution.
+
+**Independent test**: Submit task-shaped execution requests with valid and invalid objective-scoped and step-scoped image attachment refs. Valid refs must remain artifact-backed input attachments in the task snapshot; disabled, incomplete, oversized, unsupported, scriptable, future-field, incompatible-runtime, and reserved-namespace attempts must fail before execution starts.
 
 ## Source Traceability Summary
 
@@ -26,7 +33,7 @@
 - [X] T005 [P] Add failing unit tests for image content type allowlist and `image/svg+xml` rejection in `tests/unit/api/routers/test_executions.py`. Covers FR-003, FR-004, SC-002.
 - [X] T006 [P] Add failing unit tests for max count, per-file size, total size, incomplete artifacts, and unknown future fields in `tests/unit/api/routers/test_executions.py`. Covers FR-005, FR-006, FR-009, SC-002, SC-005.
 - [X] T007 [P] Add failing unit tests for artifact completion signature validation and reserved input namespace rejection in `tests/unit/workflows/temporal/test_artifacts.py` or `tests/unit/api/routers/test_temporal_artifacts.py`. Covers FR-004, FR-007, SC-004.
-- [X] T008 [P] Add failing contract coverage for task-shaped execution preserving image attachment refs in `tests/contract/test_temporal_execution_api.py`. Covers DESIGN-REQ-008, SC-001.
+- [X] T008 [P] Add failing integration/contract coverage for task-shaped execution preserving image attachment refs in `tests/contract/test_temporal_execution_api.py`. Covers DESIGN-REQ-008, SC-001.
 
 ## Phase 3: Implementation
 
@@ -41,16 +48,16 @@
 ## Phase 4: Validation
 
 - [X] T016 Run focused red/green unit coverage: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py -q`.
-- [X] T017 Run focused contract coverage: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/contract/test_temporal_execution_api.py -q`.
+- [X] T017 Run focused integration/contract coverage: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/contract/test_temporal_execution_api.py -q`.
 - [X] T018 Run final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
-- [X] T019 Run `/speckit.verify` equivalent and write `specs/195-enforce-image-artifact-policy/verification.md`.
+- [X] T019 Run final `/moonspec-verify` equivalent story validation and write `specs/195-enforce-image-artifact-policy/verification.md`.
 
 ## Dependencies and Execution Order
 
 1. T001-T003 complete before test and implementation work.
 2. T004-T008 must be added and observed failing before T009-T015.
 3. T009-T014 are backend implementation tasks; T015 is only required if frontend ownership changes.
-4. T016-T019 are final validation and verification tasks.
+4. T016-T019 are story validation and final `/moonspec-verify` tasks.
 
 ## Implementation Strategy
 

--- a/specs/195-enforce-image-artifact-policy/tasks.md
+++ b/specs/195-enforce-image-artifact-policy/tasks.md
@@ -31,7 +31,7 @@ This task list covers exactly one independently testable story from MM-368: uplo
 
 - [X] T004 [P] Add failing unit tests for task `inputAttachments` preservation and disabled-policy rejection in `tests/unit/api/routers/test_executions.py`. Covers FR-002, FR-008, SC-001, SC-003.
 - [X] T005 [P] Add failing unit tests for image content type allowlist and `image/svg+xml` rejection in `tests/unit/api/routers/test_executions.py`. Covers FR-003, FR-004, SC-002.
-- [X] T006 [P] Add failing unit tests for max count, per-file size, total size, incomplete artifacts, and unknown future fields in `tests/unit/api/routers/test_executions.py`. Covers FR-005, FR-006, FR-009, SC-002, SC-005.
+- [X] T006 [P] Add failing unit tests for max count, per-file size, total size, incomplete artifacts, unknown future fields, and unsupported target runtime with attachments in `tests/unit/api/routers/test_executions.py`. Covers FR-005, FR-006, FR-009, SC-002, SC-005.
 - [X] T007 [P] Add failing unit tests for artifact completion signature validation and reserved input namespace rejection in `tests/unit/workflows/temporal/test_artifacts.py` or `tests/unit/api/routers/test_temporal_artifacts.py`. Covers FR-004, FR-007, SC-004.
 - [X] T008 [P] Add failing integration/contract coverage for task-shaped execution preserving image attachment refs in `tests/contract/test_temporal_execution_api.py`. Covers DESIGN-REQ-008, SC-001.
 

--- a/specs/195-enforce-image-artifact-policy/tasks.md
+++ b/specs/195-enforce-image-artifact-policy/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: Enforce Image Artifact Storage and Policy
+
+**Input**: `/work/agent_jobs/mm:230435a6-2451-4a5d-9736-19e4bdb70014/repo/specs/195-enforce-image-artifact-policy/spec.md`  
+**Plan**: `/work/agent_jobs/mm:230435a6-2451-4a5d-9736-19e4bdb70014/repo/specs/195-enforce-image-artifact-policy/plan.md`  
+**Unit test command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Focused iteration commands**: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py tests/contract/test_temporal_execution_api.py -q`
+
+## Source Traceability Summary
+
+- DESIGN-REQ-008: T004, T008, T013, T015, T017
+- DESIGN-REQ-009: T005, T009, T012, T016
+- DESIGN-REQ-010: T006, T010, T012, T013, T016
+- DESIGN-REQ-017: T007, T011, T014, T016
+- FR-001 through FR-010: covered by T004-T018
+- SC-001 through SC-005: validated by T004-T008 and T016-T019
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature directory and branch in `.specify/feature.json` and `specs/195-enforce-image-artifact-policy/`.
+- [X] T002 Generate Specify, Plan, research, data model, contract, and quickstart artifacts for MM-368 in `specs/195-enforce-image-artifact-policy/`.
+- [X] T003 Update Codex agent context from the implementation plan via `.specify/scripts/bash/update-agent-context.sh`.
+
+## Phase 2: Foundational Tests
+
+- [X] T004 [P] Add failing unit tests for task `inputAttachments` preservation and disabled-policy rejection in `tests/unit/api/routers/test_executions.py`. Covers FR-002, FR-008, SC-001, SC-003.
+- [X] T005 [P] Add failing unit tests for image content type allowlist and `image/svg+xml` rejection in `tests/unit/api/routers/test_executions.py`. Covers FR-003, FR-004, SC-002.
+- [X] T006 [P] Add failing unit tests for max count, per-file size, total size, incomplete artifacts, and unknown future fields in `tests/unit/api/routers/test_executions.py`. Covers FR-005, FR-006, FR-009, SC-002, SC-005.
+- [X] T007 [P] Add failing unit tests for artifact completion signature validation and reserved input namespace rejection in `tests/unit/workflows/temporal/test_artifacts.py` or `tests/unit/api/routers/test_temporal_artifacts.py`. Covers FR-004, FR-007, SC-004.
+- [X] T008 [P] Add failing contract coverage for task-shaped execution preserving image attachment refs in `tests/contract/test_temporal_execution_api.py`. Covers DESIGN-REQ-008, SC-001.
+
+## Phase 3: Implementation
+
+- [X] T009 Implement canonical attachment ref validation helpers in `api_service/api/routers/executions.py`. Covers FR-002, FR-003, FR-004, FR-009.
+- [X] T010 Implement execution-start policy validation for disabled policy, max count, per-file size, total size, incomplete artifacts, and missing artifacts in `api_service/api/routers/executions.py`. Covers FR-005, FR-006, FR-008.
+- [X] T011 Preserve normalized `task.inputAttachments` and `task.steps[n].inputAttachments` in execution parameters and original task input snapshots in `api_service/api/routers/executions.py`. Covers FR-002, FR-010.
+- [X] T012 Implement image attachment completion validation in `moonmind/workflows/temporal/artifacts.py`, including PNG/JPEG/WebP signature sniffing and SVG rejection. Covers FR-003, FR-004, FR-005.
+- [X] T013 Add submitted attachment refs to execution artifact visibility and snapshot `attachmentRefs` in `api_service/api/routers/executions.py`. Covers FR-001, FR-002, FR-010.
+- [X] T014 Reject worker-side uploads into reserved input attachment namespaces in the artifact API/service boundary in `moonmind/workflows/temporal/artifacts.py`. Covers FR-007.
+- [X] T015 Update frontend Create-page attachment behavior only if server-owned linkage requires client adjustment in `frontend/src/entrypoints/task-create.tsx` and `frontend/src/entrypoints/task-create.test.tsx`. Covers FR-008. Existing Create-page policy behavior already hides disabled attachment entry points; no frontend code change was required.
+
+## Phase 4: Validation
+
+- [X] T016 Run focused red/green unit coverage: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py -q`.
+- [X] T017 Run focused contract coverage: `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/contract/test_temporal_execution_api.py -q`.
+- [X] T018 Run final unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T019 Run `/speckit.verify` equivalent and write `specs/195-enforce-image-artifact-policy/verification.md`.
+
+## Dependencies and Execution Order
+
+1. T001-T003 complete before test and implementation work.
+2. T004-T008 must be added and observed failing before T009-T015.
+3. T009-T014 are backend implementation tasks; T015 is only required if frontend ownership changes.
+4. T016-T019 are final validation and verification tasks.
+
+## Implementation Strategy
+
+Use TDD at API/service boundaries: write failing validation tests first, implement the narrow helpers in existing modules, rerun focused tests, then run the full unit suite. Do not create new storage tables or compatibility aliases.

--- a/specs/195-enforce-image-artifact-policy/verification.md
+++ b/specs/195-enforce-image-artifact-policy/verification.md
@@ -7,7 +7,7 @@
 
 ## Original Request Source
 
-Canonical Moon Spec orchestration input: `docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md`
+Canonical Moon Spec orchestration input: `docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md`. The original MM-368 Jira preset brief is also preserved directly in `spec.md` under "Original Jira Preset Brief" so verification can compare against the active specification without resolving the external preserved brief file.
 
 The input was classified as a single-story runtime feature request. The Jira brief points at `docs/Tasks/ImageSystem.md`; that document was treated as runtime source requirements, not docs-only work.
 

--- a/specs/195-enforce-image-artifact-policy/verification.md
+++ b/specs/195-enforce-image-artifact-policy/verification.md
@@ -43,6 +43,12 @@ The input was classified as a single-story runtime feature request. The Jira bri
 - Final unit suite:
   `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
   Result: Python 3467 passed, 1 xpassed, 101 warnings, 16 subtests passed; frontend Vitest suites 10 passed and 236 tests passed.
+- Alignment regression:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachments -q`
+  Result: 1 passed.
+- Alignment focused API suite:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py -q`
+  Result: 80 passed, 12 warnings.
 
 ## Residual Risk
 

--- a/specs/195-enforce-image-artifact-policy/verification.md
+++ b/specs/195-enforce-image-artifact-policy/verification.md
@@ -1,0 +1,49 @@
+# Verification: Enforce Image Artifact Storage and Policy
+
+**Date**: 2026-04-17  
+**Issue**: MM-368  
+**Feature**: `specs/195-enforce-image-artifact-policy`  
+**Verdict**: FULLY_IMPLEMENTED
+
+## Original Request Source
+
+Canonical Moon Spec orchestration input: `docs/tmp/jira-orchestration-inputs/MM-368-moonspec-orchestration-input.md`
+
+The input was classified as a single-story runtime feature request. The Jira brief points at `docs/Tasks/ImageSystem.md`; that document was treated as runtime source requirements, not docs-only work.
+
+## Requirement Coverage
+
+- **DESIGN-REQ-008**: Covered. Uploaded image refs are validated as existing completed artifacts, preserved in `task.inputAttachments` and `task.steps[n].inputAttachments`, linked into execution artifact refs, and included in the original task input snapshot metadata.
+- **DESIGN-REQ-009**: Covered. Server policy defaults to `image/png`, `image/jpeg`, and `image/webp`; `image/svg+xml` is always rejected even if configured.
+- **DESIGN-REQ-010**: Covered. Execution submission validates canonical ref shape, content type allowlist, max count, per-file size, total size, artifact completion, and stored artifact metadata. Artifact completion validates task input image content type and file signatures for PNG, JPEG, and WebP.
+- **DESIGN-REQ-017**: Covered. Worker-side uploads are blocked from reserved input attachment namespaces, browser direct-storage assumptions are avoided, unsupported future attachment fields fail explicitly, and unsupported runtimes continue to fail through target runtime validation.
+
+## Functional Coverage
+
+- **FR-001**: Covered by artifact-backed attachment refs and snapshot metadata without image byte embedding.
+- **FR-002**: Covered by normalized objective and step attachment preservation.
+- **FR-003**: Covered by default allowed content types.
+- **FR-004**: Covered by SVG/scriptable type rejection and allowlist checks.
+- **FR-005**: Covered by server-side validation at artifact completion and execution start.
+- **FR-006**: Covered by count, per-file size, total size, completion, and metadata consistency checks.
+- **FR-007**: Covered by reserved input namespace rejection in the artifact service.
+- **FR-008**: Covered by disabled-policy request rejection. Existing Create-page policy behavior already hides disabled attachment entry points, so no frontend change was required.
+- **FR-009**: Covered by unsupported attachment field rejection and existing unsupported target runtime rejection.
+- **FR-010**: Covered by authoritative task snapshot target binding and observability-only attachment metadata.
+
+## Test Evidence
+
+- Initial focused red run for new tests failed before implementation as expected.
+- Focused green run:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_attachments_when_policy_disabled tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_unknown_attachment_fields tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_svg_attachment_type tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_attachment_policy_limits tests/unit/workflows/temporal/test_artifacts.py::test_write_complete_rejects_invalid_task_image_signature tests/unit/workflows/temporal/test_artifacts.py::test_create_rejects_reserved_input_attachment_storage_key tests/contract/test_temporal_execution_api.py::test_task_shaped_create_preserves_image_input_attachments -q`
+  Result: 7 passed.
+- Broader focused run:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py tests/contract/test_temporal_execution_api.py -q`
+  Result: 111 passed, 13 warnings.
+- Final unit suite:
+  `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+  Result: Python 3467 passed, 1 xpassed, 101 warnings, 16 subtests passed; frontend Vitest suites 10 passed and 236 tests passed.
+
+## Residual Risk
+
+No blocking residual risk was found. Warnings observed during the final test suite are pre-existing warning-class output and did not indicate failed MM-368 coverage.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -67,13 +67,16 @@ async def _create_uploaded_artifact(
     artifact_id: str,
     *,
     status: TemporalArtifactStatus = TemporalArtifactStatus.COMPLETE,
+    content_type: str = "application/json; charset=utf-8",
+    size_bytes: int = 128,
+    metadata_json: dict[str, object] | None = None,
 ) -> str:
     async with db_base.async_session_maker() as session:
         session.add(
             TemporalArtifact(
                 artifact_id=artifact_id,
-                content_type="application/json; charset=utf-8",
-                size_bytes=128,
+                content_type=content_type,
+                size_bytes=size_bytes,
                 storage_key=f"tests/{artifact_id}.json",
                 storage_backend=TemporalArtifactStorageBackend.S3,
                 encryption=TemporalArtifactEncryption.NONE,
@@ -81,7 +84,7 @@ async def _create_uploaded_artifact(
                 retention_class=TemporalArtifactRetentionClass.STANDARD,
                 redaction_level=TemporalArtifactRedactionLevel.NONE,
                 upload_mode=TemporalArtifactUploadMode.SINGLE_PUT,
-                metadata_json={"label": "Contract test input"},
+                metadata_json=metadata_json or {"label": "Contract test input"},
             )
         )
         await session.commit()
@@ -878,6 +881,120 @@ async def test_task_shaped_create_rejects_pending_upload_input_artifact(tmp_path
             body = create_response.json()
             assert body["detail"]["code"] == "invalid_execution_request"
             assert "readable artifact" in body["detail"]["message"]
+    finally:
+        db_base.DATABASE_URL = original_db_url
+        db_base.engine = original_engine
+        db_base.async_session_maker = original_session_maker
+
+
+@pytest.mark.asyncio
+async def test_task_shaped_create_preserves_image_input_attachments(tmp_path, monkeypatch):
+    original_db_url = db_base.DATABASE_URL
+    original_engine = db_base.engine
+    original_session_maker = db_base.async_session_maker
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/temporal_contract_image_inputs.db"
+    db_base.DATABASE_URL = db_url
+    db_base.engine = create_async_engine(db_url, future=True)
+    db_base.async_session_maker = sessionmaker(
+        db_base.engine, class_=AsyncSession, expire_on_commit=False
+    )
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_max_count", 4)
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_max_bytes", 1024)
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_total_bytes", 4096)
+    monkeypatch.setattr(settings.workflow, "temporal_artifact_backend", "local_fs")
+    monkeypatch.setattr(
+        settings.workflow,
+        "temporal_artifact_root",
+        str(tmp_path / "artifacts"),
+    )
+
+    async with db_base.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    shared_user_id = uuid4()
+    app.dependency_overrides[CURRENT_USER_DEP] = lambda: SimpleNamespace(
+        id=shared_user_id, is_superuser=False
+    )
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            objective_artifact = await _create_uploaded_artifact(
+                "art_01TESTIMAGEOBJECTIVE000000",
+                content_type="image/png",
+                size_bytes=8,
+                metadata_json={"source": "task-dashboard-step-attachment"},
+            )
+            step_artifact = await _create_uploaded_artifact(
+                "art_01TESTIMAGESTEP0000000000",
+                content_type="image/webp",
+                size_bytes=12,
+                metadata_json={"source": "task-dashboard-step-attachment"},
+            )
+
+            create_response = await client.post(
+                "/api/executions",
+                json={
+                    "type": "task",
+                    "payload": {
+                        "repository": "MoonLadderStudios/MoonMind",
+                        "targetRuntime": "codex",
+                        "task": {
+                            "instructions": "Review the provided images.",
+                            "runtime": {"mode": "codex"},
+                            "inputAttachments": [
+                                {
+                                    "artifactId": objective_artifact,
+                                    "filename": "objective.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 8,
+                                }
+                            ],
+                            "steps": [
+                                {
+                                    "instructions": "Inspect the detail image.",
+                                    "inputAttachments": [
+                                        {
+                                            "artifactId": step_artifact,
+                                            "filename": "detail.webp",
+                                            "contentType": "image/webp",
+                                            "sizeBytes": 12,
+                                        }
+                                    ],
+                                }
+                            ],
+                        },
+                    },
+                },
+            )
+
+            assert create_response.status_code == 201
+            body = create_response.json()
+            async with db_base.async_session_maker() as session:
+                canonical = await session.get(
+                    TemporalExecutionCanonicalRecord,
+                    body["workflowId"],
+                )
+                assert canonical is not None
+                task = canonical.parameters["task"]
+                assert task["inputAttachments"][0]["artifactId"] == objective_artifact
+                assert task["steps"][0]["inputAttachments"][0]["artifactId"] == step_artifact
+                assert objective_artifact in canonical.artifact_refs
+                assert step_artifact in canonical.artifact_refs
+
+                snapshot_ref = canonical.memo["task_input_snapshot_ref"]
+                snapshot_artifact = await session.get(TemporalArtifact, snapshot_ref)
+                assert snapshot_artifact is not None
+                assert any(
+                    item["artifactId"] == objective_artifact
+                    and item["targetKind"] == "objective"
+                    for item in snapshot_artifact.metadata_json["attachment_refs"]
+                )
     finally:
         db_base.DATABASE_URL = original_db_url
         db_base.engine = original_engine

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -447,6 +447,147 @@ def test_create_task_shaped_execution_rejects_more_than_50_steps(
     service.create_execution.assert_not_awaited()
 
 
+def test_create_task_shaped_execution_rejects_attachments_when_policy_disabled(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", False)
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "instructions": "Review the uploaded screenshot.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000000",
+                            "filename": "wireframe.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "attachment policy is disabled" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_unknown_attachment_fields(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "instructions": "Review the uploaded screenshot.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000000",
+                            "filename": "wireframe.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                            "caption": "unsupported future field",
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "unsupported fields" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_svg_attachment_type(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    monkeypatch.setattr(
+        settings.workflow,
+        "agent_job_attachment_allowed_content_types",
+        ("image/png", "image/jpeg", "image/webp", "image/svg+xml"),
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "instructions": "Review the uploaded screenshot.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000000",
+                            "filename": "wireframe.svg",
+                            "contentType": "image/svg+xml",
+                            "sizeBytes": 128,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "image/svg+xml is not supported" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_attachment_policy_limits(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_max_count", 1)
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "instructions": "Review uploaded screenshots.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000001",
+                            "filename": "one.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                        },
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000002",
+                            "filename": "two.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "too many input attachments" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_dedupes_and_normalizes_dependencies(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -21,7 +21,11 @@ from api_service.api.routers.executions import (
 )
 from api_service.auth_providers import get_current_user
 from api_service.db.base import get_async_session
-from api_service.db.models import MoonMindWorkflowState, TemporalWorkflowType
+from api_service.db.models import (
+    MoonMindWorkflowState,
+    TemporalArtifactStatus,
+    TemporalWorkflowType,
+)
 from moonmind.config.settings import settings
 from moonmind.workflows.temporal.service import ExecutionDependencySummary
 from moonmind.workflows.temporal import (
@@ -509,6 +513,48 @@ def test_create_task_shaped_execution_rejects_unknown_attachment_fields(
 
     assert response.status_code == 422
     assert "unsupported fields" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachments(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    test_client.app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        get=AsyncMock(
+            return_value=SimpleNamespace(
+                status=TemporalArtifactStatus.COMPLETE,
+                content_type="image/png",
+                size_bytes=128,
+            )
+        )
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "targetRuntime": "unsupported_runtime",
+                "task": {
+                    "instructions": "Review the uploaded screenshot.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000000",
+                            "filename": "wireframe.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "Unsupported targetRuntime" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
 
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -38,6 +38,22 @@ from moonmind.schemas.temporal_models import (
 )
 
 
+class _ScalarRows:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[SimpleNamespace]:
+        return self._rows
+
+
+class _ExecuteResult:
+    def __init__(self, rows: list[SimpleNamespace]) -> None:
+        self._rows = rows
+
+    def scalars(self) -> _ScalarRows:
+        return _ScalarRows(self._rows)
+
+
 class _QueryHandle:
     def __init__(self, *, progress=None, ledger=None, error: Exception | None = None) -> None:
         self._progress = progress
@@ -522,14 +538,20 @@ def test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachmen
 ) -> None:
     test_client, service, _user = client
     monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
-    test_client.app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
-        get=AsyncMock(
-            return_value=SimpleNamespace(
-                status=TemporalArtifactStatus.COMPLETE,
-                content_type="image/png",
-                size_bytes=128,
-            )
+    execute = AsyncMock(
+        return_value=_ExecuteResult(
+            [
+                SimpleNamespace(
+                    artifact_id="art_01IMAGEINPUT0000000000000",
+                    status=TemporalArtifactStatus.COMPLETE,
+                    content_type="image/png",
+                    size_bytes=128,
+                )
+            ]
         )
+    )
+    test_client.app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        execute=execute
     )
 
     response = test_client.post(
@@ -556,6 +578,66 @@ def test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachmen
     assert response.status_code == 422
     assert "Unsupported targetRuntime" in response.json()["detail"]["message"]
     service.create_execution.assert_not_awaited()
+
+
+def test_create_task_shaped_execution_fetches_unique_attachments_in_one_query(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_client, service, _user = client
+    monkeypatch.setattr(settings.workflow, "agent_job_attachment_enabled", True)
+    service.create_execution.return_value = _build_execution_record()
+    execute = AsyncMock(
+        return_value=_ExecuteResult(
+            [
+                SimpleNamespace(
+                    artifact_id="art_01IMAGEINPUT0000000000001",
+                    status=TemporalArtifactStatus.COMPLETE,
+                    content_type="image/png",
+                    size_bytes=128,
+                ),
+                SimpleNamespace(
+                    artifact_id="art_01IMAGEINPUT0000000000002",
+                    status=TemporalArtifactStatus.COMPLETE,
+                    content_type="image/webp",
+                    size_bytes=256,
+                ),
+            ]
+        )
+    )
+    test_client.app.dependency_overrides[get_async_session] = lambda: SimpleNamespace(
+        execute=execute
+    )
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "task": {
+                    "instructions": "Review uploaded screenshots.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000001",
+                            "filename": "one.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 128,
+                        },
+                        {
+                            "artifactId": "art_01IMAGEINPUT0000000000002",
+                            "filename": "two.webp",
+                            "contentType": "image/webp",
+                            "sizeBytes": 256,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    execute.assert_awaited_once()
+    service.create_execution.assert_awaited_once()
 
 
 def test_create_task_shaped_execution_rejects_svg_attachment_type(

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -266,6 +266,70 @@ async def test_create_write_read_and_list_for_execution(tmp_path: Path) -> None:
             assert [item.artifact_id for item in listed] == [artifact.artifact_id]
 
 
+async def test_write_complete_rejects_invalid_task_image_signature(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Task image attachments should be sniffed server-side at completion."""
+
+    monkeypatch.setattr(
+        artifact_module.settings.workflow,
+        "agent_job_attachment_allowed_content_types",
+        ("image/png", "image/jpeg", "image/webp"),
+    )
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="image/png",
+                metadata_json={"source": "task-dashboard-step-attachment"},
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="image/png signature",
+            ):
+                await service.write_complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="user-1",
+                    payload=b"not-a-png",
+                    content_type="image/png",
+                )
+
+
+async def test_create_rejects_reserved_input_attachment_storage_key(
+    tmp_path: Path,
+) -> None:
+    """Worker artifact uploads must not impersonate input attachment namespaces."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="reserved input attachment namespace",
+            ):
+                await service.create(
+                    principal="worker-1",
+                    content_type="text/plain",
+                    metadata_json={
+                        "source": "agent-runtime",
+                        "artifact_path": "inputs/objective/screenshot.png",
+                    },
+                )
+
+
 async def test_create_uses_same_origin_content_endpoint_for_small_s3_uploads(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -303,6 +303,42 @@ async def test_write_complete_rejects_invalid_task_image_signature(
                 )
 
 
+async def test_write_complete_rejects_invalid_image_signature_without_task_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All image uploads should be sniffed, even when metadata is only diagnostic."""
+
+    monkeypatch.setattr(
+        artifact_module.settings.workflow,
+        "agent_job_attachment_allowed_content_types",
+        ("image/png", "image/jpeg", "image/webp"),
+    )
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            artifact, _upload = await service.create(
+                principal="user-1",
+                content_type="image/png",
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="image/png signature",
+            ):
+                await service.write_complete(
+                    artifact_id=artifact.artifact_id,
+                    principal="user-1",
+                    payload=b"not-a-png",
+                    content_type="image/png",
+                )
+
+
 async def test_create_rejects_reserved_input_attachment_storage_key(
     tmp_path: Path,
 ) -> None:
@@ -326,6 +362,43 @@ async def test_create_rejects_reserved_input_attachment_storage_key(
                     metadata_json={
                         "source": "agent-runtime",
                         "artifact_path": "inputs/objective/screenshot.png",
+                    },
+                )
+
+
+@pytest.mark.parametrize(
+    "reserved_path",
+    [
+        "./inputs/objective/screenshot.png",
+        "/inputs/objective/screenshot.png",
+        ".moonmind/inputs/objective/screenshot.png",
+        "/.moonmind/inputs/objective/screenshot.png",
+    ],
+)
+async def test_create_rejects_normalized_reserved_input_attachment_storage_keys(
+    tmp_path: Path,
+    reserved_path: str,
+) -> None:
+    """Reserved path checks should normalize candidates and prefixes consistently."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="reserved input attachment namespace",
+            ):
+                await service.create(
+                    principal="worker-1",
+                    content_type="text/plain",
+                    metadata_json={
+                        "source": "agent-runtime",
+                        "artifact_path": reserved_path,
                     },
                 )
 


### PR DESCRIPTION
## Summary

Implements MM-368 by enforcing artifact-backed image input attachments for task-shaped executions.

- Preserves objective-scoped and step-scoped `inputAttachments` in task parameters and original task input snapshots.
- Validates attachment policy at execution submission, including disabled policy, allowed image types, count and size limits, completed artifacts, metadata consistency, unsupported future fields, and unsupported target runtimes.
- Validates task input image artifact completion with PNG/JPEG/WebP signature checks and unconditional `image/svg+xml` rejection.
- Prevents worker-side uploads from targeting reserved input attachment namespaces.
- Adds MoonSpec artifacts, final verification, and alignment report for MM-368.

## Verification

MoonSpec verdict: `FULLY_IMPLEMENTED`

Commands run:

- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py::test_create_task_shaped_execution_rejects_unsupported_runtime_with_attachments -q` - PASS
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py -q` - PASS, 80 passed, 12 warnings
- `MOONMIND_FORCE_LOCAL_TESTS=1 pytest tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_artifacts.py tests/unit/api/routers/test_temporal_artifacts.py tests/contract/test_temporal_execution_api.py -q` - PASS, 111 passed, 13 warnings
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, Python 3467 passed, 1 xpassed, 16 subtests passed; frontend Vitest 236 tests passed

## Jira

MM-368