### PR TITLE
MM-393 add Create page repository dropdown

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/201-managed-github-secret-materialization"
+  "feature_directory": "specs/202-repository-dropdown"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ Key diagnostics:
 - Existing Temporal artifact metadata tables and configured artifact store; no new persistent storage (195-enforce-image-artifact-policy)
 - Python 3.12; TypeScript/React for Mission Control Create-page behavior + FastAPI, SQLAlchemy async ORM, Pydantic v2, Temporal artifact service, React, Vitest, existing task editing helpers (196-preserve-attachment-bindings)
 - Existing Temporal artifact metadata tables and original task input snapshot artifacts; no new persistent storage (196-preserve-attachment-bindings)
+- Python 3.12; TypeScript/React + FastAPI dashboard runtime config helpers, Pydantic settings, `httpx`, React, Vitest, pytest (202-repository-dropdown)
+- No new persistent storage; options are derived from configuration and best-effort GitHub API responses at runtime (202-repository-dropdown)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import os
+import re
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, Mapping
+from urllib.parse import urlparse
+
+import httpx
 
 from moonmind.config.settings import WorkflowSettings, settings
 from moonmind.utils.build_info import resolve_moonmind_build_id
@@ -22,6 +27,11 @@ _POLL_INTERVALS_MS = {
 }
 
 _SUPPORTED_WORKER_RUNTIMES = ("codex_cli", "gemini_cli", "claude_code", "jules", "universal")
+_OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_SSH_GITHUB_RE = re.compile(
+    r"^(?:ssh://)?git@github\.com[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$"
+)
+_GITHUB_REPOSITORY_DISCOVERY_URL = "https://api.github.com/user/repos"
 
 _JIRA_CREATE_PAGE_SOURCES = {
     "connections": "/api/jira/connections/verify",
@@ -56,10 +66,157 @@ def _validate_jira_source_templates(sources: Mapping[str, str]) -> None:
 _validate_jira_source_templates(_JIRA_CREATE_PAGE_SOURCES)
 
 
+@dataclass(frozen=True, slots=True)
+class RepositoryOption:
+    """Browser-safe repository suggestion for the Create page."""
+
+    value: str
+    label: str
+    source: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "value": self.value,
+            "label": self.label,
+            "source": self.source,
+        }
+
+
 def _build_jira_sources() -> dict[str, str]:
     """Return MoonMind-owned Jira browser endpoint templates."""
 
     return dict(_JIRA_CREATE_PAGE_SOURCES)
+
+
+def _normalize_repository_value(value: object) -> str | None:
+    """Return a browser-safe owner/repo value, or ``None`` when invalid."""
+
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    if _OWNER_REPO_RE.fullmatch(raw):
+        return raw
+
+    ssh_match = _SSH_GITHUB_RE.fullmatch(raw)
+    if ssh_match:
+        owner, repo = ssh_match.groups()
+        normalized = f"{owner}/{repo}"
+        return normalized if _OWNER_REPO_RE.fullmatch(normalized) else None
+
+    parsed = urlparse(raw)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return None
+    if parsed.hostname != "github.com":
+        return None
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) != 2:
+        return None
+    owner, repo = parts
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    normalized = f"{owner}/{repo}"
+    return normalized if _OWNER_REPO_RE.fullmatch(normalized) else None
+
+
+def _append_repository_option(
+    options: list[RepositoryOption],
+    seen: set[str],
+    value: object,
+    *,
+    source: str,
+) -> None:
+    normalized = _normalize_repository_value(value)
+    if not normalized:
+        return
+    key = normalized.lower()
+    if key in seen:
+        return
+    seen.add(key)
+    options.append(
+        RepositoryOption(value=normalized, label=normalized, source=source)
+    )
+
+
+def _fetch_github_repository_options(
+    token: str,
+) -> tuple[list[RepositoryOption], str | None]:
+    """Fetch credential-visible GitHub repositories without exposing secrets."""
+
+    if not token:
+        return [], None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        with httpx.Client(timeout=2.5) as client:
+            response = client.get(
+                _GITHUB_REPOSITORY_DISCOVERY_URL,
+                headers=headers,
+                params={
+                    "per_page": 100,
+                    "sort": "updated",
+                    "affiliation": "owner,collaborator,organization_member",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.HTTPError, ValueError):
+        return [], "GitHub repository discovery is unavailable."
+
+    options: list[RepositoryOption] = []
+    seen: set[str] = set()
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, Mapping):
+                _append_repository_option(
+                    options,
+                    seen,
+                    item.get("full_name"),
+                    source="github",
+                )
+    return options, None
+
+
+def _build_repository_options() -> dict[str, Any]:
+    """Build Create-page repository suggestions from safe runtime sources."""
+
+    options: list[RepositoryOption] = []
+    seen: set[str] = set()
+    _append_repository_option(
+        options,
+        seen,
+        settings.workflow.github_repository,
+        source="default",
+    )
+
+    configured_repos = str(getattr(settings.github, "github_repos", "") or "")
+    for raw_repo in configured_repos.split(","):
+        _append_repository_option(options, seen, raw_repo, source="configured")
+
+    discovery_error: str | None = None
+    github_enabled = bool(getattr(settings.github, "github_enabled", True))
+    github_token = str(getattr(settings.github, "github_token", "") or "").strip()
+    if github_enabled and github_token:
+        discovered, discovery_error = _fetch_github_repository_options(github_token)
+        if discovery_error:
+            discovery_error = "GitHub repository discovery is unavailable."
+        for option in discovered:
+            _append_repository_option(
+                options,
+                seen,
+                option.value,
+                source="github",
+            )
+
+    return {
+        "items": [option.to_payload() for option in options],
+        "error": discovery_error,
+    }
 
 
 def _jira_create_page_enabled() -> bool:
