### PR TITLE
MM-370 Materialize attachment manifest and workspace files

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/196-preserve-attachment-bindings"
+  "feature_directory": "specs/197-attachment-materialization"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-370-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-370-moonspec-orchestration-input.md
@@ -1,0 +1,99 @@
+# MM-370 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-370
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Materialize attachment manifest and workspace files
+- Labels: `moonmind-workflow-mm-710b9b03-7ff6-4c87-ac25-ddef82bbf280`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-370 from MM project
+Summary: Materialize attachment manifest and workspace files
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-370 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-370: Materialize attachment manifest and workspace files
+
+Source Reference
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 3.2 Canonical terminology
+  - 4. End-to-end desired-state flow
+  - 8. Prepare-time materialization contract
+- Coverage IDs:
+  - DESIGN-REQ-002
+  - DESIGN-REQ-004
+  - DESIGN-REQ-011
+
+User Story
+As a runtime executor, I need workflow prepare to deterministically download declared input attachments, write a canonical manifest, and place files in target-aware workspace paths before the relevant runtime or step executes.
+
+Acceptance Criteria
+- Prepare downloads all declared input attachments before the relevant runtime or step executes.
+- Prepare writes `.moonmind/attachments_manifest.json` using the canonical manifest entry shape.
+- Objective images are materialized under `.moonmind/inputs/objective/`.
+- Step images are materialized under `.moonmind/inputs/steps/<stepRef>/`.
+- Workspace paths are deterministic and target-aware; one target path does not depend on unrelated target ordering.
+- A stable step reference is assigned when a step has no explicit id.
+- Partial materialization is reported as failure, not best-effort success.
+
+Requirements
+- Include `artifactId`, `filename`, `contentType`, `sizeBytes`, `targetKind`, optional `stepRef`/`stepOrdinal`, `workspacePath`, and optional context/source paths in manifest entries.
+- Sanitize filenames while preserving deterministic artifactId-prefixed paths.
+- Treat execution payload and snapshot refs as the source for materialization.
+- Preserve canonical target meaning from the field that contains each ref: objective-scoped attachments from `task.inputAttachments` and step-scoped attachments from `task.steps[n].inputAttachments`.
+- Materialize objective-scoped attachments under `.moonmind/inputs/objective/<artifactId>-<sanitized-filename>`.
+- Materialize step-scoped attachments under `.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>`.
+- Ensure attachment identity and target meaning do not depend on filename conventions or unrelated target ordering.
+- Keep raw attachment bytes out of Temporal histories and task instruction text; runtime adapters consume structured refs, materialized files, and derived context.
+- Fail explicitly when any declared attachment cannot be downloaded, written, or represented in the manifest.
+
+Relevant Implementation Notes
+- The canonical control-plane field name is `inputAttachments`.
+- The canonical prepared manifest entry shape is `AttachmentManifestEntry` from `docs/Tasks/ImageSystem.md`.
+- Workflow prepare owns deterministic local file materialization.
+- Upload completion and execution snapshot persistence happen before workflow prepare receives refs.
+- The execution API snapshot is the authoritative source for attachment targeting.
+- Runtime adapters consume structured refs and derived context, not browser-local state.
+- Target-aware workspace paths must be stable for objective and step targets independently.
+- If a step has no explicit `id`, the control plane or prepare layer must assign a stable step reference for manifest and path purposes.
+- Partial materialization must stop execution as a failure, preserving diagnostics for the missing or invalid attachment.
+
+Suggested Implementation Areas
+- Workflow prepare or artifact materialization activities that download input attachments.
+- Manifest writer for `.moonmind/attachments_manifest.json`.
+- Workspace path generation and filename sanitization helpers.
+- Stable step reference assignment for steps without explicit ids.
+- Execution payload or snapshot parsing for objective-scoped and step-scoped attachment refs.
+- Failure handling and diagnostics for partial materialization.
+- Unit and workflow/activity-boundary tests covering manifest shape, path determinism, target isolation, and failure behavior.
+
+Validation
+- Verify prepare downloads every declared objective-scoped and step-scoped input attachment before the relevant runtime or step executes.
+- Verify `.moonmind/attachments_manifest.json` includes the canonical fields for every materialized attachment.
+- Verify objective-scoped attachments are written under `.moonmind/inputs/objective/`.
+- Verify step-scoped attachments are written under `.moonmind/inputs/steps/<stepRef>/`.
+- Verify generated workspace paths are deterministic and independent of unrelated target ordering.
+- Verify steps without explicit ids receive stable step references for path and manifest purposes.
+- Verify a missing, invalid, or failed attachment download produces an explicit failure instead of best-effort success.
+- Verify raw attachment bytes are not embedded in Temporal histories or task instruction text.
+
+Non-Goals
+- Generating target-aware vision context artifacts; that is covered by a separate story.
+- Preserving attachment bindings across edit and rerun reconstruction; that is covered by a separate story.
+- Enforcing upload policy, content-type policy, or artifact completion integrity beyond consuming already-declared refs.
+- Inferring target bindings from filenames, artifact links, or artifact metadata.
+- Adding generic non-image attachment support beyond the existing image input materialization contract.
+
+Needs Clarification
+- None

--- a/moonmind/agents/codex_worker/worker.py
+++ b/moonmind/agents/codex_worker/worker.py
@@ -1154,6 +1154,19 @@ class PreparedTaskWorkspace:
 
 
 @dataclass(frozen=True, slots=True)
+class InputAttachmentMaterializationTarget:
+    """One declared task input attachment with its canonical target binding."""
+
+    artifact_id: str
+    filename: str
+    content_type: str
+    size_bytes: int
+    target_kind: str
+    step_ref: str | None = None
+    step_ordinal: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ProposalSubmissionReport:
     """Compact proposal-submission output used by task finish summaries."""
 
@@ -1708,6 +1721,17 @@ class QueueApiClient:
                 raise QueueClientError(
                     f"artifact upload failed for job {job_id}: {exc}"
                 ) from exc
+
+    async def download_artifact(self, *, artifact_id: str) -> bytes:
+        path = f"/api/artifacts/{artifact_id}/download"
+        try:
+            response = await self._client.get(path)
+            response.raise_for_status()
+            return bytes(response.content)
+        except httpx.HTTPError as exc:
+            raise QueueClientError(
+                f"artifact download failed for {artifact_id}: {exc}"
+            ) from exc
 
     async def _post_json(self, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
         try:
@@ -4354,6 +4378,16 @@ class CodexWorker:
                 # Symlink already exists; this is safe to ignore for idempotent setup.
                 pass
 
+            attachment_manifest_path = await self._materialize_input_attachments(
+                job_id=job_id,
+                canonical_payload=canonical_payload,
+                repo_dir=repo_dir,
+                prepare_log_path=prepare_log_path,
+            )
+            attachment_targets = self._collect_input_attachment_targets(
+                canonical_payload
+            )
+
             context_payload = {
                 "repository": repository,
                 "runtime": canonical_payload.get("targetRuntime"),
@@ -4403,6 +4437,14 @@ class CodexWorker:
                     "home": str(home_dir),
                     "skillsActive": str(skills_active_path),
                     "artifacts": str(artifacts_dir),
+                },
+                "attachments": {
+                    "count": len(attachment_targets),
+                    "manifestPath": (
+                        str(attachment_manifest_path)
+                        if attachment_manifest_path is not None
+                        else None
+                    ),
                 },
                 "rag": self._rag_capability_metadata(),
                 "timestamp": datetime.now(UTC).isoformat(),
@@ -4469,6 +4511,223 @@ class CodexWorker:
                 },
             )
             raise
