### PR TITLE
MM-389 Document plans overview preset boundary

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/201-preview-download-task-images"
+  "feature_directory": "specs/203-document-plans-preset-boundary"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,0 +1,4 @@
+{
+  "jira_issue_key": "MM-389",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1541"
+}

--- a/docs/tmp/101-PlansOverview.md
+++ b/docs/tmp/101-PlansOverview.md
@@ -68,6 +68,8 @@ Scope: product/architecture migrations, implementation sequencing, rollout phase
 | [`docs/Tasks/SkillAndPlanContracts.md`](../Tasks/SkillAndPlanContracts.md) | §14 implementation checklist (minimum to ship). |
 | [`docs/Tasks/ImageSystem.md`](../Tasks/ImageSystem.md) | § Rollout & Migration Notes — phased vision/artifact path. |
 
+Preset composition is a control-plane authoring concern resolved before `PlanDefinition` creation; see [`docs/Tasks/TaskPresetsSystem.md`](../Tasks/TaskPresetsSystem.md) for authoring-time composition semantics. Runtime plans remain flattened execution graphs of concrete nodes and edges; see [`docs/Tasks/SkillAndPlanContracts.md`](../Tasks/SkillAndPlanContracts.md) for execution-facing plan semantics.
+
 ---
 
 ## Managed agents

--- a/docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md
@@ -1,0 +1,73 @@
+# MM-389 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-389
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document plans overview preset boundary
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-389 from MM project
+Summary: Document plans overview preset boundary
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-389 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-389: Document plans overview preset boundary
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 7. docs/Temporal/101-PlansOverview.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-024
+  - DESIGN-REQ-001
+  - DESIGN-REQ-020
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a documentation reader, I want the plans overview to link authoring-time preset composition to TaskPresetsSystem and runtime plan semantics to SkillAndPlanContracts so the boundary is discoverable.
+
+Acceptance Criteria
+- The plans overview or equivalent index includes the requested alignment paragraph near plan overview content.
+- The paragraph states preset composition belongs to the control plane and is resolved before PlanDefinition creation.
+- The paragraph states plans remain flattened execution graphs of concrete nodes and edges.
+- The paragraph links authoring-time composition semantics to TaskPresetsSystem and runtime plan semantics to SkillAndPlanContracts.
+- No additional migration checklist is added to canonical docs beyond the requested concise boundary clarification.
+
+Requirements
+- Add or update cross-links in the plans overview so the authoring/runtime boundary is obvious.
+- Keep the update intentionally minimal.
+
+Relevant Implementation Notes
+- The Jira source references `docs/Tasks/PresetComposability.md`; preserve that source reference as Jira traceability even if the source document is unavailable in the current checkout.
+- The Jira source references `docs/Temporal/101-PlansOverview.md`; the current checkout exposes the plans overview at `docs/tmp/101-PlansOverview.md`, so use the repository-current equivalent when implementing unless a canonical replacement is identified.
+- Link authoring-time preset composition semantics to `docs/Tasks/TaskPresetsSystem.md`.
+- Link runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`.
+- State that preset composition is a control-plane concern resolved before `PlanDefinition` creation.
+- State that runtime plans remain flattened execution graphs of concrete nodes and edges.
+- Keep canonical documentation desired-state focused. Do not add migration checklists or implementation backlog content outside `docs/tmp/`.
+- Preserve MM-389 anywhere downstream artifacts summarize, implement, verify, commit, or open a pull request for this work.
+
+Verification
+- Confirm the plans overview or equivalent index includes a concise boundary clarification near plan overview content.
+- Confirm the clarification states preset composition belongs to the control plane and is resolved before `PlanDefinition` creation.
+- Confirm the clarification states runtime plans remain flattened execution graphs of concrete nodes and edges.
+- Confirm the clarification links authoring-time preset composition semantics to `docs/Tasks/TaskPresetsSystem.md`.
+- Confirm the clarification links runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`.
+- Confirm canonical docs do not gain an additional migration checklist for this story.
+- Preserve MM-389 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-388 is blocked by this issue.

--- a/specs/203-document-plans-preset-boundary/checklists/requirements.md
+++ b/specs/203-document-plans-preset-boundary/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Document Plans Overview Preset Boundary
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details beyond documentation target names required by the source brief
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic except for source-required document names
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration checks
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification beyond source-required artifact names
+
+## Notes
+
+- Checklist validated against the preserved MM-389 Jira preset brief and the repository-current plans overview target.

