### PR TITLE
MM-388 Document proposal promotion with preset provenance

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/201-managed-github-secret-materialization"
+  "feature_directory": "specs/202-document-proposal-promotion"
 }

--- a/api_service/api/routers/task_proposals.py
+++ b/api_service/api/routers/task_proposals.py
@@ -38,6 +38,8 @@ from moonmind.workflows.task_proposals.service import (
 
 router = APIRouter(prefix="/api/proposals", tags=["task-proposals"])
 
+_PRESET_SOURCE_KINDS = frozenset({"preset-derived", "preset-include", "detached"})
+
 
 async def _get_service(
     session: AsyncSession = Depends(get_async_session),
@@ -73,6 +75,27 @@ def _build_task_preview(
     raw_skills = task.get("skills") or payload.get("skills")
     task_skills = raw_skills if isinstance(raw_skills, list) else None
     instructions = task.get("instructions") or payload.get("instruction")
+    authored_presets = task.get("authoredPresets")
+    authored_preset_count = (
+        len(authored_presets) if isinstance(authored_presets, list) else 0
+    )
+    raw_steps = task.get("steps")
+    steps = raw_steps if isinstance(raw_steps, list) else []
+    step_source_kinds: list[str] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        source_node = step.get("source")
+        if not isinstance(source_node, dict):
+            continue
+        kind = str(source_node.get("kind") or "").strip()
+        if kind:
+            step_source_kinds.append(kind)
+    preset_provenance = "manual"
+    if authored_preset_count > 0:
+        preset_provenance = "preserved-binding"
+    elif any(kind in _PRESET_SOURCE_KINDS for kind in step_source_kinds):
+        preset_provenance = "flattened-only"
 
     runtime_value = (
         (str(runtime_mode).strip() or None) if runtime_mode is not None else None
@@ -100,6 +123,9 @@ def _build_task_preview(
         startingBranch=starting_value,
         targetBranch=target_branch_value,
         instructions=instructions_value,
+        presetProvenance=preset_provenance,
+        authoredPresetCount=authored_preset_count,
+        stepSourceKinds=step_source_kinds,
     )
 
 

--- a/docs/Tasks/TaskProposalSystem.md
+++ b/docs/Tasks/TaskProposalSystem.md
@@ -56,6 +56,8 @@ These rules are fixed:
    proposal.
 9. When a proposal depends on agent skill context, that context must be preserved explicitly in the stored `taskCreateRequest` or preserved through documented inheritance semantics.
 10. Proposal promotion must not silently drift to unrelated skill defaults when the original proposal logic depended on explicit skill selection.
+11. Preset-derived metadata in proposals is advisory UX and reconstruction metadata, not a runtime dependency.
+12. Proposal promotion validates and submits the reviewed flat task payload; it does not depend on live preset catalog lookup or live preset re-expansion for correctness.
 
 ---
 
@@ -162,6 +164,7 @@ Generators analyze:
 3. normalized `AgentRunResult` data from managed and external agents
 4. finish-summary signals and execution diagnostics
 5. resolved skill snapshot metadata and skill-related execution context, specifically observing if a specific skill set or context contributed to the detected follow-up work (using artifact-backed skill metadata where needed rather than treating the runtime workspace as the sole source of truth)
+6. authored preset metadata and per-step source provenance when the parent run exposes reliable preset provenance
 
 Generators must:
 
@@ -170,6 +173,7 @@ Generators must:
 3. avoid side effects such as commits, pushes, or task creation
 4. redact or exclude secrets and unsafe command output
 5. **Preserve Skill Selectors:** Only emit explicit skill selectors when they materially affect the correctness or expected behavior of the follow-up work. Generic project follow-up proposals do not need to redundantly stamp all inherited defaults if doing so adds noise without preserving important intent. When the originating task explicitly selected non-default skill sets, proposals should preserve that intent unless documented otherwise.
+6. **Preserve Reliable Preset Provenance:** Proposal generators may carry forward parent-run preset provenance when the candidate work is genuinely derived from authored preset metadata or reliable step source metadata. Generators must not fabricate `task.authoredPresets`, binding IDs, include paths, or preset-derived labels for work that was manually authored, inferred from logs only, or otherwise lacks reliable binding evidence.
 
 ### 3.5 Proposal submission
 
@@ -314,12 +318,34 @@ That means:
               { "name": "moonmind-doc-writer", "version": "2.3.0" }
             ]
           },
+          "authoredPresets": [
+            {
+              "bindingId": "preset-binding-123",
+              "presetId": "runtime-quality-followup",
+              "version": "2026-04-17",
+              "includePath": ["root", "regression-coverage"],
+              "detached": false
+            }
+          ],
           "runtime": {
             "mode": "codex"
           },
           "publish": {
             "mode": "pr"
-          }
+          },
+          "steps": [
+            {
+              "title": "Add regression coverage",
+              "instructions": "Add a regression test covering retry loop detection in the Temporal runtime.",
+              "source": {
+                "kind": "preset",
+                "bindingId": "preset-binding-123",
+                "includePath": ["root", "regression-coverage"],
+                "blueprintStepSlug": "add-regression-test",
+                "detached": false
+              }
+            }
+          ]
         }
       }
     }
@@ -341,6 +367,8 @@ That means:
 6. If `task.skills` or `step.skills` are present, they must validate against the canonical agent-skill contract. Proposals must not embed full agent skill bodies inline when refs or selectors are the correct contract.
 7. Proposals should preserve execution intent, not raw runtime materialization state. Proposal payloads must **not** store mutable `.agents/skills` directory state, runtime-local materialization outputs, or ephemeral prompt bundles produced only for one adapter session.
 8. Proposal-capable work originating from a Codex managed session must already carry `task.proposeTasks` and any `task.proposalPolicy` in the canonical task payload. Proposal generation must not reconstruct this intent from session-local metadata.
+9. Proposal payloads may include optional `task.authoredPresets` and `steps[].source` provenance when the metadata is reliable. These fields are reconstruction and review metadata only; they do not change the executable meaning of the flat task payload.
+10. Proposal payloads must not contain unresolved preset include objects as runtime work. Preset-derived proposals must be execution-ready flat payloads before storage and promotion.
 
 ---
 
@@ -393,11 +421,12 @@ Promotion must follow this algorithm:
 4. apply shortcut `runtimeMode` only by constructing that override
 5. validate the merged payload against the canonical task contract, including verification of any agent-skill selectors
 6. preserve explicit skill-selection intent from the stored proposal unless the operator intentionally overrides it, ensuring promotion-time overrides do not silently drop or corrupt skill fields
-7. submit the merged task through the same Temporal-backed create path used by
+7. preserve `task.authoredPresets` and per-step `source` provenance from the stored proposal unless the operator intentionally overrides those fields through the merged payload
+8. submit the merged task through the same Temporal-backed create path used by
    `/api/executions`
-8. create a new `MoonMind.Run` through `TemporalExecutionService.create_execution()`
-9. store the promoted workflow or execution identifier on the proposal record
-10. return both the updated proposal and the new execution metadata
+9. create a new `MoonMind.Run` through `TemporalExecutionService.create_execution()`
+10. store the promoted workflow or execution identifier on the proposal record
+11. return both the updated proposal and the new execution metadata
 
 Promotion is therefore a control-plane-to-Temporal bridge, not a proposal-local
 mutation only.
@@ -410,7 +439,30 @@ Proposal promotion preserves agent skill intent from the original execution.
 * **Promotion Overrides:** Operators may override runtime at promotion time. Agent skill selectors are preserved by default. Changing the runtime does not automatically erase or rewrite agent skill intent.
 * **Incompatibilities:** If a selected skill set is incompatible with the chosen runtime, promotion must fail validation or require an explicit override path. Proposal promotion does not re-resolve skill-source precedence as an undocumented side effect.
 
-### 7.3 Runtime selection
+### 7.3 Preset provenance preservation
+
+Proposal promotion preserves reliable preset provenance from the stored proposal
+as review and reconstruction metadata.
+
+Rules:
+
+1. Default promotion uses the reviewed flat `taskCreateRequest` payload and does
+   not perform live preset catalog lookup for correctness.
+2. Default promotion does not re-expand live presets. Catalog changes after the
+   proposal was created must not silently change the promoted execution.
+3. `task.authoredPresets` and `steps[].source` are preserved by default when
+   present and valid in the stored proposal payload.
+4. If an operator intentionally edits or removes provenance through a validated
+   promotion override, the merged payload is the source of truth.
+5. A future refresh-latest workflow may exist, but it must be explicit
+   operator-selected behavior that re-resolves presets before submission and
+   presents the refreshed flat payload for validation. It is not the default
+   promotion path.
+6. Flattened-only proposals remain valid. When reliable authored preset binding
+   metadata is absent, promotion must not invent bindings or infer executable
+   preset semantics from descriptive text.
+
+### 7.4 Runtime selection
 
 Proposal promotion supports operator runtime selection.
 