@@ -240,6 +397,7 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
     default_publish_mode = (
         str(settings.workflow.default_publish_mode or "").strip().lower() or "pr"
     )
+    repository_options = _build_repository_options()
 
     system_metadata = _build_dashboard_system_metadata()
     jira_runtime_config = _build_jira_runtime_config()
@@ -323,6 +481,7 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
         "system": {
             **system_metadata,
             "defaultRepository": default_repository,
+            "repositoryOptions": repository_options,
             "defaultTaskRuntime": default_task_runtime,
             "defaultTaskModel": default_task_model,
             "defaultTaskEffort": default_task_effort,
@@ -372,5 +531,6 @@ __all__ = [
     "build_live_logs_feature_config",
     "build_runtime_config",
     "normalize_status",
+    "RepositoryOption",
     "status_maps",
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-393-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-393-moonspec-orchestration-input.md
@@ -1,0 +1,39 @@
+# MM-393 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-393
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+- Labels: None
+- Trusted fetch tool: `jira.get_issue`
+- Normalized detail source: `/api/jira/issues/MM-393`
+- Canonical source: `recommendedImports.presetInstructions` from the normalized trusted Jira issue detail response.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-393 from MM project
+Summary: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-393 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-393: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+
+We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that and show it as a dropdown in the Create Page UI
+
+## Normalized Jira Detail
+
+Acceptance criteria: None provided by Jira.
+
+Recommended step instructions:
+
+Complete Jira issue MM-393: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+
+Description
+We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that and show it as a dropdown in the Create Page UI
+

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -143,6 +143,41 @@ function withAttachmentPolicy(payload: BootPayload = mockPayload): BootPayload {
   };
 }
 
+function withRepositoryOptions(payload: BootPayload = mockPayload): BootPayload {
+  const initialData = payload.initialData as {
+    dashboardConfig: {
+      system?: Record<string, unknown>;
+    };
+  };
+  return {
+    ...payload,
+    initialData: {
+      ...initialData,
+      dashboardConfig: {
+        ...initialData.dashboardConfig,
+        system: {
+          ...initialData.dashboardConfig.system,
+          repositoryOptions: {
+            items: [
+              {
+                value: "MoonLadderStudios/MoonMind",
+                label: "MoonLadderStudios/MoonMind",
+                source: "default",
+              },
+              {
+                value: "Octo/Repo",
+                label: "Octo/Repo",
+                source: "github",
+              },
+            ],
+            error: null,
+          },
+        },
+      },
+    },
+  };
+}
+
 function withImageOnlyAttachmentPolicy(
   payload: BootPayload = mockPayload,
 ): BootPayload {
@@ -3476,6 +3511,73 @@ describe("Task Create Entrypoint", () => {
       expect(navigateTo).toHaveBeenCalledWith(
         "/tasks/mm:workflow-123?source=temporal",
       );
+    });
+  });
+
+  it("offers repository options while preserving editable repository entry", async () => {
+    renderWithClient(<TaskCreatePage payload={withRepositoryOptions()} />);
+
+    const repositoryInput = await screen.findByLabelText(/GitHub Repo/);
+    expect(repositoryInput.getAttribute("list")).toBe("queue-repository-options");
+
+    const datalist = document.querySelector<HTMLDataListElement>(
+      "#queue-repository-options",
+    );
+    expect(datalist).not.toBeNull();
+    expect(
+      Array.from(datalist?.querySelectorAll("option") || []).map(
+        (option) => option.value,
+      ),
+    ).toEqual(["MoonLadderStudios/MoonMind", "Octo/Repo"]);
+
+    fireEvent.change(repositoryInput, {
+      target: { value: "Custom/Repo" },
+    });
+    expect((repositoryInput as HTMLInputElement).value).toBe("Custom/Repo");
+  });
+
+  it("submits a selected repository option without changing unrelated draft fields", async () => {
+    renderWithClient(<TaskCreatePage payload={withRepositoryOptions()} />);
+
+    const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
+      "section",
+    );
+    expect(primaryStep).not.toBeNull();
+    fireEvent.change(await screen.findByLabelText("Instructions"), {
+      target: { value: "Run repository dropdown regression." },
+    });
+    fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
+      target: { value: "Octo/Repo" },
+    });
+    fireEvent.change(
+      within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
+      {
+        target: { value: "moonspec-orchestrate" },
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    const request = latestCreateRequest();
+    expect(request).toMatchObject({
+      payload: {
+        repository: "Octo/Repo",
+        task: {
+          instructions: "Run repository dropdown regression.",
+          runtime: {
+            mode: "codex_cli",
+          },
+        },
+      },
     });
   });
 

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -19,6 +19,7 @@ const ARTIFACT_COMPLETE_RETRY_MESSAGE = "artifact upload is not complete";
 const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
 const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
