### PR TITLE
MM-369 Preserve attachment bindings in snapshots and reruns

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/195-canonical-create-page-shell"
+  "feature_directory": "specs/196-preserve-attachment-bindings"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,8 @@ Key diagnostics:
 - TypeScript/React for Mission Control UI, Python 3.12 for FastAPI route tests + React, FastAPI, existing boot payload helpers, existing task dashboard router, Vitest, pytest (195-canonical-create-page-shell)
 - Python 3.12; TypeScript/React for existing Create-page behavior + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, existing React Create page (195-enforce-image-artifact-policy)
 - Existing Temporal artifact metadata tables and configured artifact store; no new persistent storage (195-enforce-image-artifact-policy)
+- Python 3.12; TypeScript/React for Mission Control Create-page behavior + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, React, Vitest, existing task editing helpers (196-preserve-attachment-bindings)
+- Existing Temporal artifact metadata tables and original task input snapshot artifacts; no new persistent storage (196-preserve-attachment-bindings)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/docs/tmp/jira-orchestration-inputs/MM-369-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-369-moonspec-orchestration-input.md
@@ -1,0 +1,98 @@
+# MM-369 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-369
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Preserve attachment bindings in snapshots and reruns
+- Labels: `moonmind-workflow-mm-710b9b03-7ff6-4c87-ac25-ddef82bbf280`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-369 from MM project
+Summary: Preserve attachment bindings in snapshots and reruns
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-369 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-369: Preserve attachment bindings in snapshots and reruns
+
+Source Reference
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 5.3 Authoritative snapshot contract
+  - 11. UI preview and detail contract
+  - 13. Edit and rerun durability contract
+- Coverage IDs:
+  - DESIGN-REQ-007
+  - DESIGN-REQ-015
+  - DESIGN-REQ-018
+
+User Story
+As a user editing or rerunning a task, I need MoonMind to reconstruct attachments from the authoritative task input snapshot so unchanged bindings survive and changes are always explicit.
+
+Acceptance Criteria
+- The snapshot preserves text fields, target attachment refs, step identity/order, runtime, publish, repository settings, and applied preset metadata.
+- Attachment target binding is reconstructed from the snapshot, not inferred from artifact links or filenames.
+- Unchanged attachment refs survive edit and rerun unchanged.
+- Removing an attachment and adding a new attachment are explicit user actions.
+- A text-only draft reconstruction cannot silently drop attachments.
+- The system fails explicitly if attachment bindings cannot be reconstructed.
+- Historical artifacts may remain according to retention even after an edited draft stops referencing them.
+
+Requirements
+- Persist target attachment refs in the task input snapshot.
+- Use the same attachment contract for create, edit, and rerun.
+- Keep step identity and ordering stable enough to bind step-scoped attachments.
+- Distinguish persisted attachment refs from new local files in edit/rerun flows.
+- Preserve objective-scoped attachments in `task.inputAttachments`.
+- Preserve step-scoped attachments in `task.steps[n].inputAttachments`.
+- Normalize attachment refs before workflow start without changing target binding semantics.
+- Reconstruct attachment target binding from the authoritative task input snapshot, not from artifact links, filenames, or UI-only heuristics.
+- Preserve runtime, publish, repository settings, and applied preset metadata alongside text fields and attachment refs in the snapshot.
+- Fail explicitly if edit or rerun reconstruction cannot preserve attachment bindings.
+
+Relevant Implementation Notes
+- The original task input snapshot is the source of truth for edit and rerun reconstruction.
+- Task detail, edit, and rerun previews should be organized by explicit attachment target: objective-scoped or step-scoped.
+- Preview and download surfaces must not infer target binding from filenames.
+- Preview failure must not remove access to metadata or download actions.
+- Edit and rerun surfaces must distinguish persisted attachments from new local files that have not yet been uploaded.
+- Create, edit, and rerun should use the same authoritative attachment contract.
+- Unchanged attachment refs should survive edit and rerun unchanged.
+- Removing an existing attachment and adding a new attachment should remain explicit user actions.
+- Historical source artifacts may remain according to retention policy even after an edited draft stops referencing them.
+
+Suggested Implementation Areas
+- Task input snapshot persistence for objective and step attachment refs.
+- Edit draft reconstruction from persisted task snapshots.
+- Rerun draft reconstruction from persisted task snapshots.
+- Create-page or task-detail attachment preview grouping by target.
+- Validation and error handling for missing or unreconstructable attachment bindings.
+- Tests for create, edit, and rerun attachment binding preservation.
+
+Validation
+- Verify a task snapshot preserves text fields, target attachment refs, step identity/order, runtime, publish, repository settings, and applied preset metadata.
+- Verify edit reconstruction uses persisted snapshot attachment refs and does not infer target binding from artifact links or filenames.
+- Verify rerun reconstruction preserves unchanged objective-scoped and step-scoped attachment refs.
+- Verify removing an attachment and adding a new attachment are explicit user actions.
+- Verify a text-only draft reconstruction cannot silently drop existing attachments.
+- Verify the system fails explicitly when attachment bindings cannot be reconstructed.
+- Verify historical artifacts can remain under retention when an edited draft no longer references them.
+
+Non-Goals
+- Inferring attachment target bindings from filenames, artifact links, or attachment metadata.
+- Silently dropping attachments during edit or rerun reconstruction.
+- Rewriting attachment refs through hidden compatibility transforms.
+- Changing artifact retention semantics beyond preserving references correctly in edit and rerun flows.
+- Adding generic non-image attachment support beyond this story's image attachment binding durability contract.
+
+Needs Clarification
+- None

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -686,6 +686,46 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Aattachment-edit?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:attachment-edit",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              profileId: "profile:codex-secondary",
+              model: "gpt-5.4",
+              effort: "medium",
+              repository: "MoonLadderStudios/MoonMind",
+              inputArtifactRef: "attachment-snapshot",
+              taskInputSnapshot: {
+                available: true,
+                artifactRef: "attachment-snapshot",
+                snapshotVersion: 1,
+                sourceKind: "create",
+                reconstructionMode: "authoritative",
+                disabledReasons: {},
+                fallbackEvidenceRefs: [],
+              },
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                task: {
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.4",
+                    effort: "medium",
+                    profileId: "profile:codex-secondary",
+                  },
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Arerun-123?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -989,6 +1029,17 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Aattachment-edit/update") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              accepted: true,
+              applied: "immediate",
+              message: "Inputs updated.",
+              execution: { workflowId: "mm:attachment-edit" },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Arerun-123/update") {
           return Promise.resolve({
             ok: true,
@@ -1241,6 +1292,69 @@ describe("Task Create Entrypoint", () => {
                   publish: { mode: "pr" },
                   tool: { type: "skill", name: "speckit-orchestrate" },
                 },
+              }),
+          } as Response);
+        }
+        if (url === "/api/artifacts/attachment-snapshot/download") {
+          return Promise.resolve({
+            ok: true,
+            text: async () =>
+              JSON.stringify({
+                snapshotVersion: 1,
+                source: { kind: "create" },
+                draft: {
+                  taskShape: "multi_step",
+                  task: {
+                    instructions: "Preserve the existing attachments.",
+                    inputAttachments: [
+                      {
+                        artifactId: "art-objective",
+                        filename: "objective.png",
+                        contentType: "image/png",
+                        sizeBytes: 1234,
+                      },
+                    ],
+                    runtime: {
+                      mode: "codex_cli",
+                      model: "gpt-5.4",
+                      effort: "medium",
+                      profileId: "profile:codex-secondary",
+                    },
+                    steps: [
+                      {
+                        id: "step-with-attachment",
+                        title: "Attached step",
+                        instructions: "Preserve the existing attachments.",
+                        inputAttachments: [
+                          {
+                            artifactId: "art-step",
+                            filename: "step.webp",
+                            contentType: "image/webp",
+                            sizeBytes: 4567,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+                attachmentRefs: [
+                  {
+                    artifactId: "art-objective",
+                    filename: "objective.png",
+                    contentType: "image/png",
+                    sizeBytes: 1234,
+                    targetKind: "objective",
+                  },
+                  {
+                    artifactId: "art-step",
+                    filename: "step.webp",
+                    contentType: "image/webp",
+                    sizeBytes: 4567,
+                    targetKind: "step",
+                    stepId: "step-with-attachment",
+                    stepOrdinal: 0,
+                  },
+                ],
               }),
           } as Response);
         }
@@ -1702,6 +1816,151 @@ describe("Task Create Entrypoint", () => {
       taskInstructions: "Rerun from immutable artifact input.",
       primarySkill: "speckit-orchestrate",
     });
+  });
+
+  it("reconstructs persisted objective and step attachments from the authoritative task snapshot", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution(
+      {
+        workflowId: "mm:attachment-snapshot",
+        workflowType: "MoonMind.Run",
+        taskInputSnapshot: {
+          available: true,
+          artifactRef: "art-snapshot",
+          snapshotVersion: 1,
+          sourceKind: "create",
+          reconstructionMode: "authoritative",
+          disabledReasons: {},
+          fallbackEvidenceRefs: [],
+        },
+        inputParameters: {
+          task: {
+            instructions: "Fallback inline instructions.",
+          },
+        },
+      },
+      {
+        snapshotVersion: 1,
+        source: { kind: "create" },
+        draft: {
+          taskShape: "multi_step",
+          task: {
+            instructions: "Preserve attachments from the snapshot.",
+            inputAttachments: [
+              {
+                artifactId: "art-objective",
+                filename: "objective.png",
+                contentType: "image/png",
+                sizeBytes: 1234,
+              },
+            ],
+            steps: [
+              {
+                id: "step-with-attachment",
+                title: "Attached step",
+                instructions: "Use the step attachment.",
+                inputAttachments: [
+                  {
+                    artifactId: "art-step",
+                    filename: "step.webp",
+                    contentType: "image/webp",
+                    sizeBytes: 4567,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        attachmentRefs: [
+          {
+            artifactId: "art-objective",
+            filename: "objective.png",
+            contentType: "image/png",
+            sizeBytes: 1234,
+            targetKind: "objective",
+          },
+          {
+            artifactId: "art-step",
+            filename: "step.webp",
+            contentType: "image/webp",
+            sizeBytes: 4567,
+            targetKind: "step",
+            stepId: "step-with-attachment",
+            stepOrdinal: 0,
+          },
+        ],
+      },
+    );
+
+    expect(draft.taskInstructions).toBe(
+      [
+        "Preserve attachments from the snapshot.",
+        "Use the step attachment.",
+      ].join("\n\n"),
+    );
+    expect(draft.inputAttachments).toEqual([
+      {
+        artifactId: "art-objective",
+        filename: "objective.png",
+        contentType: "image/png",
+        sizeBytes: 1234,
+      },
+    ]);
+    expect(draft.steps).toEqual([
+      expect.objectContaining({
+        id: "step-with-attachment",
+        inputAttachments: [
+          {
+            artifactId: "art-step",
+            filename: "step.webp",
+            contentType: "image/webp",
+            sizeBytes: 4567,
+          },
+        ],
+      }),
+    ]);
+  });
+
+  it("fails reconstruction when compact attachment refs cannot be bound from the task snapshot", () => {
+    expect(() =>
+      buildTemporalSubmissionDraftFromExecution(
+        {
+          workflowId: "mm:unbound-attachments",
+          workflowType: "MoonMind.Run",
+          taskInputSnapshot: {
+            available: true,
+            artifactRef: "art-snapshot",
+            snapshotVersion: 1,
+            sourceKind: "create",
+            reconstructionMode: "authoritative",
+            disabledReasons: {},
+            fallbackEvidenceRefs: [],
+          },
+          inputParameters: {
+            task: {},
+          },
+        },
+        {
+          snapshotVersion: 1,
+          source: { kind: "create" },
+          draft: {
+            taskShape: "inline_instructions",
+            task: {
+              instructions: "This snapshot lost structured attachment bindings.",
+            },
+          },
+          attachmentRefs: [
+            {
+              artifactId: "art-lost",
+              filename: "lost.png",
+              contentType: "image/png",
+              sizeBytes: 100,
+              targetKind: "step",
+              stepOrdinal: 0,
+            },
+          ],
+        },
+      ),
+    ).toThrow("Attachment bindings could not be reconstructed from this execution.");
   });
 
   it("reconstructs primary skill from object-shaped task skill selectors", () => {
@@ -2674,6 +2933,76 @@ describe("Task Create Entrypoint", () => {
     expect(
       window.sessionStorage.getItem("moonmind.temporalTaskEditing.notice"),
     ).toBe("Changes were scheduled for the next safe point.");
+  });
+
+  it("retains unchanged persisted attachment refs when editing an artifact-backed execution", async () => {
+    renderForEdit("mm:attachment-edit", withAttachmentPolicy());
+
+    const instructions = (await screen.findByLabelText(
+      "Instructions",
+    )) as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(instructions.value).toBe("Preserve the existing attachments.");
+    });
+    expect(await screen.findByText("objective.png (1.2 KB)")).toBeTruthy();
+    expect(await screen.findByText("step.webp (4.5 KB)")).toBeTruthy();
+    const downloadLinks = await screen.findAllByRole("link", {
+      name: "Download",
+    });
+    expect(downloadLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "/api/artifacts/art-objective/download",
+      "/api/artifacts/art-step/download",
+    ]);
+
+    fireEvent.change(instructions, {
+      target: { value: "Edited instructions with existing attachments." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Aattachment-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) => String(url) === "/api/executions/mm%3Aattachment-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+    expect(request).toMatchObject({
+      updateName: "UpdateInputs",
+      parametersPatch: {
+        repository: "MoonLadderStudios/MoonMind",
+        task: {
+          instructions: "Edited instructions with existing attachments.",
+          inputAttachments: [
+            {
+              artifactId: "art-objective",
+              filename: "objective.png",
+              contentType: "image/png",
+              sizeBytes: 1234,
+            },
+          ],
+          steps: [
+            {
+              id: "step-with-attachment",
+              title: "Attached step",
+              instructions: "Edited instructions with existing attachments.",
+              inputAttachments: [
+                {
+                  artifactId: "art-step",
+                  filename: "step.webp",
+                  contentType: "image/webp",
+                  sizeBytes: 4567,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
   });
 
   it("externalizes oversized edited input before sending UpdateInputs", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -1963,6 +1963,65 @@ describe("Task Create Entrypoint", () => {
     ).toThrow("Attachment bindings could not be reconstructed from this execution.");
   });
 
+  it("fails reconstruction when a repeated artifact loses one target binding", () => {
+    expect(() =>
+      buildTemporalSubmissionDraftFromExecution(
+        {
+          workflowId: "mm:duplicate-artifact-binding",
+          workflowType: "MoonMind.Run",
+          taskInputSnapshot: {
+            available: true,
+            artifactRef: "art-snapshot",
+            snapshotVersion: 1,
+            sourceKind: "create",
+            reconstructionMode: "authoritative",
+            disabledReasons: {},
+            fallbackEvidenceRefs: [],
+          },
+          inputParameters: {
+            task: {},
+          },
+        },
+        {
+          snapshotVersion: 1,
+          source: { kind: "create" },
+          draft: {
+            taskShape: "multi_step",
+            task: {
+              instructions: "The artifact is still objective-scoped.",
+              inputAttachments: [
+                {
+                  artifactId: "art-shared",
+                  filename: "shared.png",
+                  contentType: "image/png",
+                  sizeBytes: 100,
+                },
+              ],
+            },
+          },
+          attachmentRefs: [
+            {
+              artifactId: "art-shared",
+              filename: "shared.png",
+              contentType: "image/png",
+              sizeBytes: 100,
+              targetKind: "objective",
+            },
+            {
+              artifactId: "art-shared",
+              filename: "shared.png",
+              contentType: "image/png",
+              sizeBytes: 100,
+              targetKind: "step",
+              stepId: "missing-step-binding",
+              stepOrdinal: 0,
+            },
+          ],
+        },
+      ),
+    ).toThrow("Attachment bindings could not be reconstructed from this execution.");
+  });
+
   it("reconstructs primary skill from object-shaped task skill selectors", () => {
     const draft = buildTemporalSubmissionDraftFromExecution({
       workflowId: "mm:skill-selectors",
@@ -3003,6 +3062,72 @@ describe("Task Create Entrypoint", () => {
         },
       },
     });
+  });
+
+  it("serializes an explicit empty objective attachment list when refs are removed during edit", async () => {
+    renderForEdit("mm:attachment-edit", withAttachmentPolicy());
+
+    const instructions = (await screen.findByLabelText(
+      "Instructions",
+    )) as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(instructions.value).toBe("Preserve the existing attachments.");
+    });
+
+    const objectiveItem = (await screen.findByText("objective.png (1.2 KB)"))
+      .closest("li") as HTMLElement;
+    fireEvent.click(within(objectiveItem).getByRole("button", { name: "Remove" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Aattachment-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) => String(url) === "/api/executions/mm%3Aattachment-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+    expect(request.parametersPatch.task.inputAttachments).toEqual([]);
+    expect(request.parametersPatch.task.steps[0].inputAttachments).toEqual([
+      {
+        artifactId: "art-step",
+        filename: "step.webp",
+        contentType: "image/webp",
+        sizeBytes: 4567,
+      },
+    ]);
+  });
+
+  it("counts persisted refs in client attachment policy validation", async () => {
+    renderForEdit("mm:attachment-edit", withAttachmentPolicy());
+
+    const instructions = (await screen.findByLabelText(
+      "Instructions",
+    )) as HTMLTextAreaElement;
+    await waitFor(() => {
+      expect(instructions.value).toBe("Preserve the existing attachments.");
+    });
+
+    const attachmentInput = await screen.findByLabelText("Step 1 attachments");
+    fireEvent.change(attachmentInput, {
+      target: {
+        files: [
+          new File(["a"], "one.png", { type: "image/png" }),
+          new File(["b"], "two.png", { type: "image/png" }),
+          new File(["c"], "three.png", { type: "image/png" }),
+        ],
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(await screen.findByText("Too many attachments (5/4).")).toBeTruthy();
+    expect(
+      fetchSpy.mock.calls.some(([url]) => String(url) === "/api/artifacts"),
+    ).toBe(false);
   });
 
   it("externalizes oversized edited input before sending UpdateInputs", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1012,16 +1012,21 @@ function formatAttachmentBytes(value: number): string {
 function validateAttachmentFiles(
   files: File[],
   policy: AttachmentPolicy,
+  persistedRefs: StepAttachmentRef[] = [],
 ): {
   ok: boolean;
   errors: string[];
   totalBytes: number;
 } {
   const errors: string[] = [];
-  if (files.length > policy.maxCount) {
-    errors.push(`Too many attachments (${files.length}/${policy.maxCount}).`);
+  const totalCount = files.length + persistedRefs.length;
+  if (totalCount > policy.maxCount) {
+    errors.push(`Too many attachments (${totalCount}/${policy.maxCount}).`);
   }
   let totalBytes = 0;
+  persistedRefs.forEach((attachment) => {
+    totalBytes += Math.max(0, Number(attachment.sizeBytes) || 0);
+  });
   files.forEach((file) => {
     const type = String(file.type || "")
       .trim()
@@ -2875,6 +2880,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         const validation = validateAttachmentFiles(
           Object.values(nextFilesByStep).flat(),
           attachmentPolicy,
+          persistedAttachmentRefs,
         );
         if (!validation.ok) {
           setSubmitMessage(validation.errors.join(" "));
@@ -3037,16 +3043,31 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   }
 
   function removePersistedStepAttachment(localId: string, artifactId: string) {
-    updateStep(localId, {
-      inputAttachments: (
-        steps.find((step) => step.localId === localId)?.inputAttachments || []
-      ).filter((attachment) => attachment.artifactId !== artifactId),
-    });
+    setSteps((current) =>
+      current.map((step) =>
+        step.localId === localId
+          ? {
+              ...step,
+              inputAttachments: step.inputAttachments.filter(
+                (attachment) => attachment.artifactId !== artifactId,
+              ),
+            }
+          : step,
+      ),
+    );
   }
 
   const selectedAttachmentFiles = useMemo(
     () => Object.values(selectedStepAttachmentFiles).flat(),
     [selectedStepAttachmentFiles],
+  );
+
+  const persistedAttachmentRefs = useMemo(
+    () => [
+      ...persistedObjectiveAttachments,
+      ...steps.flatMap((step) => step.inputAttachments),
+    ],
+    [persistedObjectiveAttachments, steps],
   );
 
   const providerOptions = [...(providerProfilesQuery.data || [])]
@@ -3067,8 +3088,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }));
 
   const attachmentValidation = useMemo(
-    () => validateAttachmentFiles(selectedAttachmentFiles, attachmentPolicy),
-    [attachmentPolicy, selectedAttachmentFiles],
+    () =>
+      validateAttachmentFiles(
+        selectedAttachmentFiles,
+        attachmentPolicy,
+        persistedAttachmentRefs,
+      ),
+    [attachmentPolicy, persistedAttachmentRefs, selectedAttachmentFiles],
   );
 
   const modelOptions = useMemo(
@@ -3708,7 +3734,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       );
       return;
     }
-    if (selectedAttachmentFiles.length > 0) {
+    if (selectedAttachmentFiles.length > 0 || persistedAttachmentRefs.length > 0) {
       if (!attachmentPolicy.enabled) {
         setSubmitMessage("Attachments are disabled for this runtime.");
         return;
@@ -3814,6 +3840,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const hasStepContent =
         Boolean(step.instructions) ||
         stepAttachmentFiles.length > 0 ||
+        step.inputAttachments.length > 0 ||
         Boolean(stepSkillId) ||
         Boolean(stepSkillArgsRaw) ||
         stepSkillCaps.length > 0;
@@ -4002,6 +4029,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       }
       if (stepAttachments.length > 0) {
         stepPayload.inputAttachments = stepAttachments;
+      } else if (pageMode.mode !== "create") {
+        stepPayload.inputAttachments = [];
       }
       if (step.title.trim()) {
         stepPayload.title = step.title.trim();
@@ -4048,6 +4077,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 : {}),
               ...(primaryStepAttachmentRefs.length > 0
                 ? { inputAttachments: primaryStepAttachmentRefs }
+                : pageMode.mode !== "create"
+                  ? { inputAttachments: [] }
                 : {}),
               ...(primaryStepHasSkillOverride
                 ? { tool: primaryStepTool, skill: primaryStepSkill }
@@ -4147,6 +4178,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       skill: resolvedSkill,
       ...(objectiveAttachmentRefs.length > 0
         ? { inputAttachments: objectiveAttachmentRefs }
+        : pageMode.mode !== "create"
+          ? { inputAttachments: [] }
         : {}),
       ...(taskSkillSelectors ? { skills: taskSkillSelectors } : {}),
       ...(Object.keys(primarySkillArgs).length > 0 ? { inputs: primarySkillArgs } : {}),

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -9,6 +9,7 @@ import {
   recordTemporalTaskEditingClientEvent,
   resolveTaskSubmitPageMode,
   type TemporalTaskEditingExecutionContract,
+  type TemporalTaskInputAttachmentRef,
 } from "../lib/temporalTaskEditing";
 
 // This cutoff is enforced on UTF-8 encoded request bytes, not JavaScript string length.
@@ -416,6 +417,7 @@ interface StepState {
   skillRequiredCapabilities: string;
   templateStepId: string;
   templateInstructions: string;
+  inputAttachments: StepAttachmentRef[];
   storyOutput?: Record<string, unknown>;
 }
 
@@ -771,6 +773,7 @@ function createStepStateEntry(
     skillRequiredCapabilities: "",
     templateStepId: "",
     templateInstructions: "",
+    inputAttachments: [],
     ...overrides,
   };
 }
@@ -803,11 +806,25 @@ function createStepStateEntriesFromTemporalDraft(
       skillRequiredCapabilities: step.skillRequiredCapabilities.join(","),
       templateStepId: step.templateStepId,
       templateInstructions: step.templateInstructions,
+      inputAttachments: (step.inputAttachments || []).map(
+        stepAttachmentRefFromTemporal,
+      ),
       ...(step.storyOutput && Object.keys(step.storyOutput).length > 0
         ? { storyOutput: step.storyOutput }
         : {}),
     });
   });
+}
+
+function stepAttachmentRefFromTemporal(
+  attachment: TemporalTaskInputAttachmentRef,
+): StepAttachmentRef {
+  return {
+    artifactId: attachment.artifactId,
+    filename: attachment.filename,
+    contentType: attachment.contentType,
+    sizeBytes: attachment.sizeBytes,
+  };
 }
 
 function hasExplicitSkillSelection(skillId: string): boolean {
@@ -1864,6 +1881,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [selectedStepAttachmentFiles, setSelectedStepAttachmentFiles] = useState<
     Record<string, File[]>
   >({});
+  const [persistedObjectiveAttachments, setPersistedObjectiveAttachments] =
+    useState<StepAttachmentRef[]>([]);
   const [submitMessage, setSubmitMessage] = useState<string | null>(null);
   const [isApplyingPreset, setIsApplyingPreset] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -2150,6 +2169,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     const reconstructedSteps = createStepStateEntriesFromTemporalDraft(draft);
     setSteps(reconstructedSteps);
     setNextStepNumber(reconstructedSteps.length + 1);
+    setPersistedObjectiveAttachments(
+      draft.inputAttachments.map(stepAttachmentRefFromTemporal),
+    );
+    setSelectedStepAttachmentFiles({});
     setAppliedTemplates(draft.appliedTemplates);
     setAppliedTemplateFeatureRequest("");
     setScheduleMode("immediate");
@@ -3004,6 +3027,20 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         delete next[localId];
       }
       return next;
+    });
+  }
+
+  function removePersistedObjectiveAttachment(artifactId: string) {
+    setPersistedObjectiveAttachments((current) =>
+      current.filter((attachment) => attachment.artifactId !== artifactId),
+    );
+  }
+
+  function removePersistedStepAttachment(localId: string, artifactId: string) {
+    updateStep(localId, {
+      inputAttachments: (
+        steps.find((step) => step.localId === localId)?.inputAttachments || []
+      ).filter((attachment) => attachment.artifactId !== artifactId),
     });
   }
 
@@ -3908,16 +3945,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    const primaryAttachmentRefs = primaryStep
+    const uploadedPrimaryAttachmentRefs = primaryStep
       ? uploadedStepAttachments[primaryStep.localId] || []
       : [];
+    const persistedPrimaryStepAttachmentRefs = primaryStep
+      ? primaryStep.inputAttachments || []
+      : [];
+    const objectiveAttachmentRefs = [
+      ...persistedObjectiveAttachments,
+      ...uploadedPrimaryAttachmentRefs,
+    ];
+    const primaryStepAttachmentRefs = [
+      ...persistedPrimaryStepAttachmentRefs,
+      ...uploadedPrimaryAttachmentRefs,
+    ];
     const objectiveInstructionsWithAttachments = appendStepAttachmentInstructions(
       objectiveInstructions,
-      primaryAttachmentRefs,
+      uploadedPrimaryAttachmentRefs,
     );
     const primaryInstructionsWithAttachments = appendStepAttachmentInstructions(
       primaryInstructions,
-      primaryAttachmentRefs,
+      uploadedPrimaryAttachmentRefs,
     );
 
     const additionalSteps: Array<{
@@ -3934,10 +3982,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       skillCaps: stepSkillCaps,
       hasStepContent: hasPreUploadStepContent,
     } of parsedAdditionalStepInputs) {
-      const stepAttachments = uploadedStepAttachments[step.localId] || [];
+      const uploadedStepAttachmentsForStep =
+        uploadedStepAttachments[step.localId] || [];
+      const stepAttachments = [
+        ...(step.inputAttachments || []),
+        ...uploadedStepAttachmentsForStep,
+      ];
       const stepInstructions = appendStepAttachmentInstructions(
         step.instructions,
-        stepAttachments,
+        uploadedStepAttachmentsForStep,
       );
       if (!hasPreUploadStepContent && !stepInstructions) {
         continue;
@@ -3983,7 +4036,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       additionalSteps.length > 0 ||
       includePrimaryStepForObjectiveOverride ||
       hasTemplateBoundStep ||
-      primaryAttachmentRefs.length > 0;
+      primaryStepAttachmentRefs.length > 0;
 
     const normalizedSteps = includeExplicitSteps
       ? [
@@ -3993,8 +4046,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               ...(primaryInstructionsWithAttachments
                 ? { instructions: primaryInstructionsWithAttachments }
                 : {}),
-              ...(primaryAttachmentRefs.length > 0
-                ? { inputAttachments: primaryAttachmentRefs }
+              ...(primaryStepAttachmentRefs.length > 0
+                ? { inputAttachments: primaryStepAttachmentRefs }
                 : {}),
               ...(primaryStepHasSkillOverride
                 ? { tool: primaryStepTool, skill: primaryStepSkill }
@@ -4092,8 +4145,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       instructions: objectiveInstructionsWithAttachments,
       tool: resolvedTool,
       skill: resolvedSkill,
-      ...(primaryAttachmentRefs.length > 0
-        ? { inputAttachments: primaryAttachmentRefs }
+      ...(objectiveAttachmentRefs.length > 0
+        ? { inputAttachments: objectiveAttachmentRefs }
         : {}),
       ...(taskSkillSelectors ? { skills: taskSkillSelectors } : {}),
       ...(Object.keys(primarySkillArgs).length > 0 ? { inputs: primarySkillArgs } : {}),
@@ -4657,6 +4710,71 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         <p className="small">
                           {`Up to ${attachmentPolicy.maxCount} files across all steps, ${formatAttachmentBytes(attachmentPolicy.maxBytes)} each, ${formatAttachmentBytes(attachmentPolicy.totalBytes)} total.`}
                         </p>
+                        {isPrimaryStep && persistedObjectiveAttachments.length > 0 ? (
+                          <ul className="list queue-step-attachments-list">
+                            {persistedObjectiveAttachments.map((attachment) => (
+                              <li key={`objective-${attachment.artifactId}`}>
+                                <span>
+                                  {`${attachment.filename} (${formatAttachmentBytes(attachment.sizeBytes)})`}
+                                </span>
+                                <a
+                                  className="button secondary"
+                                  href={configuredArtifactDownloadUrl(
+                                    artifactDownloadEndpoint,
+                                    attachment.artifactId,
+                                  )}
+                                  download={attachment.filename}
+                                >
+                                  Download
+                                </a>
+                                <button
+                                  type="button"
+                                  className="button secondary"
+                                  onClick={() =>
+                                    removePersistedObjectiveAttachment(
+                                      attachment.artifactId,
+                                    )
+                                  }
+                                >
+                                  Remove
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
+                        {step.inputAttachments.length > 0 ? (
+                          <ul className="list queue-step-attachments-list">
+                            {step.inputAttachments.map((attachment) => (
+                              <li key={`step-${step.localId}-${attachment.artifactId}`}>
+                                <span>
+                                  {`${attachment.filename} (${formatAttachmentBytes(attachment.sizeBytes)})`}
+                                </span>
+                                <a
+                                  className="button secondary"
+                                  href={configuredArtifactDownloadUrl(
+                                    artifactDownloadEndpoint,
+                                    attachment.artifactId,
+                                  )}
+                                  download={attachment.filename}
+                                >
+                                  Download
+                                </a>
+                                <button
+                                  type="button"
+                                  className="button secondary"
+                                  onClick={() =>
+                                    removePersistedStepAttachment(
+                                      step.localId,
+                                      attachment.artifactId,
+                                    )
+                                  }
+                                >
+                                  Remove
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
                         {(selectedStepAttachmentFiles[step.localId] || []).length > 0 ? (
                           <ul className="list queue-step-attachments-list">
                             {(selectedStepAttachmentFiles[step.localId] || []).map((file) => (

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -269,8 +269,46 @@ function normalizeAttachmentRefs(value: unknown): TemporalTaskInputAttachmentRef
     .filter((entry) => entry.artifactId && entry.filename && entry.contentType);
 }
 
-function attachmentKey(ref: TemporalTaskInputAttachmentRef): string {
-  return ref.artifactId;
+function compactAttachmentBindingKey(
+  ref: Record<string, unknown>,
+): string | null {
+  const artifactId = stringValue(ref.artifactId, ref.artifact_id);
+  if (!artifactId) {
+    return null;
+  }
+  const targetKind = stringValue(
+    ref.targetKind,
+    ref.target_kind,
+    ref.target,
+  ).toLowerCase();
+  if (targetKind === 'objective' || targetKind === 'task') {
+    return `objective:${artifactId}`;
+  }
+  if (targetKind === 'step') {
+    const stepId = stringValue(ref.stepId, ref.step_id);
+    if (stepId) {
+      return `step:id:${stepId}:${artifactId}`;
+    }
+    const stepOrdinalValue = Number(ref.stepOrdinal ?? ref.step_ordinal);
+    if (Number.isInteger(stepOrdinalValue) && stepOrdinalValue >= 0) {
+      return `step:ordinal:${stepOrdinalValue}:${artifactId}`;
+    }
+    return null;
+  }
+  return null;
+}
+
+function stepAttachmentBindingKeys(
+  step: TemporalSubmissionDraft['steps'][number],
+  stepOrdinal: number,
+): string[] {
+  return (step.inputAttachments || []).flatMap((ref) => {
+    const keys = [`step:ordinal:${stepOrdinal}:${ref.artifactId}`];
+    if (step.id) {
+      keys.push(`step:id:${step.id}:${ref.artifactId}`);
+    }
+    return keys;
+  });
 }
 
 function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number] | null {
@@ -408,16 +446,27 @@ function assertSnapshotAttachmentBindings(
   artifactTask: Record<string, unknown>,
   artifactTaskSteps: TemporalSubmissionDraft['steps'],
 ): void {
-  const compactRefs = normalizeAttachmentRefs(artifactParams.attachmentRefs);
+  const compactRefs = Array.isArray(artifactParams.attachmentRefs)
+    ? artifactParams.attachmentRefs.map((entry) => objectValue(entry))
+    : [];
   if (compactRefs.length === 0) {
     return;
   }
-  const boundRefs = [
-    ...normalizeAttachmentRefs(artifactTask.inputAttachments),
-    ...artifactTaskSteps.flatMap((step) => step.inputAttachments || []),
-  ];
-  const boundKeys = new Set(boundRefs.map(attachmentKey));
-  const unbound = compactRefs.filter((ref) => !boundKeys.has(attachmentKey(ref)));
+  const compactKeys = compactRefs.map(compactAttachmentBindingKey);
+  if (compactKeys.some((key) => key === null)) {
+    throw new Error(
+      'Attachment bindings could not be reconstructed from this execution.',
+    );
+  }
+  const boundKeys = new Set([
+    ...normalizeAttachmentRefs(artifactTask.inputAttachments).map(
+      (ref) => `objective:${ref.artifactId}`,
+    ),
+    ...artifactTaskSteps.flatMap(stepAttachmentBindingKeys),
+  ]);
+  const unbound = compactKeys.filter(
+    (key): key is string => key !== null && !boundKeys.has(key),
+  );
   if (unbound.length > 0) {
     throw new Error(
       'Attachment bindings could not be reconstructed from this execution.',
@@ -603,11 +652,7 @@ export function buildTemporalSubmissionDraftFromExecution(
     inputAttachments: (() => {
       const taskAttachments = normalizeAttachmentRefs(task.inputAttachments);
       const artifactAttachments = normalizeAttachmentRefs(artifactTask.inputAttachments);
-      return artifactAttachments.length > 0 && taskAttachments.length === 0
-        ? artifactAttachments
-        : taskAttachments.length > 0
-          ? taskAttachments
-          : artifactAttachments;
+      return taskAttachments.length > 0 ? taskAttachments : artifactAttachments;
     })(),
     steps: selectDraftSteps(taskSteps, artifactTaskSteps),
     appliedTemplates: normalizeAppliedTemplates(

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -44,6 +44,13 @@ export type TemporalTaskEditingExecutionContract = {
   actions?: TemporalTaskEditingActions;
 };
 
+export type TemporalTaskInputAttachmentRef = {
+  artifactId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+};
+
 export type TemporalSubmissionDraft = {
   runtime: string | null;
   providerProfile: string | null;
@@ -55,6 +62,7 @@ export type TemporalSubmissionDraft = {
   publishMode: string | null;
   taskInstructions: string;
   primarySkill: string | null;
+  inputAttachments: TemporalTaskInputAttachmentRef[];
   steps: Array<{
     id: string;
     title: string;
@@ -64,6 +72,7 @@ export type TemporalSubmissionDraft = {
     skillRequiredCapabilities: string[];
     templateStepId: string;
     templateInstructions: string;
+    inputAttachments?: TemporalTaskInputAttachmentRef[];
     storyOutput?: Record<string, unknown>;
   }>;
   appliedTemplates: Array<{
@@ -245,6 +254,25 @@ function taskInstructionsFrom(...tasks: Record<string, unknown>[]): string {
   return '';
 }
 
+function normalizeAttachmentRefs(value: unknown): TemporalTaskInputAttachmentRef[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => objectValue(entry))
+    .map((entry) => ({
+      artifactId: stringValue(entry.artifactId, entry.artifact_id),
+      filename: stringValue(entry.filename, entry.name),
+      contentType: stringValue(entry.contentType, entry.content_type),
+      sizeBytes: Math.max(0, Number(entry.sizeBytes ?? entry.size_bytes ?? 0) || 0),
+    }))
+    .filter((entry) => entry.artifactId && entry.filename && entry.contentType);
+}
+
+function attachmentKey(ref: TemporalTaskInputAttachmentRef): string {
+  return ref.artifactId;
+}
+
 function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number] | null {
   const step = objectValue(value);
   if (Object.keys(step).length === 0) {
@@ -261,6 +289,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     id.startsWith('tpl:') ? id : '',
   );
   const storyOutput = firstObjectValue(step.storyOutput, step.story_output);
+  const inputAttachments = normalizeAttachmentRefs(step.inputAttachments);
   const result = {
     id,
     title: stringValue(step.title),
@@ -277,6 +306,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
       step.template_instructions,
       templateStepId ? instructions : '',
     ),
+    ...(inputAttachments.length > 0 ? { inputAttachments } : {}),
     ...(Object.keys(storyOutput).length > 0 ? { storyOutput } : {}),
   };
 
@@ -289,6 +319,7 @@ function draftStepFrom(value: unknown): TemporalSubmissionDraft['steps'][number]
     result.skillRequiredCapabilities.length > 0 ||
     result.templateStepId ||
     result.templateInstructions ||
+    inputAttachments.length > 0 ||
     Object.keys(storyOutput).length > 0;
   return hasContent ? result : null;
 }
@@ -313,6 +344,15 @@ function selectDraftSteps(
   taskSteps: TemporalSubmissionDraft['steps'],
   artifactTaskSteps: TemporalSubmissionDraft['steps'],
 ): TemporalSubmissionDraft['steps'] {
+  const artifactHasAttachments = artifactTaskSteps.some(
+    (step) => (step.inputAttachments || []).length > 0,
+  );
+  const taskHasAttachments = taskSteps.some(
+    (step) => (step.inputAttachments || []).length > 0,
+  );
+  if (artifactHasAttachments && !taskHasAttachments) {
+    return artifactTaskSteps;
+  }
   if (artifactTaskSteps.length > taskSteps.length) {
     return artifactTaskSteps;
   }
@@ -361,6 +401,28 @@ function normalizeAppliedTemplates(
         : [],
     }))
     .filter((entry) => entry.slug);
+}
+
+function assertSnapshotAttachmentBindings(
+  artifactParams: Record<string, unknown>,
+  artifactTask: Record<string, unknown>,
+  artifactTaskSteps: TemporalSubmissionDraft['steps'],
+): void {
+  const compactRefs = normalizeAttachmentRefs(artifactParams.attachmentRefs);
+  if (compactRefs.length === 0) {
+    return;
+  }
+  const boundRefs = [
+    ...normalizeAttachmentRefs(artifactTask.inputAttachments),
+    ...artifactTaskSteps.flatMap((step) => step.inputAttachments || []),
+  ];
+  const boundKeys = new Set(boundRefs.map(attachmentKey));
+  const unbound = compactRefs.filter((ref) => !boundKeys.has(attachmentKey(ref)));
+  if (unbound.length > 0) {
+    throw new Error(
+      'Attachment bindings could not be reconstructed from this execution.',
+    );
+  }
 }
 
 function snapshotDraftTask(
@@ -443,6 +505,11 @@ export function buildTemporalSubmissionDraftFromExecution(
   const artifactSkill = objectValue(artifactTask.skill);
   const taskSteps = draftStepsFromTask(task);
   const artifactTaskSteps = draftStepsFromTask(artifactTask);
+  assertSnapshotAttachmentBindings(
+    artifactParams,
+    artifactTask,
+    artifactTaskSteps,
+  );
 
   const artifactRepository = stringValue(artifactParams.repository);
   const taskSkills = skillSelectorNames(task.skills);
@@ -517,7 +584,10 @@ export function buildTemporalSubmissionDraftFromExecution(
       publish.mode,
       artifactPublish.mode,
     ),
-    taskInstructions: taskInstructionsFrom(task, artifactTask),
+    taskInstructions:
+      Object.keys(snapshotDraft).length > 0
+        ? taskInstructionsFrom(artifactTask, task)
+        : taskInstructionsFrom(task, artifactTask),
     primarySkill: nullableStringValue(
       execution.targetSkill,
       tool.name,
@@ -530,6 +600,15 @@ export function buildTemporalSubmissionDraftFromExecution(
       artifactSkill.name,
       artifactTaskSkills[0],
     ),
+    inputAttachments: (() => {
+      const taskAttachments = normalizeAttachmentRefs(task.inputAttachments);
+      const artifactAttachments = normalizeAttachmentRefs(artifactTask.inputAttachments);
+      return artifactAttachments.length > 0 && taskAttachments.length === 0
+        ? artifactAttachments
+        : taskAttachments.length > 0
+          ? taskAttachments
+          : artifactAttachments;
+    })(),
     steps: selectDraftSteps(taskSteps, artifactTaskSteps),
     appliedTemplates: normalizeAppliedTemplates(
       task.appliedStepTemplates || artifactTask.appliedStepTemplates,

--- a/specs/196-preserve-attachment-bindings/checklists/requirements.md
+++ b/specs/196-preserve-attachment-bindings/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Preserve Attachment Bindings in Snapshots and Reruns
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request.
+- Source design mappings cover MM-369's referenced requirements: DESIGN-REQ-007, DESIGN-REQ-015, and DESIGN-REQ-018.
+- No clarification markers remain.

--- a/specs/196-preserve-attachment-bindings/contracts/attachment-binding-reconstruction.md
+++ b/specs/196-preserve-attachment-bindings/contracts/attachment-binding-reconstruction.md
@@ -1,0 +1,111 @@
+# Contract: Attachment Binding Reconstruction
+
+## Original Task Input Snapshot
+
+Snapshot artifacts for task-shaped executions must preserve attachment refs in the canonical task body:
+
+```json
+{
+  "snapshotVersion": 1,
+  "source": { "kind": "create" },
+  "draft": {
+    "taskShape": "multi_step",
+    "repository": "MoonLadderStudios/MoonMind",
+    "targetRuntime": "codex_cli",
+    "task": {
+      "instructions": "Run the task",
+      "inputAttachments": [
+        {
+          "artifactId": "art-objective",
+          "filename": "objective.png",
+          "contentType": "image/png",
+          "sizeBytes": 1024
+        }
+      ],
+      "steps": [
+        {
+          "id": "step-1",
+          "instructions": "Inspect the image",
+          "inputAttachments": [
+            {
+              "artifactId": "art-step",
+              "filename": "step.png",
+              "contentType": "image/png",
+              "sizeBytes": 2048
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "attachmentRefs": [
+    {
+      "artifactId": "art-objective",
+      "filename": "objective.png",
+      "contentType": "image/png",
+      "sizeBytes": 1024,
+      "targetKind": "objective"
+    },
+    {
+      "artifactId": "art-step",
+      "filename": "step.png",
+      "contentType": "image/png",
+      "sizeBytes": 2048,
+      "targetKind": "step",
+      "stepId": "step-1",
+      "stepOrdinal": 0
+    }
+  ]
+}
+```
+
+Rules:
+- `draft.task.inputAttachments` is the objective-scoped source of truth.
+- `draft.task.steps[n].inputAttachments` is the step-scoped source of truth.
+- `attachmentRefs` is a compact index and diagnostic aid, not a replacement for the task body.
+- Artifact link metadata, filenames, and artifact IDs alone cannot retarget attachments.
+
+## Edit And Rerun Draft Reconstruction
+
+Given a detail response with `taskInputSnapshot.available = true` and the downloaded snapshot artifact above, the Create page must reconstruct:
+
+```json
+{
+  "inputAttachments": [
+    {
+      "artifactId": "art-objective",
+      "filename": "objective.png",
+      "contentType": "image/png",
+      "sizeBytes": 1024
+    }
+  ],
+  "steps": [
+    {
+      "id": "step-1",
+      "instructions": "Inspect the image",
+      "inputAttachments": [
+        {
+          "artifactId": "art-step",
+          "filename": "step.png",
+          "contentType": "image/png",
+          "sizeBytes": 2048
+        }
+      ]
+    }
+  ]
+}
+```
+
+Rules:
+- Persisted refs are displayed and submitted as existing refs unless the user removes them.
+- New local files remain separate until uploaded through the existing attachment flow.
+- Edit and rerun submissions include unchanged persisted refs.
+- If attachment refs are known to exist but the target binding cannot be reconstructed from the snapshot task body, draft reconstruction fails explicitly.
+
+## Failure Contract
+
+Explicit failures are required when:
+- `taskInputSnapshot.available` is false for an edit/rerun action that needs attachment binding reconstruction.
+- The snapshot is malformed or missing `draft.task`.
+- The snapshot contains attachment refs that cannot be assigned to objective or step targets.
+- Reconstruction would require inferring a target from filename, artifact link, or metadata.

--- a/specs/196-preserve-attachment-bindings/data-model.md
+++ b/specs/196-preserve-attachment-bindings/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: Preserve Attachment Bindings in Snapshots and Reruns
+
+## Task Input Snapshot
+
+Represents the saved source of truth for reconstructing edit and rerun drafts.
+
+Relevant fields:
+- `snapshotVersion`
+- `source.kind`
+- `draft.task`
+- `draft.task.inputAttachments`
+- `draft.task.steps[n].inputAttachments`
+- `draft.task.steps[n].id`
+- `draft.task.steps[n].instructions`
+- `draft.repository`
+- `draft.targetRuntime`
+- `attachmentRefs`
+
+Validation:
+- Objective-scoped refs must remain under `draft.task.inputAttachments`.
+- Step-scoped refs must remain under the corresponding `draft.task.steps[n].inputAttachments`.
+- Step identity/order must be preserved well enough to bind step-scoped refs to the intended step.
+- Missing binding data for a task that has attachment refs is a reconstruction failure.
+
+## Attachment Ref
+
+Represents an already uploaded input attachment selected for a task target.
+
+Fields:
+- `artifactId`
+- `filename`
+- `contentType`
+- `sizeBytes`
+- `targetKind`
+- optional `stepId`
+- optional `stepOrdinal`
+
+Validation:
+- `artifactId`, `filename`, and `contentType` must be non-empty when present in persisted refs.
+- `targetKind` is `objective` or `step`.
+- Step refs must identify a step through snapshot position and, when available, stable step id.
+- Attachment metadata may aid diagnostics but cannot override target binding stored in the task snapshot.
+
+## Temporal Submission Draft
+
+Frontend reconstruction model used to prefill Create-page edit and rerun state.
+
+Relevant fields:
+- `runtime`
+- `providerProfile`
+- `model`
+- `effort`
+- `repository`
+- `startingBranch`
+- `targetBranch`
+- `publishMode`
+- `taskInstructions`
+- `steps`
+- `inputAttachments`
+- `steps[n].inputAttachments`
+- `appliedTemplates`
+
+Validation:
+- Persisted attachment refs are represented separately from new local files.
+- Unchanged persisted refs are included in edit/rerun submissions unless explicitly removed by the user.
+- New local files must still go through the existing upload flow before submission.
+
+## Attachment Preview State
+
+Represents user-visible attachment rows on task detail, edit, and rerun surfaces.
+
+Fields:
+- `targetKind`
+- `stepId` or `stepOrdinal` for step-scoped targets
+- `filename`
+- `contentType`
+- `sizeBytes`
+- `artifactId`
+- optional preview status
+- optional download action
+
+Validation:
+- Preview grouping is target-aware.
+- Preview failure does not remove metadata or download actions.
+- Filenames are display labels only and never determine target binding.

--- a/specs/196-preserve-attachment-bindings/plan.md
+++ b/specs/196-preserve-attachment-bindings/plan.md
@@ -3,7 +3,7 @@
 **Branch**: `196-preserve-attachment-bindings` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
 **Input**: Single-story feature specification from `/specs/196-preserve-attachment-bindings/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+**Note**: This template is filled in by the `/moonspec-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
@@ -14,7 +14,7 @@ MM-369 requires task edit and rerun flows to reconstruct attachment bindings fro
 **Language/Version**: Python 3.12; TypeScript/React for Mission Control Create-page behavior  
 **Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, React, Vitest, existing task editing helpers  
 **Storage**: Existing Temporal artifact metadata tables and original task input snapshot artifacts; no new persistent storage  
-**Unit Testing**: pytest via `./tools/test_unit.sh`; Vitest via `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` for focused frontend iteration  
+**Unit Testing**: pytest via `./tools/test_unit.sh`; Vitest via `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` for focused frontend iteration
 **Integration Testing**: pytest contract coverage against FastAPI app + sqlite-backed metadata, plus `./tools/test_integration.sh` for hermetic integration when Docker is available  
 **Target Platform**: MoonMind API service and Mission Control Create/task detail surfaces  
 **Project Type**: Web service with React frontend and Temporal workflow orchestration backend  

--- a/specs/196-preserve-attachment-bindings/plan.md
+++ b/specs/196-preserve-attachment-bindings/plan.md
@@ -53,7 +53,8 @@ specs/196-preserve-attachment-bindings/
 ├── contracts/
 │   └── attachment-binding-reconstruction.md
 ├── tasks.md
-└── verification.md
+└── checklists/
+    └── requirements.md
 ```
 
 ### Source Code (repository root)

--- a/specs/196-preserve-attachment-bindings/plan.md
+++ b/specs/196-preserve-attachment-bindings/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Preserve Attachment Bindings in Snapshots and Reruns
+
+**Branch**: `196-preserve-attachment-bindings` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/196-preserve-attachment-bindings/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+MM-369 requires task edit and rerun flows to reconstruct attachment bindings from the authoritative task input snapshot. The implementation will extend the existing task input snapshot, Temporal task editing draft reconstruction, and Create-page edit/rerun submission paths so objective-scoped and step-scoped `inputAttachments` survive unchanged, persisted refs remain distinct from new local files, and missing binding data fails explicitly. Validation will use focused frontend unit coverage for draft reconstruction and Create-page behavior plus API/contract coverage for snapshot payloads and action availability.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control Create-page behavior  
+**Primary Dependencies**: FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, React, Vitest, existing task editing helpers  
+**Storage**: Existing Temporal artifact metadata tables and original task input snapshot artifacts; no new persistent storage  
+**Unit Testing**: pytest via `./tools/test_unit.sh`; Vitest via `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` for focused frontend iteration  
+**Integration Testing**: pytest contract coverage against FastAPI app + sqlite-backed metadata, plus `./tools/test_integration.sh` for hermetic integration when Docker is available  
+**Target Platform**: MoonMind API service and Mission Control Create/task detail surfaces  
+**Project Type**: Web service with React frontend and Temporal workflow orchestration backend  
+**Performance Goals**: Draft reconstruction remains linear in number of task steps plus submitted attachment refs; no binary attachment bytes are loaded for reconstruction  
+**Constraints**: Do not infer target binding from artifact links, filenames, or metadata; do not embed image bytes in workflow payloads or histories; fail explicitly for incomplete snapshot binding data; preserve pre-release compatibility policy by removing unsupported hidden fallbacks rather than adding compatibility aliases  
+**Scale/Scope**: One task-shaped execution snapshot with objective attachments and step attachments across the existing configured attachment limits
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Uses existing task execution, artifact, and Temporal editing surfaces.
+- II. One-Click Agent Deployment: PASS. No new external service dependency.
+- III. Avoid Vendor Lock-In: PASS. Uses generic MoonMind attachment refs rather than provider-specific files.
+- IV. Own Your Data: PASS. Attachment binding state remains in MoonMind-owned snapshots and artifacts.
+- V. Skills Are First-Class and Easy to Add: PASS. No runtime skill mutation.
+- VI. Replaceability and Scientific Method: PASS. Behavior is defined by tests and contract evidence before implementation.
+- VII. Runtime Configurability: PASS. Existing attachment policy and runtime configuration remain authoritative.
+- VIII. Modular and Extensible Architecture: PASS. Changes stay at API snapshot and UI reconstruction boundaries.
+- IX. Resilient by Default: PASS. Missing reconstruction state fails explicitly instead of silently dropping attachments.
+- X. Facilitate Continuous Improvement: PASS. Failures surface concrete draft reconstruction reasons.
+- XI. Spec-Driven Development: PASS. This plan follows a one-story spec with unit and integration evidence.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Canonical docs remain source requirements; implementation notes stay in spec artifacts.
+- XIII. Pre-release Compatibility Policy: PASS. Unsupported or incomplete internal payload shapes fail rather than compatibility-transforming attachment bindings.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/196-preserve-attachment-bindings/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── attachment-binding-reconstruction.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/routers/
+    └── executions.py
+
+frontend/
+└── src/
+    ├── lib/
+    │   └── temporalTaskEditing.ts
+    └── entrypoints/
+        ├── task-create.tsx
+        └── task-create.test.tsx
+
+tests/
+├── contract/
+│   └── test_temporal_execution_api.py
+└── unit/
+    └── api/routers/test_executions.py
+```
+
+**Structure Decision**: Preserve authoritative binding data in the existing original task input snapshot and teach the existing frontend draft reconstruction path to hydrate persisted attachment refs into edit/rerun state. Backend coverage protects snapshot shape and action availability; frontend coverage protects user-visible edit/rerun behavior.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/196-preserve-attachment-bindings/quickstart.md
+++ b/specs/196-preserve-attachment-bindings/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Preserve Attachment Bindings in Snapshots and Reruns
+
+## Focused Unit Checks
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx
+pytest tests/unit/api/routers/test_executions.py -q
+```
+
+Expected coverage:
+- Draft reconstruction preserves objective-scoped and step-scoped persisted attachment refs.
+- Create-page edit/rerun state distinguishes persisted refs from new local files.
+- Edit/rerun submissions include unchanged persisted refs and explicit add/remove changes.
+- Backend serialization exposes task input snapshot descriptors and disables edit/rerun when authoritative snapshots are missing.
+
+## Contract Checks
+
+```bash
+pytest tests/contract/test_temporal_execution_api.py -q
+```
+
+Expected coverage:
+- Task-shaped execution creation persists snapshot artifacts containing canonical `inputAttachments`.
+- Snapshot artifacts preserve attachment refs in task body and compact `attachmentRefs` metadata.
+- Artifact links and filenames do not replace task snapshot binding.
+
+## Full Local Verification
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+./tools/test_integration.sh
+```
+
+Notes:
+- `./tools/test_unit.sh` is the required final unit-test runner.
+- `./tools/test_integration.sh` requires Docker access; record the exact blocker if Docker is unavailable in the managed-agent container.

--- a/specs/196-preserve-attachment-bindings/research.md
+++ b/specs/196-preserve-attachment-bindings/research.md
@@ -1,0 +1,31 @@
+# Research: Preserve Attachment Bindings in Snapshots and Reruns
+
+## Input Classification
+
+Decision: Treat MM-369 as a single-story runtime feature request.
+Rationale: The Jira brief contains one actor, one user goal, one acceptance set, and one bounded runtime behavior: reconstruct attachment bindings from the authoritative task input snapshot during edit and rerun.
+Alternatives considered: Treating `docs/Tasks/ImageSystem.md` as a broad declarative design was rejected because the Jira brief selected only sections 5.3, 11, and 13 with specific coverage IDs.
+
+## Authoritative Binding Source
+
+Decision: Use the original task input snapshot artifact as the only authoritative source for edit/rerun attachment target binding.
+Rationale: The source design explicitly forbids inferring target binding from filenames or artifact links, and the existing execution router already persists an original task input snapshot with `draft.task.inputAttachments`, `draft.task.steps[n].inputAttachments`, and a compact `attachmentRefs` index.
+Alternatives considered: Reconstructing from artifact link metadata was rejected because metadata is observability only and can be stale or incomplete.
+
+## Draft Reconstruction Boundary
+
+Decision: Preserve persisted refs in the frontend Temporal task editing draft model, then map them into Create-page step state and submit payloads without re-uploading unchanged attachments.
+Rationale: Edit and rerun are user-facing reconstruction flows in Mission Control; the existing `frontend/src/lib/temporalTaskEditing.ts` helper centralizes draft reconstruction and `frontend/src/entrypoints/task-create.tsx` centralizes Create-page state and submission.
+Alternatives considered: Backend-only reconstruction was rejected because the browser must distinguish persisted refs from new local files before the user submits changes.
+
+## Failure Behavior
+
+Decision: Fail explicit reconstruction paths when required binding fields are unavailable instead of silently presenting a text-only draft.
+Rationale: The source design calls silent attachment loss a contract violation. Existing task editing already disables actions when the original snapshot is missing; this story extends that behavior to attachment binding completeness.
+Alternatives considered: Allowing degraded read-only drafts was rejected for active edit/rerun submission because it can lead to unintentional attachment loss.
+
+## Test Strategy
+
+Decision: Use Vitest unit tests for draft reconstruction and Create-page state behavior, pytest unit tests for backend snapshot descriptors and payload construction, and contract tests for artifact-backed task snapshots.
+Rationale: The behavior crosses frontend state reconstruction, API serialization, and artifact snapshot shape. Focused unit tests catch transformation mistakes; contract tests verify persisted API boundary behavior.
+Alternatives considered: Full compose-backed integration as the only proof was rejected because the required behavior is largely deterministic at API/UI contract boundaries and compose may be unavailable in managed-agent containers.

--- a/specs/196-preserve-attachment-bindings/spec.md
+++ b/specs/196-preserve-attachment-bindings/spec.md
@@ -104,7 +104,7 @@ Non-Goals
 Needs Clarification
 - None
 
-<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /moonspec-breakdown for technical designs that contain multiple stories. -->
 
 ## User Story - Preserve Attachment Bindings in Snapshots and Reruns
 

--- a/specs/196-preserve-attachment-bindings/spec.md
+++ b/specs/196-preserve-attachment-bindings/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Preserve Attachment Bindings in Snapshots and Reruns
+
+**Feature Branch**: `196-preserve-attachment-bindings`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-369 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-369-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-369 from MM project
+Summary: Preserve attachment bindings in snapshots and reruns
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-369 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-369: Preserve attachment bindings in snapshots and reruns
+
+Source Reference
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 5.3 Authoritative snapshot contract
+  - 11. UI preview and detail contract
+  - 13. Edit and rerun durability contract
+- Coverage IDs:
+  - DESIGN-REQ-007
+  - DESIGN-REQ-015
+  - DESIGN-REQ-018
+
+User Story
+As a user editing or rerunning a task, I need MoonMind to reconstruct attachments from the authoritative task input snapshot so unchanged bindings survive and changes are always explicit.
+
+Acceptance Criteria
+- The snapshot preserves text fields, target attachment refs, step identity/order, runtime, publish, repository settings, and applied preset metadata.
+- Attachment target binding is reconstructed from the snapshot, not inferred from artifact links or filenames.
+- Unchanged attachment refs survive edit and rerun unchanged.
+- Removing an attachment and adding a new attachment are explicit user actions.
+- A text-only draft reconstruction cannot silently drop attachments.
+- The system fails explicitly if attachment bindings cannot be reconstructed.
+- Historical artifacts may remain according to retention even after an edited draft stops referencing them.
+
+Requirements
+- Persist target attachment refs in the task input snapshot.
+- Use the same attachment contract for create, edit, and rerun.
+- Keep step identity and ordering stable enough to bind step-scoped attachments.
+- Distinguish persisted attachment refs from new local files in edit/rerun flows.
+- Preserve objective-scoped attachments in `task.inputAttachments`.
+- Preserve step-scoped attachments in `task.steps[n].inputAttachments`.
+- Normalize attachment refs before workflow start without changing target binding semantics.
+- Reconstruct attachment target binding from the authoritative task input snapshot, not from artifact links, filenames, or UI-only heuristics.
+- Preserve runtime, publish, repository settings, and applied preset metadata alongside text fields and attachment refs in the snapshot.
+- Fail explicitly if edit or rerun reconstruction cannot preserve attachment bindings.
+
+Relevant Implementation Notes
+- The original task input snapshot is the source of truth for edit and rerun reconstruction.
+- Task detail, edit, and rerun previews should be organized by explicit attachment target: objective-scoped or step-scoped.
+- Preview and download surfaces must not infer target binding from filenames.
+- Preview failure must not remove access to metadata or download actions.
+- Edit and rerun surfaces must distinguish persisted attachments from new local files that have not yet been uploaded.
+- Create, edit, and rerun should use the same authoritative attachment contract.
+- Unchanged attachment refs should survive edit and rerun unchanged.
+- Removing an existing attachment and adding a new attachment should remain explicit user actions.
+- Historical source artifacts may remain according to retention policy even after an edited draft stops referencing them.
+
+Suggested Implementation Areas
+- Task input snapshot persistence for objective and step attachment refs.
+- Edit draft reconstruction from persisted task snapshots.
+- Rerun draft reconstruction from persisted task snapshots.
+- Create-page or task-detail attachment preview grouping by target.
+- Validation and error handling for missing or unreconstructable attachment bindings.
+- Tests for create, edit, and rerun attachment binding preservation.
+
+Validation
+- Verify a task snapshot preserves text fields, target attachment refs, step identity/order, runtime, publish, repository settings, and applied preset metadata.
+- Verify edit reconstruction uses persisted snapshot attachment refs and does not infer target binding from artifact links or filenames.
+- Verify rerun reconstruction preserves unchanged objective-scoped and step-scoped attachment refs.
+- Verify removing an attachment and adding a new attachment are explicit user actions.
+- Verify a text-only draft reconstruction cannot silently drop existing attachments.
+- Verify the system fails explicitly when attachment bindings cannot be reconstructed.
+- Verify historical artifacts can remain under retention when an edited draft no longer references them.
+
+Non-Goals
+- Inferring attachment target bindings from filenames, artifact links, or attachment metadata.
+- Silently dropping attachments during edit or rerun reconstruction.
+- Rewriting attachment refs through hidden compatibility transforms.
+- Changing artifact retention semantics beyond preserving references correctly in edit and rerun flows.
+- Adding generic non-image attachment support beyond this story's image attachment binding durability contract.
+
+Needs Clarification
+- None
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Preserve Attachment Bindings in Snapshots and Reruns
+
+**Summary**: As a user editing or rerunning a task, I need MoonMind to reconstruct attachments from the authoritative task input snapshot so unchanged bindings survive and changes are always explicit.
+
+**Goal**: Users can open existing task drafts for edit or rerun and see every objective-scoped and step-scoped attachment binding preserved exactly unless they explicitly remove or replace it.
+
+**Independent Test**: Create a task with objective-scoped and step-scoped attachments, then reconstruct it for edit and rerun; the reconstructed drafts must preserve the original attachment refs, target bindings, text, step order, runtime, publish, repository, and preset metadata, while explicit remove/add actions are reflected without silently dropping unchanged attachments.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved task snapshot contains text fields, runtime, publish, repository settings, applied preset metadata, step identity/order, and objective-scoped plus step-scoped attachment refs, **When** the user opens the task for edit, **Then** the draft is reconstructed from the snapshot with every unchanged attachment ref still bound to its original target.
+2. **Given** a saved task snapshot contains objective-scoped and step-scoped attachment refs, **When** the user starts a rerun, **Then** the rerun draft preserves unchanged attachment refs and target bindings without using filenames or artifact-link metadata as the source of truth.
+3. **Given** a user removes an existing attachment or adds a new uploaded attachment during edit or rerun, **When** the draft is saved or submitted, **Then** the change is recorded as an explicit user action while all other unchanged attachment refs remain intact.
+4. **Given** a reconstruction path cannot recover attachment target bindings from the authoritative snapshot, **When** the edit or rerun draft is requested, **Then** the system fails explicitly instead of presenting a text-only draft that silently drops attachments.
+5. **Given** historical source artifacts remain available under retention after an edited draft no longer references them, **When** the edited task is inspected, **Then** the current draft references only selected attachments while historical artifacts remain governed by retention and are not treated as active bindings.
+
+### Edge Cases
+
+- A task has both objective-scoped and multiple step-scoped attachments with similar filenames.
+- A step is reordered or edited while its unchanged attachment refs should remain tied to the same logical step identity.
+- A browser or detail view can show attachment metadata, but preview generation fails.
+- An edit or rerun flow contains a mix of persisted attachment refs and new local files that are not uploaded yet.
+- A snapshot is missing the fields needed to reconstruct attachment target bindings.
+- Artifact link metadata is stale, incomplete, or inconsistent with the task snapshot.
+
+## Assumptions
+
+- The story is runtime implementation work, not documentation-only work.
+- `docs/Tasks/ImageSystem.md` is treated as source requirements for runtime behavior.
+- The canonical attachment contract remains `task.inputAttachments` for objective-scoped attachments and `task.steps[n].inputAttachments` for step-scoped attachments.
+- Existing artifact retention behavior is preserved; this story only governs whether current edit/rerun drafts retain active attachment bindings.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-007** (Source: `docs/Tasks/ImageSystem.md`, section 5.3; MM-369 brief): The task input snapshot MUST preserve text fields, target attachment refs, step identity/order, runtime, publish, repository settings, and applied preset metadata, and MUST be the source of truth for edit and rerun reconstruction. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004.
+- **DESIGN-REQ-015** (Source: `docs/Tasks/ImageSystem.md`, section 11; MM-369 brief): Task detail, edit, and rerun surfaces MUST organize previews by explicit target, MUST NOT infer target binding from filenames, MUST keep metadata/download actions available when preview fails, and MUST distinguish persisted refs from new local files. Scope: in scope. Maps to FR-005, FR-006, FR-007.
+- **DESIGN-REQ-018** (Source: `docs/Tasks/ImageSystem.md`, section 13; MM-369 brief): Create, edit, and rerun MUST use the same authoritative attachment contract; unchanged refs MUST survive unchanged; adding and removing attachments MUST be explicit; and text-only reconstruction MUST NOT silently discard attachments. Scope: in scope. Maps to FR-001, FR-003, FR-004, FR-006, FR-008, FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST persist objective-scoped and step-scoped attachment refs in the authoritative task input snapshot using the existing attachment contract.
+- **FR-002**: System MUST preserve text fields, step identity/order, runtime, publish, repository settings, and applied preset metadata alongside attachment refs in the task snapshot.
+- **FR-003**: Edit draft reconstruction MUST use the authoritative task input snapshot as the source of truth for attachment target binding.
+- **FR-004**: Rerun draft reconstruction MUST use the authoritative task input snapshot as the source of truth for attachment target binding.
+- **FR-005**: Task detail, edit, and rerun surfaces MUST present attachment previews grouped by objective-scoped and step-scoped targets without inferring target binding from filenames.
+- **FR-006**: System MUST distinguish persisted attachment refs from new local files in edit and rerun flows.
+- **FR-007**: Preview failures MUST NOT remove access to attachment metadata or available download actions.
+- **FR-008**: Removing an attachment and adding a new attachment MUST be represented as explicit user actions while unchanged refs survive unchanged.
+- **FR-009**: System MUST fail explicitly when attachment target bindings cannot be reconstructed instead of silently presenting a text-only draft or dropping attachments.
+- **FR-010**: System MUST NOT treat artifact links, filenames, or attachment metadata as the authoritative source for current target binding.
+- **FR-011**: Historical source artifacts MAY remain under retention after an edited draft stops referencing them, but they MUST NOT be treated as active bindings unless the current snapshot references them.
+
+### Key Entities
+
+- **Task Input Snapshot**: The authoritative saved task input state, including text, runtime, publish, repository, preset metadata, step identity/order, and objective/step attachment refs.
+- **Attachment Ref**: A persisted reference to an uploaded input attachment, scoped to either the task objective or a specific step target.
+- **Draft Reconstruction**: The edit or rerun process that turns a saved task input snapshot back into a user-editable draft.
+- **Attachment Target Binding**: The relationship between an attachment ref and its objective-scoped or step-scoped destination.
+- **Persisted Attachment Ref vs New Local File**: A distinction between an already uploaded attachment reference and a not-yet-uploaded local browser file selected during edit or rerun.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated coverage verifies that edit reconstruction preserves all unchanged objective-scoped and step-scoped attachment refs from the saved snapshot.
+- **SC-002**: Automated coverage verifies that rerun reconstruction preserves all unchanged objective-scoped and step-scoped attachment refs from the saved snapshot.
+- **SC-003**: Automated coverage verifies at least one remove action and one add action without losing unrelated unchanged attachment refs.
+- **SC-004**: Automated coverage verifies that reconstruction fails explicitly when a snapshot lacks required attachment binding data.
+- **SC-005**: Automated coverage verifies that attachment target binding is not inferred from filenames, artifact links, or metadata.

--- a/specs/196-preserve-attachment-bindings/tasks.md
+++ b/specs/196-preserve-attachment-bindings/tasks.md
@@ -1,0 +1,132 @@
+# Tasks: Preserve Attachment Bindings in Snapshots and Reruns
+
+**Input**: Design documents from `/specs/196-preserve-attachment-bindings/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-369 user story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: FR-001 through FR-011; acceptance scenarios 1-5; SC-001 through SC-005; DESIGN-REQ-007, DESIGN-REQ-015, DESIGN-REQ-018.
+
+**Test Commands**:
+
+- Unit tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`
+- Integration tests: `pytest tests/contract/test_temporal_execution_api.py -q`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the existing task editing and attachment surfaces before adding tests.
+
+- [X] T001 Inspect current task snapshot persistence in `api_service/api/routers/executions.py` for FR-001, FR-002, DESIGN-REQ-007
+- [X] T002 Inspect current frontend draft reconstruction in `frontend/src/lib/temporalTaskEditing.ts` and Create-page attachment state in `frontend/src/entrypoints/task-create.tsx` for FR-003 through FR-010
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the binding model used by tests and implementation.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T003 Identify the existing attachment ref fields and draft reconstruction assumptions in `frontend/src/lib/temporalTaskEditing.ts` for objective and step draft reconstruction covering FR-001, FR-003, FR-004, DESIGN-REQ-018
+- [X] T004 Identify the existing Create-page state and submission assumptions for persisted versus new attachments in `frontend/src/entrypoints/task-create.tsx` covering FR-006, FR-008
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Preserve Attachment Bindings in Snapshots and Reruns
+
+**Summary**: As a user editing or rerunning a task, I need MoonMind to reconstruct attachments from the authoritative task input snapshot so unchanged bindings survive and changes are always explicit.
+
+**Independent Test**: Create a draft from an artifact-backed task input snapshot with objective and step attachments, load it into edit/rerun Create-page state, submit without changes, then verify unchanged refs remain in the outgoing payload; removing a persisted ref or adding a new local file changes only that target.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011; acceptance scenarios 1-5; SC-001-SC-005; DESIGN-REQ-007, DESIGN-REQ-015, DESIGN-REQ-018
+
+**Test Plan**:
+
+- Unit: frontend draft transformation and Create-page state/submission behavior; backend snapshot descriptor/action guard behavior.
+- Integration: contract test for persisted task input snapshot shape containing objective and step `inputAttachments`.
+
+### Unit Tests (write first)
+
+- [X] T005 [P] Add failing frontend unit test for `buildTemporalSubmissionDraftFromExecution` preserving objective and step `inputAttachments` from the authoritative snapshot in `frontend/src/entrypoints/task-create.test.tsx` covering FR-003, FR-004, SC-001, SC-002, DESIGN-REQ-007
+- [X] T006 [P] Add failing frontend unit test for Create-page edit/rerun submission retaining unchanged persisted attachment refs in `frontend/src/entrypoints/task-create.test.tsx` covering FR-006, FR-008, SC-003, DESIGN-REQ-018
+- [X] T007 [P] Add failing frontend unit test for explicit reconstruction failure when snapshot attachment refs cannot be bound from `draft.task` in `frontend/src/entrypoints/task-create.test.tsx` covering FR-009, FR-010, SC-004, SC-005
+- [X] T008 [P] Add or extend backend unit coverage for snapshot descriptor/action availability with original snapshot requirements in `tests/unit/api/routers/test_executions.py` covering FR-009, DESIGN-REQ-018
+- [X] T009 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q` to confirm T005-T008 fail for the expected missing behavior
+
+### Integration Tests (write first)
+
+- [X] T010 Add failing contract test or extend existing task-shaped execution contract coverage in `tests/contract/test_temporal_execution_api.py` to assert snapshot task body preserves objective and step `inputAttachments` and compact refs do not replace the task body covering FR-001, FR-002, DESIGN-REQ-007
+- [X] T011 Run `pytest tests/contract/test_temporal_execution_api.py -q` to confirm T010 fails for the expected missing or incomplete behavior
+
+### Implementation
+
+- [X] T012 Implement persisted attachment ref types, normalization, and binding validation in `frontend/src/lib/temporalTaskEditing.ts` covering FR-003, FR-004, FR-009, FR-010
+- [X] T013 Implement persisted attachment ref state fields and hydration from Temporal drafts in `frontend/src/entrypoints/task-create.tsx` covering FR-005, FR-006, DESIGN-REQ-015
+- [X] T014 Implement unchanged persisted ref submission and explicit add/remove behavior in `frontend/src/entrypoints/task-create.tsx` covering FR-006, FR-008, DESIGN-REQ-018
+- [X] T015 Backend snapshot payload/descriptor changes were not needed because `tests/unit/api/routers/test_executions.py` and `tests/contract/test_temporal_execution_api.py` already verify backend binding evidence for FR-001, FR-002, FR-009
+- [X] T016 Run focused unit commands `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`, then fix failures
+- [X] T017 Run focused contract command `pytest tests/contract/test_temporal_execution_api.py -q`, then fix failures
+
+**Checkpoint**: The story is fully functional, covered by unit and contract tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Validate the completed story without adding hidden scope.
+
+- [X] T018 [P] Update `specs/196-preserve-attachment-bindings/quickstart.md` if final commands or blockers differ from the planned validation
+- [X] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification
+- [X] T020 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker
+- [X] T021 Run `/speckit.verify` and record verification evidence in the final response
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks story work
+- **Story (Phase 3)**: Depends on Foundational completion
+- **Polish (Phase 4)**: Depends on focused unit and contract tests passing or documented blockers
+
+### Within The Story
+
+- Unit tests T005-T008 must be written before implementation.
+- Integration/contract test T010 must be written before implementation.
+- Red-first confirmation T009 and T011 must complete before T012-T015.
+- Frontend draft model work T012 must precede Create-page state/submission work T013-T014.
+- Backend changes T015 are conditional and should be skipped if existing backend evidence already satisfies the contract.
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel.
+- T005, T006, T007, T008 can be authored in parallel because they cover distinct assertions.
+- T018 can run after implementation while final verification commands are queued.
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and foundational tasks.
+2. Write failing frontend and backend tests.
+3. Confirm the focused tests fail for the expected missing attachment preservation behavior.
+4. Implement draft model and Create-page state/submission changes.
+5. Update backend only if contract tests prove snapshot persistence is incomplete.
+6. Run focused unit and contract tests.
+7. Run final unit and feasible integration verification.
+8. Run `/speckit.verify`.

--- a/specs/196-preserve-attachment-bindings/tasks.md
+++ b/specs/196-preserve-attachment-bindings/tasks.md
@@ -11,9 +11,9 @@
 
 **Test Commands**:
 
-- Unit tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`
+- Unit tests: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`
 - Integration tests: `pytest tests/contract/test_temporal_execution_api.py -q`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -62,7 +62,7 @@
 - [X] T006 [P] Add failing frontend unit test for Create-page edit/rerun submission retaining unchanged persisted attachment refs in `frontend/src/entrypoints/task-create.test.tsx` covering FR-006, FR-008, SC-003, DESIGN-REQ-018
 - [X] T007 [P] Add failing frontend unit test for explicit reconstruction failure when snapshot attachment refs cannot be bound from `draft.task` in `frontend/src/entrypoints/task-create.test.tsx` covering FR-009, FR-010, SC-004, SC-005
 - [X] T008 [P] Add or extend backend unit coverage for snapshot descriptor/action availability with original snapshot requirements in `tests/unit/api/routers/test_executions.py` covering FR-009, DESIGN-REQ-018
-- [X] T009 Run `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q` to confirm T005-T008 fail for the expected missing behavior
+- [X] T009 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q` to confirm T005-T008 fail for the expected missing behavior
 
 ### Integration Tests (write first)
 
@@ -75,8 +75,9 @@
 - [X] T013 Implement persisted attachment ref state fields and hydration from Temporal drafts in `frontend/src/entrypoints/task-create.tsx` covering FR-005, FR-006, DESIGN-REQ-015
 - [X] T014 Implement unchanged persisted ref submission and explicit add/remove behavior in `frontend/src/entrypoints/task-create.tsx` covering FR-006, FR-008, DESIGN-REQ-018
 - [X] T015 Backend snapshot payload/descriptor changes were not needed because `tests/unit/api/routers/test_executions.py` and `tests/contract/test_temporal_execution_api.py` already verify backend binding evidence for FR-001, FR-002, FR-009
-- [X] T016 Run focused unit commands `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`, then fix failures
+- [X] T016 Run focused unit commands `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` and `pytest tests/unit/api/routers/test_executions.py -q`, then fix failures
 - [X] T017 Run focused contract command `pytest tests/contract/test_temporal_execution_api.py -q`, then fix failures
+- [X] T018 Validate the single MM-369 story against acceptance scenarios 1-5 using `frontend/src/entrypoints/task-create.test.tsx` and `tests/contract/test_temporal_execution_api.py`
 
 **Checkpoint**: The story is fully functional, covered by unit and contract tests, and testable independently.
 
@@ -86,10 +87,10 @@
 
 **Purpose**: Validate the completed story without adding hidden scope.
 
-- [X] T018 [P] Update `specs/196-preserve-attachment-bindings/quickstart.md` if final commands or blockers differ from the planned validation
-- [X] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification
-- [X] T020 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker
-- [X] T021 Run `/speckit.verify` and record verification evidence in the final response
+- [X] T019 [P] Update `specs/196-preserve-attachment-bindings/quickstart.md` if final commands or blockers differ from the planned validation
+- [X] T020 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification
+- [X] T021 Run `./tools/test_integration.sh` when Docker is available, or record the exact Docker socket blocker
+- [X] T022 Run `/moonspec-verify` and record verification evidence in the final response
 
 ---
 
@@ -109,12 +110,13 @@
 - Red-first confirmation T009 and T011 must complete before T012-T015.
 - Frontend draft model work T012 must precede Create-page state/submission work T013-T014.
 - Backend changes T015 are conditional and should be skipped if existing backend evidence already satisfies the contract.
+- Story validation T018 must follow focused unit and contract evidence.
 
 ### Parallel Opportunities
 
 - T001 and T002 can run in parallel.
 - T005, T006, T007, T008 can be authored in parallel because they cover distinct assertions.
-- T018 can run after implementation while final verification commands are queued.
+- T019 can run after implementation while final verification commands are queued.
 
 ---
 
@@ -129,4 +131,4 @@
 5. Update backend only if contract tests prove snapshot persistence is incomplete.
 6. Run focused unit and contract tests.
 7. Run final unit and feasible integration verification.
-8. Run `/speckit.verify`.
+8. Run `/moonspec-verify`.


### PR DESCRIPTION
## Summary

Implements MM-369: preserve objective-scoped and step-scoped attachment bindings when reconstructing task edit/rerun drafts from authoritative task input snapshots.

Key behavior:
- Preserves persisted `task.inputAttachments` and `task.steps[n].inputAttachments` from the authoritative snapshot.
- Keeps persisted attachment refs distinct from newly selected local files.
- Submits unchanged persisted refs unless explicitly removed.
- Fails reconstruction explicitly when compact attachment refs cannot be bound from the snapshot task body.
- Keeps metadata and download actions available for persisted refs.

## Jira

- Issue: MM-369

## Active MoonSpec Feature Path

- `specs/196-preserve-attachment-bindings`

## Verification Verdict

- `FULLY_IMPLEMENTED`
- Confidence: `MEDIUM` because compose-backed integration could not run in this container due missing Docker socket, while focused unit and contract integration evidence passed.

## Tests Run

- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` PASS, 123 tests
- `pytest tests/unit/api/routers/test_executions.py -q` PASS, 81 tests
- `pytest tests/contract/test_temporal_execution_api.py -q` PASS, 8 tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS, 3475 Python tests plus 244 frontend tests
- `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` PASS
- `./tools/test_integration.sh` NOT RUN: Docker unavailable (`/var/run/docker.sock` missing)

## Remaining Risks

- Compose-backed integration remains unverified in this managed container because Docker socket access is unavailable. CI or a Docker-enabled environment should run `./tools/test_integration.sh`.

## Spec Artifacts

- `specs/196-preserve-attachment-bindings/spec.md`
- `specs/196-preserve-attachment-bindings/plan.md`
- `specs/196-preserve-attachment-bindings/tasks.md`
- `specs/196-preserve-attachment-bindings/contracts/attachment-binding-reconstruction.md`