### PR TITLE
MM-378 Preset application and reapply state

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/195-canonical-create-page-shell"
+  "feature_directory": "specs/196-preset-application-reapply-state"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-378-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-378-moonspec-orchestration-input.md
@@ -1,0 +1,98 @@
+# MM-378 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-378
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Preset Application and Reapply State
+- Labels: `moonmind-workflow-mm-5818081f-60f0-45dd-ad16-3f7753de93ae`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-378 from MM project
+Summary: Preset Application and Reapply State
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-378 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-378: Preset Application and Reapply State
+
+Short Name
+preset-application-reapply-state
+
+User Story
+As a task author, I can apply reusable task presets explicitly, edit preset objective inputs, and understand when expanded steps need an explicit reapply without losing my manual step customizations.
+
+Acceptance Criteria
+- Given only the initial empty step exists, when I apply a preset, then the preset may replace the placeholder step set with expanded blueprint steps.
+- Given authored steps already exist, when I apply a preset, then expanded preset steps append to the current draft.
+- Given I select a preset without pressing Apply, then the draft does not mutate.
+- Given preset objective text is non-empty, then it is preferred over primary-step instructions for resolved objective text and title derivation.
+- Given I change preset objective text or objective-scoped attachments after applying a preset, then the preset is marked as needing explicit reapply and expanded steps are not overwritten automatically.
+- Given I manually edit a template-bound step instruction or attachment set, then that step detaches from template instruction or input identity.
+
+Requirements
+- Expose optional Preset, Feature Request / Initial Instructions, objective images, Apply, optional save-as-preset, and status controls.
+- Treat applied preset steps as expanded blueprints rather than live bindings.
+- Track template step identity only while authored instructions and attachments match the template input contract.
+- Store templateAttachments for detachment comparisons.
+- Mark applied preset state dirty when preset objective text or objective-scoped attachments change.
+- Resolve objective text from preset objective, then primary instructions, then the most recent applied preset request alias.
+- Cover preset dirty state and template detachment in tests.
+
+Independent Test
+Create page coverage verifies preset selection does not mutate the draft until Apply is pressed, initial empty steps can be replaced by expanded blueprint steps, authored drafts receive appended preset steps, preset objective text drives objective and title resolution, changed objective inputs mark the applied preset state as needing explicit reapply, and manual edits detach template-bound step instruction or input identity.
+
+Source Document
+- `docs/UI/CreatePage.md`
+
+Source Sections
+- 7.5 Template-bound steps
+- 8. Task preset contract
+- 15. Objective resolution and title derivation
+
+Coverage IDs
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-022
+- DESIGN-REQ-025
+
+Relevant Implementation Notes
+- The preset area is optional and exposes Preset, Feature Request / Initial Instructions, objective-scoped image inputs when attachment policy is enabled, Apply, optional Save Current Steps as Preset, and status text.
+- Applying a preset expands blueprint steps into the step list.
+- When the form still contains only the initial empty default step, applying a preset may replace that placeholder step set.
+- When authored steps already exist, applying a preset appends expanded preset steps to the current draft.
+- Selecting a preset alone must not modify the draft.
+- Preset application remains an explicit action.
+- Feature Request / Initial Instructions is the preset-owned objective text source.
+- Non-empty preset objective text is preferred over primary-step instructions for objective text resolution and title derivation.
+- Objective-scoped attachments are the matching structured input source for preset objective text.
+- Changing preset objective text or objective-scoped attachments after apply marks the preset state as needs reapply.
+- Reapply is explicit and must not automatically overwrite expanded steps because preset inputs changed.
+- Preset-expanded steps may carry template step identity only while authored instructions and attachment sets still match the template-authored step input contract.
+- Manual edits to template-bound step instructions detach that step from template instruction identity.
+- Manual edits to template-bound step attachment sets detach that step from template input identity.
+- `templateAttachments` stores the template-authored attachment set used for detachment comparisons.
+- Importing Jira text or Jira images into a template-bound step counts as a manual edit.
+
+Out of Scope
+- Treating applied preset steps as live bindings that update automatically when preset inputs change.
+- Automatically rewriting expanded steps when preset objective text or objective-scoped attachments change.
+- Copying objective-scoped attachments into step attachments unless a future preset contract explicitly defines that behavior.
+- Changing unrelated Create page dependency, execution context, publish, or attachment policy behavior.
+
+Verification
+- Run focused Create page frontend tests covering preset apply, append, no-mutation-on-select, dirty reapply state, objective resolution, title derivation, and template detachment behavior.
+- Verify Create page state preserves manual step customizations when preset objective inputs change.
+- Verify `templateAttachments` supports detachment comparisons for template-bound step attachment sets.
+- Run `./tools/test_unit.sh` before completion when implementation changes are made.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-378-code-review.md
+++ b/docs/tmp/jira-orchestration-reports/MM-378-code-review.md
@@ -1,0 +1,22 @@
+# MM-378 Code Review Transition
+
+## Pull Request
+
+- Jira issue: MM-378
+- Pull request: https://github.com/MoonLadderStudios/MoonMind/pull/1518
+- MoonSpec feature: `specs/196-preset-application-reapply-state`
+
+## Jira Update
+
+- Trusted tool surface: `MOONMIND_URL` `/mcp/tools`
+- PR reference action: `jira.add_comment`
+- Transition discovery action: `jira.get_transitions`
+- Matched transition: `Code Review` -> `51`
+- Transition action: `jira.transition_issue`
+- Refetch action: `jira.get_issue`
+- Confirmed status: `Code Review`
+- Confirmed status id: `10039`
+
+## Notes
+
+- The transition was performed only after validating the MM-378 PR handoff artifact contained a non-empty GitHub pull request URL.

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4309,6 +4309,225 @@ describe("Task Create Entrypoint", () => {
     ]);
   });
 
