### PR TITLE
MM-376 Canonical Create Page Shell

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/194-oauth-terminal-docker-verification"
+  "feature_directory": "specs/195-canonical-create-page-shell"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ Key diagnostics:
 - No new persistent storage; this story defines compact runtime contracts and deterministic outputs that can later be persisted by the managed-session store or export sinks (191-claude-governance-telemetry)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing OAuth provider registry, existing OAuth session workflow/activity catalog, existing terminal bridge runtime helpers (192-oauth-runner-bootstrap-pty)
 - Existing OAuth session database row and workflow/activity payloads only; no new persistent storage (192-oauth-runner-bootstrap-pty)
+- TypeScript/React for Mission Control UI, Python 3.12 for FastAPI route tests + React, FastAPI, existing boot payload helpers, existing task dashboard router, Vitest, pytest (195-canonical-create-page-shell)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/docs/tmp/jira-orchestration-inputs/MM-376-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-376-moonspec-orchestration-input.md
@@ -1,0 +1,91 @@
+# MM-376 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-376
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Canonical Create Page Shell
+- Labels: `moonmind-workflow-mm-5818081f-60f0-45dd-ad16-3f7753de93ae`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-376 from MM project
+Summary: Canonical Create Page Shell
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-376 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-376: Canonical Create Page Shell
+
+Short Name
+canonical-create-page-shell
+
+User Story
+As a task author, I can open the canonical Create page and use one MoonMind-native task composition form whose route, hosting, section order, and API boundaries are consistent across create, edit, and rerun entry points.
+
+Acceptance Criteria
+- Given I navigate to `/tasks/new`, then the server-hosted Mission Control UI renders the Create page from the server-provided runtime boot payload.
+- Given a compatibility route exists, when I visit it, then it redirects to `/tasks/new` and does not define separate product behavior.
+- Given the page renders, then the form sections appear in this order: Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+- Given any page action occurs, then the browser calls MoonMind REST APIs rather than Jira, object storage, or model providers directly.
+- Given optional presets, Jira, or image upload are unavailable, then manual task authoring remains available.
+
+Requirements
+- Expose `/tasks/new` as the canonical Create page route.
+- Render task creation, edit, and rerun modes through the same task-first composition surface.
+- Build runtime configuration server-side and pass it through the boot payload.
+- Keep artifact, Jira, provider, and object-storage interactions behind MoonMind API surfaces.
+- Preserve the canonical section order and task-first product stance.
+- Redirect compatibility aliases to `/tasks/new` without defining separate product behavior.
+- Preserve manual task authoring when optional presets, Jira import, or image upload are unavailable.
+
+Independent Test
+Create page coverage verifies that `/tasks/new` renders through the server-hosted Mission Control UI with server-provided runtime boot payload, compatibility aliases redirect to `/tasks/new`, the canonical section order is stable, page actions call MoonMind REST APIs only, and manual task authoring remains available when optional integrations are unavailable.
+
+Source Document
+- `docs/UI/CreatePage.md`
+
+Source Sections
+- 1. Purpose
+- 3. Product stance
+- 4. Route and hosting model
+- 5. Canonical page model
+- 19. Summary
+
+Coverage IDs
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-003
+- DESIGN-REQ-004
+
+Relevant Implementation Notes
+- The Create page is the single task-authoring surface for composing manual steps, applying task presets, importing Jira text and allowed images into declared draft targets, selecting dependencies, configuring execution options, and creating, editing, or rerunning task-shaped Temporal executions.
+- The Create page is a MoonMind-native task authoring surface, not a generic workflow builder, Jira-native surface, image editor, or binary transport layer.
+- Browser clients must call only MoonMind APIs; they must not call Jira, object storage, or model providers directly.
+- The canonical route is `/tasks/new`; compatibility aliases may exist only as redirects and must not create separate behavior.
+- The page is server-hosted by FastAPI and rendered by the Mission Control React/Vite UI.
+- Runtime configuration is generated server-side and passed through the boot payload.
+- Representative implementation surfaces are `frontend/src/entrypoints/task-create.tsx` and `api_service/api/routers/task_dashboard_view_model.py`.
+- The canonical page model is a single composition form ordered as Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+
+Out of Scope
+- Turning the Create page into a generic workflow builder.
+- Direct browser integrations with Jira, object storage, or model providers.
+- Changing task preset semantics beyond preserving the canonical task-first shell.
+- Changing image attachment behavior beyond preserving explicit structured input targets.
+
+Verification
+- Run focused frontend tests for the Create page entrypoint and routing behavior.
+- Verify server-side runtime boot payload generation for `/tasks/new`.
+- Verify compatibility route redirects to `/tasks/new`.
+- Verify Create page actions use MoonMind REST APIs only.
+- Run `./tools/test_unit.sh` before completion when implementation changes are made.
+
+Needs Clarification
+- None

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -143,6 +143,36 @@ function withAttachmentPolicy(payload: BootPayload = mockPayload): BootPayload {
   };
 }
 