--- a/specs/203-document-plans-preset-boundary/contracts/plans-preset-boundary.md
+++ b/specs/203-document-plans-preset-boundary/contracts/plans-preset-boundary.md
@@ -1,0 +1,27 @@
+# Contract: Plans Overview Preset Boundary
+
+## Jira Traceability
+
+This contract implements the MM-389 runtime architecture story. MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata must preserve `MM-389`.
+
+## Overview Placement Contract
+
+The plans overview or repository-current equivalent must include a concise boundary clarification near the tasks, skills, presets, and plans content.
+
+The clarification must not create a new migration checklist or replace the existing index. It should explain how the existing task preset and plan contract documents relate.
+
+## Authoring-Time Preset Contract
+
+The clarification must state that preset composition belongs to the control plane and is resolved before `PlanDefinition` creation.
+
+The authoring-time semantics link must point to `docs/Tasks/TaskPresetsSystem.md`.
+
+## Runtime Plan Contract
+
+The clarification must state that runtime plans remain flattened execution graphs of concrete nodes and edges.
+
+The runtime semantics link must point to `docs/Tasks/SkillAndPlanContracts.md`.
+
+## Validation Evidence
+
+The story is complete when `docs/tmp/101-PlansOverview.md` contains the contract language above and final MoonSpec verification confirms coverage of FR-001 through FR-009 and DESIGN-REQ-001, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-025, and DESIGN-REQ-026.

