### PR TITLE
MM-367: Targeted image attachment submission

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/194-oauth-terminal-docker-verification"
+  "feature_directory": "specs/195-targeted-image-attachment-submission"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,8 @@ Key diagnostics:
 - No new persistent storage; this story defines compact runtime contracts and deterministic outputs that can later be persisted by the managed-session store or export sinks (191-claude-governance-telemetry)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing OAuth provider registry, existing OAuth session workflow/activity catalog, existing terminal bridge runtime helpers (192-oauth-runner-bootstrap-pty)
 - Existing OAuth session database row and workflow/activity payloads only; no new persistent storage (192-oauth-runner-bootstrap-pty)
+- Python 3.12; TypeScript/React for existing Create page tests if frontend behavior changes + Pydantic v2, FastAPI, SQLAlchemy async session fixtures, existing Temporal execution router/service, React/Vitest test harness (195-targeted-image-attachment-submission)
+- Existing Temporal execution records and artifact-backed original task input snapshots; no new persistent tables (195-targeted-image-attachment-submission)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -78,6 +78,7 @@ from moonmind.workflows.tasks.model_resolver import resolve_effective_model
 from moonmind.workflows.tasks.runtime_defaults import normalize_runtime_id
 from moonmind.workflows.tasks.task_contract import (
     TaskContractError,
+    TaskInputAttachmentRef,
     TaskProposalPolicy,
     TaskSkillSelectors,
 )
@@ -1280,6 +1281,27 @@ def _normalize_task_proposal_policy(raw: Any) -> dict[str, Any] | None:
         raise _invalid_task_request(str(exc)) from exc
 
 
+def _normalize_task_input_attachments(
+    raw: Any, *, field_name: str
+) -> list[dict[str, Any]]:
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, list):
+        raise _invalid_task_request(f"{field_name} must be a JSON array.")
+
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        try:
+            attachment = TaskInputAttachmentRef.model_validate(item).model_dump(
+                by_alias=True,
+                exclude_none=True,
+            )
+        except (TaskContractError, ValidationError, ValueError) as exc:
+            raise _invalid_task_request(f"{field_name}[{index}]: {exc}") from exc
+        normalized.append(attachment)
+    return normalized
+
+
 def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
     raw_steps = task_payload.get("steps")
     if raw_steps is None:
@@ -1331,6 +1353,13 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
         if normalized_skills is not None:
             normalized_step["skills"] = normalized_skills
 
