### PR TITLE
MM-387 Document Mission Control preset provenance surfaces

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/200-jira-import-declared-targets"
+  "feature_directory": "specs/200-mission-control-preset-provenance"
 }

--- a/docs/UI/MissionControlArchitecture.md
+++ b/docs/UI/MissionControlArchitecture.md
@@ -258,7 +258,20 @@ The detail page is the right place for:
 - managed-run observability (artifact-backed logs, diagnostics — not terminal embeds)
 - action surfaces
 
-## 9.3 Advanced/debug information stays secondary
+## 9.3 Preset provenance on task surfaces
+
+Mission Control may explain preset-derived work in task list, task detail, and edit/rerun reconstruction surfaces, but **Preset provenance** is explanatory metadata, not a runtime execution model.
+
+Rules:
+
+* task list rows may show compact preset-derived context only when it helps scanning and does not crowd out title, status, workflow label, runtime, and timing fields
+* task detail may show provenance summaries and chips for **Manual**, **Preset**, and **Preset path**
+* edit/rerun reconstruction may show preserved preset bindings, detached state, and include-path context when those values are available from the submitted task snapshot
+* flat steps remain the primary execution ordering model, even when the UI groups or labels steps by preset origin
+* if preset provenance is unavailable, stale, or policy-hidden, the UI falls back to the flat step presentation without implying missing runtime work
+* preset grouping must never imply nested runtime behavior, subtasks, sub-plans, or separate workflow runs for preset includes
+
+## 9.4 Advanced/debug information stays secondary
 
 Advanced metadata may be shown in a dedicated facts rail, metadata drawer, or debug section, but it should not dominate the normal operator-facing layout.
 
@@ -470,6 +483,7 @@ Rules:
 * step rows may carry `childWorkflowId`, `childRunId`, and `taskRunId`
 * when a step has `taskRunId`, the Logs & Diagnostics area should embed or deep-link the existing `/api/task-runs/*` observability surfaces for that step
 * the client must not infer step completion or “latest output” by parsing logs or sorting raw artifacts locally
+* preset-derived step metadata may be rendered as Manual, Preset, or Preset path chips, but those chips explain provenance only and do not change step order, dependency semantics, or completion rules
 
 The task detail page must include a dedicated **Observability** area for managed-run evidence. This is the canonical UI hierarchy:
 
@@ -745,6 +759,9 @@ Rollout order:
 * do not expose raw source-precedence logic directly to ordinary users
 * keep submit flows organized around task-shaped product language
 * let the backend decide the workflow type and execution routing
+* `/tasks/new` may preview composed presets and show preset grouping before submission
+* unresolved preset includes must be rejected before runtime submission; they must not be sent as task work for a worker or adapter to resolve later
+* submit previews may explain preset provenance, but the submitted execution payload remains flat resolved steps plus durable task snapshot metadata
 
 ## 15.3 Backend mapping for submit
 
@@ -852,6 +869,9 @@ Mission Control should support:
 * respect preview/raw access policy signals
 * do not assume all artifacts are safe for inline display
 * treat artifacts as immutable references
+* Expansion summaries or preset include-tree artifacts are secondary explanatory evidence
+* flat steps, step logs, diagnostics, and output artifacts remain the canonical execution evidence
+* the UI must not infer execution order, step completion, or latest output from Expansion summaries
 
 ## 17.4 Run scoping
 
@@ -875,6 +895,9 @@ The generic artifact panel remains secondary to the step-expander artifact group
 * advanced/debug term: **workflow execution**
 * use **agent skill** or **skill set** for instruction bundles
 * never present Temporal Task Queues as the UI meaning of “queue”
+* use **preset** for operator-facing authored preset concepts
+* use **binding** or **provenance** for internal preset metadata
+* do not describe preset includes as subtasks, sub-plans, or separate workflow runs
 
 ## 18.2 Identifier policy
 