+  it("does not mutate the draft when selecting a preset before apply", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Keep this authored step." },
+    });
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+
+    expect(screen.getByDisplayValue("Keep this authored step.")).toBeTruthy();
+    expect(
+      screen.queryByDisplayValue("Clarify the {{ inputs.feature_name }} scope."),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeTruthy();
+  });
+
+  it("marks an applied preset dirty when preset objective text changes manually", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create with revised objective" },
+      },
+    );
+
+    expect(
+      screen.getByText(
+        "Preset instructions changed. Reapply the preset to regenerate preset-derived steps.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reapply preset" })).toBeTruthy();
+    expect(
+      screen.getByDisplayValue("Clarify the {{ inputs.feature_name }} scope."),
+    ).toBeTruthy();
+  });
+
+  it("marks an applied preset dirty when objective attachments change and submits them as task attachments", async () => {
+    renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+
+    const objectiveFile = new File(["objective image"], "objective.png", {
+      type: "image/png",
+    });
+    fireEvent.change(
+      await screen.findByLabelText(
+        "Feature Request / Initial Instructions attachments",
+      ),
+      {
+        target: { files: [objectiveFile] },
+      },
+    );
+
+    expect(screen.getByRole("button", { name: "Reapply preset" })).toBeTruthy();
+    expect(
+      screen.getByDisplayValue("Clarify the {{ inputs.feature_name }} scope."),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const artifactCreateCall = fetchSpy.mock.calls.find(
+      ([url, init]) =>
+        String(url) === "/api/artifacts" &&
+        String(init?.body || "").includes(
+          "task-dashboard-objective-attachment",
+        ),
+    );
+    expect(JSON.parse(String(artifactCreateCall?.[1]?.body))).toMatchObject({
+      content_type: "image/png",
+      size_bytes: objectiveFile.size,
+      metadata: {
+        filename: "objective.png",
+        source: "task-dashboard-objective-attachment",
+        target: "Feature Request / Initial Instructions",
+      },
+    });
+
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+    expect(request.payload.task.inputAttachments).toEqual([
+      {
+        artifactId: "art-001",
+        filename: "objective.png",
+        contentType: "image/png",
+        sizeBytes: objectiveFile.size,
+      },
+    ]);
+    expect(request.payload.task.steps[0].inputAttachments).toBeUndefined();
+  });
+
+  it("detaches template step identity when a template-bound step attachment changes", async () => {
+    renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+
+    const file = new File(["step image"], "step.png", { type: "image/png" });
+    fireEvent.change(await screen.findByLabelText("Step 1 attachments"), {
+      target: { files: [file] },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+    expect(request.payload.task.steps[0]).toEqual(
+      expect.objectContaining({
+        instructions: expect.stringContaining(
+          "Clarify the {{ inputs.feature_name }} scope.",
+        ),
+        inputAttachments: [
+          {
+            artifactId: "art-001",
+            filename: "step.png",
+            contentType: "image/png",
+            sizeBytes: file.size,
+          },
+        ],
+      }),
+    );
+    expect([undefined, null, ""]).toContain(
+      request.payload.task.steps[0]?.id,
+    );
+  });
+
   it("derives the task objective from feature-request template input aliases", () => {
     expect(
       resolveObjectiveInstructions("", "", [
@@ -5879,7 +6098,7 @@ describe("Task Create Entrypoint", () => {
       throw new Error("Expected Jira image download to be pending.");
     }
     imageDownload.resolve();
-    expect(await screen.findByText("wireframe.png (10 B)")).toBeTruthy();
+    expect(await screen.findByText("wireframe.png")).toBeTruthy();
     expect(
       screen.getByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1884,6 +1884,43 @@ describe("Task Create Entrypoint", () => {
     ]);
   });
 
+  it("reconstructs template attachments for editable Temporal steps", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:template-attachments",
+      workflowType: "MoonMind.Run",
+      inputParameters: {
+        task: {
+          instructions: "Edit a template-backed task.",
+          steps: [
+            {
+              id: "tpl:speckit-demo:1.2.3:01",
+              instructions: "Clarify the template scope.",
+              templateStepId: "tpl:speckit-demo:1.2.3:01",
+              templateInstructions: "Clarify the template scope.",
+              inputAttachments: [
+                {
+                  artifactId: "art-template",
+                  filename: "template.png",
+                  contentType: "image/png",
+                  sizeBytes: 14,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(draft.steps[0]?.templateAttachments).toEqual([
+      {
+        artifactId: "art-template",
+        filename: "template.png",
+        contentType: "image/png",
+        sizeBytes: 14,
+      },
+    ]);
+  });
+
   it("does not synthesize a task objective into an editable step", () => {
     const draft = buildTemporalSubmissionDraftFromExecution({
       workflowId: "mm:objective-differs",
@@ -4526,6 +4563,95 @@ describe("Task Create Entrypoint", () => {
     expect([undefined, null, ""]).toContain(
       request.payload.task.steps[0]?.id,
     );
+  });
+
+  it("preserves template step identity when template attachments remain unchanged", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (
+        url.startsWith(
+          "/api/task-step-templates/speckit-demo:expand?scope=global",
+        )
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            steps: [
+              {
+                id: "tpl:speckit-demo:1.2.3:01",
+                title: "Clarify spec",
+                instructions: "Clarify the {{ inputs.feature_name }} scope.",
+                inputAttachments: [
+                  {
+                    artifactId: "art-template",
+                    filename: "template.png",
+                    contentType: "image/png",
+                    sizeBytes: 10,
+                  },
+                ],
+                skill: {
+                  id: "speckit-clarify",
+                  args: { feature: "Task Create" },
+                },
+              },
+            ],
+            appliedTemplate: {
+              slug: "speckit-demo",
+              version: "1.2.3",
+            },
+            warnings: [],
+          }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) as ReturnType<typeof window.fetch>;
+    });
+
+    renderWithClient(<TaskCreatePage payload={withAttachmentPolicy()} />);
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const executionCall = fetchSpy.mock.calls
+      .filter(([url]) => String(url) === "/api/executions")
+      .at(-1);
+    const request = JSON.parse(String(executionCall?.[1]?.body));
+    expect(request.payload.task.steps[0]).toEqual(
+      expect.objectContaining({
+        id: "tpl:speckit-demo:1.2.3:01",
+        instructions: "Clarify the {{ inputs.feature_name }} scope.",
+      }),
+    );
+    expect(request.payload.task.steps[0].inputAttachments).toBeUndefined();
   });
 
   it("derives the task objective from feature-request template input aliases", () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -366,6 +366,8 @@ interface ExpandedStepPayload {
   instructions?: string;
   skill?: TaskTemplateStepSkill;
   tool?: TaskTemplateStepSkill;
+  inputAttachments?: StepAttachmentRef[];
+  attachments?: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
   story_output?: Record<string, unknown>;
 }
@@ -416,6 +418,7 @@ interface StepState {
   skillRequiredCapabilities: string;
   templateStepId: string;
   templateInstructions: string;
+  templateAttachments: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
 }
 
@@ -771,6 +774,7 @@ function createStepStateEntry(
     skillRequiredCapabilities: "",
     templateStepId: "",
     templateInstructions: "",
+    templateAttachments: [],
     ...overrides,
   };
 }
@@ -803,6 +807,11 @@ function createStepStateEntriesFromTemporalDraft(
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
+      templateAttachments: Array.isArray(
+        (step as { templateAttachments?: StepAttachmentRef[] }).templateAttachments,
+      )
+        ? (step as { templateAttachments?: StepAttachmentRef[] }).templateAttachments || []
+        : [],
       ...(step.storyOutput && Object.keys(step.storyOutput).length > 0
         ? { storyOutput: step.storyOutput }
         : {}),
@@ -891,8 +900,30 @@ function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
     !step.skillArgs.trim() &&
     !step.skillRequiredCapabilities.trim() &&
     !step.templateStepId.trim() &&
-    !step.templateInstructions.trim()
+    !step.templateInstructions.trim() &&
+    step.templateAttachments.length === 0
   );
+}
+
+function attachmentIdentity(item: StepAttachmentRef | File): string {
+  if ("artifactId" in item && item.artifactId) {
+    return `artifact:${item.artifactId}`;
+  }
+  if (item instanceof File) {
+    return ["file", item.name, item.type || "", String(item.size || 0)].join(
+      ":",
+    );
+  }
+  return [
+    "file",
+    item.filename,
+    item.contentType || "",
+    String(item.sizeBytes || 0),
+  ].join(":");
+}
+
+function attachmentSignature(items: Array<StepAttachmentRef | File>): string {
+  return items.map(attachmentIdentity).sort().join("|");
 }
 
 function isTemplateBoundStepForInstructions(
@@ -902,6 +933,18 @@ function isTemplateBoundStepForInstructions(
     step?.templateStepId &&
       step.id === step.templateStepId &&
       step.instructions === step.templateInstructions,
+  );
+}
+
+function isTemplateBoundStepForAttachments(
+  step: StepState | null | undefined,
+  attachments: Array<StepAttachmentRef | File>,
+): boolean {
+  return Boolean(
+    step?.templateStepId &&
+      step.id === step.templateStepId &&
+      attachmentSignature(attachments) ===
+        attachmentSignature(step.templateAttachments),
   );
 }
 
@@ -1109,6 +1152,11 @@ function mapExpandedStepToState(
       : step.story_output && typeof step.story_output === "object"
         ? step.story_output
         : undefined;
+  const templateAttachments = Array.isArray(step.inputAttachments)
+    ? step.inputAttachments
+    : Array.isArray(step.attachments)
+      ? step.attachments
+      : [];
   return createStepStateEntry(index, {
     id: stepId,
     title: String(step.title || "").trim(),
@@ -1118,6 +1166,7 @@ function mapExpandedStepToState(
     skillRequiredCapabilities: extractCapabilityCsv(tool.requiredCapabilities),
     templateStepId: stepId,
     templateInstructions: instructions,
+    templateAttachments,
     ...(storyOutput ? { storyOutput } : {}),
   });
 }
@@ -1434,9 +1483,14 @@ async function createStepAttachmentArtifact(
   file: File,
   repository: string,
   stepLabel: string,
+  options: {
+    source?: string;
+    target?: string;
+  } = {},
 ): Promise<StepAttachmentRef> {
   const filename = file.name || "attachment";
   const contentType = String(file.type || "application/octet-stream").trim();
+  const source = options.source || "task-dashboard-step-attachment";
   let createResponse: Response;
   try {
     createResponse = await fetch(createEndpoint, {
@@ -1452,8 +1506,8 @@ async function createStepAttachmentArtifact(
           label: `${stepLabel} Attachment`,
           filename,
           repository: repository || null,
-          source: "task-dashboard-step-attachment",
-          stepLabel,
+          source,
+          ...(options.target ? { target: options.target } : { stepLabel }),
         },
       }),
     });
@@ -1842,6 +1896,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [presetReapplyNeeded, setPresetReapplyNeeded] = useState(false);
   const [appliedTemplateFeatureRequest, setAppliedTemplateFeatureRequest] =
     useState("");
+  const [
+    appliedTemplateObjectiveAttachmentSignature,
+    setAppliedTemplateObjectiveAttachmentSignature,
+  ] = useState("");
   const [appliedTemplates, setAppliedTemplates] = useState<
     AppliedTemplateState[]
   >([]);
@@ -1864,6 +1922,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedStepAttachmentFiles, setSelectedStepAttachmentFiles] = useState<
     Record<string, File[]>
   >({});
+  const [objectiveAttachmentFiles, setObjectiveAttachmentFiles] = useState<
+    File[]
+  >([]);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -2801,7 +2862,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const room = Math.max(
       0,
       attachmentPolicy.maxCount -
-        Object.values(selectedStepAttachmentFiles).flat().length,
+        selectedAttachmentFiles.length,
     );
     const toDownload = eligible.slice(0, room);
     if (toDownload.length === 0) {
@@ -2857,7 +2918,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           setSubmitMessage(validation.errors.join(" "));
           return;
         }
-        setSelectedStepAttachmentFiles(nextFilesByStep);
+        updateStepAttachments(targetLocalId, [...existingFiles, ...files]);
       }
       const messages: string[] = [];
       if (eligible.length > toDownload.length) {
@@ -2877,6 +2938,83 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       }
       if (messages.length > 0) {
         setSubmitMessage(messages.join(" "));
+      }
+    } catch (error) {
+      const failure =
+        error instanceof Error
+          ? error
+          : new Error("Failed to download Jira images.");
+      setSubmitMessage(failure.message);
+    }
+  }
+
+  async function importSelectedJiraObjectiveImages(
+    issue: JiraIssueDetail,
+  ): Promise<void> {
+    const attachments = Array.isArray(issue.attachments) ? issue.attachments : [];
+    if (!attachmentPolicy.enabled || attachments.length === 0) {
+      return;
+    }
+    const eligible = attachments.filter(
+      (attachment) => !validateJiraImageAttachment(attachment, attachmentPolicy),
+    );
+    if (eligible.length === 0) {
+      setSubmitMessage(
+        "Jira images are not supported by the current attachment policy.",
+      );
+      return;
+    }
+    const existingKeys = new Set(
+      objectiveAttachmentFiles.map(
+        (file) => `${file.name}:${file.size}:${file.type}`,
+      ),
+    );
+    const room = Math.max(0, attachmentPolicy.maxCount - selectedAttachmentFiles.length);
+    const toDownload = eligible.slice(0, room);
+    if (toDownload.length === 0) {
+      setSubmitMessage("Attachment limit reached before Jira images could be added.");
+      return;
+    }
+    try {
+      const downloaded = await Promise.allSettled(
+        toDownload.map(async (attachment) => {
+          const response = await fetch(attachment.downloadUrl);
+          if (!response.ok) {
+            throw new Error(
+              await responseErrorMessage(response, "Failed to download Jira image."),
+            );
+          }
+          const blob = await response.blob();
+          const type = String(
+            blob.type || attachment.contentType || "",
+          ).toLowerCase();
+          const file = new File([blob], attachment.filename, { type });
+          return existingKeys.has(`${file.name}:${file.size}:${file.type}`)
+            ? null
+            : file;
+        }),
+      );
+      const files = downloaded
+        .filter(
+          (result): result is PromiseFulfilledResult<File | null> =>
+            result.status === "fulfilled",
+        )
+        .map((result) => result.value)
+        .filter((file): file is File => file !== null);
+      if (files.length > 0) {
+        const nextFiles = [...objectiveAttachmentFiles, ...files];
+        const validation = validateAttachmentFiles(
+          [
+            ...nextFiles,
+            ...Object.values(selectedStepAttachmentFiles).flat(),
+          ],
+          attachmentPolicy,
+        );
+        if (!validation.ok) {
+          setSubmitMessage(validation.errors.join(" "));
+          return;
+        }
+        updateObjectiveAttachments(nextFiles);
       }
     } catch (error) {
       const failure =
@@ -2915,10 +3053,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           importTarget,
         ),
       );
-      if (appliedTemplates.length > 0) {
-        setPresetReapplyNeeded(true);
-      }
-      await importSelectedJiraImages(issue, steps[0]?.localId);
+      updatePresetReapplyStateForObjective(nextText, objectiveAttachmentFiles);
+      await importSelectedJiraObjectiveImages(issue);
       return;
     }
 
@@ -2955,16 +3091,25 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     await importSelectedJiraImages(issue, importTarget.localId);
   }
 
+  function updatePresetReapplyStateForObjective(
+    nextText: string,
+    nextFiles: File[],
+  ) {
+    if (appliedTemplates.length === 0) {
+      setPresetReapplyNeeded(false);
+      return;
+    }
+    setPresetReapplyNeeded(
+      nextText.trim() !== appliedTemplateFeatureRequest.trim() ||
+        attachmentSignature(nextFiles) !==
+          appliedTemplateObjectiveAttachmentSignature,
+    );
+  }
+
   function handleTemplateFeatureRequestChange(value: string) {
     setTemplateFeatureRequest(value);
     setPresetJiraProvenance(null);
-    if (
-      presetReapplyNeeded &&
-      (!value.trim() ||
-        value.trim() === appliedTemplateFeatureRequest.trim())
-    ) {
-      setPresetReapplyNeeded(false);
-    }
+    updatePresetReapplyStateForObjective(value, objectiveAttachmentFiles);
   }
 
   function addDependency(workflowId: string) {
@@ -2996,6 +3141,19 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }
 
   function updateStepAttachments(localId: string, files: File[]) {
+    setSteps((current) =>
+      current.map((step) => {
+        if (
+          step.localId !== localId ||
+          !step.templateStepId ||
+          step.id !== step.templateStepId ||
+          isTemplateBoundStepForAttachments(step, files)
+        ) {
+          return step;
+        }
+        return { ...step, id: "" };
+      }),
+    );
     setSelectedStepAttachmentFiles((current) => {
       const next = { ...current };
       if (files.length > 0) {
@@ -3007,9 +3165,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     });
   }
 
+  function updateObjectiveAttachments(files: File[]) {
+    setObjectiveAttachmentFiles(files);
+    updatePresetReapplyStateForObjective(templateFeatureRequest, files);
+  }
+
   const selectedAttachmentFiles = useMemo(
-    () => Object.values(selectedStepAttachmentFiles).flat(),
-    [selectedStepAttachmentFiles],
+    () => [
+      ...objectiveAttachmentFiles,
+      ...Object.values(selectedStepAttachmentFiles).flat(),
+    ],
+    [objectiveAttachmentFiles, selectedStepAttachmentFiles],
   );
 
   const providerOptions = [...(providerProfilesQuery.data || [])]
@@ -3385,6 +3551,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         (current) => current + Math.max(expandedSteps.length, 1),
       );
       setAppliedTemplateFeatureRequest(templateFeatureRequest.trim());
+      setAppliedTemplateObjectiveAttachmentSignature(
+        attachmentSignature(objectiveAttachmentFiles),
+      );
       setPresetReapplyNeeded(false);
       if (expandedSteps.length > 0) {
         const appliedTemplate = expanded.appliedTemplate || {};
@@ -3872,9 +4041,26 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
 
     setIsSubmitting(true);
+    let uploadedObjectiveAttachments: StepAttachmentRef[] = [];
     let uploadedStepAttachments: Record<string, StepAttachmentRef[]> = {};
     try {
       if (selectedAttachmentFiles.length > 0) {
+        if (objectiveAttachmentFiles.length > 0) {
+          uploadedObjectiveAttachments = await Promise.all(
+            objectiveAttachmentFiles.map((file) =>
+              createStepAttachmentArtifact(
+                artifactCreateEndpoint,
+                file,
+                normalizedRepository,
+                "Feature Request / Initial Instructions",
+                {
+                  source: "task-dashboard-objective-attachment",
+                  target: "Feature Request / Initial Instructions",
+                },
+              ),
+            ),
+          );
+        }
         const uploadEntries = await Promise.all(
           steps.map(async (step, index) => {
             const files = selectedStepAttachmentFiles[step.localId] || [];
@@ -3911,6 +4097,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const primaryAttachmentRefs = primaryStep
       ? uploadedStepAttachments[primaryStep.localId] || []
       : [];
+    const taskLevelAttachmentRefs = [
+      ...uploadedObjectiveAttachments,
+      ...primaryAttachmentRefs,
+    ];
     const objectiveInstructionsWithAttachments = appendStepAttachmentInstructions(
       objectiveInstructions,
       primaryAttachmentRefs,
@@ -4007,8 +4197,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           if (!sourceStep) {
             return entry.payload;
           }
+          const payloadAttachments = Array.isArray(
+            entry.payload.inputAttachments,
+          )
+            ? (entry.payload.inputAttachments as StepAttachmentRef[])
+            : [];
+          const shouldPreserveStepId =
+            !sourceStep.templateStepId ||
+            sourceStep.id !== sourceStep.templateStepId ||
+            (String(entry.payload.instructions || sourceStep.instructions) ===
+              sourceStep.templateInstructions &&
+              isTemplateBoundStepForAttachments(sourceStep, payloadAttachments));
           return {
-            ...(sourceStep.id.trim() ? { id: sourceStep.id.trim() } : {}),
+            ...(shouldPreserveStepId && sourceStep.id.trim()
+              ? { id: sourceStep.id.trim() }
+              : {}),
             ...(sourceStep.title.trim()
               ? { title: sourceStep.title.trim() }
               : {}),
@@ -4092,8 +4295,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       instructions: objectiveInstructionsWithAttachments,
       tool: resolvedTool,
       skill: resolvedSkill,
-      ...(primaryAttachmentRefs.length > 0
-        ? { inputAttachments: primaryAttachmentRefs }
+      ...(taskLevelAttachmentRefs.length > 0
+        ? { inputAttachments: taskLevelAttachmentRefs }
         : {}),
       ...(taskSkillSelectors ? { skills: taskSkillSelectors } : {}),
       ...(Object.keys(primarySkillArgs).length > 0 ? { inputs: primarySkillArgs } : {}),
@@ -4237,7 +4440,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       if (inputArtifactRef) {
         await linkInputArtifact(inputArtifactRef, created);
       }
-      for (const attachment of Object.values(uploadedStepAttachments).flat()) {
+      for (const attachment of [
+        ...uploadedObjectiveAttachments,
+        ...Object.values(uploadedStepAttachments).flat(),
+      ]) {
         await linkInputArtifact(attachment.artifactId, created, {
           linkType: "input.attachment",
           label: attachment.filename,
@@ -4815,6 +5021,42 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   handleTemplateFeatureRequestChange(event.target.value)
                 }
               />
+              {attachmentPolicy.enabled ? (
+                <div className="queue-step-attachments">
+                  <label>
+                    Objective images
+                    <input
+                      type="file"
+                      data-step-field="objective-attachments"
+                      multiple
+                      accept={attachmentPolicy.allowedContentTypes.join(",")}
+                      aria-label="Feature Request / Initial Instructions attachments"
+                      onChange={(event) =>
+                        updateObjectiveAttachments(
+                          Array.from(event.target.files || []),
+                        )
+                      }
+                    />
+                  </label>
+                  <p className="small">
+                    {`Up to ${attachmentPolicy.maxCount} files across the objective and all steps, ${formatAttachmentBytes(attachmentPolicy.maxBytes)} each, ${formatAttachmentBytes(attachmentPolicy.totalBytes)} total.`}
+                  </p>
+                  {objectiveAttachmentFiles.length > 0 ? (
+                    <ul className="list queue-step-attachments-list">
+                      {objectiveAttachmentFiles.map((file) => (
+                        <li key={`${file.name}:${file.size}:${file.type}`}>
+                          <span>
+                            <strong>{file.name}</strong>{" "}
+                            <span className="small">
+                              {`${file.type || "application/octet-stream"}, ${formatAttachmentBytes(file.size)}`}
+                            </span>
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
             <div className="actions">
               <button

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -807,11 +807,7 @@ function createStepStateEntriesFromTemporalDraft(
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
-      templateAttachments: Array.isArray(
-        (step as { templateAttachments?: StepAttachmentRef[] }).templateAttachments,
-      )
-        ? (step as { templateAttachments?: StepAttachmentRef[] }).templateAttachments || []
-        : [],
+      templateAttachments: step.templateAttachments || [],
       ...(step.storyOutput && Object.keys(step.storyOutput).length > 0
         ? { storyOutput: step.storyOutput }
         : {}),
@@ -906,20 +902,20 @@ function isEmptyStepStateEntry(step: StepState | null | undefined): boolean {
 }
 
 function attachmentIdentity(item: StepAttachmentRef | File): string {
-  if ("artifactId" in item && item.artifactId) {
-    return `artifact:${item.artifactId}`;
-  }
   if (item instanceof File) {
     return ["file", item.name, item.type || "", String(item.size || 0)].join(
       ":",
     );
   }
-  return [
-    "file",
-    item.filename,
-    item.contentType || "",
-    String(item.sizeBytes || 0),
-  ].join(":");
+  if (item.filename || item.contentType || item.sizeBytes) {
+    return [
+      "file",
+      item.filename,
+      item.contentType || "",
+      String(item.sizeBytes || 0),
+    ].join(":");
+  }
+  return `artifact:${item.artifactId}`;
 }
 
 function attachmentSignature(items: Array<StepAttachmentRef | File>): string {
@@ -4202,12 +4198,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           )
             ? (entry.payload.inputAttachments as StepAttachmentRef[])
             : [];
+          const effectivePayloadAttachments =
+            Array.isArray(entry.payload.inputAttachments) ||
+            !sourceStep.templateStepId ||
+            sourceStep.id !== sourceStep.templateStepId
+              ? payloadAttachments
+              : sourceStep.templateAttachments;
           const shouldPreserveStepId =
             !sourceStep.templateStepId ||
             sourceStep.id !== sourceStep.templateStepId ||
             (String(entry.payload.instructions || sourceStep.instructions) ===
               sourceStep.templateInstructions &&
-              isTemplateBoundStepForAttachments(sourceStep, payloadAttachments));
+              isTemplateBoundStepForAttachments(
+                sourceStep,
+                effectivePayloadAttachments,
+              ));
           return {
             ...(shouldPreserveStepId && sourceStep.id.trim()
               ? { id: sourceStep.id.trim() }

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -64,6 +64,12 @@ export type TemporalSubmissionDraft = {
     skillRequiredCapabilities: string[];
     templateStepId: string;
     templateInstructions: string;
+    templateAttachments?: Array<{
+      artifactId: string;
+      filename: string;
+      contentType: string;
+      sizeBytes: number;
+    }>;
     storyOutput?: Record<string, unknown>;
   }>;
   appliedTemplates: Array<{
@@ -222,6 +228,57 @@ function stringArrayValue(...values: unknown[]): string[] {
   return [];
 }
 
+function attachmentRefsValue(...values: unknown[]): Array<{
+  artifactId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}> {
+  for (const value of values) {
+    if (!Array.isArray(value)) {
+      continue;
+    }
+    const normalized = value
+      .map((item) => {
+        const attachment = objectValue(item);
+        const artifactId = stringValue(
+          attachment.artifactId,
+          attachment.artifact_id,
+        );
+        const filename = stringValue(attachment.filename, attachment.name);
+        const contentType = stringValue(
+          attachment.contentType,
+          attachment.content_type,
+        );
+        const rawSize = attachment.sizeBytes ?? attachment.size_bytes;
+        const sizeBytes = Math.max(0, Number(rawSize) || 0);
+        if (!artifactId && !filename) {
+          return null;
+        }
+        return {
+          artifactId,
+          filename,
+          contentType,
+          sizeBytes,
+        };
+      })
+      .filter(
+        (
+          item,
+        ): item is {
+          artifactId: string;
+          filename: string;
+          contentType: string;
+          sizeBytes: number;
+        } => Boolean(item),
+      );
+    if (normalized.length > 0) {
+      return normalized;
+    }
+  }
+  return [];
+}
+
 function firstObjectValue(...values: unknown[]): Record<string, unknown> {
   for (const value of values) {
     const normalized = objectValue(value);
@@ -261,6 +318,13 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     id.startsWith('tpl:') ? id : '',
   );
   const storyOutput = firstObjectValue(step.storyOutput, step.story_output);
+  const templateAttachments = attachmentRefsValue(
+    step.templateAttachments,
+    step.template_attachments,
+    step.inputAttachments,
+    step.input_attachments,
+    step.attachments,
+  );
   const result = {
     id,
     title: stringValue(step.title),
@@ -277,6 +341,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
       step.template_instructions,
       templateStepId ? instructions : '',
     ),
+    ...(templateAttachments.length > 0 ? { templateAttachments } : {}),
     ...(Object.keys(storyOutput).length > 0 ? { storyOutput } : {}),
   };
 
@@ -289,6 +354,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     result.skillRequiredCapabilities.length > 0 ||
     result.templateStepId ||
     result.templateInstructions ||
+    templateAttachments.length > 0 ||
     Object.keys(storyOutput).length > 0;
   return hasContent ? result : null;
 }

--- a/specs/196-preset-application-reapply-state/checklists/requirements.md
+++ b/specs/196-preset-application-reapply-state/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Preset Application and Reapply State
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details leak into user-facing requirements beyond required source traceability
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] Specification preserves the MM-378 source request for verification
+
+## Notes
+
+- No incomplete items.

--- a/specs/196-preset-application-reapply-state/contracts/create-page-preset-state.md
+++ b/specs/196-preset-application-reapply-state/contracts/create-page-preset-state.md
@@ -1,0 +1,31 @@
+# Create Page Preset State Contract
+
+## Preset Application
+
+- Selecting a preset updates only selected preset UI state.
+- Pressing Apply or Reapply fetches template details and expansion from MoonMind REST endpoints.
+- If the draft contains only the initial empty step, expanded preset steps replace that placeholder.
+- If authored steps exist, expanded preset steps append after current steps.
+- A successful Apply/Reapply records applied preset metadata and clears dirty state.
+
+## Preset Objective Inputs
+
+- Feature Request / Initial Instructions is the first source for resolved task objective text.
+- Objective-scoped attachments are task-level input attachments.
+- Changing objective text or objective-scoped attachments after Apply/Reapply marks the preset state dirty.
+- Dirty state changes the action label to `Reapply preset` and status text explains that reapply is explicit.
+- Dirty state must not mutate already expanded steps.
+
+## Template-Bound Steps
+
+- Preset-expanded steps may submit their template step ID only while authored instructions and attachment identity still match the template-authored input contract.
+- Manual instruction edits detach template instruction identity.
+- Manual attachment changes detach template input identity.
+- Jira text or image import into a template-bound step is a manual edit.
+
+## Payload Boundary
+
+- Task objective text is submitted through `payload.task.instructions`.
+- Objective-scoped attachments are submitted through `payload.task.inputAttachments`.
+- Step-scoped attachments are submitted through `payload.task.steps[n].inputAttachments`.
+- Applied template metadata is submitted through `payload.task.appliedStepTemplates` only after Apply/Reapply succeeds.

--- a/specs/196-preset-application-reapply-state/data-model.md
+++ b/specs/196-preset-application-reapply-state/data-model.md
@@ -1,0 +1,29 @@
+# Data Model: Preset Application and Reapply State
+
+## Preset Objective Input
+
+- `templateFeatureRequest`: preset-owned objective text.
+- `objectiveAttachmentFiles`: local files selected for the preset objective target.
+- `objectiveAttachmentRefs`: uploaded artifact references submitted as task-level `inputAttachments`.
+- Validation: governed by server-provided attachment policy; invalid attachments block submission before upload.
+
+## Applied Preset State
+
+- `appliedTemplates`: existing applied template metadata sent as `appliedStepTemplates`.
+- `appliedTemplateFeatureRequest`: text value captured after the last successful Apply/Reapply.
+- `appliedTemplateObjectiveAttachmentSignature`: normalized identity of objective-scoped attachments captured after the last successful Apply/Reapply.
+- State transition: clean after successful Apply/Reapply; dirty when objective text or objective attachment signature differs from the last applied values.
+
+## Template-Bound Step
+
+- `id`: submitted template step ID only while the step remains template-bound.
+- `templateStepId`: original template step ID.
+- `templateInstructions`: original template-authored instructions.
+- `templateAttachments`: original template-authored attachment identity snapshot.
+- State transition: instruction edits clear `id`; attachment-set edits clear template input identity and prevent preserving stale template step identity in the submitted payload.
+
+## Attachment Identity
+
+- Artifact-backed attachment identity: artifact ID.
+- Local or imported attachment identity: filename, content type, and size.
+- Comparison: order-insensitive set comparison for detachment checks.

--- a/specs/196-preset-application-reapply-state/plan.md
+++ b/specs/196-preset-application-reapply-state/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Preset Application and Reapply State
+
+**Branch**: `196-preset-application-reapply-state` | **Date**: 2026-04-17 | **Spec**: `specs/196-preset-application-reapply-state/spec.md`  
+**Input**: Single-story feature specification from `specs/196-preset-application-reapply-state/spec.md`
+
+## Summary
+
+Implement MM-378 by tightening the existing Create page preset state model around explicit Apply/Reapply behavior, objective-scoped attachments, and template-bound step detachment. The technical approach is to extend the existing React draft state and focused Vitest coverage without introducing new backend storage or service dependencies.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI  
+**Primary Dependencies**: React, existing Create page entrypoint, existing task template catalog endpoints, existing artifact upload/link helpers, Vitest, Testing Library  
+**Storage**: No new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: Focused UI request-shape tests in `frontend/src/entrypoints/task-create.test.tsx` validate task payloads and artifact attachment behavior through mocked MoonMind REST endpoints; no compose-backed integration dependency is required for this UI state story  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web UI  
+**Performance Goals**: No additional preset or artifact network requests except when the user explicitly applies a preset, imports Jira images, selects files, or submits the draft  
+**Constraints**: Preserve explicit Apply/Reapply semantics, preserve manual step customizations, keep attachments structured rather than embedded in instruction text, keep browser calls behind MoonMind REST endpoints, and preserve Jira issue key MM-378 in artifacts  
+**Scale/Scope**: One Create page entrypoint and its focused tests
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing MoonMind preset and task orchestration surfaces.
+- II. One-Click Agent Deployment: PASS. No new services, secrets, or deployment requirements.
+- III. Avoid Vendor Lock-In: PASS. UI continues to use MoonMind REST surfaces rather than direct provider APIs.
+- IV. Own Your Data: PASS. Attachments remain MoonMind artifacts and task draft state.
+- V. Skills Are First-Class and Easy to Add: PASS. Preset behavior remains template-driven and skill-compatible.
+- VI. Replaceable Scaffolding: PASS. Adds focused tests around the UI contract rather than new orchestration scaffolding.
+- VII. Runtime Configurability: PASS. Attachment availability remains governed by server-provided runtime policy.
+- VIII. Modular Architecture: PASS. Changes stay in the existing Create page entrypoint and tests.
+- IX. Resilient by Default: PASS. Manual customizations are preserved and optional integrations remain explicit.
+- X. Continuous Improvement: PASS. Verification evidence will be recorded in `verification.md`.
+- XI. Spec-Driven Development: PASS. Runtime changes follow this one-story Moon Spec.
+- XII. Canonical Documentation Separation: PASS. Runtime work stays in specs and source; canonical docs are unchanged.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility alias or silent transform is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/196-preset-application-reapply-state/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-preset-state.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+```
+
+**Structure Decision**: Preserve the existing Create page implementation surface. Extend local draft state, payload normalization, and tests in the existing entrypoint instead of introducing a new state module for this narrowly scoped story.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/196-preset-application-reapply-state/quickstart.md
+++ b/specs/196-preset-application-reapply-state/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Preset Application and Reapply State
+
+## Focused Validation
+
+Run the focused Create page test file:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+## Story Scenarios
+
+1. Open the Create page with the task template catalog enabled.
+2. Select a preset and verify steps do not change until Apply is clicked.
+3. With only the empty default step present, click Apply and verify expanded preset steps replace the placeholder.
+4. Add authored step content, click Apply, and verify expanded preset steps append.
+5. Enter Feature Request / Initial Instructions and verify task objective and derived title use that text.
+6. After Apply, change objective text or objective-scoped attachments and verify the UI shows Reapply preset without changing expanded step content.
+7. Edit or import into a template-bound step instruction or attachment target and verify submitted step payload no longer preserves stale template identity.
+
+## Final Validation
+
+Run the full unit suite before completion when feasible:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```

--- a/specs/196-preset-application-reapply-state/research.md
+++ b/specs/196-preset-application-reapply-state/research.md
@@ -1,0 +1,33 @@
+# Research: Preset Application and Reapply State
+
+## Preset Dirty State
+
+Decision: Track preset reapply state from both preset objective text and objective-scoped attachment changes after a preset has been applied.
+
+Rationale: MM-378 requires changed preset objective inputs to mark the applied preset as dirty without automatically overwriting expanded steps. The existing Create page already has `presetReapplyNeeded`; expanding the state trigger is the smallest coherent change.
+
+Alternatives considered: Re-expanding automatically on text change was rejected because the source design forbids silent overwrites. Storing dirty state only in submitted payload was rejected because the user needs visible feedback before submission.
+
+## Objective-Scoped Attachments
+
+Decision: Add a preset objective attachment target that uses the existing attachment policy, upload validation, artifact creation, and task-level `inputAttachments` payload shape.
+
+Rationale: The source design requires objective images to belong to the preset-owned objective field and to submit through task-level attachments. Reusing existing upload helpers keeps behavior consistent with step attachments.
+
+Alternatives considered: Reusing Step 1 attachments for preset objective images was rejected because it binds objective context to a step-specific target and obscures reapply dirty state. Embedding attachment references in instruction text was rejected by the artifact policy and source design.
+
+## Template Attachment Detachment
+
+Decision: Capture a template attachment snapshot on preset-expanded steps and compare authored attachment identity against that snapshot before preserving template input identity.
+
+Rationale: Template-bound steps must detach when attachment sets no longer match the template input contract. A compact browser-side identity snapshot is sufficient for local draft comparisons and does not require backend storage changes.
+
+Alternatives considered: Treating any step attachment change as instruction detachment only was rejected because the source design distinguishes instruction and input identity. Deferring detachment to the backend was rejected because the Create page has enough draft state to submit the correct identity.
+
+## Test Strategy
+
+Decision: Use focused Vitest tests in `frontend/src/entrypoints/task-create.test.tsx` for both unit-like state helpers and request-shape integration behavior.
+
+Rationale: The story is a browser UI state and payload normalization change. Existing tests already mock MoonMind REST endpoints and inspect Create page requests, giving reliable coverage without compose services.
+
+Alternatives considered: Adding backend tests was rejected because no backend contract changes are planned. Playwright was rejected because the existing Create page coverage is Vitest-based and faster for this state flow.

--- a/specs/196-preset-application-reapply-state/spec.md
+++ b/specs/196-preset-application-reapply-state/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: Preset Application and Reapply State
+
+**Feature Branch**: `196-preset-application-reapply-state`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**:
+
+```text
+# MM-378 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-378
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Preset Application and Reapply State
+- Labels: `moonmind-workflow-mm-5818081f-60f0-45dd-ad16-3f7753de93ae`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-378 from MM project
+Summary: Preset Application and Reapply State
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-378 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-378: Preset Application and Reapply State
+
+Short Name
+preset-application-reapply-state
+
+User Story
+As a task author, I can apply reusable task presets explicitly, edit preset objective inputs, and understand when expanded steps need an explicit reapply without losing my manual step customizations.
+
+Acceptance Criteria
+- Given only the initial empty step exists, when I apply a preset, then the preset may replace the placeholder step set with expanded blueprint steps.
+- Given authored steps already exist, when I apply a preset, then expanded preset steps append to the current draft.
+- Given I select a preset without pressing Apply, then the draft does not mutate.
+- Given preset objective text is non-empty, then it is preferred over primary-step instructions for resolved objective text and title derivation.
+- Given I change preset objective text or objective-scoped attachments after applying a preset, then the preset is marked as needing explicit reapply and expanded steps are not overwritten automatically.
+- Given I manually edit a template-bound step instruction or attachment set, then that step detaches from template instruction or input identity.
+
+Requirements
+- Expose optional Preset, Feature Request / Initial Instructions, objective images, Apply, optional save-as-preset, and status controls.
+- Treat applied preset steps as expanded blueprints rather than live bindings.
+- Track template step identity only while authored instructions and attachments match the template input contract.
+- Store templateAttachments for detachment comparisons.
+- Mark applied preset state dirty when preset objective text or objective-scoped attachments change.
+- Resolve objective text from preset objective, then primary instructions, then the most recent applied preset request alias.
+- Cover preset dirty state and template detachment in tests.
+
+Independent Test
+Create page coverage verifies preset selection does not mutate the draft until Apply is pressed, initial empty steps can be replaced by expanded blueprint steps, authored drafts receive appended preset steps, preset objective text drives objective and title resolution, changed objective inputs mark the applied preset state as needing explicit reapply, and manual edits detach template-bound step instruction or input identity.
+
+Source Document
+- `docs/UI/CreatePage.md`
+
+Source Sections
+- 7.5 Template-bound steps
+- 8. Task preset contract
+- 15. Objective resolution and title derivation
+
+Coverage IDs
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-012
+- DESIGN-REQ-022
+- DESIGN-REQ-025
+
+Relevant Implementation Notes
+- The preset area is optional and exposes Preset, Feature Request / Initial Instructions, objective-scoped image inputs when attachment policy is enabled, Apply, optional Save Current Steps as Preset, and status text.
+- Applying a preset expands blueprint steps into the step list.
+- When the form still contains only the initial empty default step, applying a preset may replace that placeholder step set.
+- When authored steps already exist, applying a preset appends expanded preset steps to the current draft.
+- Selecting a preset alone must not modify the draft.
+- Preset application remains an explicit action.
+- Feature Request / Initial Instructions is the preset-owned objective text source.
+- Non-empty preset objective text is preferred over primary-step instructions for objective text resolution and title derivation.
+- Objective-scoped attachments are the matching structured input source for preset objective text.
+- Changing preset objective text or objective-scoped attachments after apply marks the preset state as needs reapply.
+- Reapply is explicit and must not automatically overwrite expanded steps because preset inputs changed.
+- Preset-expanded steps may carry template step identity only while authored instructions and attachment sets still match the template-authored step input contract.
+- Manual edits to template-bound step instructions detach that step from template instruction identity.
+- Manual edits to template-bound step attachment sets detach that step from template input identity.
+- `templateAttachments` stores the template-authored attachment set used for detachment comparisons.
+- Importing Jira text or Jira images into a template-bound step counts as a manual edit.
+
+Out of Scope
+- Treating applied preset steps as live bindings that update automatically when preset inputs change.
+- Automatically rewriting expanded steps when preset objective text or objective-scoped attachments change.
+- Copying objective-scoped attachments into step attachments unless a future preset contract explicitly defines that behavior.
+- Changing unrelated Create page dependency, execution context, publish, or attachment policy behavior.
+
+Verification
+- Run focused Create page frontend tests covering preset apply, append, no-mutation-on-select, dirty reapply state, objective resolution, title derivation, and template detachment behavior.
+- Verify Create page state preserves manual step customizations when preset objective inputs change.
+- Verify `templateAttachments` supports detachment comparisons for template-bound step attachment sets.
+- Run `./tools/test_unit.sh` before completion when implementation changes are made.
+
+Needs Clarification
+- None
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include Create page runtime behavior, production state handling, and focused validation tests.
+
+## User Story - Preset Application and Reapply State
+
+**Summary**: As a task author, I want reusable task presets to apply only when I explicitly choose Apply or Reapply so that edited preset objective inputs and manually customized expanded steps remain under my control.
+
+**Goal**: Task authors can apply a preset to generate blueprint steps, edit preset objective text or objective-scoped attachments after apply, see a clear reapply-needed state, and keep manually customized template-derived steps from being treated as still template-bound.
+
+**Independent Test**: Render the Create page, select and apply a preset, modify preset objective inputs and template-bound step inputs, then submit. The story passes when selecting a preset alone does not mutate steps, applying replaces only the initial empty step or appends to authored steps, preset objective text drives task objective and title, changed preset objective text or objective-scoped attachments mark the preset as needing explicit reapply without overwriting expanded steps, and edited template-bound instructions or attachments detach template identity.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Create page contains only its initial empty step, **when** a task author applies a preset, **then** the expanded preset blueprint steps replace the placeholder step set.
+2. **Given** the Create page already contains authored step content, **when** a task author applies a preset, **then** the expanded preset blueprint steps append after the existing authored steps.
+3. **Given** a task author selects a preset in the preset picker, **when** Apply has not been pressed, **then** the current draft steps remain unchanged.
+4. **Given** preset objective text is non-empty, **when** the task objective and title are resolved, **then** that preset objective text is preferred over the primary step instructions and the latest applied preset request alias.
+5. **Given** a preset has already been applied, **when** the task author changes preset objective text or objective-scoped attachments, **then** the preset area is marked as needing explicit reapply and expanded steps are not overwritten automatically.
+6. **Given** a preset-expanded step is still template-bound, **when** the task author edits that step's instruction text or attachment set, **then** the step detaches from template instruction or input identity before submission.
+
+### Edge Cases
+
+- Applying a preset that expands to zero steps keeps the draft valid with one empty step.
+- Reverting preset objective text back to the last applied value clears the reapply-needed state when no other preset objective inputs are dirty.
+- Selecting a different preset clears stale apply status without mutating draft steps.
+- Jira import into the preset objective field counts as a preset objective text change.
+- Jira image import or local file selection into the preset objective target counts as an objective-scoped attachment change.
+- Jira text or image import into a template-bound step counts as a manual edit.
+
+## Assumptions
+
+- The existing Create page task template catalog remains the preset source.
+- Objective-scoped attachments use the existing attachment policy and artifact upload path, but are bound to task-level `inputAttachments` instead of a specific step.
+- Template attachment identity can be compared by stable attachment attributes available in the browser draft: artifact ID when present, otherwise filename, content type, and size.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-010**: Source section 7.5 requires preset-expanded steps to remain template-bound only while authored instructions and attachment sets match the template-authored step input contract, with Jira imports counting as manual edits. Scope: in scope. Maps to FR-006, FR-007, and FR-008.
+- **DESIGN-REQ-011**: Source section 8.1 requires the preset area to expose Preset, Feature Request / Initial Instructions, objective-scoped image inputs when attachments are enabled, Apply, optional save-as-preset, and status text. Scope: in scope. Maps to FR-001 and FR-005.
+- **DESIGN-REQ-012**: Source sections 8.2 through 8.4 require preset selection to be non-mutating, preset application to be explicit, initial empty steps to be replaceable, authored steps to receive appended preset steps, and changed preset inputs to require explicit reapply without automatic step overwrites. Scope: in scope. Maps to FR-002, FR-003, FR-005, and FR-009.
+- **DESIGN-REQ-022**: Source section 15 requires resolved objective text to prefer preset Feature Request / Initial Instructions, then primary step instructions, then the latest applied preset request alias. Scope: in scope. Maps to FR-004.
+- **DESIGN-REQ-025**: Source sections 7.4, 7.5, and 15 require objective-scoped attachments to remain task-level objective inputs and template-bound step attachments to detach when manually changed. Scope: in scope. Maps to FR-005, FR-007, and FR-008.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Create page MUST expose optional preset controls: Preset, Feature Request / Initial Instructions, objective-scoped image inputs when attachment policy is enabled, Apply or Reapply, optional Save Current Steps as Preset, and preset status text.
+- **FR-002**: Selecting a preset in the preset picker MUST NOT mutate authored step instructions, step attachments, applied template metadata, task objective text, or submitted task payload until Apply is pressed.
+- **FR-003**: Applying a preset MUST replace the initial empty placeholder step set, but MUST append expanded preset steps when authored steps already exist.
+- **FR-004**: Resolved task objective text and title derivation MUST prefer non-empty preset objective text over primary step instructions and the latest applied preset request alias.
+- **FR-005**: After a preset has been applied, changing preset objective text or objective-scoped attachments MUST mark the preset as needing explicit reapply and MUST NOT automatically overwrite expanded steps.
+- **FR-006**: Preset-expanded steps MUST carry template step identity only while authored instructions match template instructions.
+- **FR-007**: Preset-expanded steps MUST carry template input identity only while authored attachment sets match the template attachment set used for detachment comparisons.
+- **FR-008**: Manual edits, Jira text imports, Jira image imports, and local attachment changes on template-bound steps MUST detach the affected step from template instruction or input identity before submission.
+- **FR-009**: Reapplying a dirty preset MUST be explicit and MUST update the applied preset state only after Apply or Reapply succeeds.
+- **FR-010**: Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve Jira issue key MM-378.
+
+### Key Entities
+
+- **Preset Objective Input**: The preset-owned Feature Request / Initial Instructions text plus objective-scoped attachments that form task-level objective context.
+- **Applied Preset State**: The stored applied template metadata and last applied preset objective inputs used to determine whether reapply is needed.
+- **Template-Bound Step**: A step generated from a preset blueprint that still matches its template-authored instruction and attachment input contract.
+- **Template Attachment Snapshot**: The attachment identity set captured from a preset-expanded step for later detachment comparisons.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Focused Create page tests verify preset selection alone leaves the step draft unchanged.
+- **SC-002**: Focused Create page tests verify Apply replaces the initial empty step and appends to authored step drafts.
+- **SC-003**: Focused Create page tests verify preset objective text controls task objective and derived title when non-empty.
+- **SC-004**: Focused Create page tests verify changed preset objective text and objective-scoped attachments show Reapply preset without changing expanded step content.
+- **SC-005**: Focused Create page tests verify manually edited or Jira-imported template-bound step instructions submit without template step ID.
+- **SC-006**: Focused Create page tests verify changed template-bound step attachments submit without template input identity.
+- **SC-007**: Verification evidence preserves MM-378 as the source Jira issue for the feature.

--- a/specs/196-preset-application-reapply-state/tasks.md
+++ b/specs/196-preset-application-reapply-state/tasks.md
@@ -1,0 +1,80 @@
+# Tasks: Preset Application and Reapply State
+
+**Input**: Design documents from `specs/196-preset-application-reapply-state/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and UI/request-shape integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code.
+
+**Test Commands**:
+
+- Focused UI tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Full unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final verification: `/moonspec-verify`
+
+## Traceability Inventory
+
+- FR-001, DESIGN-REQ-011: preset controls and objective image target.
+- FR-002, SC-001, DESIGN-REQ-012: selecting a preset is non-mutating.
+- FR-003, SC-002, DESIGN-REQ-012: Apply replaces initial empty step and appends to authored drafts.
+- FR-004, SC-003, DESIGN-REQ-022: preset objective text drives objective and title.
+- FR-005, FR-009, SC-004, DESIGN-REQ-012, DESIGN-REQ-025: changed objective inputs mark explicit reapply and do not overwrite steps.
+- FR-006, FR-007, FR-008, SC-005, SC-006, DESIGN-REQ-010, DESIGN-REQ-025: template-bound instruction and attachment detachment.
+- FR-010, SC-007: MM-378 remains visible in artifacts and verification.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm MM-378 source input and single-story traceability in `docs/tmp/jira-orchestration-inputs/MM-378-moonspec-orchestration-input.md` and `specs/196-preset-application-reapply-state/spec.md`.
+- [X] T002 Confirm existing Create page preset, Jira import, attachment, and submission surfaces in `frontend/src/entrypoints/task-create.tsx`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing focused UI test harness covers Create page preset and request-shape behavior in `frontend/src/entrypoints/task-create.test.tsx`.
+
+## Phase 3: Story - Preset Application and Reapply State
+
+**Summary**: As a task author, I want reusable task presets to apply only when I explicitly choose Apply or Reapply so that edited preset objective inputs and manually customized expanded steps remain under my control.
+
+**Independent Test**: Render the Create page, select and apply a preset, modify preset objective inputs and template-bound step inputs, then submit. The story passes when selecting a preset alone does not mutate steps, applying replaces only the initial empty step or appends to authored steps, preset objective text drives task objective and title, changed preset objective text or objective-scoped attachments mark the preset as needing explicit reapply, and edited template-bound instructions or attachments detach template identity.
+
+**Traceability**: FR-001 through FR-010, SC-001 through SC-007, DESIGN-REQ-010 through DESIGN-REQ-012, DESIGN-REQ-022, DESIGN-REQ-025, MM-378.
+
+### Unit Tests
+
+- [X] T004 Add focused UI test proving selecting a preset does not mutate existing step draft state in `frontend/src/entrypoints/task-create.test.tsx` (FR-002, SC-001, DESIGN-REQ-012).
+- [X] T005 Add focused UI tests proving Apply replaces an initial empty step and appends to authored steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, SC-002, DESIGN-REQ-012).
+- [X] T006 Add focused UI test proving preset objective text controls objective and title resolution in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, SC-003, DESIGN-REQ-022).
+- [X] T007 Add focused UI tests proving manual preset objective text and objective-scoped attachment changes mark Reapply preset without mutating expanded steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-005, FR-009, SC-004, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-025).
+- [X] T008 Add focused UI tests proving template-bound step instruction and attachment edits detach template identity in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, FR-007, FR-008, SC-005, SC-006, DESIGN-REQ-010, DESIGN-REQ-025).
+
+### Red-First Confirmation
+
+- [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm new tests fail for missing objective attachment target, dirty-state trigger, or template attachment detachment before production edits.
+
+### Implementation
+
+- [X] T010 Add objective-scoped preset attachment draft state, UI, validation, upload, task-level payload submission, and reapply dirty-state tracking in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-005, FR-009, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-025).
+- [X] T011 Add template attachment snapshots and attachment-set detachment logic for preset-expanded steps in `frontend/src/entrypoints/task-create.tsx` (FR-006, FR-007, FR-008, DESIGN-REQ-010, DESIGN-REQ-025).
+- [X] T012 Preserve existing preset Apply replacement/append behavior, non-mutating selection, and objective/title resolution; make only test-driven fixes in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-003, FR-004, DESIGN-REQ-012, DESIGN-REQ-022).
+- [X] T013 Run focused UI tests and fix failures in `frontend/src/entrypoints/task-create.tsx` or `frontend/src/entrypoints/task-create.test.tsx` only as needed (FR-001 through FR-009).
+
+## Phase 4: Polish And Verification
+
+- [X] T014 Run full unit suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T015 Run `/moonspec-verify` and record the result in `specs/196-preset-application-reapply-state/verification.md` (FR-010, SC-007).
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story tests.
+- T004-T008 must be written before T010-T012.
+- T009 confirms red-first behavior before implementation.
+- T010-T013 complete the story.
+- T014-T015 run after focused tests pass.
+
+## Parallel Opportunities
+
+- T004 through T008 can be drafted in the same focused UI test file but must be validated as one red-first batch.
+- T010 and T011 touch the same implementation file and must run sequentially.
+
+## Notes
+
+- This task list covers exactly one story: MM-378.

--- a/specs/196-preset-application-reapply-state/tasks.md
+++ b/specs/196-preset-application-reapply-state/tasks.md
@@ -46,34 +46,41 @@
 - [X] T007 Add focused UI tests proving manual preset objective text and objective-scoped attachment changes mark Reapply preset without mutating expanded steps in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-005, FR-009, SC-004, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-025).
 - [X] T008 Add focused UI tests proving template-bound step instruction and attachment edits detach template identity in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, FR-007, FR-008, SC-005, SC-006, DESIGN-REQ-010, DESIGN-REQ-025).
 
+### Integration Tests
+
+- [X] T009 Add request-shape integration coverage proving submitted task payloads carry objective-scoped attachments at task input level and omit detached template identities after manual step edits in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-005, FR-007, FR-008, FR-009, SC-004, SC-006, DESIGN-REQ-011, DESIGN-REQ-025).
+
 ### Red-First Confirmation
 
-- [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm new tests fail for missing objective attachment target, dirty-state trigger, or template attachment detachment before production edits.
+- [X] T010 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and confirm new tests fail for missing objective attachment target, dirty-state trigger, or template attachment detachment before production edits.
 
 ### Implementation
 
-- [X] T010 Add objective-scoped preset attachment draft state, UI, validation, upload, task-level payload submission, and reapply dirty-state tracking in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-005, FR-009, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-025).
-- [X] T011 Add template attachment snapshots and attachment-set detachment logic for preset-expanded steps in `frontend/src/entrypoints/task-create.tsx` (FR-006, FR-007, FR-008, DESIGN-REQ-010, DESIGN-REQ-025).
-- [X] T012 Preserve existing preset Apply replacement/append behavior, non-mutating selection, and objective/title resolution; make only test-driven fixes in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-003, FR-004, DESIGN-REQ-012, DESIGN-REQ-022).
-- [X] T013 Run focused UI tests and fix failures in `frontend/src/entrypoints/task-create.tsx` or `frontend/src/entrypoints/task-create.test.tsx` only as needed (FR-001 through FR-009).
+- [X] T011 Add objective-scoped preset attachment draft state, UI, validation, upload, task-level payload submission, and reapply dirty-state tracking in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-005, FR-009, DESIGN-REQ-011, DESIGN-REQ-012, DESIGN-REQ-025).
+- [X] T012 Add template attachment snapshots and attachment-set detachment logic for preset-expanded steps in `frontend/src/entrypoints/task-create.tsx` (FR-006, FR-007, FR-008, DESIGN-REQ-010, DESIGN-REQ-025).
+- [X] T013 Preserve existing preset Apply replacement/append behavior, non-mutating selection, and objective/title resolution; make only test-driven fixes in `frontend/src/entrypoints/task-create.tsx` (FR-002, FR-003, FR-004, DESIGN-REQ-012, DESIGN-REQ-022).
+
+### Story Validation
+
+- [X] T014 Run focused UI and request-shape tests, then fix failures in `frontend/src/entrypoints/task-create.tsx` or `frontend/src/entrypoints/task-create.test.tsx` only as needed (FR-001 through FR-009, SC-001 through SC-006).
 
 ## Phase 4: Polish And Verification
 
-- [X] T014 Run full unit suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
-- [X] T015 Run `/moonspec-verify` and record the result in `specs/196-preset-application-reapply-state/verification.md` (FR-010, SC-007).
+- [X] T015 Run full unit suite with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`.
+- [X] T016 Run `/moonspec-verify` and record the result in `specs/196-preset-application-reapply-state/verification.md` (FR-010, SC-007).
 
 ## Dependencies & Execution Order
 
 - T001-T003 must complete before story tests.
-- T004-T008 must be written before T010-T012.
-- T009 confirms red-first behavior before implementation.
-- T010-T013 complete the story.
-- T014-T015 run after focused tests pass.
+- T004-T009 must be written before T011-T013.
+- T010 confirms red-first behavior before implementation.
+- T011-T014 complete the story.
+- T015-T016 run after focused tests pass.
 
 ## Parallel Opportunities
 
-- T004 through T008 can be drafted in the same focused UI test file but must be validated as one red-first batch.
-- T010 and T011 touch the same implementation file and must run sequentially.
+- T004 through T009 can be drafted in the same focused UI test file but must be validated as one red-first batch.
+- T011 and T012 touch the same implementation file and must run sequentially.
 
 ## Notes
 

--- a/specs/196-preset-application-reapply-state/verification.md
+++ b/specs/196-preset-application-reapply-state/verification.md
@@ -1,0 +1,70 @@
+# MoonSpec Verification Report
+
+**Feature**: Preset Application and Reapply State  
+**Spec**: `/work/agent_jobs/mm:c1902fbb-1092-45ac-85e9-9373b56217d4/repo/specs/196-preset-application-reapply-state/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving Jira issue `MM-378` and `docs/tmp/jira-orchestration-inputs/MM-378-moonspec-orchestration-input.md`  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Red-first focused runner | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` | PASS after implementation | Before production edits, the new focused tests failed for missing manual dirty-state behavior, missing objective attachment target, and missing template attachment detachment. |
+| Focused Vitest | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` | PASS | 124 tests passed. |
+| TypeScript | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS | No type errors. |
+| Full unit suite | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python unit suite passed with 3475 passed, 1 xpassed, 16 subtests passed; frontend Vitest suite passed with 10 files and 245 tests. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `frontend/src/entrypoints/task-create.tsx`, `frontend/src/entrypoints/task-create.test.tsx` | VERIFIED | Preset controls include objective attachment input when attachment policy is enabled. |
+| FR-002 | `does not mutate the draft when selecting a preset before apply` | VERIFIED | Preset selection leaves authored step state unchanged until Apply. |
+| FR-003 | Existing `applies a preset into task steps and submits them` and related focused tests | VERIFIED | Apply replacement and append behavior preserved. |
+| FR-004 | Existing objective/title tests and `resolveObjectiveInstructions` coverage | VERIFIED | Preset objective text remains first objective source and title source. |
+| FR-005 | `marks an applied preset dirty when preset objective text changes manually`; objective attachment dirty-state test | VERIFIED | Dirty state appears without changing expanded step content. |
+| FR-006 | `detaches template step identity when Jira import edits a template-bound step` | VERIFIED | Instruction edits clear template step ID before submit. |
+| FR-007 | `detaches template step identity when a template-bound step attachment changes` | VERIFIED | Attachment changes clear stale template identity. |
+| FR-008 | Jira import tests and attachment detachment tests | VERIFIED | Jira text/image and local attachment changes are treated as manual edits. |
+| FR-009 | Apply/Reapply dirty-state tests | VERIFIED | Reapply is explicit and applied template state updates only after Apply/Reapply succeeds. |
+| FR-010 | `spec.md`, `tasks.md`, this `verification.md` | VERIFIED | MM-378 is preserved in artifacts and verification evidence. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| SCN-001 | Existing preset apply tests | VERIFIED | Initial empty step replacement remains covered. |
+| SCN-002 | Existing preset apply tests with authored draft coverage | VERIFIED | Authored step drafts receive appended preset steps. |
+| SCN-003 | New non-mutating selection test | VERIFIED | Selecting a preset alone leaves draft unchanged. |
+| SCN-004 | Existing objective resolution and submit payload tests | VERIFIED | Preset objective text drives objective and title. |
+| SCN-005 | New dirty-state tests | VERIFIED | Text and objective attachment changes show Reapply preset without overwriting expanded steps. |
+| SCN-006 | Existing Jira instruction detachment test and new attachment detachment test | VERIFIED | Template-bound identity detaches for instruction and attachment edits. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-010 | `frontend/src/entrypoints/task-create.tsx`, detachment tests | VERIFIED | Template-bound step identity is conditional on instruction and attachment match. |
+| DESIGN-REQ-011 | Objective attachment UI and tests | VERIFIED | Preset area exposes objective attachment target when policy permits. |
+| DESIGN-REQ-012 | Apply/Reapply tests | VERIFIED | Preset selection is non-mutating; Apply/Reapply is explicit. |
+| DESIGN-REQ-022 | Objective resolution tests | VERIFIED | Preset objective text remains first objective source. |
+| DESIGN-REQ-025 | Objective attachment payload and detachment tests | VERIFIED | Objective attachments submit at task level; template-bound step attachment edits detach. |
+| Constitution XI | `spec.md`, `plan.md`, `tasks.md`, implementation tests | VERIFIED | Change followed one-story Moon Spec lifecycle. |
+| Constitution XII | `docs/tmp/jira-orchestration-inputs/MM-378-moonspec-orchestration-input.md`, `specs/196-preset-application-reapply-state/` | VERIFIED | Jira input and implementation evidence stay outside canonical desired-state docs. |
+
+## Original Request Alignment
+
+- PASS: The implementation uses the MM-378 Jira preset brief as the canonical Moon Spec input, implements the single-story runtime behavior, preserves MM-378 in artifacts, and validates preset apply/reapply and template detachment behavior.
+
+## Gaps
+
+- None.
+
+## Remaining Work
+
+- None.
+
+## Decision
+
+- FULLY_IMPLEMENTED. The story has production behavior and focused plus full-suite test evidence.


### PR DESCRIPTION
## Jira
- Jira issue key: MM-378

## MoonSpec
- Active feature path: `specs/196-preset-application-reapply-state`
- Verification verdict: FULLY_IMPLEMENTED

## Summary
- Implement Create page preset Apply/Reapply behavior with preset objective dirty-state tracking.
- Add objective-scoped preset attachments that submit as task-level input attachments.
- Detach template identity when template-bound step instructions or attachment sets are manually changed.
- Preserve MM-378 Moon Spec artifacts and final verification coverage.

## Tests run
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` PASS: Python unit wrapper passed; focused Create page Vitest file passed 124 tests.
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` PASS.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS: Python unit suite passed with 3475 passed, 1 xpassed, 16 subtests; frontend suite passed with 10 files and 245 tests.

## Remaining risks
- None identified in final MoonSpec verification.