@@ -423,7 +475,7 @@ Rules:
    proposal payload
 4. disabled runtimes must fail validation before a workflow is created
 
-### 7.4 Response contract
+### 7.5 Response contract
 
 The promote API response must include:
 
@@ -456,6 +508,7 @@ The system must surface:
 3. links from execution detail to proposals filtered by
    `originSource=workflow` and `originId=<workflow_id>`
 4. **Proposal-Review Visibility:** Proposal detail or promotion UI may need to present a compact summary of execution context showing whether the proposal carries explicit skill selectors or inherits deployment defaults, alongside runtime, repository, and publish settings.
+5. **Preset-Provenance Visibility:** Proposal detail or promotion UI may distinguish manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work. These labels are explanatory review metadata and must not imply nested runtime work, live preset expansion, subtasks, sub-plans, or separate workflow runs.
 
 ### 8.3 Failure handling
 

--- a/docs/Tasks/TaskProposalSystem.md
+++ b/docs/Tasks/TaskProposalSystem.md
@@ -320,11 +320,9 @@ That means:
           },
           "authoredPresets": [
             {
-              "bindingId": "preset-binding-123",
               "presetId": "runtime-quality-followup",
               "version": "2026-04-17",
-              "includePath": ["root", "regression-coverage"],
-              "detached": false
+              "includePath": ["root", "regression-coverage"]
             }
           ],
           "runtime": {
@@ -338,11 +336,10 @@ That means:
               "title": "Add regression coverage",
               "instructions": "Add a regression test covering retry loop detection in the Temporal runtime.",
               "source": {
-                "kind": "preset",
-                "bindingId": "preset-binding-123",
+                "kind": "preset-derived",
+                "presetId": "runtime-quality-followup",
                 "includePath": ["root", "regression-coverage"],
-                "blueprintStepSlug": "add-regression-test",
-                "detached": false
+                "originalStepId": "add-regression-test"
               }
             }
           ]