--- a/docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md
@@ -1,0 +1,76 @@
+# MM-387 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-387
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document Mission Control preset provenance surfaces
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-387 from MM project
+Summary: Document Mission Control preset provenance surfaces
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-387 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-387: Document Mission Control preset provenance surfaces
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 5. docs/UI/MissionControlArchitecture.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-022
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a Mission Control operator, I want task lists, detail pages, and create/edit flows to explain preset-derived work without implying nested runtime behavior.
+
+Acceptance Criteria
+- MissionControlArchitecture includes preset-composition scope for preview, edit, and detail rendering without making composition a runtime concept.
+- Task detail behavior may show provenance summaries and chips for Manual, Preset, and Preset path.
+- Steps remain execution-first; preset grouping is explanatory metadata, not the primary ordering model.
+- Submit integration allows `/tasks/new` to preview composed presets but forbids unresolved preset includes as runtime work.
+- Expansion tree artifacts or summaries are secondary evidence; flat steps, logs, diagnostics, and output artifacts remain canonical execution evidence.
+- Vocabulary distinguishes user-facing preset from internal preset binding/provenance and forbids subtask, sub-plan, or separate workflow-run labels for includes.
+
+Requirements
+- Document Mission Control preview, detail, edit, and submit behavior for preset-derived work.
+- Document detail-page provenance affordances and execution-first ordering.
+- Document artifact/evidence hierarchy for expansion summaries versus execution evidence.
+- Document compatibility vocabulary for preset includes.
+
+Relevant Implementation Notes
+- The canonical active documentation target is `docs/UI/MissionControlArchitecture.md`.
+- The issue references `docs/Tasks/PresetComposability.md`; preserve the reference as Jira traceability even if the source document is unavailable in the current checkout.
+- Preserve desired-state documentation under canonical `docs/` files and keep volatile migration or implementation tracking under `docs/tmp/`.
+- Mission Control may explain preset-derived work in previews, task lists, task details, and create/edit flows, but preset composition must not become a runtime execution concept.
+- Task detail provenance summaries and chips may expose Manual, Preset, and Preset path metadata as explanatory context while keeping flat steps as the execution-first ordering model.
+- Submit integration for `/tasks/new` may preview composed presets, but runtime work must not include unresolved preset includes.
+- Expansion tree artifacts or summaries are secondary evidence; flat steps, logs, diagnostics, and output artifacts remain canonical execution evidence.
+- User-facing vocabulary should say preset for operator concepts and binding/provenance for internal metadata, while avoiding subtask, sub-plan, or separate workflow-run labels for preset includes.
+
+Verification
+- Confirm `docs/UI/MissionControlArchitecture.md` documents preset-composition scope for preview, edit, task list, and task detail rendering without making composition a runtime concept.
+- Confirm task detail documentation allows provenance summaries and chips for Manual, Preset, and Preset path while preserving flat execution-first step ordering.
+- Confirm submit integration documentation for `/tasks/new` allows composed preset previews and forbids unresolved preset includes as runtime work.
+- Confirm artifact and evidence hierarchy treats expansion summaries as secondary evidence behind flat steps, logs, diagnostics, and output artifacts.
+- Confirm vocabulary distinguishes user-facing preset concepts from internal binding/provenance metadata and avoids subtask, sub-plan, or separate workflow-run labels for preset includes.
+- Preserve MM-387 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-388 blocks this issue.
+- MM-386 is blocked by this issue.

--- a/docs/tmp/jira-orchestration-reports/MM-387-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-387-code-review-transition.md
@@ -1,0 +1,20 @@
+# MM-387 Code Review Transition
+
+## Result
+
+- Jira issue: MM-387
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1535
+- Trusted PR handoff artifact: `/work/agent_jobs/mm:bbb364fb-4f0d-41bd-b3f9-d1d5c8483294/artifacts/jira-orchestrate-pr.json`
+- Trusted issue fetch tool: `jira.get_issue`
+- Trusted transition discovery tool: `jira.get_transitions`
+- Trusted Jira-visible PR reference tool: `jira.add_comment`
+- Trusted transition tool: `jira.transition_issue`
+- Matched transition: `Code Review`
+- Transition ID returned by Jira: `51`
+- Jira comment ID: `10694`
+- Confirmed final status from `jira.get_issue`: `Code Review`
+
+## Notes
+
+- The Code Review transition was only run after confirming the PR handoff artifact contained `jira_issue_key=MM-387` and a non-empty GitHub pull request URL.
+- The pull request reference was added as a Jira-visible comment before transition.

--- a/specs/200-mission-control-preset-provenance/checklists/requirements.md
+++ b/specs/200-mission-control-preset-provenance/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Mission Control Preset Provenance Surfaces
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The brief is classified as one independently testable story for Mission Control preset provenance surfaces.
+- Runtime mode is preserved by specifying observable Mission Control behavior; planning may satisfy the story through canonical runtime architecture documentation if implementation inspection finds no code change required.

--- a/specs/200-mission-control-preset-provenance/contracts/mission-control-preset-provenance.md
+++ b/specs/200-mission-control-preset-provenance/contracts/mission-control-preset-provenance.md
@@ -1,0 +1,34 @@
+# Contract: Mission Control Preset Provenance Surfaces
+
+## Scope
+
+This contract defines the operator-visible behavior Mission Control must follow when showing preset-derived work.
+
+## Preview And Submit
+
+- `/tasks/new` may show composed preset previews before submission.
+- Preview may group steps by preset binding or include path, but submitted runtime work must be flat resolved steps.
+- Unresolved preset includes must be blocked before runtime submission.
+
+## Task List And Detail
+
+- Task list surfaces may show compact preset-derived context only when it helps scanning.
+- Task detail may show provenance summaries and chips for Manual, Preset, and Preset path.
+- Flat steps remain the primary execution ordering model in all task detail views.
+
+## Evidence Hierarchy
+
+- Canonical execution evidence is flat steps, logs, diagnostics, and output artifacts.
+- Expansion tree artifacts or summaries are secondary explanatory evidence.
+- The UI must not infer runtime completion, latest output, or execution order from expansion summaries.
+
+## Vocabulary
+
+- User-facing language should use preset for operator concepts.
+- Internal details should use binding or provenance.
+- Preset includes must not be labeled as subtasks, sub-plans, or separate workflow runs.
+
+## Traceability
+
+- MoonSpec artifacts and verification evidence must preserve MM-387.
+- Source mappings: DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-025, DESIGN-REQ-026.

