### PR TITLE
[codex] Preserve merge automation requests

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1393,6 +1393,7 @@ def _normalize_publish_payload(raw_publish: Any) -> dict[str, Any]:
         "prBody",
         "verificationSkipReason",
         "verification",
+        "mergeAutomation",
     ):
         if key not in publish_payload:
             continue
@@ -1408,6 +1409,10 @@ def _normalize_publish_payload(raw_publish: Any) -> dict[str, Any]:
     if "baseBranch" in normalized and "prBaseBranch" not in normalized:
         normalized["prBaseBranch"] = normalized["baseBranch"]
     return normalized
+
+
+def _normalize_merge_automation_payload(raw_merge_automation: Any) -> dict[str, Any]:
+    return _coerce_mapping(raw_merge_automation)
 
 
 def _normalize_story_output_payload(raw_story_output: Any) -> dict[str, Any]:
@@ -1899,6 +1904,12 @@ async def _create_execution_from_task_request(
         else {}
     )
     publish_payload = _normalize_publish_payload(task_payload.get("publish"))
+    merge_automation_payload = _normalize_merge_automation_payload(
+        payload.get("mergeAutomation") or payload.get("merge_automation")
+    )
+    task_merge_automation_payload = _normalize_merge_automation_payload(
+        task_payload.get("mergeAutomation") or task_payload.get("merge_automation")
+    )
     story_output_payload = _normalize_story_output_payload(
         task_payload.get("storyOutput") or task_payload.get("story_output")
     )
@@ -1942,6 +1953,10 @@ async def _create_execution_from_task_request(
         normalized_task_for_planner["title"] = task_title
     if publish_payload:
         normalized_task_for_planner["publish"] = dict(publish_payload)
+    if task_merge_automation_payload:
+        normalized_task_for_planner["mergeAutomation"] = dict(
+            task_merge_automation_payload
+        )
     if story_output_payload:
         normalized_task_for_planner["storyOutput"] = dict(story_output_payload)
     git_payload = (
@@ -2050,6 +2065,8 @@ async def _create_execution_from_task_request(
     }
     if story_output_payload:
         initial_parameters["storyOutput"] = dict(story_output_payload)
+    if merge_automation_payload:
+        initial_parameters["mergeAutomation"] = dict(merge_automation_payload)
     if instructions:
         initial_parameters["instructions"] = instructions
     if normalized_task_for_planner:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -727,6 +727,93 @@ def test_create_task_shaped_execution_preserves_task_title_and_publish_overrides
     assert initial_parameters["task"]["publish"]["prBody"] == "Adds integration tests and updates callback routing."
 
 
+def test_create_task_shaped_execution_preserves_merge_automation_request(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "publishMode": "pr",
+                "mergeAutomation": {
+                    "enabled": True,
+                    "mergeMethod": "squash",
+                    "fallbackPollSeconds": 60,
+                },
+                "task": {
+                    "instructions": "Implement and publish a pull request.",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {"mode": "pr"},
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["publishMode"] == "pr"
+    assert initial_parameters["task"]["publish"]["mode"] == "pr"
+    assert initial_parameters["mergeAutomation"] == {
+        "enabled": True,
+        "mergeMethod": "squash",
+        "fallbackPollSeconds": 60,
+    }
+
+
+def test_create_task_shaped_execution_preserves_nested_merge_automation_request(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions",
+        json={
+            "type": "task",
+            "payload": {
+                "repository": "MoonLadderStudios/MoonMind",
+                "targetRuntime": "codex_cli",
+                "task": {
+                    "instructions": "Implement and publish a pull request.",
+                    "runtime": {"mode": "codex_cli"},
+                    "publish": {
+                        "mode": "pr",
+                        "mergeAutomation": {
+                            "enabled": True,
+                            "mergeMethod": "rebase",
+                        },
+                    },
+                    "mergeAutomation": {
+                        "enabled": True,
+                        "automatedReview": "optional",
+                    },
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    initial_parameters = service.create_execution.await_args.kwargs[
+        "initial_parameters"
+    ]
+    assert initial_parameters["task"]["mergeAutomation"] == {
+        "enabled": True,
+        "automatedReview": "optional",
+    }
+    assert initial_parameters["task"]["publish"]["mergeAutomation"] == {
+        "enabled": True,
+        "mergeMethod": "rebase",
+    }
+
+
 def test_create_task_shaped_execution_preserves_story_output_contract(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes task-shaped execution creation so merge automation configuration selected on the Create page is preserved when the API maps the request into `MoonMind.Run` initial parameters.

## Root Cause

The Create page submitted `payload.mergeAutomation`, but the task-shaped execution API rebuilt a normalized `initial_parameters` payload and did not copy that field forward. Nested merge automation fields under `task.publish` were also filtered out by the publish payload whitelist.

## Changes

- Preserve root `payload.mergeAutomation` as `initial_parameters.mergeAutomation`.
- Preserve nested `task.mergeAutomation` and `task.publish.mergeAutomation` shapes already supported by `MoonMind.Run`.
- Add API regression coverage for the current UI request shape and nested merge automation shapes.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_run_merge_gate_start.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-create.test.tsx`