### PR TITLE
The browse Jira issue feature should allow you to click on an issue and then automatically append that issue’s text formatted in the standard MoonMind

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5010,6 +5010,10 @@ describe("Task Create Entrypoint", () => {
         "Failed to load Jira issue. You can continue creating the task manually. Jira issue detail failed.",
       ),
     ).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: /ENG-202/ }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
     expect(screen.queryByRole("button", { name: "Replace target text" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Append to target text" })).toBeNull();
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
@@ -5017,6 +5021,109 @@ describe("Task Create Entrypoint", () => {
     );
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing preset instructions.",
+    );
+  });
+
+  it("waits for a fresh Jira issue detail response before appending cached issue text", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    let issueDetailRequests = 0;
+    let resolveFreshIssue: (() => void) | null = null;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        issueDetailRequests += 1;
+        if (issueDetailRequests === 1) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              issueKey: "ENG-202",
+              url: "https://jira.example.test/browse/ENG-202",
+              summary: "Build browser shell",
+              issueType: "Story",
+              column: { id: "doing", name: "Doing" },
+              status: { id: "3", name: "In Progress" },
+              descriptionText: "Let operators browse Jira stories.",
+              acceptanceCriteriaText:
+                "Given a board, users can select a story preview.",
+              recommendedImports: {
+                presetInstructions:
+                  "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+                stepInstructions:
+                  "Complete Jira issue ENG-202: Build browser shell",
+              },
+            }),
+          } as Response);
+        }
+        return new Promise<Response>((resolve) => {
+          resolveFreshIssue = () => {
+            resolve({
+              ok: true,
+              json: async () => ({
+                issueKey: "ENG-202",
+                url: "https://jira.example.test/browse/ENG-202",
+                summary: "Build browser shell",
+                issueType: "Story",
+                column: { id: "doing", name: "Doing" },
+                status: { id: "3", name: "In Progress" },
+                descriptionText: "Fresh Jira issue details.",
+                acceptanceCriteriaText:
+                  "Given a board, users can select a story preview.",
+                recommendedImports: {
+                  presetInstructions:
+                    "ENG-202: Build browser shell\n\nFresh Jira issue details.",
+                  stepInstructions:
+                    "Complete Jira issue ENG-202: Build browser shell",
+                },
+              }),
+            } as Response);
+          };
+        });
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    const presetInstructions = await screen.findByLabelText(
+      "Feature Request / Initial Instructions",
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for preset instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+    fireEvent.change(presetInstructions, {
+      target: { value: "Reset instructions." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for preset instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "To Do 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+
+    await waitFor(() => {
+      expect(resolveFreshIssue).not.toBeNull();
+    });
+    expect(screen.getByRole("dialog", { name: "Browse Jira issue" })).toBeTruthy();
+    expect((presetInstructions as HTMLTextAreaElement).value).toBe(
+      "Reset instructions.",
+    );
+
+    resolveFreshIssue?.();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+    expect((presetInstructions as HTMLTextAreaElement).value).toBe(
+      "Reset instructions.\n\n---\n\nENG-202: Build browser shell\n\nFresh Jira issue details.",
     );
   });
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4572,9 +4572,9 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
     const requestUrls = fetchSpy.mock.calls.map(([input]) => String(input));
     expect(requestUrls).toContain("/api/jira/boards/42/columns?projectKey=ENG");
     expect(requestUrls).toContain("/api/jira/boards/42/issues?projectKey=ENG");
@@ -4907,26 +4907,32 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
-  it("loads Jira issue preview when an issue is selected", async () => {
+  it("appends Jira issue text immediately when an issue is selected", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
+    const presetInstructions = await screen.findByLabelText(
+      "Feature Request / Initial Instructions",
+    );
     fireEvent.click(
-      await screen.findByRole("button", {
+      screen.getByRole("button", {
         name: "Browse Jira issue for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
 
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+    expect((presetInstructions as HTMLTextAreaElement).value).toBe(
+      "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+    );
     expect(
-      await screen.findByText("Let operators browse Jira stories."),
-    ).toBeTruthy();
-    expect(
-      screen.getByText("Given a board, users can select a story preview."),
-    ).toBeTruthy();
+      screen.queryByText("Given a board, users can select a story preview."),
+    ).toBeNull();
   });
 
-  it("does not mutate draft fields when selecting a Jira issue preview", async () => {
+  it("appends only to the selected target when selecting a Jira issue", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const stepInstructions = await screen.findByLabelText("Instructions");
@@ -4947,14 +4953,14 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-
-    expect(await screen.findAllByText("Let operators browse Jira stories."))
-      .not.toHaveLength(0);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing step instructions.",
     );
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
-      "Keep existing preset instructions.",
+      "Keep existing preset instructions.\n\n---\n\nENG-202: Build browser shell\n\nLet operators browse Jira stories.",
     );
   });
 
@@ -5014,7 +5020,7 @@ describe("Task Create Entrypoint", () => {
     );
   });
 
-  it("replaces preset instructions with selected Jira import text", async () => {
+  it("appends preset instructions with selected Jira import text", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const stepInstructions = await screen.findByLabelText("Instructions");
@@ -5035,18 +5041,16 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
 
-    expect(await screen.findAllByText("Let operators browse Jira stories."))
-      .not.toHaveLength(0);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
 
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing step instructions.",
     );
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
-      "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+      "Keep existing preset instructions.\n\n---\n\nENG-202: Build browser shell\n\nLet operators browse Jira stories.",
     );
   });
 
@@ -5067,17 +5071,17 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
 
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Append to target text" }));
 
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing preset instructions.\n\n---\n\nENG-202: Build browser shell\n\nLet operators browse Jira stories.",
     );
   });
 
-  it("replaces only the selected step instructions with Jira import text", async () => {
+  it("appends only the selected step instructions with Jira import text", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const primaryStep = await screen.findByLabelText("Instructions");
@@ -5109,12 +5113,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
 
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
 
     expect((primaryStep as HTMLTextAreaElement).value).toBe(
       "Keep primary instructions.",
@@ -5122,28 +5124,30 @@ describe("Task Create Entrypoint", () => {
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Keep preset instructions.",
     );
-    expect(secondStep.value).toBe("Complete Jira issue ENG-202: Build browser shell");
+    expect(secondStep.value).toBe(
+      "Replace this secondary step.\n\n---\n\nComplete Jira issue ENG-202: Build browser shell",
+    );
     expect(thirdStep.value).toBe("Keep tertiary instructions.");
   });
 
-  it("defaults step-target Jira imports to execution brief mode", async () => {
+  it("uses execution brief text for step-target Jira imports", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
+    const stepInstructions = await screen.findByLabelText("Instructions");
     fireEvent.click(
-      await screen.findByRole("button", {
+      screen.getByRole("button", {
         name: "Browse Jira issue for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    expect((screen.getByLabelText("Import mode") as HTMLSelectElement).value)
-      .toBe("execution-brief");
-    expect(
-      screen.getByText("Complete Jira issue ENG-202: Build browser shell"),
-    ).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+    expect(screen.queryByLabelText("Import mode")).toBeNull();
+    expect((stepInstructions as HTMLTextAreaElement).value).toBe(
+      "Complete Jira issue ENG-202: Build browser shell",
+    );
   });
 
   it("uses an unnamed Jira issue fallback when issue title metadata is empty", async () => {
@@ -5183,17 +5187,14 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
 
-    expect(await screen.findByText("Complete Jira issue (unnamed)")).toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
-
-    expect((stepInstructions as HTMLTextAreaElement).value).toBe(
-      "Complete Jira issue (unnamed)",
-    );
+    await waitFor(() => {
+      expect((stepInstructions as HTMLTextAreaElement).value).toBe(
+        "Complete Jira issue (unnamed)",
+      );
+    });
   });
 
-  it("preserves existing target text when selected Jira import mode is empty", async () => {
+  it("preserves existing target text when selected Jira import text is empty", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -5240,50 +5241,27 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
     await waitFor(() => {
-      expect(screen.getByLabelText("Import mode")).toBeTruthy();
+      expect(
+        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
+      ).toBeNull();
     });
-    fireEvent.change(screen.getByLabelText("Import mode"), {
-      target: { value: "acceptance-only" },
-    });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+
 
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
-      "Keep existing preset instructions.",
+      "Keep existing preset instructions.\n\n---\n\nENG-202: Build browser shell",
     );
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Browse Jira issue" }),
       ).toBeNull();
     });
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
-      }),
-    );
-    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
-    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    await waitFor(() => {
-      expect(screen.getByLabelText("Import mode")).toBeTruthy();
-    });
-    fireEvent.change(screen.getByLabelText("Import mode"), {
-      target: { value: "description-only" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Append to target text" }));
 
     expect((stepInstructions as HTMLTextAreaElement).value).toBe(
       "Keep existing step instructions.",
     );
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
-      ).toBeNull();
-    });
   });
 
-  it("imports selected Jira text by mode", async () => {
+  it("imports selected Jira text in the standard preset format", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetInstructions = await screen.findByLabelText(
@@ -5297,24 +5275,13 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findAllByText("Let operators browse Jira stories."))
-      .not.toHaveLength(0);
-
-    fireEvent.change(screen.getByLabelText("Import mode"), {
-      target: { value: "acceptance-only" },
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
 
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
-      "Given a board, users can select a story preview.",
+      "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
     );
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("dialog", { name: "Browse Jira issue" }),
-      ).toBeNull();
-    });
   });
 
   it("marks preset instructions as needing reapply after Jira import changes an applied preset", async () => {
@@ -5349,11 +5316,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByText(
@@ -5379,7 +5345,7 @@ describe("Task Create Entrypoint", () => {
     expect(screen.getByRole("button", { name: "Apply" })).toBeTruthy();
   });
 
-  it("does not mark preset instructions as needing reapply when Jira import leaves text unchanged", async () => {
+  it("marks preset instructions as needing reapply when Jira import appends to matching text", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
     const presetSelect = await screen.findByLabelText("Preset");
@@ -5413,17 +5379,16 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         "Preset instructions changed. Reapply the preset to regenerate preset-derived steps.",
       ),
-    ).toBeNull();
+    ).toBeTruthy();
   });
 
   it("detaches template step identity when Jira import edits a template-bound step", async () => {
@@ -5458,11 +5423,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
@@ -5482,7 +5446,8 @@ describe("Task Create Entrypoint", () => {
         instructions: "Clarify the {{ inputs.feature_name }} scope.",
       }),
       expect.objectContaining({
-        instructions: "Complete Jira issue ENG-202: Build browser shell",
+        instructions:
+          "Write a plan for the task builder recovery.\n\n---\n\nComplete Jira issue ENG-202: Build browser shell",
       }),
     ]);
     expect([undefined, null, ""]).toContain(
@@ -5529,11 +5494,10 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.queryByText(
@@ -5552,11 +5516,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByLabelText(
@@ -5576,9 +5539,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Append to target text" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByLabelText("Jira import provenance for Step 1 instructions")
@@ -5646,11 +5610,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Browse Jira issue" }),
@@ -5689,11 +5652,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Browse Jira issue" }),
@@ -5707,7 +5669,7 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "Replace target text" }),
+      await screen.findByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();
     expect((screen.getByLabelText("Project") as HTMLSelectElement).value).toBe(
       "ENG",
@@ -5748,11 +5710,6 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: /MY-PROJ-123/ }),
     );
-    expect(await screen.findByText("Keep the full Jira project key."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Browse Jira issue" }),
@@ -5766,7 +5723,7 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(
-      await screen.findByRole("button", { name: "Replace target text" }),
+      await screen.findByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();
     expect((screen.getByLabelText("Project") as HTMLSelectElement).value).toBe(
       "MY-PROJ",
@@ -5791,11 +5748,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByLabelText(
@@ -5823,11 +5779,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByLabelText("Jira import provenance for Step 1 instructions"),
@@ -5850,11 +5805,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.getByLabelText("Jira import provenance for Step 1 instructions"),
@@ -5900,11 +5854,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findAllByText("Let operators browse Jira stories."))
-      .not.toHaveLength(0);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
 
     expect(
       screen.queryByLabelText(
@@ -5923,11 +5876,10 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
-    expect(await screen.findByText("Let operators browse Jira stories."))
-      .toBeTruthy();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Replace target text" }),
-    );
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
     await waitFor(() => {
       expect(
         screen.queryByRole("dialog", { name: "Browse Jira issue" }),

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5027,7 +5027,7 @@ describe("Task Create Entrypoint", () => {
   it("waits for a fresh Jira issue detail response before appending cached issue text", async () => {
     const defaultFetch = fetchSpy.getMockImplementation();
     let issueDetailRequests = 0;
-    let resolveFreshIssue: (() => void) | null = null;
+    const freshIssue = { resolve: null as (() => void) | null };
     fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const path = url.split("?")[0];
@@ -5056,7 +5056,7 @@ describe("Task Create Entrypoint", () => {
           } as Response);
         }
         return new Promise<Response>((resolve) => {
-          resolveFreshIssue = () => {
+          freshIssue.resolve = () => {
             resolve({
               ok: true,
               json: async () => ({
@@ -5111,14 +5111,14 @@ describe("Task Create Entrypoint", () => {
     fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
 
     await waitFor(() => {
-      expect(resolveFreshIssue).not.toBeNull();
+      expect(freshIssue.resolve).not.toBeNull();
     });
     expect(screen.getByRole("dialog", { name: "Browse Jira issue" })).toBeTruthy();
     expect((presetInstructions as HTMLTextAreaElement).value).toBe(
       "Reset instructions.",
     );
 
-    resolveFreshIssue?.();
+    freshIssue.resolve?.();
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
     });

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -250,8 +250,6 @@ type JiraImportMode =
   | "description-only"
   | "acceptance-only";
 
-type JiraWriteMode = "replace" | "append";
-
 interface JiraImportProvenance {
   issueKey: string;
   boardId: string;
@@ -690,7 +688,7 @@ function jiraImportTextForMode(
 function writeJiraImportedText(
   currentText: string,
   importedText: string,
-  writeMode: JiraWriteMode,
+  writeMode: "replace" | "append",
 ): string {
   const normalizedImport = importedText.trim();
   if (writeMode === "replace" || !currentText.trim()) {
@@ -1854,6 +1852,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedJiraBoardId, setSelectedJiraBoardId] = useState("");
   const [activeJiraColumnId, setActiveJiraColumnId] = useState("");
   const [selectedJiraIssueKey, setSelectedJiraIssueKey] = useState("");
+  const [pendingJiraImportIssueKey, setPendingJiraImportIssueKey] =
+    useState("");
   const [jiraImportMode, setJiraImportMode] =
     useState<JiraImportMode>("preset-brief");
   const [presetJiraProvenance, setPresetJiraProvenance] =
@@ -1864,7 +1864,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedStepAttachmentFiles, setSelectedStepAttachmentFiles] = useState<
     Record<string, File[]>
   >({});
-  const [jiraImageImporting, setJiraImageImporting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -2655,6 +2654,24 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const jiraImportWillCustomizeTemplateStep =
     isTemplateBoundStepForInstructions(jiraTargetStep);
 
+  useEffect(() => {
+    if (
+      !jiraBrowserOpen ||
+      !pendingJiraImportIssueKey ||
+      !selectedJiraIssue ||
+      selectedJiraIssueKey !== pendingJiraImportIssueKey
+    ) {
+      return;
+    }
+    setPendingJiraImportIssueKey("");
+    void importSelectedJiraIssue();
+  }, [
+    jiraBrowserOpen,
+    pendingJiraImportIssueKey,
+    selectedJiraIssue,
+    selectedJiraIssueKey,
+  ]);
+
   function jiraProvenanceForTarget(
     target: JiraImportTarget,
   ): JiraImportProvenance | null {
@@ -2705,9 +2722,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       nextBoardId,
     );
     setJiraImportTarget(target);
-    setJiraImportMode(provenance?.importMode || defaultJiraImportMode(target));
+    setJiraImportMode(defaultJiraImportMode(target));
     setJiraBrowserOpen(true);
     setSelectedJiraIssueKey(provenance?.issueKey || "");
+    setPendingJiraImportIssueKey("");
   }
 
   function closeJiraBrowser() {
@@ -2740,6 +2758,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   function selectJiraColumn(columnId: string) {
     setActiveJiraColumnId(columnId);
     setSelectedJiraIssueKey("");
+    setPendingJiraImportIssueKey("");
+  }
+
+  function selectJiraIssue(issueKey: string) {
+    setPendingJiraImportIssueKey(issueKey);
+    setSelectedJiraIssueKey(issueKey);
   }
 
   async function importSelectedJiraImages(
@@ -2776,7 +2800,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       setSubmitMessage("Attachment limit reached before Jira images could be added.");
       return;
     }
-    setJiraImageImporting(true);
     try {
       const downloaded = await Promise.allSettled(
         toDownload.map(async (attachment) => {
@@ -2853,12 +2876,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           ? error
           : new Error("Failed to download Jira images.");
       setSubmitMessage(failure.message);
-    } finally {
-      setJiraImageImporting(false);
     }
   }
 
-  async function importSelectedJiraIssue(writeMode: JiraWriteMode) {
+  async function importSelectedJiraIssue() {
     closeJiraBrowser();
     const issue = selectedJiraIssue;
     const importTarget = jiraImportTarget;
@@ -2872,7 +2893,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const nextText = writeJiraImportedText(
         templateFeatureRequest,
         selectedJiraImportText,
-        writeMode,
+        "append",
       );
       if (nextText.trim() === templateFeatureRequest.trim()) {
         return;
@@ -2901,7 +2922,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       instructions: writeJiraImportedText(
         targetStep.instructions,
         selectedJiraImportText,
-        writeMode,
+        "append",
       ),
     });
     const provenance = createJiraProvenance(
@@ -4433,7 +4454,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             ? "jira-issue-button active"
                             : "jira-issue-button"
                         }
-                        onClick={() => setSelectedJiraIssueKey(issue.issueKey)}
+                        disabled={Boolean(pendingJiraImportIssueKey)}
+                        onClick={() => selectJiraIssue(issue.issueKey)}
                       >
                         <strong>{issue.issueKey}</strong>
                         <span>{issue.summary}</span>
@@ -4454,96 +4476,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 </div>
               </div>
 
-              <aside className="jira-issue-preview stack">
+              <aside className="jira-issue-action stack">
                 {jiraIssueError ? (
                   <p className="notice small">{jiraIssueError}</p>
                 ) : selectedJiraIssueKey && jiraIssueDetailQuery.isLoading ? (
-                  <p className="small">Loading Jira issue...</p>
-                ) : selectedJiraIssue ? (
-                  <>
-                    <div>
-                      <p className="small">{selectedJiraIssue.issueKey}</p>
-                      <h4>{selectedJiraIssue.summary}</h4>
-                    </div>
-                    {selectedJiraIssue.descriptionText ? (
-                      <section>
-                        <strong>Description</strong>
-                        <p style={{ whiteSpace: "pre-wrap" }}>
-                          {selectedJiraIssue.descriptionText}
-                        </p>
-                      </section>
-                    ) : null}
-                    {selectedJiraIssue.acceptanceCriteriaText ? (
-                      <section>
-                        <strong>Acceptance criteria</strong>
-                        <p style={{ whiteSpace: "pre-wrap" }}>
-                          {selectedJiraIssue.acceptanceCriteriaText}
-                        </p>
-                      </section>
-                    ) : null}
-                    {Array.isArray(selectedJiraIssue.attachments) &&
-                    selectedJiraIssue.attachments.length > 0 ? (
-                      <section>
-                        <strong>Images</strong>
-                        <ul className="list">
-                          {selectedJiraIssue.attachments.map((attachment) => (
-                            <li key={attachment.id}>
-                              {attachment.filename}
-                              {attachment.sizeBytes
-                                ? ` (${formatAttachmentBytes(attachment.sizeBytes)})`
-                                : ""}
-                            </li>
-                          ))}
-                        </ul>
-                        <p className="small">
-                          {attachmentPolicy.enabled
-                            ? "Imported text will add supported Jira images to task attachments."
-                            : "Jira images are available, but image attachments are disabled for this runtime."}
-                        </p>
-                      </section>
-                    ) : null}
-                    <label>
-                      Import mode
-                      <select
-                        value={jiraImportMode}
-                        onChange={(event) =>
-                          setJiraImportMode(event.target.value as JiraImportMode)
-                        }
-                      >
-                        <option value="preset-brief">Preset brief</option>
-                        <option value="execution-brief">Execution brief</option>
-                        <option value="description-only">Description only</option>
-                        <option value="acceptance-only">
-                          Acceptance criteria only
-                        </option>
-                      </select>
-                    </label>
-                    <section>
-                      <strong>Import preview</strong>
-                      <p style={{ whiteSpace: "pre-wrap" }}>
-                        {selectedJiraImportText}
-                      </p>
-                    </section>
-                    <div className="actions">
-                      <button
-                        type="button"
-                        disabled={jiraImageImporting}
-                        onClick={() => void importSelectedJiraIssue("replace")}
-                      >
-                        Replace target text
-                      </button>
-                      <button
-                        type="button"
-                        className="secondary"
-                        disabled={jiraImageImporting}
-                        onClick={() => void importSelectedJiraIssue("append")}
-                      >
-                        Append to target text
-                      </button>
-                    </div>
-                  </>
+                  <p className="small">Adding Jira issue to instructions...</p>
                 ) : (
-                  <p className="small">Choose a Jira issue to preview.</p>
+                  <p className="small">
+                    Select an issue to append it to {jiraTargetText}.
+                  </p>
                 )}
               </aside>
             </div>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -2658,14 +2658,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (
       !jiraBrowserOpen ||
       !pendingJiraImportIssueKey ||
-      !selectedJiraIssue ||
       selectedJiraIssueKey !== pendingJiraImportIssueKey
     ) {
+      return;
+    }
+    if (jiraIssueDetailQuery.isError) {
+      setPendingJiraImportIssueKey("");
+      return;
+    }
+    if (jiraIssueDetailQuery.isFetching || !selectedJiraIssue) {
       return;
     }
     setPendingJiraImportIssueKey("");
     void importSelectedJiraIssue();
   }, [
+    jiraIssueDetailQuery.isError,
+    jiraIssueDetailQuery.isFetching,
     jiraBrowserOpen,
     pendingJiraImportIssueKey,
     selectedJiraIssue,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1651,7 +1651,7 @@ button.secondary:hover {
   box-shadow: none;
 }
 
-.jira-issue-preview {
+.jira-issue-action {
   min-width: 0;
   padding: 0.75rem;
   border: 1px solid rgb(var(--mm-border));


### PR DESCRIPTION
The browse Jira issue feature should allow you to click on an issue and then automatically append that issue’s text formatted in the standard MoonMind way into the instructions box. There should be no preview, the action should happen immediately once you select an issue, and there should be no need to choose replace vs append.