+function withoutOptionalAuthoringIntegrations(
+  payload: BootPayload = mockPayload,
+): BootPayload {
+  const initialData = payload.initialData as {
+    dashboardConfig: {
+      sources?: Record<string, unknown>;
+      system?: Record<string, unknown>;
+    };
+  };
+  const { jira: _jiraSources, ...sources } =
+    initialData.dashboardConfig.sources || {};
+  const {
+    jiraIntegration: _jiraIntegration,
+    attachmentPolicy: _attachmentPolicy,
+    taskTemplateCatalog: _taskTemplateCatalog,
+    ...system
+  } = initialData.dashboardConfig.system || {};
+  return {
+    ...payload,
+    initialData: {
+      ...initialData,
+      dashboardConfig: {
+        ...initialData.dashboardConfig,
+        sources,
+        system,
+      },
+    },
+  };
+}
+
 function withJiraSessionMemory(
   rememberLastBoardInSession: boolean,
   payload: BootPayload = mockPayload,
@@ -211,6 +241,12 @@ describe("Task Create Entrypoint", () => {
       string,
       unknown
     >;
+  }
+
+  function canonicalCreateSections(): string[] {
+    return Array.from(
+      document.querySelectorAll<HTMLElement>("[data-canonical-create-section]"),
+    ).map((element) => element.dataset.canonicalCreateSection || "");
   }
 
   beforeEach(() => {
@@ -3608,6 +3644,106 @@ describe("Task Create Entrypoint", () => {
     expect(await screen.findByDisplayValue("3")).not.toBeNull();
     expect(screen.getByText("Task Presets (optional)")).not.toBeNull();
     expect(screen.getByText("Schedule (optional)")).not.toBeNull();
+  });
+
+  it("exposes the canonical Create page section order in create mode", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    await screen.findByText("Step 1 (Primary)");
+
+    expect(canonicalCreateSections()).toEqual([
+      "Header",
+      "Steps",
+      "Task Presets",
+      "Dependencies",
+      "Execution context",
+      "Execution controls",
+      "Schedule",
+      "Submit",
+    ]);
+  });
+
+  it("uses the same Create page composition surface for edit and rerun modes", async () => {
+    const { unmount } = renderForEdit("mm:artifact-edit");
+
+    await screen.findByRole("heading", { name: "Edit Task" });
+    expect(canonicalCreateSections()).toEqual([
+      "Header",
+      "Steps",
+      "Task Presets",
+      "Dependencies",
+      "Execution context",
+      "Execution controls",
+      "Submit",
+    ]);
+    unmount();
+
+    window.history.pushState(
+      {},
+      "Task Rerun",
+      "/tasks/new?rerunExecutionId=mm%3Arerun-123",
+    );
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    await screen.findByRole("heading", { name: "Rerun Task" });
+    expect(canonicalCreateSections()).toEqual([
+      "Header",
+      "Steps",
+      "Task Presets",
+      "Dependencies",
+      "Execution context",
+      "Execution controls",
+      "Submit",
+    ]);
+  });
+
+  it("keeps manual authoring available without optional presets Jira or image upload", async () => {
+    renderWithClient(
+      <TaskCreatePage payload={withoutOptionalAuthoringIntegrations()} />,
+    );
+
+    expect(await screen.findByText("Step 1 (Primary)")).not.toBeNull();
+    expect(await screen.findByLabelText("Instructions")).not.toBeNull();
+    expect(screen.queryByLabelText("Preset")).toBeNull();
+    expect(screen.queryByText("Browse Jira issue")).toBeNull();
+    expect(screen.queryByLabelText(/attachments/i)).toBeNull();
+    expect(screen.getByRole("button", { name: "Create" })).not.toBeNull();
+  });
+
+  it("uses only MoonMind REST endpoints while submitting a manually authored task", async () => {
+    renderWithClient(
+      <TaskCreatePage payload={withoutOptionalAuthoringIntegrations()} />,
+    );
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Submit through MoonMind REST only." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const urls = fetchSpy.mock.calls.map(([url]) => String(url));
+    expect(urls).toContain("/api/executions");
+    expect(
+      urls.every(
+        (url) =>
+          url.startsWith("/api/") ||
+          url.startsWith("/api?") ||
+          url === "/api",
+      ),
+    ).toBe(true);
+    expect(
+      urls.some((url) =>
+        /atlassian|jira\.|amazonaws|storage\.googleapis|openai|anthropic|googleapis/i.test(
+          url,
+        ),
+      ),
+    ).toBe(false);
   });
 
   it("updates provider-profile options when the selected runtime changes", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -4288,9 +4288,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
   return (
     <div className="stack">
-      <div>
+      <section data-canonical-create-section="Header" aria-label="Header">
         <h2 className="page-title">{pageTitle}</h2>
-      </div>
+      </section>
 
       {pageMode.mode !== "create" && temporalDraftQuery.isLoading ? (
         <p className="notice" role="status">
@@ -4562,7 +4562,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           disabled={isTemporalFormBlocked}
           aria-busy={isTemporalFormBlocked}
         >
-        <section className="queue-steps-section stack">
+        <section
+          className="queue-steps-section stack"
+          data-canonical-create-section="Steps"
+          aria-label="Steps"
+        >
           <div id="queue-steps-list" className="stack">
             <datalist id={SKILL_OPTIONS_DATALIST_ID}>
               <option value="auto" />
@@ -4807,7 +4811,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         </details>
 
         {taskTemplateCatalogEnabled ? (
-          <div className="card stack">
+          <section
+            className="card stack"
+            data-canonical-create-section="Task Presets"
+            aria-label="Task Presets"
+          >
             <div className="actions">
               <strong>Task Presets (optional)</strong>
             </div>
@@ -4882,10 +4890,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             <p className="small" id="queue-template-message">
               {presetStatusText}
             </p>
-          </div>
+          </section>
         ) : null}
 
-        <section className="card stack">
+        <section
+          className="card stack"
+          data-canonical-create-section="Dependencies"
+          aria-label="Dependencies"
+        >
           <div>
             <strong>Dependencies</strong>
             <p className="small">
@@ -4961,6 +4973,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           </p>
         </section>
 
+        <section
+          className="stack"
+          data-canonical-create-section="Execution context"
+          aria-label="Execution context"
+        >
         <label>
           Runtime
           <select
@@ -5098,7 +5115,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             </span>
           </label>
         ) : null}
+        </section>
 
+        <section
+          className="stack"
+          data-canonical-create-section="Execution controls"
+          aria-label="Execution controls"
+        >
         <div className="grid-2" data-runtime-visibility="worker">
           <label>
             Priority
@@ -5135,9 +5158,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           />
           Propose Tasks
         </label>
+        </section>
 
         {pageMode.mode === "create" ? (
-        <details className="card" id="schedule-panel">
+        <details
+          className="card"
+          id="schedule-panel"
+          data-canonical-create-section="Schedule"
+          aria-label="Schedule"
+        >
           <summary>
             <strong>Schedule (optional)</strong>
           </summary>
@@ -5238,6 +5267,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         </details>
         ) : null}
 
+        <section
+          className="stack"
+          data-canonical-create-section="Submit"
+          aria-label="Submit"
+        >
         <div className="actions">
           <button
             type="submit"
@@ -5249,7 +5283,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             {primaryCta}
           </button>
         </div>
-        </fieldset>
 
         <p
           id="queue-submit-message"
@@ -5261,6 +5294,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         >
           {submitMessage || ""}
         </p>
+        </section>
+        </fieldset>
       </form>
     </div>
   );

--- a/specs/195-canonical-create-page-shell/checklists/requirements.md
+++ b/specs/195-canonical-create-page-shell/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Canonical Create Page Shell
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The input is classified as a single-story runtime feature request from Jira issue MM-376.
+- Source design requirements from `docs/UI/CreatePage.md` are mapped to functional requirements.

--- a/specs/195-canonical-create-page-shell/contracts/create-page-shell.md
+++ b/specs/195-canonical-create-page-shell/contracts/create-page-shell.md
@@ -1,0 +1,55 @@
+# Contract: Create Page Shell
+
+## Server Route Contract
+
+`GET /tasks/new`
+
+Expected behavior:
+- Requires the same dashboard authentication as other Mission Control task pages.
+- Returns the Mission Control React shell.
+- Boot payload `page` is `task-create`.
+- Boot payload `initialData.dashboardConfig` is built for current path `/tasks/new`.
+
+`GET /tasks/create`
+
+Expected behavior:
+- Returns a redirect to `/tasks/new`.
+- Does not render a separate Create page shell.
+
+## Browser Shell Contract
+
+The Create page form exposes canonical section metadata using `data-canonical-create-section`.
+
+Create mode section order:
+1. Header
+2. Steps
+3. Task Presets
+4. Dependencies
+5. Execution context
+6. Execution controls
+7. Schedule
+8. Submit
+
+Edit and rerun modes:
+- Use the same task composition page entrypoint.
+- May omit creation-only schedule controls.
+- Must preserve Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, and Submit ordering.
+
+## REST Boundary Contract
+
+Browser actions use MoonMind REST endpoints from the boot payload or defaults:
+- Task creation: configured temporal create endpoint, default `/api/executions`.
+- Task update/rerun: configured temporal update endpoint.
+- Artifact operations: configured temporal artifact endpoints.
+- Jira browsing: configured `/api/jira/...` endpoints when Jira integration is enabled.
+- Provider profile selection: configured `/api/v1/provider-profiles`.
+- Task presets: configured `/api/task-step-templates...` endpoints.
+
+The browser must not call Jira, object storage, or model provider URLs directly as part of this page shell story.
+
+## Optional Integration Contract
+
+When optional integrations are unavailable:
+- Missing Jira configuration hides Jira browsing without disabling manual instructions.
+- Missing or disabled attachment policy hides image upload without disabling manual instructions.
+- Missing task preset catalog hides or disables preset controls without disabling manual steps and task submission.

--- a/specs/195-canonical-create-page-shell/data-model.md
+++ b/specs/195-canonical-create-page-shell/data-model.md
@@ -1,0 +1,45 @@
+# Data Model: Canonical Create Page Shell
+
+## Create Page Shell
+
+Represents the browser-visible task authoring surface served at `/tasks/new`.
+
+Fields:
+- `route`: canonical page path. Must be `/tasks/new`.
+- `page`: boot payload page id. Must be `task-create`.
+- `runtimeConfig`: server-generated endpoint and feature configuration.
+- `sections`: ordered collection of canonical section identifiers.
+
+Validation rules:
+- `route` must remain `/tasks/new`.
+- Compatibility routes may redirect to `/tasks/new` but must not produce their own shell state.
+- `runtimeConfig` must come from the server boot payload.
+
+## Canonical Section
+
+Represents a stable Create page form region.
+
+Fields:
+- `name`: one of Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+- `order`: one-based section position.
+- `available`: whether the section is currently present for the page mode/runtime configuration.
+
+Validation rules:
+- Create mode must expose Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit in that order when task presets are enabled.
+- Optional integration content inside a section must not prevent the base manual authoring surface from rendering.
+- Edit and rerun mode may hide creation-only schedule controls while preserving the same composition surface.
+
+## Runtime Boot Payload
+
+Represents server-provided page configuration consumed by the React entrypoint.
+
+Fields:
+- `page`: Mission Control page id.
+- `initialData.dashboardConfig.sources`: MoonMind REST endpoints.
+- `initialData.dashboardConfig.system`: runtime defaults and optional feature config.
+- `initialData.dashboardConfig.features`: enabled product capabilities.
+
+Validation rules:
+- The Create page boot payload must identify the `task-create` page.
+- Browser code must use configured MoonMind REST endpoints for page actions.
+- Missing optional Jira or attachment settings must not block manual task authoring.

--- a/specs/195-canonical-create-page-shell/plan.md
+++ b/specs/195-canonical-create-page-shell/plan.md
@@ -1,0 +1,75 @@
+# Implementation Plan: Canonical Create Page Shell
+
+**Branch**: `195-canonical-create-page-shell` | **Date**: 2026-04-17 | **Spec**: `specs/195-canonical-create-page-shell/spec.md`  
+**Input**: Single-story feature specification from `specs/195-canonical-create-page-shell/spec.md`
+
+## Summary
+
+Implement MM-376 by making the existing Create page shell explicitly expose the canonical task-first section model while preserving the existing server route, boot payload, create/edit/rerun composition flow, and MoonMind REST-only boundary. The technical approach is to add stable section metadata around existing Create page controls without changing task submission semantics, and to extend focused backend and frontend tests for route hosting, section order, edit/rerun reuse, REST endpoint use, and optional-integration absence.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI, Python 3.12 for FastAPI route tests  
+**Primary Dependencies**: React, FastAPI, existing boot payload helpers, existing task dashboard router, Vitest, pytest  
+**Storage**: No new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py` and `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: Existing UI request-shape tests exercise the browser-to-MoonMind REST boundary; no new compose dependency is required for this shell story  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web UI plus FastAPI shell route  
+**Performance Goals**: No additional network requests and no extra render-blocking data dependencies  
+**Constraints**: Keep `/tasks/new` canonical, keep compatibility routes redirect-only, keep optional integrations optional, keep browser calls behind MoonMind REST endpoints, and preserve edit/rerun reuse of the task composition surface  
+**Scale/Scope**: One Create page shell and its existing route/tests
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Preserves existing task orchestration routes and does not introduce a competing runtime.
+- II. One-Click Agent Deployment: PASS. No new services, secrets, or deployment dependencies.
+- III. Avoid Vendor Lock-In: PASS. Browser calls stay behind MoonMind APIs instead of direct provider calls.
+- IV. Own Your Data: PASS. Task inputs and artifacts continue through MoonMind-controlled endpoints.
+- V. Skills Are First-Class and Easy to Add: PASS. The task-first form remains compatible with existing skill and preset selection.
+- VI. Replaceable Scaffolding: PASS. Adds contract tests around the UI shell rather than coupling to volatile implementation internals.
+- VII. Runtime Configurability: PASS. Runtime configuration remains server-generated and passed through the boot payload.
+- VIII. Modular Architecture: PASS. Route hosting remains in the dashboard router; UI shell grouping remains in the Create page entrypoint.
+- IX. Resilient by Default: PASS. Optional integrations remain non-blocking and manual authoring stays available.
+- X. Continuous Improvement: PASS. Verification evidence will be recorded in `verification.md`.
+- XI. Spec-Driven Development: PASS. Runtime changes follow this one-story Moon Spec.
+- XII. Canonical Documentation Separation: PASS. Desired-state docs remain canonical; implementation evidence stays under `specs/` and `docs/tmp`.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility alias is added; existing redirect behavior is tested and preserved.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/195-canonical-create-page-shell/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-shell.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/api/routers/
+├── task_dashboard.py
+└── task_dashboard_view_model.py
+
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+
+tests/unit/api/routers/
+└── test_task_dashboard.py
+```
+
+**Structure Decision**: Preserve the existing server route and Create page entrypoint. Add explicit canonical section metadata in the React shell, and extend existing route and UI tests rather than introducing new modules.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/195-canonical-create-page-shell/quickstart.md
+++ b/specs/195-canonical-create-page-shell/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart: Canonical Create Page Shell
+
+## Focused Validation
+
+Run the backend route coverage:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py
+```
+
+Run the focused Create page UI coverage:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+## End-to-End Story Checks
+
+1. Open `/tasks/new`.
+2. Confirm the page is the Create page rendered from the Mission Control React shell.
+3. Confirm the canonical section order in create mode is Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+4. Visit `/tasks/create` and confirm it redirects to `/tasks/new`.
+5. Submit a manual task with optional Jira and attachment controls unavailable and confirm the browser posts to the MoonMind task creation endpoint.
+6. Open edit and rerun URLs under `/tasks/new` and confirm they reuse the same task composition surface.
+
+## Final Validation
+
+Run the full unit suite before completion:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```

--- a/specs/195-canonical-create-page-shell/research.md
+++ b/specs/195-canonical-create-page-shell/research.md
@@ -1,0 +1,33 @@
+# Research: Canonical Create Page Shell
+
+## Route Hosting
+
+Decision: Preserve the existing FastAPI `/tasks/new` route and `/tasks/create` redirect alias.
+
+Rationale: The current router already serves `task-create` with `build_runtime_config("/tasks/new")` and redirects `/tasks/create` to `/tasks/new`. The story needs validation and explicit shell behavior, not a new route.
+
+Alternatives considered: Adding another route or client-side redirect was rejected because the source design requires `/tasks/new` as canonical and compatibility aliases to redirect rather than define product behavior.
+
+## Canonical Section Exposure
+
+Decision: Add stable `data-canonical-create-section` metadata and accessible labels to existing Create page regions.
+
+Rationale: The current form already contains the required controls, but the section model is not explicit enough for tests or downstream tooling to assert the desired order. Metadata preserves visual behavior while making the shell contract deterministic.
+
+Alternatives considered: Adding large visible headings was rejected because it would change product copy and layout more than needed for the story. Snapshot-style DOM tests were rejected because they are brittle.
+
+## Optional Integration Behavior
+
+Decision: Validate manual authoring with default boot payload settings that omit Jira and attachment policy while keeping task template behavior optional through the existing runtime config.
+
+Rationale: Manual steps and submission already exist independently of Jira and image attachments. Tests should prove this contract without requiring disabled integrations to be simulated by external services.
+
+Alternatives considered: Adding new feature flags was rejected because optional integration availability already flows through server runtime configuration.
+
+## Test Strategy
+
+Decision: Use focused Vitest tests for shell section order, edit/rerun reuse, REST submission endpoint, and optional-integration absence; use existing pytest route tests for server hosting and redirect behavior.
+
+Rationale: These tests cover the browser and server boundaries named by the story without requiring Docker-backed services.
+
+Alternatives considered: Playwright end-to-end coverage was rejected for this story because the existing unit/UI harness already exercises the required shell and request-shape behavior hermetically.

--- a/specs/195-canonical-create-page-shell/spec.md
+++ b/specs/195-canonical-create-page-shell/spec.md
@@ -1,0 +1,174 @@
+# Feature Specification: Canonical Create Page Shell
+
+**Feature Branch**: `195-canonical-create-page-shell`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**:
+
+```text
+# MM-376 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-376
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Canonical Create Page Shell
+- Labels: `moonmind-workflow-mm-5818081f-60f0-45dd-ad16-3f7753de93ae`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-376 from MM project
+Summary: Canonical Create Page Shell
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-376 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-376: Canonical Create Page Shell
+
+Short Name
+canonical-create-page-shell
+
+User Story
+As a task author, I can open the canonical Create page and use one MoonMind-native task composition form whose route, hosting, section order, and API boundaries are consistent across create, edit, and rerun entry points.
+
+Acceptance Criteria
+- Given I navigate to `/tasks/new`, then the server-hosted Mission Control UI renders the Create page from the server-provided runtime boot payload.
+- Given a compatibility route exists, when I visit it, then it redirects to `/tasks/new` and does not define separate product behavior.
+- Given the page renders, then the form sections appear in this order: Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+- Given any page action occurs, then the browser calls MoonMind REST APIs rather than Jira, object storage, or model providers directly.
+- Given optional presets, Jira, or image upload are unavailable, then manual task authoring remains available.
+
+Requirements
+- Expose `/tasks/new` as the canonical Create page route.
+- Render task creation, edit, and rerun modes through the same task-first composition surface.
+- Build runtime configuration server-side and pass it through the boot payload.
+- Keep artifact, Jira, provider, and object-storage interactions behind MoonMind API surfaces.
+- Preserve the canonical section order and task-first product stance.
+- Redirect compatibility aliases to `/tasks/new` without defining separate product behavior.
+- Preserve manual task authoring when optional presets, Jira import, or image upload are unavailable.
+
+Independent Test
+Create page coverage verifies that `/tasks/new` renders through the server-hosted Mission Control UI with server-provided runtime boot payload, compatibility aliases redirect to `/tasks/new`, the canonical section order is stable, page actions call MoonMind REST APIs only, and manual task authoring remains available when optional integrations are unavailable.
+
+Source Document
+- `docs/UI/CreatePage.md`
+
+Source Sections
+- 1. Purpose
+- 3. Product stance
+- 4. Route and hosting model
+- 5. Canonical page model
+- 19. Summary
+
+Coverage IDs
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-003
+- DESIGN-REQ-004
+
+Relevant Implementation Notes
+- The Create page is the single task-authoring surface for composing manual steps, applying task presets, importing Jira text and allowed images into declared draft targets, selecting dependencies, configuring execution options, and creating, editing, or rerunning task-shaped Temporal executions.
+- The Create page is a MoonMind-native task authoring surface, not a generic workflow builder, Jira-native surface, image editor, or binary transport layer.
+- Browser clients must call only MoonMind APIs; they must not call Jira, object storage, or model providers directly.
+- The canonical route is `/tasks/new`; compatibility aliases may exist only as redirects and must not create separate behavior.
+- The page is server-hosted by FastAPI and rendered by the Mission Control React/Vite UI.
+- Runtime configuration is generated server-side and passed through the boot payload.
+- Representative implementation surfaces are `frontend/src/entrypoints/task-create.tsx` and `api_service/api/routers/task_dashboard_view_model.py`.
+- The canonical page model is a single composition form ordered as Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+
+Out of Scope
+- Turning the Create page into a generic workflow builder.
+- Direct browser integrations with Jira, object storage, or model providers.
+- Changing task preset semantics beyond preserving the canonical task-first shell.
+- Changing image attachment behavior beyond preserving explicit structured input targets.
+
+Verification
+- Run focused frontend tests for the Create page entrypoint and routing behavior.
+- Verify server-side runtime boot payload generation for `/tasks/new`.
+- Verify compatibility route redirects to `/tasks/new`.
+- Verify Create page actions use MoonMind REST APIs only.
+- Run `./tools/test_unit.sh` before completion when implementation changes are made.
+
+Needs Clarification
+- None
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include product behavior checks, production shell structure where missing, and validation tests.
+
+## User Story - Canonical Create Page Shell
+
+**Summary**: As a task author, I want `/tasks/new` to render one MoonMind-native task composition form so that create, edit, and rerun entry points use the same route, hosting model, section order, and MoonMind API boundaries.
+
+**Goal**: Task authors can rely on `/tasks/new` as the canonical Create page with a stable task-first shell, server-provided runtime configuration, redirect-only compatibility aliases, and manual authoring that continues to work when optional integrations are unavailable.
+
+**Independent Test**: Render and submit the Create page with optional integrations disabled and enabled. The story passes when `/tasks/new` receives the server boot payload, compatibility aliases redirect to `/tasks/new`, the canonical section order is exposed as Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit, submission uses MoonMind REST endpoints only, and manual task authoring remains available without presets, Jira, or image upload.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author navigates to `/tasks/new`, **when** the server responds, **then** the Mission Control React shell is rendered with a boot payload that contains Create page runtime configuration.
+2. **Given** a compatibility create route exists, **when** a task author visits it, **then** it redirects to `/tasks/new` and does not render separate Create page behavior.
+3. **Given** the Create page renders, **when** the form shell is inspected, **then** its canonical sections are exposed in this order: Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+4. **Given** a task author submits a manually authored task, **when** the browser performs network requests, **then** task creation, artifact, Jira, provider profile, and template interactions use MoonMind REST endpoints rather than direct Jira, object-storage, or model-provider calls.
+5. **Given** optional presets, Jira integration, and image upload are unavailable, **when** the Create page renders, **then** manual task authoring and task submission remain available.
+6. **Given** edit or rerun mode opens through `/tasks/new`, **when** the draft loads, **then** it uses the same Create page composition surface rather than a separate edit or rerun page.
+
+### Edge Cases
+
+- Runtime configuration omits optional template catalog settings.
+- Runtime configuration omits Jira integration settings.
+- Runtime configuration disables attachment policy or omits artifact upload affordances.
+- Compatibility aliases include a trailing slash or malformed path.
+- The page is opened in edit or rerun mode with query parameters.
+
+## Assumptions
+
+- The existing FastAPI task dashboard route remains the server-hosted entry point for Mission Control pages.
+- Existing Create page controls may be grouped into explicit canonical shell sections without changing their task submission semantics.
+- Browser provider-profile and template catalog fetches are MoonMind REST calls and are allowed page actions.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source section 1 requires the Create page to be the single task-authoring surface for manual steps, attachments, presets, Jira imports, dependencies, execution configuration, and create/edit/rerun of task-shaped Temporal executions. Scope: in scope. Maps to FR-001, FR-004, FR-005, FR-006, and FR-009.
+- **DESIGN-REQ-002**: Source section 3 requires the Create page to remain a MoonMind-native task authoring surface, with browser clients calling MoonMind APIs and manual authoring remaining first-class when optional integrations are unavailable. Scope: in scope. Maps to FR-006, FR-007, FR-008, and FR-009.
+- **DESIGN-REQ-003**: Source section 4 requires `/tasks/new` to be the canonical route, compatibility aliases to redirect to it, server-side runtime configuration to flow through the boot payload, and all page actions to use MoonMind REST APIs. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-007, and FR-009.
+- **DESIGN-REQ-004**: Source sections 5 and 19 require a single task-first composition form with the canonical sections ordered as Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit, while avoiding image-editor, Jira-native, or binary-transport behavior. Scope: in scope. Maps to FR-004, FR-005, FR-006, FR-008, and FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST serve the Create page at `/tasks/new` through the Mission Control React shell.
+- **FR-002**: The `/tasks/new` server response MUST include server-generated runtime configuration in the boot payload.
+- **FR-003**: Compatibility create routes MUST redirect to `/tasks/new` and MUST NOT define separate product behavior.
+- **FR-004**: The Create page MUST expose exactly one task-first composition form for create mode.
+- **FR-005**: Edit and rerun modes opened from `/tasks/new` MUST use the same composition surface as create mode.
+- **FR-006**: The Create page form shell MUST expose canonical sections in this order: Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+- **FR-007**: Create page browser actions MUST call MoonMind REST API endpoints and MUST NOT call Jira, object storage, or model providers directly.
+- **FR-008**: Manual task authoring and submission MUST remain available when optional presets, Jira integration, or image upload are unavailable.
+- **FR-009**: The Create page MUST remain a MoonMind-native task surface and MUST NOT become a generic workflow builder, Jira-native surface, image editor, or binary transport layer.
+- **FR-010**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key MM-376.
+
+### Key Entities
+
+- **Create Page Shell**: The server-rendered Mission Control page that hosts the task composition form and receives runtime configuration through the boot payload.
+- **Task Composition Form**: The single form used for create, edit, and rerun task authoring.
+- **Canonical Section**: An ordered form region with one of the section names defined by the Create Page desired-state contract.
+- **Runtime Boot Payload**: Server-generated configuration passed to the browser to define MoonMind REST endpoints and optional feature availability.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Backend route tests verify `/tasks/new` renders the React shell and includes the Create page boot payload.
+- **SC-002**: Backend route tests verify compatibility create aliases redirect to `/tasks/new` without rendering independent content.
+- **SC-003**: Frontend tests verify the canonical section order is Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit.
+- **SC-004**: Frontend tests verify create, edit, and rerun modes use the same Create page composition surface.
+- **SC-005**: Frontend request-shape tests verify task submission uses the configured MoonMind REST create endpoint.
+- **SC-006**: Frontend tests verify manual task authoring remains available when optional presets, Jira integration, and image upload are absent.
+- **SC-007**: Verification evidence preserves MM-376 as the source Jira issue for the feature.

--- a/specs/195-canonical-create-page-shell/tasks.md
+++ b/specs/195-canonical-create-page-shell/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: Canonical Create Page Shell
+
+**Input**: Design documents from `specs/195-canonical-create-page-shell/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and UI/request-shape integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code.
+
+**Test Commands**:
+
+- Backend route tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py`
+- Focused UI tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Full unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final verification: `/moonspec-verify`
+
+## Traceability Inventory
+
+- FR-001, FR-002, SC-001, DESIGN-REQ-003: `/tasks/new` server shell and boot payload.
+- FR-003, SC-002, DESIGN-REQ-003: compatibility route redirects to `/tasks/new`.
+- FR-004, FR-005, FR-006, SC-003, SC-004, DESIGN-REQ-001, DESIGN-REQ-004: one composition form and canonical section order across create/edit/rerun.
+- FR-007, SC-005, DESIGN-REQ-002, DESIGN-REQ-003: browser actions use MoonMind REST endpoints.
+- FR-008, SC-006, DESIGN-REQ-001, DESIGN-REQ-002: manual authoring works without optional presets, Jira, or image upload.
+- FR-009, DESIGN-REQ-004: scope stays task-first and MoonMind-native.
+- FR-010, SC-007: MM-376 remains visible in artifacts and verification.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm MM-376 source input and single-story traceability in `docs/tmp/jira-orchestration-inputs/MM-376-moonspec-orchestration-input.md` and `specs/195-canonical-create-page-shell/spec.md`.
+- [X] T002 Confirm existing Create page route and shell surfaces in `api_service/api/routers/task_dashboard.py`, `api_service/api/routers/task_dashboard_view_model.py`, and `frontend/src/entrypoints/task-create.tsx`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing test harnesses cover backend dashboard routes and Create page UI behavior in `tests/unit/api/routers/test_task_dashboard.py` and `frontend/src/entrypoints/task-create.test.tsx`.
+
+## Phase 3: Story - Canonical Create Page Shell
+
+**Summary**: As a task author, I want `/tasks/new` to render one MoonMind-native task composition form so that create, edit, and rerun entry points use the same route, hosting model, section order, and MoonMind API boundaries.
+
+**Independent Test**: Render and submit the Create page with optional integrations disabled and enabled. The story passes when `/tasks/new` receives the server boot payload, compatibility aliases redirect to `/tasks/new`, the canonical section order is exposed as Header, Steps, Task Presets, Dependencies, Execution context, Execution controls, Schedule, Submit, submission uses MoonMind REST endpoints only, and manual task authoring remains available without presets, Jira, or image upload.
+
+**Traceability**: FR-001 through FR-010, SC-001 through SC-007, DESIGN-REQ-001 through DESIGN-REQ-004, MM-376.
+
+### Unit Tests
+
+- [X] T004 Add backend route test assertions for `/tasks/new` boot payload page and current-path runtime config in `tests/unit/api/routers/test_task_dashboard.py` (FR-001, FR-002, SC-001, DESIGN-REQ-003).
+- [X] T005 Add frontend shell tests for canonical Create page section order in create mode in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, FR-006, SC-003, DESIGN-REQ-004).
+- [X] T006 Add frontend shell tests proving edit and rerun modes reuse the Create page composition surface in `frontend/src/entrypoints/task-create.test.tsx` (FR-005, SC-004, DESIGN-REQ-001).
+- [X] T007 Add frontend tests proving manual authoring remains available without optional Jira, attachment policy, or task preset catalog in `frontend/src/entrypoints/task-create.test.tsx` (FR-008, SC-006, DESIGN-REQ-002).
+
+### Integration Tests
+
+- [X] T008 Add or update UI request-shape test proving task submission uses the configured MoonMind REST create endpoint and no direct external endpoint in `frontend/src/entrypoints/task-create.test.tsx` (FR-007, SC-005, DESIGN-REQ-003).
+- [X] T009 Run backend route and focused UI tests to confirm new shell tests fail for missing explicit section metadata or payload assertions before production edits.
+
+### Implementation
+
+- [X] T010 Add stable canonical section metadata and accessible labels around the Create page header, steps, task presets, dependencies, execution context, execution controls, schedule, and submit regions in `frontend/src/entrypoints/task-create.tsx` (FR-004, FR-006, FR-009, DESIGN-REQ-004).
+- [X] T011 Preserve route and boot payload behavior in `api_service/api/routers/task_dashboard.py` and `api_service/api/routers/task_dashboard_view_model.py`; make only test-driven fixes if route tests expose drift (FR-001, FR-002, FR-003, DESIGN-REQ-003).
+- [X] T012 Run focused backend and UI tests, then fix failures in `frontend/src/entrypoints/task-create.tsx`, `frontend/src/entrypoints/task-create.test.tsx`, or route tests only as needed (FR-001 through FR-009).
+
+## Phase 4: Polish And Verification
+
+- [X] T013 Run full unit suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T014 Run `/moonspec-verify` and record the result in `specs/195-canonical-create-page-shell/verification.md` (FR-010, SC-007).
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story tests.
+- T004-T008 must be written before T010-T011.
+- T009 confirms red-first behavior before implementation.
+- T010-T012 complete the story.
+- T013-T014 run after focused tests pass.
+
+## Parallel Opportunities
+
+- T004 and T005 can be authored independently because they touch different test files.
+- T006, T007, and T008 can be drafted together in the same UI test file but must be validated as one red-first test batch.
+
+## Notes
+
+- This task list covers exactly one story: MM-376.

--- a/specs/195-canonical-create-page-shell/verification.md
+++ b/specs/195-canonical-create-page-shell/verification.md
@@ -1,0 +1,69 @@
+# MoonSpec Verification Report
+
+**Feature**: Canonical Create Page Shell  
+**Spec**: `/work/agent_jobs/mm:8d79e9ee-c046-49f3-9168-b0300bb4f9ee/repo/specs/195-canonical-create-page-shell/spec.md`  
+**Original Request Source**: `spec.md` `Input`, sourced from Jira issue MM-376  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Backend route focus | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py` | PASS | 26 passed during focused route validation. |
+| Focused UI | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` | PASS | Python phase passed; focused Vitest file passed with 119 tests. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python unit phase: 3462 passed, 1 xpassed, 16 subtests passed. Frontend phase: 10 files passed, 240 tests passed. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | This shell story has no compose-backed service boundary or new persisted workflow behavior; route/UI request-shape coverage exercises the relevant browser-to-MoonMind REST boundary. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `api_service/api/routers/task_dashboard.py:403`; `tests/unit/api/routers/test_task_dashboard.py:183` | VERIFIED | `/tasks/new` serves the `task-create` shell. |
+| FR-002 | `api_service/api/routers/task_dashboard.py:414`; `tests/unit/api/routers/test_task_dashboard.py:183` | VERIFIED | Boot payload includes server-generated runtime config for `/tasks/new`. |
+| FR-003 | `api_service/api/routers/task_dashboard.py:418`; `tests/unit/api/routers/test_task_dashboard.py:204` | VERIFIED | `/tasks/create` redirects to `/tasks/new`. |
+| FR-004 | `frontend/src/entrypoints/task-create.tsx:4567`; `frontend/src/entrypoints/task-create.test.tsx:3649` | VERIFIED | Create mode exposes one task-first composition form with canonical shell metadata. |
+| FR-005 | `frontend/src/entrypoints/task-create.tsx:4291`; `frontend/src/entrypoints/task-create.test.tsx:3666` | VERIFIED | Edit and rerun modes reuse the same Create page surface, minus creation-only schedule. |
+| FR-006 | `frontend/src/entrypoints/task-create.tsx:4291`, `frontend/src/entrypoints/task-create.tsx:4567`, `frontend/src/entrypoints/task-create.tsx:4816`, `frontend/src/entrypoints/task-create.tsx:4898`, `frontend/src/entrypoints/task-create.tsx:4978`, `frontend/src/entrypoints/task-create.tsx:5122`, `frontend/src/entrypoints/task-create.tsx:5167`, `frontend/src/entrypoints/task-create.tsx:5272`; `frontend/src/entrypoints/task-create.test.tsx:3649` | VERIFIED | Canonical sections are exposed in order. |
+| FR-007 | `frontend/src/entrypoints/task-create.test.tsx:3713`; `api_service/api/routers/task_dashboard_view_model.py:207` | VERIFIED | Task submission and configured page actions stay behind MoonMind REST endpoint paths. |
+| FR-008 | `frontend/src/entrypoints/task-create.test.tsx:3700` | VERIFIED | Manual instructions and Create submission remain available without optional presets, Jira, or image upload. |
+| FR-009 | `frontend/src/entrypoints/task-create.tsx:4567`; `frontend/src/entrypoints/task-create.test.tsx:3649` | VERIFIED | The change annotates the existing task shell and does not add Jira-native, image-editor, provider-direct, or generic workflow-builder behavior. |
+| FR-010 | `specs/195-canonical-create-page-shell/spec.md`; this report | VERIFIED | MM-376 is preserved in source artifacts and verification. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| Scenario 1 | `tests/unit/api/routers/test_task_dashboard.py:183` | VERIFIED | `/tasks/new` renders `task-create` with runtime config. |
+| Scenario 2 | `tests/unit/api/routers/test_task_dashboard.py:204` | VERIFIED | Compatibility route redirects to `/tasks/new`. |
+| Scenario 3 | `frontend/src/entrypoints/task-create.test.tsx:3649` | VERIFIED | Create mode section order is asserted exactly. |
+| Scenario 4 | `frontend/src/entrypoints/task-create.test.tsx:3713` | VERIFIED | Manual submission posts to MoonMind REST and rejects direct external endpoints. |
+| Scenario 5 | `frontend/src/entrypoints/task-create.test.tsx:3700` | VERIFIED | Manual authoring survives missing optional integrations. |
+| Scenario 6 | `frontend/src/entrypoints/task-create.test.tsx:3666` | VERIFIED | Edit and rerun reuse the Create page composition surface. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-001 | `frontend/src/entrypoints/task-create.test.tsx:3666`; existing create/edit/rerun task shell | VERIFIED | Single task-authoring surface remains shared. |
+| DESIGN-REQ-002 | `frontend/src/entrypoints/task-create.test.tsx:3700`; `frontend/src/entrypoints/task-create.test.tsx:3713` | VERIFIED | MoonMind-native API boundary and manual authoring are covered. |
+| DESIGN-REQ-003 | `api_service/api/routers/task_dashboard.py:403`; `api_service/api/routers/task_dashboard.py:418`; `tests/unit/api/routers/test_task_dashboard.py:183` | VERIFIED | Canonical route, redirect alias, boot payload, and REST boundary are validated. |
+| DESIGN-REQ-004 | `frontend/src/entrypoints/task-create.tsx:4291`; `frontend/src/entrypoints/task-create.test.tsx:3649` | VERIFIED | Canonical section model is explicit and ordered. |
+| Constitution XI | `specs/195-canonical-create-page-shell/spec.md`, `plan.md`, `tasks.md`, and this verification report | VERIFIED | Spec-driven artifacts exist for one story and map to tests. |
+| Constitution XII | `docs/UI/CreatePage.md` remains canonical; implementation notes are under `specs/195-canonical-create-page-shell/` and `docs/tmp/` | VERIFIED | Desired-state docs were not converted into migration backlog. |
+
+## Original Request Alignment
+
+- PASS. The implementation uses the MM-376 Jira preset brief as the canonical Moon Spec input, treats `docs/UI/CreatePage.md` as runtime source requirements, classifies the work as one single-story feature request, and implements the first incomplete stage through verification.
+
+## Gaps
+
+- None.
+
+## Remaining Work
+
+- None.
+
+## Decision
+
+- The story is fully implemented and verified. No additional implementation work is required for MM-376.

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -22,6 +23,21 @@ from api_service.api.routers.task_dashboard import (
     _resolve_user_dependency_overrides,
     router,
 )
+
+
+_BOOT_PAYLOAD_SCRIPT_RE = re.compile(
+    r"<script\b"
+    r"(?=[^>]*\bid=[\"']moonmind-ui-boot[\"'])"
+    r"(?=[^>]*\btype=[\"']application/json[\"'])"
+    r"[^>]*>(?P<payload>.*?)</script>",
+    re.DOTALL,
+)
+
+
+def _extract_boot_payload(response_text: str) -> dict[str, object]:
+    match = _BOOT_PAYLOAD_SCRIPT_RE.search(response_text)
+    assert match is not None
+    return json.loads(match.group("payload"))
 
 
 def _write_dashboard_test_manifest(root: Path) -> Path:
@@ -186,11 +202,7 @@ def test_task_create_route_uses_canonical_boot_payload(client: TestClient) -> No
 
     assert response.status_code == 200
     assert "moonmind-ui-boot" in response.text
-    boot_json = response.text.split(
-        '<script id="moonmind-ui-boot" type="application/json">',
-        maxsplit=1,
-    )[1].split("</script>", maxsplit=1)[0]
-    boot_payload = json.loads(boot_json)
+    boot_payload = _extract_boot_payload(response.text)
 
     assert boot_payload["page"] == "task-create"
     dashboard_config = boot_payload["initialData"]["dashboardConfig"]

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import tempfile
 from contextlib import contextmanager
+from html.parser import HTMLParser
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterator
@@ -25,19 +25,35 @@ from api_service.api.routers.task_dashboard import (
 )
 
 
-_BOOT_PAYLOAD_SCRIPT_RE = re.compile(
-    r"<script\b"
-    r"(?=[^>]*\bid=[\"']moonmind-ui-boot[\"'])"
-    r"(?=[^>]*\btype=[\"']application/json[\"'])"
-    r"[^>]*>(?P<payload>.*?)</script>",
-    re.DOTALL,
-)
+class _BootPayloadParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._capturing = False
+        self.payload_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "script":
+            return
+        attr_map = dict(attrs)
+        self._capturing = (
+            attr_map.get("id") == "moonmind-ui-boot"
+            and attr_map.get("type") == "application/json"
+        )
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing:
+            self.payload_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "script":
+            self._capturing = False
 
 
 def _extract_boot_payload(response_text: str) -> dict[str, object]:
-    match = _BOOT_PAYLOAD_SCRIPT_RE.search(response_text)
-    assert match is not None
-    return json.loads(match.group("payload"))
+    parser = _BootPayloadParser()
+    parser.feed(response_text)
+    assert parser.payload_parts
+    return json.loads("".join(parser.payload_parts))
 
 
 def _write_dashboard_test_manifest(root: Path) -> Path:

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -180,6 +180,27 @@ def test_static_sub_routes_render_react_shell(client: TestClient) -> None:
         assert "__moonmind_customElementsDefineGuard" not in response.text
 
 
+def test_task_create_route_uses_canonical_boot_payload(client: TestClient) -> None:
+    """GET /tasks/new renders the task-create shell with server runtime config."""
+    response = client.get("/tasks/new")
+
+    assert response.status_code == 200
+    assert "moonmind-ui-boot" in response.text
+    boot_json = response.text.split(
+        '<script id="moonmind-ui-boot" type="application/json">',
+        maxsplit=1,
+    )[1].split("</script>", maxsplit=1)[0]
+    boot_payload = json.loads(boot_json)
+
+    assert boot_payload["page"] == "task-create"
+    dashboard_config = boot_payload["initialData"]["dashboardConfig"]
+    assert dashboard_config["initialPath"] == "/tasks/new"
+    assert dashboard_config["sources"]["temporal"]["create"].startswith("/api/")
+    assert dashboard_config["sources"]["temporal"]["artifactCreate"].startswith(
+        "/api/"
+    )
+
+
 def test_alias_routes_redirect_to_canonical_paths(client: TestClient) -> None:
     """GET /tasks/create and /tasks/tasks-list must return 307 redirects to canonical routes."""
     create_resp = client.get("/tasks/create", follow_redirects=False)


### PR DESCRIPTION
## Jira
- Issue: MM-376

## MoonSpec
- Active feature path: `specs/195-canonical-create-page-shell`

## Verification
- Verdict: FULLY_IMPLEMENTED

## Tests Run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

## Remaining Risks
- Hermetic compose-backed integration was not run because this story changes the browser shell, route boot payload, and MoonMind REST request shape without adding a compose-backed service boundary. Coverage is provided by backend route tests, focused UI tests, request-shape assertions, and the full unit suite.