+        normalized_input_attachments = _normalize_task_input_attachments(
+            step_payload.get("inputAttachments"),
+            field_name=f"payload.task.steps[{index}].inputAttachments",
+        )
+        if normalized_input_attachments:
+            normalized_step["inputAttachments"] = normalized_input_attachments
+
         raw_skill = (
             step_payload.get("skill")
             if isinstance(step_payload.get("skill"), Mapping)
@@ -1366,6 +1395,7 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                 "id",
                 "title",
                 "instructions",
+                "inputAttachments",
                 "skill",
                 "skills",
                 "tool",
@@ -1920,6 +1950,12 @@ async def _create_execution_from_task_request(
     normalized_task_for_planner["proposeTasks"] = propose_tasks
     if normalized_proposal_policy is not None:
         normalized_task_for_planner["proposalPolicy"] = normalized_proposal_policy
+    normalized_input_attachments = _normalize_task_input_attachments(
+        task_payload.get("inputAttachments"),
+        field_name="payload.task.inputAttachments",
+    )
+    if normalized_input_attachments:
+        normalized_task_for_planner["inputAttachments"] = normalized_input_attachments
     if normalized_task_skills is not None:
         normalized_task_for_planner["skills"] = normalized_task_skills
     if normalized_tool is not None:

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1354,7 +1354,8 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
             normalized_step["skills"] = normalized_skills
 
         normalized_input_attachments = _normalize_task_input_attachments(
-            step_payload.get("inputAttachments"),
+            step_payload.get("inputAttachments")
+            or step_payload.get("input_attachments"),
             field_name=f"payload.task.steps[{index}].inputAttachments",
         )
         if normalized_input_attachments:
@@ -1396,6 +1397,7 @@ def _normalize_task_steps(task_payload: dict[str, Any]) -> list[dict[str, Any]]:
                 "title",
                 "instructions",
                 "inputAttachments",
+                "input_attachments",
                 "skill",
                 "skills",
                 "tool",
@@ -1951,7 +1953,8 @@ async def _create_execution_from_task_request(
     if normalized_proposal_policy is not None:
         normalized_task_for_planner["proposalPolicy"] = normalized_proposal_policy
     normalized_input_attachments = _normalize_task_input_attachments(
-        task_payload.get("inputAttachments"),
+        task_payload.get("inputAttachments")
+        or task_payload.get("input_attachments"),
         field_name="payload.task.inputAttachments",
     )
     if normalized_input_attachments:

--- a/docs/tmp/jira-orchestration-inputs/MM-367-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-367-moonspec-orchestration-input.md
@@ -1,0 +1,77 @@
+# MM-367 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-367
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Create targeted image attachment submission
+- Labels: `moonmind-workflow-mm-710b9b03-7ff6-4c87-ac25-ddef82bbf280`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-367 from MM project
+Summary: Create targeted image attachment submission
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-367 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-367: Create targeted image attachment submission
+
+Short Name
+targeted-image-attachment-submission
+
+Source Reference
+- Source document: `docs/Tasks/ImageSystem.md`
+- Source title: Task Image Input System
+- Source sections: 1. Purpose, 3. Product stance and terminology, 4. End-to-end desired-state flow, 5. Control-plane contract, 15. Non-goals
+- Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-020
+
+User Story
+As a task author, I need the Create page and task-shaped execution submission to bind images to the objective or a specific step using structured `inputAttachments` refs so MoonMind.Run receives explicit lightweight references instead of raw image data.
+
+Acceptance Criteria
+- Create flow supports image refs on the task objective and on individual steps.
+- Submitted payloads use `task.inputAttachments` and `task.steps[n].inputAttachments` as the only canonical target fields.
+- Attachment identity and target meaning are not inferred from filenames.
+- The workflow input carries artifact refs and compact metadata, not embedded image bytes or image data URLs.
+- Legacy queue-specific attachment routes are not treated as the desired-state submission contract.
+
+Requirements
+- Use `inputAttachments` as the canonical control-plane field name.
+- Preserve objective-scoped and step-scoped target meaning from the containing field.
+- Normalize `TaskInputAttachmentRef` objects before workflow start.
+- Keep all browser upload and download flows behind MoonMind-owned API endpoints.
+- Represent explicit image-system non-goals in validation or documentation for this contract surface.
+
+Relevant Implementation Notes
+- The canonical submit path is task-shaped execution submission through `/api/executions`.
+- Objective-scoped attachments are submitted through `task.inputAttachments`.
+- Step-scoped attachments are submitted through `task.steps[n].inputAttachments`.
+- The execution API must preserve target scoping through create, edit, and rerun.
+- The original task input snapshot remains the source of truth for reconstructing attachment bindings.
+- Workflow input should carry artifact refs and compact metadata only; uploaded image bytes and data URLs must stay out of workflow payloads and Temporal histories.
+- Runtime adapters should consume structured refs or derived context for the target they are executing, not browser-local state or filename conventions.
+
+Non-Goals
+- Embedding raw image bytes in execution create payloads.
+- Embedding images into instruction markdown as data URLs.
+- Implicit attachment sharing across steps.
+- Live Jira sync.
+- Generic non-image attachment types by default.
+- Provider-specific multimodal message formats as the control-plane contract.
+
+Validation
+- Verify objective-scoped image refs are accepted and preserved as `task.inputAttachments`.
+- Verify step-scoped image refs are accepted and preserved as `task.steps[n].inputAttachments`.
+- Verify submitted payloads and workflow input contain artifact refs and compact metadata, not image bytes or data URLs.
+- Verify target binding survives task create, edit, and rerun flows without relying on filenames.
+- Verify legacy queue-specific attachment routes are not documented or used as the desired-state submission contract.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-367-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-367-code-review-transition.md
@@ -1,0 +1,22 @@
+# MM-367 Code Review Transition
+
+Date: 2026-04-17
+
+## Pull Request Gate
+
+- Jira issue key: MM-367
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1515
+- Handoff artifact checked: `/work/agent_jobs/mm:18eb3be1-491b-4fde-a336-77313aaa479c/artifacts/jira-orchestrate-pr.json`
+
+## Jira Update
+
+- Trusted transition tool: `jira.transition_issue`
+- Matched transition: `Code Review`
+- Transition ID returned by Jira: `51`
+- Confirmed final status from `jira.get_issue`: `Code Review`
+- Jira-visible PR reference: comment `10680`
+
+## Notes
+
+- The issue was not moved to Code Review until the pull request URL was confirmed.
+- No raw Jira credentials were used from the agent shell.

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -42,6 +42,22 @@ _NO_COMMIT_PUSH_PATTERN = re.compile(
     r"\bdo\s+not\s+commit(?:\s+or\s+push|/push)\b",
     re.IGNORECASE,
 )
+_DATA_IMAGE_URL_PATTERN = re.compile(r"^data:image/", re.IGNORECASE)
+_EMBEDDED_ATTACHMENT_DATA_FIELDS = frozenset(
+    {
+        "base64",
+        "bytes",
+        "content",
+        "data",
+        "data_url",
+        "dataUrl",
+        "dataURL",
+        "image_data",
+        "imageData",
+        "raw",
+        "rawBytes",
+    }
+)
 
 
 class TaskContractError(ValueError):
@@ -57,6 +73,16 @@ def _clean_str(value: object) -> str:
 def _clean_optional_str(value: object) -> str | None:
     cleaned = _clean_str(value)
     return cleaned or None
+
+
+def _contains_data_image_url(value: object) -> bool:
+    if isinstance(value, str):
+        return _DATA_IMAGE_URL_PATTERN.match(value.strip()) is not None
+    if isinstance(value, Mapping):
+        return any(_contains_data_image_url(item) for item in value.values())
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return any(_contains_data_image_url(item) for item in value)
+    return False
 
 
 def _default_publish_mode() -> str:
@@ -621,6 +647,48 @@ class TaskProposalPolicy(BaseModel):
         return lowered
 
 
+class TaskInputAttachmentRef(BaseModel):
+    """Compact task input attachment reference for task-shaped submissions."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    artifact_id: str = Field(..., alias="artifactId")
+    filename: str = Field(..., alias="filename")
+    content_type: str = Field(..., alias="contentType")
+    size_bytes: int = Field(..., alias="sizeBytes", ge=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_embedded_image_data(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            raise TaskContractError("inputAttachments entries must be objects")
+        payload = dict(value)
+        blocked = sorted(
+            key
+            for key in payload
+            if str(key).strip() in _EMBEDDED_ATTACHMENT_DATA_FIELDS
+        )
+        if blocked or _contains_data_image_url(payload):
+            raise TaskContractError(
+                "inputAttachments entries must not include embedded image data"
+            )
+        return payload
+
+    @field_validator("artifact_id", "filename", "content_type", mode="before")
+    @classmethod
+    def _normalize_required_string(cls, value: object) -> str:
+        cleaned = _clean_optional_str(value)
+        if not cleaned:
+            raise TaskContractError(
+                "inputAttachments entries require artifactId, filename, and contentType"
+            )
+        if _contains_data_image_url(cleaned):
+            raise TaskContractError(
+                "inputAttachments entries must not include embedded image data"
+            )
+        return cleaned
+
+
 class TaskStepSpec(BaseModel):
     """Optional execution step contained within a canonical task payload."""
 
@@ -631,11 +699,23 @@ class TaskStepSpec(BaseModel):
     instructions: str | None = Field(None, alias="instructions")
     skill: TaskSkillSelection | None = Field(None, alias="skill")
     skills: TaskSkillSelectors | None = Field(None, alias="skills")
+    input_attachments: list[TaskInputAttachmentRef] = Field(
+        default_factory=list, alias="inputAttachments"
+    )
 
     @field_validator("id", "title", "instructions", mode="before")
     @classmethod
     def _normalize_optional_strings(cls, value: object) -> str | None:
         return _clean_optional_str(value)
+
+    @field_validator("input_attachments", mode="before")
+    @classmethod
+    def _normalize_input_attachments(cls, value: object) -> object:
+        if value is None or value == "":
+            return []
+        if not isinstance(value, list):
+            raise TaskContractError("task.steps[].inputAttachments must be a list")
+        return value
 
     @model_validator(mode="before")
     @classmethod
@@ -687,6 +767,9 @@ class TaskExecutionSpec(BaseModel):
         default_factory=_default_propose_tasks, alias="proposeTasks"
     )
     steps: list[TaskStepSpec] = Field(default_factory=list, alias="steps")
+    input_attachments: list[TaskInputAttachmentRef] = Field(
+        default_factory=list, alias="inputAttachments"
+    )
     container: TaskContainerSelection | None = Field(None, alias="container")
     proposal_policy: TaskProposalPolicy | None = Field(None, alias="proposalPolicy")
 
@@ -694,6 +777,15 @@ class TaskExecutionSpec(BaseModel):
     @classmethod
     def _normalize_instructions(cls, value: object) -> str | None:
         return _clean_optional_str(value)
+
+    @field_validator("input_attachments", mode="before")
+    @classmethod
+    def _normalize_input_attachments(cls, value: object) -> object:
+        if value is None or value == "":
+            return []
+        if not isinstance(value, list):
+            raise TaskContractError("task.inputAttachments must be a list")
+        return value
 
     @field_validator("propose_tasks", mode="before")
     @classmethod
@@ -1386,6 +1478,7 @@ __all__ = [
     "SUPPORTED_EXECUTION_RUNTIMES",
     "CanonicalTaskPayload",
     "TaskContractError",
+    "TaskInputAttachmentRef",
     "build_task_stage_plan",
     "build_canonical_task_view",
     "has_attachment_mutation_fields",

--- a/specs/195-targeted-image-attachment-submission/checklists/requirements.md
+++ b/specs/195-targeted-image-attachment-submission/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Targeted Image Attachment Submission
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Runtime scope is bounded to task-shaped image attachment refs, target binding, normalization, and snapshot preservation. Linked artifact policy hardening remains out of scope for MM-367.

--- a/specs/195-targeted-image-attachment-submission/contracts/task-input-attachments.md
+++ b/specs/195-targeted-image-attachment-submission/contracts/task-input-attachments.md
@@ -1,0 +1,89 @@
+# Contract: Task Input Attachments
+
+## Endpoint
+
+`POST /api/executions`
+
+## Task-Shaped Request
+
+```json
+{
+  "type": "task",
+  "payload": {
+    "repository": "owner/repo",
+    "targetRuntime": "codex",
+    "task": {
+      "instructions": "Use the objective image.",
+      "inputAttachments": [
+        {
+          "artifactId": "art_objective_123",
+          "filename": "objective.png",
+          "contentType": "image/png",
+          "sizeBytes": 48213
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-1",
+          "instructions": "Use the step image.",
+          "inputAttachments": [
+            {
+              "artifactId": "art_step_456",
+              "filename": "step.png",
+              "contentType": "image/png",
+              "sizeBytes": 72109
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Expected Workflow Input
+
+`MoonMind.Run` initial parameters include:
+
+```json
+{
+  "task": {
+    "inputAttachments": [
+      {
+        "artifactId": "art_objective_123",
+        "filename": "objective.png",
+        "contentType": "image/png",
+        "sizeBytes": 48213
+      }
+    ],
+    "steps": [
+      {
+        "id": "step-1",
+        "instructions": "Use the step image.",
+        "inputAttachments": [
+          {
+            "artifactId": "art_step_456",
+            "filename": "step.png",
+            "contentType": "image/png",
+            "sizeBytes": 72109
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Validation Failures
+
+The endpoint returns `422 invalid_execution_request` when:
+- `inputAttachments` is not an array.
+- Any attachment ref is not an object.
+- Required compact metadata is missing or blank.
+- `sizeBytes` is not a valid non-negative integer.
+- The attachment object contains raw byte/content fields such as `bytes`, `data`, `dataUrl`, `dataURL`, `content`, or `base64`.
+- Any attachment string value begins with `data:image/`.
+
+## Non-Canonical Fields
+
+Legacy `attachments`, `attachmentIds`, and `attachment_ids` are not the canonical image input submission contract for task-shaped execution.

--- a/specs/195-targeted-image-attachment-submission/data-model.md
+++ b/specs/195-targeted-image-attachment-submission/data-model.md
@@ -1,0 +1,38 @@
+# Data Model: Targeted Image Attachment Submission
+
+## TaskInputAttachmentRef
+
+Represents one lightweight image attachment reference submitted in a task-shaped execution request.
+
+Fields:
+- `artifactId`: Non-empty MoonMind artifact identifier.
+- `filename`: Non-empty original filename for operator visibility.
+- `contentType`: Non-empty MIME type, expected to be an allowed image type by policy.
+- `sizeBytes`: Non-negative byte size for the uploaded artifact.
+
+Validation:
+- Must be an object.
+- Must not include raw bytes, base64 payloads, inline content, or data URL fields.
+- String values must not begin with `data:image/`.
+- Missing required compact metadata fails validation.
+
+## Attachment Target Binding
+
+Represents the target meaning derived from where a ref appears in the task-shaped payload.
+
+Target rules:
+- `task.inputAttachments` means objective-scoped attachment.
+- `task.steps[n].inputAttachments` means step-scoped attachment for that step.
+- Target meaning is never inferred from filename, artifact id, or link metadata.
+
+## Task Input Snapshot
+
+Existing artifact-backed snapshot of the original task-shaped input.
+
+Relevant fields:
+- `draft.task.inputAttachments`
+- `draft.task.steps[n].inputAttachments`
+
+Validation:
+- Snapshot data must preserve canonical attachment fields for edit/rerun reconstruction.
+- Snapshot reconstruction must not rely on legacy `attachments`, `attachmentIds`, or `attachment_ids` mutation fields.

--- a/specs/195-targeted-image-attachment-submission/plan.md
+++ b/specs/195-targeted-image-attachment-submission/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: Targeted Image Attachment Submission
+
+**Branch**: `195-targeted-image-attachment-submission` | **Date**: 2026-04-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/specs/195-targeted-image-attachment-submission/spec.md`
+
+## Summary
+
+Task-shaped execution submissions must preserve objective-scoped and step-scoped image attachment refs as structured `inputAttachments` data from the Create page through `/api/executions` into `MoonMind.Run` initial parameters and the original task input snapshot. The implementation will add typed attachment-ref validation to the canonical task contract, normalize task-level and step-level attachment refs in the execution router, reject raw image bytes/data URLs and filename-derived target shortcuts, and prove the behavior with unit and contract tests.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for existing Create page tests if frontend behavior changes  
+**Primary Dependencies**: Pydantic v2, FastAPI, SQLAlchemy async session fixtures, existing Temporal execution router/service, React/Vitest test harness  
+**Storage**: Existing Temporal execution records and artifact-backed original task input snapshots; no new persistent tables  
+**Unit Testing**: pytest through targeted Python tests and `./tools/test_unit.sh` for final verification  
+**Integration Testing**: pytest contract coverage for `/api/executions`; existing frontend Vitest coverage for Create page attachment submission when needed  
+**Target Platform**: MoonMind API service and dashboard runtime  
+**Project Type**: Web service plus dashboard frontend  
+**Performance Goals**: Attachment ref normalization is linear in submitted refs and bounded by existing task/step limits  
+**Constraints**: Do not embed image bytes or data URLs in workflow payloads or Temporal histories; do not use legacy queue attachment routes as canonical; preserve in-flight Temporal compatibility by adding optional fields only  
+**Scale/Scope**: One task-shaped submit request with objective-level refs and up to the existing step limit for step-level refs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The story preserves MoonMind orchestration contracts and does not recreate agent behavior.
+- II. One-Click Agent Deployment: PASS. No new external service or required secret is introduced.
+- III. Avoid Vendor Lock-In: PASS. Attachment refs are provider-neutral artifact references.
+- IV. Own Your Data: PASS. Image bytes remain behind MoonMind artifact APIs and refs are carried through owned workflow payloads.
+- V. Skills Are First-Class and Easy to Add: PASS. No skill registration or runtime-specific skill behavior changes.
+- VI. Replaceable Scaffolding: PASS. Behavior is protected by contract tests around stable boundaries.
+- VII. Runtime Configurability: PASS. Existing attachment policy remains configuration-driven; this story does not hardcode new policy values.
+- VIII. Modular and Extensible Architecture: PASS. Validation belongs in task contract/router boundaries.
+- IX. Resilient by Default: PASS. Snapshot preservation supports edit/rerun recovery and avoids large workflow history payloads.
+- X. Facilitate Continuous Improvement: PASS. Verification evidence will be produced through tests and Moon Spec tasks.
+- XI. Spec-Driven Development: PASS. This plan follows the single-story spec.
+- XII. Canonical Documentation Separation: PASS. Runtime work is specified under `specs/`; no canonical docs are rewritten as backlog.
+- XIII. Pre-release Compatibility Policy: PASS. Optional additive fields preserve current callers; unsupported malformed attachment refs fail fast.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/195-targeted-image-attachment-submission/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-input-attachments.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/tasks/
+└── task_contract.py
+
+api_service/api/routers/
+└── executions.py
+
+tests/unit/workflows/tasks/
+└── test_task_contract.py
+
+tests/unit/api/routers/
+└── test_executions.py
+
+tests/contract/
+└── test_temporal_execution_api.py
+
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+```
+
+**Structure Decision**: Use the existing task contract and execution router boundary. Frontend files are listed because the Create page already owns attachment uploads and may receive targeted test coverage, but production changes are expected to stay backend-focused unless tests reveal a UI payload gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/195-targeted-image-attachment-submission/quickstart.md
+++ b/specs/195-targeted-image-attachment-submission/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Targeted Image Attachment Submission
+
+## Focused Unit Validation
+
+```bash
+./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py
+```
+
+Expected:
+- Valid objective and step `inputAttachments` refs are accepted.
+- Missing compact metadata, raw byte/content fields, and image data URLs are rejected.
+- `/api/executions` forwards valid refs into `MoonMind.Run` initial parameters.
+
+## Contract Validation
+
+```bash
+./tools/test_unit.sh tests/contract/test_temporal_execution_api.py
+```
+
+Expected:
+- Task-shaped execution create succeeds with objective and step refs.
+- The original task input snapshot artifact preserves `task.inputAttachments` and `task.steps[n].inputAttachments`.
+
+## Full Unit Suite
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected:
+- Required unit suite passes before `/speckit.verify`.

--- a/specs/195-targeted-image-attachment-submission/quickstart.md
+++ b/specs/195-targeted-image-attachment-submission/quickstart.md
@@ -28,4 +28,4 @@ Expected:
 ```
 
 Expected:
-- Required unit suite passes before `/speckit.verify`.
+- Required unit suite passes before `/moonspec-verify`.

--- a/specs/195-targeted-image-attachment-submission/research.md
+++ b/specs/195-targeted-image-attachment-submission/research.md
@@ -1,0 +1,41 @@
+# Research: Targeted Image Attachment Submission
+
+## Canonical Attachment Ref Shape
+
+Decision: Model `TaskInputAttachmentRef` as a compact object with `artifactId`, `filename`, `contentType`, and `sizeBytes`.
+
+Rationale: `docs/Tasks/ImageSystem.md` defines this as the canonical reference shape, and the existing Create page already emits that object when uploading step attachments.
+
+Alternatives considered: Reusing legacy `attachments` or `attachmentIds` fields was rejected because the source design explicitly excludes queue-specific attachment routes and fields from the desired-state contract.
+
+## Validation Boundary
+
+Decision: Validate attachment refs in `moonmind/workflows/tasks/task_contract.py` and normalize them again in the `/api/executions` task-shaped router before workflow start.
+
+Rationale: The task contract covers canonical task payload construction, while the router builds `MoonMind.Run` initial parameters directly and currently copies only selected task fields. Both boundaries need evidence so malformed refs fail fast and valid refs are preserved into workflow input.
+
+Alternatives considered: Frontend-only validation was rejected because API clients can submit task-shaped requests directly.
+
+## Raw Bytes And Data URLs
+
+Decision: Reject fields or values that embed raw image bytes, base64 content, or `data:image/...` URLs inside attachment refs.
+
+Rationale: The source design forbids raw bytes and data URLs in execution create payloads, task instruction markdown, and workflow histories. Explicit validation gives deterministic failure instead of silently storing large or unsafe payloads.
+
+Alternatives considered: Silently stripping raw fields was rejected because it can hide author intent and make edit/rerun reconstruction misleading.
+
+## Snapshot Reconstruction
+
+Decision: Preserve attachment bindings in the existing original task input snapshot artifact by keeping refs under `task.inputAttachments` and `task.steps[n].inputAttachments`.
+
+Rationale: Snapshot artifacts already preserve the task payload for edit/rerun reconstruction. Keeping the canonical fields there avoids new tables and aligns with the source design's authoritative snapshot contract.
+
+Alternatives considered: Adding a new persisted attachment-binding table was rejected because the story requires no new storage and the snapshot already carries the task-shaped input.
+
+## Testing Strategy
+
+Decision: Add unit tests for contract validation and router normalization, plus contract coverage that verifies `/api/executions` persists snapshot attachment refs.
+
+Rationale: Unit tests cover fast failure modes; contract tests cover the API and artifact snapshot boundary that downstream edit/rerun depends on.
+
+Alternatives considered: Full Docker-backed integration was rejected for this story because the acceptance boundary is task-shaped submission and workflow-start payload construction, not artifact materialization or vision context generation.

--- a/specs/195-targeted-image-attachment-submission/spec.md
+++ b/specs/195-targeted-image-attachment-submission/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Targeted Image Attachment Submission
+
+**Feature Branch**: `195-targeted-image-attachment-submission`
+**Created**: 2026-04-17
+**Status**: Draft
+**Input**:
+
+```text
+# MM-367 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-367
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Create targeted image attachment submission
+- Labels: `moonmind-workflow-mm-710b9b03-7ff6-4c87-ac25-ddef82bbf280`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-367 from MM project
+Summary: Create targeted image attachment submission
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-367 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-367: Create targeted image attachment submission
+
+Short Name
+targeted-image-attachment-submission
+
+Source Reference
+- Source document: `docs/Tasks/ImageSystem.md`
+- Source title: Task Image Input System
+- Source sections: 1. Purpose, 3. Product stance and terminology, 4. End-to-end desired-state flow, 5. Control-plane contract, 15. Non-goals
+- Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-020
+
+User Story
+As a task author, I need the Create page and task-shaped execution submission to bind images to the objective or a specific step using structured `inputAttachments` refs so MoonMind.Run receives explicit lightweight references instead of raw image data.
+
+Acceptance Criteria
+- Create flow supports image refs on the task objective and on individual steps.
+- Submitted payloads use `task.inputAttachments` and `task.steps[n].inputAttachments` as the only canonical target fields.
+- Attachment identity and target meaning are not inferred from filenames.
+- The workflow input carries artifact refs and compact metadata, not embedded image bytes or image data URLs.
+- Legacy queue-specific attachment routes are not treated as the desired-state submission contract.
+
+Requirements
+- Use `inputAttachments` as the canonical control-plane field name.
+- Preserve objective-scoped and step-scoped target meaning from the containing field.
+- Normalize `TaskInputAttachmentRef` objects before workflow start.
+- Keep all browser upload and download flows behind MoonMind-owned API endpoints.
+- Represent explicit image-system non-goals in validation or documentation for this contract surface.
+
+Relevant Implementation Notes
+- The canonical submit path is task-shaped execution submission through `/api/executions`.
+- Objective-scoped attachments are submitted through `task.inputAttachments`.
+- Step-scoped attachments are submitted through `task.steps[n].inputAttachments`.
+- The execution API must preserve target scoping through create, edit, and rerun.
+- The original task input snapshot remains the source of truth for reconstructing attachment bindings.
+- Workflow input should carry artifact refs and compact metadata only; uploaded image bytes and data URLs must stay out of workflow payloads and Temporal histories.
+- Runtime adapters should consume structured refs or derived context for the target they are executing, not browser-local state or filename conventions.
+
+Non-Goals
+- Embedding raw image bytes in execution create payloads.
+- Embedding images into instruction markdown as data URLs.
+- Implicit attachment sharing across steps.
+- Live Jira sync.
+- Generic non-image attachment types by default.
+- Provider-specific multimodal message formats as the control-plane contract.
+
+Validation
+- Verify objective-scoped image refs are accepted and preserved as `task.inputAttachments`.
+- Verify step-scoped image refs are accepted and preserved as `task.steps[n].inputAttachments`.
+- Verify submitted payloads and workflow input contain artifact refs and compact metadata, not image bytes or data URLs.
+- Verify target binding survives task create, edit, and rerun flows without relying on filenames.
+- Verify legacy queue-specific attachment routes are not documented or used as the desired-state submission contract.
+
+Needs Clarification
+- None
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.
+
+## User Story - Submit Targeted Image Attachments
+
+**Summary**: As a task author, I want the Create page and task-shaped execution submission to bind image attachment refs to either the task objective or a specific step so that MoonMind.Run receives explicit lightweight references with durable target meaning.
+
+**Goal**: Task submissions preserve objective-scoped and step-scoped image attachment refs through the control-plane contract without embedding image bytes, relying on filenames, or using legacy queue attachment routes.
+
+**Independent Test**: Submit task-shaped execution payloads that include objective-level and step-level image attachment refs. The story passes when the execution request accepts both scopes, normalizes each attachment into the workflow input using only `task.inputAttachments` and `task.steps[n].inputAttachments`, preserves target meaning from the containing field, and rejects or excludes raw image bytes, data URLs, filename-derived targeting, and legacy queue-specific attachment routes as canonical submission behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author attaches an image to the task objective, **when** the Create page submits the task-shaped execution request, **then** the payload carries the ref under `task.inputAttachments` and MoonMind.Run receives an objective-scoped lightweight attachment ref.
+2. **Given** a task author attaches an image to a specific task step, **when** the Create page submits the task-shaped execution request, **then** the payload carries the ref under that step's `inputAttachments` field and MoonMind.Run receives a step-scoped lightweight attachment ref.
+3. **Given** an image ref is submitted for either scope, **when** the control plane normalizes the task payload before workflow start, **then** target meaning comes from the containing field and is not inferred from the filename.
+4. **Given** a task submission contains image attachment information, **when** the workflow input is built, **then** it contains artifact refs and compact metadata only and does not embed image bytes or image data URLs.
+5. **Given** legacy queue-specific attachment fields or routes are available elsewhere in the system, **when** task-shaped execution submission is used, **then** they are not treated as the desired-state contract for image attachment submission.
+6. **Given** a task input snapshot is stored for later edit or rerun, **when** the task is reconstructed, **then** objective and step attachment bindings are preserved from the snapshot rather than inferred from artifact links alone.
+
+### Edge Cases
+
+- The same image filename is used for objective-scoped and step-scoped attachments.
+- A step attachment is submitted for a step that has an explicit id and ordinal.
+- A submitted attachment ref is missing required compact metadata such as artifact id, filename, content type, or size.
+- A task submission attempts to include embedded image bytes or a data URL in an attachment ref.
+- A task is edited or rerun after the original submission and must preserve attachment targeting.
+
+## Assumptions
+
+- Image bytes have already been uploaded through MoonMind-owned artifact APIs before the task-shaped execution request is accepted.
+- This story covers image attachment refs and target preservation in task-shaped submission; artifact storage enforcement and image policy hardening are tracked by linked issue MM-368.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source `docs/Tasks/ImageSystem.md` section 1. Purpose. The system MUST let users attach images to the task objective or to individual steps and submit lightweight references into MoonMind.Run. Scope: in scope. Mapped to FR-001, FR-002, FR-003.
+- **DESIGN-REQ-002**: Source `docs/Tasks/ImageSystem.md` section 3. Product stance and terminology. Uploaded image bytes MUST NOT be embedded in Temporal histories or task instruction text; the control plane MUST submit structured attachment references. Scope: in scope. Mapped to FR-004, FR-005.
+- **DESIGN-REQ-003**: Source `docs/Tasks/ImageSystem.md` section 3.2 Canonical terminology. The canonical control-plane field name MUST be `inputAttachments`, with objective refs submitted through `task.inputAttachments` and step refs through `task.steps[n].inputAttachments`. Scope: in scope. Mapped to FR-001, FR-002.
+- **DESIGN-REQ-004**: Source `docs/Tasks/ImageSystem.md` section 3.2 Canonical terminology. Target meaning MUST come from the field that contains the ref, and attachment identity MUST NOT depend on filename conventions. Scope: in scope. Mapped to FR-003, FR-008.
+- **DESIGN-REQ-005**: Source `docs/Tasks/ImageSystem.md` section 4. End-to-end desired-state flow. The execution API MUST validate and persist the authoritative snapshot of attachment targeting before MoonMind.Run starts. Scope: in scope. Mapped to FR-006, FR-007.
+- **DESIGN-REQ-006**: Source `docs/Tasks/ImageSystem.md` section 5. Control-plane contract. The canonical submit path is task-shaped execution submission through `/api/executions`; legacy queue-specific attachment submission routes are not the desired-state contract. Scope: in scope. Mapped to FR-001, FR-009.
+- **DESIGN-REQ-020**: Source `docs/Tasks/ImageSystem.md` section 15. Non-goals. The story MUST exclude embedded raw image bytes, data URLs in instruction markdown, implicit attachment sharing across steps, live Jira sync, generic non-image attachment types by default, and provider-specific multimodal message formats as the control-plane contract. Scope: in scope as guardrails. Mapped to FR-004, FR-005, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST accept objective-scoped image attachment refs only through `task.inputAttachments` in task-shaped execution submissions.
+- **FR-002**: The system MUST accept step-scoped image attachment refs only through `task.steps[n].inputAttachments` in task-shaped execution submissions.
+- **FR-003**: The system MUST preserve attachment target meaning from the containing objective or step field during request normalization and workflow input construction.
+- **FR-004**: The system MUST reject or exclude embedded image bytes from task attachment refs and workflow inputs.
+- **FR-005**: The system MUST reject or exclude image data URLs from task attachment refs, instruction markdown, and workflow inputs.
+- **FR-006**: The system MUST normalize every accepted `TaskInputAttachmentRef` before workflow start into compact metadata containing artifact id, filename, content type, and size.
+- **FR-007**: The system MUST persist enough task input snapshot data to reconstruct objective-scoped and step-scoped attachment bindings during edit and rerun flows.
+- **FR-008**: The system MUST NOT infer attachment target identity from filenames, artifact names, or other naming conventions.
+- **FR-009**: The system MUST NOT treat legacy queue-specific attachment routes or fields as the canonical image submission contract for task-shaped execution.
+- **FR-010**: The system MUST keep explicit image-system non-goals visible through validation failures, omitted payload support, or documentation on this contract surface.
+
+### Key Entities
+
+- **TaskInputAttachmentRef**: A lightweight image attachment reference submitted by the control plane with artifact id, filename, content type, and size metadata.
+- **Attachment Target Binding**: The durable association between a submitted attachment ref and either the task objective or one specific task step.
+- **Task Input Snapshot**: The stored original task-shaped submission data used to reconstruct task text, steps, runtime settings, and target attachment refs during edit and rerun flows.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Objective-scoped and step-scoped image attachment refs can be submitted in one task-shaped request and are represented distinctly in the workflow input.
+- **SC-002**: Unit validation covers missing compact metadata, embedded bytes, image data URLs, and filename-collision target handling.
+- **SC-003**: Integration coverage proves `/api/executions` preserves objective and step attachment target bindings through workflow-start payload construction.
+- **SC-004**: Edit or rerun reconstruction tests prove target bindings are preserved from the task input snapshot.
+- **SC-005**: No successful task-shaped image attachment submission depends on a legacy queue-specific attachment field or route.

--- a/specs/195-targeted-image-attachment-submission/tasks.md
+++ b/specs/195-targeted-image-attachment-submission/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py`
 - Integration tests: `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -83,7 +83,7 @@
 
 - [X] T015 Run `./tools/test_unit.sh` for final unit-suite verification
 - [X] T016 Review `docs/Tasks/ImageSystem.md` and generated artifacts to confirm source design coverage remains accurate without rewriting canonical docs (DESIGN-REQ-001-DESIGN-REQ-006, DESIGN-REQ-020)
-- [X] T017 Run `/speckit.verify` to validate the final implementation against the original MM-367 feature request
+- [X] T017 Run `/moonspec-verify` to validate the final implementation against the original MM-367 feature request
 
 ---
 
@@ -120,4 +120,4 @@
 4. Implement typed attachment-ref validation and router forwarding.
 5. Run targeted tests until they pass.
 6. Run full unit verification.
-7. Run `/speckit.verify`.
+7. Run `/moonspec-verify`.

--- a/specs/195-targeted-image-attachment-submission/tasks.md
+++ b/specs/195-targeted-image-attachment-submission/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: Targeted Image Attachment Submission
+
+**Input**: Design documents from `/specs/195-targeted-image-attachment-submission/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around a single user story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: FR-001 through FR-010, SC-001 through SC-005, and DESIGN-REQ-001 through DESIGN-REQ-006/DESIGN-REQ-020 are covered by the unit, router, and contract test tasks below.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py`
+- Integration tests: `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the existing task-shaped execution surfaces and feature artifacts are ready.
+
+- [X] T001 Verify feature artifacts and active feature pointer for 195-targeted-image-attachment-submission in `.specify/feature.json` and `specs/195-targeted-image-attachment-submission/spec.md`
+- [X] T002 Inspect existing attachment submission behavior in `frontend/src/entrypoints/task-create.tsx`, `moonmind/workflows/tasks/task_contract.py`, and `api_service/api/routers/executions.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish the validation and API contract boundaries before story implementation.
+
+- [X] T003 [P] Confirm no new storage or migrations are needed for snapshot-preserved attachment refs in `specs/195-targeted-image-attachment-submission/data-model.md` (FR-007, DESIGN-REQ-005)
+- [X] T004 [P] Confirm the task-shaped attachment contract in `specs/195-targeted-image-attachment-submission/contracts/task-input-attachments.md` covers objective refs, step refs, and validation failures (FR-001-FR-010, DESIGN-REQ-001-DESIGN-REQ-006, DESIGN-REQ-020)
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Submit Targeted Image Attachments
+
+**Summary**: As a task author, I want the Create page and task-shaped execution submission to bind image attachment refs to either the task objective or a specific step so that MoonMind.Run receives explicit lightweight references with durable target meaning.
+
+**Independent Test**: Submit task-shaped execution payloads that include objective-level and step-level image attachment refs and verify the API accepts, normalizes, forwards, and snapshots them without raw bytes, data URLs, filename-derived targeting, or legacy attachment fields.
+
+**Traceability**: FR-001-FR-010, SC-001-SC-005, DESIGN-REQ-001-DESIGN-REQ-006, DESIGN-REQ-020
+
+**Test Plan**:
+
+- Unit: task contract attachment-ref validation and execution router normalization/failure modes
+- Integration: `/api/executions` contract coverage for workflow-start payload and original task input snapshot preservation
+
+### Unit Tests (write first)
+
+- [X] T005 [P] Add failing unit tests for valid objective and step `inputAttachments` refs in `tests/unit/workflows/tasks/test_task_contract.py` (FR-001, FR-002, FR-003, FR-006, DESIGN-REQ-001, DESIGN-REQ-003)
+- [X] T006 [P] Add failing unit tests for missing metadata, raw content fields, image data URLs, and filename-collision target handling in `tests/unit/workflows/tasks/test_task_contract.py` (FR-004, FR-005, FR-008, FR-010, DESIGN-REQ-002, DESIGN-REQ-004, DESIGN-REQ-020)
+- [X] T007 [P] Add failing router unit tests proving task-level and step-level `inputAttachments` are forwarded into `MoonMind.Run` initial parameters and invalid refs return 422 in `tests/unit/api/routers/test_executions.py` (FR-001-FR-006, FR-008)
+- [X] T008 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py` and confirm T005-T007 fail for the expected missing validation/forwarding behavior
+
+### Integration Tests (write first)
+
+- [X] T009 Add failing contract test proving `/api/executions` persists objective and step attachment refs in the original task input snapshot artifact in `tests/contract/test_temporal_execution_api.py` (FR-007, SC-003, SC-004, DESIGN-REQ-005)
+- [X] T010 Run `./tools/test_unit.sh tests/contract/test_temporal_execution_api.py` and confirm T009 fails for the expected missing snapshot or workflow-input behavior
+
+### Implementation
+
+- [X] T011 Implement `TaskInputAttachmentRef` validation and attach it to task and step models in `moonmind/workflows/tasks/task_contract.py` (FR-001-FR-006, FR-008, FR-010, DESIGN-REQ-001-DESIGN-REQ-004, DESIGN-REQ-020)
+- [X] T012 Implement execution-router attachment normalization and forwarding for task-level and step-level refs in `api_service/api/routers/executions.py` (FR-001-FR-007, SC-001, SC-003, DESIGN-REQ-001, DESIGN-REQ-005)
+- [X] T013 Verify legacy `attachments`, `attachmentIds`, and `attachment_ids` remain non-canonical and unsupported for edit mutation paths in `moonmind/workflows/tasks/task_contract.py` and `api_service/api/routers/executions.py` (FR-009, SC-005, DESIGN-REQ-006)
+- [X] T014 Run `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py` and fix failures until targeted unit and contract tests pass
+
+**Checkpoint**: The story is fully functional, covered by unit and contract tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Validate the single-story implementation without adding hidden scope.
+
+- [X] T015 Run `./tools/test_unit.sh` for final unit-suite verification
+- [X] T016 Review `docs/Tasks/ImageSystem.md` and generated artifacts to confirm source design coverage remains accurate without rewriting canonical docs (DESIGN-REQ-001-DESIGN-REQ-006, DESIGN-REQ-020)
+- [X] T017 Run `/speckit.verify` to validate the final implementation against the original MM-367 feature request
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story work
+- **Story (Phase 3)**: Depends on Foundational phase completion
+- **Polish (Phase 4)**: Depends on story tests and implementation passing
+
+### Within The Story
+
+- T005-T007 must be written before T011-T012.
+- T008 must confirm expected red state before production implementation.
+- T009 must be written before T012.
+- T010 must confirm expected red state before production implementation.
+- T011 and T012 are sequential because router normalization depends on the final ref shape.
+- T014 must pass before T015 and T017.
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel.
+- T005, T006, and T007 can be authored in parallel because they touch different test files or independent cases.
+
+---
+
+## Implementation Strategy
+
+1. Complete setup/foundational checks.
+2. Add unit and contract tests first.
+3. Confirm targeted tests fail for missing validation or forwarding.
+4. Implement typed attachment-ref validation and router forwarding.
+5. Run targeted tests until they pass.
+6. Run full unit verification.
+7. Run `/speckit.verify`.

--- a/tests/contract/test_temporal_execution_api.py
+++ b/tests/contract/test_temporal_execution_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -26,6 +27,7 @@ from api_service.db.models import (
 )
 from api_service.main import app
 from moonmind.config.settings import settings
+from moonmind.workflows import get_temporal_artifact_service
 from moonmind.workflows.temporal.service import TemporalExecutionService
 
 CURRENT_USER_DEP = get_current_user()
@@ -746,6 +748,27 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                         "requiredCapabilities": ["git"],
                         "task": {
                             "instructions": "Implement Temporal submit redirect coverage.",
+                            "inputAttachments": [
+                                {
+                                    "artifactId": "art-objective",
+                                    "filename": "same-name.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 10,
+                                }
+                            ],
+                            "steps": [
+                                {
+                                    "instructions": "Review the step screenshot.",
+                                    "inputAttachments": [
+                                        {
+                                            "artifactId": "art-step",
+                                            "filename": "same-name.png",
+                                            "contentType": "image/png",
+                                            "sizeBytes": 20,
+                                        }
+                                    ],
+                                }
+                            ],
                             "runtime": {
                                 "mode": "codex",
                                 "model": "gpt-5.3-codex",
@@ -809,11 +832,53 @@ async def test_task_shaped_create_returns_temporal_identity_and_redirect(
                     body["workflowId"],
                 )
                 assert canonical is not None
+                assert canonical.parameters["task"]["inputAttachments"] == [
+                    {
+                        "artifactId": "art-objective",
+                        "filename": "same-name.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 10,
+                    }
+                ]
+                assert canonical.parameters["task"]["steps"][0][
+                    "inputAttachments"
+                ] == [
+                    {
+                        "artifactId": "art-step",
+                        "filename": "same-name.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 20,
+                    }
+                ]
                 assert (
                     canonical.memo["task_input_snapshot_ref"]
                     == snapshot["artifactRef"]
                 )
                 assert snapshot["artifactRef"] in canonical.artifact_refs
+                artifact_service = get_temporal_artifact_service(session)
+                _, stored = await artifact_service.read(
+                    artifact_id=snapshot["artifactRef"],
+                    principal=str(shared_user_id),
+                )
+                snapshot_payload = json.loads(stored.decode("utf-8"))
+                assert snapshot_payload["draft"]["task"]["inputAttachments"] == [
+                    {
+                        "artifactId": "art-objective",
+                        "filename": "same-name.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 10,
+                    }
+                ]
+                assert snapshot_payload["draft"]["task"]["steps"][0][
+                    "inputAttachments"
+                ] == [
+                    {
+                        "artifactId": "art-step",
+                        "filename": "same-name.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 20,
+                    }
+                ]
     finally:
         db_base.DATABASE_URL = original_db_url
         db_base.engine = original_engine

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1036,6 +1036,73 @@ def test_create_task_shaped_execution_forwards_input_attachments(
     ]
 
 
+def test_create_task_shaped_execution_normalizes_snake_case_input_attachments(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """MM-367: router normalization accepts Pydantic field-name aliases."""
+
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Inspect submitted screenshots.",
+                    "input_attachments": [
+                        {
+                            "artifactId": "art-objective",
+                            "filename": "objective.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "instructions": "Inspect the step screenshot.",
+                            "input_attachments": [
+                                {
+                                    "artifactId": "art-step",
+                                    "filename": "step.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 20,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["task"]["inputAttachments"] == [
+        {
+            "artifactId": "art-objective",
+            "filename": "objective.png",
+            "contentType": "image/png",
+            "sizeBytes": 10,
+        }
+    ]
+    step_payload = initial_parameters["task"]["steps"][0]
+    assert step_payload["inputAttachments"] == [
+        {
+            "artifactId": "art-step",
+            "filename": "step.png",
+            "contentType": "image/png",
+            "sizeBytes": 20,
+        }
+    ]
+    assert "input_attachments" not in step_payload
+
+
 def test_create_task_shaped_execution_rejects_embedded_attachment_data(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -971,6 +971,107 @@ def test_create_task_shaped_execution_allows_pr_resolver_with_starting_branch(
     }
 
 
+def test_create_task_shaped_execution_forwards_input_attachments(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """MM-367: objective and step attachment refs reach MoonMind.Run parameters."""
+
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Inspect submitted screenshots.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art-objective",
+                            "filename": "same-name.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "instructions": "Inspect the step screenshot.",
+                            "inputAttachments": [
+                                {
+                                    "artifactId": "art-step",
+                                    "filename": "same-name.png",
+                                    "contentType": "image/png",
+                                    "sizeBytes": 20,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["task"]["inputAttachments"] == [
+        {
+            "artifactId": "art-objective",
+            "filename": "same-name.png",
+            "contentType": "image/png",
+            "sizeBytes": 10,
+        }
+    ]
+    assert initial_parameters["task"]["steps"][0]["inputAttachments"] == [
+        {
+            "artifactId": "art-step",
+            "filename": "same-name.png",
+            "contentType": "image/png",
+            "sizeBytes": 20,
+        }
+    ]
+
+
+def test_create_task_shaped_execution_rejects_embedded_attachment_data(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    """MM-367: task-shaped submit rejects inline image payloads in refs."""
+
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "Moon/Mind",
+                "targetRuntime": "codex",
+                "task": {
+                    "instructions": "Inspect submitted screenshot.",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art-inline",
+                            "filename": "inline.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 10,
+                            "dataUrl": "data:image/png;base64,AAAA",
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "invalid_execution_request"
+    assert "embedded image data" in response.json()["detail"]["message"]
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_derives_pr_resolver_title_from_tool_inputs(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from moonmind.workflows.tasks.task_contract import (
+    build_canonical_task_view,
     TaskExecutionSpec,
     TaskStepSpec,
 )
@@ -82,3 +84,106 @@ def test_task_step_spec_with_step_skills() -> None:
     assert spec.skills is not None
     assert spec.skills.exclude == ["bad-skill"]
     assert spec.skills.materialization_mode == "none"
+
+
+def test_task_input_attachments_preserve_objective_and_step_targets() -> None:
+    """MM-367: objective and step refs remain distinct canonical fields."""
+
+    canonical = build_canonical_task_view(
+        job_type="task",
+        payload={
+            "repository": "Moon/Mind",
+            "targetRuntime": "codex",
+            "task": {
+                "instructions": "Inspect the images.",
+                "inputAttachments": [
+                    {
+                        "artifactId": "art-objective",
+                        "filename": "same-name.png",
+                        "contentType": "image/png",
+                        "sizeBytes": 10,
+                    }
+                ],
+                "steps": [
+                    {
+                        "instructions": "Inspect the step image.",
+                        "inputAttachments": [
+                            {
+                                "artifactId": "art-step",
+                                "filename": "same-name.png",
+                                "contentType": "image/png",
+                                "sizeBytes": 20,
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+    )
+
+    assert canonical["task"]["inputAttachments"] == [
+        {
+            "artifactId": "art-objective",
+            "filename": "same-name.png",
+            "contentType": "image/png",
+            "sizeBytes": 10,
+        }
+    ]
+    assert canonical["task"]["steps"][0]["inputAttachments"] == [
+        {
+            "artifactId": "art-step",
+            "filename": "same-name.png",
+            "contentType": "image/png",
+            "sizeBytes": 20,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "attachment",
+    [
+        {"filename": "missing-id.png", "contentType": "image/png", "sizeBytes": 10},
+        {
+            "artifactId": "art-inline",
+            "filename": "inline.png",
+            "contentType": "image/png",
+            "sizeBytes": 10,
+            "dataUrl": "data:image/png;base64,AAAA",
+        },
+        {
+            "artifactId": "art-data-filename",
+            "filename": "data:image/png;base64,AAAA",
+            "contentType": "image/png",
+            "sizeBytes": 10,
+        },
+    ],
+)
+def test_task_input_attachments_reject_incomplete_or_embedded_data(
+    attachment: dict[str, object],
+) -> None:
+    """MM-367: refs stay compact and cannot carry inline image payloads."""
+
+    with pytest.raises(ValidationError):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Inspect image.",
+                "inputAttachments": [attachment],
+            }
+        )
+
+
+def test_task_input_attachments_must_be_lists() -> None:
+    """MM-367: canonical attachment fields are arrays."""
+
+    with pytest.raises(ValidationError, match="task.inputAttachments must be a list"):
+        TaskExecutionSpec.model_validate(
+            {
+                "instructions": "Inspect image.",
+                "inputAttachments": {
+                    "artifactId": "art-objective",
+                    "filename": "objective.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 10,
+                },
+            }
+        )


### PR DESCRIPTION
## Summary
- MM-367: add canonical task-shaped `inputAttachments` support for objective-scoped and step-scoped image attachment refs.
- Validate compact attachment refs in the task contract and reject embedded image data/data URLs.
- Normalize and forward task-level and step-level refs through `/api/executions` into `MoonMind.Run` initial parameters and the original task input snapshot.
- Add Moon Spec artifacts and preserve the original Jira preset brief for verification.

## Jira Issue
- MM-367

## Active MoonSpec Feature Path
- `specs/195-targeted-image-attachment-submission`

## Verification Verdict
- FULLY_IMPLEMENTED

## Tests Run
- `./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/api/routers/test_executions.py tests/contract/test_temporal_execution_api.py`
  - Python: 92 passed, 36 warnings
  - Frontend: 10 files passed, 236 tests passed
- `./tools/test_unit.sh`
  - Python: 3468 passed, 1 xpassed, 119 warnings, 16 subtests passed
  - Frontend: 10 files passed, 236 tests passed

## Remaining Risks
- No blocking risks found.
- The test suite still reports existing deprecation/runtime warnings from unrelated areas; no failures.

## Evidence
- `TaskInputAttachmentRef` validation and task/step attachment fields in `moonmind/workflows/tasks/task_contract.py`.
- `/api/executions` normalization and forwarding in `api_service/api/routers/executions.py`.
- Unit coverage in `tests/unit/workflows/tasks/test_task_contract.py` and `tests/unit/api/routers/test_executions.py`.
- Contract coverage in `tests/contract/test_temporal_execution_api.py` for workflow parameters and original task input snapshot preservation.