--- a/specs/200-mission-control-preset-provenance/data-model.md
+++ b/specs/200-mission-control-preset-provenance/data-model.md
@@ -1,0 +1,35 @@
+# Data Model: Mission Control Preset Provenance Surfaces
+
+## Preset Provenance
+
+- **Purpose**: Explain whether a task or step originated manually, from a preset, or from a preset include path.
+- **Fields**:
+  - `kind`: Manual, Preset, or Preset path.
+  - `label`: Operator-facing compact label.
+  - `presetPath`: Optional include path or preset lineage.
+  - `detached`: Whether the step no longer follows the preset binding.
+- **Validation Rules**:
+  - Provenance is explanatory metadata and does not alter execution ordering.
+  - Unknown or unavailable provenance must degrade to flat step presentation.
+
+## Composed Preset Preview
+
+- **Purpose**: Explain preset-derived draft content before submission.
+- **Fields**:
+  - `bindings`: Authored preset bindings included in the draft.
+  - `flatSteps`: Resolved step order intended for submission.
+  - `unresolvedIncludes`: Any includes that failed to resolve.
+- **Validation Rules**:
+  - Unresolved includes must be blocked before runtime submission.
+  - Preview grouping must not replace flat submitted step order.
+
+## Expansion Summary
+
+- **Purpose**: Secondary evidence describing preset expansion.
+- **Fields**:
+  - `includeTree`: Optional tree summary of included presets.
+  - `stepMappings`: Optional mapping from flat steps to preset paths.
+  - `generatedAt`: Summary generation timestamp when available.
+- **Validation Rules**:
+  - Expansion summaries are secondary to flat steps, logs, diagnostics, and output artifacts.
+  - Missing or stale expansion summaries must not block execution evidence review.

