### PR TITLE
MM-383 Add composable preset expansion contracts

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/194-oauth-terminal-docker-verification"
+  "feature_directory": "specs/195-composable-preset-expansion"
 }

--- a/api_service/api/schemas.py
+++ b/api_service/api/schemas.py
@@ -374,9 +374,14 @@ class TaskTemplateStepBlueprintSchema(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    kind: Optional[Literal["step", "include"]] = None
     slug: Optional[str] = None
     title: Optional[str] = None
-    instructions: str
+    instructions: Optional[str] = None
+    version: Optional[str] = None
+    alias: Optional[str] = None
+    scope: Optional[Literal["global", "personal"]] = None
+    input_mapping: dict[str, Any] = Field(default_factory=dict, alias="inputMapping")
     skill: Optional[TaskTemplateStepSkillSchema] = None
     annotations: dict[str, Any] = Field(default_factory=dict)
 
@@ -478,6 +483,7 @@ class TaskTemplateExpandResponseSchema(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     steps: list[dict[str, Any]] = Field(default_factory=list)
+    composition: dict[str, Any] = Field(default_factory=dict)
     applied_template: TaskTemplateAppliedMetadataSchema = Field(
         ..., alias="appliedTemplate"
     )

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -54,8 +54,24 @@ _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
 _STEP_RESERVED_KEYS = frozenset(
-    {"id", "title", "slug", "instructions", "skill", "skills", "annotations"}
+    {
+        "id",
+        "kind",
+        "title",
+        "slug",
+        "version",
+        "alias",
+        "scope",
+        "inputMapping",
+        "input_mapping",
+        "instructions",
+        "skill",
+        "skills",
+        "annotations",
+    }
 )
+_STEP_KIND = "step"
+_INCLUDE_KIND = "include"
 logger = logging.getLogger(__name__)
 
 
@@ -231,6 +247,27 @@ def _build_step_id(
     *, slug: str, version: str, index: int, inputs: dict[str, Any]
 ) -> str:
     return f"tpl:{slug}:{version}:{index:02d}:{_hash_from_inputs(inputs)}"
+
+
+def _template_path_label(
+    *, slug: str, version: str, alias: str | None = None
+) -> str:
+    label = f"{slug}@{version}"
+    if alias:
+        return f"{alias}:{label}"
+    return label
+
+
+def _format_include_path(path: list[str]) -> str:
+    return " -> ".join(path)
+
+
+def _composition_capabilities(node: dict[str, Any]) -> list[str]:
+    capabilities = list(node.get("requiredCapabilities") or [])
+    for child in node.get("includes") or []:
+        if isinstance(child, dict):
+            capabilities.extend(_composition_capabilities(child))
+    return _normalize_capabilities(capabilities)
 
 
 def _render_value(
@@ -619,7 +656,7 @@ class TaskTemplateCatalogService:
             steps=validated_steps,
             annotations=dict(annotations or {}),
             required_capabilities=derived_capabilities,
-            max_step_count=max(1, len(validated_steps)),
+            max_step_count=max(25, len(validated_steps)),
             release_status=release_status,
             seed_source=seed_source,
         )
@@ -710,6 +747,7 @@ class TaskTemplateCatalogService:
         if not steps:
             raise TaskTemplateValidationError("Template steps must not be empty.")
         validated: list[dict[str, Any]] = []
+        include_aliases: set[str] = set()
         for index, raw_step in enumerate(steps, start=1):
             if not isinstance(raw_step, dict):
                 raise TaskTemplateValidationError(
@@ -722,6 +760,49 @@ class TaskTemplateCatalogService:
                 raise TaskTemplateValidationError(
                     f"Step {index} uses forbidden keys: {', '.join(blocked)}."
                 )
+            kind = str(raw_step.get("kind") or _STEP_KIND).strip().lower()
+            if kind not in {_STEP_KIND, _INCLUDE_KIND}:
+                raise TaskTemplateValidationError(
+                    f"Step {index} kind must be one of: {_STEP_KIND}, {_INCLUDE_KIND}."
+                )
+            if kind == _INCLUDE_KIND:
+                include_slug = _normalize_slug(str(raw_step.get("slug") or ""))
+                include_version = str(raw_step.get("version") or "").strip()
+                include_alias = _normalize_slug(str(raw_step.get("alias") or ""))
+                if not include_version:
+                    raise TaskTemplateValidationError(
+                        f"Step {index} include requires a pinned version."
+                    )
+                if include_alias in include_aliases:
+                    raise TaskTemplateValidationError(
+                        f"Step {index} include alias '{include_alias}' is duplicated."
+                    )
+                include_aliases.add(include_alias)
+                include_scope = raw_step.get("scope")
+                include_payload: dict[str, Any] = {
+                    "kind": _INCLUDE_KIND,
+                    "slug": include_slug,
+                    "version": include_version,
+                    "alias": include_alias,
+                }
+                if include_scope is not None:
+                    include_payload["scope"] = _normalize_scope(str(include_scope)).value
+                input_mapping = raw_step.get("inputMapping", raw_step.get("input_mapping"))
+                if input_mapping is not None:
+                    if not isinstance(input_mapping, dict):
+                        raise TaskTemplateValidationError(
+                            f"Step {index} include inputMapping must be an object."
+                        )
+                    include_payload["inputMapping"] = dict(input_mapping)
+                annotations = raw_step.get("annotations")
+                if annotations is not None:
+                    if not isinstance(annotations, dict):
+                        raise TaskTemplateValidationError(
+                            f"Step {index} annotations must be an object when provided."
+                        )
+                    include_payload["annotations"] = dict(annotations)
+                validated.append(include_payload)
+                continue
             instructions = str(raw_step.get("instructions") or "").strip()
             if not instructions:
                 raise TaskTemplateValidationError(
@@ -776,6 +857,214 @@ class TaskTemplateCatalogService:
             validated.append(step_payload)
         return validated
 
+    def _select_template_version(
+        self, template: TaskStepTemplate, version: str
+    ) -> TaskStepTemplateVersion:
+        for candidate in template.versions:
+            if candidate.version == version:
+                return candidate
+        raise TaskTemplateNotFoundError("Template version not found.")
+
+    async def _expand_version_steps(
+        self,
+        *,
+        template: TaskStepTemplate,
+        version_model: TaskStepTemplateVersion,
+        scope: TaskTemplateScopeType,
+        scope_ref: str | None,
+        variables: dict[str, Any],
+        root_slug: str,
+        root_version: str,
+        root_inputs: dict[str, Any],
+        root_max_step_count: int,
+        enforce_limit: bool,
+        path: list[str],
+        visited: set[tuple[str, str, str]],
+        resolved_steps: list[dict[str, Any]],
+        alias: str | None = None,
+    ) -> dict[str, Any]:
+        node: dict[str, Any] = {
+            "slug": template.slug,
+            "version": version_model.version,
+            "scope": scope.value,
+            "path": list(path),
+            "stepIds": [],
+            "includes": [],
+            "requiredCapabilities": _normalize_capabilities(
+                list(template.required_capabilities or [])
+                + list(version_model.required_capabilities or [])
+            ),
+        }
+        if alias:
+            node["alias"] = alias
+
+        for source_index, source_step in enumerate(version_model.steps or [], start=1):
+            rendered = _render_value(
+                self._template_env, source_step, variables=variables
+            )
+            if not isinstance(rendered, dict):
+                raise TaskTemplateValidationError(
+                    f"Expanded step at {_format_include_path(path)} must be an object."
+                )
+            kind = str(rendered.get("kind") or _STEP_KIND).strip().lower()
+            if kind == _INCLUDE_KIND:
+                include_slug = _normalize_slug(str(rendered.get("slug") or ""))
+                include_version = str(rendered.get("version") or "").strip()
+                include_alias = _normalize_slug(str(rendered.get("alias") or ""))
+                include_scope = _normalize_scope(str(rendered.get("scope") or scope.value))
+                include_scope_ref = (
+                    None
+                    if include_scope is TaskTemplateScopeType.GLOBAL
+                    else scope_ref
+                )
+                include_path = [
+                    *path,
+                    _template_path_label(
+                        slug=include_slug,
+                        version=include_version,
+                        alias=include_alias,
+                    ),
+                ]
+                if scope is TaskTemplateScopeType.GLOBAL and include_scope is TaskTemplateScopeType.PERSONAL:
+                    raise TaskTemplateValidationError(
+                        "Global presets cannot include personal presets at "
+                        f"{_format_include_path(include_path)}."
+                    )
+                target_key = (include_scope.value, include_slug, include_version)
+                if target_key in visited:
+                    raise TaskTemplateValidationError(
+                        "Preset include cycle detected at "
+                        f"{_format_include_path(include_path)}."
+                    )
+                try:
+                    child_template = await self._get_template_for_scope(
+                        slug=include_slug,
+                        scope=include_scope,
+                        scope_ref=include_scope_ref,
+                    )
+                    child_version = self._select_template_version(
+                        child_template, include_version
+                    )
+                except TaskTemplateError as exc:
+                    raise TaskTemplateValidationError(
+                        f"Preset include target unavailable at "
+                        f"{_format_include_path(include_path)}: {exc}"
+                    ) from exc
+                if child_version.release_status is TaskTemplateReleaseStatus.INACTIVE:
+                    raise TaskTemplateValidationError(
+                        f"Preset include target is inactive at "
+                        f"{_format_include_path(include_path)}."
+                    )
+                input_mapping = rendered.get("inputMapping") or {}
+                if not isinstance(input_mapping, dict):
+                    raise TaskTemplateValidationError(
+                        f"Preset include inputMapping must be an object at "
+                        f"{_format_include_path(include_path)}."
+                    )
+                try:
+                    child_inputs = self._resolve_inputs(
+                        schema=_effective_inputs_schema(
+                            slug=child_template.slug,
+                            inputs_schema=child_version.inputs_schema or [],
+                        ),
+                        submitted=dict(input_mapping),
+                    )
+                except TaskTemplateValidationError as exc:
+                    raise TaskTemplateValidationError(
+                        f"Preset include input mapping is incompatible at "
+                        f"{_format_include_path(include_path)}: {exc}"
+                    ) from exc
+                child_variables = {
+                    **variables,
+                    "inputs": child_inputs,
+                }
+                child_node = await self._expand_version_steps(
+                    template=child_template,
+                    version_model=child_version,
+                    scope=include_scope,
+                    scope_ref=include_scope_ref,
+                    variables=child_variables,
+                    root_slug=root_slug,
+                    root_version=root_version,
+                    root_inputs=root_inputs,
+                    root_max_step_count=root_max_step_count,
+                    enforce_limit=enforce_limit,
+                    path=include_path,
+                    visited={*visited, target_key},
+                    resolved_steps=resolved_steps,
+                    alias=include_alias,
+                )
+                node["includes"].append(child_node)
+                node["stepIds"].extend(child_node["stepIds"])
+                continue
+
+            if kind != _STEP_KIND:
+                raise TaskTemplateValidationError(
+                    f"Expanded step kind must be one of: {_STEP_KIND}, {_INCLUDE_KIND}."
+                )
+            blocked = sorted(
+                key for key in rendered if str(key).strip() in _FORBIDDEN_STEP_KEYS
+            )
+            if blocked:
+                raise TaskTemplateValidationError(
+                    f"Expanded step uses forbidden keys at {_format_include_path(path)}: "
+                    f"{', '.join(blocked)}."
+                )
+            instructions = str(rendered.get("instructions") or "").strip()
+            if not instructions:
+                raise TaskTemplateValidationError(
+                    f"Expanded step instructions may not be empty at "
+                    f"{_format_include_path(path)}."
+                )
+            if _UNRESOLVED_PLACEHOLDER_PATTERN.search(instructions):
+                raise TaskTemplateValidationError(
+                    f"Expanded instructions still contain unresolved template "
+                    f"placeholders at {_format_include_path(path)}."
+                )
+            next_index = len(resolved_steps) + 1
+            if enforce_limit and next_index > root_max_step_count:
+                raise TaskTemplateValidationError(
+                    f"Template expansion exceeded max_step_count={root_max_step_count} "
+                    f"at {_format_include_path(path)}."
+                )
+            step_payload: dict[str, Any] = {
+                "id": _build_step_id(
+                    slug=root_slug,
+                    version=root_version,
+                    index=next_index,
+                    inputs=root_inputs,
+                ),
+                "instructions": instructions,
+                "presetProvenance": {
+                    "root": {"slug": root_slug, "version": root_version},
+                    "source": {
+                        "slug": template.slug,
+                        "version": version_model.version,
+                        "scope": scope.value,
+                        "stepIndex": source_index,
+                    },
+                    "path": list(path),
+                },
+            }
+            if alias:
+                step_payload["presetProvenance"]["alias"] = alias
+            title = str(rendered.get("title") or "").strip()
+            if title:
+                step_payload["title"] = title
+            if isinstance(rendered.get("skill"), dict):
+                step_payload["skill"] = rendered["skill"]
+            step_payload.update(
+                {
+                    str(key).strip(): value
+                    for key, value in rendered.items()
+                    if str(key).strip()
+                    and str(key).strip() not in _STEP_RESERVED_KEYS
+                }
+            )
+            resolved_steps.append(step_payload)
+            node["stepIds"].append(step_payload["id"])
+        return node
+
     async def expand_template(
         self,
         *,
@@ -795,13 +1084,7 @@ class TaskTemplateCatalogService:
             scope=normalized_scope,
             scope_ref=normalized_scope_ref,
         )
-        selected_version = None
-        for candidate in template.versions:
-            if candidate.version == version:
-                selected_version = candidate
-                break
-        if selected_version is None:
-            raise TaskTemplateNotFoundError("Template version not found.")
+        selected_version = self._select_template_version(template, version)
 
         validated_inputs = self._resolve_inputs(
             schema=_effective_inputs_schema(
@@ -821,62 +1104,29 @@ class TaskTemplateCatalogService:
         warnings: list[str] = []
         enforce_limit = options.should_enforce_step_limit if options else True
         max_step_count = max(int(selected_version.max_step_count or 25), 1)
-        if enforce_limit and len(selected_version.steps or []) > max_step_count:
-            raise TaskTemplateValidationError(
-                f"Template expansion exceeded max_step_count={max_step_count}."
-            )
-
-        for index, source_step in enumerate(selected_version.steps or [], start=1):
-            rendered = _render_value(
-                self._template_env, source_step, variables=variables
-            )
-            if not isinstance(rendered, dict):
-                raise TaskTemplateValidationError(
-                    "Expanded step payload must be an object."
-                )
-            blocked = sorted(
-                key for key in rendered if str(key).strip() in _FORBIDDEN_STEP_KEYS
-            )
-            if blocked:
-                raise TaskTemplateValidationError(
-                    f"Expanded step uses forbidden keys: {', '.join(blocked)}."
-                )
-            instructions = str(rendered.get("instructions") or "").strip()
-            if not instructions:
-                raise TaskTemplateValidationError(
-                    "Expanded step instructions may not be empty."
-                )
-            if _UNRESOLVED_PLACEHOLDER_PATTERN.search(instructions):
-                raise TaskTemplateValidationError(
-                    "Expanded instructions still contain unresolved template placeholders."
-                )
-            step_payload: dict[str, Any] = {
-                "id": _build_step_id(
-                    slug=template.slug,
-                    version=selected_version.version,
-                    index=index,
-                    inputs=validated_inputs,
-                ),
-                "instructions": instructions,
-            }
-            title = str(rendered.get("title") or "").strip()
-            if title:
-                step_payload["title"] = title
-            if isinstance(rendered.get("skill"), dict):
-                step_payload["skill"] = rendered["skill"]
-            step_payload.update(
-                {
-                    str(key).strip(): value
-                    for key, value in rendered.items()
-                    if str(key).strip()
-                    and str(key).strip() not in _STEP_RESERVED_KEYS
-                }
-            )
-            resolved_steps.append(step_payload)
+        root_path = [
+            _template_path_label(slug=template.slug, version=selected_version.version)
+        ]
+        composition = await self._expand_version_steps(
+            template=template,
+            version_model=selected_version,
+            scope=normalized_scope,
+            scope_ref=normalized_scope_ref,
+            variables=variables,
+            root_slug=template.slug,
+            root_version=selected_version.version,
+            root_inputs=validated_inputs,
+            root_max_step_count=max_step_count,
+            enforce_limit=enforce_limit,
+            path=root_path,
+            visited={(normalized_scope.value, template.slug, selected_version.version)},
+            resolved_steps=resolved_steps,
+        )
 
         template_caps = _normalize_capabilities(
             list(template.required_capabilities or [])
             + list(selected_version.required_capabilities or [])
+            + _composition_capabilities(composition)
             + [
                 cap
                 for step in resolved_steps
@@ -905,6 +1155,7 @@ class TaskTemplateCatalogService:
         _METRICS.increment("expand")
         return {
             "steps": resolved_steps,
+            "composition": composition,
             "appliedTemplate": {
                 "slug": template.slug,
                 "version": selected_version.version,

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -70,6 +70,18 @@ _STEP_RESERVED_KEYS = frozenset(
         "annotations",
     }
 )
+_INCLUDE_STEP_KEYS = frozenset(
+    {
+        "kind",
+        "slug",
+        "version",
+        "alias",
+        "scope",
+        "inputMapping",
+        "input_mapping",
+        "annotations",
+    }
+)
 _STEP_KIND = "step"
 _INCLUDE_KIND = "include"
 logger = logging.getLogger(__name__)
@@ -766,12 +778,26 @@ class TaskTemplateCatalogService:
                     f"Step {index} kind must be one of: {_STEP_KIND}, {_INCLUDE_KIND}."
                 )
             if kind == _INCLUDE_KIND:
+                unsupported = sorted(
+                    key
+                    for key in raw_step
+                    if str(key).strip() not in _INCLUDE_STEP_KEYS
+                )
+                if unsupported:
+                    raise TaskTemplateValidationError(
+                        f"Step {index} include uses unsupported keys: "
+                        f"{', '.join(unsupported)}."
+                    )
                 include_slug = _normalize_slug(str(raw_step.get("slug") or ""))
                 include_version = str(raw_step.get("version") or "").strip()
                 include_alias = _normalize_slug(str(raw_step.get("alias") or ""))
                 if not include_version:
                     raise TaskTemplateValidationError(
                         f"Step {index} include requires a pinned version."
+                    )
+                if _UNRESOLVED_PLACEHOLDER_PATTERN.search(include_version):
+                    raise TaskTemplateValidationError(
+                        f"Step {index} include version must be a literal pinned version."
                     )
                 if include_alias in include_aliases:
                     raise TaskTemplateValidationError(

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -1555,7 +1555,7 @@ class TaskTemplateCatalogService:
                     steps=validated_steps,
                     annotations=annotations,
                     required_capabilities=derived_capabilities,
-                    max_step_count=max(1, len(validated_steps)),
+                    max_step_count=max(25, len(validated_steps)),
                     release_status=TaskTemplateReleaseStatus.ACTIVE,
                     seed_source=item.get("seedSource"),
                 )
@@ -1576,7 +1576,7 @@ class TaskTemplateCatalogService:
                 ):
                     version_model.required_capabilities = list(derived_capabilities)
                     updated = True
-                max_step_count = max(1, len(validated_steps))
+                max_step_count = max(25, len(validated_steps))
                 if int(version_model.max_step_count or 0) != max_step_count:
                     version_model.max_step_count = max_step_count
                     updated = True

--- a/docs/Tasks/TaskPresetsSystem.md
+++ b/docs/Tasks/TaskPresetsSystem.md
@@ -51,6 +51,11 @@ Plan Executor (MoonMind.Run workflow)
 | **Step** | A single node in a Plan that invokes one tool (skill subtype). See `Step` dataclass. |
 | **Tool / Skill** | An executable capability with input/output schemas, policies, and activity bindings. See `ToolDefinition`. |
 | **Expansion** | The server-side compilation of a preset + user inputs into a `PlanDefinition`. |
+| **Preset Include** | A compositional preset-version entry that references another preset by slug and pinned version. |
+| **Expansion Tree** | The recursive include graph resolved during expansion, including aliases and include paths. |
+| **Flattened Plan** | The ordered concrete step list produced after all includes are resolved. This is the execution-facing shape. |
+| **Preset Provenance** | Compact metadata attached to flattened steps identifying the root preset, source preset, pinned version, alias, and include path. |
+| **Detachment** | Save-as-preset behavior where customized, partial, or provenance-mismatched steps are serialized as concrete steps instead of preserving include semantics. |
 
 ---
 
@@ -166,10 +171,12 @@ Each entry in `inputs_schema` declares a parameterizable field:
 
 ### 4.4 Step blueprints
 
-Each entry in `steps` is a Jinja2 template that expands into a Plan node:
+Each entry in `steps` is a Jinja2 template that expands into a Plan node. Entries
+without an explicit `kind` are treated as `kind: step` for compatibility:
 
 ```yaml
 - title: Invoke moonspec-specify
+  kind: step
   instructions: |-
     Run moonspec-specify with the canonical feature request:
     {{ inputs.feature_request }}
@@ -183,11 +190,39 @@ Each entry in `steps` is a Jinja2 template that expands into a Plan node:
     phase: specification
 ```
 
-**Allowed keys**: `instructions`, `title`, `slug`, `skill`, `annotations`.
+**Allowed keys**: `kind`, `instructions`, `title`, `slug`, `skill`, `annotations`.
 
 **Forbidden keys** (prevent runtime override via presets): `runtime`, `targetRuntime`, `target_runtime`, `model`, `effort`, `repository`, `repo`, `git`, `publish`, `container`.
 
-### 4.5 YAML seed format
+### 4.5 Preset includes
+
+Preset versions MAY include other preset versions as compile-time composition
+entries:
+
+```yaml
+- kind: include
+  slug: shared-quality-checks
+  version: 1.0.0
+  alias: quality
+  scope: global
+  inputMapping:
+    feature_request: "{{ inputs.feature_request }}"
+```
+
+Rules:
+
+- `slug`, pinned `version`, and `alias` are required.
+- `inputMapping` supplies the child preset inputs after the parent entry is rendered.
+- Repeated child includes in one parent version MUST use distinct aliases.
+- Child step overrides are not supported in v1; a child preset expands from its own pinned version and mapped inputs only.
+- `scope` defaults to the parent preset scope when omitted. Personal presets MAY include global presets, but GLOBAL presets MUST NOT include PERSONAL presets.
+- Missing, unreadable, inactive, cyclic, or input-incompatible includes are rejected before executable steps are returned.
+
+Composition is control-plane behavior only. Includes are fully resolved before a
+`PlanDefinition` artifact is stored or submitted; the executor does not evaluate
+nested preset semantics.
+
+### 4.6 YAML seed format
 
 Global presets can be seeded from YAML files in `api_service/data/task_step_templates/`:
 
@@ -237,21 +272,36 @@ Expansion is a server-side, deterministic compilation that transforms a preset +
 3. Build Jinja2 variable context
    └── { inputs: {...}, context: {...}, now: ISO-timestamp, iso_today: YYYY-MM-DD }
 
-4. Render step blueprints
+4. Render step blueprints and includes
    └── Apply SandboxedEnvironment to each step's instructions/title
    └── Reject any unresolved {{ ... }} placeholders
    └── Reject any forbidden keys in rendered output
+   └── For `kind: include`, render `inputMapping` and resolve the child preset
+       version by slug, scope, and pinned version
 
-5. Generate deterministic step IDs
+5. Resolve composition
+   └── Recursively resolve include entries into an expansion tree
+   └── Reject cycles with a path such as parent@1.0.0 → child:shared@1.0.0
+   └── Reject GLOBAL → PERSONAL includes
+   └── Reject missing, unreadable, inactive, or child-input-incompatible includes
+   └── Enforce `max_step_count` after flattening
+
+6. Generate deterministic step IDs
    └── Format: tpl:{slug}:{version}:{index:02d}:{input_hash}
    └── input_hash = sha256(canonical JSON of inputs)[:8]
+   └── `index` is the flattened step index from the root preset expansion
 
-6. Resolve registry snapshot                              ← NEW
+7. Attach provenance
+   └── Each flattened step receives `presetProvenance`
+   └── Provenance includes root slug/version, source slug/version/scope,
+       source step index, include alias, and include path
+
+8. Resolve registry snapshot                              ← NEW
    └── Load current skill registry
    └── Compute snapshot digest
    └── Store snapshot as artifact, capture ArtifactRef
 
-7. Map steps to Plan nodes                                ← NEW
+9. Map steps to Plan nodes                                ← NEW
    └── For each rendered step:
    │   ├── Resolve skill.id → ToolDefinition(name, version) from registry
    │   ├── Validate step inputs against ToolDefinition.input_schema
@@ -259,7 +309,7 @@ Expansion is a server-side, deterministic compilation that transforms a preset +
    └── Infer edges from sequential ordering (linear chain)
        └── Future: support explicit dependency annotations in blueprints
 
-8. Assemble PlanDefinition                                ← NEW
+10. Assemble PlanDefinition                                ← NEW
    └── plan_version: "1.0"
    └── metadata: { title, created_at, registry_snapshot }
    └── policy: { failure_mode: from preset annotations or default FAIL_FAST,
@@ -267,11 +317,11 @@ Expansion is a server-side, deterministic compilation that transforms a preset +
    └── nodes: [Step, ...]
    └── edges: [PlanEdge, ...] (linear chain by default)
 
-9. Store Plan artifact                                    ← NEW
+11. Store Plan artifact                                    ← NEW
    └── Write PlanDefinition JSON as immutable artifact
    └── Return ArtifactRef for workflow submission
 
-10. Record audit metadata
+12. Record audit metadata
     └── Write appliedPreset { slug, version, inputs, planArtifactRef, appliedAt }
     └── Update recents table (top 5 per user)
 ```
@@ -327,6 +377,17 @@ The `skill.id` field in step blueprints maps to registered `ToolDefinition` entr
 | `repo.apply_patch@2.1.0` | Pinned to specific version. |
 
 Resolution failures (skill not found, version mismatch) produce expansion errors, not runtime failures.
+
+### 5.7 Composition output
+
+Expansion returns both:
+
+- `steps[]`: the flattened execution-facing step list.
+- `composition`: the expansion tree used for preview and audit.
+
+Flattened steps include `presetProvenance` so downstream audit, preview, and
+save-as-preset flows can understand the source of each concrete step without
+re-resolving the include graph.
 
 ---
 
@@ -468,6 +529,12 @@ The save service sanitizes steps (strips forbidden keys), scans for secrets (Git
 - Scrub detected secrets (highlighted in UI).
 - Parameterize repeated values as input placeholders.
 - Choose scope (personal; global requires admin promotion).
+- Preserve an include only when the selected steps exactly match an intact
+  provenance subtree from one include expansion and the source preset/version is
+  still readable.
+- Serialize detached, partial, reordered, or customized selections as concrete
+  `kind: step` entries so saved presets never silently retain stale nested
+  semantics.
 
 ---
 

--- a/docs/tmp/jira-orchestration-inputs/MM-383-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-383-moonspec-orchestration-input.md
@@ -1,0 +1,74 @@
+# MM-383 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-383
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document composable preset expansion contracts
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-383 from MM project
+Summary: Document composable preset expansion contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-383 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-383: Document composable preset expansion contracts
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - Design posture throughout
+  - 1. docs/Tasks/TaskPresetsSystem.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a task platform engineer, I want TaskPresetsSystem to define composable preset entries and deterministic expansion so presets can reuse other presets without changing runtime execution semantics.
+
+Acceptance Criteria
+- TaskPresetsSystem defines Preset Include, Expansion Tree, Flattened Plan, Preset Provenance, and Detachment.
+- Preset version steps are documented as a union of kind: step and kind: include entries with required pinned include versions and distinct aliases for repeated child includes.
+- Scope rules prevent GLOBAL presets from including PERSONAL presets and reject unreadable, missing, inactive, or incompatible includes.
+- The composable expansion pipeline documents recursive resolution, cycle detection, limit enforcement, deterministic ID assignment, provenance attachment, flattening, and artifact/audit storage.
+- Cycle and limit failures include enough detail to identify the include path that caused rejection.
+- Save-as-preset semantics preserve intact includes only when exact provenance remains and serialize detached or custom steps as concrete steps.
+- The executor boundary explicitly states that nested preset semantics are resolved before PlanDefinition storage.
+
+Requirements
+- Define preset composition as compile-time control-plane behavior only.
+- Document kind: include storage semantics with pinned version, alias, input mapping, and no v1 child override behavior.
+- Document deterministic resolved step ID inputs and per-step provenance shape.
+- Document expand API output that can return composition and flat plan views.
+- Document exact-match preservation semantics for save-as-preset.
+
+Verification
+- Confirm the canonical documentation updates preserve desired-state documentation under `docs/` and keep volatile implementation planning under `docs/tmp/`.
+- Confirm coverage for DESIGN-REQ-001 through DESIGN-REQ-010, DESIGN-REQ-025, and DESIGN-REQ-026 from `docs/Tasks/PresetComposability.md`.
+- Run documentation-focused validation and relevant tests for task preset behavior if implementation touches executable preset contracts.
+
+Out of Scope
+- Changing runtime execution semantics for already-expanded `PlanDefinition` storage.
+- Implementing unpinned include resolution or child override behavior.
+- Allowing GLOBAL presets to include PERSONAL presets.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5457,6 +5457,10 @@ export interface components {
             steps?: {
                 [key: string]: unknown;
             }[];
+            /** Composition */
+            composition?: {
+                [key: string]: unknown;
+            };
             appliedTemplate: components["schemas"]["TaskTemplateAppliedMetadataSchema"];
             /** Capabilities */
             capabilities?: string[];
@@ -5603,12 +5607,24 @@ export interface components {
          * @description Template step blueprint definition.
          */
         TaskTemplateStepBlueprintSchema: {
+            /** Kind */
+            kind?: ("step" | "include") | null;
             /** Slug */
             slug?: string | null;
             /** Title */
             title?: string | null;
             /** Instructions */
-            instructions: string;
+            instructions?: string | null;
+            /** Version */
+            version?: string | null;
+            /** Alias */
+            alias?: string | null;
+            /** Scope */
+            scope?: ("personal" | "global") | null;
+            /** Inputmapping */
+            inputMapping?: {
+                [key: string]: unknown;
+            };
             skill?: components["schemas"]["TaskTemplateStepSkillSchema"] | null;
             /** Annotations */
             annotations?: {

--- a/specs/195-composable-preset-expansion/checklists/requirements.md
+++ b/specs/195-composable-preset-expansion/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Composable Preset Expansion
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The Jira source document `docs/Tasks/PresetComposability.md` is absent in this checkout, so the preserved MM-383 Jira preset brief is treated as the canonical source for source-design mappings.

--- a/specs/195-composable-preset-expansion/contracts/task-template-composition.md
+++ b/specs/195-composable-preset-expansion/contracts/task-template-composition.md
@@ -1,0 +1,102 @@
+# Contract: Task Template Composition
+
+## Preset Version Step Union
+
+Concrete step entry:
+
+```json
+{
+  "kind": "step",
+  "title": "Run tests",
+  "instructions": "Run the test suite.",
+  "skill": {"id": "auto", "args": {}},
+  "annotations": {}
+}
+```
+
+Existing entries without `kind` are treated as `kind: step`.
+
+Include entry:
+
+```json
+{
+  "kind": "include",
+  "slug": "child-preset",
+  "version": "1.0.0",
+  "alias": "child-checks",
+  "scope": "global",
+  "inputMapping": {
+    "feature_request": "{{ inputs.feature_request }}"
+  }
+}
+```
+
+Rules:
+- `version` is required and pinned.
+- `alias` is required.
+- `inputMapping` is optional and supplies child preset inputs.
+- Child step overrides are not accepted.
+- Global parent presets cannot include personal child presets.
+
+## Expand Response
+
+The expand response remains compatible with existing consumers:
+
+```json
+{
+  "steps": [
+    {
+      "id": "tpl:parent:1.0.0:01:abcd1234",
+      "title": "Child step",
+      "instructions": "Do work",
+      "skill": {"id": "auto", "args": {}},
+      "presetProvenance": {
+        "root": {"slug": "parent", "version": "1.0.0"},
+        "source": {
+          "slug": "child",
+          "version": "1.0.0",
+          "scope": "global",
+          "stepIndex": 1
+        },
+        "alias": "child-checks",
+        "path": ["parent@1.0.0", "child-checks:child@1.0.0"]
+      }
+    }
+  ],
+  "composition": {
+    "slug": "parent",
+    "version": "1.0.0",
+    "scope": "global",
+    "path": ["parent@1.0.0"],
+    "stepIds": ["tpl:parent:1.0.0:01:abcd1234"],
+    "includes": []
+  },
+  "appliedTemplate": {
+    "slug": "parent",
+    "version": "1.0.0",
+    "inputs": {},
+    "stepIds": ["tpl:parent:1.0.0:01:abcd1234"],
+    "appliedAt": "..."
+  },
+  "capabilities": ["codex"],
+  "warnings": []
+}
+```
+
+## Failure Contract
+
+Expansion fails before returning executable steps when:
+- Include path contains a cycle.
+- Flattened step count exceeds root `max_step_count`.
+- Include target is missing, unreadable, inactive, or input-incompatible.
+- A global preset includes a personal preset.
+
+Failure messages include the include path, for example:
+
+```text
+Preset include cycle detected at parent@1.0.0 -> child:child@1.0.0 -> parent:parent@1.0.0.
+```
+
+## Executor Boundary
+
+Preset includes are resolved before execution-facing `PlanDefinition` storage. The executor receives concrete steps and provenance metadata only; it does not evaluate include graphs.

--- a/specs/195-composable-preset-expansion/data-model.md
+++ b/specs/195-composable-preset-expansion/data-model.md
@@ -1,0 +1,73 @@
+# Data Model: Composable Preset Expansion
+
+## Preset Include
+
+Represents a compositional entry inside an existing preset version `steps` JSON array.
+
+Fields:
+- `kind`: Required literal `include`.
+- `slug`: Required child preset slug.
+- `version`: Required child preset version label. Must be pinned.
+- `alias`: Required alias for this include instance. Repeated child includes in the same parent must use distinct aliases.
+- `scope`: Optional child scope. Defaults to the parent scope. `global` and `personal` are valid values.
+- `inputMapping`: Optional object mapping child input names to literal or rendered values.
+
+Validation rules:
+- Global parent presets cannot include personal child presets.
+- Missing, unreadable, inactive, or input-incompatible child versions are rejected.
+- Child step overrides are not supported.
+
+## Expansion Tree
+
+Represents the resolved include graph for one expansion request.
+
+Fields:
+- `slug`
+- `version`
+- `scope`
+- `alias` when the node is reached by include
+- `path`: Ordered include path from root to node
+- `includes`: Child expansion tree nodes
+- `stepIds`: Flattened step IDs emitted from this node
+
+Validation rules:
+- A `(scope, slug, version)` already present in the current path is a cycle.
+- Error messages for cycles and limit failures include the path.
+
+## Flattened Plan
+
+Represents the concrete ordered steps returned by expansion and consumed by existing downstream boundaries.
+
+Fields:
+- Existing step fields such as `id`, `title`, `instructions`, `skill`, and annotations.
+- `presetProvenance`: Source metadata for audit and save-as-preset reasoning.
+
+Validation rules:
+- Step IDs remain deterministic for the root preset, selected version, flattened index, and root input set.
+- The root preset `max_step_count` applies after include flattening.
+
+## Preset Provenance
+
+Metadata attached to each flattened step.
+
+Fields:
+- `root`: Root preset slug and version.
+- `source`: Source preset slug, version, concrete source step index, and scope.
+- `path`: Include path from root to the source step.
+- `alias`: Include alias for child-provided steps, absent for root concrete steps.
+
+Validation rules:
+- Provenance must be present on steps produced through the composable expansion path.
+- Provenance is compact metadata, not embedded large skill or preset content.
+
+## Detachment
+
+Save-as-preset classification for a selected group of expanded steps.
+
+States:
+- `intact_include`: Selection exactly matches a provenance subtree and can be serialized as an include.
+- `detached_steps`: Selection is customized, partial, or provenance-mismatched and must be serialized as concrete steps.
+
+Validation rules:
+- Exact-match preservation is allowed only when source provenance remains unchanged.
+- Detached or custom steps never preserve include semantics silently.

--- a/specs/195-composable-preset-expansion/plan.md
+++ b/specs/195-composable-preset-expansion/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Composable Preset Expansion
+
+**Branch**: `195-composable-preset-expansion` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story feature specification from `specs/195-composable-preset-expansion/spec.md`
+
+## Summary
+
+Implement MM-383 by extending the task template catalog expansion service to treat preset includes as compile-time control-plane composition. Preset versions will accept concrete steps and include entries, recursively resolve active child versions into the existing flattened step output, attach provenance and composition metadata, enforce scope/cycle/limit/input rules, and document the executor boundary. Unit tests cover expansion semantics and failure modes; service-level tests exercise the catalog boundary used by API routes and seed synchronization.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: FastAPI service layer, SQLAlchemy async sessions, Pydantic v2 schemas, Jinja2 `SandboxedEnvironment`, existing task template catalog models  
+**Storage**: Existing `TaskStepTemplate` and `TaskStepTemplateVersion` rows with JSON step payloads; no new tables  
+**Unit Testing**: pytest via `./tools/test_unit.sh`, focused iteration with `pytest tests/unit/api/test_task_step_templates_service.py`  
+**Integration Testing**: Existing service-boundary tests through pytest; full hermetic integration via `./tools/test_integration.sh` when Docker is available  
+**Target Platform**: MoonMind API service and managed-agent Linux runtime  
+**Project Type**: Web service control plane with Temporal plan execution downstream  
+**Performance Goals**: Expansion remains deterministic and bounded by `max_step_count`; recursive include traversal rejects cycles before unbounded work  
+**Constraints**: No new persistent storage; global presets cannot include personal presets; nested semantics must resolve before execution-facing plan output; preserve concrete-step-only compatibility  
+**Scale/Scope**: One independently testable task preset composition story covering the catalog expansion service, API response metadata, tests, and canonical docs
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Composition stays in the orchestration control plane and does not replace agents or executor behavior.
+- II. One-Click Agent Deployment: PASS. No new required services or secrets.
+- III. Avoid Vendor Lock-In: PASS. The feature is catalog-local and does not bind to a provider.
+- IV. Own Your Data: PASS. Composition metadata remains in local catalog and expansion outputs.
+- V. Skills Are First-Class and Easy to Add: PASS. Presets compose existing skill-backed steps without mutating skill contracts.
+- VI. Replaceable Scaffolding: PASS. The behavior is implemented behind the existing catalog service boundary with tests.
+- VII. Runtime Configurability: PASS. Existing catalog inputs and limits remain operator-controlled through stored preset versions.
+- VIII. Modular Architecture: PASS. Changes are scoped to task template catalog service, schemas as needed, docs, and tests.
+- IX. Resilient by Default: PASS. Recursive expansion is bounded, deterministic, and fails fast on invalid include graphs.
+- X. Continuous Improvement: PASS. Errors identify include paths and verification artifacts preserve MM-383 traceability.
+- XI. Spec-Driven Development: PASS. This spec, plan, tasks, implementation, and verification artifacts drive the change.
+- XII. Canonical Documentation Separation: PASS. Desired-state docs are updated in `docs/Tasks/TaskPresetsSystem.md`; volatile orchestration input stays in `docs/tmp/`.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases are introduced; existing concrete-step expansion remains directly supported.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/195-composable-preset-expansion/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── task-template-composition.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+├── services/
+│   └── task_templates/
+│       └── catalog.py
+└── api/
+    └── schemas.py
+
+docs/
+└── Tasks/
+    └── TaskPresetsSystem.md
+
+tests/
+└── unit/
+    └── api/
+        └── test_task_step_templates_service.py
+```
+
+**Structure Decision**: Extend the existing task template catalog service because it already owns preset validation, seed synchronization, input resolution, deterministic step IDs, expansion responses, recents, and capability aggregation.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/195-composable-preset-expansion/quickstart.md
+++ b/specs/195-composable-preset-expansion/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Composable Preset Expansion
+
+## Focused Unit Validation
+
+```bash
+pytest tests/unit/api/test_task_step_templates_service.py -q
+```
+
+Expected coverage:
+- Concrete-step-only expansion remains compatible.
+- Parent presets flatten active child includes.
+- Flattened steps include deterministic IDs and provenance.
+- Composition metadata describes the include tree.
+- Scope, cycle, inactive target, incompatible input, and limit failures include useful paths.
+
+## Full Unit Suite
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Hermetic Integration Suite
+
+```bash
+./tools/test_integration.sh
+```
+
+Run when Docker is available. This story does not add new external credentials.
+
+## Manual Contract Check
+
+1. Create a global child preset with one or more concrete steps.
+2. Create a global parent preset with a `kind: include` entry referencing the child slug and pinned version.
+3. Expand the parent preset.
+4. Confirm `steps[]` contains only concrete executable steps.
+5. Confirm `composition` and each step's `presetProvenance` preserve MM-383 contract semantics.
+6. Confirm no executor or `PlanDefinition` path needs to resolve includes at runtime.

--- a/specs/195-composable-preset-expansion/research.md
+++ b/specs/195-composable-preset-expansion/research.md
@@ -1,0 +1,49 @@
+# Research: Composable Preset Expansion
+
+## Input Classification
+
+Decision: Treat MM-383 as a single-story runtime feature request.
+
+Rationale: The Jira brief contains one user story for task platform engineers and a bounded acceptance set around composable preset expansion. The requested mode is runtime, and the brief points at task preset system requirements, so behavior is implemented in the catalog expansion service rather than as documentation-only work.
+
+Alternatives considered: Treating the request as a broad declarative design was rejected because the brief already selects one independently testable story. Treating it as docs-only was rejected because runtime mode was explicitly selected.
+
+## Source Document Availability
+
+Decision: Use the preserved MM-383 Jira preset brief as the canonical source for DESIGN-REQ mappings.
+
+Rationale: The Jira brief references `docs/Tasks/PresetComposability.md`, but that file is absent in the current checkout. The existing `docs/Tasks/TaskPresetsSystem.md` provides the current catalog baseline and is the canonical documentation target.
+
+Alternatives considered: Blocking on the missing source document was rejected because the trusted Jira issue already includes the source requirements needed for this story.
+
+## Include Representation
+
+Decision: Represent preset version entries as a union of default concrete steps and `kind: include` entries with `slug`, pinned `version`, `alias`, optional `scope`, and `inputMapping`.
+
+Rationale: This preserves existing concrete-step payloads while making composition explicit and deterministic. Existing presets without `kind` remain concrete steps.
+
+Alternatives considered: Introducing a separate include table was rejected because MM-383 requires no new persistent storage and composition can be represented in the existing JSON step payload.
+
+## Expansion Strategy
+
+Decision: Resolve includes recursively inside `TaskTemplateCatalogService.expand_template`, producing the existing flat `steps[]` response plus `composition` and per-step `presetProvenance`.
+
+Rationale: The catalog service already owns expansion, input validation, deterministic IDs, capabilities, recents, and warnings. Resolving before returning steps keeps nested semantics away from executor boundaries.
+
+Alternatives considered: Deferring include resolution to the plan executor was rejected because the brief requires compile-time control-plane behavior and no runtime execution semantic changes.
+
+## Failure Handling
+
+Decision: Fail fast with `TaskTemplateValidationError` messages that include a human-readable include path.
+
+Rationale: Existing service tests already assert validation exceptions. Path-bearing messages satisfy cycle and limit diagnostics without adding a new error hierarchy.
+
+Alternatives considered: Returning partial expansion warnings was rejected because missing, inactive, incompatible, cyclic, or scope-invalid includes must not produce executable steps.
+
+## Test Strategy
+
+Decision: Add focused pytest service tests covering successful include flattening, provenance/composition metadata, scope rejection, cycle path rejection, inactive or incompatible child rejection, and flattened limit enforcement.
+
+Rationale: The task template catalog service is the real boundary used by API routes and seed synchronization, and unit-level async database tests already exist for it. Full integration tests are unchanged unless Docker-backed CI is available.
+
+Alternatives considered: Browser/UI tests were rejected because the selected story is expansion-contract behavior, not catalog UI rendering.

--- a/specs/195-composable-preset-expansion/spec.md
+++ b/specs/195-composable-preset-expansion/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Composable Preset Expansion
+
+**Feature Branch**: `195-composable-preset-expansion`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**:
+
+```text
+# MM-383 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-383
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document composable preset expansion contracts
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-383 from MM project
+Summary: Document composable preset expansion contracts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-383 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-383: Document composable preset expansion contracts
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - Design posture throughout
+  - 1. docs/Tasks/TaskPresetsSystem.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a task platform engineer, I want TaskPresetsSystem to define composable preset entries and deterministic expansion so presets can reuse other presets without changing runtime execution semantics.
+
+Acceptance Criteria
+- TaskPresetsSystem defines Preset Include, Expansion Tree, Flattened Plan, Preset Provenance, and Detachment.
+- Preset version steps are documented as a union of kind: step and kind: include entries with required pinned include versions and distinct aliases for repeated child includes.
+- Scope rules prevent GLOBAL presets from including PERSONAL presets and reject unreadable, missing, inactive, or incompatible includes.
+- The composable expansion pipeline documents recursive resolution, cycle detection, limit enforcement, deterministic ID assignment, provenance attachment, flattening, and artifact/audit storage.
+- Cycle and limit failures include enough detail to identify the include path that caused rejection.
+- Save-as-preset semantics preserve intact includes only when exact provenance remains and serialize detached or custom steps as concrete steps.
+- The executor boundary explicitly states that nested preset semantics are resolved before PlanDefinition storage.
+
+Requirements
+- Define preset composition as compile-time control-plane behavior only.
+- Document kind: include storage semantics with pinned version, alias, input mapping, and no v1 child override behavior.
+- Document deterministic resolved step ID inputs and per-step provenance shape.
+- Document expand API output that can return composition and flat plan views.
+- Document exact-match preservation semantics for save-as-preset.
+
+Verification
+- Confirm the canonical documentation updates preserve desired-state documentation under `docs/` and keep volatile implementation planning under `docs/tmp/`.
+- Confirm coverage for DESIGN-REQ-001 through DESIGN-REQ-010, DESIGN-REQ-025, and DESIGN-REQ-026 from `docs/Tasks/PresetComposability.md`.
+- Run documentation-focused validation and relevant tests for task preset behavior if implementation touches executable preset contracts.
+
+Out of Scope
+- Changing runtime execution semantics for already-expanded `PlanDefinition` storage.
+- Implementing unpinned include resolution or child override behavior.
+- Allowing GLOBAL presets to include PERSONAL presets.
+```
+
+## User Story - Composable Preset Expansion
+
+**Summary**: As a task platform engineer, I want task presets to support pinned include entries that expand deterministically so reusable preset building blocks can be composed before runtime execution.
+
+**Goal**: Preset authors can declare includes in preset versions, and operators receive a deterministic flattened plan with provenance while the executor continues to consume only resolved steps.
+
+**Independent Test**: Can be fully tested by creating parent and child presets, expanding the parent, and verifying the flattened steps, provenance, include rejection rules, cycle and limit failures, and executor-boundary documentation without running a Temporal workflow.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active child preset with concrete steps and an active parent preset with a pinned include entry, **When** the parent is expanded, **Then** the response contains the child steps in a deterministic flattened order with provenance that identifies the root preset, child preset, version, alias, and include path.
+2. **Given** a global parent preset attempts to include a personal child preset, **When** expansion is requested, **Then** expansion is rejected before producing executable steps.
+3. **Given** an include references a missing, unreadable, inactive, or input-incompatible preset version, **When** expansion is requested, **Then** expansion fails with an error that identifies the include path and reason.
+4. **Given** presets include each other recursively or exceed the configured expansion step limit, **When** expansion is requested, **Then** expansion fails with an error that identifies the include path responsible for rejection.
+5. **Given** a task is saved back as a preset from provenance-preserving expanded steps, **When** the saved selection exactly matches an include subtree, **Then** the include can remain intact; otherwise detached or customized steps are serialized as concrete steps.
+6. **Given** a flattened plan is submitted for execution, **When** runtime execution begins, **Then** no nested preset semantics remain in the executor boundary.
+
+### Edge Cases
+
+- Repeated inclusion of the same child preset is allowed only when each include has a distinct alias in the parent version.
+- Child preset inputs must be provided through the parent include input mapping; child presets do not receive ad hoc v1 override behavior.
+- Include expansion must remain deterministic when the same root preset and inputs are expanded repeatedly.
+- A source document named by the Jira brief, `docs/Tasks/PresetComposability.md`, is absent in the current checkout; the preserved MM-383 Jira brief is the canonical source for these requirements.
+
+## Assumptions
+
+- Include entries resolve within the existing task template catalog and use existing scope visibility rules.
+- Personal presets may include global presets, but global presets may not include personal presets.
+- The current runtime continues to expose legacy `steps[]` expansion output while adding composition and provenance metadata for the same flattened plan view.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Preset versions MUST support a step union with concrete `kind: step` entries and compositional `kind: include` entries.
+- **FR-002**: Include entries MUST require a child preset slug, pinned child version, and distinct alias when the same parent includes child presets.
+- **FR-003**: Include entries MUST support explicit input mapping into the child preset and MUST NOT support child step override behavior.
+- **FR-004**: Expansion MUST recursively resolve include entries into a flattened ordered step list before execution-facing output is produced.
+- **FR-005**: Expansion MUST detect include cycles and return an error that identifies the include path.
+- **FR-006**: Expansion MUST enforce the root preset expansion step limit after includes are flattened and return an error that identifies the include path that exceeded the limit.
+- **FR-007**: Expansion MUST reject global-to-personal includes and reject missing, unreadable, inactive, or input-incompatible child preset versions.
+- **FR-008**: Expanded steps MUST include deterministic identifiers and provenance metadata that identify the root preset, source preset, pinned version, include alias, and include path.
+- **FR-009**: Expansion output MUST expose both the flattened step plan and composition metadata suitable for preview or audit use.
+- **FR-010**: Save-as-preset semantics MUST preserve intact include provenance only for exact matches and serialize detached or customized selections as concrete steps.
+- **FR-011**: Runtime executor documentation and behavior MUST keep nested preset semantics resolved before `PlanDefinition` storage and execution.
+- **FR-012**: MoonSpec artifacts, verification evidence, commit text, and pull request metadata for this work MUST retain Jira issue key `MM-383` and the original Jira preset brief.
+
+### Key Entities
+
+- **Preset Include**: A versioned catalog reference inside a preset version with slug, pinned version, alias, optional scope, and input mapping.
+- **Expansion Tree**: The recursive include graph resolved during expansion, including aliases and paths.
+- **Flattened Plan**: The ordered concrete step list produced by expansion and consumed by existing execution boundaries.
+- **Preset Provenance**: Metadata attached to each flattened step that records where the step came from.
+- **Detachment**: The save-as-preset state where customized or partially selected steps become concrete steps instead of preserved includes.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source "Design posture throughout" requires preset composition to remain compile-time control-plane behavior only. Scope: in scope. Maps to FR-004, FR-011.
+- **DESIGN-REQ-002**: Source "TaskPresetsSystem" requires terms for Preset Include, Expansion Tree, Flattened Plan, Preset Provenance, and Detachment. Scope: in scope. Maps to FR-001, FR-008, FR-010.
+- **DESIGN-REQ-003**: Source "TaskPresetsSystem" requires preset version steps to be a union of concrete steps and includes. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-004**: Source "TaskPresetsSystem" requires includes to use pinned versions. Scope: in scope. Maps to FR-002.
+- **DESIGN-REQ-005**: Source "TaskPresetsSystem" requires distinct aliases for repeated child includes. Scope: in scope. Maps to FR-002.
+- **DESIGN-REQ-006**: Source "TaskPresetsSystem" requires scope rules that prevent global presets from including personal presets. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-007**: Source "TaskPresetsSystem" requires missing, unreadable, inactive, or incompatible includes to be rejected. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-008**: Source "TaskPresetsSystem" requires recursive resolution, cycle detection, limit enforcement, deterministic ID assignment, provenance attachment, flattening, and artifact or audit storage. Scope: in scope. Maps to FR-004, FR-005, FR-006, FR-008, FR-009.
+- **DESIGN-REQ-009**: Source "TaskPresetsSystem" requires cycle and limit failures to identify the include path. Scope: in scope. Maps to FR-005, FR-006.
+- **DESIGN-REQ-010**: Source "TaskPresetsSystem" requires save-as-preset exact-match preservation and detached concrete-step serialization. Scope: in scope. Maps to FR-010.
+- **DESIGN-REQ-025**: Source "Cross-document invariants" requires expand API output to support composition and flat plan views. Scope: in scope. Maps to FR-009.
+- **DESIGN-REQ-026**: Source "Cross-document invariants" requires executor boundaries to receive resolved nested preset semantics before `PlanDefinition` storage. Scope: in scope. Maps to FR-011.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Expanding a parent preset with one pinned child include returns the expected concrete child steps in stable order with deterministic IDs and provenance metadata.
+- **SC-002**: Expansion fails with path-bearing validation errors for global-to-personal include attempts, cycles, missing or inactive child versions, incompatible child inputs, and flattened step limit excess.
+- **SC-003**: Existing non-composed preset expansion behavior remains compatible for concrete-step-only presets.
+- **SC-004**: Task preset system documentation describes include storage, expansion, provenance, detachment, and executor boundary semantics.
+- **SC-005**: Final verification can compare implementation evidence against the preserved `MM-383` Jira preset brief.

--- a/specs/195-composable-preset-expansion/tasks.md
+++ b/specs/195-composable-preset-expansion/tasks.md
@@ -71,8 +71,8 @@
 
 ## Verification Notes
 
-- Focused service/API command: `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` passed with 27 tests.
-- Full unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3466 Python tests, 16 subtests, and 236 frontend tests.
+- Focused service/API command: `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` passed with 29 tests, including seed-sync include limit coverage.
+- Full unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3468 Python tests, 16 subtests, and 236 frontend tests.
 - Hermetic integration command was not run because Docker is unavailable in this managed workspace: `dial unix /var/run/docker.sock: connect: no such file or directory`.
 - Final `/moonspec-verify` verdict: `FULLY_IMPLEMENTED` with integration-suite execution blocked only by the workspace Docker socket, while service/API boundary tests cover the MM-383 composition contract.
 

--- a/specs/195-composable-preset-expansion/tasks.md
+++ b/specs/195-composable-preset-expansion/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: Composable Preset Expansion
+
+**Input**: Design documents from `/specs/195-composable-preset-expansion/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Source Traceability**: MM-383 Jira preset brief is preserved in `spec.md` and `docs/tmp/jira-orchestration-inputs/MM-383-moonspec-orchestration-input.md`. Tasks cover FR-001 through FR-012, acceptance scenarios 1-6, SC-001 through SC-005, and DESIGN-REQ-001 through DESIGN-REQ-010 plus DESIGN-REQ-025 and DESIGN-REQ-026.
+
+**Test Commands**:
+
+- Unit tests: `pytest tests/unit/api/test_task_step_templates_service.py -q`
+- Integration tests: `./tools/test_integration.sh` when Docker is available
+- Final verification: `/speckit.verify`
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature pointer is `specs/195-composable-preset-expansion` in `.specify/feature.json`
+- [X] T002 [P] Review existing task template catalog expansion service in `api_service/services/task_templates/catalog.py`
+- [X] T003 [P] Review current task preset documentation in `docs/Tasks/TaskPresetsSystem.md`
+
+## Phase 2: Foundational
+
+- [X] T004 Define include-entry validation expectations for FR-001 through FR-003 in `tests/unit/api/test_task_step_templates_service.py`
+- [X] T005 Define recursive expansion failure expectations for FR-005 through FR-007 in `tests/unit/api/test_task_step_templates_service.py`
+- [X] T006 Define provenance and composition response expectations for FR-008 and FR-009 in `tests/unit/api/test_task_step_templates_service.py`
+
+## Phase 3: Story - Composable Preset Expansion
+
+**Summary**: As a task platform engineer, I want task presets to support pinned include entries that expand deterministically so reusable preset building blocks can be composed before runtime execution.
+
+**Independent Test**: Create parent and child presets, expand the parent, and verify flattened steps, provenance, include rejection rules, cycle and limit failures, and executor-boundary documentation without running a Temporal workflow.
+
+**Traceability**: FR-001-FR-012, SC-001-SC-005, DESIGN-REQ-001-DESIGN-REQ-010, DESIGN-REQ-025, DESIGN-REQ-026
+
+### Unit Tests
+
+- [X] T007 [P] Add failing unit test for successful child include flattening with deterministic IDs, provenance, composition metadata, and capabilities in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-008, FR-009, SC-001)
+- [X] T008 [P] Add failing unit test rejecting global parent to personal child include in `tests/unit/api/test_task_step_templates_service.py` (FR-007, DESIGN-REQ-006, SC-002)
+- [X] T009 [P] Add failing unit tests for include cycle paths, flattened limit paths, inactive child versions, and incompatible child inputs in `tests/unit/api/test_task_step_templates_service.py` (FR-005, FR-006, FR-007, DESIGN-REQ-007, DESIGN-REQ-009, SC-002)
+- [X] T010 Run `pytest tests/unit/api/test_task_step_templates_service.py -q` and confirm new tests fail for missing include behavior
+
+### Implementation
+
+- [X] T011 Implement `kind: step` / `kind: include` validation, pinned versions, aliases, and input mapping in `api_service/services/task_templates/catalog.py` (FR-001, FR-002, FR-003)
+- [X] T012 Implement recursive include expansion, scope checks, inactive/missing/incompatible rejection, cycle detection, and flattened limit enforcement in `api_service/services/task_templates/catalog.py` (FR-004, FR-005, FR-006, FR-007)
+- [X] T013 Implement flattened-step deterministic provenance and `composition` response metadata in `api_service/services/task_templates/catalog.py` (FR-008, FR-009)
+- [X] T014 Update `docs/Tasks/TaskPresetsSystem.md` with composable preset terminology, include storage semantics, expansion pipeline, save-as-preset detachment semantics, and executor boundary rules (FR-010, FR-011, DESIGN-REQ-001-DESIGN-REQ-010, DESIGN-REQ-025, DESIGN-REQ-026)
+- [X] T015 Run `pytest tests/unit/api/test_task_step_templates_service.py -q` until focused unit tests pass
+
+### Integration And Story Validation
+
+- [X] T016 Validate existing task template API/service contract compatibility through focused service tests and document Docker integration status in verification evidence (SC-003)
+- [X] T017 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or document the exact blocker
+- [X] T018 Run `./tools/test_integration.sh` when Docker is available or document the exact blocker
+
+## Phase 4: Polish And Verification
+
+- [X] T019 Review MM-383 traceability across `spec.md`, `tasks.md`, implementation notes, and docs (FR-012, SC-005)
+- [X] T020 Run `/speckit.verify` and record the final verification result
+
+## Verification Notes
+
+- Focused service/API command: `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` passed with 27 tests.
+- Full unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3466 Python tests, 16 subtests, and 236 frontend tests.
+- Hermetic integration command was not run because Docker is unavailable in this managed workspace: `dial unix /var/run/docker.sock: connect: no such file or directory`.
+- Final `/speckit.verify` verdict: `FULLY_IMPLEMENTED` with integration-suite execution blocked only by the workspace Docker socket, while service/API boundary tests cover the MM-383 composition contract.
+
+## Dependencies & Execution Order
+
+- Phase 1 before Phase 2.
+- T004-T006 define test expectations before T007-T010.
+- T011-T014 depend on failing tests from T010.
+- T015 must pass before T016-T020.
+- T017 and T018 are final-suite checks after focused tests pass.
+
+## Implementation Strategy
+
+Use the existing async service test fixture and catalog service boundary. Keep persistence unchanged by storing include entries in the existing version `steps` JSON. Preserve concrete-step-only compatibility and avoid changing executor behavior.

--- a/specs/195-composable-preset-expansion/tasks.md
+++ b/specs/195-composable-preset-expansion/tasks.md
@@ -11,7 +11,7 @@
 
 - Unit tests: `pytest tests/unit/api/test_task_step_templates_service.py -q`
 - Integration tests: `./tools/test_integration.sh` when Docker is available
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Phase 1: Setup
 
@@ -38,41 +38,51 @@
 - [X] T007 [P] Add failing unit test for successful child include flattening with deterministic IDs, provenance, composition metadata, and capabilities in `tests/unit/api/test_task_step_templates_service.py` (FR-001, FR-004, FR-008, FR-009, SC-001)
 - [X] T008 [P] Add failing unit test rejecting global parent to personal child include in `tests/unit/api/test_task_step_templates_service.py` (FR-007, DESIGN-REQ-006, SC-002)
 - [X] T009 [P] Add failing unit tests for include cycle paths, flattened limit paths, inactive child versions, and incompatible child inputs in `tests/unit/api/test_task_step_templates_service.py` (FR-005, FR-006, FR-007, DESIGN-REQ-007, DESIGN-REQ-009, SC-002)
-- [X] T010 Run `pytest tests/unit/api/test_task_step_templates_service.py -q` and confirm new tests fail for missing include behavior
+
+### Integration Tests
+
+- [X] T010 [P] Add failing API-boundary integration-style test proving expand responses retain `composition` metadata in `tests/unit/api/routers/test_task_step_templates.py` (FR-009, DESIGN-REQ-025, SC-003)
+
+### Red-First Confirmation
+
+- [X] T011 Run `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` and confirm new unit and API-boundary tests fail for missing include behavior
 
 ### Implementation
 
-- [X] T011 Implement `kind: step` / `kind: include` validation, pinned versions, aliases, and input mapping in `api_service/services/task_templates/catalog.py` (FR-001, FR-002, FR-003)
-- [X] T012 Implement recursive include expansion, scope checks, inactive/missing/incompatible rejection, cycle detection, and flattened limit enforcement in `api_service/services/task_templates/catalog.py` (FR-004, FR-005, FR-006, FR-007)
-- [X] T013 Implement flattened-step deterministic provenance and `composition` response metadata in `api_service/services/task_templates/catalog.py` (FR-008, FR-009)
-- [X] T014 Update `docs/Tasks/TaskPresetsSystem.md` with composable preset terminology, include storage semantics, expansion pipeline, save-as-preset detachment semantics, and executor boundary rules (FR-010, FR-011, DESIGN-REQ-001-DESIGN-REQ-010, DESIGN-REQ-025, DESIGN-REQ-026)
-- [X] T015 Run `pytest tests/unit/api/test_task_step_templates_service.py -q` until focused unit tests pass
+- [X] T012 Implement `kind: step` / `kind: include` validation, pinned versions, aliases, and input mapping in `api_service/services/task_templates/catalog.py` (FR-001, FR-002, FR-003)
+- [X] T013 Implement recursive include expansion, scope checks, inactive/missing/incompatible rejection, cycle detection, and flattened limit enforcement in `api_service/services/task_templates/catalog.py` (FR-004, FR-005, FR-006, FR-007)
+- [X] T014 Implement flattened-step deterministic provenance and `composition` response metadata in `api_service/services/task_templates/catalog.py` and `api_service/api/schemas.py` (FR-008, FR-009)
+- [X] T015 Update `docs/Tasks/TaskPresetsSystem.md` with composable preset terminology, include storage semantics, expansion pipeline, save-as-preset detachment semantics, and executor boundary rules (FR-010, FR-011, DESIGN-REQ-001-DESIGN-REQ-010, DESIGN-REQ-025, DESIGN-REQ-026)
+
+### Story Validation
+
+- [X] T016 Run `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` until focused unit and API-boundary tests pass
 
 ### Integration And Story Validation
 
-- [X] T016 Validate existing task template API/service contract compatibility through focused service tests and document Docker integration status in verification evidence (SC-003)
-- [X] T017 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or document the exact blocker
-- [X] T018 Run `./tools/test_integration.sh` when Docker is available or document the exact blocker
+- [X] T017 Validate existing task template API/service contract compatibility through focused service tests and document Docker integration status in verification evidence (SC-003)
+- [X] T018 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or document the exact blocker
+- [X] T019 Run `./tools/test_integration.sh` when Docker is available or document the exact blocker
 
 ## Phase 4: Polish And Verification
 
-- [X] T019 Review MM-383 traceability across `spec.md`, `tasks.md`, implementation notes, and docs (FR-012, SC-005)
-- [X] T020 Run `/speckit.verify` and record the final verification result
+- [X] T020 Review MM-383 traceability across `spec.md`, `tasks.md`, implementation notes, and docs (FR-012, SC-005)
+- [X] T021 Run `/moonspec-verify` and record the final verification result
 
 ## Verification Notes
 
 - Focused service/API command: `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` passed with 27 tests.
 - Full unit command: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed with 3466 Python tests, 16 subtests, and 236 frontend tests.
 - Hermetic integration command was not run because Docker is unavailable in this managed workspace: `dial unix /var/run/docker.sock: connect: no such file or directory`.
-- Final `/speckit.verify` verdict: `FULLY_IMPLEMENTED` with integration-suite execution blocked only by the workspace Docker socket, while service/API boundary tests cover the MM-383 composition contract.
+- Final `/moonspec-verify` verdict: `FULLY_IMPLEMENTED` with integration-suite execution blocked only by the workspace Docker socket, while service/API boundary tests cover the MM-383 composition contract.
 
 ## Dependencies & Execution Order
 
 - Phase 1 before Phase 2.
 - T004-T006 define test expectations before T007-T010.
-- T011-T014 depend on failing tests from T010.
-- T015 must pass before T016-T020.
-- T017 and T018 are final-suite checks after focused tests pass.
+- T012-T015 depend on failing tests from T011.
+- T016 must pass before T017-T021.
+- T018 and T019 are final-suite checks after focused tests pass.
 
 ## Implementation Strategy
 

--- a/tests/unit/api/routers/test_task_step_templates.py
+++ b/tests/unit/api/routers/test_task_step_templates.py
@@ -99,6 +99,13 @@ def test_expand_template_success() -> None:
     client, catalog, _ = _build_app()
     catalog.expand_template.return_value = {
         "steps": [{"id": "tpl:demo:1.0.0:01:abcd1234", "instructions": "do work"}],
+        "composition": {
+            "slug": "demo",
+            "version": "1.0.0",
+            "scope": "global",
+            "stepIds": ["tpl:demo:1.0.0:01:abcd1234"],
+            "includes": [],
+        },
         "appliedTemplate": {
             "slug": "demo",
             "version": "1.0.0",
@@ -119,6 +126,7 @@ def test_expand_template_success() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["appliedTemplate"]["slug"] == "demo"
+    assert payload["composition"]["slug"] == "demo"
     assert payload["capabilities"] == ["codex", "git"]
 
 

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -10,10 +10,11 @@ import pytest
 import yaml
 from sqlalchemy import UniqueConstraint, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import selectinload, sessionmaker
 
 from api_service.db.models import (
     Base,
+    TaskStepTemplate,
     TaskStepTemplateRecent,
     TaskTemplateReleaseStatus,
     TaskTemplateScopeType,
@@ -22,6 +23,7 @@ from api_service.services.task_templates.catalog import (
     ExpandOptions,
     TaskTemplateCatalogService,
     TaskTemplateNotFoundError,
+    TaskTemplateValidationError,
 )
 from api_service.services.task_templates.save import TaskTemplateSaveService
 from moonmind.config.settings import settings
@@ -107,6 +109,389 @@ async def test_create_and_expand_template_deterministic_ids(tmp_path):
     assert set(expanded["capabilities"]) >= {"codex", "docker"}
     assert expanded["appliedTemplate"]["slug"] == "pr-check"
     assert expanded["appliedTemplate"]["version"] == "1.0.0"
+
+
+async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path):
+    user_id = uuid4()
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="child-checks",
+                title="Child Checks",
+                description="Reusable checks",
+                scope="global",
+                scope_ref=None,
+                tags=["checks"],
+                inputs_schema=[
+                    {
+                        "name": "target",
+                        "label": "Target",
+                        "type": "text",
+                        "required": True,
+                    }
+                ],
+                steps=[
+                    {
+                        "title": "Lint target",
+                        "instructions": "Lint {{ inputs.target }}",
+                        "skill": {
+                            "id": "auto",
+                            "args": {},
+                            "requiredCapabilities": ["docker"],
+                        },
+                    },
+                    {
+                        "title": "Test target",
+                        "instructions": "Test {{ inputs.target }}",
+                    },
+                ],
+                annotations={},
+                required_capabilities=["codex"],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="parent-flow",
+                title="Parent Flow",
+                description="Composed flow",
+                scope="global",
+                scope_ref=None,
+                tags=["composed"],
+                inputs_schema=[
+                    {
+                        "name": "feature",
+                        "label": "Feature",
+                        "type": "text",
+                        "required": True,
+                    }
+                ],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "child-checks",
+                        "version": "1.0.0",
+                        "alias": "quality",
+                        "scope": "global",
+                        "inputMapping": {"target": "{{ inputs.feature }}"},
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=user_id,
+            )
+
+            expanded = await service.expand_template(
+                slug="parent-flow",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={"feature": "preset composition"},
+                context={},
+                options=ExpandOptions(should_enforce_step_limit=True),
+                user_id=user_id,
+            )
+
+    assert [step["title"] for step in expanded["steps"]] == [
+        "Lint target",
+        "Test target",
+    ]
+    assert expanded["steps"][0]["id"].startswith("tpl:parent-flow:1.0.0:01:")
+    assert expanded["steps"][1]["id"].startswith("tpl:parent-flow:1.0.0:02:")
+    assert "preset composition" in expanded["steps"][0]["instructions"]
+    assert set(expanded["capabilities"]) >= {"codex", "docker"}
+    provenance = expanded["steps"][0]["presetProvenance"]
+    assert provenance["root"] == {"slug": "parent-flow", "version": "1.0.0"}
+    assert provenance["source"]["slug"] == "child-checks"
+    assert provenance["source"]["version"] == "1.0.0"
+    assert provenance["alias"] == "quality"
+    assert provenance["path"] == [
+        "parent-flow@1.0.0",
+        "quality:child-checks@1.0.0",
+    ]
+    assert expanded["composition"]["includes"][0]["alias"] == "quality"
+    assert expanded["composition"]["includes"][0]["stepIds"] == [
+        step["id"] for step in expanded["steps"]
+    ]
+
+
+async def test_expand_template_rejects_global_parent_personal_include(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="global-parent",
+                title="Global Parent",
+                description="Cannot include personal presets",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "personal-child",
+                        "version": "1.0.0",
+                        "alias": "private",
+                        "scope": "personal",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="Global presets cannot include personal presets.*private:personal-child@1.0.0",
+            ):
+                await service.expand_template(
+                    slug="global-parent",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                    options=ExpandOptions(),
+                )
+
+
+async def test_expand_template_rejects_include_cycles_with_path(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="preset-a",
+                title="Preset A",
+                description="Starts cycle",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "preset-b",
+                        "version": "1.0.0",
+                        "alias": "b",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="preset-b",
+                title="Preset B",
+                description="Completes cycle",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "preset-a",
+                        "version": "1.0.0",
+                        "alias": "a",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="Preset include cycle detected.*preset-a@1.0.0.*b:preset-b@1.0.0.*a:preset-a@1.0.0",
+            ):
+                await service.expand_template(
+                    slug="preset-a",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                    options=ExpandOptions(),
+                )
+
+
+async def test_expand_template_rejects_inactive_and_incompatible_includes(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="inactive-child",
+                title="Inactive Child",
+                description="Inactive child",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[{"instructions": "inactive"}],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+                release_status=TaskTemplateReleaseStatus.INACTIVE,
+            )
+            await service.create_template(
+                slug="input-child",
+                title="Input Child",
+                description="Requires input",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[
+                    {
+                        "name": "topic",
+                        "label": "Topic",
+                        "type": "text",
+                        "required": True,
+                    }
+                ],
+                steps=[{"instructions": "Handle {{ inputs.topic }}"}],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="bad-parent",
+                title="Bad Parent",
+                description="Invalid children",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "inactive-child",
+                        "version": "1.0.0",
+                        "alias": "inactive",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="input-parent",
+                title="Input Parent",
+                description="Missing child input",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "input-child",
+                        "version": "1.0.0",
+                        "alias": "requires-topic",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="inactive.*inactive:inactive-child@1.0.0",
+            ):
+                await service.expand_template(
+                    slug="bad-parent",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                    options=ExpandOptions(),
+                )
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="requires-topic:input-child@1.0.0.*Missing required template input 'topic'",
+            ):
+                await service.expand_template(
+                    slug="input-parent",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                    options=ExpandOptions(),
+                )
+
+
+async def test_expand_template_enforces_flattened_limit_with_include_path(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="two-step-child",
+                title="Two Step Child",
+                description="Two concrete steps",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {"instructions": "first child step"},
+                    {"instructions": "second child step"},
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            await service.create_template(
+                slug="limited-parent",
+                title="Limited Parent",
+                description="Limit should apply after flattening",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=[
+                    {
+                        "kind": "include",
+                        "slug": "two-step-child",
+                        "version": "1.0.0",
+                        "alias": "two",
+                        "scope": "global",
+                    }
+                ],
+                annotations={},
+                required_capabilities=[],
+                created_by=None,
+            )
+            template = (
+                await session.execute(
+                    select(TaskStepTemplate)
+                    .where(TaskStepTemplate.slug == "limited-parent")
+                    .options(selectinload(TaskStepTemplate.latest_version))
+                )
+            ).scalar_one()
+            assert template.latest_version is not None
+            template.latest_version.max_step_count = 1
+            await session.commit()
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="max_step_count=1.*two:two-step-child@1.0.0",
+            ):
+                await service.expand_template(
+                    slug="limited-parent",
+                    scope="global",
+                    scope_ref=None,
+                    version="1.0.0",
+                    inputs={},
+                    context={},
+                    options=ExpandOptions(should_enforce_step_limit=True),
+                )
 
 
 async def test_template_recents_declares_unique_user_version_constraint() -> None:

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1102,6 +1102,105 @@ async def test_sync_seed_templates_creates_missing_seed(tmp_path):
             assert template.latest_version.steps[0]["skill"]["id"] == "moonspec-specify"
 
 
+async def test_sync_seed_templates_preserves_default_expansion_limit_for_includes(
+    tmp_path,
+):
+    seed_dir = tmp_path / "seeds"
+    seed_data = {
+        "slug": "composed-seed",
+        "title": "Composed Seed",
+        "description": "Seeded preset with child include",
+        "scope": "global",
+        "version": "1.0.0",
+        "steps": [
+            {
+                "kind": "include",
+                "slug": "shared-child",
+                "version": "1.0.0",
+                "alias": "shared",
+                "scope": "global",
+            }
+        ],
+        "inputs": [],
+        "annotations": {"sourceSkill": "composed-seed"},
+    }
+    _write_seed_template(seed_dir, seed_data)
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="composed-seed",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+
+    assert template.latest_version is not None
+    assert template.latest_version.max_step_count == 25
+
+
+async def test_sync_seed_templates_updates_existing_include_limit_default(tmp_path):
+    seed_dir = tmp_path / "seeds"
+    seed_data = {
+        "slug": "composed-seed",
+        "title": "Composed Seed",
+        "description": "Seeded preset with child include",
+        "scope": "global",
+        "version": "1.0.0",
+        "steps": [
+            {
+                "kind": "include",
+                "slug": "shared-child",
+                "version": "1.0.0",
+                "alias": "shared",
+                "scope": "global",
+            }
+        ],
+        "inputs": [],
+        "annotations": {"sourceSkill": "composed-seed"},
+    }
+    _write_seed_template(seed_dir, seed_data)
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.create_template(
+                slug="composed-seed",
+                title="Composed Seed",
+                description="Seeded preset with child include",
+                scope="global",
+                scope_ref=None,
+                tags=[],
+                inputs_schema=[],
+                steps=seed_data["steps"],
+                annotations={"sourceSkill": "composed-seed"},
+                required_capabilities=[],
+                created_by=None,
+            )
+            template = await service._get_template_for_scope(
+                slug="composed-seed",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+            assert template.latest_version is not None
+            template.latest_version.max_step_count = 1
+            await session.commit()
+
+            result = await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service._get_template_for_scope(
+                slug="composed-seed",
+                scope=TaskTemplateScopeType.GLOBAL,
+                scope_ref=None,
+            )
+
+    assert result.updated == 1
+    assert template.latest_version is not None
+    assert template.latest_version.max_step_count == 25
+
+
 async def test_sync_seed_templates_updates_existing_seed(tmp_path):
     seed_dir = tmp_path / "seeds"
     seed_data = {

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -214,6 +214,78 @@ async def test_expand_template_flattens_pinned_include_with_provenance(tmp_path)
     ]
 
 
+async def test_create_template_rejects_templated_include_version(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="include version must be a literal pinned version",
+            ):
+                await service.create_template(
+                    slug="runtime-selected-parent",
+                    title="Runtime Selected Parent",
+                    description="Invalid dynamic child selection",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[
+                        {
+                            "name": "child_version",
+                            "label": "Child version",
+                            "type": "text",
+                        }
+                    ],
+                    steps=[
+                        {
+                            "kind": "include",
+                            "slug": "child-checks",
+                            "version": "{{ inputs.child_version }}",
+                            "alias": "checks",
+                            "scope": "global",
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+
+async def test_create_template_rejects_unsupported_include_fields(tmp_path):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+
+            with pytest.raises(
+                TaskTemplateValidationError,
+                match="include uses unsupported keys: instructions, skill",
+            ):
+                await service.create_template(
+                    slug="override-parent",
+                    title="Override Parent",
+                    description="Invalid child overrides",
+                    scope="global",
+                    scope_ref=None,
+                    tags=[],
+                    inputs_schema=[],
+                    steps=[
+                        {
+                            "kind": "include",
+                            "slug": "child-checks",
+                            "version": "1.0.0",
+                            "alias": "checks",
+                            "scope": "global",
+                            "instructions": "Override child instructions",
+                            "skill": {"id": "moonspec-verify"},
+                        }
+                    ],
+                    annotations={},
+                    required_capabilities=[],
+                    created_by=None,
+                )
+
+
 async def test_expand_template_rejects_global_parent_personal_include(tmp_path):
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as session:


### PR DESCRIPTION
## Summary
- Add runtime support for composable task preset includes with pinned child versions, aliases, input mapping, recursive flattening, path-aware validation, provenance, and composition metadata.
- Preserve composition metadata through the task template API schema and document the desired-state preset composition contract.
- Add MoonSpec artifacts for MM-383 and focused service/API coverage, including seed-sync expansion limit behavior for include-based presets.

## Verification
- `pytest tests/unit/api/test_task_step_templates_service.py tests/unit/api/routers/test_task_step_templates.py -q` PASS, 29 tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS, 3468 Python tests plus 236 frontend tests
- `git diff --check` PASS
- `./tools/test_integration.sh` NOT RUN because Docker is unavailable in the managed workspace: `/var/run/docker.sock` is missing

## MoonSpec Verify
- Verdict: FULLY_IMPLEMENTED
- Jira traceability: MM-383 preserved in MoonSpec artifacts and implementation notes