### PR TITLE
MM-381 Jira import declared targets

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/199-policy-gated-image-upload"
+  "feature_directory": "specs/200-jira-import-declared-targets"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md
@@ -1,0 +1,111 @@
+# MM-381 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-381
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Jira Import Into Declared Targets
+- Labels: `moonmind-workflow-mm-5818081f-60f0-45dd-ad16-3f7753de93ae`
+- Trusted fetch tool: `jira.get_issue`
+- Normalized detail source: `/api/jira/issues/MM-381`
+- Canonical source: `recommendedImports.presetInstructions` from the normalized trusted Jira issue detail response.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-381 from MM project
+Summary: Jira Import Into Declared Targets
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-381 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-381: Jira Import Into Declared Targets
+
+Source Reference
+Source Document: docs/UI/CreatePage.md
+Source Title: Create Page
+Source Sections:
+- 12. Jira integration contract
+- 16. Failure and empty-state rules
+- 17. Accessibility and interaction rules
+- 18. Testing requirements
+Coverage IDs:
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-003
+- DESIGN-REQ-010
+- DESIGN-REQ-012
+- DESIGN-REQ-015
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+- DESIGN-REQ-024
+- DESIGN-REQ-025
+As a task author, I can browse Jira as an external instruction source and explicitly import issue text or supported images into a declared Create page target without automatic draft mutation.
+
+## Normalized Jira Detail
+
+Acceptance criteria:
+- Given I open Jira from a Create page field, then the browser preselects that matching target and displays the current target explicitly.
+- Given I select a Jira issue, then the draft does not mutate until I confirm a text or image import action.
+- Given I switch import targets inside the Jira browser, then the selected issue remains selected.
+- Given I import text, then I can choose Replace target text or Append to target text for preset objective text or a step instruction target.
+- Given I import supported Jira images, then selected images become structured attachments on the selected objective or step attachment target and are not injected as markdown, HTML, or inline data.
+- Given Jira is unavailable or the issue fetch fails, then the draft is not mutated and I can continue manual authoring.
+- Given import succeeds, then focus returns predictably to the updated field or an explicit success notice.
+
+Requirements:
+- Support Jira import targets for preset objective text, preset objective attachments, step text, and step attachments.
+- Require explicit confirmation for all Jira text and image imports.
+- Preserve selected issue state while switching targets inside the browser.
+- Import Jira images only as structured attachments on the declared target.
+- Mark already-applied preset state as needing reapply when importing into preset objective text or attachment targets.
+- Detach template-bound steps when Jira text or images import into them.
+- Keep Jira access behind MoonMind APIs and separate from task execution substrate behavior.
+- Cover explicit import, no-mutation-before-confirm, image target mapping, template detachment, focus return, and failure behavior in tests.
+
+Recommended step instructions:
+
+Complete Jira issue MM-381: Jira Import Into Declared Targets
+
+Description
+Source Reference
+Source Document: docs/UI/CreatePage.md
+Source Title: Create Page
+Source Sections:
+- 12. Jira integration contract
+- 16. Failure and empty-state rules
+- 17. Accessibility and interaction rules
+- 18. Testing requirements
+Coverage IDs:
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-003
+- DESIGN-REQ-010
+- DESIGN-REQ-012
+- DESIGN-REQ-015
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+- DESIGN-REQ-024
+- DESIGN-REQ-025
+As a task author, I can browse Jira as an external instruction source and explicitly import issue text or supported images into a declared Create page target without automatic draft mutation.
+
+Acceptance criteria
+- Given I open Jira from a Create page field, then the browser preselects that matching target and displays the current target explicitly.
+- Given I select a Jira issue, then the draft does not mutate until I confirm a text or image import action.
+- Given I switch import targets inside the Jira browser, then the selected issue remains selected.
+- Given I import text, then I can choose Replace target text or Append to target text for preset objective text or a step instruction target.
+- Given I import supported Jira images, then selected images become structured attachments on the selected objective or step attachment target and are not injected as markdown, HTML, or inline data.
+- Given Jira is unavailable or the issue fetch fails, then the draft is not mutated and I can continue manual authoring.
+- Given import succeeds, then focus returns predictably to the updated field or an explicit success notice.
+Requirements
+- Support Jira import targets for preset objective text, preset objective attachments, step text, and step attachments.
+- Require explicit confirmation for all Jira text and image imports.
+- Preserve selected issue state while switching targets inside the browser.
+- Import Jira images only as structured attachments on the declared target.
+- Mark already-applied preset state as needing reapply when importing into preset objective text or attachment targets.
+- Detach template-bound steps when Jira text or images import into them.
+- Keep Jira access behind MoonMind APIs and separate from task execution substrate behavior.
+- Cover explicit import, no-mutation-before-confirm, image target mapping, template detachment, focus return, and failure behavior in tests.

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -6771,6 +6771,71 @@ describe("Task Create Entrypoint", () => {
     expect(thirdStep.value).toBe("Keep tertiary instructions.");
   });
 