+
+    @staticmethod
+    def _sanitize_attachment_workspace_segment(value: object, *, fallback: str) -> str:
+        text = str(value or "").replace("\\", "/").strip()
+        basename = Path(text).name
+        sanitized = re.sub(r"[^A-Za-z0-9._-]+", "_", basename).strip("._")
+        return sanitized or fallback
+
+    @classmethod
+    def _attachment_step_ref(cls, step: Mapping[str, Any], index: int) -> str:
+        explicit = str(step.get("id") or "").strip()
+        if explicit:
+            return cls._sanitize_attachment_workspace_segment(
+                explicit, fallback=f"step-{index + 1}"
+            )
+        return f"step-{index + 1}"
+
+    @staticmethod
+    def _require_attachment_ref_field(
+        ref: Mapping[str, Any], *, field: str, field_name: str
+    ) -> str:
+        value = str(ref.get(field) or "").strip()
+        if not value:
+            raise ValueError(f"{field_name}.{field} is required")
+        return value
+
+    @classmethod
+    def _build_attachment_target(
+        cls,
+        raw: Any,
+        *,
+        field_name: str,
+        target_kind: str,
+        step_ref: str | None = None,
+        step_ordinal: int | None = None,
+    ) -> InputAttachmentMaterializationTarget:
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"{field_name} must be an object")
+        artifact_id = cls._require_attachment_ref_field(
+            raw, field="artifactId", field_name=field_name
+        )
+        filename = cls._require_attachment_ref_field(
+            raw, field="filename", field_name=field_name
+        )
+        content_type = cls._require_attachment_ref_field(
+            raw, field="contentType", field_name=field_name
+        )
+        size_raw = raw.get("sizeBytes")
+        if isinstance(size_raw, bool):
+            raise ValueError(f"{field_name}.sizeBytes must be a non-negative integer")
+        try:
+            size_bytes = int(size_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{field_name}.sizeBytes must be a non-negative integer"
+            ) from exc
+        if size_bytes < 0:
+            raise ValueError(f"{field_name}.sizeBytes must be a non-negative integer")
+        return InputAttachmentMaterializationTarget(
+            artifact_id=artifact_id,
+            filename=filename,
+            content_type=content_type,
+            size_bytes=size_bytes,
+            target_kind=target_kind,
+            step_ref=step_ref,
+            step_ordinal=step_ordinal,
+        )
+
+    @classmethod
+    def _collect_input_attachment_targets(
+        cls, canonical_payload: Mapping[str, Any]
+    ) -> list[InputAttachmentMaterializationTarget]:
+        task_node = canonical_payload.get("task")
+        task = task_node if isinstance(task_node, Mapping) else {}
+        targets: list[InputAttachmentMaterializationTarget] = []
+        objective_refs = task.get("inputAttachments")
+        if objective_refs is not None:
+            if not isinstance(objective_refs, list):
+                raise ValueError("task.inputAttachments must be a list")
+            for index, raw in enumerate(objective_refs):
+                targets.append(
+                    cls._build_attachment_target(
+                        raw,
+                        field_name=f"task.inputAttachments[{index}]",
+                        target_kind="objective",
+                    )
+                )
+
+        raw_steps = task.get("steps")
+        if raw_steps is None:
+            return targets
+        if not isinstance(raw_steps, list):
+            raise ValueError("task.steps must be a list")
+        for step_index, raw_step in enumerate(raw_steps):
+            if not isinstance(raw_step, Mapping):
+                continue
+            step_refs = raw_step.get("inputAttachments")
+            if step_refs is None:
+                continue
+            if not isinstance(step_refs, list):
+                raise ValueError(
+                    f"task.steps[{step_index}].inputAttachments must be a list"
+                )
+            step_ref = cls._attachment_step_ref(raw_step, step_index)
+            for ref_index, raw_ref in enumerate(step_refs):
+                targets.append(
+                    cls._build_attachment_target(
+                        raw_ref,
+                        field_name=(
+                            f"task.steps[{step_index}].inputAttachments[{ref_index}]"
+                        ),
+                        target_kind="step",
+                        step_ref=step_ref,
+                        step_ordinal=step_index,
+                    )
+                )
+        return targets
+
+    @classmethod
+    def _attachment_workspace_relative_path(
+        cls, target: InputAttachmentMaterializationTarget
+    ) -> Path:
+        filename = cls._sanitize_attachment_workspace_segment(
+            target.filename, fallback="attachment"
+        )
+        output_name = f"{target.artifact_id}-{filename}"
+        if target.target_kind == "objective":
+            return Path(".moonmind") / "inputs" / "objective" / output_name
+        if target.target_kind == "step" and target.step_ref:
+            step_ref = cls._sanitize_attachment_workspace_segment(
+                target.step_ref, fallback="step"
+            )
+            return Path(".moonmind") / "inputs" / "steps" / step_ref / output_name
+        raise ValueError(f"unsupported attachment target kind: {target.target_kind}")
+
+    @staticmethod
+    def _attachment_manifest_entry(
+        *,
+        target: InputAttachmentMaterializationTarget,
+        workspace_path: Path,
+    ) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "artifactId": target.artifact_id,
+            "filename": target.filename,
+            "contentType": target.content_type,
+            "sizeBytes": target.size_bytes,
+            "targetKind": target.target_kind,
+            "workspacePath": workspace_path.as_posix(),
+        }
+        if target.step_ref is not None:
+            entry["stepRef"] = target.step_ref
+        if target.step_ordinal is not None:
+            entry["stepOrdinal"] = target.step_ordinal
+        return entry
+
+    async def _materialize_input_attachments(
+        self,
+        *,
+        job_id: UUID,
+        canonical_payload: Mapping[str, Any],
+        repo_dir: Path,
+        prepare_log_path: Path,
+    ) -> Path | None:
+        targets = self._collect_input_attachment_targets(canonical_payload)
+        if not targets:
+            return None
+        manifest_entries: list[dict[str, Any]] = []
+        moonmind_dir = repo_dir / ".moonmind"
+        inputs_dir = moonmind_dir / "inputs"
+        inputs_dir.mkdir(parents=True, exist_ok=True)
+        for target in targets:
+            relative_path = self._attachment_workspace_relative_path(target)
+            absolute_path = repo_dir / relative_path
+            try:
+                payload = await self._queue_client.download_artifact(
+                    artifact_id=target.artifact_id
+                )
+                absolute_path.parent.mkdir(parents=True, exist_ok=True)
+                absolute_path.write_bytes(payload)
+            except Exception as exc:
+                self._append_stage_log(
+                    prepare_log_path,
+                    (
+                        "input attachment materialization failed: "
+                        f"{target.artifact_id} ({target.target_kind}): {exc}"
+                    ),
+                )
+                raise RuntimeError(
+                    "failed to materialize input attachment "
+                    f"{target.artifact_id}: {exc}"
+                ) from exc
+            manifest_entries.append(
+                self._attachment_manifest_entry(
+                    target=target, workspace_path=relative_path
+                )
+            )
+
+        manifest_path = moonmind_dir / "attachments_manifest.json"
+        manifest_payload = {"version": 1, "attachments": manifest_entries}
+        try:
+            manifest_path.write_text(
+                json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            self._append_stage_log(
+                prepare_log_path,
+                f"input attachment manifest write failed: {exc}",
+            )
+            raise RuntimeError(
+                f"failed to write input attachment manifest: {exc}"
+            ) from exc
+        self._append_stage_log(
+            prepare_log_path,
+            f"materialized {len(targets)} input attachment(s) for job {job_id}",
+        )
+        return manifest_path
 
     async def _run_prepare_git_identity_preflight(
         self,

--- a/specs/197-attachment-materialization/checklists/requirements.md
+++ b/specs/197-attachment-materialization/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Materialize Attachment Manifest and Workspace Files
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Checklist validated against the canonical MM-370 Jira preset brief in `docs/tmp/jira-orchestration-inputs/MM-370-moonspec-orchestration-input.md`.
+- Runtime mode selected; `docs/Tasks/ImageSystem.md` is treated as source requirements for product behavior.

--- a/specs/197-attachment-materialization/contracts/attachment-materialization.md
+++ b/specs/197-attachment-materialization/contracts/attachment-materialization.md
@@ -1,0 +1,92 @@
+# Contract: Attachment Materialization
+
+Source story: MM-370 Jira preset brief for prepare-time attachment manifest and workspace files.
+
+## Inputs
+
+Prepare reads the canonical task payload:
+
+```json
+{
+  "task": {
+    "inputAttachments": [
+      {
+        "artifactId": "art_objective",
+        "filename": "diagram.png",
+        "contentType": "image/png",
+        "sizeBytes": 123
+      }
+    ],
+    "steps": [
+      {
+        "id": "review",
+        "inputAttachments": [
+          {
+            "artifactId": "art_step",
+            "filename": "screen.png",
+            "contentType": "image/png",
+            "sizeBytes": 456
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Outputs
+
+Prepare writes local files:
+
+```text
+.moonmind/inputs/objective/art_objective-diagram.png
+.moonmind/inputs/steps/review/art_step-screen.png
+```
+
+Prepare writes `.moonmind/attachments_manifest.json`:
+
+```json
+{
+  "version": 1,
+  "attachments": [
+    {
+      "artifactId": "art_objective",
+      "filename": "diagram.png",
+      "contentType": "image/png",
+      "sizeBytes": 123,
+      "targetKind": "objective",
+      "workspacePath": ".moonmind/inputs/objective/art_objective-diagram.png"
+    },
+    {
+      "artifactId": "art_step",
+      "filename": "screen.png",
+      "contentType": "image/png",
+      "sizeBytes": 456,
+      "targetKind": "step",
+      "stepRef": "review",
+      "stepOrdinal": 0,
+      "workspacePath": ".moonmind/inputs/steps/review/art_step-screen.png"
+    }
+  ]
+}
+```
+
+## Rules
+
+- `targetKind` is derived only from the containing field.
+- Objective entries do not include `stepRef`.
+- Step entries include `stepRef`; when the source step has no id, prepare uses a stable ordinal fallback.
+- `workspacePath` is relative to the repository workspace.
+- File names are sanitized and prefixed with `artifactId`.
+- Manifest writing is all-or-failure: any undeclared, missing, unreadable, or unwritable attachment fails prepare.
+- Raw bytes are written only to local workspace files, never to workflow payloads, task instruction text, or Temporal history.
+
+## Errors
+
+Prepare fails before runtime execution when:
+- an attachment ref is not an object,
+- a required ref field is missing,
+- a filename cannot produce a safe output basename,
+- an artifact download fails,
+- a workspace file write fails,
+- manifest serialization or write fails.

--- a/specs/197-attachment-materialization/data-model.md
+++ b/specs/197-attachment-materialization/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Materialize Attachment Manifest and Workspace Files
+
+## Input Attachment Ref
+
+Represents a declared input attachment already validated before prepare.
+
+Fields:
+- `artifactId`: required MoonMind artifact id.
+- `filename`: required original filename for operator context and deterministic sanitized output naming.
+- `contentType`: required normalized MIME type.
+- `sizeBytes`: required byte size.
+
+Validation:
+- Must be an object from `task.inputAttachments` or `task.steps[n].inputAttachments`.
+- Must not include embedded binary or data URL content.
+- Target meaning comes from the containing field, not from the ref itself.
+
+## Attachment Target
+
+Represents where a declared attachment belongs.
+
+Fields:
+- `targetKind`: `objective` or `step`.
+- `stepRef`: required for step targets in materialized output.
+- `stepOrdinal`: optional zero-based source step index for diagnostics.
+
+State rules:
+- Objective attachments come only from `task.inputAttachments`.
+- Step attachments come only from `task.steps[n].inputAttachments`.
+- Explicit step ids are preferred as `stepRef`.
+- Missing step ids receive deterministic ordinal fallback references.
+
+## Attachment Manifest Entry
+
+Represents one materialized attachment in `.moonmind/attachments_manifest.json`.
+
+Fields:
+- `artifactId`
+- `filename`
+- `contentType`
+- `sizeBytes`
+- `targetKind`
+- `workspacePath`
+- `stepRef` when `targetKind` is `step`
+- `stepOrdinal` when `targetKind` is `step`
+- `visionContextPath` when later context generation produces one
+- `sourceArtifactPath` when a source artifact path is exposed
+
+Validation:
+- One entry exists for every successfully materialized declared attachment.
+- `workspacePath` points inside `.moonmind/inputs/objective/` or `.moonmind/inputs/steps/<stepRef>/`.
+- Entries are deterministic for the same canonical payload.
+
+## Materialized Attachment File
+
+Represents the local workspace copy consumed by runtimes.
+
+Path rules:
+- Objective: `.moonmind/inputs/objective/<artifactId>-<sanitized-filename>`
+- Step: `.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>`
+
+Validation:
+- Filename is sanitized to prevent path traversal.
+- Artifact id prefix prevents collisions for repeated filenames.
+- Missing or failed writes fail prepare.
+
+## Prepare Failure
+
+Represents a terminal prepare-stage failure for partial materialization.
+
+Fields:
+- `artifactId` when known.
+- `targetKind` when known.
+- `stepRef` and `stepOrdinal` for step targets when known.
+- Human-readable reason.
+
+State transition:
+- `declared` -> `materialized` when bytes are downloaded, written, and represented in manifest.
+- `declared` -> `failed` when any download/write/manifest step fails.
+- `failed` stops prepare and prevents runtime execution.

--- a/specs/197-attachment-materialization/plan.md
+++ b/specs/197-attachment-materialization/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan: Materialize Attachment Manifest and Workspace Files
+
+**Branch**: `197-attachment-materialization` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `/specs/197-attachment-materialization/spec.md`
+
+**Note**: This template is filled in by the `/moonspec-plan` workflow. The repository setup script could not run in this managed branch because the active branch is `mm-370-8edeb6d2`, so artifacts were generated manually from `.specify/feature.json`.
+
+## Summary
+
+MM-370 requires prepare-time materialization for task input attachments. The implementation will extend the existing worker prepare stage so objective-scoped and step-scoped `inputAttachments` from the canonical task payload are downloaded through the trusted MoonMind API, written to deterministic target-aware workspace paths, and recorded in `.moonmind/attachments_manifest.json`. Validation will use unit coverage for path, manifest, stable step reference, and failure behavior plus worker prepare boundary coverage to prove attachments are present before runtime execution.
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, httpx, existing Codex worker prepare stage, existing Temporal artifact download API  
+**Storage**: Existing artifact store for source bytes; local per-job workspace files under `.moonmind/inputs/` and `.moonmind/attachments_manifest.json`; no new persistent storage  
+**Unit Testing**: pytest via `./tools/test_unit.sh`, with focused pytest targets for iteration  
+**Integration Testing**: pytest worker/activity boundary coverage in the required unit suite, plus `./tools/test_integration.sh` for hermetic integration when Docker is available  
+**Target Platform**: MoonMind managed-agent worker containers and per-job workspaces  
+**Project Type**: Python worker/runtime orchestration service  
+**Performance Goals**: Materialization is linear in declared attachment count and streams or writes compact image bytes without embedding them in workflow history  
+**Constraints**: Do not infer target binding from filenames or artifact metadata; do not embed image bytes in Temporal histories or task instruction text; fail explicitly for partial materialization; preserve MM-370 traceability  
+**Scale/Scope**: One task-shaped execution payload with objective attachments and step attachments within existing configured attachment limits
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Extends the existing worker prepare stage and artifact API rather than introducing a new runtime.
+- II. One-Click Agent Deployment: PASS. No new external dependency.
+- III. Avoid Vendor Lock-In: PASS. Uses generic MoonMind artifact refs and workspace files, not provider-specific file APIs.
+- IV. Own Your Data: PASS. Artifact bytes remain in MoonMind-owned storage and per-job workspaces.
+- V. Skills Are First-Class and Easy to Add: PASS. No runtime skill mutation.
+- VI. Replaceability and Scientific Method: PASS. Behavior is covered by deterministic tests at the prepare boundary.
+- VII. Runtime Configurability: PASS. Existing attachment policy and artifact API remain authoritative before prepare.
+- VIII. Modular and Extensible Architecture: PASS. Materialization is isolated to prepare helpers and worker boundary wiring.
+- IX. Resilient by Default: PASS. Partial materialization fails explicitly before runtime execution.
+- X. Facilitate Continuous Improvement: PASS. Failures include concrete materialization diagnostics.
+- XI. Spec-Driven Development: PASS. This plan follows a one-story MM-370 spec with traceable tests.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Canonical docs remain source requirements; implementation notes stay in spec artifacts.
+- XIII. Pre-release Compatibility Policy: PASS. Unsupported or invalid internal payload shapes fail rather than compatibility-transforming target bindings.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/197-attachment-materialization/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── attachment-materialization.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+└── agents/codex_worker/
+    └── worker.py
+
+tests/
+└── unit/
+    └── agents/codex_worker/
+        └── test_attachment_materialization.py
+```
+
+**Structure Decision**: Implement prepare-time attachment materialization in the existing Codex worker prepare boundary because that is where per-job workspace paths, `.moonmind` directories, logs, and pre-runtime setup are already controlled. Keep validation focused on helper behavior and prepare-stage boundary effects.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/197-attachment-materialization/quickstart.md
+++ b/specs/197-attachment-materialization/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Materialize Attachment Manifest and Workspace Files
+
+## Focused Unit Validation
+
+Run the new attachment materialization tests:
+
+```bash
+./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py
+```
+
+Expected coverage:
+- objective attachments write under `.moonmind/inputs/objective/`
+- step attachments write under `.moonmind/inputs/steps/<stepRef>/`
+- manifest entries include canonical fields
+- unsafe filenames are sanitized
+- stable fallback step refs are assigned
+- failed downloads stop prepare
+
+## Full Unit Validation
+
+Run the required unit suite before final verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Hermetic Integration Validation
+
+When Docker is available, run the required hermetic integration suite:
+
+```bash
+./tools/test_integration.sh
+```
+
+## Manual Story Check
+
+1. Submit or construct a task-shaped payload with both `task.inputAttachments` and `task.steps[n].inputAttachments`.
+2. Run worker prepare for the task.
+3. Confirm `.moonmind/attachments_manifest.json` exists in the repo workspace.
+4. Confirm objective files exist under `.moonmind/inputs/objective/`.
+5. Confirm step files exist under `.moonmind/inputs/steps/<stepRef>/`.
+6. Confirm a missing artifact fails prepare and prevents runtime execution.
+
+## Traceability
+
+Confirm `MM-370` is preserved in:
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `verification.md`
+- commit text and pull request metadata when delivery metadata is created

--- a/specs/197-attachment-materialization/research.md
+++ b/specs/197-attachment-materialization/research.md
@@ -1,0 +1,43 @@
+# Research: Materialize Attachment Manifest and Workspace Files
+
+## Input Classification
+
+Decision: Treat the MM-370 Jira preset brief as a single-story runtime feature request.
+Rationale: The brief has one actor, one prepare-time behavior, one source document slice, and one independently testable result: declared attachments are downloaded, locally materialized, and represented in a canonical manifest before runtime or step execution.
+Alternatives considered: Treating `docs/Tasks/ImageSystem.md` as a broad declarative design was rejected because the brief already selects sections 3.2, 4, and 8 and narrows the work to prepare-time materialization only.
+
+## Materialization Boundary
+
+Decision: Implement materialization in the existing Codex worker `_run_prepare_stage` boundary.
+Rationale: That boundary owns per-job workspace creation, `.moonmind` symlink setup, `task_context.json`, prepare logs, and pre-runtime execution state. Materializing attachments there ensures files and manifest exist before execute-stage runtime invocation.
+Alternatives considered: Materializing in the API service was rejected because workspace paths are per-worker local state. Materializing in runtime adapters was rejected because target-aware attachment setup should happen before any specific adapter consumes the workspace.
+
+## Attachment Source
+
+Decision: Use the canonical task payload `task.inputAttachments` and `task.steps[n].inputAttachments` as the source of target binding.
+Rationale: `docs/Tasks/ImageSystem.md` states target meaning comes from the field containing the ref, and prior stories preserved those refs in the authoritative task snapshot. This avoids filename, artifact metadata, or UI heuristics.
+Alternatives considered: Reading artifact links or artifact metadata was rejected because those are observability and access surfaces, not authoritative target-binding state.
+
+## Workspace Paths
+
+Decision: Write objective files under `.moonmind/inputs/objective/<artifactId>-<sanitized-filename>` and step files under `.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>`.
+Rationale: This exactly matches the source design contract and keeps target directories isolated. Prefixing by artifact id preserves determinism even when filenames collide.
+Alternatives considered: A flat `.moonmind/inputs/` directory was rejected because it loses explicit target grouping. Ordering-derived filenames were rejected because unrelated target ordering must not affect paths.
+
+## Stable Step References
+
+Decision: Use explicit step `id` when provided; otherwise derive a deterministic ordinal-based reference such as `step-1`.
+Rationale: The source design requires stable step references when ids are absent. Ordinal-based fallback is deterministic for the canonical payload and matches the step ordinal recorded in the manifest.
+Alternatives considered: Hashing step content was rejected because edits to instructions would change paths for the same ordered step. Random ids were rejected because repeated prepare runs would not be stable.
+
+## Failure Handling
+
+Decision: Treat any download, write, sanitization, or manifest failure as a prepare-stage failure.
+Rationale: Partial materialization would present incomplete runtime context and violates the source requirement. Failing in prepare prevents runtime execution from consuming missing inputs.
+Alternatives considered: Best-effort manifest entries with errors were rejected because the acceptance criteria explicitly require failure, not best-effort success.
+
+## Test Strategy
+
+Decision: Add focused pytest coverage for helper behavior plus a worker prepare boundary test that proves manifest and files are created before execution.
+Rationale: Unit tests can cover path determinism, filename sanitization, stable step refs, and failure modes without requiring Docker. Boundary coverage protects the invocation shape used by the worker.
+Alternatives considered: Only testing low-level helpers was rejected because the story changes prepare-stage behavior. Only integration tests were rejected because they would be slower and less focused for red-first iteration.

--- a/specs/197-attachment-materialization/spec.md
+++ b/specs/197-attachment-materialization/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Materialize Attachment Manifest and Workspace Files
+
+**Feature Branch**: `197-attachment-materialization`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-370 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-370-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-370 from MM project
+Summary: Materialize attachment manifest and workspace files
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-370 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-370: Materialize attachment manifest and workspace files
+
+Source Reference
+- Source Document: `docs/Tasks/ImageSystem.md`
+- Source Title: Task Image Input System
+- Source Sections:
+  - 3.2 Canonical terminology
+  - 4. End-to-end desired-state flow
+  - 8. Prepare-time materialization contract
+- Coverage IDs:
+  - DESIGN-REQ-002
+  - DESIGN-REQ-004
+  - DESIGN-REQ-011
+
+User Story
+As a runtime executor, I need workflow prepare to deterministically download declared input attachments, write a canonical manifest, and place files in target-aware workspace paths before the relevant runtime or step executes.
+
+Acceptance Criteria
+- Prepare downloads all declared input attachments before the relevant runtime or step executes.
+- Prepare writes `.moonmind/attachments_manifest.json` using the canonical manifest entry shape.
+- Objective images are materialized under `.moonmind/inputs/objective/`.
+- Step images are materialized under `.moonmind/inputs/steps/<stepRef>/`.
+- Workspace paths are deterministic and target-aware; one target path does not depend on unrelated target ordering.
+- A stable step reference is assigned when a step has no explicit id.
+- Partial materialization is reported as failure, not best-effort success.
+
+Requirements
+- Include `artifactId`, `filename`, `contentType`, `sizeBytes`, `targetKind`, optional `stepRef`/`stepOrdinal`, `workspacePath`, and optional context/source paths in manifest entries.
+- Sanitize filenames while preserving deterministic artifactId-prefixed paths.
+- Treat execution payload and snapshot refs as the source for materialization.
+- Preserve canonical target meaning from the field that contains each ref: objective-scoped attachments from `task.inputAttachments` and step-scoped attachments from `task.steps[n].inputAttachments`.
+- Materialize objective-scoped attachments under `.moonmind/inputs/objective/<artifactId>-<sanitized-filename>`.
+- Materialize step-scoped attachments under `.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>`.
+- Ensure attachment identity and target meaning do not depend on filename conventions or unrelated target ordering.
+- Keep raw attachment bytes out of Temporal histories and task instruction text; runtime adapters consume structured refs, materialized files, and derived context.
+- Fail explicitly when any declared attachment cannot be downloaded, written, or represented in the manifest.
+
+Relevant Implementation Notes
+- The canonical control-plane field name is `inputAttachments`.
+- The canonical prepared manifest entry shape is `AttachmentManifestEntry` from `docs/Tasks/ImageSystem.md`.
+- Workflow prepare owns deterministic local file materialization.
+- Upload completion and execution snapshot persistence happen before workflow prepare receives refs.
+- The execution API snapshot is the authoritative source for attachment targeting.
+- Runtime adapters consume structured refs and derived context, not browser-local state.
+- Target-aware workspace paths must be stable for objective and step targets independently.
+- If a step has no explicit `id`, the control plane or prepare layer must assign a stable step reference for manifest and path purposes.
+- Partial materialization must stop execution as a failure, preserving diagnostics for the missing or invalid attachment.
+
+Suggested Implementation Areas
+- Workflow prepare or artifact materialization activities that download input attachments.
+- Manifest writer for `.moonmind/attachments_manifest.json`.
+- Workspace path generation and filename sanitization helpers.
+- Stable step reference assignment for steps without explicit ids.
+- Execution payload or snapshot parsing for objective-scoped and step-scoped attachment refs.
+- Failure handling and diagnostics for partial materialization.
+- Unit and workflow/activity-boundary tests covering manifest shape, path determinism, target isolation, and failure behavior.
+
+Validation
+- Verify prepare downloads every declared objective-scoped and step-scoped input attachment before the relevant runtime or step executes.
+- Verify `.moonmind/attachments_manifest.json` includes the canonical fields for every materialized attachment.
+- Verify objective-scoped attachments are written under `.moonmind/inputs/objective/`.
+- Verify step-scoped attachments are written under `.moonmind/inputs/steps/<stepRef>/`.
+- Verify generated workspace paths are deterministic and independent of unrelated target ordering.
+- Verify steps without explicit ids receive stable step references for path and manifest purposes.
+- Verify a missing, invalid, or failed attachment download produces an explicit failure instead of best-effort success.
+- Verify raw attachment bytes are not embedded in Temporal histories or task instruction text.
+
+Non-Goals
+- Generating target-aware vision context artifacts; that is covered by a separate story.
+- Preserving attachment bindings across edit and rerun reconstruction; that is covered by a separate story.
+- Enforcing upload policy, content-type policy, or artifact completion integrity beyond consuming already-declared refs.
+- Inferring target bindings from filenames, artifact links, or artifact metadata.
+- Adding generic non-image attachment support beyond the existing image input materialization contract.
+
+Needs Clarification
+- None
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /moonspec-breakdown for technical designs that contain multiple stories. -->
+
+## User Story - Materialize Attachment Inputs During Prepare
+
+**Summary**: As a runtime executor, I need workflow prepare to deterministically download declared input attachments, write a canonical manifest, and place files in target-aware workspace paths before the relevant runtime or step executes.
+
+**Goal**: Every runtime or step that receives declared image attachments can rely on local files and a canonical manifest that preserve objective-scoped and step-scoped target meaning without depending on filenames, artifact metadata, or unrelated attachment ordering.
+
+**Independent Test**: Start a task-shaped execution containing objective-scoped and step-scoped input attachment refs, including a step without an explicit id, and verify prepare downloads all declared attachments, writes `.moonmind/attachments_manifest.json`, materializes files under deterministic target-aware workspace paths, and fails explicitly if any attachment cannot be materialized.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task execution contains completed objective-scoped input attachment refs, **When** workflow prepare runs, **Then** each declared attachment is downloaded before runtime execution, materialized under `.moonmind/inputs/objective/`, and represented in `.moonmind/attachments_manifest.json` with the canonical manifest fields.
+2. **Given** a task execution contains completed step-scoped input attachment refs, **When** workflow prepare runs, **Then** each declared attachment is downloaded before the relevant step executes, materialized under `.moonmind/inputs/steps/<stepRef>/`, and represented in the manifest with `targetKind`, `stepRef`, and `stepOrdinal` when applicable.
+3. **Given** a step with input attachments has no explicit id, **When** workflow prepare generates workspace paths and manifest entries, **Then** the system assigns a stable step reference so repeated prepare runs for the same payload produce the same step directory and manifest target.
+4. **Given** objective and step attachments are supplied in different target groups or orderings, **When** prepare generates workspace paths, **Then** each target path is deterministic and does not depend on unrelated target ordering.
+5. **Given** any declared attachment cannot be downloaded, written, sanitized, or represented in the manifest, **When** prepare runs, **Then** execution fails explicitly with materialization diagnostics rather than continuing with partial inputs.
+
+### Edge Cases
+
+- Objective-scoped and step-scoped attachments use the same filename.
+- A filename contains unsafe path characters or an empty sanitized basename.
+- Multiple steps omit explicit ids while carrying step-scoped attachments.
+- Attachments are reordered within one target or unrelated targets are added.
+- A download succeeds but local file writing or manifest writing fails.
+- A declared attachment ref is missing a required canonical field.
+
+## Assumptions
+
+- The story is runtime implementation work, not documentation-only work.
+- `docs/Tasks/ImageSystem.md` is treated as source requirements for runtime behavior.
+- Attachment upload policy and artifact completion validation have already accepted the declared refs before prepare runs.
+- The canonical control-plane field remains `inputAttachments`.
+- Objective-scoped attachments are represented by `task.inputAttachments`; step-scoped attachments are represented by `task.steps[n].inputAttachments`.
+- Raw attachment bytes must remain outside task instruction text and Temporal histories.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-002** (Source: `docs/Tasks/ImageSystem.md`, section 3.2; MM-370 brief): The system MUST preserve canonical target meaning from `inputAttachments`, using objective-scoped refs from `task.inputAttachments`, step-scoped refs from `task.steps[n].inputAttachments`, and canonical prepared-manifest fields for every materialized attachment. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-007.
+- **DESIGN-REQ-004** (Source: `docs/Tasks/ImageSystem.md`, section 4; MM-370 brief): Runtime prepare MUST consume structured refs from the execution snapshot, not browser-local state, and prepare MUST complete deterministic materialization before runtime or step execution. Scope: in scope. Maps to FR-001, FR-004, FR-008, FR-010.
+- **DESIGN-REQ-011** (Source: `docs/Tasks/ImageSystem.md`, section 8; MM-370 brief): Workflow prepare MUST download all declared input attachments, write `.moonmind/attachments_manifest.json`, materialize raw files into stable target-aware locations, assign stable step references when needed, and treat partial materialization as failure. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-005, FR-006, FR-009, FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Workflow prepare MUST download every declared objective-scoped and step-scoped input attachment before the relevant runtime or step executes.
+- **FR-002**: Workflow prepare MUST write `.moonmind/attachments_manifest.json` with one manifest entry per materialized attachment.
+- **FR-003**: Each manifest entry MUST include `artifactId`, `filename`, `contentType`, `sizeBytes`, `targetKind`, `workspacePath`, optional `stepRef`, optional `stepOrdinal`, and optional derived context or source paths when those artifacts exist.
+- **FR-004**: Manifest target meaning MUST be derived from the structured field containing the attachment ref, not from filenames, artifact links, artifact metadata, or browser-local state.
+- **FR-005**: Objective-scoped attachments MUST be materialized under `.moonmind/inputs/objective/<artifactId>-<sanitized-filename>`.
+- **FR-006**: Step-scoped attachments MUST be materialized under `.moonmind/inputs/steps/<stepRef>/<artifactId>-<sanitized-filename>`.
+- **FR-007**: Filename sanitization MUST prevent path traversal or unsafe workspace paths while preserving deterministic artifactId-prefixed output names.
+- **FR-008**: Workspace paths MUST be deterministic for a given attachment target and MUST NOT depend on unrelated target ordering.
+- **FR-009**: Steps without explicit ids that carry step-scoped attachments MUST receive stable step references for manifest and workspace path purposes.
+- **FR-010**: Prepare MUST fail explicitly when any declared attachment cannot be downloaded, written, sanitized, or represented in the manifest, and MUST NOT report partial materialization as success.
+- **FR-011**: Raw attachment bytes MUST NOT be embedded in Temporal histories, execution payloads, or task instruction text as part of prepare-time materialization.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-370` and the original Jira preset brief for traceability.
+
+### Key Entities
+
+- **Input Attachment Ref**: A structured reference to an uploaded input attachment, including artifact identity, filename, content type, and byte size.
+- **Attachment Target**: The objective-scoped or step-scoped location that owns an input attachment ref.
+- **Attachment Manifest Entry**: A durable prepare output describing one materialized attachment, its source ref, target binding, local workspace path, and optional derived artifact paths.
+- **Stable Step Reference**: The deterministic identifier used for manifest entries and workspace directories when a step has no explicit id.
+- **Materialized Attachment File**: The local workspace copy of an input attachment available to the runtime or step executor.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated coverage verifies objective-scoped attachments are downloaded, materialized under `.moonmind/inputs/objective/`, and listed in `.moonmind/attachments_manifest.json`.
+- **SC-002**: Automated coverage verifies step-scoped attachments are downloaded, materialized under `.moonmind/inputs/steps/<stepRef>/`, and listed in the manifest with step target fields.
+- **SC-003**: Automated coverage verifies steps without explicit ids receive stable step references for manifest and path generation.
+- **SC-004**: Automated coverage verifies workspace paths are deterministic and independent of unrelated target ordering.
+- **SC-005**: Automated coverage verifies unsafe filenames are sanitized without losing deterministic artifactId-prefixed naming.
+- **SC-006**: Automated coverage verifies missing, invalid, or failed attachment materialization produces an explicit failure and does not report partial success.
+- **SC-007**: Final verification confirms `MM-370` and the original Jira preset brief are preserved in the active MoonSpec artifacts and delivery metadata.

--- a/specs/197-attachment-materialization/tasks.md
+++ b/specs/197-attachment-materialization/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
 - Integration tests: `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -89,8 +89,8 @@
 ## Phase 4: Polish & Verification
 
 - [X] T018 [P] Review `specs/197-attachment-materialization/quickstart.md` against the implemented commands and update only if command evidence changes (SC-007)
-- [X] T019 Create `specs/197-attachment-materialization/verification.md` with implementation evidence, test results, MM-370 traceability, and `/speckit.verify` verdict (FR-012, SC-007)
-- [X] T020 Run final `/speckit.verify` equivalent against `specs/197-attachment-materialization/spec.md` and preserve MM-370 in verification output (FR-012)
+- [X] T019 Create `specs/197-attachment-materialization/verification.md` with implementation evidence, test results, MM-370 traceability, and `/moonspec-verify` verdict (FR-012, SC-007)
+- [X] T020 Run final `/moonspec-verify` equivalent against `specs/197-attachment-materialization/spec.md` and preserve MM-370 in verification output (FR-012)
 
 ---
 

--- a/specs/197-attachment-materialization/tasks.md
+++ b/specs/197-attachment-materialization/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: Materialize Attachment Manifest and Workspace Files
+
+**Input**: Design documents from `/specs/197-attachment-materialization/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style worker boundary tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-370 story so prepare-time materialization remains independently testable.
+
+**Source Traceability**: Tasks cover FR-001 through FR-012, acceptance scenarios 1-5, edge cases, SC-001 through SC-007, and DESIGN-REQ-002, DESIGN-REQ-004, and DESIGN-REQ-011.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
+- Integration tests: `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup
+
+**Purpose**: Verify target files and testing location.
+
+- [X] T001 Verify existing worker prepare stage in `moonmind/agents/codex_worker/worker.py` and create focused test file `tests/unit/agents/codex_worker/test_attachment_materialization.py` if absent (FR-001, DESIGN-REQ-004)
+- [X] T002 Confirm `.specify/feature.json` points to `specs/197-attachment-materialization` and MM-370 is preserved in `specs/197-attachment-materialization/spec.md` (FR-012, SC-007)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Establish the prepare materialization helper contract before story behavior.
+
+- [X] T003 Define the attachment materialization helper surface in `moonmind/agents/codex_worker/worker.py` for collecting objective/step refs, deriving stable step refs, sanitizing filenames, computing workspace paths, downloading bytes, and writing manifest entries (FR-001-FR-010)
+
+**Checkpoint**: Helper surface identified; story tests and implementation can begin.
+
+---
+
+## Phase 3: Story - Materialize Attachment Inputs During Prepare
+
+**Summary**: As a runtime executor, I need workflow prepare to deterministically download declared input attachments, write a canonical manifest, and place files in target-aware workspace paths before the relevant runtime or step executes.
+
+**Independent Test**: Start a task-shaped execution payload containing objective-scoped and step-scoped input attachment refs, including a step without an explicit id, and verify prepare downloads all declared attachments, writes `.moonmind/attachments_manifest.json`, materializes files under deterministic target-aware workspace paths, and fails explicitly if any attachment cannot be materialized.
+
+**Traceability**: FR-001-FR-012; SC-001-SC-007; acceptance scenarios 1-5; DESIGN-REQ-002, DESIGN-REQ-004, DESIGN-REQ-011
+
+**Test Plan**:
+
+- Unit: ref collection, filename sanitization, stable step refs, deterministic workspace paths, manifest shape, and failure behavior.
+- Integration-style boundary: `_run_prepare_stage` writes `.moonmind/attachments_manifest.json` and materialized files before returning `PreparedTaskWorkspace`.
+
+### Unit Tests (write first) ⚠️
+
+- [X] T004 [P] Add failing unit tests for objective and step ref collection plus canonical manifest fields in `tests/unit/agents/codex_worker/test_attachment_materialization.py` (FR-001, FR-002, FR-003, FR-004, SC-001, SC-002, DESIGN-REQ-002)
+- [X] T005 [P] Add failing unit tests for deterministic workspace paths, unsafe filename sanitization, repeated filenames, and unrelated target ordering in `tests/unit/agents/codex_worker/test_attachment_materialization.py` (FR-005, FR-006, FR-007, FR-008, SC-004, SC-005, DESIGN-REQ-011)
+- [X] T006 [P] Add failing unit tests for stable fallback step references when step ids are absent in `tests/unit/agents/codex_worker/test_attachment_materialization.py` (FR-009, SC-003, DESIGN-REQ-011)
+- [X] T007 [P] Add failing unit test for explicit prepare failure on download failure or malformed refs in `tests/unit/agents/codex_worker/test_attachment_materialization.py` (FR-010, SC-006, acceptance scenario 5)
+
+### Integration Tests (write first) ⚠️
+
+- [X] T008 Add failing worker prepare boundary test proving `_run_prepare_stage` writes `.moonmind/attachments_manifest.json`, objective files, and step files before returning in `tests/unit/agents/codex_worker/test_attachment_materialization.py` (FR-001-FR-006, SC-001, SC-002, DESIGN-REQ-004)
+
+### Red-First Confirmation ⚠️
+
+- [X] T009 Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and confirm the new tests fail for missing materialization behavior before production changes (T004-T008)
+
+### Implementation
+
+- [X] T010 Implement attachment ref collection and stable target derivation in `moonmind/agents/codex_worker/worker.py` (FR-001, FR-004, FR-009, DESIGN-REQ-002)
+- [X] T011 Implement filename sanitization and deterministic workspace path generation in `moonmind/agents/codex_worker/worker.py` (FR-005, FR-006, FR-007, FR-008, DESIGN-REQ-011)
+- [X] T012 Implement artifact download and local file writing through the worker's trusted API client in `moonmind/agents/codex_worker/worker.py` (FR-001, FR-005, FR-006, DESIGN-REQ-004)
+- [X] T013 Implement `.moonmind/attachments_manifest.json` writing with canonical manifest entries in `moonmind/agents/codex_worker/worker.py` (FR-002, FR-003, SC-001, SC-002)
+- [X] T014 Implement explicit materialization failure handling and prepare-stage diagnostics in `moonmind/agents/codex_worker/worker.py` (FR-010, SC-006)
+- [X] T015 Wire materialization into `_run_prepare_stage` before `task_context.json` completion and include manifest path metadata without embedding bytes in `moonmind/agents/codex_worker/worker.py` (FR-011, acceptance scenarios 1-4)
+
+### Story Validation
+
+- [X] T016 Run `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` and fix failures until the story passes (SC-001-SC-006)
+- [X] T017 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification or document the exact blocker (FR-001-FR-012)
+
+**Checkpoint**: The MM-370 story is fully functional, covered by unit and worker boundary tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Verification
+
+- [X] T018 [P] Review `specs/197-attachment-materialization/quickstart.md` against the implemented commands and update only if command evidence changes (SC-007)
+- [X] T019 Create `specs/197-attachment-materialization/verification.md` with implementation evidence, test results, MM-370 traceability, and `/speckit.verify` verdict (FR-012, SC-007)
+- [X] T020 Run final `/speckit.verify` equivalent against `specs/197-attachment-materialization/spec.md` and preserve MM-370 in verification output (FR-012)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish & Verification (Phase 4)**: Depends on story validation.
+
+### Within The Story
+
+- Unit and boundary tests (T004-T008) must be written before implementation.
+- Red-first confirmation (T009) must happen before production implementation tasks T010-T015.
+- Ref collection and path helpers (T010-T011) precede download and manifest wiring (T012-T015).
+- Story validation (T016-T017) follows implementation.
+
+### Parallel Opportunities
+
+- T004-T007 can be authored in parallel because they cover independent behaviors in one test file but should be applied sequentially to avoid edit conflicts.
+- T018 can run in parallel with verification drafting only after story tests pass.
+
+---
+
+## Implementation Strategy
+
+1. Add tests describing the target contract in the focused worker test file.
+2. Confirm tests fail before production changes.
+3. Implement small helper functions in `moonmind/agents/codex_worker/worker.py` and wire them into `_run_prepare_stage`.
+4. Run focused tests until passing.
+5. Run full unit verification, then document final verification evidence.

--- a/specs/197-attachment-materialization/verification.md
+++ b/specs/197-attachment-materialization/verification.md
@@ -55,4 +55,4 @@
 
 ## Final Verdict
 
-The MM-370 single-story runtime feature is implemented and verified against the preserved Jira preset brief. The implementation satisfies the one-story spec, source design mappings, and required unit/worker-boundary evidence.
+The MM-370 single-story runtime feature is implemented and verified against the preserved Jira preset brief. The implementation satisfies the one-story spec, source design mappings, and required unit/worker-boundary evidence through the `/moonspec-verify` equivalent recorded here.

--- a/specs/197-attachment-materialization/verification.md
+++ b/specs/197-attachment-materialization/verification.md
@@ -1,0 +1,58 @@
+# MoonSpec Verification Report
+
+**Feature**: Materialize Attachment Manifest and Workspace Files  
+**Spec**: `specs/197-attachment-materialization/spec.md`  
+**Original Request Source**: `spec.md` Input and MM-370 Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Focused unit and worker boundary | `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` | PASS | 7 Python tests passed; runner also executed frontend Vitest with 10 files and 256 tests passed. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3499 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest then passed 10 files and 256 tests. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | Docker socket unavailable: `unix:///var/run/docker.sock` did not exist in this managed workspace. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `CodexWorker._materialize_input_attachments`; `test_materialize_input_attachments_writes_files_and_manifest`; `test_prepare_stage_materializes_attachments_before_return` | VERIFIED | Declared objective and step attachments are downloaded before prepare returns. |
+| FR-002 | `CodexWorker._materialize_input_attachments`; manifest assertions in focused tests | VERIFIED | `.moonmind/attachments_manifest.json` is written with one entry per materialized attachment. |
+| FR-003 | `CodexWorker._attachment_manifest_entry`; manifest assertions in focused tests | VERIFIED | Canonical fields are present, with step metadata only for step targets. |
+| FR-004 | `CodexWorker._collect_input_attachment_targets`; target field tests | VERIFIED | Target meaning is derived from `task.inputAttachments` and `task.steps[n].inputAttachments`. |
+| FR-005 | `CodexWorker._attachment_workspace_relative_path`; objective path assertions | VERIFIED | Objective attachments materialize under `.moonmind/inputs/objective/`. |
+| FR-006 | `CodexWorker._attachment_workspace_relative_path`; step path assertions | VERIFIED | Step attachments materialize under `.moonmind/inputs/steps/<stepRef>/`. |
+| FR-007 | `_sanitize_attachment_workspace_segment`; unsafe filename tests | VERIFIED | Path traversal and unsafe filename characters are sanitized while preserving artifact id prefixes. |
+| FR-008 | Path determinism test with unrelated target insertion | VERIFIED | Existing target paths do not change when an unrelated target is added. |
+| FR-009 | `_attachment_step_ref`; fallback step reference tests | VERIFIED | Missing step ids receive stable ordinal fallback refs such as `step-2`. |
+| FR-010 | Download failure test and prepare failure path | VERIFIED | Missing downloads raise explicit prepare materialization errors and do not produce success. |
+| FR-011 | Implementation writes bytes only to local workspace files and stores only manifest path/count in task context | VERIFIED | No raw bytes are embedded in task context, payload, or instructions by this implementation. |
+| FR-012 | MM-370 preserved in spec, plan, tasks, quickstart, and this verification report | VERIFIED | Delivery metadata should also preserve MM-370 when a commit or PR is created. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| Objective attachments materialize before runtime | Focused materialization and prepare-stage boundary tests | VERIFIED | Files and manifest entries are present before `_run_prepare_stage` returns. |
+| Step attachments materialize before relevant step | Focused materialization and prepare-stage boundary tests | VERIFIED | Step manifest entries include `stepRef` and `stepOrdinal`. |
+| Missing step id receives stable step reference | `test_collect_attachment_targets_preserves_canonical_target_fields` | VERIFIED | Fallback refs are deterministic for the canonical step ordinal. |
+| Workspace paths independent of unrelated target ordering | `test_attachment_workspace_paths_do_not_depend_on_unrelated_target_order` | VERIFIED | Existing paths remain stable after adding an unrelated objective attachment. |
+| Partial materialization fails explicitly | `test_materialize_input_attachments_fails_on_download_error` | VERIFIED | Missing artifact download raises a prepare materialization error. |
+
+## Source Design Coverage
+
+| Source Requirement | Evidence | Status | Notes |
+|--------------------|----------|--------|-------|
+| DESIGN-REQ-002 | Target collection and manifest entry tests | VERIFIED | Canonical target meaning and manifest shape are preserved. |
+| DESIGN-REQ-004 | `_run_prepare_stage` boundary test | VERIFIED | Prepare consumes structured refs and materializes before runtime execution can begin. |
+| DESIGN-REQ-011 | Path, manifest, fallback step ref, and failure tests | VERIFIED | Prepare downloads all declared refs, writes the manifest, uses stable paths, and fails partial materialization. |
+
+## Risks
+
+- `./tools/test_integration.sh` could not run because Docker is unavailable in this managed worker. The story-specific worker boundary is covered in the unit suite; run hermetic integration in a Docker-enabled environment before merge if required by branch policy.
+
+## Final Verdict
+
+The MM-370 single-story runtime feature is implemented and verified against the preserved Jira preset brief. The implementation satisfies the one-story spec, source design mappings, and required unit/worker-boundary evidence.

--- a/tests/unit/agents/codex_worker/test_attachment_materialization.py
+++ b/tests/unit/agents/codex_worker/test_attachment_materialization.py
@@ -12,7 +12,6 @@ from moonmind.agents.codex_worker.handlers import WorkerExecutionResult
 from moonmind.agents.codex_worker.worker import (
     CodexWorker,
     CodexWorkerConfig,
-    QueueSystemStatus,
 )
 
 

--- a/tests/unit/agents/codex_worker/test_attachment_materialization.py
+++ b/tests/unit/agents/codex_worker/test_attachment_materialization.py
@@ -1,0 +1,325 @@
+"""Tests for prepare-time task input attachment materialization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from moonmind.agents.codex_worker.handlers import WorkerExecutionResult
+from moonmind.agents.codex_worker.worker import (
+    CodexWorker,
+    CodexWorkerConfig,
+    QueueSystemStatus,
+)
+
+
+class _FakeQueueClient:
+    def __init__(self, downloads: dict[str, bytes] | None = None) -> None:
+        self.downloads = dict(downloads or {})
+        self.events: list[dict[str, object]] = []
+        self.live_session_reports: list[dict[str, object]] = []
+        self.live_session_state: dict[str, object] | None = None
+        self.live_session_heartbeats: list[str] = []
+
+    async def download_artifact(self, *, artifact_id: str) -> bytes:
+        try:
+            return self.downloads[artifact_id]
+        except KeyError as exc:
+            raise RuntimeError(f"missing artifact: {artifact_id}") from exc
+
+    async def append_event(self, *, job_id, worker_id, level, message, payload=None):
+        self.events.append(
+            {
+                "job_id": str(job_id),
+                "worker_id": worker_id,
+                "level": level,
+                "message": message,
+                "payload": payload or {},
+            }
+        )
+
+    async def report_live_session(self, **payload):
+        self.live_session_reports.append(dict(payload))
+        status = str(payload.get("status") or "").strip().lower()
+        if status:
+            self.live_session_state = {"session": {"status": status}}
+        return self.live_session_state or {}
+
+    async def heartbeat_live_session(self, *, job_id, worker_id):
+        self.live_session_heartbeats.append(str(job_id))
+        return self.live_session_state or {}
+
+
+class _FakeHandler:
+    async def handle(
+        self, *, job_id, payload, cancel_event=None, output_chunk_callback=None
+    ):
+        return WorkerExecutionResult(succeeded=True, summary="ok", error_message=None)
+
+
+def _worker(tmp_path: Path, queue: _FakeQueueClient | None = None) -> CodexWorker:
+    return CodexWorker(
+        config=CodexWorkerConfig(
+            moonmind_url="http://localhost:5000",
+            worker_id="worker-1",
+            worker_token=None,
+            poll_interval_ms=100,
+            lease_seconds=120,
+            workdir=tmp_path,
+        ),
+        queue_client=queue or _FakeQueueClient(),  # type: ignore[arg-type]
+        codex_exec_handler=_FakeHandler(),  # type: ignore[arg-type]
+    )
+
+
+def _canonical_payload() -> dict[str, object]:
+    return {
+        "repository": "https://example.test/repo.git",
+        "targetRuntime": "codex",
+        "task": {
+            "inputAttachments": [
+                {
+                    "artifactId": "art_objective",
+                    "filename": "../Objective Diagram.png",
+                    "contentType": "image/png",
+                    "sizeBytes": 3,
+                }
+            ],
+            "steps": [
+                {
+                    "id": "review-step",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_step",
+                            "filename": "screen/shot.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 4,
+                        }
+                    ],
+                },
+                {
+                    "instructions": "No id",
+                    "inputAttachments": [
+                        {
+                            "artifactId": "art_no_id",
+                            "filename": "same.png",
+                            "contentType": "image/png",
+                            "sizeBytes": 5,
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def test_collect_attachment_targets_preserves_canonical_target_fields(
+    tmp_path: Path,
+) -> None:
+    worker = _worker(tmp_path)
+
+    targets = worker._collect_input_attachment_targets(_canonical_payload())
+
+    assert [target.target_kind for target in targets] == ["objective", "step", "step"]
+    assert targets[0].artifact_id == "art_objective"
+    assert targets[0].step_ref is None
+    assert targets[1].step_ref == "review-step"
+    assert targets[1].step_ordinal == 0
+    assert targets[2].step_ref == "step-2"
+    assert targets[2].step_ordinal == 1
+
+
+def test_attachment_workspace_paths_are_target_aware_and_sanitized(
+    tmp_path: Path,
+) -> None:
+    worker = _worker(tmp_path)
+    targets = worker._collect_input_attachment_targets(_canonical_payload())
+
+    paths = [
+        worker._attachment_workspace_relative_path(target).as_posix()
+        for target in targets
+    ]
+
+    assert paths == [
+        ".moonmind/inputs/objective/art_objective-Objective_Diagram.png",
+        ".moonmind/inputs/steps/review-step/art_step-shot.png",
+        ".moonmind/inputs/steps/step-2/art_no_id-same.png",
+    ]
+
+
+def test_attachment_workspace_paths_do_not_depend_on_unrelated_target_order(
+    tmp_path: Path,
+) -> None:
+    worker = _worker(tmp_path)
+    original = _canonical_payload()
+    reordered = _canonical_payload()
+    task = reordered["task"]
+    assert isinstance(task, dict)
+    task["inputAttachments"] = [
+        {
+            "artifactId": "art_other",
+            "filename": "other.png",
+            "contentType": "image/png",
+            "sizeBytes": 1,
+        },
+        *task["inputAttachments"],
+    ]
+
+    original_paths = {
+        target.artifact_id: worker._attachment_workspace_relative_path(
+            target
+        ).as_posix()
+        for target in worker._collect_input_attachment_targets(original)
+    }
+    reordered_paths = {
+        target.artifact_id: worker._attachment_workspace_relative_path(
+            target
+        ).as_posix()
+        for target in worker._collect_input_attachment_targets(reordered)
+    }
+
+    assert reordered_paths["art_objective"] == original_paths["art_objective"]
+    assert reordered_paths["art_step"] == original_paths["art_step"]
+    assert reordered_paths["art_no_id"] == original_paths["art_no_id"]
+
+
+def test_collect_attachment_targets_rejects_malformed_refs(tmp_path: Path) -> None:
+    worker = _worker(tmp_path)
+    payload = _canonical_payload()
+    task = payload["task"]
+    assert isinstance(task, dict)
+    task["inputAttachments"] = [{"artifactId": "art_missing_filename"}]
+
+    with pytest.raises(ValueError, match="filename is required"):
+        worker._collect_input_attachment_targets(payload)
+
+
+@pytest.mark.asyncio
+async def test_materialize_input_attachments_writes_files_and_manifest(
+    tmp_path: Path,
+) -> None:
+    queue = _FakeQueueClient(
+        {
+            "art_objective": b"one",
+            "art_step": b"step",
+            "art_no_id": b"no-id",
+        }
+    )
+    worker = _worker(tmp_path, queue)
+    repo_dir = tmp_path / "job" / "repo"
+    repo_dir.mkdir(parents=True)
+
+    manifest_path = await worker._materialize_input_attachments(
+        job_id=uuid4(),
+        canonical_payload=_canonical_payload(),
+        repo_dir=repo_dir,
+        prepare_log_path=tmp_path / "prepare.log",
+    )
+
+    assert manifest_path == repo_dir / ".moonmind" / "attachments_manifest.json"
+    assert (
+        repo_dir / ".moonmind/inputs/objective/art_objective-Objective_Diagram.png"
+    ).read_bytes() == b"one"
+    assert (
+        repo_dir / ".moonmind/inputs/steps/review-step/art_step-shot.png"
+    ).read_bytes() == b"step"
+    assert (
+        repo_dir / ".moonmind/inputs/steps/step-2/art_no_id-same.png"
+    ).read_bytes() == b"no-id"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["version"] == 1
+    assert manifest["attachments"] == [
+        {
+            "artifactId": "art_objective",
+            "filename": "../Objective Diagram.png",
+            "contentType": "image/png",
+            "sizeBytes": 3,
+            "targetKind": "objective",
+            "workspacePath": (
+                ".moonmind/inputs/objective/"
+                "art_objective-Objective_Diagram.png"
+            ),
+        },
+        {
+            "artifactId": "art_step",
+            "filename": "screen/shot.png",
+            "contentType": "image/png",
+            "sizeBytes": 4,
+            "targetKind": "step",
+            "stepRef": "review-step",
+            "stepOrdinal": 0,
+            "workspacePath": ".moonmind/inputs/steps/review-step/art_step-shot.png",
+        },
+        {
+            "artifactId": "art_no_id",
+            "filename": "same.png",
+            "contentType": "image/png",
+            "sizeBytes": 5,
+            "targetKind": "step",
+            "stepRef": "step-2",
+            "stepOrdinal": 1,
+            "workspacePath": ".moonmind/inputs/steps/step-2/art_no_id-same.png",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_materialize_input_attachments_fails_on_download_error(
+    tmp_path: Path,
+) -> None:
+    worker = _worker(tmp_path, _FakeQueueClient({}))
+    repo_dir = tmp_path / "job" / "repo"
+    repo_dir.mkdir(parents=True)
+
+    with pytest.raises(
+        RuntimeError, match="failed to materialize input attachment art_objective"
+    ):
+        await worker._materialize_input_attachments(
+            job_id=uuid4(),
+            canonical_payload=_canonical_payload(),
+            repo_dir=repo_dir,
+            prepare_log_path=tmp_path / "prepare.log",
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_stage_materializes_attachments_before_return(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    queue = _FakeQueueClient(
+        {
+            "art_objective": b"one",
+            "art_step": b"step",
+            "art_no_id": b"no-id",
+        }
+    )
+    worker = _worker(tmp_path, queue)
+
+    async def _noop_git_identity(**kwargs):
+        return None
+
+    monkeypatch.setattr(
+        worker, "_run_prepare_git_identity_preflight", _noop_git_identity
+    )
+
+    prepared = await worker._run_prepare_stage(
+        job_id=uuid4(),
+        canonical_payload=_canonical_payload(),
+        source_payload={"workdirMode": "existing"},
+        selected_skills=[],
+        job_type="task",
+        skill_meta={},
+    )
+
+    manifest_path = prepared.repo_dir / ".moonmind" / "attachments_manifest.json"
+    assert manifest_path.exists()
+    assert (
+        prepared.repo_dir
+        / ".moonmind/inputs/objective/art_objective-Objective_Diagram.png"
+    ).exists()
+    task_context = json.loads(prepared.task_context_path.read_text(encoding="utf-8"))
+    assert task_context["attachments"]["manifestPath"] == str(manifest_path)
+    assert task_context["attachments"]["count"] == 3


### PR DESCRIPTION
## Jira
- Issue: MM-370

## Active MoonSpec
- Feature path: `specs/197-attachment-materialization`

## Summary
- Implements attachment materialization for the Codex worker prepare stage.
- Downloads canonical objective and step input attachments into `.moonmind/inputs/...` before runtime execution.
- Writes `.moonmind/attachments_manifest.json` with target metadata, stable sanitized paths, and explicit partial-materialization failure behavior.

## Verification Verdict
- MoonSpec verification: `FULLY_IMPLEMENTED`
- Verification report: `specs/197-attachment-materialization/verification.md`

## Tests Run
- `./tools/test_unit.sh tests/unit/agents/codex_worker/test_attachment_materialization.py` PASS
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` PASS
- `python -m py_compile moonmind/agents/codex_worker/worker.py tests/unit/agents/codex_worker/test_attachment_materialization.py` PASS
- `git diff --check moonmind/agents/codex_worker/worker.py tests/unit/agents/codex_worker/test_attachment_materialization.py specs/197-attachment-materialization` PASS

## Remaining Risks
- `./tools/test_integration.sh` could not run in this managed workspace because the Docker socket was unavailable at `/var/run/docker.sock`. Story-specific worker boundary coverage is included in the unit suite; run hermetic integration in a Docker-enabled environment before merge if branch policy requires it.