--- a/docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md
@@ -1,0 +1,80 @@
+# MM-388 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-388
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document proposal promotion with preset provenance
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-388 from MM project
+Summary: Document proposal promotion with preset provenance
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-388 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-388: Document proposal promotion with preset provenance
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 6. docs/Tasks/TaskProposalSystem.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-023
+  - DESIGN-REQ-015
+  - DESIGN-REQ-019
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a proposal reviewer, I want task proposals to preserve reliable preset metadata when available while promoting the reviewed flat task payload without live re-expansion drift.
+
+Acceptance Criteria
+- TaskProposalSystem invariants state preset-derived metadata is advisory UX/reconstruction metadata, not a runtime dependency.
+- Proposal promotion does not require live preset catalog lookup for correctness.
+- Canonical proposal payload examples may include task.authoredPresets and per-step source provenance alongside execution-ready flat steps.
+- Promotion preserves authoredPresets and per-step provenance by default while validating the flat task payload as usual.
+- Promotion does not re-expand live presets by default and documents any future refresh-latest workflow as explicit, not default.
+- Proposal generators may preserve reliable parent-run preset provenance but must not fabricate bindings for work not authored from a preset.
+- Proposal detail can distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only work.
+
+Requirements
+- Document proposal payload support for optional authored preset metadata.
+- Document promotion behavior that avoids drift between review and promotion.
+- Document generator guidance for reliable versus fabricated provenance.
+- Document UI/observability treatment of proposal provenance states.
+
+Relevant Implementation Notes
+- The canonical active documentation target is `docs/Tasks/TaskProposalSystem.md`.
+- The issue references `docs/Tasks/PresetComposability.md`; preserve the reference as Jira traceability even if the source document is unavailable in the current checkout.
+- Preserve desired-state documentation under canonical `docs/` files and keep volatile migration or implementation tracking under `docs/tmp/`.
+- Preset-derived metadata in proposals is advisory UX and reconstruction metadata, not a runtime dependency.
+- Proposal promotion must validate and submit the reviewed flat task payload without requiring live preset catalog lookup or live preset re-expansion.
+- Canonical proposal payload examples may include `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps.
+- Promotion should preserve authored preset metadata and per-step provenance by default while treating any future refresh-latest behavior as an explicit workflow.
+- Proposal generators may preserve reliable parent-run preset provenance but must not fabricate preset bindings for work that was not authored from a preset.
+- Proposal detail and observability surfaces should distinguish manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+
+Verification
+- Confirm `docs/Tasks/TaskProposalSystem.md` states preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency.
+- Confirm proposal promotion documentation avoids live preset catalog lookup and live preset re-expansion for correctness by default.
+- Confirm canonical proposal payload examples include execution-ready flat steps and may include optional `task.authoredPresets` plus per-step `source` provenance.
+- Confirm promotion behavior preserves authored preset metadata and per-step provenance by default while validating the flat task payload as usual.
+- Confirm any future refresh-latest workflow is documented as explicit, not default.
+- Confirm proposal generator guidance allows preserving reliable parent-run preset provenance and forbids fabricated bindings for work not authored from a preset.
+- Confirm proposal detail or observability documentation distinguishes manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+- Preserve MM-388 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-389 blocks this issue.
+- MM-387 is blocked by this issue.

--- a/frontend/src/entrypoints/proposals.tsx
+++ b/frontend/src/entrypoints/proposals.tsx
@@ -13,6 +13,9 @@ const TaskPreviewSchema = z
     runtimeMode: z.string().nullable().optional(),
     skillId: z.string().nullable().optional(),
     taskSkills: z.array(z.string()).nullable().optional(),
+    presetProvenance: z.string().nullable().optional(),
+    authoredPresetCount: z.number().nullable().optional(),
+    stepSourceKinds: z.array(z.string()).nullable().optional(),
   })
   .passthrough();
 
@@ -40,6 +43,17 @@ function formatWhen(iso: string | null | undefined): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   return date.toLocaleString();
+}
+
+function formatPresetProvenance(preview: z.infer<typeof TaskPreviewSchema> | null | undefined): string {
+  const provenance = preview?.presetProvenance;
+  if (provenance === 'preserved-binding') {
+    const count = preview?.authoredPresetCount || 0;
+    return count > 0 ? `Preserved binding (${count})` : 'Preserved binding';
+  }
+  if (provenance === 'flattened-only') return 'Flattened only';
+  if (provenance === 'manual') return 'Manual';
+  return '—';
 }
 
 function replaceUrlQuery(params: URLSearchParams) {
@@ -274,6 +288,7 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
                       <th>ID</th>
                       <th>Runtime</th>
                       <th>Skill</th>
+                      <th>Provenance</th>
                       <th>Repository</th>
                       <th>Status</th>
                       <th>Title</th>
@@ -292,6 +307,7 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
                         </td>
                         <td>{row.taskPreview?.runtimeMode || '—'}</td>
                         <td>{formatTaskSkills(row.taskPreview?.taskSkills, row.taskPreview?.skillId)}</td>
+                        <td>{formatPresetProvenance(row.taskPreview)}</td>
                         <td>{row.repository || '—'}</td>
                         <td>
                           <span className={executionStatusPillClasses(row.status)}>
@@ -366,6 +382,10 @@ export function ProposalsPage({ payload }: { payload: BootPayload }) {
                       <div>
                         <dt>Skill</dt>
                         <dd>{formatTaskSkills(row.taskPreview?.taskSkills, row.taskPreview?.skillId)}</dd>
+                      </div>
+                      <div>
+                        <dt>Provenance</dt>
+                        <dd>{formatPresetProvenance(row.taskPreview)}</dd>
                       </div>
                       <div>
                         <dt>Repository</dt>

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -5369,6 +5369,15 @@ export interface components {
             targetBranch?: string | null;
             /** Instructions */
             instructions?: string | null;
+            /** Presetprovenance */
+            presetProvenance?: string | null;
+            /**
+             * Authoredpresetcount
+             * @default 0
+             */
+            authoredPresetCount: number;
+            /** Stepsourcekinds */
+            stepSourceKinds?: string[];
         };
         /**
          * TaskTemplateAppliedMetadataSchema

--- a/moonmind/schemas/task_proposal_models.py
+++ b/moonmind/schemas/task_proposal_models.py
@@ -38,6 +38,9 @@ class TaskProposalTaskPreview(BaseModel):
     starting_branch: Optional[str] = Field(None, alias="startingBranch")
     target_branch: Optional[str] = Field(None, alias="targetBranch")
     instructions: Optional[str] = Field(None, alias="instructions")
+    preset_provenance: Optional[str] = Field(None, alias="presetProvenance")
+    authored_preset_count: int = Field(0, alias="authoredPresetCount")
+    step_source_kinds: list[str] = Field(default_factory=list, alias="stepSourceKinds")
 
 
 class TaskProposalModel(BaseModel):

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 from urllib.parse import urlsplit
 
 from pydantic import (
@@ -689,6 +689,98 @@ class TaskInputAttachmentRef(BaseModel):
         return cleaned
 
 
+class TaskStepSource(BaseModel):
+    """Optional provenance for a step in a compiled task payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    kind: Literal["manual", "preset-derived", "preset-include", "detached"] | None = (
+        Field(None, alias="kind")
+    )
+    preset_id: str | None = Field(None, alias="presetId")
+    preset_slug: str | None = Field(None, alias="presetSlug")
+    version: str | None = Field(None, alias="version")
+    include_path: list[str] | None = Field(None, alias="includePath")
+    original_step_id: str | None = Field(None, alias="originalStepId")
+
+    @field_validator(
+        "kind",
+        "preset_id",
+        "preset_slug",
+        "version",
+        "original_step_id",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_strings(cls, value: object) -> str | None:
+        return _clean_optional_str(value)
+
+    @field_validator("include_path", mode="before")
+    @classmethod
+    def _normalize_include_path(cls, value: object) -> list[str] | None:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, list):
+            raise TaskContractError("task.steps[].source.includePath must be a list")
+        normalized = [
+            cleaned
+            for item in value
+            if (cleaned := _clean_optional_str(item)) is not None
+        ]
+        return normalized or None
+
+
+class AuthoredPresetBinding(BaseModel):
+    """Optional preset binding metadata used to compile a task payload."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    preset_id: str | None = Field(None, alias="presetId")
+    preset_slug: str | None = Field(None, alias="presetSlug")
+    version: str | None = Field(None, alias="version")
+    alias: str | None = Field(None, alias="alias")
+    include_path: list[str] | None = Field(None, alias="includePath")
+    input_mapping: dict[str, Any] | None = Field(None, alias="inputMapping")
+    scope: str | None = Field(None, alias="scope")
+
+    @field_validator(
+        "preset_id",
+        "preset_slug",
+        "version",
+        "alias",
+        "scope",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_strings(cls, value: object) -> str | None:
+        return _clean_optional_str(value)
+
+    @field_validator("include_path", mode="before")
+    @classmethod
+    def _normalize_include_path(cls, value: object) -> list[str] | None:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, list):
+            raise TaskContractError("task.authoredPresets[].includePath must be a list")
+        normalized = [
+            cleaned
+            for item in value
+            if (cleaned := _clean_optional_str(item)) is not None
+        ]
+        return normalized or None
+
+    @field_validator("input_mapping", mode="before")
+    @classmethod
+    def _normalize_input_mapping(cls, value: object) -> dict[str, Any] | None:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, dict):
+            raise TaskContractError(
+                "task.authoredPresets[].inputMapping must be an object"
+            )
+        return dict(value)
+
+
 class TaskStepSpec(BaseModel):
     """Optional execution step contained within a canonical task payload."""
 
@@ -699,6 +791,7 @@ class TaskStepSpec(BaseModel):
     instructions: str | None = Field(None, alias="instructions")
     skill: TaskSkillSelection | None = Field(None, alias="skill")
     skills: TaskSkillSelectors | None = Field(None, alias="skills")
+    source: TaskStepSource | None = Field(None, alias="source")
     input_attachments: list[TaskInputAttachmentRef] = Field(
         default_factory=list, alias="inputAttachments"
     )
@@ -772,6 +865,9 @@ class TaskExecutionSpec(BaseModel):
     )
     container: TaskContainerSelection | None = Field(None, alias="container")
     proposal_policy: TaskProposalPolicy | None = Field(None, alias="proposalPolicy")
+    authored_presets: list[AuthoredPresetBinding] | None = Field(
+        None, alias="authoredPresets"
+    )
 
     @field_validator("instructions", mode="before")
     @classmethod
@@ -785,6 +881,15 @@ class TaskExecutionSpec(BaseModel):
             return []
         if not isinstance(value, list):
             raise TaskContractError("task.inputAttachments must be a list")
+        return value
+
+    @field_validator("authored_presets", mode="before")
+    @classmethod
+    def _normalize_authored_presets(cls, value: object) -> object:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, list):
+            raise TaskContractError("task.authoredPresets must be a list")
         return value
 
     @field_validator("propose_tasks", mode="before")
@@ -1477,8 +1582,10 @@ __all__ = [
     "LEGACY_TASK_JOB_TYPES",
     "SUPPORTED_EXECUTION_RUNTIMES",
     "CanonicalTaskPayload",
+    "AuthoredPresetBinding",
     "TaskContractError",
     "TaskInputAttachmentRef",
+    "TaskStepSource",
     "build_task_stage_plan",
     "build_canonical_task_view",
     "has_attachment_mutation_fields",

--- a/specs/202-document-proposal-promotion/checklists/requirements.md
+++ b/specs/202-document-proposal-promotion/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Proposal Promotion Preset Provenance
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request from `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md`.
+- The source brief references `docs/Tasks/PresetComposability.md`, which is absent in this checkout; the preserved Jira brief and `docs/Tasks/TaskProposalSystem.md` are the active sources.

--- a/specs/202-document-proposal-promotion/contracts/proposal-promotion-preset-provenance.md
+++ b/specs/202-document-proposal-promotion/contracts/proposal-promotion-preset-provenance.md
@@ -1,0 +1,23 @@
+# Contract: Proposal Promotion Preset Provenance
+
+## Scope
+
+This contract defines the observable Task Proposal System behavior required by MM-388.
+
+## Required Contract Outcomes
+
+1. Proposal invariants state preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency.
+2. Stored proposal payload examples may include optional `task.authoredPresets` and `steps[].source` metadata alongside execution-ready flat steps.
+3. Default promotion validates and submits the reviewed flat task payload without live preset catalog lookup.
+4. Default promotion preserves authored preset metadata and per-step provenance when present unless the operator intentionally overrides those fields through a validated override.
+5. Default promotion does not live re-expand presets.
+6. Any refresh-latest preset workflow is explicit operator-selected behavior and not the default promotion path.
+7. Proposal generators may preserve reliable parent-run preset provenance and must not fabricate bindings when reliable binding metadata is unavailable.
+8. Proposal detail and observability can distinguish manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+
+## Verification Commands
+
+```bash
+rg -n "preset-derived metadata|authoredPresets|live preset catalog|live re-expansion|refresh-latest|flattened-only|fabricate.*binding|preset provenance" docs/Tasks/TaskProposalSystem.md
+rg -n "MM-388|DESIGN-REQ-015|DESIGN-REQ-019|DESIGN-REQ-023|DESIGN-REQ-025|DESIGN-REQ-026" specs/202-document-proposal-promotion docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md
+```

--- a/specs/202-document-proposal-promotion/data-model.md
+++ b/specs/202-document-proposal-promotion/data-model.md
@@ -4,7 +4,7 @@
 
 Represents optional task-level provenance copied from an authored task snapshot.
 
-- Fields: preset binding identity, authored preset references, include tree summary, detachment state when available.
+- Fields: preset id or slug, version, alias, include tree summary, input mapping, and scope when available.
 - Rules: metadata is advisory UX/reconstruction context and never executable runtime logic.
 - Validation: promotion preserves it by default when present and validates the merged flat task payload as usual.
 
@@ -12,7 +12,7 @@ Represents optional task-level provenance copied from an authored task snapshot.
 
 Represents optional per-step source metadata.
 
-- Fields: source kind, binding id, include path, blueprint step slug, detached flag when available.
+- Fields: source kind, preset id or slug, version, include path, and original step id when available.
 - Rules: may distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only states.
 - Validation: malformed provenance must not be silently converted into executable behavior.
 

--- a/specs/202-document-proposal-promotion/data-model.md
+++ b/specs/202-document-proposal-promotion/data-model.md
@@ -1,0 +1,31 @@
+# Data Model: Proposal Promotion Preset Provenance
+
+## Authored Preset Metadata
+
+Represents optional task-level provenance copied from an authored task snapshot.
+
+- Fields: preset binding identity, authored preset references, include tree summary, detachment state when available.
+- Rules: metadata is advisory UX/reconstruction context and never executable runtime logic.
+- Validation: promotion preserves it by default when present and validates the merged flat task payload as usual.
+
+## Step Source Provenance
+
+Represents optional per-step source metadata.
+
+- Fields: source kind, binding id, include path, blueprint step slug, detached flag when available.
+- Rules: may distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only states.
+- Validation: malformed provenance must not be silently converted into executable behavior.
+
+## Flat Task Payload
+
+Represents the execution-ready proposal payload promoted through the normal task creation path.
+
+- Fields: repository, task instructions, runtime, publish policy, flat steps, optional authored preset metadata, optional per-step source provenance.
+- Rules: default promotion submits this reviewed payload without live preset catalog lookup or live re-expansion.
+
+## Refresh-Latest Workflow
+
+Represents a future explicit workflow that would intentionally refresh preset contents before submission.
+
+- Fields: explicit operator intent, selected preset bindings, refreshed result, validation evidence.
+- Rules: out of scope for default promotion; must never be implied as automatic behavior.

--- a/specs/202-document-proposal-promotion/plan.md
+++ b/specs/202-document-proposal-promotion/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Proposal Promotion Preset Provenance
+
+**Branch**: `202-document-proposal-promotion` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)
+**Input**: Single-story feature specification from `specs/202-document-proposal-promotion/spec.md`
+
+## Summary
+
+Implement MM-388 by updating the canonical Task Proposal System runtime contract so proposal promotion preserves reliable preset provenance metadata while validating and submitting the reviewed flat task payload. The technical approach is to update `docs/Tasks/TaskProposalSystem.md` as the desired-state proposal contract, then validate that the contract covers advisory provenance semantics, optional authored preset fields, no default live re-expansion, generator guidance, observability states, and MM-388 traceability.
+
+## Technical Context
+
+**Language/Version**: Markdown documentation for MoonMind runtime task proposal architecture
+**Primary Dependencies**: Existing `docs/Tasks/TaskProposalSystem.md`, preserved MM-388 Jira preset brief, adjacent preset-composability MoonSpec artifacts
+**Storage**: No new persistent storage; documents describe semantics for existing proposal payloads and task snapshot metadata
+**Unit Testing**: Documentation contract checks with `rg` against `docs/Tasks/TaskProposalSystem.md` and generated MoonSpec artifacts
+**Integration Testing**: End-to-end documentation validation by reviewing the canonical Task Proposal System contract against MM-388 acceptance scenarios and final `/moonspec-verify`
+**Target Platform**: Proposal generation, proposal detail/observability, and proposal promotion surfaces
+**Project Type**: Runtime task proposal architecture contract documentation
+**Performance Goals**: No runtime performance impact; promotion avoids live preset expansion by default
+**Constraints**: Preserve canonical docs as desired-state documentation, keep volatile planning under `docs/tmp/` or `specs/`, do not introduce compatibility aliases or hidden runtime fallback behavior, and preserve Jira issue key MM-388 in artifacts
+**Scale/Scope**: One canonical documentation file plus MoonSpec artifacts for one independently testable story
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story keeps proposal promotion on the standard Temporal-backed create path and does not introduce a separate execution model.
+- II. One-Click Agent Deployment: PASS. No services, secrets, dependencies, or setup steps are added.
+- III. Avoid Vendor Lock-In: PASS. The proposal contract is provider-neutral.
+- IV. Own Your Data: PASS. Preset provenance remains MoonMind-owned task snapshot metadata, not live external lookup.
+- V. Skills Are First-Class and Easy to Add: PASS. The story keeps preset provenance distinct from agent instruction bundles and executable tools.
+- VI. Replaceable Scaffolding: PASS. Promotion relies on stable flat payload contracts rather than re-running volatile preset expansion logic.
+- VII. Runtime Configurability: PASS. No hardcoded runtime configuration is introduced.
+- VIII. Modular Architecture: PASS. Generator, storage, promotion, and UI/observability semantics remain distinct.
+- IX. Resilient by Default: PASS. Promotion avoids drift caused by changed live preset catalog state.
+- X. Continuous Improvement: PASS. Verification evidence identifies remaining documentation or runtime-contract gaps.
+- XI. Spec-Driven Development: PASS. This one-story MoonSpec drives the change.
+- XII. Canonical Documentation Separation: PASS. Canonical docs describe desired state; migration notes remain outside canonical docs.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility shim or semantic fallback is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/202-document-proposal-promotion/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── proposal-promotion-preset-provenance.md
+├── tasks.md
+├── verification.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+└── Tasks/
+    └── TaskProposalSystem.md
+
+docs/tmp/
+└── jira-orchestration-inputs/
+    └── MM-388-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Update `docs/Tasks/TaskProposalSystem.md` because MM-388 targets proposal payload, generator, promotion, and proposal detail semantics. Do not create replacement canonical docs or move volatile planning into `docs/`.
+
+## Complexity Tracking
+
+No constitution violations.
+
+## Setup Notes
+
+- The input was classified as a single-story feature request from `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md`.
+- `.specify/feature.json` points to `specs/202-document-proposal-promotion`.

--- a/specs/202-document-proposal-promotion/quickstart.md
+++ b/specs/202-document-proposal-promotion/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Proposal Promotion Preset Provenance
+
+## Focused Documentation Contract Check
+
+```bash
+rg -n "preset-derived metadata|authoredPresets|live preset catalog|live re-expansion|refresh-latest|flattened-only|fabricate.*binding|preset provenance" docs/Tasks/TaskProposalSystem.md
+```
+
+Expected result: matches show proposal invariants, payload examples, default promotion behavior, refresh-latest explicitness, generator guidance, and proposal detail/observability states.
+
+## Source Traceability Check
+
+```bash
+rg -n "MM-388|DESIGN-REQ-015|DESIGN-REQ-019|DESIGN-REQ-023|DESIGN-REQ-025|DESIGN-REQ-026" specs/202-document-proposal-promotion docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md
+```
+
+Expected result: all source IDs and the Jira issue key remain visible in MoonSpec artifacts and the canonical orchestration input.
+
+## Full Unit Suite
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Expected result: pass, or record an exact environment blocker in verification evidence.
+
+## End-to-End Review
+
+Review `docs/Tasks/TaskProposalSystem.md` and confirm:
+
+- preset-derived metadata is advisory UX/reconstruction metadata,
+- proposal promotion avoids live preset catalog lookup and live re-expansion by default,
+- optional `task.authoredPresets` and per-step `source` provenance can coexist with flat executable steps,
+- promotion preserves provenance by default,
+- refresh-latest behavior is explicit,
+- generators preserve reliable provenance but do not fabricate bindings,
+- detail/observability distinguishes manual, preserved-binding preset-derived, and flattened-only proposal states.

--- a/specs/202-document-proposal-promotion/research.md
+++ b/specs/202-document-proposal-promotion/research.md
@@ -1,0 +1,25 @@
+# Research: Proposal Promotion Preset Provenance
+
+## Input Classification
+
+Decision: Treat the MM-388 Jira preset brief as a single-story runtime feature request.
+Rationale: The brief contains one actor, one outcome, one canonical documentation target, and one independently testable proposal-promotion behavior set.
+Alternatives considered: Broad design breakdown was rejected because the request does not ask to split `PresetComposability`; docs-only mode was rejected because the user selected runtime mode.
+
+## Source Artifacts
+
+Decision: Use `docs/Tasks/TaskProposalSystem.md` and the preserved MM-388 orchestration input as active sources.
+Rationale: The Jira brief references `docs/Tasks/PresetComposability.md`, but that file is absent in the current checkout. The brief explicitly targets section 6, `docs/Tasks/TaskProposalSystem.md`, and the synthesized orchestration input preserves the source requirements.
+Alternatives considered: Blocking on the missing source document was rejected because the Jira brief contains enough acceptance criteria and source IDs to proceed.
+
+## Runtime Contract Strategy
+
+Decision: Update the canonical Task Proposal System desired-state contract rather than backend code.
+Rationale: Existing adjacent preset-composability stories use canonical docs as runtime contracts. MM-388 asks to document proposal promotion behavior, generator guidance, payload examples, and UI/observability treatment.
+Alternatives considered: Adding code tests first was rejected because this story's current acceptance surface is contract/documentation verification; executable code changes can be introduced later if verification finds implementation drift.
+
+## Test Strategy
+
+Decision: Use focused `rg` contract checks as unit-style evidence, source traceability checks as integration-style evidence, full unit tests when feasible, and final MoonSpec verification.
+Rationale: The implementation target is Markdown runtime contract text. Focused checks directly validate the contractual terms and source traceability without requiring external services.
+Alternatives considered: Compose-backed integration tests were rejected because no runtime service behavior or API schema is changed in this story.

--- a/specs/202-document-proposal-promotion/spec.md
+++ b/specs/202-document-proposal-promotion/spec.md
@@ -135,7 +135,7 @@ Dependencies
 ### Key Entities
 
 - **Authored Preset Metadata**: Optional task-level provenance describing preset bindings that were reliably authored into a task before flattening.
-- **Step Source Provenance**: Optional per-step metadata that identifies manual, preset-derived, include path, blueprint step, or detached state without becoming executable logic.
+- **Step Source Provenance**: Optional per-step metadata that identifies manual, preset-derived, preset-include, or detached state with preset references, include path, and original step id when available, without becoming executable logic.
 - **Flat Task Payload**: The execution-ready proposal payload that promotion validates and submits to create a new run.
 - **Flattened-Only Proposal**: A proposal whose steps may have originated from previous preset expansion but no longer carry reliable authored preset bindings.
 - **Refresh-Latest Workflow**: An explicit future workflow that would intentionally re-resolve current preset definitions before submission.

--- a/specs/202-document-proposal-promotion/spec.md
+++ b/specs/202-document-proposal-promotion/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Proposal Promotion Preset Provenance
+
+**Feature Branch**: `202-document-proposal-promotion`
+**Created**: 2026-04-17
+**Status**: Draft
+**Input**:
+
+```text
+# MM-388 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-388
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Document proposal promotion with preset provenance
+- Labels: `moonmind-workflow-mm-22746271-d34b-494d-bdf8-5c9daefbbdd4`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-388 from MM project
+Summary: Document proposal promotion with preset provenance
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-388 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-388: Document proposal promotion with preset provenance
+
+Source Reference
+- Source Document: docs/Tasks/PresetComposability.md
+- Source Title: Preset Composability
+- Source Sections:
+  - 6. docs/Tasks/TaskProposalSystem.md
+  - 8. Cross-document invariants
+- Coverage IDs:
+  - DESIGN-REQ-023
+  - DESIGN-REQ-015
+  - DESIGN-REQ-019
+  - DESIGN-REQ-025
+  - DESIGN-REQ-026
+
+User Story
+As a proposal reviewer, I want task proposals to preserve reliable preset metadata when available while promoting the reviewed flat task payload without live re-expansion drift.
+
+Acceptance Criteria
+- TaskProposalSystem invariants state preset-derived metadata is advisory UX/reconstruction metadata, not a runtime dependency.
+- Proposal promotion does not require live preset catalog lookup for correctness.
+- Canonical proposal payload examples may include task.authoredPresets and per-step source provenance alongside execution-ready flat steps.
+- Promotion preserves authoredPresets and per-step provenance by default while validating the flat task payload as usual.
+- Promotion does not re-expand live presets by default and documents any future refresh-latest workflow as explicit, not default.
+- Proposal generators may preserve reliable parent-run preset provenance but must not fabricate bindings for work not authored from a preset.
+- Proposal detail can distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only work.
+
+Requirements
+- Document proposal payload support for optional authored preset metadata.
+- Document promotion behavior that avoids drift between review and promotion.
+- Document generator guidance for reliable versus fabricated provenance.
+- Document UI/observability treatment of proposal provenance states.
+
+Relevant Implementation Notes
+- The canonical active documentation target is `docs/Tasks/TaskProposalSystem.md`.
+- The issue references `docs/Tasks/PresetComposability.md`; preserve the reference as Jira traceability even if the source document is unavailable in the current checkout.
+- Preserve desired-state documentation under canonical `docs/` files and keep volatile migration or implementation tracking under `docs/tmp/`.
+- Preset-derived metadata in proposals is advisory UX and reconstruction metadata, not a runtime dependency.
+- Proposal promotion must validate and submit the reviewed flat task payload without requiring live preset catalog lookup or live preset re-expansion.
+- Canonical proposal payload examples may include `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps.
+- Promotion should preserve authored preset metadata and per-step provenance by default while treating any future refresh-latest behavior as an explicit workflow.
+- Proposal generators may preserve reliable parent-run preset provenance but must not fabricate preset bindings for work that was not authored from a preset.
+- Proposal detail and observability surfaces should distinguish manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+
+Verification
+- Confirm `docs/Tasks/TaskProposalSystem.md` states preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency.
+- Confirm proposal promotion documentation avoids live preset catalog lookup and live preset re-expansion for correctness by default.
+- Confirm canonical proposal payload examples include execution-ready flat steps and may include optional `task.authoredPresets` plus per-step `source` provenance.
+- Confirm promotion behavior preserves authored preset metadata and per-step provenance by default while validating the flat task payload as usual.
+- Confirm any future refresh-latest workflow is documented as explicit, not default.
+- Confirm proposal generator guidance allows preserving reliable parent-run preset provenance and forbids fabricated bindings for work not authored from a preset.
+- Confirm proposal detail or observability documentation distinguishes manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+- Preserve MM-388 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-389 blocks this issue.
+- MM-387 is blocked by this issue.
+```
+
+## User Story - Proposal Promotion Preset Provenance
+
+**Summary**: As a proposal reviewer, I want task proposals to preserve reliable preset metadata when available while promoting the reviewed flat task payload without live re-expansion drift.
+
+**Goal**: Reviewers can approve proposal promotion knowing that optional preset provenance remains available for reconstruction and UX context, while the promoted execution still uses the already-reviewed flat task payload and never depends on live preset catalog correctness.
+
+**Independent Test**: Can be tested by reviewing the Task Proposal System contract and validating that it defines preset provenance as advisory metadata, keeps proposal promotion on the reviewed flat payload, preserves optional authored preset and per-step source fields, forbids default live re-expansion, and distinguishes manual, preserved-binding, and flattened-only proposal states.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stored proposal contains reliable authored preset metadata and per-step source provenance, **When** a reviewer promotes it without overriding those fields, **Then** promotion preserves the metadata while validating and submitting the flat task payload as the execution contract.
+2. **Given** a stored proposal was generated from a flat payload with no reliable preset binding, **When** proposal generation and detail rendering describe it, **Then** they must not fabricate authored preset bindings and must present it as flattened-only or manual work as applicable.
+3. **Given** a live preset catalog has changed since the proposal was created, **When** the proposal is promoted, **Then** promotion must not use live catalog lookup or re-expand presets by default.
+4. **Given** a future operator wants refreshed preset contents, **When** documentation describes that flow, **Then** it must be explicit refresh-latest behavior rather than default promotion behavior.
+5. **Given** downstream MoonSpec, implementation notes, verification, commit text, or pull request metadata are generated for this work, **When** traceability is reviewed, **Then** the Jira issue key MM-388 remains present.
+
+### Edge Cases
+
+- A source document named by the Jira brief, `docs/Tasks/PresetComposability.md`, is absent in the current checkout; the preserved MM-388 Jira brief and current `docs/Tasks/TaskProposalSystem.md` are the active sources for this story.
+- A proposal may contain no preset provenance, preserved authored preset metadata, or only flattened per-step source metadata; each state must be distinguishable without changing execution semantics.
+- A candidate generator may know the parent run used presets but lack reliable binding metadata for a proposed follow-up; it must avoid inventing bindings.
+- Live preset definitions may be deleted, renamed, or changed after proposal creation; default promotion still uses the reviewed flat payload.
+
+## Assumptions
+
+- The selected runtime mode means `docs/Tasks/TaskProposalSystem.md` is treated as a runtime contract for proposal behavior, even though this story updates canonical documentation.
+- `task.authoredPresets` and `steps[].source` are optional task payload metadata fields already introduced by adjacent preset-composability documentation and must remain non-executable provenance.
+- This story does not require executable backend or UI code changes unless verification finds current implementation contradicts the runtime contract.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Task Proposal System MUST state that preset-derived proposal metadata is advisory UX and reconstruction metadata, not a runtime dependency.
+- **FR-002**: Proposal promotion MUST validate and submit the reviewed flat task payload without requiring live preset catalog lookup for correctness.
+- **FR-003**: Canonical proposal payload examples MAY include optional `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps.
+- **FR-004**: Promotion MUST preserve `task.authoredPresets` and per-step provenance by default when present, unless an operator intentionally overrides those fields through a validated promotion override.
+- **FR-005**: Proposal promotion MUST NOT re-expand live presets by default.
+- **FR-006**: Any future refresh-latest preset workflow MUST be documented as explicit operator-selected behavior, not default promotion behavior.
+- **FR-007**: Proposal generators MAY preserve reliable parent-run preset provenance but MUST NOT fabricate authored preset bindings for work that was not authored from a preset or lacks reliable binding metadata.
+- **FR-008**: Proposal detail and observability surfaces MUST distinguish manual work, preset-derived work with preserved binding metadata, and preset-derived flattened-only work.
+- **FR-009**: Canonical documentation updates MUST remain desired-state documentation and keep volatile migration or implementation tracking out of canonical docs.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST retain Jira issue key `MM-388` and the original Jira preset brief.
+
+### Key Entities
+
+- **Authored Preset Metadata**: Optional task-level provenance describing preset bindings that were reliably authored into a task before flattening.
+- **Step Source Provenance**: Optional per-step metadata that identifies manual, preset-derived, include path, blueprint step, or detached state without becoming executable logic.
+- **Flat Task Payload**: The execution-ready proposal payload that promotion validates and submits to create a new run.
+- **Flattened-Only Proposal**: A proposal whose steps may have originated from previous preset expansion but no longer carry reliable authored preset bindings.
+- **Refresh-Latest Workflow**: An explicit future workflow that would intentionally re-resolve current preset definitions before submission.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-015**: Source "Cross-document invariants" requires compile-time-only composition and no live runtime preset expansion. Scope: in scope. Maps to FR-002, FR-005, FR-006.
+- **DESIGN-REQ-019**: Source "Snapshot durability and reconstruction" requires authored preset metadata and per-step provenance to remain available with flat execution payloads. Scope: in scope. Maps to FR-003, FR-004.
+- **DESIGN-REQ-023**: Source "TaskProposalSystem proposal promotion" requires proposals to preserve reliable preset metadata while promoting the reviewed flat task payload without live re-expansion drift. Scope: in scope. Maps to FR-001 through FR-008.
+- **DESIGN-REQ-025**: Source "Snapshot durability and evidence" requires provenance and expansion metadata to remain reconstruction evidence, not runtime execution logic. Scope: in scope. Maps to FR-001, FR-002, FR-008.
+- **DESIGN-REQ-026**: Source "Execution-plane boundary" requires user-facing labels to avoid implying nested runtime workflows for preset includes. Scope: in scope. Maps to FR-008.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Review of `docs/Tasks/TaskProposalSystem.md` finds an invariant that preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency.
+- **SC-002**: Review of promotion flow documentation finds no required live preset catalog lookup or live re-expansion for default promotion correctness.
+- **SC-003**: Review of canonical proposal payload examples finds execution-ready flat steps may coexist with optional `task.authoredPresets` and per-step `source` provenance.
+- **SC-004**: Review of promotion behavior finds authored preset metadata and per-step provenance are preserved by default when present.
+- **SC-005**: Review of generator guidance finds reliable provenance may be preserved and fabricated bindings are forbidden.
+- **SC-006**: Review of proposal detail or observability documentation finds manual, preserved-binding preset-derived, and flattened-only proposal states are distinguishable.
+- **SC-007**: All five in-scope source design requirements map to at least one functional requirement, and MM-388 remains present in MoonSpec artifacts and verification evidence.

--- a/specs/202-document-proposal-promotion/tasks.md
+++ b/specs/202-document-proposal-promotion/tasks.md
@@ -1,0 +1,91 @@
+# Tasks: Proposal Promotion Preset Provenance
+
+**Input**: Design documents from `specs/202-document-proposal-promotion/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Documentation contract checks and source traceability checks are REQUIRED before and after implementation. Write or define checks first, confirm they fail for missing contract language, then update canonical documentation.
+
+**Test Commands**:
+
+- Focused documentation contract check: `rg -n "preset-derived metadata|authoredPresets|live preset catalog|live re-expansion|refresh-latest|flattened-only|fabricate.*binding|preset provenance" docs/Tasks/TaskProposalSystem.md`
+- Source traceability check: `rg -n "MM-388|DESIGN-REQ-015|DESIGN-REQ-019|DESIGN-REQ-023|DESIGN-REQ-025|DESIGN-REQ-026" specs/202-document-proposal-promotion docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md`
+- Full unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Final verification: `/moonspec-verify`
+
+## Traceability Inventory
+
+- FR-001, DESIGN-REQ-023, DESIGN-REQ-025: preset-derived proposal metadata is advisory UX/reconstruction metadata, not a runtime dependency.
+- FR-002, FR-005, DESIGN-REQ-015: promotion validates and submits the reviewed flat payload without live preset catalog lookup or live re-expansion by default.
+- FR-003, DESIGN-REQ-019: proposal payload examples may include optional `task.authoredPresets` and per-step `source` provenance.
+- FR-004, SC-004: promotion preserves authored preset metadata and per-step provenance by default.
+- FR-006: refresh-latest preset behavior is explicit and not default.
+- FR-007, SC-005: generators preserve reliable provenance and do not fabricate bindings.
+- FR-008, DESIGN-REQ-026: detail and observability distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only work.
+- FR-009: canonical docs remain desired-state; volatile planning stays under `docs/tmp/` and `specs/`.
+- FR-010, SC-007: MM-388 and original Jira preset brief remain visible in artifacts and verification evidence.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active MM-388 feature directory and source input in `.specify/feature.json`, `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md`, and `specs/202-document-proposal-promotion/spec.md` (FR-010, SC-007).
+- [X] T002 Confirm `docs/Tasks/TaskProposalSystem.md` is the canonical documentation target and `docs/Tasks/PresetComposability.md` is absent in the current checkout in `specs/202-document-proposal-promotion/research.md` (FR-009).
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing Task Proposal System sections for invariants, generation, payload rules, promotion, and observability in `docs/Tasks/TaskProposalSystem.md` (FR-001 through FR-008).
+
+## Phase 3: Story - Proposal Promotion Preset Provenance
+
+**Summary**: As a proposal reviewer, I want task proposals to preserve reliable preset metadata when available while promoting the reviewed flat task payload without live re-expansion drift.
+
+**Independent Test**: Review `docs/Tasks/TaskProposalSystem.md` and confirm it defines advisory preset provenance semantics, optional authored preset and per-step source fields, default flat-payload promotion without live re-expansion, generator non-fabrication rules, and proposal detail/observability provenance states.
+
+**Traceability**: FR-001 through FR-010, SC-001 through SC-007, DESIGN-REQ-015, DESIGN-REQ-019, DESIGN-REQ-023, DESIGN-REQ-025, DESIGN-REQ-026, MM-388.
+
+### Unit Tests
+
+- [X] T004 Add the focused documentation contract check command in `specs/202-document-proposal-promotion/quickstart.md` (FR-001 through FR-008, SC-001 through SC-006).
+- [X] T005 Add the source traceability check command in `specs/202-document-proposal-promotion/quickstart.md` (FR-010, SC-007).
+
+### Integration Tests
+
+- [X] T006 Add end-to-end review criteria in `specs/202-document-proposal-promotion/contracts/proposal-promotion-preset-provenance.md` covering payload examples, promotion preservation, generator guidance, refresh-latest explicitness, and detail/observability states (FR-001 through FR-008, SC-001 through SC-006).
+
+### Red-First Confirmation
+
+- [X] T007 Run `rg -n "preset-derived metadata|authoredPresets|live preset catalog|live re-expansion|refresh-latest|flattened-only|fabricate.*binding|preset provenance" docs/Tasks/TaskProposalSystem.md` and confirm it fails before documentation edits (FR-001 through FR-008, SC-001 through SC-006).
+
+### Implementation
+
+- [X] T008 Update Task Proposal System invariants in `docs/Tasks/TaskProposalSystem.md` to state preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency (FR-001, DESIGN-REQ-023, DESIGN-REQ-025).
+- [X] T009 Update proposal generation guidance in `docs/Tasks/TaskProposalSystem.md` to preserve reliable parent-run preset provenance and forbid fabricated authored preset bindings (FR-007, SC-005).
+- [X] T010 Update canonical proposal payload example and rules in `docs/Tasks/TaskProposalSystem.md` to include optional `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps (FR-003, DESIGN-REQ-019).
+- [X] T011 Update promotion flow in `docs/Tasks/TaskProposalSystem.md` to preserve authored preset metadata and per-step provenance by default while validating the flat task payload (FR-002, FR-004).
+- [X] T012 Update promotion behavior in `docs/Tasks/TaskProposalSystem.md` to forbid default live preset catalog lookup and live re-expansion, and document any refresh-latest workflow as explicit (FR-002, FR-005, FR-006, DESIGN-REQ-015).
+- [X] T013 Update proposal detail and observability guidance in `docs/Tasks/TaskProposalSystem.md` to distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only work (FR-008, DESIGN-REQ-026).
+
+### Story Validation
+
+- [X] T014 Run focused documentation contract and source traceability checks, then fix `docs/Tasks/TaskProposalSystem.md` or MoonSpec artifacts as needed (FR-001 through FR-010, SC-001 through SC-007).
+
+## Phase 4: Polish And Verification
+
+- [X] T015 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or record the exact environment blocker in `specs/202-document-proposal-promotion/verification.md` (FR-009).
+- [X] T016 Run `/moonspec-verify` and record the result in `specs/202-document-proposal-promotion/verification.md` (FR-010, SC-007).
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story validation.
+- T004-T006 define the validation surface before implementation.
+- T007 must run before T008-T013.
+- T008-T013 all edit `docs/Tasks/TaskProposalSystem.md` and should run sequentially.
+- T014 validates the story before full unit and final verification tasks.
+
+## Parallel Opportunities
+
+- T004 and T005 can be reviewed independently because they validate different quickstart checks.
+- T006 can be reviewed independently from quickstart command checks.
+
+## Notes
+
+- This task list covers exactly one story: MM-388.
+- Runtime mode is preserved by treating `docs/Tasks/TaskProposalSystem.md` as the source of runtime proposal behavior requirements.

--- a/specs/202-document-proposal-promotion/tasks.md
+++ b/specs/202-document-proposal-promotion/tasks.md
@@ -14,9 +14,9 @@
 
 ## Traceability Inventory
 
-- FR-001, DESIGN-REQ-023, DESIGN-REQ-025: preset-derived proposal metadata is advisory UX/reconstruction metadata, not a runtime dependency.
-- FR-002, FR-005, DESIGN-REQ-015: promotion validates and submits the reviewed flat payload without live preset catalog lookup or live re-expansion by default.
-- FR-003, DESIGN-REQ-019: proposal payload examples may include optional `task.authoredPresets` and per-step `source` provenance.
+- FR-001, SC-001, DESIGN-REQ-023, DESIGN-REQ-025: preset-derived proposal metadata is advisory UX/reconstruction metadata, not a runtime dependency.
+- FR-002, FR-005, SC-002, DESIGN-REQ-015: promotion validates and submits the reviewed flat payload without live preset catalog lookup or live re-expansion by default.
+- FR-003, SC-003, DESIGN-REQ-019: proposal payload examples may include optional `task.authoredPresets` and per-step `source` provenance.
 - FR-004, SC-004: promotion preserves authored preset metadata and per-step provenance by default.
 - FR-006: refresh-latest preset behavior is explicit and not default.
 - FR-007, SC-005: generators preserve reliable provenance and do not fabricate bindings.
@@ -56,9 +56,9 @@
 
 ### Implementation
 
-- [X] T008 Update Task Proposal System invariants in `docs/Tasks/TaskProposalSystem.md` to state preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency (FR-001, DESIGN-REQ-023, DESIGN-REQ-025).
+- [X] T008 Update Task Proposal System invariants in `docs/Tasks/TaskProposalSystem.md` to state preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency (FR-001, SC-001, DESIGN-REQ-023, DESIGN-REQ-025).
 - [X] T009 Update proposal generation guidance in `docs/Tasks/TaskProposalSystem.md` to preserve reliable parent-run preset provenance and forbid fabricated authored preset bindings (FR-007, SC-005).
-- [X] T010 Update canonical proposal payload example and rules in `docs/Tasks/TaskProposalSystem.md` to include optional `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps (FR-003, DESIGN-REQ-019).
+- [X] T010 Update canonical proposal payload example and rules in `docs/Tasks/TaskProposalSystem.md` to include optional `task.authoredPresets` and per-step `source` provenance alongside execution-ready flat steps (FR-003, SC-003, DESIGN-REQ-019).
 - [X] T011 Update promotion flow in `docs/Tasks/TaskProposalSystem.md` to preserve authored preset metadata and per-step provenance by default while validating the flat task payload (FR-002, FR-004).
 - [X] T012 Update promotion behavior in `docs/Tasks/TaskProposalSystem.md` to forbid default live preset catalog lookup and live re-expansion, and document any refresh-latest workflow as explicit (FR-002, FR-005, FR-006, DESIGN-REQ-015).
 - [X] T013 Update proposal detail and observability guidance in `docs/Tasks/TaskProposalSystem.md` to distinguish manual, preset-derived with preserved binding metadata, and preset-derived flattened-only work (FR-008, DESIGN-REQ-026).