--- a/specs/203-document-plans-preset-boundary/plan.md
+++ b/specs/203-document-plans-preset-boundary/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Document Plans Overview Preset Boundary
+
+**Branch**: `203-document-plans-preset-boundary` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/203-document-plans-preset-boundary/spec.md`
+
+## Summary
+
+Implement MM-389 by updating the repository-current plans overview so readers can discover that preset composition is a control-plane authoring concern resolved before `PlanDefinition` creation, while runtime plans remain flattened execution graphs of concrete nodes and edges. The technical approach is to add one concise boundary paragraph near the existing tasks, skills, presets, and plans content in `docs/tmp/101-PlansOverview.md`, linking authoring-time semantics to `docs/Tasks/TaskPresetsSystem.md` and runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`. Verification focuses on focused documentation checks, source traceability, and final MoonSpec verification against the preserved MM-389 Jira preset brief.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation for MoonMind runtime plan and preset architecture
+**Primary Dependencies**: Existing `docs/tmp/101-PlansOverview.md`, `docs/Tasks/TaskPresetsSystem.md`, `docs/Tasks/SkillAndPlanContracts.md`, preserved MM-389 Jira preset brief
+**Storage**: No new persistent storage; documents describe existing plan and preset semantics
+**Unit Testing**: Documentation contract checks with `rg` against `docs/tmp/101-PlansOverview.md` and generated MoonSpec artifacts
+**Integration Testing**: End-to-end documentation validation by reviewing the plans overview against MM-389 acceptance scenarios and running final `/moonspec-verify`
+**Target Platform**: MoonMind control plane, preset authoring surfaces, and runtime plan executor contract
+**Project Type**: Runtime architecture documentation contract
+**Performance Goals**: No runtime performance impact; documentation must clarify boundaries without adding runtime preset expansion work
+**Constraints**: Preserve desired-state documentation boundaries, keep volatile planning under `docs/tmp/` and `specs/`, do not add migration checklists to canonical docs, and preserve Jira issue key MM-389 in artifacts
+**Scale/Scope**: One plans overview file plus MoonSpec artifacts for one independently testable story
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story clarifies the boundary between preset authoring and runtime plan execution without replacing agents or tools.
+- II. One-Click Agent Deployment: PASS. No services, secrets, dependencies, or setup steps are added.
+- III. Avoid Vendor Lock-In: PASS. The boundary applies to all plan producers and executors.
+- IV. Own Your Data: PASS. Plan artifacts and preset provenance remain MoonMind-managed artifacts.
+- V. Skills Are First-Class and Easy to Add: PASS. The story preserves the distinction between authoring-time presets and executable plan contracts.
+- VI. Replaceable Scaffolding: PASS. Preset composition stays isolated from runtime execution semantics.
+- VII. Runtime Configurability: PASS. No runtime configuration is introduced.
+- VIII. Modular Architecture: PASS. Preset authoring, plan contracts, and execution stay separate.
+- IX. Resilient by Default: PASS. The clarified boundary discourages hidden runtime fallback for unresolved preset includes.
+- X. Continuous Improvement: PASS. Verification records evidence against the preserved Jira brief.
+- XI. Spec-Driven Development: PASS. This one-story MoonSpec drives the change.
+- XII. Canonical Documentation Separation: PASS. The change is concise and does not add canonical migration checklist content.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility layer or semantic fallback is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/203-document-plans-preset-boundary/
+├── spec.md
+├── plan.md
+├── research.md
+├── quickstart.md
+├── contracts/
+│   └── plans-preset-boundary.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Documentation
+
+```text
+docs/tmp/
+├── 101-PlansOverview.md
+└── jira-orchestration-inputs/
+    └── MM-389-moonspec-orchestration-input.md
+
+docs/Tasks/
+├── TaskPresetsSystem.md
+└── SkillAndPlanContracts.md
+```
+
+**Structure Decision**: Update `docs/tmp/101-PlansOverview.md` because it is the repository-current plans overview equivalent named by MM-389. Use existing links to the two canonical task documents and add one clarifying paragraph instead of creating a new index or canonical migration checklist.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Setup Notes
+
+- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` was attempted but rejected the managed branch name `mm-389-c85d78af` because it expects a branch like `001-feature-name`.
+- `.specify/feature.json` points to `specs/203-document-plans-preset-boundary` for this managed run.

--- a/specs/203-document-plans-preset-boundary/quickstart.md
+++ b/specs/203-document-plans-preset-boundary/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Document Plans Overview Preset Boundary
+
+## Focused Documentation Contract Check
+
+Run after updating `docs/tmp/101-PlansOverview.md`:
+
+```bash
+rg -n "control plane|PlanDefinition|flattened execution graphs|TaskPresetsSystem|SkillAndPlanContracts" docs/tmp/101-PlansOverview.md
+```
+
+Expected result:
+- The plans overview includes a concise boundary clarification near the tasks, skills, presets, and plans section.
+- Preset composition is described as a control-plane concern resolved before `PlanDefinition` creation.
+- Runtime plans are described as flattened execution graphs of concrete nodes and edges.
+- The paragraph links to both `TaskPresetsSystem` and `SkillAndPlanContracts`.
+
+## No Canonical Migration Checklist Check
+
+```bash
+! rg -n "MM-389|Document plans overview preset boundary|preset boundary" docs --glob '!docs/tmp/**'
+```
+
+Expected result: no canonical docs outside `docs/tmp/` contain a new MM-389 migration checklist or story-specific backlog entry.
+
+## Source Traceability Check
+
+```bash
+rg -n "MM-389|DESIGN-REQ-001|DESIGN-REQ-020|DESIGN-REQ-024|DESIGN-REQ-025|DESIGN-REQ-026" specs/203-document-plans-preset-boundary docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md
+```
+
+Expected result: MM-389 and all in-scope source design requirements are present in MoonSpec artifacts.
+
+## Full Unit Suite
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Expected result: full unit suite passes. This documentation-contract story does not require new executable unit tests unless implementation changes runtime code.
+
+## Hermetic Integration Suite
+
+```bash
+./tools/test_integration.sh
+```
+
+Run when Docker is available. This story does not require credentials or external providers.
+
+## Final MoonSpec Verification
+
+Run final verification against the active feature:
+
+```text
+/moonspec-verify
+```
+
+Expected result:
+- The preserved MM-389 Jira preset brief is the canonical input.
+- `docs/tmp/101-PlansOverview.md` satisfies FR-001 through FR-008.
+- MoonSpec artifacts preserve MM-389 for FR-009.
+- Verification records any environment blockers for full unit or integration commands.

--- a/specs/203-document-plans-preset-boundary/research.md
+++ b/specs/203-document-plans-preset-boundary/research.md
@@ -1,0 +1,41 @@
+# Research: Document Plans Overview Preset Boundary
+
+## Input Classification
+
+Decision: Treat MM-389 as a single-story runtime feature request.
+
+Rationale: The Jira preset brief contains one user story, one bounded documentation target, and specific acceptance criteria around a concise authoring/runtime boundary paragraph. The selected mode is runtime, so the documentation is treated as source requirements for product behavior rather than a docs-only preference.
+
+Alternatives considered: Treating the input as a broad declarative design was rejected because the brief already selects one independently testable story. Treating it as an existing feature directory was rejected until `specs/203-document-plans-preset-boundary` was created by the specify stage.
+
+## Source Document Availability
+
+Decision: Use the preserved MM-389 Jira preset brief, `docs/tmp/101-PlansOverview.md`, `docs/Tasks/TaskPresetsSystem.md`, and `docs/Tasks/SkillAndPlanContracts.md` as active sources.
+
+Rationale: The brief references `docs/Tasks/PresetComposability.md`, but that file is absent in the current checkout. It also references `docs/Temporal/101-PlansOverview.md`, while the current repository exposes the plans overview at `docs/tmp/101-PlansOverview.md`. The target documents contain the required current semantics: `TaskPresetsSystem` describes preset expansion into `PlanDefinition`, and `SkillAndPlanContracts` describes flattened runtime plan semantics.
+
+Alternatives considered: Blocking on missing source paths was rejected because the preserved brief is specific and the repository-current equivalent files contain the required semantics.
+
+## Implementation Surface
+
+Decision: Update `docs/tmp/101-PlansOverview.md` and MoonSpec artifacts only unless verification discovers executable drift.
+
+Rationale: MM-389 asks for the plans overview or equivalent index to include a concise cross-document boundary clarification. The implementation target is a documentation index, not a runtime code path.
+
+Alternatives considered: Updating `docs/Tasks/TaskPresetsSystem.md` or `docs/Tasks/SkillAndPlanContracts.md` was rejected because those documents already contain the source semantics and MM-389 is specifically about discoverability from the overview.
+
+## Boundary Text Shape
+
+Decision: Add one paragraph directly below the tasks, skills, presets, and plans table.
+
+Rationale: This keeps the alignment near plan overview content and avoids adding a new migration checklist. The paragraph can link both source documents and state the control-plane/runtime boundary in one place.
+
+Alternatives considered: Adding a new subsection was rejected as heavier than the requested concise clarification. Editing canonical docs was rejected because the repository-current overview is under `docs/tmp/` and the story asks not to add canonical migration checklist content.
+
+## Test Strategy
+
+Decision: Use focused documentation contract checks, source traceability checks, and final MoonSpec verification rather than adding executable unit tests.
+
+Rationale: The planned implementation changes Markdown only. Focused `rg` checks can verify the required paragraph content and links. If implementation discovers code changes are needed, tasks must add appropriate unit and integration coverage at the real boundary before changing code.
+
+Alternatives considered: Adding synthetic code tests was rejected because they would not exercise a real runtime boundary for this documentation-index story.

--- a/specs/203-document-plans-preset-boundary/spec.md
+++ b/specs/203-document-plans-preset-boundary/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Document Plans Overview Preset Boundary
+
+**Feature Branch**: `203-document-plans-preset-boundary`
+**Created**: 2026-04-17
+**Status**: Draft
+**Input**:
+
+```text
+# MM-389 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-389
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document plans overview preset boundary
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-389 from MM project
+Summary: Document plans overview preset boundary
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-389 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-389: Document plans overview preset boundary
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 7. docs/Temporal/101-PlansOverview.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-024
+  - DESIGN-REQ-001
+  - DESIGN-REQ-020
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a documentation reader, I want the plans overview to link authoring-time preset composition to TaskPresetsSystem and runtime plan semantics to SkillAndPlanContracts so the boundary is discoverable.
+
+Acceptance Criteria
+- The plans overview or equivalent index includes the requested alignment paragraph near plan overview content.
+- The paragraph states preset composition belongs to the control plane and is resolved before PlanDefinition creation.
+- The paragraph states plans remain flattened execution graphs of concrete nodes and edges.
+- The paragraph links authoring-time composition semantics to TaskPresetsSystem and runtime plan semantics to SkillAndPlanContracts.
+- No additional migration checklist is added to canonical docs beyond the requested concise boundary clarification.
+
+Requirements
+- Add or update cross-links in the plans overview so the authoring/runtime boundary is obvious.
+- Keep the update intentionally minimal.
+
+Relevant Implementation Notes
+- The Jira source references `docs/Tasks/PresetComposability.md`; preserve that source reference as Jira traceability even if the source document is unavailable in the current checkout.
+- The Jira source references `docs/Temporal/101-PlansOverview.md`; the current checkout exposes the plans overview at `docs/tmp/101-PlansOverview.md`, so use the repository-current equivalent when implementing unless a canonical replacement is identified.
+- Link authoring-time preset composition semantics to `docs/Tasks/TaskPresetsSystem.md`.
+- Link runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`.
+- State that preset composition is a control-plane concern resolved before `PlanDefinition` creation.
+- State that runtime plans remain flattened execution graphs of concrete nodes and edges.
+- Keep canonical documentation desired-state focused. Do not add migration checklists or implementation backlog content outside `docs/tmp/`.
+- Preserve MM-389 anywhere downstream artifacts summarize, implement, verify, commit, or open a pull request for this work.
+
+Verification
+- Confirm the plans overview or equivalent index includes a concise boundary clarification near plan overview content.
+- Confirm the clarification states preset composition belongs to the control plane and is resolved before `PlanDefinition` creation.
+- Confirm the clarification states runtime plans remain flattened execution graphs of concrete nodes and edges.
+- Confirm the clarification links authoring-time preset composition semantics to `docs/Tasks/TaskPresetsSystem.md`.
+- Confirm the clarification links runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`.
+- Confirm canonical docs do not gain an additional migration checklist for this story.
+- Preserve MM-389 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-388 is blocked by this issue.
+```
+
+## User Story - Plans Overview Preset Boundary
+
+**Summary**: As a documentation reader, I want the plans overview to make the preset authoring/runtime boundary discoverable through concise cross-links.
+
+**Goal**: Readers can distinguish preset composition as a control-plane authoring concern from runtime plan execution semantics without hunting across Task Presets and Skill/Plan contract documents.
+
+**Independent Test**: Review the plans overview or repository-current equivalent and confirm it contains one concise boundary clarification near the task, skills, presets, and plans content, with links to authoring-time preset composition semantics and runtime plan semantics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader opens the plans overview, **When** they review the task, skills, presets, and plans section, **Then** they can find a concise paragraph that explains the authoring/runtime preset boundary.
+2. **Given** the paragraph describes preset composition, **When** it names the control-plane boundary, **Then** it states composition is resolved before `PlanDefinition` creation.
+3. **Given** the paragraph describes runtime plans, **When** it names execution semantics, **Then** it states plans remain flattened execution graphs of concrete nodes and edges.
+4. **Given** a reader needs deeper detail, **When** they follow links from the paragraph, **Then** authoring-time semantics point to `TaskPresetsSystem` and runtime plan semantics point to `SkillAndPlanContracts`.
+5. **Given** canonical documentation is reviewed, **When** this story is complete, **Then** it has not added a new migration checklist to canonical docs beyond the concise boundary clarification.
+6. **Given** downstream MoonSpec, implementation notes, verification, commit text, or pull request metadata are generated, **When** traceability is reviewed, **Then** the Jira issue key MM-389 remains present.
+
+### Edge Cases
+
+- The Jira brief references `docs/Tasks/PresetComposability.md`, but that file is absent in the current checkout; the preserved MM-389 brief, `docs/Tasks/TaskPresetsSystem.md`, and `docs/Tasks/SkillAndPlanContracts.md` are the active sources.
+- The Jira brief references `docs/Temporal/101-PlansOverview.md`, while the repository-current overview is `docs/tmp/101-PlansOverview.md`; the current file is treated as the equivalent target.
+- The plans overview is itself under `docs/tmp/`; the change must stay concise and must not move migration backlog into canonical docs.
+- Existing table entries already link the two target documents separately; the new clarification must explain the boundary between them instead of duplicating table rows.
+
+## Assumptions
+
+- The selected runtime mode means the documentation target is treated as runtime source requirements for product behavior, even though the implementation change is a documentation contract update.
+- `docs/tmp/101-PlansOverview.md` is the repository-current equivalent of the Jira-referenced plans overview.
+- This story does not require executable code changes unless planning discovers implementation drift from the documented runtime contract.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001**: Source "Plans overview alignment" requires the plans overview or equivalent index to include the requested alignment paragraph near plan overview content. Scope: in scope. Maps to FR-001, FR-002.
+- **DESIGN-REQ-020**: Source "Preset composition boundary" requires preset composition to belong to the control plane and be resolved before `PlanDefinition` creation. Scope: in scope. Maps to FR-003, FR-004.
+- **DESIGN-REQ-024**: Source "Runtime plan shape" requires plans to remain flattened execution graphs of concrete nodes and edges. Scope: in scope. Maps to FR-005.
+- **DESIGN-REQ-025**: Source "Cross-document links" requires authoring-time composition semantics to link to `TaskPresetsSystem` and runtime plan semantics to link to `SkillAndPlanContracts`. Scope: in scope. Maps to FR-006, FR-007.
+- **DESIGN-REQ-026**: Source "Canonical documentation boundary" requires no additional migration checklist in canonical docs beyond the concise boundary clarification. Scope: in scope. Maps to FR-008.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The plans overview or repository-current equivalent MUST include one concise boundary clarification near the tasks, skills, presets, and plans content.
+- **FR-002**: The clarification MUST be discoverable from the existing plan overview context without creating a replacement index or new documentation hierarchy.
+- **FR-003**: The clarification MUST state that preset composition belongs to the control plane.
+- **FR-004**: The clarification MUST state that preset composition is resolved before `PlanDefinition` creation.
+- **FR-005**: The clarification MUST state that runtime plans remain flattened execution graphs of concrete nodes and edges.
+- **FR-006**: The clarification MUST link authoring-time preset composition semantics to `docs/Tasks/TaskPresetsSystem.md`.
+- **FR-007**: The clarification MUST link runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`.
+- **FR-008**: Canonical documentation MUST NOT gain an additional migration checklist for this story.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST retain Jira issue key `MM-389` and the original Jira preset brief.
+
+### Key Entities
+
+- **Plans Overview**: The repository index that helps readers discover plan-shaped documentation and related task, skill, preset, and plan contracts.
+- **Control-Plane Preset Composition**: Authoring-time preset selection and expansion work that is resolved before a runtime `PlanDefinition` exists.
+- **Runtime Plan Semantics**: The execution-facing contract where plans are flattened graphs of concrete nodes and edges.
+- **Boundary Clarification**: The concise paragraph that links preset authoring semantics to runtime plan semantics without adding migration backlog.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Review of the plans overview finds one paragraph near the tasks, skills, presets, and plans section that explains the preset authoring/runtime boundary.
+- **SC-002**: The paragraph includes the phrases or equivalent semantics for "control plane" and "before `PlanDefinition` creation".
+- **SC-003**: The paragraph includes the phrase or equivalent semantics for "flattened execution graphs of concrete nodes and edges".
+- **SC-004**: The paragraph links to `docs/Tasks/TaskPresetsSystem.md` for authoring-time preset composition semantics.
+- **SC-005**: The paragraph links to `docs/Tasks/SkillAndPlanContracts.md` for runtime plan semantics.
+- **SC-006**: Review confirms no new migration checklist was added to canonical docs for this story.
+- **SC-007**: All five in-scope source design requirements map to at least one functional requirement, and MM-389 remains present in MoonSpec artifacts and verification evidence.

