### PR TITLE
[codex] Harden PR resolver terminal contract

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -8,6 +8,8 @@ description: Master orchestrator to resolve a PR by diagnosing state and delegat
 ## Purpose
 You are the master orchestrator for finishing Pull Requests. Use bounded retries to keep finalize resilient, and delegate actual fixes to specialized skills (`fix-merge-conflicts`, `fix-comments`, `fix-ci`) when blockers are actionable.
 
+The task is not complete until the target PR is merged or is proven already merged. A local fix, local commit, passing local test run, unresolved review reply, or unpushed branch is not a successful PR resolution.
+
 ## Inputs (skill args)
 - inputs.repo (optional)
 - inputs.pr (optional)
@@ -19,8 +21,8 @@ You are the master orchestrator for finishing Pull Requests. Use bounded retries
 - inputs.finalizeMaxSleepSeconds (default 120)
 - inputs.finalizeMaxElapsedSeconds (default 1800)
 
-## Primary Command (use first)
-Run the orchestration entrypoint. **You MUST provide the `--pr` argument** (using either the PR number or the branch name) to ensure the script targets the correct PR, even if you are on a different branch or detached HEAD:
+## Primary Command (mandatory first action)
+Run the orchestration entrypoint before making manual changes. **You MUST provide the `--pr` argument** (using either the PR number or the branch name) to ensure the script targets the correct PR, even if you are on a different branch or detached HEAD:
 
 ```bash
 python3 .agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py \
@@ -36,6 +38,36 @@ python3 .agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py \
 This writes:
 - `var/pr_resolver/result.json` (terminal orchestration summary)
 - `var/pr_resolver/attempts/*.json` (per-attempt finalize/full artifacts)
+
+If this command does not run, does not write `var/pr_resolver/result.json`, or exits before producing a parseable result, stop as blocked with the command output and do not report success.
+
+## Terminal Success Contract
+Allowed successful terminal states:
+- `var/pr_resolver/result.json` has `status=merged` and `merge_outcome=merged`.
+- The PR is independently confirmed as already merged after a snapshot/finalize race.
+
+Everything else is blocked, failed, or still in-progress. In particular, never finish with `task complete` or a success summary when:
+- the PR remains open,
+- the branch is ahead of origin,
+- a push failed,
+- GitHub auth is unavailable,
+- `gh pr merge` failed,
+- review comments remain actionable,
+- CI is running, degraded, or failing,
+- mergeability is unknown, dirty, or blocked.
+
+After any local commit-producing remediation, verify the exact current `HEAD` is visible on the remote PR branch before continuing. If `git push`, `gh`, or any GitHub connector path cannot publish the commit, stop as blocked with reason `publish_unavailable`; do not proceed to finalize and do not report success.
+
+## Main Loop
+Repeat this state machine until a terminal success or manual blocker:
+
+1. Run the Primary Command.
+2. Read `var/pr_resolver/result.json`.
+3. If `status=merged` and `merge_outcome=merged`, confirm the PR is merged and finish.
+4. If `status=blocked` or `status=attempts_exhausted`, inspect `next_step`.
+5. Execute the matching specialized skill exactly once for that blocker, then return to step 1.
+6. If the same blocker repeats after its specialized skill ran and no remote PR branch change is visible, stop as blocked and report the artifact details.
+7. If the blocker is transient CI or mergeability state, wait only within the configured retry/backoff caps, then return to step 1.
 
 ## Retry Policy
 - Full-remediation escalation reasons:
@@ -61,7 +93,7 @@ When orchestration returns `status=blocked` or `status=attempts_exhausted`, insp
 - `wait_for_ci_and_retry_finalize` / `retry_finalize_after_backoff`: do not mutate; wait and re-run orchestration.
 - `manual_review`: stop and report the blocker with artifact details.
 
-After applying any fix, run the orchestration command again.
+After applying any fix, run the orchestration command again. Do not summarize the task as complete before the rerun returns the Terminal Success Contract.
 
 ## Lightweight Commands
 - Finalize-only gate checker:
@@ -81,3 +113,4 @@ python3 .agents/skills/pr-resolver/bin/pr_resolve_full.py --pr <pr_number_or_bra
 - Do NOT invent custom conflict/CI/comment workflows; always execute the specialized skill instructions.
 - Respect retry caps; if retries are exhausted, return `attempts_exhausted` and stop.
 - This skill is allowed to commit/push and merge (task.publish.mode MUST be none).
+- A failed push, missing GitHub auth, or missing remote branch update is an unresolved PR blocker, even if all code changes are committed locally.

--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -65,8 +65,8 @@ Repeat this state machine until a terminal success or manual blocker:
 2. Read `var/pr_resolver/result.json`.
 3. If `status=merged` and `merge_outcome=merged`, confirm the PR is merged and finish.
 4. If `status=blocked` or `status=attempts_exhausted`, inspect `next_step`.
-5. Execute the matching specialized skill exactly once for that blocker, then return to step 1.
-6. If the same blocker repeats after its specialized skill ran and no remote PR branch change is visible, stop as blocked and report the artifact details.
+5. If the same blocker repeats after its specialized skill ran and no remote PR branch change is visible, stop as blocked and report the artifact details.
+6. Execute the matching specialized skill exactly once for that blocker, then return to step 1.
 7. If the blocker is transient CI or mergeability state, wait only within the configured retry/backoff caps, then return to step 1.
 
 ## Retry Policy

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1257,3 +1257,12 @@ def test_pr_resolver_skill_requires_orchestrated_merge_completion() -> None:
     assert "merge_outcome=merged" in skill_text
     assert "reason `publish_unavailable`" in skill_text
     assert "branch is ahead of origin" in skill_text
+
+    repeated_blocker_step = (
+        "If the same blocker repeats after its specialized skill ran and no remote "
+        "PR branch change is visible"
+    )
+    skill_execution_step = "Execute the matching specialized skill exactly once"
+    assert skill_text.index(repeated_blocker_step) < skill_text.index(
+        skill_execution_step
+    )

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -1242,3 +1242,18 @@ def test_review_comment_with_thread_resolved_via_enrichment(
     assert summary["actionableCommentCount"] == 1
     assert summary["actionableCommentIds"] == [2]
     assert summary["nonActionableReasonCounts"].get("thread_resolved") == 1
+
+
+def test_pr_resolver_skill_requires_orchestrated_merge_completion() -> None:
+    skill_text = (
+        REPO_ROOT / ".agents" / "skills" / "pr-resolver" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Primary Command (mandatory first action)" in skill_text
+    assert "Terminal Success Contract" in skill_text
+    assert "Main Loop" in skill_text
+    assert "A local fix, local commit" in skill_text
+    assert "status=merged" in skill_text
+    assert "merge_outcome=merged" in skill_text
+    assert "reason `publish_unavailable`" in skill_text
+    assert "branch is ahead of origin" in skill_text


### PR DESCRIPTION
## Summary
- Require pr-resolver runs to execute the orchestration entrypoint before ad hoc remediation.
- Define success only as a merged or independently already-merged PR.
- Treat failed push, missing GitHub auth, or an unpushed local commit as unresolved blockers.
- Add a unit guard so the terminal contract stays present in the skill instructions.

## Root Cause
A managed PR-resolution workflow could exit successfully after local remediation even when the PR remained open because the skill did not make remote merge completion a hard terminal contract.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`