--- a/specs/202-document-proposal-promotion/verification.md
+++ b/specs/202-document-proposal-promotion/verification.md
@@ -40,6 +40,18 @@
 | Explicit refresh-latest | `docs/Tasks/TaskProposalSystem.md` 7.3 | VERIFIED | Refresh-latest is explicit future behavior. |
 | MM-388 traceability | MoonSpec artifacts and orchestration input | VERIFIED | MM-388 remains present. |
 
+## Success Criteria Coverage
+
+| Criterion | Evidence | Status | Notes |
+|-----------|----------|--------|-------|
+| SC-001 | `docs/Tasks/TaskProposalSystem.md` Core Invariants | VERIFIED | Preset-derived metadata is advisory UX/reconstruction metadata and not a runtime dependency. |
+| SC-002 | `docs/Tasks/TaskProposalSystem.md` Core Invariants and 7.3 | VERIFIED | Default promotion has no required live preset catalog lookup or live re-expansion. |
+| SC-003 | `docs/Tasks/TaskProposalSystem.md` candidate example and payload rules | VERIFIED | Flat executable proposal payload may coexist with optional `task.authoredPresets` and per-step `source`. |
+| SC-004 | `docs/Tasks/TaskProposalSystem.md` 7.1 and 7.3 | VERIFIED | Authored preset metadata and per-step provenance are preserved by default when present. |
+| SC-005 | `docs/Tasks/TaskProposalSystem.md` 3.4 | VERIFIED | Generator guidance preserves reliable provenance and forbids fabricated bindings. |
+| SC-006 | `docs/Tasks/TaskProposalSystem.md` 8.2 | VERIFIED | Proposal detail/observability can distinguish manual, preserved-binding preset-derived, and flattened-only states. |
+| SC-007 | `specs/202-document-proposal-promotion/spec.md`; `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md` | VERIFIED | Source design requirements map to functional requirements and MM-388 remains present. |
+
 ## Constitution And Source Design Coverage
 
 | Item | Evidence | Status | Notes |