--- a/specs/203-document-plans-preset-boundary/tasks.md
+++ b/specs/203-document-plans-preset-boundary/tasks.md
@@ -1,0 +1,103 @@
+# Tasks: Document Plans Overview Preset Boundary
+
+**Input**: Design documents from `specs/203-document-plans-preset-boundary/`
+**Prerequisites**: plan.md, spec.md, research.md, contracts/
+
+**Tests**: Documentation contract checks and source traceability checks are REQUIRED before and after implementation. Write or define checks first, confirm they fail or are incomplete for missing boundary language, then update the plans overview.
+
+**Test Commands**:
+
+- Focused documentation contract check: `rg -n "control plane|PlanDefinition|flattened execution graphs|TaskPresetsSystem|SkillAndPlanContracts" docs/tmp/101-PlansOverview.md`
+- No canonical migration checklist check: `! rg -n "MM-389|Document plans overview preset boundary|preset boundary" docs --glob '!docs/tmp/**'`
+- Source traceability check: `rg -n "MM-389|DESIGN-REQ-001|DESIGN-REQ-020|DESIGN-REQ-024|DESIGN-REQ-025|DESIGN-REQ-026" specs/203-document-plans-preset-boundary docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md`
+- Full unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Hermetic integration tests: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Traceability Inventory
+
+- FR-001, FR-002, SC-001, DESIGN-REQ-001: concise boundary clarification appears near the tasks, skills, presets, and plans content.
+- FR-003, FR-004, SC-002, DESIGN-REQ-020: preset composition belongs to the control plane and is resolved before `PlanDefinition` creation.
+- FR-005, SC-003, DESIGN-REQ-024: runtime plans remain flattened execution graphs of concrete nodes and edges.
+- FR-006, FR-007, SC-004, SC-005, DESIGN-REQ-025: authoring-time semantics link to `TaskPresetsSystem`; runtime semantics link to `SkillAndPlanContracts`.
+- FR-008, SC-006, DESIGN-REQ-026: no additional migration checklist is added to canonical docs.
+- FR-009, SC-007: MM-389 and original Jira preset brief remain visible in artifacts and verification evidence.
+- Acceptance scenarios 1-5: overview review confirms placement, boundary text, links, and no canonical checklist.
+- Acceptance scenario 6: traceability review confirms MM-389 remains present.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active MM-389 feature directory and source input in `.specify/feature.json`, `docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md`, and `specs/203-document-plans-preset-boundary/spec.md` (FR-009, SC-007).
+- [X] T002 Confirm `docs/tmp/101-PlansOverview.md` is the repository-current plans overview target and `docs/Tasks/PresetComposability.md` is absent in the current checkout in `specs/203-document-plans-preset-boundary/research.md` (FR-001, FR-008).
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect existing preset and plan semantics in `docs/Tasks/TaskPresetsSystem.md`, `docs/Tasks/SkillAndPlanContracts.md`, and `docs/tmp/101-PlansOverview.md` before test authoring (FR-003 through FR-007).
+
+## Phase 3: Story - Plans Overview Preset Boundary
+
+**Summary**: As a documentation reader, I want the plans overview to make the preset authoring/runtime boundary discoverable through concise cross-links.
+
+**Independent Test**: Review the plans overview or repository-current equivalent and confirm it contains one concise boundary clarification near the task, skills, presets, and plans content, with links to authoring-time preset composition semantics and runtime plan semantics.
+
+**Traceability**: FR-001 through FR-009, SC-001 through SC-007, DESIGN-REQ-001, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-025, DESIGN-REQ-026, MM-389.
+
+### Unit Tests
+
+- [X] T004 Add focused documentation contract check command in `specs/203-document-plans-preset-boundary/quickstart.md` (FR-001 through FR-007, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-025).
+- [X] T005 Add no-canonical-migration-checklist command in `specs/203-document-plans-preset-boundary/quickstart.md` (FR-008, SC-006, DESIGN-REQ-026).
+- [X] T006 Add source traceability check command in `specs/203-document-plans-preset-boundary/quickstart.md` (FR-009, SC-007).
+
+### Integration Tests
+
+- [X] T007 Add end-to-end contract review criteria in `specs/203-document-plans-preset-boundary/contracts/plans-preset-boundary.md` covering placement, control-plane boundary, runtime plan semantics, links, and no migration checklist (FR-001 through FR-008, SC-001 through SC-006, DESIGN-REQ-001, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-025, DESIGN-REQ-026).
+- [X] T008 Add final story validation commands in `specs/203-document-plans-preset-boundary/quickstart.md` for full unit tests, hermetic integration tests, and `/moonspec-verify` (FR-008, FR-009, SC-007).
+
+### Red-First Confirmation
+
+- [X] T009 Run `rg -n "control plane|PlanDefinition|flattened execution graphs|TaskPresetsSystem|SkillAndPlanContracts" docs/tmp/101-PlansOverview.md` and confirm it is incomplete before documentation edits (FR-001 through FR-007, SC-001 through SC-005).
+- [X] T010 Run source traceability check before artifact completion and confirm only the preserved Jira input exists before generated MoonSpec artifacts (FR-009, SC-007).
+
+### Implementation
+
+- [X] T011 Update `docs/tmp/101-PlansOverview.md` with one concise paragraph near tasks, skills, presets, and plans that states preset composition is control-plane work resolved before `PlanDefinition` creation, runtime plans are flattened execution graphs of concrete nodes and edges, and links to `TaskPresetsSystem` and `SkillAndPlanContracts` (FR-001 through FR-007, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-020, DESIGN-REQ-024, DESIGN-REQ-025).
+
+### Story Validation
+
+- [X] T012 Run focused documentation contract, no-canonical-migration-checklist, and source traceability checks from `specs/203-document-plans-preset-boundary/quickstart.md`, then fix `docs/tmp/101-PlansOverview.md` or MoonSpec artifacts as needed (FR-001 through FR-009, SC-001 through SC-007).
+
+## Phase 4: Polish And Verification
+
+- [X] T013 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record the exact environment blocker in `specs/203-document-plans-preset-boundary/verification.md` (FR-008).
+- [X] T014 Run `./tools/test_integration.sh` when Docker is available or record the exact environment blocker in `specs/203-document-plans-preset-boundary/verification.md` (FR-008).
+- [X] T015 Run `/moonspec-verify` and record the result in `specs/203-document-plans-preset-boundary/verification.md` (FR-009, SC-007).
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story test authoring.
+- T004-T008 define the validation surface before implementation.
+- T009-T010 must run before T011.
+- T011 edits `docs/tmp/101-PlansOverview.md`.
+- T012 validates the story before full unit, integration, and final verification tasks.
+- T013-T015 complete final evidence after story validation passes or blockers are recorded.
+
+## Parallel Opportunities
+
+- T004 and T006 can be reviewed independently because they validate different quickstart checks.
+- T007 can be reviewed independently from quickstart command checks because it touches `specs/203-document-plans-preset-boundary/contracts/plans-preset-boundary.md`.
+- T013 and T014 can run independently after T012 when the environment supports both test suites.
+
+## Implementation Strategy
+
+1. Complete setup and source inspection.
+2. Define unit-style documentation checks and integration-style review checks.
+3. Run red-first checks and capture missing boundary language before editing.
+4. Update only `docs/tmp/101-PlansOverview.md` unless validation discovers artifact drift.
+5. Rerun focused checks and traceability checks.
+6. Run full unit and hermetic integration suites when available.
+7. Run `/moonspec-verify` against the preserved MM-389 Jira preset brief.
+
+## Notes
+
+- This task list covers exactly one story: MM-389.
+- The standard MoonSpec prerequisite helper may reject managed branch names; use `.specify/feature.json` as the active feature pointer in this managed run.