--- a/specs/200-mission-control-preset-provenance/plan.md
+++ b/specs/200-mission-control-preset-provenance/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Mission Control Preset Provenance Surfaces
+
+**Branch**: `200-mission-control-preset-provenance` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/200-mission-control-preset-provenance/spec.md`
+
+## Summary
+
+Implement MM-387 by updating the canonical Mission Control architecture contract so task previews, list/detail surfaces, and create/edit flows can explain preset-derived work without implying nested runtime behavior. The technical approach is to update `docs/UI/MissionControlArchitecture.md` as the desired-state UI runtime contract, then validate that the contract covers preset provenance presentation, flat execution ordering, submit-time unresolved include rejection, evidence hierarchy, and vocabulary boundaries.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation for MoonMind runtime UI architecture
+**Primary Dependencies**: Existing `docs/UI/MissionControlArchitecture.md`, preserved MM-387 Jira preset brief, existing MoonSpec artifacts
+**Storage**: No new persistent storage; documents describe UI semantics for existing task snapshots, step provenance, and execution evidence
+**Unit Testing**: Documentation contract checks with `rg` against `docs/UI/MissionControlArchitecture.md` and generated MoonSpec artifacts
+**Integration Testing**: End-to-end documentation validation by reviewing the canonical Mission Control contract against MM-387 acceptance scenarios and final `/moonspec-verify`
+**Target Platform**: Mission Control task list, detail, create/edit, and submit surfaces
+**Project Type**: Runtime UI architecture contract documentation
+**Performance Goals**: No runtime performance impact; provenance explanations remain metadata and do not add runtime preset expansion work
+**Constraints**: Preserve canonical docs as desired-state documentation, keep volatile planning under `docs/tmp/` or `specs/`, do not introduce compatibility aliases or hidden runtime fallback behavior, and preserve Jira issue key MM-387 in artifacts
+**Scale/Scope**: One canonical documentation file plus MoonSpec artifacts for one independently testable story
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story keeps preset composition in control-plane semantics and prevents UI language from implying nested runtime execution.
+- II. One-Click Agent Deployment: PASS. No services, secrets, dependencies, or setup steps are added.
+- III. Avoid Vendor Lock-In: PASS. The UI contract is provider-neutral.
+- IV. Own Your Data: PASS. Preset provenance is presented from MoonMind-owned task snapshot and execution evidence metadata.
+- V. Skills Are First-Class and Easy to Add: PASS. The story keeps agent skills distinct from presets and runtime concepts.
+- VI. Replaceable Scaffolding: PASS. The contract treats provenance as explanatory metadata and preserves flat execution evidence.
+- VII. Runtime Configurability: PASS. No hardcoded runtime configuration is introduced.
+- VIII. Modular Architecture: PASS. Preview, detail, submit, and evidence presentation boundaries remain separate from execution workers.
+- IX. Resilient by Default: PASS. The UI contract avoids live preset lookup or unresolved include submission at runtime.
+- X. Continuous Improvement: PASS. Verification evidence identifies remaining documentation or runtime-contract gaps.
+- XI. Spec-Driven Development: PASS. This one-story MoonSpec drives the change.
+- XII. Canonical Documentation Separation: PASS. Canonical docs describe desired state; migration notes remain outside canonical docs.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility shim or semantic fallback is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/200-mission-control-preset-provenance/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── mission-control-preset-provenance.md
+├── tasks.md
+├── verification.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+└── UI/
+    └── MissionControlArchitecture.md
+
+docs/tmp/
+└── jira-orchestration-inputs/
+    └── MM-387-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Update `docs/UI/MissionControlArchitecture.md` because MM-387 targets Mission Control preview, edit, list, detail, submit, evidence, and vocabulary behavior. Do not create replacement canonical docs or move volatile planning into `docs/`.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Setup Notes
+
+- The input was classified as a single-story feature request from `docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md`.
+- `.specify/feature.json` points to `specs/200-mission-control-preset-provenance`.

--- a/specs/200-mission-control-preset-provenance/quickstart.md
+++ b/specs/200-mission-control-preset-provenance/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Mission Control Preset Provenance Surfaces
+
+## Focused Documentation Contract Check
+
+```bash
+rg -n "Preset provenance|Manual|Preset path|unresolved preset includes|Expansion summaries|subtask|sub-plan|separate workflow" docs/UI/MissionControlArchitecture.md
+```
+
+Expected result: matches show Mission Control preview, task detail, submit, evidence hierarchy, and vocabulary rules for preset provenance.
+
+## Source Traceability Check
+
+```bash
+rg -n "MM-387|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-022|DESIGN-REQ-025|DESIGN-REQ-026" specs/200-mission-control-preset-provenance docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md
+```
+
+Expected result: all source IDs and the Jira issue key remain visible in MoonSpec artifacts and the canonical orchestration input.
+
+## Full Unit Verification
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Expected result: pass, unless blocked by unrelated environment constraints.
+
+## End-To-End Review
+
+Review `docs/UI/MissionControlArchitecture.md` and confirm:
+
+- preview, edit/rerun, task list, and task detail surfaces can explain preset-derived work;
+- task detail allows Manual, Preset, and Preset path chips or summaries;
+- flat steps remain primary execution order;
+- `/tasks/new` forbids unresolved preset includes as runtime work;
+- expansion summaries remain secondary evidence;
+- vocabulary avoids subtask, sub-plan, and separate workflow-run labels for preset includes.

--- a/specs/200-mission-control-preset-provenance/research.md
+++ b/specs/200-mission-control-preset-provenance/research.md
@@ -1,0 +1,25 @@
+# Research: Mission Control Preset Provenance Surfaces
+
+## Runtime Intent
+
+Decision: Treat MM-387 as runtime UI behavior requirements expressed through the canonical Mission Control architecture contract.
+Rationale: The user explicitly selected runtime mode, and the Jira brief asks Mission Control surfaces to explain preset-derived work without changing runtime execution semantics.
+Alternatives considered: A docs-only story was rejected because docs mode was not explicitly requested.
+
+## Canonical Target
+
+Decision: Use `docs/UI/MissionControlArchitecture.md` as the active target.
+Rationale: The Jira brief names MissionControlArchitecture as the source section, and this document already owns task list, detail, submit, artifact, and vocabulary behavior.
+Alternatives considered: `docs/Tasks/PresetComposability.md` is referenced by the Jira issue but is absent in the current checkout; the reference is preserved for traceability.
+
+## Validation Strategy
+
+Decision: Use focused `rg` contract checks plus end-to-end review against the spec and source design mappings.
+Rationale: The implementation target is a canonical architecture contract; checking for required terms and reading the updated sections gives direct evidence without starting services.
+Alternatives considered: Full frontend unit tests are not required unless executable React behavior changes.
+
+## Evidence Hierarchy
+
+Decision: Keep expansion summaries secondary to flat steps, logs, diagnostics, and output artifacts.
+Rationale: This preserves the runtime execution model and avoids implying nested workflow runs or sub-plans for preset includes.
+Alternatives considered: Promoting expansion summaries to primary evidence was rejected because it conflicts with MM-387 and cross-document invariants.

--- a/specs/200-mission-control-preset-provenance/spec.md
+++ b/specs/200-mission-control-preset-provenance/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: Mission Control Preset Provenance Surfaces
+
+**Feature Branch**: `200-mission-control-preset-provenance`
+**Created**: 2026-04-17
+**Status**: Draft
+**Input**:
+
+```text
+# MM-387 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-387
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document Mission Control preset provenance surfaces
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-387 from MM project
+Summary: Document Mission Control preset provenance surfaces
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-387 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-387: Document Mission Control preset provenance surfaces
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 5. docs/UI/MissionControlArchitecture.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-022
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a Mission Control operator, I want task lists, detail pages, and create/edit flows to explain preset-derived work without implying nested runtime behavior.
+
+Acceptance Criteria
+- MissionControlArchitecture includes preset-composition scope for preview, edit, and detail rendering without making composition a runtime concept.
+- Task detail behavior may show provenance summaries and chips for Manual, Preset, and Preset path.
+- Steps remain execution-first; preset grouping is explanatory metadata, not the primary ordering model.
+- Submit integration allows `/tasks/new` to preview composed presets but forbids unresolved preset includes as runtime work.
+- Expansion tree artifacts or summaries are secondary evidence; flat steps, logs, diagnostics, and output artifacts remain canonical execution evidence.
+- Vocabulary distinguishes user-facing preset from internal preset binding/provenance and forbids subtask, sub-plan, or separate workflow-run labels for includes.
+
+Requirements
+- Document Mission Control preview, detail, edit, and submit behavior for preset-derived work.
+- Document detail-page provenance affordances and execution-first ordering.
+- Document artifact/evidence hierarchy for expansion summaries versus execution evidence.
+- Document compatibility vocabulary for preset includes.
+
+Relevant Implementation Notes
+- The canonical active documentation target is `docs/UI/MissionControlArchitecture.md`.
+- The issue references `docs/Tasks/PresetComposability.md`; preserve the reference as Jira traceability even if the source document is unavailable in the current checkout.
+- Preserve desired-state documentation under canonical `docs/` files and keep volatile migration or implementation tracking under `docs/tmp/`.
+- Mission Control may explain preset-derived work in previews, task lists, task details, and create/edit flows, but preset composition must not become a runtime execution concept.
+- Task detail provenance summaries and chips may expose Manual, Preset, and Preset path metadata as explanatory context while keeping flat steps as the execution-first ordering model.
+- Submit integration for `/tasks/new` may preview composed presets, but runtime work must not include unresolved preset includes.
+- Expansion tree artifacts or summaries are secondary evidence; flat steps, logs, diagnostics, and output artifacts remain canonical execution evidence.
+- User-facing vocabulary should say preset for operator concepts and binding/provenance for internal metadata, while avoiding subtask, sub-plan, or separate workflow-run labels for preset includes.
+
+Verification
+- Confirm `docs/UI/MissionControlArchitecture.md` documents preset-composition scope for preview, edit, task list, and task detail rendering without making composition a runtime concept.
+- Confirm task detail documentation allows provenance summaries and chips for Manual, Preset, and Preset path while preserving flat execution-first step ordering.
+- Confirm submit integration documentation for `/tasks/new` allows composed preset previews and forbids unresolved preset includes as runtime work.
+- Confirm artifact and evidence hierarchy treats expansion summaries as secondary evidence behind flat steps, logs, diagnostics, and output artifacts.
+- Confirm vocabulary distinguishes user-facing preset concepts from internal binding/provenance metadata and avoids subtask, sub-plan, or separate workflow-run labels for preset includes.
+- Preserve MM-387 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-388 blocks this issue.
+- MM-386 is blocked by this issue.
+```
+
+## User Story - Mission Control Preset Provenance Surfaces
+
+**Summary**: As a Mission Control operator, I want task lists, detail pages, and create/edit flows to explain preset-derived work without implying nested runtime behavior.
+
+**Goal**: Operators can understand which submitted steps came from manual authoring, a preset, or a preset include path while Mission Control keeps flat execution steps, logs, diagnostics, and artifacts as the canonical execution evidence.
+
+**Independent Test**: Can be tested by reviewing the Mission Control UI architecture contract and validating that it defines preset provenance presentation for preview, edit, list/detail, submit, artifact evidence, and vocabulary without turning preset composition into a runtime execution model.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task draft contains composed preset steps, **When** `/tasks/new` previews the draft before submission, **Then** Mission Control may show preset grouping and provenance while ensuring unresolved preset includes are not submitted as runtime work.
+2. **Given** a submitted task contains manual and preset-derived steps, **When** an operator views the task detail page, **Then** the detail surface may show provenance summaries and chips for Manual, Preset, and Preset path while keeping flat steps as the primary execution ordering.
+3. **Given** task list or edit/rerun flows expose preset-derived work, **When** Mission Control presents that context, **Then** preset metadata is explanatory and must not imply nested subtasks, sub-plans, separate workflow runs, or runtime preset expansion.
+4. **Given** expansion tree artifacts or summaries are available, **When** the operator reviews execution evidence, **Then** those summaries remain secondary to flat steps, logs, diagnostics, and output artifacts.
+5. **Given** downstream MoonSpec, implementation notes, verification, commit text, or pull request metadata are generated for this work, **When** traceability is reviewed, **Then** the Jira issue key MM-387 remains present.
+
+### Edge Cases
+
+- A source document named by the Jira brief, `docs/Tasks/PresetComposability.md`, is absent in the current checkout; the preserved MM-387 Jira brief and current `docs/UI/MissionControlArchitecture.md` are the active sources for this story.
+- A task may contain only manual steps, only preset-derived steps, or a mix of manual, preset, included, and detached steps; the UI must not make the ordering ambiguous.
+- A composed preset preview may fail or produce unresolved includes; unresolved preset includes must be rejected before runtime submission rather than hidden in the UI.
+- Expansion summaries may be missing or stale; flat steps, logs, diagnostics, and output artifacts remain canonical execution evidence.
+
+## Assumptions
+
+- The selected runtime mode means the Mission Control architecture document is treated as runtime source requirements for product behavior, even though this story updates the canonical UI contract.
+- `docs/UI/MissionControlArchitecture.md` is the correct canonical location for Mission Control task list, detail, submit, and compatibility vocabulary behavior.
+- This story does not require executable React behavior changes unless planning discovers that existing implementation contradicts the runtime contract.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mission Control MUST define preset provenance presentation for task previews, task edit/rerun reconstruction, task lists, and task detail pages.
+- **FR-002**: Mission Control MAY show preset grouping and provenance summaries only as explanatory metadata and MUST NOT make preset composition a runtime execution concept.
+- **FR-003**: Task detail behavior MUST allow provenance summaries and chips for Manual, Preset, and Preset path metadata.
+- **FR-004**: Task step presentation MUST keep flat steps as the primary execution ordering model even when preset grouping is available.
+- **FR-005**: Submit integration for `/tasks/new` MUST allow preview of composed presets and MUST forbid unresolved preset includes from being submitted as runtime work.
+- **FR-006**: Expansion tree artifacts or summaries MUST be presented as secondary evidence behind flat steps, logs, diagnostics, and output artifacts.
+- **FR-007**: User-facing vocabulary MUST distinguish presets from internal binding/provenance metadata and MUST avoid subtask, sub-plan, or separate workflow-run labels for preset includes.
+- **FR-008**: Canonical documentation updates MUST remain desired-state documentation and keep volatile migration or implementation tracking out of canonical docs.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST retain Jira issue key `MM-387` and the original Jira preset brief.
+
+### Key Entities
+
+- **Preset Provenance**: Metadata that explains whether a task or step originated manually, from a preset, or from a preset include path.
+- **Preset Path Chip**: A compact UI label that may identify Manual, Preset, or Preset path context without changing execution ordering.
+- **Composed Preset Preview**: The `/tasks/new` preview state that explains included preset structure before submission.
+- **Expansion Summary**: A secondary artifact or summary that describes preset expansion but is not canonical execution evidence.
+- **Flat Execution Steps**: The ordered runtime step list that remains canonical for execution, logs, diagnostics, and output artifacts.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-014**: Source "Create/edit preset behavior" requires create/edit flows to preserve preset context while keeping execution based on resolved flat steps. Scope: in scope. Maps to FR-001, FR-002, FR-004, FR-005.
+- **DESIGN-REQ-015**: Source "Cross-document invariants" requires compile-time-only composition and no live runtime preset expansion. Scope: in scope. Maps to FR-002, FR-005.
+- **DESIGN-REQ-022**: Source "MissionControlArchitecture preset surfaces" requires Mission Control preview, edit, list, and detail surfaces to explain preset-derived work without implying nested runtime behavior. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004.
+- **DESIGN-REQ-025**: Source "Snapshot durability and evidence" requires expansion summaries to remain secondary to canonical execution evidence. Scope: in scope. Maps to FR-006.
+- **DESIGN-REQ-026**: Source "Execution-plane boundary" requires user-facing labels to avoid implying separate runtime workflows for preset includes. Scope: in scope. Maps to FR-007.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Review of the canonical Mission Control architecture finds explicit preset provenance scope for preview, edit/rerun, task list, and task detail surfaces.
+- **SC-002**: Review of task detail architecture finds Manual, Preset, and Preset path provenance summaries or chips documented as explanatory metadata.
+- **SC-003**: Review of submit integration rules finds composed preset preview allowed and unresolved preset includes forbidden as runtime work.
+- **SC-004**: Review of evidence hierarchy finds expansion summaries secondary to flat steps, logs, diagnostics, and output artifacts.
+- **SC-005**: Review of compatibility vocabulary finds preset include labels must not use subtask, sub-plan, or separate workflow-run terminology.
+- **SC-006**: All five in-scope source design requirements map to at least one functional requirement, and MM-387 remains present in MoonSpec artifacts and verification evidence.

--- a/specs/200-mission-control-preset-provenance/tasks.md
+++ b/specs/200-mission-control-preset-provenance/tasks.md
@@ -1,0 +1,89 @@
+# Tasks: Mission Control Preset Provenance Surfaces
+
+**Input**: Design documents from `specs/200-mission-control-preset-provenance/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Documentation contract checks and source traceability checks are REQUIRED before and after implementation. Write or define checks first, confirm they fail for missing contract language, then update canonical documentation.
+
+**Test Commands**:
+
+- Focused documentation contract check: `rg -n "Preset provenance|Manual|Preset path|unresolved preset includes|Expansion summaries|subtask|sub-plan|separate workflow" docs/UI/MissionControlArchitecture.md`
+- Source traceability check: `rg -n "MM-387|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-022|DESIGN-REQ-025|DESIGN-REQ-026" specs/200-mission-control-preset-provenance docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md`
+- Full unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final verification: `/moonspec-verify`
+
+## Traceability Inventory
+
+- FR-001, DESIGN-REQ-022: Mission Control defines preset provenance presentation for preview, edit/rerun, list, and detail surfaces.
+- FR-002, DESIGN-REQ-015: Provenance is explanatory metadata and not a runtime execution concept.
+- FR-003, SC-002: task detail allows Manual, Preset, and Preset path summaries or chips.
+- FR-004: flat steps remain the primary execution ordering model.
+- FR-005, SC-003, DESIGN-REQ-014: `/tasks/new` can preview composed presets and blocks unresolved includes before runtime submission.
+- FR-006, SC-004, DESIGN-REQ-025: expansion summaries remain secondary to canonical execution evidence.
+- FR-007, DESIGN-REQ-026: vocabulary avoids subtask, sub-plan, and separate workflow-run labels for preset includes.
+- FR-008: canonical docs remain desired-state; volatile planning stays under `docs/tmp/` and `specs/`.
+- FR-009, SC-006: MM-387 and original Jira preset brief remain visible in artifacts and verification evidence.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active MM-387 feature directory and source input in `.specify/feature.json`, `docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md`, and `specs/200-mission-control-preset-provenance/spec.md` (FR-009, SC-006).
+- [X] T002 Confirm `docs/UI/MissionControlArchitecture.md` is the canonical documentation target and `docs/Tasks/PresetComposability.md` is absent in the current checkout in `specs/200-mission-control-preset-provenance/research.md` (FR-008).
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm the existing Mission Control architecture sections for task list, detail, submit integration, artifact evidence, and compatibility vocabulary in `docs/UI/MissionControlArchitecture.md` (FR-001 through FR-007).
+
+## Phase 3: Story - Mission Control Preset Provenance Surfaces
+
+**Summary**: As a Mission Control operator, I want task lists, detail pages, and create/edit flows to explain preset-derived work without implying nested runtime behavior.
+
+**Independent Test**: Review `docs/UI/MissionControlArchitecture.md` and confirm it defines preset provenance presentation for preview, edit/rerun, task list/detail, submit, evidence hierarchy, and vocabulary while preserving flat execution semantics.
+
+**Traceability**: FR-001 through FR-009, SC-001 through SC-006, DESIGN-REQ-014, DESIGN-REQ-015, DESIGN-REQ-022, DESIGN-REQ-025, DESIGN-REQ-026, MM-387.
+
+### Unit Tests
+
+- [X] T004 Add or confirm the focused documentation contract check command in `specs/200-mission-control-preset-provenance/quickstart.md` (FR-001 through FR-007, SC-001 through SC-005).
+- [X] T005 Add or confirm the source traceability check command in `specs/200-mission-control-preset-provenance/quickstart.md` (FR-009, SC-006).
+
+### Integration Tests
+
+- [X] T006 Add or confirm end-to-end review criteria in `specs/200-mission-control-preset-provenance/contracts/mission-control-preset-provenance.md` covering preview, detail, flat step ordering, submit blocking, evidence hierarchy, and vocabulary (FR-001 through FR-007, SC-001 through SC-005).
+
+### Red-First Confirmation
+
+- [X] T007 Run `rg -n "Preset provenance|Manual|Preset path|unresolved preset includes|Expansion summaries|subtask|sub-plan|separate workflow" docs/UI/MissionControlArchitecture.md` and confirm it fails or is incomplete before documentation edits (FR-001 through FR-007, SC-001 through SC-005).
+
+### Implementation
+
+- [X] T008 Update Mission Control task list, detail, and edit/rerun architecture in `docs/UI/MissionControlArchitecture.md` to define preset provenance presentation as explanatory metadata (FR-001, FR-002, DESIGN-REQ-022).
+- [X] T009 Update task detail step presentation in `docs/UI/MissionControlArchitecture.md` to allow Manual, Preset, and Preset path summaries or chips while preserving flat step ordering (FR-003, FR-004).
+- [X] T010 Update submit integration rules in `docs/UI/MissionControlArchitecture.md` to allow composed preset previews and forbid unresolved preset includes as runtime work (FR-005, SC-003, DESIGN-REQ-014, DESIGN-REQ-015).
+- [X] T011 Update artifact/evidence hierarchy and compatibility vocabulary in `docs/UI/MissionControlArchitecture.md` so expansion summaries are secondary evidence and preset includes are not labeled as subtasks, sub-plans, or separate workflow runs (FR-006, FR-007, SC-004, SC-005, DESIGN-REQ-025, DESIGN-REQ-026).
+
+### Story Validation
+
+- [X] T012 Run focused documentation contract and source traceability checks, then fix `docs/UI/MissionControlArchitecture.md` or MoonSpec artifacts as needed (FR-001 through FR-009, SC-001 through SC-006).
+
+## Phase 4: Polish And Verification
+
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record the exact environment blocker in `specs/200-mission-control-preset-provenance/verification.md` (FR-008).
+- [X] T014 Run `/moonspec-verify` and record the result in `specs/200-mission-control-preset-provenance/verification.md` (FR-009, SC-006).
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story validation.
+- T004-T006 define the validation surface before implementation.
+- T007 must run before T008-T011.
+- T008-T011 all edit `docs/UI/MissionControlArchitecture.md` and should run sequentially.
+- T012 validates the story before full unit and final verification tasks.
+
+## Parallel Opportunities
+
+- T004 and T005 can be reviewed independently because they validate different quickstart checks.
+- T006 can be reviewed independently from quickstart command checks.
+
+## Notes
+
+- This task list covers exactly one story: MM-387.
+- Runtime mode is preserved by treating `docs/UI/MissionControlArchitecture.md` as the source of runtime UI behavior requirements.