--- a/specs/202-document-proposal-promotion/verification.md
+++ b/specs/202-document-proposal-promotion/verification.md
@@ -1,0 +1,64 @@
+# MoonSpec Verification Report
+
+**Feature**: Proposal Promotion Preset Provenance
+**Spec**: `/work/agent_jobs/mm:eb68abc4-9e32-4ba7-9f0a-8bd343ed7e15/repo/specs/202-document-proposal-promotion/spec.md`
+**Original Request Source**: spec.md `Input` preserves MM-388 Jira preset brief
+**Verdict**: FULLY_IMPLEMENTED
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+|-------|---------|--------|-------|
+| Focused contract | `rg -n "preset-derived metadata\|authoredPresets\|live preset catalog\|live re-expansion\|refresh-latest\|flattened-only\|fabricate.*binding\|preset provenance" docs/Tasks/TaskProposalSystem.md` | PASS | Found invariants, generator guidance, payload example/rules, promotion behavior, refresh-latest explicitness, and observability states. |
+| Source traceability | `rg -n "MM-388\|DESIGN-REQ-015\|DESIGN-REQ-019\|DESIGN-REQ-023\|DESIGN-REQ-025\|DESIGN-REQ-026" specs/202-document-proposal-promotion docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md` | PASS | Jira key and all source IDs are preserved in orchestration input and MoonSpec artifacts. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3531 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest 10 files and 273 tests passed. |
+| MoonSpec prerequisites | `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | NOT RUN | Script refuses current managed branch `mm-388-07df7c48` because it does not match `###-feature-name`; `.specify/feature.json` points to this feature directory. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+|-------------|----------|--------|-------|
+| FR-001 | `docs/Tasks/TaskProposalSystem.md` Core Invariants | VERIFIED | Preset-derived metadata is advisory UX/reconstruction metadata, not a runtime dependency. |
+| FR-002 | `docs/Tasks/TaskProposalSystem.md` Core Invariants and 7.3 | VERIFIED | Promotion validates and submits the reviewed flat payload without live catalog lookup. |
+| FR-003 | `docs/Tasks/TaskProposalSystem.md` candidate example and payload rules | VERIFIED | Example includes optional `task.authoredPresets` and per-step `source` provenance with flat payload semantics. |
+| FR-004 | `docs/Tasks/TaskProposalSystem.md` promotion algorithm and 7.3 | VERIFIED | Promotion preserves authored preset metadata and step provenance by default unless intentionally overridden. |
+| FR-005 | `docs/Tasks/TaskProposalSystem.md` 7.3 | VERIFIED | Default promotion does not re-expand live presets. |
+| FR-006 | `docs/Tasks/TaskProposalSystem.md` 7.3 | VERIFIED | Refresh-latest behavior is explicit operator-selected behavior, not default promotion. |
+| FR-007 | `docs/Tasks/TaskProposalSystem.md` 3.4 | VERIFIED | Generators may preserve reliable provenance and must not fabricate bindings. |
+| FR-008 | `docs/Tasks/TaskProposalSystem.md` 8.2 | VERIFIED | Detail/promotion UI may distinguish manual, preserved-binding preset-derived, and flattened-only states. |
+| FR-009 | `docs/Tasks/TaskProposalSystem.md`; `specs/202-document-proposal-promotion/plan.md` | VERIFIED | Canonical doc remains desired-state; volatile work remains under `specs/` and `docs/tmp/`. |
+| FR-010 | `specs/202-document-proposal-promotion/spec.md`; `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md` | VERIFIED | MM-388 and the original brief are preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+|----------|----------|--------|-------|
+| Reliable provenance promotion | `docs/Tasks/TaskProposalSystem.md` 7.1 and 7.3 | VERIFIED | Stored provenance is preserved by default while flat payload validation remains required. |
+| No fabricated bindings | `docs/Tasks/TaskProposalSystem.md` 3.4 and 7.3 | VERIFIED | Generator and promotion rules forbid invented bindings. |
+| Changed live catalog | `docs/Tasks/TaskProposalSystem.md` Core Invariants and 7.3 | VERIFIED | Default promotion does not depend on live catalog lookup or re-expansion. |
+| Explicit refresh-latest | `docs/Tasks/TaskProposalSystem.md` 7.3 | VERIFIED | Refresh-latest is explicit future behavior. |
+| MM-388 traceability | MoonSpec artifacts and orchestration input | VERIFIED | MM-388 remains present. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+|------|----------|--------|-------|
+| DESIGN-REQ-015 | `docs/Tasks/TaskProposalSystem.md` 7.3 | VERIFIED | Compile-time-only composition and no live runtime preset expansion are preserved. |
+| DESIGN-REQ-019 | `docs/Tasks/TaskProposalSystem.md` payload example/rules | VERIFIED | Authored preset metadata and per-step source provenance remain available beside flat payloads. |
+| DESIGN-REQ-023 | `docs/Tasks/TaskProposalSystem.md` Core Invariants, 3.4, 7.3, 8.2 | VERIFIED | Proposal promotion preserves reliable metadata without live re-expansion drift. |
+| DESIGN-REQ-025 | `docs/Tasks/TaskProposalSystem.md` Core Invariants and payload rules | VERIFIED | Provenance is reconstruction evidence, not executable runtime logic. |
+| DESIGN-REQ-026 | `docs/Tasks/TaskProposalSystem.md` 8.2 | VERIFIED | Labels avoid implying nested runtime work, subtasks, sub-plans, or separate workflow runs. |
+| Constitution XII | `docs/Tasks/TaskProposalSystem.md`; `docs/tmp/jira-orchestration-inputs/MM-388-moonspec-orchestration-input.md` | VERIFIED | Canonical docs describe desired state; volatile input remains in `docs/tmp`. |
+
+## Original Request Alignment
+
+- PASS: The implementation uses the MM-388 Jira preset brief as canonical input, treats the request as one runtime story, updates `docs/Tasks/TaskProposalSystem.md`, preserves MM-388, and validates the documented behavior with focused checks plus the full unit runner.
+
+## Gaps
+
+- None.
+
+## Remaining Work
+
+- None.