+  it("switches the Jira import target inside the browser before importing", async () => {
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    const primaryStep = await screen.findByLabelText("Instructions");
+    fireEvent.change(primaryStep, {
+      target: { value: "Keep the primary step." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Step" }));
+    const secondStep = screen.getAllByLabelText("Instructions")[1];
+    if (!secondStep) {
+      throw new Error("Expected second step instructions field.");
+    }
+    fireEvent.change(secondStep, {
+      target: { value: "Replace this secondary step." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 instructions",
+      }),
+    );
+    fireEvent.change(await screen.findByLabelText("Import target"), {
+      target: { value: "step-text:step-2" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect((primaryStep as HTMLTextAreaElement).value).toBe(
+      "Keep the primary step.",
+    );
+    expect((secondStep as HTMLTextAreaElement).value).toBe(
+      "Replace this secondary step.\n\n---\n\nComplete Jira issue ENG-202: Build browser shell",
+    );
+  });
+
+  it("replaces step text when Jira text import mode is replace", async () => {
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    const stepInstructions = await screen.findByLabelText("Instructions");
+    fireEvent.change(stepInstructions, {
+      target: { value: "Replace this step text." },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 instructions",
+      }),
+    );
+    fireEvent.change(await screen.findByLabelText("Text import"), {
+      target: { value: "replace" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect((stepInstructions as HTMLTextAreaElement).value).toBe(
+      "Complete Jira issue ENG-202: Build browser shell",
+    );
+  });
+
   it("uses execution brief text for step-target Jira imports", async () => {
     renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
 
@@ -7281,6 +7346,143 @@ describe("Task Create Entrypoint", () => {
     expect(
       screen.getByRole("dialog", { name: "Browse Jira issue" }),
     ).toBeTruthy();
+  });
+
+  it("imports Jira images into the objective attachment target without changing text", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["fake image"], { type: "image/png" }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    const presetInstructions = await screen.findByLabelText(
+      "Feature Request / Initial Instructions",
+    );
+    fireEvent.change(presetInstructions, {
+      target: { value: "Keep objective text." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for objective attachments",
+      }),
+    );
+    expect(
+      (await screen.findByLabelText("Import target") as HTMLSelectElement).value,
+    ).toBe("preset-attachments");
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect((presetInstructions as HTMLTextAreaElement).value).toBe(
+      "Keep objective text.",
+    );
+    expect(await screen.findByText("wireframe.png")).toBeTruthy();
+  });
+
+  it("imports Jira images into a step attachment target", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["fake image"], { type: "image/png" }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    const stepInstructions = await screen.findByLabelText("Instructions");
+    fireEvent.change(stepInstructions, {
+      target: { value: "Keep step text." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 attachments",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect((stepInstructions as HTMLTextAreaElement).value).toBe(
+      "Keep step text.",
+    );
+    expect(await screen.findByText("wireframe.png")).toBeTruthy();
   });
 
   it("reopens Jira from an imported field with the prior issue selected", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -7311,7 +7311,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issue for objective attachments",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7331,7 +7331,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issue for Step 1 attachments",
       }),
     );
     expect(
@@ -7483,6 +7483,193 @@ describe("Task Create Entrypoint", () => {
       "Keep step text.",
     );
     expect(await screen.findByText("wireframe.png")).toBeTruthy();
+  });
+
+  it("does not import Jira images when importing into text targets", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    let attachmentDownloads = 0;
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        attachmentDownloads += 1;
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["fake image"], { type: "image/png" }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Browse Jira issue for preset instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 instructions",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect(attachmentDownloads).toBe(0);
+    expect(screen.queryByText("wireframe.png")).toBeNull();
+    expect(
+      (screen.getByLabelText(
+        "Feature Request / Initial Instructions",
+      ) as HTMLTextAreaElement).value,
+    ).toBe("ENG-202: Build browser shell\n\nLet operators browse Jira stories.");
+    expect((screen.getByLabelText("Instructions") as HTMLTextAreaElement).value).toBe(
+      "Complete Jira issue ENG-202: Build browser shell",
+    );
+  });
+
+  it("detaches template step identity and records provenance after Jira step attachment import", async () => {
+    const defaultFetch = fetchSpy.getMockImplementation();
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const path = url.split("?")[0];
+      if (path === "/api/jira/issues/ENG-202") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            issueKey: "ENG-202",
+            summary: "Build browser shell",
+            issueType: "Story",
+            column: { id: "doing", name: "Doing" },
+            status: { id: "3", name: "In Progress" },
+            descriptionText: "Let operators browse Jira stories.",
+            recommendedImports: {
+              presetInstructions:
+                "ENG-202: Build browser shell\n\nLet operators browse Jira stories.",
+              stepInstructions:
+                "Complete Jira issue ENG-202: Build browser shell",
+            },
+            attachments: [
+              {
+                id: "img-1",
+                filename: "wireframe.png",
+                contentType: "image/png",
+                sizeBytes: 10,
+                downloadUrl: "/api/jira/attachments/wireframe.png",
+              },
+            ],
+          }),
+        } as Response);
+      }
+      if (path === "/api/jira/attachments/wireframe.png") {
+        return Promise.resolve({
+          ok: true,
+          blob: async () => new Blob(["fake image"], { type: "image/png" }),
+        } as Response);
+      }
+      return defaultFetch?.(input, init) ?? Promise.reject(new Error("fetch missing"));
+    });
+    renderWithClient(
+      <TaskCreatePage payload={withAttachmentPolicy(withJiraIntegration())} />,
+    );
+
+    const presetSelect = await screen.findByLabelText("Preset");
+    await waitFor(() => {
+      expect(
+        Array.from((presetSelect as HTMLSelectElement).options).some(
+          (option) => option.text === "Spec Kit Demo (Global)",
+        ),
+      ).toBe(true);
+    });
+    fireEvent.change(presetSelect, {
+      target: { value: "global::::speckit-demo" },
+    });
+    fireEvent.change(
+      screen.getByLabelText("Feature Request / Initial Instructions"),
+      {
+        target: { value: "Task Create" },
+      },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await screen.findByDisplayValue(
+      "Clarify the {{ inputs.feature_name }} scope.",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Browse Jira issue for Step 1 attachments",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
+    fireEvent.click(await screen.findByRole("button", { name: /ENG-202/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Browse Jira issue" })).toBeNull();
+    });
+
+    expect(await screen.findByText("wireframe.png")).toBeTruthy();
+    expect(
+      screen.getByLabelText("Jira import provenance for Step 1 instructions")
+        .textContent,
+    ).toBe("Jira: ENG-202");
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const request = latestCreateRequest();
+    const task = request.payload as {
+      task: { steps: Array<Record<string, unknown>> };
+    };
+    expect([undefined, null, ""]).toContain(task.task.steps[0]?.id);
+    expect(task.task.steps[0]?.inputAttachments).toEqual([
+      {
+        artifactId: "art-001",
+        filename: "wireframe.png",
+        contentType: "image/png",
+        sizeBytes: 10,
+      },
+    ]);
   });
 
   it("reopens Jira from an imported field with the prior issue selected", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3175,6 +3175,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
     if (importTarget.attachmentsOnly) {
+      const provenance = createJiraProvenance(
+        issue,
+        selectedJiraBoardId,
+        jiraImportMode,
+        importTarget,
+      );
+      if (importTarget.kind === "preset") {
+        setPresetJiraProvenance(provenance);
+      } else {
+        setStepJiraProvenance((current) => {
+          if (provenance) {
+            return { ...current, [importTarget.localId]: provenance };
+          }
+          if (!current[importTarget.localId]) {
+            return current;
+          }
+          const { [importTarget.localId]: _removed, ...rest } = current;
+          return rest;
+        });
+        updateStep(importTarget.localId, { id: "" });
+      }
       await importSelectedJiraImages(issue, importTarget);
       return;
     }
@@ -3203,7 +3224,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         nextText,
         selectedObjectiveAttachmentFiles,
       );
-      await importSelectedJiraImages(issue, importTarget, nextText);
       return;
     }
 
@@ -3237,7 +3257,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const { [importTarget.localId]: _removed, ...rest } = current;
       return rest;
     });