--- a/specs/200-mission-control-preset-provenance/verification.md
+++ b/specs/200-mission-control-preset-provenance/verification.md
@@ -1,0 +1,53 @@
+# MoonSpec Verification Report
+
+**Feature**: Mission Control Preset Provenance Surfaces
+**Spec**: `specs/200-mission-control-preset-provenance/spec.md`
+**Original Request Source**: spec.md `Input` preserves MM-387 Jira preset brief
+**Verdict**: FULLY_IMPLEMENTED
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Documentation contract | `rg -n "Preset provenance|Manual|Preset path|unresolved preset includes|Expansion summaries|subtask|sub-plan|separate workflow" docs/UI/MissionControlArchitecture.md` | PASS | Found required Mission Control provenance, submit, evidence, and vocabulary terms. |
+| Source traceability | `rg -n "MM-387|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-022|DESIGN-REQ-025|DESIGN-REQ-026" specs/200-mission-control-preset-provenance docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md` | PASS | Jira key and all source IDs are preserved in the orchestration input and MoonSpec artifacts. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python: 3506 passed, 1 xpassed, 16 subtests passed. Frontend: 10 files passed, 267 tests passed. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `docs/UI/MissionControlArchitecture.md` §9.3 | VERIFIED | Defines preset provenance for list, detail, and edit/rerun surfaces. |
+| FR-002 | `docs/UI/MissionControlArchitecture.md` §9.3 | VERIFIED | States preset provenance is explanatory metadata, not a runtime execution model. |
+| FR-003 | `docs/UI/MissionControlArchitecture.md` §9.3 and §12.2 | VERIFIED | Allows Manual, Preset, and Preset path summaries or chips. |
+| FR-004 | `docs/UI/MissionControlArchitecture.md` §9.3 and §12.2 | VERIFIED | Flat steps remain the primary execution ordering model. |
+| FR-005 | `docs/UI/MissionControlArchitecture.md` §15.2 | VERIFIED | `/tasks/new` may preview composed presets and must reject unresolved preset includes before runtime submission. |
+| FR-006 | `docs/UI/MissionControlArchitecture.md` §17.3 | VERIFIED | Expansion summaries are secondary to flat steps, logs, diagnostics, and output artifacts. |
+| FR-007 | `docs/UI/MissionControlArchitecture.md` §9.3 and §18.1 | VERIFIED | Vocabulary forbids subtask, sub-plan, and separate workflow-run labels for preset includes. |
+| FR-008 | `docs/UI/MissionControlArchitecture.md`; `specs/200-mission-control-preset-provenance/` | VERIFIED | Canonical doc remains desired-state; volatile work is isolated to specs and docs/tmp. |
+| FR-009 | `specs/200-mission-control-preset-provenance/spec.md`; `docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md` | VERIFIED | MM-387 and original Jira preset brief are preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| Composed preset preview | `docs/UI/MissionControlArchitecture.md` §15.2 | VERIFIED | Preview is allowed; unresolved includes are blocked before runtime submission. |
+| Task detail provenance | `docs/UI/MissionControlArchitecture.md` §9.3 and §12.2 | VERIFIED | Provenance summaries and chips are documented without changing flat step ordering. |
+| List/edit explanatory metadata | `docs/UI/MissionControlArchitecture.md` §9.3 | VERIFIED | Provenance is explanatory and not nested runtime behavior. |
+| Evidence hierarchy | `docs/UI/MissionControlArchitecture.md` §17.3 | VERIFIED | Expansion summaries are secondary evidence. |
+| Traceability | MoonSpec artifacts and orchestration input | VERIFIED | MM-387 remains present. |
+
+## Source Design Coverage
+
+| Source ID | Evidence | Status |
+|-----------|----------|--------|
+| DESIGN-REQ-014 | `docs/UI/MissionControlArchitecture.md` §15.2 | VERIFIED |
+| DESIGN-REQ-015 | `docs/UI/MissionControlArchitecture.md` §9.3 and §15.2 | VERIFIED |
+| DESIGN-REQ-022 | `docs/UI/MissionControlArchitecture.md` §9.3 and §12.2 | VERIFIED |
+| DESIGN-REQ-025 | `docs/UI/MissionControlArchitecture.md` §17.3 | VERIFIED |
+| DESIGN-REQ-026 | `docs/UI/MissionControlArchitecture.md` §18.1 | VERIFIED |
+
+## Verdict Rationale
+
+The implementation satisfies the preserved MM-387 input and the one-story MoonSpec. The canonical Mission Control architecture now defines preset provenance surfaces, flat-step ordering, submit-time unresolved include rejection, evidence hierarchy, and vocabulary boundaries. Focused checks and the full unit suite passed.