+const REPOSITORY_OPTIONS_DATALIST_ID = "queue-repository-options";
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
@@ -123,6 +124,14 @@ interface DashboardConfig {
     defaultTaskModelByRuntime?: Record<string, string>;
     defaultTaskEffortByRuntime?: Record<string, string>;
     supportedTaskRuntimes?: string[];
+    repositoryOptions?: {
+      items?: Array<{
+        value?: string | null;
+        label?: string | null;
+        source?: string | null;
+      }>;
+      error?: string | null;
+    };
     providerProfiles?: {
       list?: string;
     };
@@ -3527,6 +3536,27 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     ],
   );
 
+  const repositoryOptions = useMemo(() => {
+    const items = dashboardConfig.system?.repositoryOptions?.items;
+    const seen = new Set<string>();
+    return (Array.isArray(items) ? items : [])
+      .map((item) => ({
+        value: String(item?.value || "").trim(),
+        label: String(item?.label || item?.value || "").trim(),
+      }))
+      .filter((item) => {
+        if (!item.value) {
+          return false;
+        }
+        const key = item.value.toLowerCase();
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      });
+  }, [dashboardConfig.system?.repositoryOptions?.items]);
+
   const presetStatusText = useMemo(() => {
     if (presetReapplyNeeded) {
       return PRESET_REAPPLY_REQUIRED_MESSAGE;
@@ -5176,6 +5206,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 <option key={item} value={item} />
               ))}
             </datalist>