--- a/tests/unit/api/routers/test_task_proposals.py
+++ b/tests/unit/api/routers/test_task_proposals.py
@@ -302,6 +302,44 @@ def test_get_proposal_includes_similar(client: tuple[TestClient, AsyncMock, Asyn
     assert body["similar"]
 
 
+def test_get_proposal_preview_includes_preset_provenance(
+    client: tuple[TestClient, AsyncMock, AsyncMock],
+) -> None:
+    test_client, service, _execution_service = client
+    proposal = _build_proposal()
+    proposal.task_create_request = {
+        "type": "task",
+        "payload": {
+            "repository": "Moon/Repo",
+            "task": {
+                "instructions": "Add regression coverage",
+                "authoredPresets": [
+                    {
+                        "presetId": "runtime-quality-followup",
+                        "includePath": ["root", "regression-coverage"],
+                    }
+                ],
+                "steps": [
+                    {
+                        "title": "Add regression coverage",
+                        "source": {"kind": "preset-derived"},
+                    }
+                ],
+            },
+        },
+    }
+    service.get_proposal.return_value = proposal
+    service.get_similar_proposals.return_value = []
+
+    response = test_client.get(f"/api/proposals/{proposal.id}")
+
+    assert response.status_code == 200
+    preview = response.json()["taskPreview"]
+    assert preview["presetProvenance"] == "preserved-binding"
+    assert preview["authoredPresetCount"] == 1
+    assert preview["stepSourceKinds"] == ["preset-derived"]
+
+
 def test_update_priority_endpoint(client: tuple[TestClient, AsyncMock, AsyncMock]) -> None:
     test_client, service, _execution_service = client
     proposal = _build_proposal()

--- a/tests/unit/workflows/task_proposals/test_service.py
+++ b/tests/unit/workflows/task_proposals/test_service.py
@@ -493,6 +493,71 @@ async def test_promote_proposal_applies_runtime_override() -> None:
 
 
 @pytest.mark.asyncio
+async def test_promote_proposal_preserves_preset_provenance() -> None:
+    repo = AsyncMock()
+    proposal = SimpleNamespace(
+        id=uuid4(),
+        status=TaskProposalStatus.OPEN,
+        repository="Moon/Repo",
+        promoted_at=None,
+        promoted_by_user_id=None,
+        decided_by_user_id=None,
+        decision_note=None,
+        task_create_request={
+            "payload": {
+                "repository": "Moon/Repo",
+                "task": {
+                    "instructions": "Add regression coverage",
+                    "authoredPresets": [
+                        {
+                            "presetId": "runtime-quality-followup",
+                            "version": "2026-04-17",
+                            "includePath": ["root", "regression-coverage"],
+                        }
+                    ],
+                    "steps": [
+                        {
+                            "title": "Add regression coverage",
+                            "instructions": "Write the regression test.",
+                            "source": {
+                                "kind": "preset-derived",
+                                "presetId": "runtime-quality-followup",
+                                "includePath": ["root", "regression-coverage"],
+                                "originalStepId": "add-regression-test",
+                            },
+                        }
+                    ],
+                },
+            }
+        },
+    )
+    repo.get_proposal_for_update.return_value = proposal
+    service = TaskProposalService(repo, redactor=SecretRedactor([], "***"))
+
+    updated_proposal, final_request = await service.promote_proposal(
+        proposal_id=proposal.id,
+        promoted_by_user_id=uuid4(),
+    )
+
+    repo.commit.assert_awaited()
+    assert updated_proposal.status is TaskProposalStatus.PROMOTED
+    task = final_request["payload"]["task"]
+    assert task["authoredPresets"] == [
+        {
+            "presetId": "runtime-quality-followup",
+            "version": "2026-04-17",
+            "includePath": ["root", "regression-coverage"],
+        }
+    ]
+    assert task["steps"][0]["source"] == {
+        "kind": "preset-derived",
+        "presetId": "runtime-quality-followup",
+        "includePath": ["root", "regression-coverage"],
+        "originalStepId": "add-regression-test",
+    }
+
+
+@pytest.mark.asyncio
 async def test_promote_proposal_override_normalizes_managed_runtime_ids() -> None:
     repo = AsyncMock()
     proposal = SimpleNamespace(
@@ -587,7 +652,6 @@ async def test_promote_proposal_override_normalizes_runtime_mapping_aliases(
     repo.commit.assert_awaited()
     assert updated_proposal.status is TaskProposalStatus.PROMOTED
     assert final_request["payload"]["task"]["runtime"]["mode"] == "claude"
-
 
 
 


### PR DESCRIPTION
Jira issue key: MM-388

Active MoonSpec feature path: specs/202-document-proposal-promotion

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- Focused contract check: PASS
- Source traceability check: PASS
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh: PASS (3531 Python tests passed, 1 xpassed, 16 subtests passed; frontend Vitest 10 files and 273 tests passed)

Remaining risks:
- None known.

Notes:
- Current branch: mm-388-07df7c48
- The branch includes a local commit with message: MM-388 document proposal promotion provenance