### PR DESCRIPTION
## Jira Issue

MM-387

## Active MoonSpec Feature Path

`specs/200-mission-control-preset-provenance`

## Summary

- Adds the MM-387 MoonSpec artifacts for Mission Control preset provenance surfaces.
- Updates `docs/UI/MissionControlArchitecture.md` to define preset provenance behavior across task list/detail/edit surfaces, `/tasks/new` preview/submit rules, evidence hierarchy, and vocabulary boundaries.
- Preserves the original MM-387 Jira preset brief and source design mappings for final verification.

## Verification Verdict

`FULLY_IMPLEMENTED`

## Tests Run

- Focused documentation contract check: PASS
  - `rg -n "Preset provenance|Manual|Preset path|unresolved preset includes|Expansion summaries|subtask|sub-plan|separate workflow" docs/UI/MissionControlArchitecture.md`
- Source traceability check: PASS
  - `rg -n "MM-387|DESIGN-REQ-014|DESIGN-REQ-015|DESIGN-REQ-022|DESIGN-REQ-025|DESIGN-REQ-026" specs/200-mission-control-preset-provenance docs/tmp/jira-orchestration-inputs/MM-387-moonspec-orchestration-input.md`
- Full unit suite: PASS
  - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
  - Python: 3506 passed, 1 xpassed, 119 warnings, 16 subtests passed
  - Frontend: 10 files passed, 267 tests passed

## Remaining Risks

- GitHub reported `mergeable=false` immediately after PR creation; this may require conflict or mergeability investigation before merge.
- Local `git push` over HTTPS is unavailable in this non-interactive runtime, so the final cleanup commit was applied to the branch through the authenticated GitHub connector.