+            <datalist id={REPOSITORY_OPTIONS_DATALIST_ID}>
+              {repositoryOptions.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </datalist>
 
             {steps.map((step, index) => {
               const isPrimaryStep = index === 0;
@@ -5906,6 +5943,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           GitHub Repo
           <input
             name="repository"
+            list={REPOSITORY_OPTIONS_DATALIST_ID}
             value={repository}
             placeholder="owner/repo"
             onChange={(event) => setRepository(event.target.value)}

--- a/specs/202-repository-dropdown/checklists/requirements.md
+++ b/specs/202-repository-dropdown/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Create Page Repository Dropdown
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The input was classified as a single-story runtime feature.
+- `docs/UI/CreatePage.md` is treated as source requirements for runtime behavior, not as a documentation-only target.

--- a/specs/202-repository-dropdown/contracts/repository-options.md
+++ b/specs/202-repository-dropdown/contracts/repository-options.md
@@ -1,0 +1,40 @@
+# Contract: Create Page Repository Options
+
+## Runtime Boot Payload
+
+The Create page runtime config exposes repository suggestions under:
+
+```ts
+interface DashboardConfig {
+  system?: {
+    repositoryOptions?: {
+      items: RepositoryOption[];
+      error?: string | null;
+    };
+  };
+}
+
+interface RepositoryOption {
+  value: string;
+  label: string;
+  source: "default" | "configured" | "github";
+}
+```
+
+Rules:
+
+- `value` is the exact owner/repo string that may be submitted as the task repository.
+- `label` is display-only and must not contain credential material.
+- `source` is non-secret provenance for operator-visible debugging and test assertions.
+- `error` is optional, sanitized, and must not block manual entry.
+- The browser treats this as suggestions, not as the exhaustive allowed repository set.
+
+## Create Page Interaction
+
+Rules:
+
+- The repository field remains an editable text input.
+- When `repositoryOptions.items` is non-empty, the field is associated with a datalist.
+- Choosing an option updates the existing `repository` draft value.
+- Submitting uses the selected or typed repository value in the existing execution create payload.
+- Existing owner/repo validation remains authoritative at submit time.

--- a/specs/202-repository-dropdown/data-model.md
+++ b/specs/202-repository-dropdown/data-model.md
@@ -1,0 +1,44 @@
+# Data Model: Create Page Repository Dropdown
+
+## Repository Option
+
+Represents one repository candidate safe to expose to the browser.
+
+Fields:
+
+- `value`: Required owner/repo repository identifier used as the submitted repository value.
+- `label`: Required display label. Defaults to `value`.
+- `source`: Required source classification: `default`, `configured`, or `github`.
+
+Validation:
+
+- `value` must match owner/repo syntax.
+- Values containing URL credentials, tokens, query strings, fragments, or unsupported hosts are rejected.
+- Duplicate values are collapsed case-insensitively while preserving the first source priority.
+
+## Repository Options Result
+
+Represents the Create page repository suggestion payload.
+
+Fields:
+
+- `items`: Ordered list of `RepositoryOption`.
+- `error`: Optional non-secret warning string when credential-based discovery failed.
+
+Validation:
+
+- `items` may be empty.
+- `error` must never include token-like values, secret refs, authorization headers, cookies, or raw GitHub response bodies.
+
+## Create Page Draft Repository
+
+Represents the repository value in the browser draft.
+
+Fields:
+
+- `repository`: Editable string. May be selected from repository options or manually typed.
+
+Validation:
+
+- Submit-time validation remains the existing owner/repo requirement.
+- Selecting an option must update only this field.

--- a/specs/202-repository-dropdown/plan.md
+++ b/specs/202-repository-dropdown/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Create Page Repository Dropdown
+
+**Branch**: `202-repository-dropdown` | **Date**: 2026-04-17 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story feature specification from `/specs/202-repository-dropdown/spec.md`
+
+**Note**: This plan follows the Moon Spec lifecycle for MM-393 and treats the feature as runtime implementation work.
+
+## Summary
+
+Task authors need repository suggestions on the Create page so they can select configured and credential-visible Git repositories without typing owner/repo values manually. The implementation will add a MoonMind-owned repository option model and API-backed discovery helper on the dashboard view-model boundary, expose repository option metadata in the Create page boot payload, and render those options as editable datalist suggestions in the repository field. Tests cover backend normalization/discovery and frontend selection/submission behavior.
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React  
+**Primary Dependencies**: FastAPI dashboard runtime config helpers, Pydantic settings, `httpx`, React, Vitest, pytest  
+**Storage**: No new persistent storage; options are derived from configuration and best-effort GitHub API responses at runtime  
+**Unit Testing**: `./tools/test_unit.sh` for final unit verification; focused pytest and Vitest commands during iteration  
+**Integration Testing**: Existing Create page Vitest integration-style tests and FastAPI/dashboard view-model tests; no compose-backed integration required because no persistent service boundary changes  
+**Target Platform**: MoonMind API service and Mission Control Create page  
+**Project Type**: Web application with Python API/control plane and TypeScript frontend  
+**Performance Goals**: Create page rendering remains responsive; repository option discovery is bounded and best-effort  
+**Constraints**: Browser clients must call MoonMind APIs/configuration only and must never receive raw GitHub credentials, secret refs, or credential-bearing URLs  
+**Scale/Scope**: One Create page repository field and runtime boot payload path; repository discovery is limited to configured repositories plus a bounded GitHub repository listing
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. Repository discovery stays behind MoonMind control-plane boundaries and does not alter agent runtimes.
+- II. One-Click Agent Deployment: PASS. Missing GitHub credentials degrade to configured/default repositories without blocking local startup.
+- III. Avoid Vendor Lock-In: PASS. GitHub-specific discovery is optional and isolated behind repository option source metadata.
+- IV. Own Your Data: PASS. The browser receives only non-secret repository option metadata.
+- V. Skills Are First-Class: PASS. No skill contract changes.
+- VI. Replaceable Scaffolding: PASS. The repository option helper is thin and can be replaced by richer connectors later.
+- VII. Runtime Configurability: PASS. Configured repositories and credentials drive behavior at runtime.
+- VIII. Modular and Extensible Architecture: PASS. The change is scoped to dashboard view-model/runtime config and Create page rendering.
+- IX. Resilient by Default: PASS. Discovery errors are best-effort and do not block manual authoring.
+- X. Facilitate Continuous Improvement: PASS. Tests and MoonSpec artifacts preserve evidence.
+- XI. Spec-Driven Development: PASS. This plan implements the single-story spec.
+- XII. Canonical Documentation Separates Desired State from Migration Backlog: PASS. Implementation tracking remains under `specs/` and `docs/tmp/`.
+- XIII. Pre-release Compatibility Policy: PASS. No compatibility aliases or hidden fallbacks are introduced for internal contracts.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/202-repository-dropdown/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── repository-options.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+api_service/
+└── api/routers/task_dashboard_view_model.py
+
+frontend/
+└── src/entrypoints/task-create.tsx
+
+tests/
+└── unit/api/routers/test_task_dashboard_view_model.py
+
+frontend/src/entrypoints/
+└── task-create.test.tsx
+```
+
+**Structure Decision**: Use the existing Mission Control web app structure: Python builds runtime boot configuration and TypeScript renders the Create page form. No new package, table, migration, or runtime worker component is needed.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/202-repository-dropdown/quickstart.md
+++ b/specs/202-repository-dropdown/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Create Page Repository Dropdown
+
+## Focused Unit Validation
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py
+```
+
+Expected result:
+
+- Configured default and `GITHUB_REPOS` values are normalized into repository options.
+- Credential-visible GitHub repositories are included when the mocked GitHub API succeeds.
+- Invalid, duplicate, and credential-bearing values are excluded.
+- Discovery failure returns configured/manual-safe options without leaking secrets.
+
+## Focused Frontend Validation
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected result:
+
+- The repository field exposes dropdown suggestions from runtime config.
+- Selecting an option updates the repository field.
+- Submit payload uses the selected repository value.
+- Manual owner/repo entry remains possible when no options are present.
+
+## Final Validation
+
+```bash
+./tools/test_unit.sh
+```
+
+Expected result:
+
+- Required unit suite passes.
+- MM-393 remains referenced in MoonSpec artifacts and verification evidence.

--- a/specs/202-repository-dropdown/research.md
+++ b/specs/202-repository-dropdown/research.md
@@ -1,0 +1,33 @@
+# Research: Create Page Repository Dropdown
+
+## Repository Option Source
+
+Decision: Build repository options from the workflow default repository, comma-delimited `GITHUB_REPOS`, and best-effort GitHub API repository listing when credentials can be resolved.
+
+Rationale: The Jira brief asks for repositories the operator has added plus repositories available through credentials. Existing settings already expose `workflow.github_repository`, `github.github_repos`, and GitHub token resolution helpers, so the feature can reuse configured state without new storage.
+
+Alternatives considered: A new database-backed repository registry was rejected because the story does not require persistence. A closed select fed only by settings was rejected because it would not satisfy credential-visible repository discovery.
+
+## Browser Contract
+
+Decision: Keep the repository control as an editable text input with datalist suggestions.
+
+Rationale: The current Create page accepts manually typed owner/repo values and validates them on submit. A datalist preserves manual entry while offering selectable options, matching the graceful-degradation requirement.
+
+Alternatives considered: A closed dropdown was rejected because it would block repositories that cannot be discovered. A separate modal picker was rejected as unnecessary for the single-story scope.
+
+## Secret Boundary
+
+Decision: Expose only owner/repo option values, labels, source metadata, and non-secret warnings in runtime config.
+
+Rationale: The Create page must remain browser-safe. Tokens, secret refs, authorization headers, cookies, and credential-bearing clone URLs must never enter the boot payload.
+
+Alternatives considered: Passing credential status details to the browser was rejected because it risks leaking operator configuration. Surfacing raw clone URLs was rejected because configured URLs may contain credentials or unnecessary host data.
+
+## Testing Strategy
+
+Decision: Cover normalization/discovery in Python unit tests and Create page option rendering/submission in Vitest.
+
+Rationale: Repository option normalization and credential fallback are backend behavior, while datalist rendering and submit payload behavior are frontend behavior. Existing test suites already cover both boundaries.
+
+Alternatives considered: Compose-backed integration tests were rejected because this story does not add persistent infrastructure or service topology.

--- a/specs/202-repository-dropdown/spec.md
+++ b/specs/202-repository-dropdown/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Create Page Repository Dropdown
+
+**Feature Branch**: `202-repository-dropdown`  
+**Created**: 2026-04-17  
+**Status**: Draft  
+**Input**:
+
+```text
+Use the Jira preset brief for MM-393 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-393-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-393 from MM project
+Summary: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-393 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-393: We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that
+
+We should retrieve a list of git repos that you've added + ones that are available using your credentials if we can detect that and show it as a dropdown in the Create Page UI
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+- Input class: single-story feature request.
+- Mode: runtime.
+- Source design treatment: `docs/UI/CreatePage.md` defines the existing Create Page runtime contract and is used as supporting source requirements, not as a docs-only target.
+- Resume decision: no existing `MM-393` spec artifacts were present, so the workflow starts at Specify.
+
+## User Story - Create Page Repository Dropdown
+
+**Summary**: As a task author, I want the Create page repository field to offer known and credential-visible repositories as selectable options so that I can target a run without manually typing an owner/repo value.
+
+**Goal**: Task authors can choose a repository from a dropdown populated by MoonMind configuration and any detectable GitHub repositories available through configured credentials, while still retaining manual entry when repository discovery is unavailable.
+
+**Independent Test**: Can be fully tested by opening `/tasks/new` with configured repository options and a mocked repository-discovery response, selecting a repository from the dropdown, submitting a task, and verifying the submitted payload uses the selected owner/repo value while manual repository entry still works when discovery fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** MoonMind has a default repository or configured repository list, **When** the Create page renders, **Then** the repository field offers those repositories as selectable dropdown options.
+2. **Given** MoonMind can detect additional repositories through configured GitHub credentials, **When** the Create page repository options load, **Then** those repositories are available in the same dropdown without exposing credential material to the browser.
+3. **Given** a task author chooses a repository option, **When** they submit the task, **Then** the selected repository is sent as the task repository value.
+4. **Given** repository discovery is unavailable or returns no options, **When** the Create page renders, **Then** manual repository entry remains available and existing repository validation still applies.
+5. **Given** repository options include duplicates or invalid repository strings, **When** options are prepared for the browser, **Then** duplicates are removed and invalid values are not offered as selectable options.
+
+### Edge Cases
+
+- GitHub integration is disabled.
+- No GitHub credentials are configured.
+- GitHub credentials are configured but repository listing fails or times out.
+- Configured repository values include whitespace, duplicates, unsupported URL formats, or invalid owner/repo strings.
+- The configured default repository is not present in the discovered repository list.
+- The task author types a valid repository that is not present in the dropdown.
+
+## Assumptions
+
+- The Create page repository value remains an editable text field with dropdown suggestions rather than a closed select, because users may need to enter repositories that are not detectable.
+- Configured repositories include the workflow default repository and comma-delimited `GITHUB_REPOS` values when present.
+- Credential-visible repository discovery is best-effort; failures must not block task authoring or submit.
+- Browser clients receive only repository names and metadata needed for display, never GitHub tokens or secret refs.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: `docs/UI/CreatePage.md`, sections 3-6): The Create page MUST remain a MoonMind-native task authoring surface whose browser actions go through MoonMind REST APIs and whose execution context includes the repository field. Scope: in scope. Maps to FR-001, FR-002, FR-006, FR-009.
+- **DESIGN-REQ-002** (Source: `docs/UI/CreatePage.md`, sections 5 and 6): Runtime, provider, model, effort, repository, branches, and publish mode are part of the execution context draft model. Scope: in scope. Maps to FR-003, FR-007.
+- **DESIGN-REQ-003** (Source: `docs/UI/CreatePage.md`, sections 16-17): Optional integration failures MUST leave manual authoring available and validation feedback associated with the affected target. Scope: in scope. Maps to FR-004, FR-008.
+- **DESIGN-REQ-004** (Source: MM-393 Jira brief): The Create page repository control SHOULD retrieve repositories the user has added plus repositories available through credentials when detectable and show them as dropdown options. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-005, FR-006.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose repository options to the Create page using MoonMind-owned API/configuration surfaces.
+- **FR-002**: System MUST include configured repositories in repository options, including the workflow default repository and configured repository list values when present.
+- **FR-003**: System MUST attempt to include credential-visible GitHub repositories when GitHub integration and resolvable credentials are available.
+- **FR-004**: Repository option discovery failures MUST NOT prevent the Create page from rendering or block manual repository entry.
+- **FR-005**: Repository options MUST be normalized to selectable owner/repo values and MUST exclude invalid or credential-bearing values.
+- **FR-006**: Repository option data exposed to the browser MUST NOT include raw tokens, secret refs, authorization headers, cookies, or credential-bearing clone URLs.
+- **FR-007**: The Create page repository field MUST render repository options as dropdown suggestions while preserving free-form manual entry.
+- **FR-008**: Existing repository validation MUST continue to reject missing or invalid repository values at submit time.
+- **FR-009**: Selecting a repository option MUST update the submitted task repository value without changing unrelated draft fields.
+- **FR-010**: System MUST preserve Jira issue key MM-393 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Repository Option**: A selectable repository candidate with an owner/repo value, display label, and source classification such as configured default, configured list, or GitHub credentials.
+- **Repository Discovery Result**: The best-effort set of repository options returned to the Create page, including any non-secret warning state needed for graceful degradation.
+- **Create Page Draft**: Browser state containing the selected or manually entered repository and the rest of the task execution context.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Backend unit coverage verifies configured default and configured-list repositories appear in normalized repository options.
+- **SC-002**: Backend unit coverage verifies credential-visible GitHub repositories are included when the GitHub API returns accessible repositories.
+- **SC-003**: Backend unit coverage verifies invalid, duplicate, and credential-bearing repository strings are excluded from repository options.
+- **SC-004**: Frontend tests verify the repository field exposes dropdown suggestions while allowing manual owner/repo entry.
+- **SC-005**: Frontend tests verify selecting a repository option submits that repository value.
+- **SC-006**: Frontend or backend tests verify repository discovery failure does not block Create page rendering or manual repository submission.
+- **SC-007**: Verification evidence preserves MM-393 as the source Jira issue for the feature.

--- a/specs/202-repository-dropdown/tasks.md
+++ b/specs/202-repository-dropdown/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Create Page Repository Dropdown
+
+**Input**: Design documents from `/specs/202-repository-dropdown/`  
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around a single user story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: MM-393, FR-001 through FR-010, SC-001 through SC-007, DESIGN-REQ-001 through DESIGN-REQ-004.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py`
+- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Verify existing project and test surfaces needed for this story
+
+- [X] T001 Verify repository option work uses existing dashboard runtime config and Create page files in `api_service/api/routers/task_dashboard_view_model.py` and `frontend/src/entrypoints/task-create.tsx`
+- [X] T002 Verify focused backend and frontend test commands from `specs/202-repository-dropdown/quickstart.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core repository option contract and normalization prerequisites
+
+**CRITICAL**: No story implementation work can begin until this phase is complete
+
+- [X] T003 Define the browser-safe repository option contract in `specs/202-repository-dropdown/contracts/repository-options.md` for FR-001, FR-005, FR-006
+- [X] T004 Confirm no persistent storage or migration is required in `specs/202-repository-dropdown/plan.md` for FR-004
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin
+
+---
+
+## Phase 3: Story - Create Page Repository Dropdown
+
+**Summary**: As a task author, I want the Create page repository field to offer known and credential-visible repositories as selectable options so that I can target a run without manually typing an owner/repo value.
+
+**Independent Test**: Open `/tasks/new` with configured repository options and mocked credential-visible repositories, select an option, submit, and verify the selected repository is submitted while manual entry still works when discovery is unavailable.
+
+**Traceability**: MM-393, FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004
+
+**Test Plan**:
+
+- Unit: repository option normalization, configured repositories, credential-visible GitHub repositories, invalid/duplicate/secret-bearing exclusions, sanitized discovery failure.
+- Integration: Create page repository datalist rendering, option selection, submit payload, manual fallback.
+
+### Unit Tests (write first)
+
+> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
+
+- [X] T005 Add failing unit tests for configured default and `GITHUB_REPOS` repository options covering FR-001, FR-002, SC-001 in `tests/unit/api/routers/test_task_dashboard_view_model.py`
+- [X] T006 Add failing unit tests for credential-visible GitHub repository inclusion and discovery failure degradation covering FR-003, FR-004, SC-002, SC-006 in `tests/unit/api/routers/test_task_dashboard_view_model.py`
+- [X] T007 Add failing unit tests for invalid, duplicate, and credential-bearing repository exclusion covering FR-005, FR-006, SC-003 in `tests/unit/api/routers/test_task_dashboard_view_model.py`
+- [X] T008 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py` to confirm T005-T007 fail for the expected reason
+
+### Integration Tests (write first)
+
+- [X] T009 Add failing Create page test for repository datalist rendering and option selection covering FR-007, SC-004 in `frontend/src/entrypoints/task-create.test.tsx`
+- [X] T010 Add failing Create page test for selected option submission and manual fallback covering FR-008, FR-009, SC-005, SC-006 in `frontend/src/entrypoints/task-create.test.tsx`
+- [X] T011 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` to confirm T009-T010 fail for the expected reason
+
+### Implementation
+
+- [X] T012 Implement repository option normalization, configured repository collection, GitHub API best-effort discovery, and sanitized error handling for FR-001 through FR-006 in `api_service/api/routers/task_dashboard_view_model.py`
+- [X] T013 Expose `system.repositoryOptions` in Create page runtime config for FR-001 through FR-006 in `api_service/api/routers/task_dashboard_view_model.py`
+- [X] T014 Extend the Create page dashboard config type and repository input datalist rendering for FR-007 in `frontend/src/entrypoints/task-create.tsx`
+- [X] T015 Preserve existing submit validation and selected/manual repository payload behavior for FR-008 and FR-009 in `frontend/src/entrypoints/task-create.tsx`
+- [X] T016 Run focused backend and frontend commands, fix failures, and verify the story passes end-to-end for SC-001 through SC-006
+
+**Checkpoint**: The story is fully functional, covered by unit and integration tests, and testable independently
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that strengthen the completed story without changing its core scope
+
+- [X] T017 [P] Update MoonSpec verification evidence and preserve MM-393 references in `specs/202-repository-dropdown/quickstart.md`
+- [X] T018 Run `./tools/test_unit.sh` for final required unit-suite verification
+- [X] T019 Run `/speckit.verify` to validate the final implementation against the original MM-393 feature request
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS story work
+- **Story (Phase 3)**: Depends on Foundational phase completion
+- **Polish (Phase 4)**: Depends on the story being functionally complete and tests passing
+
+### Within The Story
+
+- Unit tests T005-T007 MUST be written and FAIL before implementation
+- Integration tests T009-T010 MUST be written and FAIL before implementation
+- Red-first confirmation tasks T008 and T011 MUST complete before production code tasks T012-T015
+- Backend runtime config support precedes frontend option rendering
+- Story complete before polish work
+
+### Parallel Opportunities
+
+- T005, T006, and T007 touch the same backend test file and must be applied sequentially.
+- T009 and T010 touch the same frontend test file and must be applied sequentially.
+- T017 can run after implementation while final validation is prepared.
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 artifact/contract checks.
+2. Add backend unit tests and confirm they fail.
+3. Add frontend tests and confirm they fail.
+4. Implement backend repository option discovery and runtime config.
+5. Implement frontend datalist suggestions without changing manual entry semantics.
+6. Run focused backend and frontend tests until passing.
+7. Run full `./tools/test_unit.sh`.
+8. Run `/speckit.verify`.
+
+---
+
+## Notes
+
+- The task list covers one story only.
+- Repository options are suggestions, not an authorization or allowlist boundary.
+- GitHub discovery is best-effort and must not block manual authoring.
+- Browser payloads must remain free of raw credentials and secret refs.

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -364,6 +364,8 @@ def test_build_runtime_config_uses_claude_from_runtime_env(monkeypatch) -> None:
 
 def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
     monkeypatch.setattr(settings.workflow, "github_repository", "Octo/Repo")
+    monkeypatch.setattr(settings.github, "github_repos", None)
+    monkeypatch.setattr(settings.github, "github_token", None)
     monkeypatch.setattr(settings.workflow, "codex_model", "gpt-test-codex")
     monkeypatch.setattr(settings.workflow, "codex_effort", "medium")
     monkeypatch.setattr(settings.workflow, "default_task_runtime", "codex_cli")
@@ -373,6 +375,10 @@ def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
     config = dashboard_view_model.build_runtime_config("/tasks")
 
     assert config["system"]["defaultRepository"] == "Octo/Repo"
+    assert config["system"]["repositoryOptions"] == {
+        "items": [{"value": "Octo/Repo", "label": "Octo/Repo", "source": "default"}],
+        "error": None,
+    }
     assert config["system"]["defaultTaskModel"] == "gpt-test-codex"
     assert config["system"]["defaultTaskEffort"] == "medium"
     assert config["system"]["defaultTaskModelByRuntime"]["codex_cli"] == "gpt-test-codex"
@@ -380,6 +386,97 @@ def test_build_runtime_config_uses_settings_defaults(monkeypatch) -> None:
     assert config["system"]["defaultTaskEffortByRuntime"]["codex_cli"] == "medium"
     assert config["system"]["defaultPublishMode"] == "branch"
     assert config["system"]["defaultProposeTasks"] is False
+
+
+def test_build_runtime_config_includes_configured_repository_options(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "github_repository", "Octo/Repo")
+    monkeypatch.setattr(
+        settings.github,
+        "github_repos",
+        "Octo/Repo, MoonLadderStudios/MoonMind, https://github.com/Example/App.git, bad-value",
+    )
+    monkeypatch.setattr(settings.github, "github_token", None)
+
+    config = dashboard_view_model.build_runtime_config("/tasks/new")
+
+    assert config["system"]["repositoryOptions"]["items"] == [
+        {"value": "Octo/Repo", "label": "Octo/Repo", "source": "default"},
+        {
+            "value": "MoonLadderStudios/MoonMind",
+            "label": "MoonLadderStudios/MoonMind",
+            "source": "configured",
+        },
+        {"value": "Example/App", "label": "Example/App", "source": "configured"},
+    ]
+
+
+def test_build_runtime_config_includes_credential_visible_github_repositories(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings.workflow, "github_repository", "Octo/Repo")
+    monkeypatch.setattr(settings.github, "github_repos", None)
+    monkeypatch.setattr(settings.github, "github_token", "ghp_test_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_fetch_github_repository_options",
+        lambda token: (
+            [
+                dashboard_view_model.RepositoryOption(
+                    value="MoonLadderStudios/MoonMind",
+                    label="MoonLadderStudios/MoonMind",
+                    source="github",
+                )
+            ],
+            None,
+        ),
+    )
+
+    config = dashboard_view_model.build_runtime_config("/tasks/new")
+
+    assert config["system"]["repositoryOptions"]["items"] == [
+        {"value": "Octo/Repo", "label": "Octo/Repo", "source": "default"},
+        {
+            "value": "MoonLadderStudios/MoonMind",
+            "label": "MoonLadderStudios/MoonMind",
+            "source": "github",
+        },
+    ]
+
+
+def test_build_runtime_config_sanitizes_repository_options_and_errors(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        settings.workflow,
+        "github_repository",
+        "https://token@example.com/Secret/Repo.git",
+    )
+    monkeypatch.setattr(
+        settings.github,
+        "github_repos",
+        "Octo/Repo, octo/repo, https://github.com/Valid/Repo.git?token=secret, git@github.com:Another/Repo.git",
+    )
+    monkeypatch.setattr(settings.github, "github_token", "ghp_secret_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_fetch_github_repository_options",
+        lambda token: (
+            [],
+            "GitHub repository discovery failed; ghp_secret_token was not exposed.",
+        ),
+    )
+
+    config = dashboard_view_model.build_runtime_config("/tasks/new")
+
+    assert config["system"]["repositoryOptions"]["items"] == [
+        {"value": "Octo/Repo", "label": "Octo/Repo", "source": "configured"},
+        {"value": "Another/Repo", "label": "Another/Repo", "source": "configured"},
+    ]
+    assert "ghp_secret_token" not in config["system"]["repositoryOptions"]["error"]
 
 
 def test_build_runtime_config_uses_repo_runtime_model_defaults(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add browser-safe repository options to the Create page runtime config from configured repositories and best-effort GitHub credential discovery.
- Render repository suggestions as an editable datalist so manual owner/repo entry continues to work.
- Preserve MM-393 traceability through MoonSpec artifacts and task evidence.

## MoonSpec Verification
- Verdict: FULLY_IMPLEMENTED
- Spec: specs/202-repository-dropdown/spec.md
- Original request: MM-393 repository dropdown for added and credential-visible Git repositories in the Create Page UI.

## Tests
- PASS: .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks
- PASS: ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard_view_model.py
- PASS: ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
- PASS: ./tools/test_unit.sh