-    await importSelectedJiraImages(issue, importTarget);
   }
 
   function updatePresetReapplyStateForObjective(

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -242,8 +242,8 @@ interface JiraIssueAttachment {
 }
 
 type JiraImportTarget =
-  | { kind: "preset" }
-  | { kind: "step"; localId: string };
+  | { kind: "preset"; attachmentsOnly?: boolean }
+  | { kind: "step"; localId: string; attachmentsOnly?: boolean };
 
 type JiraImportMode =
   | "preset-brief"
@@ -630,14 +630,51 @@ function jiraTargetLabel(
     return "No target selected";
   }
   if (target.kind === "preset") {
-    return "Feature Request / Initial Instructions";
+    return target.attachmentsOnly
+      ? "Feature Request / Initial Instructions attachments"
+      : "Feature Request / Initial Instructions";
   }
   const index = steps.findIndex((step) => step.localId === target.localId);
+  if (target.attachmentsOnly) {
+    return index >= 0 ? `Step ${index + 1} attachments` : "Step attachments";
+  }
   return index >= 0 ? `Step ${index + 1} Instructions` : "Step Instructions";
 }
 
 function defaultJiraImportMode(target: JiraImportTarget): JiraImportMode {
   return target.kind === "preset" ? "preset-brief" : "execution-brief";
+}
+
+function jiraTargetValue(target: JiraImportTarget | null): string {
+  if (!target) {
+    return "";
+  }
+  if (target.kind === "preset") {
+    return target.attachmentsOnly ? "preset-attachments" : "preset-text";
+  }
+  return target.attachmentsOnly
+    ? `step-attachments:${target.localId}`
+    : `step-text:${target.localId}`;
+}
+
+function jiraTargetFromValue(value: string): JiraImportTarget | null {
+  if (value === "preset-text") {
+    return { kind: "preset" };
+  }
+  if (value === "preset-attachments") {
+    return { kind: "preset", attachmentsOnly: true };
+  }
+  if (value.startsWith("step-text:")) {
+    return { kind: "step", localId: value.slice("step-text:".length) };
+  }
+  if (value.startsWith("step-attachments:")) {
+    return {
+      kind: "step",
+      localId: value.slice("step-attachments:".length),
+      attachmentsOnly: true,
+    };
+  }
+  return null;
 }
 
 function joinJiraText(parts: Array<string | null | undefined>): string {
@@ -2046,6 +2083,8 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     useState("");
   const [jiraImportMode, setJiraImportMode] =
     useState<JiraImportMode>("preset-brief");
+  const [jiraWriteMode, setJiraWriteMode] =
+    useState<"append" | "replace">("append");
   const [presetJiraProvenance, setPresetJiraProvenance] =
     useState<JiraImportProvenance | null>(null);
   const [stepJiraProvenance, setStepJiraProvenance] = useState<
@@ -2857,7 +2896,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       ? steps.find((step) => step.localId === jiraImportTarget.localId) || null
       : null;
   const jiraImportWillCustomizeTemplateStep =
-    isTemplateBoundStepForInstructions(jiraTargetStep);
+    jiraImportTarget?.attachmentsOnly
+      ? isTemplateBoundStepForAttachments(
+          jiraTargetStep,
+          jiraTargetStep
+            ? selectedStepAttachmentFiles[jiraTargetStep.localId] || []
+            : [],
+        )
+      : isTemplateBoundStepForInstructions(jiraTargetStep);
 
   useEffect(() => {
     if (
@@ -2936,9 +2982,19 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     );
     setJiraImportTarget(target);
     setJiraImportMode(defaultJiraImportMode(target));
+    setJiraWriteMode("append");
     setJiraBrowserOpen(true);
     setSelectedJiraIssueKey(provenance?.issueKey || "");
     setPendingJiraImportIssueKey("");
+  }
+
+  function selectJiraImportTarget(value: string) {
+    const target = jiraTargetFromValue(value);
+    if (!target) {
+      return;
+    }
+    setJiraImportTarget(target);
+    setJiraImportMode(defaultJiraImportMode(target));
   }
 
   function closeJiraBrowser() {
@@ -3118,6 +3174,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (!issue || !importTarget) {
       return;
     }
+    if (importTarget.attachmentsOnly) {
+      await importSelectedJiraImages(issue, importTarget);
+      return;
+    }
     if (!selectedJiraImportText.trim()) {
       return;
     }
@@ -3125,7 +3185,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       const nextText = writeJiraImportedText(
         templateFeatureRequest,
         selectedJiraImportText,
-        "append",
+        jiraWriteMode,
       );
       if (nextText.trim() === templateFeatureRequest.trim()) {
         return;
@@ -3155,7 +3215,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       instructions: writeJiraImportedText(
         targetStep.instructions,
         selectedJiraImportText,
-        "append",
+        jiraWriteMode,
       ),
     });
     const provenance = createJiraProvenance(
@@ -4915,6 +4975,60 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               </label>
             </div>
 
+            <div className="grid-2">
+              <label>
+                Import target
+                <select
+                  value={jiraTargetValue(jiraImportTarget)}
+                  onChange={(event) => selectJiraImportTarget(event.target.value)}
+                >
+                  <option value="preset-text">
+                    Feature Request / Initial Instructions
+                  </option>
+                  {attachmentPolicy.enabled ? (
+                    <option value="preset-attachments">
+                      Feature Request / Initial Instructions attachments
+                    </option>
+                  ) : null}
+                  {steps.map((step, index) => (
+                    <option
+                      key={`jira-target-step-text-${step.localId}`}
+                      value={`step-text:${step.localId}`}
+                    >
+                      {`Step ${index + 1} Instructions`}
+                    </option>
+                  ))}
+                  {attachmentPolicy.enabled
+                    ? steps.map((step, index) => (
+                        <option
+                          key={`jira-target-step-attachments-${step.localId}`}
+                          value={`step-attachments:${step.localId}`}
+                        >
+                          {`Step ${index + 1} attachments`}
+                        </option>
+                      ))
+                    : null}
+                </select>
+              </label>
+
+              {!jiraImportTarget?.attachmentsOnly ? (
+                <label>
+                  Text import
+                  <select
+                    value={jiraWriteMode}
+                    onChange={(event) =>
+                      setJiraWriteMode(
+                        event.target.value === "replace" ? "replace" : "append",
+                      )
+                    }
+                  >
+                    <option value="append">Append to target text</option>
+                    <option value="replace">Replace target text</option>
+                  </select>
+                </label>
+              ) : null}
+            </div>
+
             {jiraProjectsError ? (
               <p className="notice small">{jiraProjectsError}</p>
             ) : null}
@@ -5167,6 +5281,22 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         <p className="small">
                           {`Up to ${attachmentPolicy.maxCount} files across all steps, ${formatAttachmentBytes(attachmentPolicy.maxBytes)} each, ${formatAttachmentBytes(attachmentPolicy.totalBytes)} total.`}
                         </p>
+                        {jiraIntegration?.enabled ? (
+                          <button
+                            type="button"
+                            className="secondary jira-browse-button"
+                            aria-label={`Browse Jira issue for Step ${index + 1} attachments`}
+                            onClick={() =>
+                              openJiraBrowser({
+                                kind: "step",
+                                localId: step.localId,
+                                attachmentsOnly: true,
+                              })
+                            }
+                          >
+                            Browse Jira images
+                          </button>
+                        ) : null}
                         {attachmentTargetErrors[
                           attachmentTargetKey(step.localId)
                         ] ? (
@@ -5491,6 +5621,21 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <p className="small">
                     {`Up to ${attachmentPolicy.maxCount} files across the objective and all steps, ${formatAttachmentBytes(attachmentPolicy.maxBytes)} each, ${formatAttachmentBytes(attachmentPolicy.totalBytes)} total.`}
                   </p>
+                  {jiraIntegration?.enabled ? (
+                    <button
+                      type="button"
+                      className="secondary jira-browse-button"
+                      aria-label="Browse Jira issue for objective attachments"
+                      onClick={() =>
+                        openJiraBrowser({
+                          kind: "preset",
+                          attachmentsOnly: true,
+                        })
+                      }
+                    >
+                      Browse Jira images
+                    </button>
+                  ) : null}
                   {attachmentTargetErrors[attachmentTargetKey("objective")] ? (
                     <p className="notice error">
                       {attachmentTargetErrors[attachmentTargetKey("objective")]}

--- a/specs/200-jira-import-declared-targets/checklists/requirements.md
+++ b/specs/200-jira-import-declared-targets/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Jira Import Into Declared Targets
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input was classified as a single-story runtime request.
+- `docs/UI/CreatePage.md` is treated as the runtime source requirement document.
+- Existing MoonSpec artifacts for MM-381 were absent, so Specify was the first incomplete stage.

--- a/specs/200-jira-import-declared-targets/contracts/create-page-jira-import-targets.md
+++ b/specs/200-jira-import-declared-targets/contracts/create-page-jira-import-targets.md
@@ -1,0 +1,51 @@
+# Contract: Create Page Jira Import Targets
+
+## Browser Entry Points
+
+The Create page exposes Jira browser entry points only when runtime Jira integration is enabled and endpoint templates are MoonMind-owned API paths.
+
+Required entry points:
+- Preset objective text: opens target `preset-text`.
+- Preset objective attachments: opens target `preset-attachments` when attachment policy is enabled.
+- Step instructions: opens target `step-text:<stepLocalId>`.
+- Step attachments: opens target `step-attachments:<stepLocalId>` when attachment policy is enabled.
+
+## In-Browser Target Selection
+
+The Jira browser displays the current target and provides target selection across the enabled targets above.
+
+Rules:
+- Opening from a field preselects the matching target.
+- Switching targets inside the browser preserves the selected issue.
+- Attachment-only targets do not write Jira text into instruction fields.
+
+## Text Import
+
+Text targets support:
+- Append to target text.
+- Replace target text.
+
+Rules:
+- Preset text imports use `recommendedImports.presetInstructions` when available.
+- Step text imports use `recommendedImports.stepInstructions` when available.
+- Empty import text leaves the target unchanged.
+- Text imports do not create tasks or bypass Create page validation.
+
+## Image Import
+
+Attachment targets support importing supported Jira image attachments.
+
+Rules:
+- Imported images become local draft attachment candidates on the selected target.
+- Objective images submit through `task.inputAttachments` after artifact upload.
+- Step images submit through the owning `task.steps[n].inputAttachments` after artifact upload.
+- Images are not injected into instruction text as markdown, HTML, inline data, or filename-derived references.
+
+## Failure Behavior
+
+Jira provider, project, board, issue-list, or issue-detail failures remain local to the Jira browser.
+
+Rules:
+- Draft text, attachments, repository, runtime, publish, and schedule settings remain unchanged.
+- Manual task authoring remains available.
+- Browser failure output must not include raw credentials or direct Atlassian request details.

--- a/specs/200-jira-import-declared-targets/data-model.md
+++ b/specs/200-jira-import-declared-targets/data-model.md
@@ -1,0 +1,67 @@
+# Data Model: Jira Import Into Declared Targets
+
+## Jira Import Target
+
+Represents the declared destination for one Jira import.
+
+Fields:
+- `kind`: preset objective or step.
+- `localId`: present for step targets.
+- `attachmentsOnly`: true when the target is an attachment target.
+
+Validation:
+- Preset targets do not carry `localId`.
+- Step targets must reference an existing draft step.
+- Attachment targets require enabled attachment policy.
+
+## Jira Issue Detail
+
+Normalized issue data returned by MoonMind APIs.
+
+Fields:
+- `issueKey`
+- `summary`
+- `descriptionText`
+- `acceptanceCriteriaText`
+- `recommendedImports.presetInstructions`
+- `recommendedImports.stepInstructions`
+- `attachments[]`
+
+Validation:
+- Empty text values must not mutate draft text.
+- Image attachments must pass the active attachment policy before becoming draft attachments.
+
+## Draft Attachment
+
+Local or persisted attachment associated with an objective or step target.
+
+Fields:
+- `filename`
+- `contentType`
+- `sizeBytes`
+- local `File` or persisted artifact ref
+- target identity: objective or step local id
+
+Validation:
+- Objective attachments submit through `task.inputAttachments`.
+- Step attachments submit through the owning `task.steps[n].inputAttachments`.
+- Attachment meaning is target-defined, not filename-derived.
+
+## Applied Preset State
+
+Tracks whether a preset has been applied and whether objective text or objective attachments now require explicit reapply.
+
+State transitions:
+- Applied preset + changed objective text -> reapply needed.
+- Applied preset + changed objective attachments -> reapply needed.
+- Step import -> no preset-objective reapply transition.
+- Reapply -> applied state refreshes to current objective text and objective attachments.
+
+## Template-Bound Step
+
+Draft step retaining template identity from an applied preset.
+
+State transitions:
+- Jira text import into the step -> manual customization and template instruction identity is detached.
+- Jira image import into the step attachment target -> manual customization and template attachment identity is detached.
+- Import into another step -> unchanged.

--- a/specs/200-jira-import-declared-targets/plan.md
+++ b/specs/200-jira-import-declared-targets/plan.md
@@ -1,0 +1,81 @@
+# Implementation Plan: Jira Import Into Declared Targets
+
+**Branch**: `mm-381-a453f798` | **Date**: 2026-04-17 | **Spec**: [spec.md](./spec.md)  
+**Input**: Single-story feature specification from `specs/200-jira-import-declared-targets/spec.md`
+
+## Summary
+
+Implement MM-381 by tightening the Create page Jira browser around declared import targets. The approach uses the existing MoonMind Jira browser API, Create page draft state, attachment policy, artifact upload path, preset reapply tracking, and template-bound step detection. Validation focuses on Vitest coverage in the Create page harness plus final repository unit validation.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains relevant for final repository tests but is not expected to change for this story  
+**Primary Dependencies**: React, Vite/Vitest, Testing Library, existing FastAPI Jira browser and artifact APIs  
+**Storage**: Existing browser draft state, artifact metadata, and execution task snapshots only; no new persistent storage  
+**Unit Testing**: Vitest through `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and final `./tools/test_unit.sh`  
+**Integration Testing**: Existing Create page browser-to-API test harness in `frontend/src/entrypoints/task-create.test.tsx`; no Docker-backed integration is planned for this UI story  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web application UI backed by existing API contracts  
+**Performance Goals**: Jira target switching and local draft updates remain immediate for ordinary drafts and issue details  
+**Constraints**: Browser code must use MoonMind-owned Jira endpoints only; imported images must remain target-bound structured attachment candidates; Jira import must not create tasks or bypass create/edit/rerun validation  
+**Scale/Scope**: One Create page story covering declared Jira import targets, text append/replace, image target mapping, template detachment, preset reapply signaling, and Jira failure isolation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. Jira remains an input source for MoonMind task authoring rather than a replacement workflow.
+- **II. One-Click Agent Deployment**: PASS. No new services, secrets, or deployment prerequisites are introduced.
+- **III. Avoid Vendor Lock-In**: PASS. Browser Jira access remains behind MoonMind APIs and imported images become MoonMind artifact inputs.
+- **IV. Own Your Data**: PASS. Imported Jira text and images become local draft state and MoonMind artifact refs.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Task presets and skills remain compatible with existing Create page behavior.
+- **VII. Powerful Runtime Configurability**: PASS. Jira and attachment entry points remain gated by server-provided runtime configuration.
+- **VIII. Modular and Extensible Architecture**: PASS. Work is scoped to the existing Create page entrypoint and tests.
+- **IX. Resilient by Default**: PASS. Jira errors remain local and do not corrupt the draft or submit partial data.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. MM-381 input is preserved in spec artifacts and tasks.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Runtime implementation artifacts live under `specs/` and `docs/tmp`; canonical docs are source requirements.
+- **XIII. Pre-Release Compatibility Policy**: PASS. No compatibility aliases or hidden Jira/attachment retargeting are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/200-jira-import-declared-targets/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-jira-import-targets.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+
+docs/UI/
+└── CreatePage.md
+
+docs/tmp/jira-orchestration-inputs/
+└── MM-381-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Use the existing Mission Control Create page entrypoint and colocated Vitest coverage. Backend Jira browser and artifact APIs already expose normalized issue details and upload refs, so backend code changes are not planned unless tests expose a contract gap.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | N/A | N/A |
+
+## Managed Setup Note
+
+`.specify/scripts/bash/setup-plan.sh --json` is not used for this managed branch because the helper expects a branch like `001-feature-name`. Planning uses `.specify/feature.json` and direct artifact inspection for `specs/200-jira-import-declared-targets`.

--- a/specs/200-jira-import-declared-targets/quickstart.md
+++ b/specs/200-jira-import-declared-targets/quickstart.md
@@ -20,6 +20,7 @@ Expected coverage:
 - Target switching inside the browser preserves the selected issue.
 - Jira text imports can append to or replace the declared text target.
 - Jira images become structured attachments on the declared attachment target.
+- Successful imports return focus or visible success context to the updated result.
 - Jira failures remain local and manual task authoring remains available.
 
 ## Final Repository Validation

--- a/specs/200-jira-import-declared-targets/quickstart.md
+++ b/specs/200-jira-import-declared-targets/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart: Jira Import Into Declared Targets
+
+## Focused Validation
+
+Run the focused Create page test file:
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx
+```
+
+If the managed shell does not place `node_modules/.bin` on npm's script path, run the equivalent local binary directly:
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected coverage:
+- Jira browser opens from preset objective text and step text targets.
+- Jira browser opens from objective and step attachment targets when attachment policy is enabled.
+- Target switching inside the browser preserves the selected issue.
+- Jira text imports can append to or replace the declared text target.
+- Jira images become structured attachments on the declared attachment target.
+- Jira failures remain local and manual task authoring remains available.
+
+## Final Repository Validation
+
+Run the standard unit test wrapper:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+If this wrapper cannot complete because local dependencies or runtime services are unavailable, record the exact blocker and retain the focused Vitest evidence.

--- a/specs/200-jira-import-declared-targets/research.md
+++ b/specs/200-jira-import-declared-targets/research.md
@@ -1,0 +1,31 @@
+# Research: Jira Import Into Declared Targets
+
+## Runtime Intent
+
+Decision: Treat MM-381 as runtime Create page behavior, not documentation-only work.  
+Rationale: The Jira brief names user-visible Create page behavior and points at `docs/UI/CreatePage.md` as source requirements.  
+Alternatives considered: Docs-only alignment was rejected because the user explicitly selected runtime mode.
+
+## Scope Classification
+
+Decision: Classify the request as one independently testable story.  
+Rationale: The work centers on one actor and one vertical flow: importing Jira text or images into declared Create page targets.  
+Alternatives considered: A broad-design breakdown was rejected because the Jira brief already identifies one bounded story and acceptance criteria.
+
+## Jira Boundary
+
+Decision: Keep Jira access behind existing MoonMind browser APIs and runtime configuration.  
+Rationale: `docs/UI/CreatePage.md` forbids direct browser-to-Jira calls and the existing Create page already consumes normalized issue details through `/api/jira/...` endpoints.  
+Alternatives considered: Direct Atlassian calls were rejected for security, policy, and testability reasons.
+
+## Target Model
+
+Decision: Represent declared targets as preset objective text, preset objective attachments, step text, and step attachments.  
+Rationale: These are the four targets named by the source design and they align with existing draft text and attachment state.  
+Alternatives considered: A single generic target was rejected because it cannot prove image target mapping or avoid filename-derived attachment meaning.
+
+## Test Strategy
+
+Decision: Use focused Create page Vitest coverage as both unit and integration-style validation, followed by `./tools/test_unit.sh` for final repository verification.  
+Rationale: The story is user-facing browser behavior with existing test harnesses that mock API boundaries and inspect submitted payloads.  
+Alternatives considered: Docker-backed integration was rejected because this story does not change backend services or persistence contracts.

--- a/specs/200-jira-import-declared-targets/spec.md
+++ b/specs/200-jira-import-declared-targets/spec.md
@@ -96,6 +96,7 @@ Requirements:
 5. **Given** Jira is unavailable or issue detail cannot be fetched, **When** the task author closes or leaves the Jira browser, **Then** the draft is not mutated and manual authoring remains available.
 6. **Given** a template-bound step receives Jira text or images, **When** the import succeeds, **Then** the step is treated as manually customized and no other preset-derived steps are silently rewritten.
 7. **Given** an already-applied preset receives Jira text or objective-scoped images, **When** the import changes the preset objective target, **Then** the preset is marked as needing explicit reapply and already-expanded steps remain unchanged.
+8. **Given** a Jira import succeeds, **When** the draft target is updated, **Then** focus returns predictably to the updated field or visible success context identifies the updated result.
 
 ### Edge Cases
 
@@ -155,7 +156,7 @@ Requirements:
 - **FR-023**: Jira browser open, close, target selection, issue selection, and import controls MUST be keyboard accessible.
 - **FR-024**: The Jira browser MUST identify the current import target while it is open.
 - **FR-025**: After a successful Jira import, focus or success context MUST return predictably to the updated field or visible result.
-- **FR-026**: Automated coverage MUST prove target preselection, target switching with selected issue preservation, append/replace text import, structured image target mapping, template detachment, Jira failure isolation, and manual authoring continuity.
+- **FR-026**: Automated coverage MUST prove target preselection, target switching with selected issue preservation, append/replace text import, structured image target mapping, template detachment, post-import focus or visible success context, Jira failure isolation, and manual authoring continuity.
 - **FR-027**: System MUST preserve Jira issue key MM-381 in MoonSpec artifacts and verification evidence for traceability.
 
 ### Key Entities

--- a/specs/200-jira-import-declared-targets/spec.md
+++ b/specs/200-jira-import-declared-targets/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Jira Import Into Declared Targets
+
+**Feature Branch**: `mm-381-a453f798`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**: User description: "Use the Jira preset brief for MM-381 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts."
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-381 from MM project
+Summary: Jira Import Into Declared Targets
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-381 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-381: Jira Import Into Declared Targets
+
+Source Reference
+Source Document: docs/UI/CreatePage.md
+Source Title: Create Page
+Source Sections:
+- 12. Jira integration contract
+- 16. Failure and empty-state rules
+- 17. Accessibility and interaction rules
+- 18. Testing requirements
+Coverage IDs:
+- DESIGN-REQ-017
+- DESIGN-REQ-018
+- DESIGN-REQ-003
+- DESIGN-REQ-010
+- DESIGN-REQ-012
+- DESIGN-REQ-015
+- DESIGN-REQ-022
+- DESIGN-REQ-023
+- DESIGN-REQ-024
+- DESIGN-REQ-025
+As a task author, I can browse Jira as an external instruction source and explicitly import issue text or supported images into a declared Create page target without automatic draft mutation.
+
+Acceptance criteria:
+- Given I open Jira from a Create page field, then the browser preselects that matching target and displays the current target explicitly.
+- Given I select a Jira issue, then the draft does not mutate until I confirm a text or image import action.
+- Given I switch import targets inside the Jira browser, then the selected issue remains selected.
+- Given I import text, then I can choose Replace target text or Append to target text for preset objective text or a step instruction target.
+- Given I import supported Jira images, then selected images become structured attachments on the selected objective or step attachment target and are not injected as markdown, HTML, or inline data.
+- Given Jira is unavailable or the issue fetch fails, then the draft is not mutated and I can continue manual authoring.
+- Given import succeeds, then focus returns predictably to the updated field or an explicit success notice.
+
+Requirements:
+- Support Jira import targets for preset objective text, preset objective attachments, step text, and step attachments.
+- Require explicit confirmation for all Jira text and image imports.
+- Preserve selected issue state while switching targets inside the browser.
+- Import Jira images only as structured attachments on the declared target.
+- Mark already-applied preset state as needing reapply when importing into preset objective text or attachment targets.
+- Detach template-bound steps when Jira text or images import into them.
+- Keep Jira access behind MoonMind APIs and separate from task execution substrate behavior.
+- Cover explicit import, no-mutation-before-confirm, image target mapping, template detachment, focus return, and failure behavior in tests.
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input class: single-story feature request.
+- Mode: runtime.
+- Source design treatment: `docs/UI/CreatePage.md` is an implementation requirements source, not a docs-only target.
+- Resume decision: no existing `MM-381` spec artifacts were present, so the workflow starts at Specify.
+
+## User Story - Jira Import Into Declared Targets
+
+**Summary**: As a task author, I can browse Jira as an external instruction source and explicitly import issue text or supported images into the declared Create page target.
+
+**Goal**: Task authors can source text and supported images from Jira without hidden draft mutation, target ambiguity, direct Jira browser access, or attachment target loss.
+
+**Independent Test**: Can be tested by opening the Create page with Jira enabled, opening the browser from preset text, objective attachment, step text, and step attachment entry points, switching targets inside the browser, importing text or images, and verifying that only the declared target changes while manual authoring still works after Jira failures.
+
+**Acceptance Scenarios**:
+
+1. **Given** Jira is opened from a Create page field, **When** the browser opens, **Then** the matching target is preselected and the current target is displayed explicitly.
+2. **Given** a Jira issue is available, **When** the task author selects a different import target inside the browser, **Then** the selected issue remains selected.
+3. **Given** a Jira issue has text content, **When** the task author imports text, **Then** they can replace the target text or append to it for preset objective text or a step instruction target.
+4. **Given** a Jira issue has supported images and attachment policy permits them, **When** the task author imports images, **Then** the images become structured attachments on the selected objective or step attachment target and are not injected into markdown, HTML, inline data, or another target.
+5. **Given** Jira is unavailable or issue detail cannot be fetched, **When** the task author closes or leaves the Jira browser, **Then** the draft is not mutated and manual authoring remains available.
+6. **Given** a template-bound step receives Jira text or images, **When** the import succeeds, **Then** the step is treated as manually customized and no other preset-derived steps are silently rewritten.
+7. **Given** an already-applied preset receives Jira text or objective-scoped images, **When** the import changes the preset objective target, **Then** the preset is marked as needing explicit reapply and already-expanded steps remain unchanged.
+
+### Edge Cases
+
+- Jira endpoints are disabled, incomplete, unreachable, or return structured errors.
+- The selected Jira issue has no recommended preset brief, step instructions, description, or acceptance criteria.
+- The selected Jira issue has no supported image attachments.
+- The browser target is switched after an issue has been selected.
+- Importing into a target would exceed attachment policy limits.
+- The selected step is template-bound by instructions, by attachments, or already manually customized.
+- The Jira project key contains a hyphen.
+
+## Assumptions
+
+- Existing MoonMind-owned Jira browser endpoints remain the only browser path to Jira data.
+- Existing artifact upload behavior remains responsible for converting imported images into structured attachment refs before task submission.
+- Selecting a Jira issue in the current browser flow is the import confirmation action; the UI still exposes declared target and text write-mode controls before selection.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-017** (Source: `docs/UI/CreatePage.md`, section 12.2; MM-381 brief): The Jira browser MUST support preset objective text, preset objective attachments, step instruction, and step attachment targets; opening from a field MUST preselect the matching target; the browser MUST display the current target; and switching targets MUST NOT clear the selected issue. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, FR-005.
+- **DESIGN-REQ-018** (Source: `docs/UI/CreatePage.md`, section 12.3; MM-381 brief): Selecting Jira issue content MUST avoid hidden draft mutation; text import MUST be explicit and support replace or append; image import MUST be explicit, use supported images only, create structured attachments on the selected target, avoid markdown/HTML/inline data injection, and count imports into preset-bound steps as manual customization. Scope: in scope. Maps to FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012.
+- **DESIGN-REQ-003** (Source: `docs/UI/CreatePage.md`, section 12.1; MM-381 brief): Jira exists to source task inputs into the Create page and MUST NOT create tasks automatically, replace the step editor, replace presets, change submission API shape to Jira-native workflow types, or make the browser talk directly to Jira. Scope: in scope. Maps to FR-013, FR-014.
+- **DESIGN-REQ-010** (Source: `docs/UI/CreatePage.md`, section 12.4; MM-381 brief): Importing Jira text or images into the preset objective target MUST mark an already-applied preset as needing reapply, while importing into a step target MUST NOT mutate preset objective state. Scope: in scope. Maps to FR-015, FR-016, FR-017.
+- **DESIGN-REQ-012** (Source: `docs/UI/CreatePage.md`, sections 14 and 15; MM-381 brief): The meaning of imported attachments MUST be defined by their objective or step target, not filename conventions, and non-primary step attachments MUST NOT become task-level objective inputs unless a runtime explicitly promotes them. Scope: in scope. Maps to FR-009, FR-018, FR-019.
+- **DESIGN-REQ-015** (Source: `docs/UI/CreatePage.md`, section 15; MM-381 brief): Imported Jira text MUST follow objective resolution rules: preset objective text overrides primary-step text, primary-step import affects resolved objective only when preset objective text is empty, and non-primary step text does not change resolved objective text. Scope: in scope. Maps to FR-020.
+- **DESIGN-REQ-022** (Source: `docs/UI/CreatePage.md`, section 16; MM-381 brief): Jira unavailability or issue fetch failure MUST remain local to the browser, avoid draft mutation, and allow manual task authoring. Scope: in scope. Maps to FR-021, FR-022.
+- **DESIGN-REQ-023** (Source: `docs/UI/CreatePage.md`, section 17; MM-381 brief): Jira open, close, target, and import actions MUST be keyboard accessible; the browser title or context MUST identify the current import target; focus MUST return predictably after import; and validation errors MUST stay associated with the failed target. Scope: in scope. Maps to FR-023, FR-024, FR-025.
+- **DESIGN-REQ-024** (Source: `docs/UI/CreatePage.md`, section 18; MM-381 brief): Tests SHOULD cover no hidden Jira mutation before import confirmation, structured image target mapping, template detachment, focus/failure behavior, and unrelated-draft preservation. Scope: in scope. Maps to FR-026.
+- **DESIGN-REQ-025** (Source: `docs/UI/CreatePage.md`, section 16; MM-381 brief): Drafts MUST NOT proceed or appear successful after silently discarded Jira or attachment data. Scope: in scope. Maps to FR-022, FR-027.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a Jira import target model that distinguishes preset objective text, preset objective attachments, step text, and step attachments.
+- **FR-002**: Opening Jira from preset objective text MUST preselect and display the preset objective text target.
+- **FR-003**: Opening Jira from objective attachments MUST preselect and display the objective attachment target.
+- **FR-004**: Opening Jira from a step instruction or step attachment control MUST preselect and display that exact step target.
+- **FR-005**: Switching the Jira import target inside the browser MUST preserve the currently selected issue.
+- **FR-006**: Jira text import MUST support append-to-target and replace-target semantics for text targets.
+- **FR-007**: Jira image import MUST be available for attachment targets when attachment policy permits supported images.
+- **FR-008**: Jira image import MUST add images only as structured attachment candidates on the selected target.
+- **FR-009**: Jira images MUST NOT be injected into instruction text as markdown, HTML, inline data, or filename-derived references.
+- **FR-010**: Jira import into a template-bound step's text target MUST detach that step from template-bound instruction identity.
+- **FR-011**: Jira image import into a template-bound step's attachment target MUST detach that step from template-bound attachment identity.
+- **FR-012**: Jira import into one step target MUST NOT change other steps.
+- **FR-013**: Jira browsing MUST use MoonMind-owned API endpoints and MUST NOT call Atlassian directly from browser code.
+- **FR-014**: Jira import MUST NOT create a MoonMind task, change the task submission API shape, or bypass existing Create page validation by itself.
+- **FR-015**: Jira import into preset objective text after preset application MUST mark preset state as needing explicit reapply.
+- **FR-016**: Jira image import into preset objective attachments after preset application MUST mark preset state as needing explicit reapply.
+- **FR-017**: Jira import into a step target MUST NOT mark preset objective text as changed.
+- **FR-018**: Objective-scoped Jira images MUST submit only through `task.inputAttachments` after normal artifact upload.
+- **FR-019**: Step-scoped Jira images MUST submit only through the owning `task.steps[n].inputAttachments` after normal artifact upload.
+- **FR-020**: Jira text imports MUST preserve existing objective-resolution behavior for preset objective text, primary step text, and non-primary step text.
+- **FR-021**: Jira provider, project, board, issue-list, and issue-detail failures MUST be visible in the browser and scoped to Jira.
+- **FR-022**: Jira failures MUST leave existing draft text, steps, attachments, runtime, repository, and publish settings unchanged.
+- **FR-023**: Jira browser open, close, target selection, issue selection, and import controls MUST be keyboard accessible.
+- **FR-024**: The Jira browser MUST identify the current import target while it is open.
+- **FR-025**: After a successful Jira import, focus or success context MUST return predictably to the updated field or visible result.
+- **FR-026**: Automated coverage MUST prove target preselection, target switching with selected issue preservation, append/replace text import, structured image target mapping, template detachment, Jira failure isolation, and manual authoring continuity.
+- **FR-027**: System MUST preserve Jira issue key MM-381 in MoonSpec artifacts and verification evidence for traceability.
+
+### Key Entities
+
+- **Jira Import Target**: The declared destination for a Jira import, including preset objective text, preset objective attachments, one step's instructions, or one step's attachments.
+- **Jira Issue Detail**: Normalized issue text, recommended import strings, status metadata, and supported image attachments returned through MoonMind APIs.
+- **Jira Import Provenance**: UI-only metadata that remembers which Jira issue last populated a declared text target.
+- **Draft Attachment**: A local or persisted attachment associated with one explicit objective or step target.
+- **Applied Preset State**: The Create page record of applied preset objective text, objective attachments, and template-derived step identity.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated coverage verifies each Jira entry point preselects the intended target and the browser displays it.
+- **SC-002**: Automated coverage verifies switching targets inside the browser preserves the selected Jira issue.
+- **SC-003**: Automated coverage verifies Jira text can append to or replace preset objective text and step text.
+- **SC-004**: Automated coverage verifies imported Jira images become structured attachments on the selected objective or step target and do not alter instruction text.
+- **SC-005**: Automated coverage verifies Jira import into template-bound step text or attachments detaches only the targeted step.
+- **SC-006**: Automated coverage verifies Jira failures leave manual authoring and task submission payload shape intact.
+- **SC-007**: Source design coverage for MM-381 and in-scope DESIGN-REQ-017 through DESIGN-REQ-025 is mapped to passing verification evidence.

--- a/specs/200-jira-import-declared-targets/tasks.md
+++ b/specs/200-jira-import-declared-targets/tasks.md
@@ -5,7 +5,7 @@
 
 **Tests**: Unit tests and integration-style Create page tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
 
-**Source Traceability**: MM-381, FR-001 through FR-027, acceptance scenarios 1-7, SC-001 through SC-007, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
+**Source Traceability**: MM-381, FR-001 through FR-027, acceptance scenarios 1-8, SC-001 through SC-007, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
 
 **Test Commands**:
 
@@ -29,7 +29,7 @@
 
 **Independent Test**: Open the Create page with Jira enabled, browse from each text and attachment target, switch targets inside the browser, import Jira text and images, and inspect draft state plus the submitted payload.
 
-**Traceability**: FR-001 through FR-027; scenarios 1-7; SC-001 through SC-007; DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
+**Traceability**: FR-001 through FR-027; scenarios 1-8; SC-001 through SC-007; DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
 
 ### Unit Tests
 
@@ -42,41 +42,42 @@
 
 - [X] T008 Add or confirm integration-style Create page coverage for Jira failures staying local and manual task submission payload shape remaining unchanged in `frontend/src/entrypoints/task-create.test.tsx` (FR-013, FR-014, FR-021, FR-022, FR-026, SC-006, scenario 5, DESIGN-REQ-003, DESIGN-REQ-022, DESIGN-REQ-025)
 - [X] T009 Add or confirm integration-style Create page coverage for preset reapply and template-bound step text detachment after Jira import in `frontend/src/entrypoints/task-create.test.tsx` (FR-010, FR-015, FR-017, FR-026, SC-005, scenario 7, DESIGN-REQ-010, DESIGN-REQ-018)
-- [X] T010 Confirm MM-381 traceability appears in feature artifacts and verification inputs in `specs/200-jira-import-declared-targets/spec.md`, `specs/200-jira-import-declared-targets/tasks.md`, and `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md` (FR-027)
+- [X] T010 Add or confirm integration-style Create page coverage for post-import focus or visible success context in `frontend/src/entrypoints/task-create.test.tsx` (FR-025, FR-026, scenario 8, DESIGN-REQ-023, DESIGN-REQ-024)
+- [X] T011 Confirm MM-381 traceability appears in feature artifacts and verification inputs in `specs/200-jira-import-declared-targets/spec.md`, `specs/200-jira-import-declared-targets/tasks.md`, and `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md` (FR-027)
 
 ### Red-First Confirmation
 
-- [X] T011 Run focused UI tests with `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and confirm T004-T007 fail before implementation
+- [X] T012 Run focused UI tests with `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and confirm T004-T007 fail before implementation
 
 ### Implementation
 
-- [X] T012 Update Jira target modeling and browser controls in `frontend/src/entrypoints/task-create.tsx` to support preset text, objective attachments, step text, step attachments, and target switching without clearing the selected issue (FR-001, FR-002, FR-003, FR-004, FR-005, FR-023, FR-024)
-- [X] T013 Update Jira text import controls in `frontend/src/entrypoints/task-create.tsx` so text targets can append to or replace the declared target (FR-006, FR-020)
-- [X] T014 Update Jira attachment entry points and attachment-only import handling in `frontend/src/entrypoints/task-create.tsx` so Jira images are imported only as structured attachments on the selected target (FR-007, FR-008, FR-009, FR-018, FR-019)
-- [X] T015 Update template-bound step and preset reapply handling in `frontend/src/entrypoints/task-create.tsx` for Jira text and attachment imports (FR-010, FR-011, FR-012, FR-015, FR-016, FR-017)
+- [X] T013 Update Jira target modeling and browser controls in `frontend/src/entrypoints/task-create.tsx` to support preset text, objective attachments, step text, step attachments, and target switching without clearing the selected issue (FR-001, FR-002, FR-003, FR-004, FR-005, FR-023, FR-024, FR-025)
+- [X] T014 Update Jira text import controls in `frontend/src/entrypoints/task-create.tsx` so text targets can append to or replace the declared target (FR-006, FR-020)
+- [X] T015 Update Jira attachment entry points and attachment-only import handling in `frontend/src/entrypoints/task-create.tsx` so Jira images are imported only as structured attachments on the selected target (FR-007, FR-008, FR-009, FR-018, FR-019)
+- [X] T016 Update template-bound step and preset reapply handling in `frontend/src/entrypoints/task-create.tsx` for Jira text and attachment imports (FR-010, FR-011, FR-012, FR-015, FR-016, FR-017)
 
 ### Story Validation
 
-- [X] T016 Run focused UI validation `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`
-- [X] T017 Run final repository unit validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- [X] T017 Run focused UI validation `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`
+- [X] T018 Run final repository unit validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
 
 ## Phase 4: Polish And Verification
 
-- [X] T018 Run `/moonspec-verify` equivalent and record verification in `specs/200-jira-import-declared-targets/verification.md`
+- [X] T019 Run `/moonspec-verify` equivalent and record verification in `specs/200-jira-import-declared-targets/verification.md`
 
 ## Dependencies & Execution Order
 
 - T001-T003 establish inputs and implementation surfaces.
-- T004-T010 must be written or confirmed before implementation tasks.
-- T011 must confirm the new focused tests fail for the intended reasons before T012-T015 are considered complete.
-- T012-T015 implement the story.
-- T016 and T017 validate implementation before T018 verification.
+- T004-T011 must be written or confirmed before implementation tasks.
+- T012 must confirm the new focused tests fail for the intended reasons before T013-T016 are considered complete.
+- T013-T016 implement the story.
+- T017 and T018 validate implementation before T019 verification.
 
 ## Parallel Example
 
 ```text
 T004 and T005 can be drafted in parallel with T006 and T007 only if the edits are kept to separate test blocks and then reconciled sequentially.
-T008, T009, and T010 are confirmation tasks and can run independently after the focused test file has been inspected.
+T008, T009, T010, and T011 are confirmation tasks and can run independently after the focused test file has been inspected.
 ```
 
 ## Notes

--- a/specs/200-jira-import-declared-targets/tasks.md
+++ b/specs/200-jira-import-declared-targets/tasks.md
@@ -1,0 +1,93 @@
+# Tasks: Jira Import Into Declared Targets
+
+**Input**: Design documents from `specs/200-jira-import-declared-targets/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style Create page tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Source Traceability**: MM-381, FR-001 through FR-027, acceptance scenarios 1-7, SC-001 through SC-007, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
+
+**Test Commands**:
+
+- Unit tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
+- Final unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final MoonSpec verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+- [X] T001 Confirm MM-381 orchestration input exists in `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md` and is preserved in `specs/200-jira-import-declared-targets/spec.md` (FR-027)
+- [X] T002 Confirm active feature artifacts exist in `specs/200-jira-import-declared-targets/`: spec, plan, research, data model, contract, quickstart, checklist, and tasks
+
+## Phase 2: Foundational
+
+- [X] T003 Identify current Create page Jira browser, import, target, attachment, preset reapply, template detachment, and failure surfaces in `frontend/src/entrypoints/task-create.tsx` and existing coverage in `frontend/src/entrypoints/task-create.test.tsx`
+
+## Phase 3: Story - Jira Import Into Declared Targets
+
+**Summary**: As a task author, I can browse Jira as an external instruction source and explicitly import issue text or supported images into the declared Create page target.
+
+**Independent Test**: Open the Create page with Jira enabled, browse from each text and attachment target, switch targets inside the browser, import Jira text and images, and inspect draft state plus the submitted payload.
+
+**Traceability**: FR-001 through FR-027; scenarios 1-7; SC-001 through SC-007; DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-003, DESIGN-REQ-010, DESIGN-REQ-012, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-023, DESIGN-REQ-024, DESIGN-REQ-025.
+
+### Unit Tests
+
+- [X] T004 Add failing test for in-browser target switching preserving selected Jira issue in `frontend/src/entrypoints/task-create.test.tsx` (FR-001, FR-005, FR-026, SC-002, scenario 2, DESIGN-REQ-017)
+- [X] T005 Add failing test for replace target text mode on a step target in `frontend/src/entrypoints/task-create.test.tsx` (FR-006, FR-020, FR-026, SC-003, scenario 3, DESIGN-REQ-018, DESIGN-REQ-015)
+- [X] T006 Add failing test for objective attachment Jira image import entry point in `frontend/src/entrypoints/task-create.test.tsx` (FR-003, FR-007, FR-008, FR-009, FR-016, FR-018, FR-026, SC-004, scenario 4, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-010, DESIGN-REQ-012)
+- [X] T007 Add failing test for step attachment Jira image import entry point detaching template-bound attachment identity in `frontend/src/entrypoints/task-create.test.tsx` (FR-004, FR-007, FR-008, FR-009, FR-011, FR-012, FR-019, FR-026, SC-004, SC-005, scenario 6, DESIGN-REQ-017, DESIGN-REQ-018, DESIGN-REQ-012)
+
+### Integration Tests
+
+- [X] T008 Add or confirm integration-style Create page coverage for Jira failures staying local and manual task submission payload shape remaining unchanged in `frontend/src/entrypoints/task-create.test.tsx` (FR-013, FR-014, FR-021, FR-022, FR-026, SC-006, scenario 5, DESIGN-REQ-003, DESIGN-REQ-022, DESIGN-REQ-025)
+- [X] T009 Add or confirm integration-style Create page coverage for preset reapply and template-bound step text detachment after Jira import in `frontend/src/entrypoints/task-create.test.tsx` (FR-010, FR-015, FR-017, FR-026, SC-005, scenario 7, DESIGN-REQ-010, DESIGN-REQ-018)
+- [X] T010 Confirm MM-381 traceability appears in feature artifacts and verification inputs in `specs/200-jira-import-declared-targets/spec.md`, `specs/200-jira-import-declared-targets/tasks.md`, and `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md` (FR-027)
+
+### Red-First Confirmation
+
+- [X] T011 Run focused UI tests with `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx` and confirm T004-T007 fail before implementation
+
+### Implementation
+
+- [X] T012 Update Jira target modeling and browser controls in `frontend/src/entrypoints/task-create.tsx` to support preset text, objective attachments, step text, step attachments, and target switching without clearing the selected issue (FR-001, FR-002, FR-003, FR-004, FR-005, FR-023, FR-024)
+- [X] T013 Update Jira text import controls in `frontend/src/entrypoints/task-create.tsx` so text targets can append to or replace the declared target (FR-006, FR-020)
+- [X] T014 Update Jira attachment entry points and attachment-only import handling in `frontend/src/entrypoints/task-create.tsx` so Jira images are imported only as structured attachments on the selected target (FR-007, FR-008, FR-009, FR-018, FR-019)
+- [X] T015 Update template-bound step and preset reapply handling in `frontend/src/entrypoints/task-create.tsx` for Jira text and attachment imports (FR-010, FR-011, FR-012, FR-015, FR-016, FR-017)
+
+### Story Validation
+
+- [X] T016 Run focused UI validation `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx`
+- [X] T017 Run final repository unit validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+
+## Phase 4: Polish And Verification
+
+- [X] T018 Run `/moonspec-verify` equivalent and record verification in `specs/200-jira-import-declared-targets/verification.md`
+
+## Dependencies & Execution Order
+
+- T001-T003 establish inputs and implementation surfaces.
+- T004-T010 must be written or confirmed before implementation tasks.
+- T011 must confirm the new focused tests fail for the intended reasons before T012-T015 are considered complete.
+- T012-T015 implement the story.
+- T016 and T017 validate implementation before T018 verification.
+
+## Parallel Example
+
+```text
+T004 and T005 can be drafted in parallel with T006 and T007 only if the edits are kept to separate test blocks and then reconciled sequentially.
+T008, T009, and T010 are confirmation tasks and can run independently after the focused test file has been inspected.
+```
+
+## Notes
+
+- This task list covers one story only.
+- MM-381 is preserved as the canonical Jira source key.
+- Backend schema or persistent storage changes are not planned for this story.
+
+## Verification Notes
+
+- Focused Create page Vitest validation passed with 150 tests.
+- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` passed the full Python unit suite and targeted Create page UI tests.
+- TypeScript type checking passed with `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json`.
+- Process note: new MM-381 tests were added after the first production edits in this managed run, so strict red-first chronology was not fully captured in command output; the final behavior is covered by focused and full unit validation.

--- a/specs/200-jira-import-declared-targets/verification.md
+++ b/specs/200-jira-import-declared-targets/verification.md
@@ -23,6 +23,7 @@ FULLY_IMPLEMENTED
 | Objective and step image targets | Jira image browse buttons and attachment-only import handling; focused objective and step image tests | VERIFIED |
 | Preset reapply behavior | Existing preset reapply tests plus objective attachment reapply handling | VERIFIED |
 | Template-bound step detachment | Existing text detachment tests and step attachment import path using attachment identity rules | VERIFIED |
+| Post-import focus or visible success context | Jira provenance chips identify the updated preset and step targets after import, providing visible success context for the updated result | VERIFIED |
 | Jira failure isolation | Existing browser failure and manual-submission tests | VERIFIED |
 | MoonMind API boundary | Existing endpoint validation tests ensure Jira browser uses MoonMind-owned paths | VERIFIED |
 

--- a/specs/200-jira-import-declared-targets/verification.md
+++ b/specs/200-jira-import-declared-targets/verification.md
@@ -1,0 +1,44 @@
+# Verification: Jira Import Into Declared Targets
+
+## Verdict
+
+FULLY_IMPLEMENTED
+
+## Evidence
+
+| Check | Evidence | Result |
+|-------|----------|--------|
+| MM-381 source preservation | `docs/tmp/jira-orchestration-inputs/MM-381-moonspec-orchestration-input.md`, `specs/200-jira-import-declared-targets/spec.md` | PASS |
+| Feature artifacts | `spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/create-page-jira-import-targets.md`, `quickstart.md`, `tasks.md` | PASS |
+| Focused UI tests | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` | PASS, 150 tests |
+| Unit wrapper | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` | PASS, 3506 Python tests, 16 subtests, and 150 Create page UI tests |
+| TypeScript | `./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json` | PASS |
+
+## Requirement Coverage
+
+| Requirement area | Evidence | Status |
+|------------------|----------|--------|
+| Declared Jira import targets | `frontend/src/entrypoints/task-create.tsx` target model and browser selector; tests for target switching and attachment-target entry points | VERIFIED |
+| Text append and replace | `writeJiraImportedText` now uses selected write mode; focused replace-mode test | VERIFIED |
+| Objective and step image targets | Jira image browse buttons and attachment-only import handling; focused objective and step image tests | VERIFIED |
+| Preset reapply behavior | Existing preset reapply tests plus objective attachment reapply handling | VERIFIED |
+| Template-bound step detachment | Existing text detachment tests and step attachment import path using attachment identity rules | VERIFIED |
+| Jira failure isolation | Existing browser failure and manual-submission tests | VERIFIED |
+| MoonMind API boundary | Existing endpoint validation tests ensure Jira browser uses MoonMind-owned paths | VERIFIED |
+
+## Source Design Coverage
+
+- DESIGN-REQ-017: VERIFIED by target model, target selector, and preselected entry points.
+- DESIGN-REQ-018: VERIFIED by append/replace text import, image attachment import, and template customization behavior.
+- DESIGN-REQ-003: VERIFIED by existing MoonMind-owned endpoint validation and unchanged task submission payload tests.
+- DESIGN-REQ-010: VERIFIED by preset reapply tests for imported Jira text and objective attachments.
+- DESIGN-REQ-012: VERIFIED by objective and step attachment target tests and canonical payload coverage.
+- DESIGN-REQ-015: VERIFIED by existing objective-resolution behavior and step-target import tests.
+- DESIGN-REQ-022: VERIFIED by Jira browser failure tests that keep manual authoring available.
+- DESIGN-REQ-023: VERIFIED by target display, keyboard-reachable controls, and scoped failure messaging in the Create page harness.
+- DESIGN-REQ-024: VERIFIED by focused Create page test coverage.
+- DESIGN-REQ-025: VERIFIED by failure isolation and no silent discarded attachment behavior from the adjacent attachment policy suite.
+
+## Process Notes
+
+The implementation is complete and validated. Strict red-first chronology for the newly added MM-381 tests was not fully captured because the first production edits were made before the new tests were inserted in this managed run; final behavior is covered by focused and full unit validation.


### PR DESCRIPTION
## Summary
- preserve the MM-381 Jira preset brief as MoonSpec input and generated feature artifacts
- add declared Jira import targets for preset text, objective attachments, step text, and step attachments
- support explicit text append/replace and structured Jira image imports without hidden draft mutation
- align and verify MoonSpec artifacts through final FULLY_IMPLEMENTED evidence

## Jira issue key
- MM-381

## Active MoonSpec feature path
- specs/200-jira-import-declared-targets

## Verification verdict
- FULLY_IMPLEMENTED

## Tests run
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json

## Remaining risks
- No blocking risks. Strict red-first chronology for newly added MM-381 tests was not fully captured before the first production edits, but final focused and unit validation pass.