--- a/specs/203-document-plans-preset-boundary/verification.md
+++ b/specs/203-document-plans-preset-boundary/verification.md
@@ -1,0 +1,61 @@
+# MoonSpec Verification Report
+
+**Feature**: Document Plans Overview Preset Boundary  
+**Spec**: `specs/203-document-plans-preset-boundary/spec.md`  
+**Original Request Source**: spec.md `Input` / MM-389 Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| ----- | ------- | ------ | ----- |
+| Focused documentation contract | `rg -n "control plane|PlanDefinition|flattened execution graphs|TaskPresetsSystem|SkillAndPlanContracts" docs/tmp/101-PlansOverview.md` | PASS | Found the existing table links and the new paragraph at `docs/tmp/101-PlansOverview.md:71`. |
+| Canonical migration checklist guard | `! rg -n "MM-389|Document plans overview preset boundary|preset boundary" docs --glob '!docs/tmp/**'` | PASS | Produced no matches outside `docs/tmp/`, as expected. |
+| Source traceability | `rg -n "MM-389|DESIGN-REQ-001|DESIGN-REQ-020|DESIGN-REQ-024|DESIGN-REQ-025|DESIGN-REQ-026" specs/203-document-plans-preset-boundary docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md` | PASS | MM-389 and all in-scope source design requirement IDs are preserved. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3531 Python tests passed, 1 xpassed, 16 subtests passed; 274 frontend tests passed. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | Blocked by environment: Docker socket unavailable at `unix:///var/run/docker.sock`. |
+| MoonSpec prerequisite helper | `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | NOT RUN | Helper rejects managed branch `mm-389-c85d78af` because it expects a numeric feature branch name. Verification used `.specify/feature.json` and direct artifact paths. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| ----------- | -------- | ------ | ----- |
+| FR-001 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Boundary clarification appears near the tasks, skills, presets, and plans section. |
+| FR-002 | `docs/tmp/101-PlansOverview.md:61` and `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Existing overview structure is preserved; no replacement index was created. |
+| FR-003 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | States preset composition is a control-plane authoring concern. |
+| FR-004 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | States composition is resolved before `PlanDefinition` creation. |
+| FR-005 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | States runtime plans remain flattened execution graphs of concrete nodes and edges. |
+| FR-006 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Links authoring-time semantics to `docs/Tasks/TaskPresetsSystem.md`. |
+| FR-007 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Links runtime plan semantics to `docs/Tasks/SkillAndPlanContracts.md`. |
+| FR-008 | Canonical migration checklist guard | VERIFIED | No story-specific migration checklist was added outside `docs/tmp/`. |
+| FR-009 | `specs/203-document-plans-preset-boundary/spec.md`, `tasks.md`, `verification.md`, and `docs/tmp/jira-orchestration-inputs/MM-389-moonspec-orchestration-input.md` | VERIFIED | MM-389 and the preserved Jira preset brief remain in MoonSpec artifacts and verification evidence. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| -------- | -------- | ------ | ----- |
+| SCN-001 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Reader can find the boundary clarification in the relevant section. |
+| SCN-002 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Control-plane boundary and pre-`PlanDefinition` resolution are explicit. |
+| SCN-003 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Runtime flattened graph semantics are explicit. |
+| SCN-004 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Both required links are present. |
+| SCN-005 | Canonical migration checklist guard | VERIFIED | No additional canonical migration checklist was introduced. |
+| SCN-006 | Source traceability check | VERIFIED | MM-389 remains present in source input, spec artifacts, tasks, and verification. |
+
+## Source Design Coverage
+
+| Source ID | Evidence | Status | Notes |
+| --------- | -------- | ------ | ----- |
+| DESIGN-REQ-001 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Paragraph is near the plans overview content. |
+| DESIGN-REQ-020 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Control-plane and pre-`PlanDefinition` boundary is stated. |
+| DESIGN-REQ-024 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Runtime flattened graph shape is stated. |
+| DESIGN-REQ-025 | `docs/tmp/101-PlansOverview.md:71` | VERIFIED | Links point to TaskPresetsSystem and SkillAndPlanContracts. |
+| DESIGN-REQ-026 | Canonical migration checklist guard | VERIFIED | No canonical docs gained a migration checklist for this story. |
+
+## Residual Risk
+
+- Hermetic integration could not run because the managed container does not expose Docker. This is not blocking for the MM-389 documentation-boundary story because focused checks and the full unit suite passed, and the implementation did not change runtime code.
+
+## Final Verdict
+
+`FULLY_IMPLEMENTED`: MM-389 is implemented, tested, aligned, and verified against the preserved Jira preset brief.


### PR DESCRIPTION
## Summary

- Jira issue key: MM-389
- Active MoonSpec feature path: `specs/203-document-plans-preset-boundary`
- Added the plans overview boundary clarification linking authoring-time preset composition semantics to TaskPresetsSystem and runtime plan semantics to SkillAndPlanContracts.
- Preserved the MM-389 Jira preset brief and MoonSpec verification evidence.
- Synced with current `main` and renumbered the MoonSpec folder to the next global spec number to avoid the `201-*` collision.

## Verification

- Verification verdict: FULLY_IMPLEMENTED
- Focused documentation contract check: PASS
- Canonical migration checklist guard: PASS
- Source traceability check: PASS
- `git merge-tree origin/main HEAD`: PASS locally after conflict resolution
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`: PASS, 3531 Python tests passed and 274 frontend tests passed
- `./tools/test_integration.sh`: NOT RUN, Docker socket unavailable at `unix:///var/run/docker.sock` in the managed runtime

## Remaining Risks

- Hermetic integration was not run because Docker is unavailable in this managed container. The implementation changes documentation and MoonSpec artifacts only; focused checks and the full unit suite passed.