### PR TITLE
[codex] Add Create page tooltips and branch contract docs

### DIFF
--- a/docs/ExternalAgents/JulesAdapter.md
+++ b/docs/ExternalAgents/JulesAdapter.md
@@ -302,14 +302,9 @@ Those are provider-specific extensions, not replacements for the core lifecycle 
 
 The Jules API only supports `AUTO_CREATE_PR` as an automation mode. There is no true “branch only” mode.
 
-That means when a user requests `publishMode == "branch"`, MoonMind must treat “land changes directly on the target branch” as a MoonMind-owned post-completion outcome rather than a Jules-native publish mode.
+That means when a user requests `publishMode == "branch"`, MoonMind must treat "land changes directly on the authored branch" as a MoonMind-owned post-completion outcome rather than a Jules-native publish mode.
 
-Additionally, `startingBranch` may affect both:
-
-- where Jules starts work
-- the initial PR target
-
-So MoonMind may need to correct the target branch before merge.
+Jules receives a single authored `branch` reference. MoonMind no longer assumes authored inputs provide both a base branch and a target branch. For PR mode, `branch` is the PR base and Jules/provider automation manages work/head branch creation.
 
 ## 8.2 Mechanism
 
@@ -318,13 +313,13 @@ MoonMind handles branch publication with a post-completion flow:
 1. Jules creates a PR using `AUTO_CREATE_PR`
 2. MoonMind waits for terminal completion
 3. MoonMind fetches the Jules result and extracts the PR URL
-4. MoonMind optionally updates the PR base branch if `targetBranch != startingBranch`
+4. MoonMind verifies or corrects the PR base so it targets the authored `branch` when the provider result does not already do so
 5. MoonMind merges the PR through `repo.merge_pr`
 
 This lets MoonMind support:
 
 - `publishMode == "pr"` → leave PR open
-- `publishMode == "branch"` → merge changes into the target branch
+- `publishMode == "branch"` → merge changes into the authored branch
 
 ## 8.3 Workflow flow
 
@@ -333,13 +328,13 @@ When `publishMode == "branch"` and the provider is Jules:
 1. `JulesAgentAdapter.do_start()` sets `automationMode = "AUTO_CREATE_PR"`
 2. `MoonMind.AgentRun` waits for Jules to reach terminal completion
 3. `integration.jules.fetch_result` returns a canonical `AgentRunResult` containing PR metadata
-4. MoonMind optionally updates the PR base branch
+4. MoonMind verifies or corrects the PR base branch against the single authored `branch`
 5. MoonMind calls `repo.merge_pr`
 6. the final MoonMind result reflects whether branch publication actually succeeded
 
 ## 8.4 Truthfulness rule
 
-If `publishMode == "branch"`, MoonMind must not report success unless the changes actually land on the target branch.
+If `publishMode == "branch"`, MoonMind must not report success unless the changes actually land on the authored branch.
 
 That means these failures must prevent a successful branch-publication outcome:
 

--- a/docs/Tasks/TaskArchitecture.md
+++ b/docs/Tasks/TaskArchitecture.md
@@ -14,6 +14,7 @@ It maps how the control plane translates user intent from Mission Control — in
 - step-authored instructions
 - objective-scoped and step-scoped input attachments
 - runtime and publish choices
+- repository and single authored branch selection
 - agent skill selection intent
 - presets, Jira imports, and dependency declarations
 
@@ -142,6 +143,7 @@ The control plane is responsible for all of the following.
 - render the Create page
 - validate repository, runtime, publish mode, dependencies, and attachment policy
 - collect text fields, preset state, Jira imports, and input attachments into a coherent draft
+- render repository, Branch, and Publish Mode together in the Steps card. `Publish Mode` remains submission data; only its visual placement changes.
 
 ### 5.2 Artifact upload orchestration
 
@@ -249,8 +251,7 @@ interface TaskPayload {
     mode?: "none" | "branch" | "pr";
   };
   git?: {
-    startingBranch?: string;
-    targetBranch?: string;
+    branch?: string;
   };
   appliedStepTemplates?: unknown[];
   dependsOn?: string[];
@@ -266,6 +267,10 @@ Rules:
 - these fields are part of the task contract, not incidental UI metadata
 - the absence of attachments is valid
 - the presence of attachments must be preserved across create, detail, edit, and rerun
+- `task.git.branch` is the single authored branch field; new create, edit, and rerun payloads do not include `targetBranch`
+- for `publish.mode === "pr"`, `task.git.branch` is the selected repository branch / PR base and the PR head branch is runtime-generated or provider-managed
+- for `publish.mode === "branch"`, `task.git.branch` is the branch to update/push
+- `Publish Mode` remains part of task submission semantics; only its Create page placement changes
 - the execution-facing payload is resolved before workers consume it; `authoredPresets` and `source` metadata are for reconstruction, audit, diagnostics, and safe rerun semantics
 
 ---
@@ -283,6 +288,7 @@ Rules:
   - step-scoped attachment refs
   - step order and identity
   - runtime and publish selections
+  - repository and single authored branch selection
   - preset application metadata
   - pinned preset bindings
   - include-tree summary

--- a/docs/Tasks/TaskPublishing.md
+++ b/docs/Tasks/TaskPublishing.md
@@ -18,36 +18,22 @@ The agent runs in its workspace but no git operations occur after completion. Us
 
 After the agent completes, the infrastructure pushes the current work branch to the remote. The agent is instructed to commit but **not** to push or create a PR — that is handled deterministically by the runtime.
 
-`branch` publish supports both of these operator intents:
+For new authored submissions, `branch` publish uses a single operator-selected `branch` field. That branch is the branch to update and push. MoonMind no longer exposes a separate "clone from X, push to Y" authoring model.
 
-- **Update a new or separate work branch:** set `startingBranch` to the branch to clone from and `targetBranch` to the branch that should receive the agent's commits.
-- **Update an existing branch in place:** set `startingBranch` and `targetBranch` to the same non-hard-protected branch. MoonMind checks out that branch, lets the agent commit on it, and pushes the branch back to `origin`.
-
-Examples:
+Example:
 
 ```json
 {
   "publishMode": "branch",
   "git": {
-    "startingBranch": "main",
-    "targetBranch": "codex/lift-jira-config-tests"
-  }
-}
-```
-
-```json
-{
-  "publishMode": "branch",
-  "git": {
-    "startingBranch": "156-jira-ui-runtime-config",
-    "targetBranch": "156-jira-ui-runtime-config"
+    "branch": "156-jira-ui-runtime-config"
   }
 }
 ```
 
 ### `pr`
 
-Same as `branch`, but after the push completes the workflow creates a pull request via the `repo.create_pr` activity. The PR merges the head branch into the base branch (see [Branch Resolution](#branch-resolution) below).
+For PR publication, the authored `branch` is the selected repository branch and PR base. MoonMind creates or obtains a runtime-generated work branch for the PR head, pushes changes there, and creates a pull request back to the authored base branch.
 
 When merge automation is explicitly enabled for a PR-publishing task, successful PR publication starts a parent-owned `MoonMind.MergeAutomation` child workflow. The original `MoonMind.Run` remains in `awaiting_external` while merge automation waits for configured external readiness signals and runs `pr-resolver` with publish mode `none`; downstream dependencies on the original task are satisfied only after merge automation succeeds.
 
@@ -55,7 +41,7 @@ When merge automation is explicitly enabled for a PR-publishing task, successful
 
 ### Auto-generated Branches
 
-When `publishMode` is `pr` and no explicit head branch is provided, the runtime planner auto-generates a branch name:
+When `publishMode` is `pr`, the runtime planner auto-generates a work/head branch name:
 
 ```
 {clean-title-prefix}-{uuid8}
@@ -70,50 +56,54 @@ When `publishMode` is `pr` and no explicit head branch is provided, the runtime 
 
 ### Branch Fields
 
-The two primary branch fields used consistently across UI, API, and internal logic:
+New authored submissions use one branch field consistently across UI, API, snapshots, and runtime planning:
 
-| Field            | Role | Description |
-|------------------|------|-------------|
-| `startingBranch` | Base | The branch to clone from. Also used as the PR base (merge destination). |
-| `targetBranch`   | Head | The name for the agent's work branch. Becomes the PR head (source of changes). |
+| Field | Role | Description |
+| --- | --- | --- |
+| `branch` | Authored branch selection | For `publishMode: pr`, the selected repo branch and PR base. For `publishMode: branch`, the branch to update and push. |
 
-For `publishMode: branch`, `targetBranch` may equal `startingBranch` when the desired outcome is to update that existing branch directly. For `publishMode: pr`, `targetBranch` must be distinct from the PR base branch because it is the PR source branch.
+`targetBranch` is not an authored or operator-facing field in new submissions. For PR mode, the head/work branch is runtime-generated or provider-managed and is not part of the create-form contract. `Publish Mode` remains part of the task contract; only its UI placement changed.
 
-Additional fallback field:
+### Legacy Migration
 
-| Field            | Role | Description |
-|------------------|------|-------------|
-| `branch`         | Fallback | General-purpose fallback for either head or base when the specific field is absent. |
+Older snapshots and execution payloads may still contain `startingBranch` and `targetBranch`.
 
-The runtime planner resolves these from multiple sources in priority order:
+Rules:
 
-1. `git` payload (`task.git.startingBranch`, `task.git.targetBranch`)
-2. Task payload (`task.startingBranch`, etc.)
-3. Selected skill inputs
-4. Parameter payload
-5. Input payload
+- New authored submissions must emit `git.branch` only.
+- `startingBranch` may be normalized to the new authored `branch` when reconstructing older submissions.
+- Legacy `targetBranch` may be retained only as historical metadata for audit/debug displays.
+- Legacy `targetBranch` must never drive active new submission logic.
+- Legacy two-branch branch-publish snapshots whose old intent cannot be represented by one authored `branch` must surface a reconstruction warning instead of pretending to round-trip exactly.
 
 ## Branch Resolution
 
-When the workflow creates a PR (`publishMode: pr`), it resolves the **head branch** (where changes live) and the **base branch** (where the PR merges into).
+Runtime planning starts from the authored `branch`.
 
-### Head Branch (PR source)
-
-Resolved via this fallback chain:
-
-1. Agent execution outputs: `outputs.branch` → `outputs.targetBranch`
-2. Workspace spec: `targetBranch` → `branch`
-3. Last plan node inputs: `targetBranch` → `branch`
-
-If no head branch can be resolved, the workflow raises an error.
-
-### Base Branch (PR destination)
+### Authored Branch
 
 Resolved via this fallback chain:
 
-1. `workspaceSpec.startingBranch`
-2. Last plan node inputs: `startingBranch`
-3. Default: `main`
+1. `task.git.branch`
+2. `task.branch`
+3. Selected skill inputs
+4. Parameter payload
+5. Input payload
+6. Repository default branch
+
+For `publishMode: pr`, the authored branch is the PR base branch. The PR head branch is resolved separately from runtime-managed work-branch state, such as workspace metadata, adapter result metadata, or provider PR metadata.
+
+For `publishMode: branch`, the authored branch is the branch the infrastructure updates and pushes.
+
+### Work Branch (PR source)
+
+When the workflow creates a PR, it resolves the work/head branch from runtime-owned sources:
+
+1. Provider or agent execution outputs such as `outputs.branch`
+2. Workspace work-branch metadata
+3. Runtime planner generated branch name
+
+If no PR head branch can be resolved for `publishMode: pr`, the workflow raises an error.
 
 ## Post-Agent Git Push
 
@@ -127,9 +117,9 @@ Before pushing, the runtime resolves the current branch name (`git rev-parse --a
 - `master`
 - `HEAD` / detached or unknown branch state
 
-For `publishMode: pr`, the configured base branch remains protected because the workflow must push a separate head branch and then create a PR back to the base.
+For `publishMode: pr`, the authored base branch remains protected because the workflow pushes a separate runtime-owned head branch and creates a PR back to the base.
 
-For `publishMode: branch`, the configured base branch is publishable when it is also the intended target branch. This is the explicit same-branch update case: `startingBranch == targetBranch`, excluding the hard-protected names above.
+For `publishMode: branch`, the authored `branch` is publishable only when it is not one of the hard-protected names above.
 
 If the branch is protected, the push is skipped with a warning log. This prevents accidental pushes to production branches if the agent switched branches or if branch creation failed.
 

--- a/docs/UI/MissionControlArchitecture.md
+++ b/docs/UI/MissionControlArchitecture.md
@@ -191,8 +191,11 @@ Runtime config may still expose sources such as:
 - `manifests`
 - `schedules`
 - `temporal`
+- `githubBranches` or equivalent MoonMind-owned repository branch lookup endpoint
 
 That does not mean the user-facing task UI should give all of those equal primary visibility.
+
+The Create page branch selector is a data dependency on MoonMind-owned GitHub branch lookup. The browser must call the configured MoonMind API source, not GitHub directly. Runtime config supplies the endpoint template or source key used to fetch branches for the selected repository.
 
 ## 8.2 Task surface posture
 
@@ -759,9 +762,12 @@ Rollout order:
 * do not expose raw source-precedence logic directly to ordinary users
 * keep submit flows organized around task-shaped product language
 * let the backend decide the workflow type and execution routing
+* browser clients call MoonMind APIs only; Jira, GitHub, object storage, Temporal Server, and model providers remain behind MoonMind-controlled API surfaces
 * `/tasks/new` may preview composed presets and show preset grouping before submission
 * unresolved preset includes must be rejected before runtime submission; they must not be sent as task work for a worker or adapter to resolve later
 * submit previews may explain preset provenance, but the submitted execution payload remains flat resolved steps plus durable task snapshot metadata
+* repository, branch, and publish controls live together in the Steps card: choose repo, fetch branch options through the MoonMind branch source, populate the Branch dropdown, then render Publish Mode alongside it
+* `Publish Mode` remains part of task submission semantics; this is a visual placement change, not removal from the contract
 
 ## 15.3 Backend mapping for submit
 
@@ -769,7 +775,7 @@ The dashboard submits task-shaped requests plus task-level intent such as:
 
 * instructions
 * runtime choice
-* repository/workspace context
+* repository/workspace context, including the single authored branch selection
 * artifacts
 * optional scheduling intent
 * skill-selection intent

--- a/docs/UI/MissionControlStyleGuide.md
+++ b/docs/UI/MissionControlStyleGuide.md
@@ -573,7 +573,35 @@ CSS cannot truly vary border width around a standard rectangle. Use gradient bor
 }
 ```
 
-### 9.5 Status Chips
+### 9.5 Inline Selector Rows
+
+Use inline selector rows for compact dropdowns inside cards when the controls are tightly coupled and need to scan as one decision group.
+
+Create-page repository controls use this pattern:
+
+- Branch on the left.
+- Publish Mode on the right.
+- Both controls sit in the Steps card with no label above the control.
+- `Publish Mode` is not removed from the task contract; only its visual placement changes.
+
+Treatment:
+
+- Use Codex-like inline dropdown styling: compact height, tight horizontal spacing, subdued border, and readable selected value.
+- Do not copy the exact Codex screenshot iconography.
+- The Branch control should use a branch-like affordance, such as a fork/branch glyph, but the icon must be distinct from the Codex reference.
+- The Publish Mode control may use a compact publish/output affordance or text-only dropdown when the branch icon already anchors the row.
+- Keep accessible names explicit even when visual labels are omitted.
+- On narrow screens, wrap the row so Branch remains first and Publish Mode follows.
+- Preserve stable dimensions so branch loading, empty, error, and stale-selection states do not shift adjacent controls.
+
+Spacing and alignment:
+
+- Row gap: `0.5rem` to `0.75rem`.
+- Branch control should flex wider than Publish Mode.
+- Publish Mode should keep enough width for `branch` and `pr` without truncation.
+- Vertically align icons, selected values, and chevrons on the same centerline.
+
+### 9.6 Status Chips
 
 Map status consistently:
 
@@ -598,7 +626,7 @@ Step-row patterns:
 - keep Logs & Diagnostics blocks visually denser than Summary and Checks blocks
 - preserve table-first comparison on desktop; use stacked step cards only on narrow mobile layouts
 
-### 9.6 Live Output Pane
+### 9.7 Live Output Pane
 
 For `.queue-live-output`:
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -4701,7 +4701,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -4801,7 +4801,7 @@ describe("Task Create Entrypoint", () => {
     const stepInstructions = await screen.findByLabelText("Instructions");
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -4860,7 +4860,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6131,7 +6131,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6147,7 +6147,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
 
@@ -6162,7 +6162,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6230,7 +6230,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6296,7 +6296,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6313,7 +6313,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6353,7 +6353,7 @@ describe("Task Create Entrypoint", () => {
     const stepInstructions = await screen.findByLabelText("Instructions");
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6389,7 +6389,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6417,7 +6417,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6459,7 +6459,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6501,7 +6501,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6624,7 +6624,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -6661,7 +6661,7 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6694,7 +6694,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6745,7 +6745,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6835,7 +6835,7 @@ describe("Task Create Entrypoint", () => {
     );
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6849,7 +6849,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "To Do 1" }));
@@ -6889,7 +6889,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6919,7 +6919,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -6961,7 +6961,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 2 instructions",
+        name: "Browse Jira issues for Step 2 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7001,7 +7001,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.change(await screen.findByLabelText("Import target"), {
@@ -7031,7 +7031,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.change(await screen.findByLabelText("Text import"), {
@@ -7054,7 +7054,7 @@ describe("Task Create Entrypoint", () => {
     const stepInstructions = await screen.findByLabelText("Instructions");
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7099,7 +7099,7 @@ describe("Task Create Entrypoint", () => {
     const stepInstructions = await screen.findByLabelText("Instructions");
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7153,7 +7153,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7188,7 +7188,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7229,7 +7229,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7292,7 +7292,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7336,7 +7336,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 2 instructions",
+        name: "Browse Jira issues for Step 2 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7400,7 +7400,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 2 instructions",
+        name: "Browse Jira issues for Step 2 instructions",
       }),
     );
 
@@ -7429,7 +7429,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7452,7 +7452,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7523,7 +7523,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for objective attachments",
+        name: "Browse Jira images for objective attachments",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7543,7 +7543,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 attachments",
+        name: "Browse Jira images for Step 1 attachments",
       }),
     );
     expect(
@@ -7613,7 +7613,7 @@ describe("Task Create Entrypoint", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for objective attachments",
+        name: "Browse Jira images for objective attachments",
       }),
     );
     expect(
@@ -7682,7 +7682,7 @@ describe("Task Create Entrypoint", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 attachments",
+        name: "Browse Jira images for Step 1 attachments",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7746,7 +7746,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7757,7 +7757,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7847,7 +7847,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 attachments",
+        name: "Browse Jira images for Step 1 attachments",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7889,7 +7889,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -7906,7 +7906,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -7931,7 +7931,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -7960,7 +7960,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -7985,7 +7985,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -8016,7 +8016,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -8042,7 +8042,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -8091,7 +8091,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -8113,7 +8113,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for Step 1 instructions",
+        name: "Browse Jira issues for Step 1 instructions",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Doing 1" }));
@@ -8181,7 +8181,7 @@ describe("Task Create Entrypoint", () => {
     });
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     expect(
@@ -8227,7 +8227,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -8253,7 +8253,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -8286,7 +8286,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -8317,7 +8317,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -8373,7 +8373,7 @@ describe("Task Create Entrypoint", () => {
 
       fireEvent.click(
         await screen.findByRole("button", {
-          name: "Browse Jira issue for preset instructions",
+          name: "Browse Jira issues for preset instructions",
         }),
       );
 
@@ -8435,7 +8435,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
 
@@ -8498,7 +8498,7 @@ describe("Task Create Entrypoint", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: "Browse Jira issue for preset instructions",
+        name: "Browse Jira issues for preset instructions",
       }),
     );
     expect(

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -363,6 +363,19 @@ describe("Task Create Entrypoint", () => {
     ).map((element) => element.dataset.canonicalCreateSection || "");
   }
 
+  function expectAllButtonsHaveTitles(container: ParentNode = document): void {
+    const missingTitles = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    )
+      .filter((button) => !button.getAttribute("title")?.trim())
+      .map(
+        (button) =>
+          button.getAttribute("aria-label") || button.textContent?.trim() || "",
+      );
+
+    expect(missingTitles).toEqual([]);
+  }
+
   beforeEach(() => {
     window.history.pushState({}, "Task Create", "/tasks/new");
     window.sessionStorage.clear();
@@ -4650,7 +4663,7 @@ describe("Task Create Entrypoint", () => {
 
     const presetsSection = await screen.findByLabelText("Task Presets");
     const saveButton = within(presetsSection).getByRole("button", {
-      name: "Save Current Steps as Preset",
+      name: "Save preset",
     });
     const applyButton = within(presetsSection).getByRole("button", {
       name: "Apply",
@@ -4667,6 +4680,53 @@ describe("Task Create Entrypoint", () => {
     );
     expect(saveButton.querySelector("svg")).not.toBeNull();
     expect(saveButton.textContent).toBe("");
+  });
+
+  it("adds hover tooltips to Create page buttons", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    await screen.findByText("Step 1 (Primary)");
+
+    expectAllButtonsHaveTitles();
+    expect(
+      screen.getByRole("button", { name: "Add Step" }).getAttribute("title"),
+    ).toBe("Add another task step");
+    expect(
+      screen.getByRole("button", { name: "Create" }).getAttribute("title"),
+    ).toBe("Create this task");
+  });
+
+  it("adds hover tooltips to Jira browser buttons", async () => {
+    renderWithClient(<TaskCreatePage payload={withJiraIntegration()} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Browse Jira issue for preset instructions",
+      }),
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Browse Jira issue",
+    });
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: "To Do 1" }))
+        .toBeTruthy();
+    });
+
+    expectAllButtonsHaveTitles(dialog);
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Close Jira browser" })
+        .getAttribute("title"),
+    ).toBe("Close Jira browser");
+    expect(
+      within(dialog).getByRole("button", { name: "To Do 1" }).getAttribute("title"),
+    ).toBe("Show Jira issues in To Do");
+    expect(
+      within(dialog).getByRole("button", { name: /ENG-101/ }).getAttribute("title"),
+    ).toBe(
+      "Import Jira issue ENG-101 into Feature Request / Initial Instructions",
+    );
   });
 
   it("exposes the canonical Create page section order in create mode", async () => {
@@ -5886,7 +5946,7 @@ describe("Task Create Entrypoint", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Save Current Steps as Preset/ }),
+      screen.getByRole("button", { name: "Save preset" }),
     );
 
     await waitFor(() => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -4932,6 +4932,15 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       : pageMode.mode === "rerun"
         ? "Rerun Task"
         : "Create";
+  const primaryCtaTooltip =
+    pageMode.mode === "edit"
+      ? "Save changes to this task draft"
+      : pageMode.mode === "rerun"
+        ? "Start a new run from this task draft"
+        : "Create this task";
+  const applyPresetTooltip = presetReapplyNeeded
+    ? "Reapply the selected preset to update preset-derived steps"
+    : "Apply the selected preset to the task draft";
   const modeLoadError =
     pageMode.mode !== "create" && !temporalTaskEditingEnabled
       ? "Temporal task editing is not enabled."
@@ -4985,6 +4994,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 type="button"
                 className="queue-step-icon-button"
                 aria-label="Close Jira browser"
+                title="Close Jira browser"
                 onClick={closeJiraBrowser}
               >
                 <CloseIcon />
@@ -5123,6 +5133,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           : "secondary jira-column-tab"
                       }
                       aria-pressed={column.id === activeJiraColumnId}
+                      title={`Show Jira issues in ${column.name}`}
                       onClick={() => selectJiraColumn(column.id)}
                     >
                       {`${column.name} ${Number(column.count || 0)}`}
@@ -5146,6 +5157,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             : "jira-issue-button"
                         }
                         disabled={Boolean(pendingJiraImportIssueKey)}
+                        title={`Import Jira issue ${issue.issueKey} into ${jiraTargetText}`}
                         onClick={() => selectJiraIssue(issue.issueKey)}
                       >
                         <strong>{issue.issueKey}</strong>
@@ -5296,6 +5308,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           type="button"
                           className="secondary jira-browse-button"
                           aria-label={`Browse Jira issue for Step ${index + 1} instructions`}
+                          title={`Browse Jira issues for Step ${index + 1} instructions`}
                           onClick={() =>
                             openJiraBrowser({
                               kind: "step",
@@ -5352,6 +5365,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             type="button"
                             className="secondary jira-browse-button"
                             aria-label={`Browse Jira issue for Step ${index + 1} attachments`}
+                            title={`Browse Jira images for Step ${index + 1} attachments`}
                             onClick={() =>
                               openJiraBrowser({
                                 kind: "step",
@@ -5388,12 +5402,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                     attachment.artifactId,
                                   )}
                                   download={attachment.filename}
+                                  title={`Download objective attachment ${attachment.filename}`}
                                 >
                                   Download
                                 </a>
                                 <button
                                   type="button"
                                   className="button secondary"
+                                  title={`Remove objective attachment ${attachment.filename}`}
                                   onClick={() =>
                                     removePersistedObjectiveAttachment(
                                       attachment.artifactId,
@@ -5420,12 +5436,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                     attachment.artifactId,
                                   )}
                                   download={attachment.filename}
+                                  title={`Download Step ${index + 1} attachment ${attachment.filename}`}
                                 >
                                   Download
                                 </a>
                                 <button
                                   type="button"
                                   className="button secondary"
+                                  title={`Remove Step ${index + 1} attachment ${attachment.filename}`}
                                   onClick={() =>
                                     removePersistedStepAttachment(
                                       step.localId,
@@ -5478,6 +5496,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                     type="button"
                                     className="secondary"
                                     aria-label={`Retry upload for Step ${index + 1} attachment ${file.name}`}
+                                    title={`Retry upload for Step ${index + 1} attachment ${file.name}`}
                                     onClick={() =>
                                       clearAttachmentTargetError(
                                         attachmentTargetKey(step.localId),
@@ -5491,6 +5510,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                                   type="button"
                                   className="secondary"
                                   aria-label={`Remove Step ${index + 1} attachment ${file.name}`}
+                                  title={`Remove Step ${index + 1} attachment ${file.name}`}
                                   onClick={() =>
                                     removeStepAttachment(step.localId, file)
                                   }
@@ -5598,7 +5618,12 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             </div>
 
             <div className="actions queue-step-add queue-step-actions">
-              <button type="button" data-step-action="add" onClick={addStep}>
+              <button
+                type="button"
+                data-step-action="add"
+                title="Add another task step"
+                onClick={addStep}
+              >
                 Add Step
               </button>
               <button
@@ -5607,6 +5632,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 disabled={isTemporalFormBlocked}
                 aria-disabled={isSubmitting || isTemporalFormBlocked}
                 aria-busy={isSubmitting}
+                title={primaryCtaTooltip}
               >
                 {primaryCta}
               </button>
@@ -5686,6 +5712,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     type="button"
                     className="secondary jira-browse-button"
                     aria-label="Browse Jira issue for preset instructions"
+                    title="Browse Jira issues for preset instructions"
                     onClick={() => openJiraBrowser({ kind: "preset" })}
                   >
                     Browse Jira issue
@@ -5733,6 +5760,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                       type="button"
                       className="secondary jira-browse-button"
                       aria-label="Browse Jira issue for objective attachments"
+                      title="Browse Jira images for objective attachments"
                       onClick={() =>
                         openJiraBrowser({
                           kind: "preset",
@@ -5787,6 +5815,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                               type="button"
                               className="secondary"
                               aria-label={`Retry upload for objective attachment ${file.name}`}
+                              title={`Retry upload for objective attachment ${file.name}`}
                               onClick={() =>
                                 clearAttachmentTargetError(
                                   attachmentTargetKey("objective"),
@@ -5800,6 +5829,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                             type="button"
                             className="secondary"
                             aria-label={`Remove objective attachment ${file.name}`}
+                            title={`Remove objective attachment ${file.name}`}
                             onClick={() => removeObjectiveAttachment(file)}
                           >
                             Remove
@@ -5817,7 +5847,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   type="button"
                   id="queue-template-save-current"
                   className="queue-step-icon-button"
-                  aria-label="Save Current Steps as Preset"
+                  aria-label="Save preset"
                   title="Save the current steps as a reusable preset"
                   onClick={handleSaveCurrentStepsAsPreset}
                 >
@@ -5830,6 +5860,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 onClick={handleApplyPreset}
                 aria-disabled={isApplyingPreset}
                 aria-busy={isApplyingPreset}
+                title={applyPresetTooltip}
               >
                 {presetReapplyNeeded ? "Reapply preset" : "Apply"}
               </button>
@@ -5874,6 +5905,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               <button
                 type="button"
                 id="queue-dependency-add"
+                title="Add the selected prerequisite run"
                 onClick={() => addDependency(selectedDependencyWorkflowId)}
               >
                 Add dependency
@@ -5904,6 +5936,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     <button
                       type="button"
                       className="secondary small"
+                      title={`Remove dependency ${workflowId}`}
                       onClick={() => removeDependency(workflowId)}
                     >
                       Remove

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -5307,7 +5307,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                         <button
                           type="button"
                           className="secondary jira-browse-button"
-                          aria-label={`Browse Jira issue for Step ${index + 1} instructions`}
+                          aria-label={`Browse Jira issues for Step ${index + 1} instructions`}
                           title={`Browse Jira issues for Step ${index + 1} instructions`}
                           onClick={() =>
                             openJiraBrowser({
@@ -5364,7 +5364,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                           <button
                             type="button"
                             className="secondary jira-browse-button"
-                            aria-label={`Browse Jira issue for Step ${index + 1} attachments`}
+                            aria-label={`Browse Jira images for Step ${index + 1} attachments`}
                             title={`Browse Jira images for Step ${index + 1} attachments`}
                             onClick={() =>
                               openJiraBrowser({
@@ -5711,7 +5711,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   <button
                     type="button"
                     className="secondary jira-browse-button"
-                    aria-label="Browse Jira issue for preset instructions"
+                    aria-label="Browse Jira issues for preset instructions"
                     title="Browse Jira issues for preset instructions"
                     onClick={() => openJiraBrowser({ kind: "preset" })}
                   >
@@ -5759,7 +5759,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     <button
                       type="button"
                       className="secondary jira-browse-button"
-                      aria-label="Browse Jira issue for objective attachments"
+                      aria-label="Browse Jira images for objective attachments"
                       title="Browse Jira images for objective attachments"
                       onClick={() =>
                         openJiraBrowser({

--- a/specs/045-submit-runtime-selector/contracts/submit-work-form.md
+++ b/specs/045-submit-runtime-selector/contracts/submit-work-form.md
@@ -4,7 +4,7 @@
 
 | Runtime `value` | Label | Mode | Visible Fields | Hidden Fields | Redirect on success |
 | --- | --- | --- | --- | --- | --- |
-| `codex` (default) | `Codex worker` | worker | `instruction`, queue step editor, presets, model/effort, repo + branch inputs, publish mode, worker priority, max attempts, propose tasks | Orchestrator fields (`targetService`, `priority`, `approvalToken`) | `/tasks/queue/{jobId}` |
+| `codex` (default) | `Codex worker` | worker | `instruction`, queue step editor, presets, model/effort, repo + branch + publish controls, worker priority, max attempts, propose tasks | Orchestrator fields (`targetService`, `priority`, `approvalToken`) | `/tasks/queue/{jobId}` |
 | `gemini` | `Gemini worker` | worker | Same as worker list | Orchestrator fields | `/tasks/queue/{jobId}` |
 | `claude` | `Claude worker` | worker | Same as worker list | Orchestrator fields | `/tasks/queue/{jobId}` |
 | `orchestrator` | `Orchestrator` | orchestrator | `instruction`, `targetService`, enum `priority`, optional `approvalToken` | All queue-only fields | `/tasks/orchestrator/{runId}` |
@@ -26,13 +26,46 @@
 | `payload.task.instructions` | string | ✅ | Shared textarea / resolved feature request text. |
 | `payload.task.skill` | object | ✅ | Contains `id`, `args`, optional `requiredCapabilities`. Primary step inherits defaults when blank. |
 | `payload.task.runtime` | object | ✅ | `{ mode, model?, effort? }`. Model/effort omitted only when blank. |
-| `payload.task.git` | object | ✅ | `{ startingBranch, newBranch }` with `null` values trimmed before send. |
+| `payload.task.git` | object | ✅ | `{ branch }` with blank values trimmed before send. New submissions must not include `targetBranch`. |
 | `payload.task.publish.mode` | enum (`pr`, `branch`, `none`) | ✅ | Derived from dropdown. Additional PR metadata remains `null`. |
 | `payload.task.steps` | array | optional | Only present when explicit steps exist (primary mismatch, extra steps, or template-bound steps). |
 | `payload.task.appliedStepTemplates` | array | optional | Includes preset metadata when templates were applied. |
 | `payload.task.proposeTasks` | boolean | ✅ | Mirrors checkbox state. |
 
 Response: `{ id: "uuid" }` (or `jobId`) is required for redirect.
+
+## 2.1 Steps-card repository controls
+
+The Steps card owns the compact repository execution row:
+
+| Control | Behavior |
+| --- | --- |
+| Repository | Existing repository selector/input sourced from runtime config and MoonMind APIs. |
+| Branch | Replaces the old `Starting Branch` label. This is the single authored branch field. |
+| Publish Mode | Rendered inline with Branch in the Steps card. `Publish Mode` remains part of submission semantics; only visual placement changes. |
+
+Rules:
+
+- The old `Target Branch` control is removed entirely and must not be rendered by create, edit, or rerun forms.
+- Branch and Publish Mode use compact inline dropdown treatment in one row: Branch on the left, Publish Mode on the right.
+- This compact row has no label above either control; the affordance label is conveyed by inline text/icon styling and accessible names.
+- The controls should use Codex-like inline dropdown styling but must not copy the exact Codex screenshot iconography.
+- The branch control uses a branch-like affordance with a different icon than the Codex screenshot.
+- Branch options are runtime-config/API-driven, never hardcoded in the browser bundle.
+
+## 2.2 GitHub-backed branch dropdown
+
+Branch selection is MoonMind-owned:
+
+- The browser talks only to MoonMind APIs, never directly to GitHub.
+- Runtime config exposes the branch lookup source endpoint used by the Create page.
+- The Branch dropdown is disabled until a valid repository is selected.
+- After repo selection, the browser fetches branches through the configured MoonMind API.
+- Loading state keeps the dropdown disabled or clearly busy.
+- Empty state explains that no branches were returned for the selected repository.
+- Error state explains that branch lookup failed and lets manual task creation continue when policy allows.
+- When repository changes, any selected branch that is not present in the new repo's branch list is cleared or marked stale before submit.
+- New submissions emit the selected value as `payload.task.git.branch`.
 
 ## 3. Orchestrator submission payload contract
 

--- a/specs/105-jules-provider-adapter/contracts/jules-bundle-runtime-contract.md
+++ b/specs/105-jules-provider-adapter/contracts/jules-bundle-runtime-contract.md
@@ -59,9 +59,11 @@ When `publishMode == "branch"`:
 
 - MoonMind must request Jules PR automation at start.
 - MoonMind must extract the resulting PR URL after provider completion.
-- If `targetBranch` differs from `startingBranch`, MoonMind must update the PR base before merge.
+- Jules receives a single authored `branch` reference. MoonMind must treat that branch as the intended branch-publication destination.
 - MoonMind must merge the PR successfully before reporting branch publication success.
 - If any of these steps fail, MoonMind must surface a non-success outcome.
+
+For `publishMode == "pr"`, the authored `branch` is the PR base. Jules/provider automation manages the work/head branch; MoonMind must not require authored inputs to provide both base and target branches.
 
 ## 6. Truthful Bundle Result Semantics
 
@@ -71,4 +73,4 @@ MoonMind must treat a bundled run as incomplete or failed when:
 
 - required checklist outcomes were not actually completed,
 - required verification fails,
-- requested branch publication does not land on the intended target branch.
+- requested branch publication does not land on the intended authored branch.

--- a/specs/157-temporal-task-editing/contracts/temporal-task-editing.openapi.yaml
+++ b/specs/157-temporal-task-editing/contracts/temporal-task-editing.openapi.yaml
@@ -179,18 +179,16 @@ components:
           type:
             - string
             - "null"
-        startingBranch:
+        branch:
           type:
             - string
             - "null"
-        targetBranch:
-          type:
-            - string
-            - "null"
+          description: "Single authored branch selection. Edit and rerun UIs must not reintroduce a visible Target Branch field."
         publishMode:
           type:
             - string
             - "null"
+          description: "Task publish mode retained for submission semantics; visual placement may be inline with Branch in the Steps card."
         targetSkill:
           type:
             - string

--- a/specs/157-temporal-task-editing/data-model.md
+++ b/specs/157-temporal-task-editing/data-model.md
@@ -18,9 +18,8 @@ Represents the detail payload used to decide whether an execution can be edited 
 - `model` / `requestedModel` / `resolvedModel`: Model selection state available to prefill later form modes.
 - `effort`: Runtime effort setting when present.
 - `repository`: Repository identifier associated with the task.
-- `startingBranch`: Starting branch or default branch state.
-- `targetBranch`: Target/publish branch state.
-- `publishMode`: Publish behavior selected for the task.
+- `branch`: Single authored branch selection used to prefill the shared form.
+- `publishMode`: Publish behavior selected for the task. This remains task submission data even when the Create page renders it inline with Branch in the Steps card.
 - `targetSkill` / `taskSkills`: Skill selection state.
 - `actions`: State-aware capability set.
 
@@ -30,6 +29,21 @@ Represents the detail payload used to decide whether an execution can be edited 
 - `workflowType` must be `MoonMind.Run` before Edit or Rerun entry points are exposed.
 - `inputParameters` must be an object; missing values are acceptable for Phase 1 visibility but must be treated as incomplete by later draft reconstruction.
 - Artifact references are immutable historical references; edit/rerun submit phases must create new artifact references for changed content.
+- Edit flows must never reintroduce a visible `Target Branch` field.
+- Saving an edited task always emits the new single-branch contract (`branch`) and must not emit a fresh `targetBranch`.
+
+### Legacy Branch Compatibility
+
+Older executions may contain `startingBranch` and `targetBranch`.
+
+| Legacy shape | Edit reconstruction behavior |
+| --- | --- |
+| `startingBranch` only | Normalize to `branch`. |
+| `startingBranch == targetBranch` | Normalize the shared value to `branch`. |
+| PR publish snapshot with differing values | Normalize authored `branch` to old `startingBranch`; preserve old `targetBranch` only as opaque historical metadata for audit/debug. |
+| Branch-publish snapshot with differing values | Mark as non-round-trippable under the new single-branch model and show a warning before allowing save. |
+
+Compatibility normalization is a load-time reconstruction concern only. Edited submissions use `branch` plus `publishMode`; `targetBranch` is never active submission logic.
 
 ## Action Capability Set
 

--- a/specs/161-temporal-task-drafts/contracts/temporal-task-drafts.openapi.yaml
+++ b/specs/161-temporal-task-drafts/contracts/temporal-task-drafts.openapi.yaml
@@ -149,18 +149,16 @@ components:
           type:
             - string
             - "null"
-        startingBranch:
+        branch:
           type:
             - string
             - "null"
-        targetBranch:
-          type:
-            - string
-            - "null"
+          description: "Single authored branch selection. Legacy startingBranch values normalize here; legacy targetBranch is historical metadata only."
         publishMode:
           type:
             - string
             - "null"
+          description: "Task publish mode. This remains submission semantics even when rendered inline with Branch in the Steps card."
         targetSkill:
           type:
             - string
@@ -188,10 +186,9 @@ components:
           type: string
         repository:
           type: string
-        startingBranch:
+        branch:
           type: string
-        targetBranch:
-          type: string
+          description: "Single authored branch selection for create/edit/rerun forms. New draft writes must not include targetBranch."
         publishMode:
           type: string
         taskInstructions:

--- a/specs/161-temporal-task-drafts/data-model.md
+++ b/specs/161-temporal-task-drafts/data-model.md
@@ -28,7 +28,7 @@ Existing Temporal execution used to reconstruct the form draft.
 - `actions`: capability set from backend
 - `inputParameters`: structured task input state
 - `inputArtifactRef`: optional immutable artifact reference for historical input state
-- Runtime and task fields: runtime, provider profile, model, effort, repository, branches, publish mode, skill, and template state where available
+- Runtime and task fields: runtime, provider profile, model, effort, repository, branch, publish mode, skill, and template state where available
 
 **Validation Rules**
 
@@ -64,8 +64,7 @@ The shared form state reconstructed from a Temporal source execution and optiona
 - `model`
 - `effort`
 - `repository`
-- `startingBranch`
-- `targetBranch`
+- `branch`
 - `publishMode`
 - `taskInstructions`
 - `primarySkill`
@@ -74,8 +73,25 @@ The shared form state reconstructed from a Temporal source execution and optiona
 **Validation Rules**
 
 - `taskInstructions` are required for a trustworthy reconstructed draft.
+- `branch` is the only active branch field in new draft writes.
+- Draft write paths must not require or emit both `startingBranch` and `targetBranch`.
+- `publishMode` remains part of the task submission contract, even though the Create page renders it inline with Branch in the Steps card instead of as a separate Execution context card control.
 - Other first-slice fields should be filled when available and left as normal form defaults only when that matches existing create-form behavior.
 - Draft construction must not mutate source execution data or historical artifacts.
+
+## Legacy Branch Normalization
+
+Older Temporal execution payloads and snapshots may still contain two branch fields. Reconstruction normalizes them into the single authored `branch` field before the form becomes editable.
+
+| Legacy shape | New draft result |
+| --- | --- |
+| `startingBranch` only | Normalize `startingBranch` to `branch`. |
+| `startingBranch == targetBranch` | Normalize the shared value to `branch`. |
+| PR publish snapshot with differing `startingBranch` and `targetBranch` | Normalize authored `branch` to old `startingBranch`, because it represented the PR base. Preserve old `targetBranch` only as opaque legacy metadata for audit/debug. |
+| Branch publish snapshot with differing `startingBranch` and `targetBranch` | Mark the draft as non-round-trippable under the new model and require a reconstruction warning. Preserve old `targetBranch` only as opaque historical metadata; do not use it for active submission logic. |
+| `targetBranch` only | Treat as incomplete legacy metadata and require a reconstruction warning before submit. |
+
+New authored submissions must not reintroduce `targetBranch`; edited or rerun drafts always submit the single `branch` contract.
 
 ## Input Artifact Reference
 

--- a/specs/169-temporal-rerun-submit/contracts/temporal-rerun-submit.openapi.yaml
+++ b/specs/169-temporal-rerun-submit/contracts/temporal-rerun-submit.openapi.yaml
@@ -116,18 +116,16 @@ components:
           type:
             - string
             - "null"
-        startingBranch:
+        branch:
           type:
             - string
             - "null"
-        targetBranch:
-          type:
-            - string
-            - "null"
+          description: "Single authored branch selection used by rerun drafts. Legacy targetBranch is historical metadata only."
         publishMode:
           type:
             - string
             - "null"
+          description: "Task publish mode retained for rerun submission semantics; visual placement is not a separate schema concern."
         targetSkill:
           type:
             - string

--- a/specs/169-temporal-rerun-submit/data-model.md
+++ b/specs/169-temporal-rerun-submit/data-model.md
@@ -32,9 +32,8 @@ Represents the operator-reviewable shared form state reconstructed from executio
 | `model` | string or null | No | Model value prefilled when reconstructable. |
 | `effort` | string or null | No | Effort value prefilled when reconstructable. |
 | `repository` | string or null | No | Repository prefilled from execution or artifact input. |
-| `startingBranch` | string or null | No | Starting branch prefilled when available. |
-| `targetBranch` | string or null | No | Target branch prefilled when available. |
-| `publishMode` | string or null | No | Publish mode prefilled when available. |
+| `branch` | string or null | No | Single authored branch selection prefilled when reconstructable. |
+| `publishMode` | string or null | No | Publish mode prefilled when available. It remains part of rerun submission semantics even when rendered inline with Branch. |
 | `taskInstructions` | string | Yes | Operator-visible task instructions reconstructed from inline inputs or artifact content. |
 | `primarySkill` | string or null | No | Primary skill/template selection when reconstructable. |
 | `appliedTemplates` | array | No | Template state preserved for review when present. |
@@ -44,6 +43,21 @@ Represents the operator-reviewable shared form state reconstructed from executio
 - `taskInstructions` is required; rerun submission must be blocked when instructions cannot be reconstructed.
 - Artifact-backed inputs must be loaded before building a submittable draft when inline instructions are absent.
 - Incomplete or malformed artifact content must not produce a misleading partial rerun form.
+- Rerun drafts surface only `branch`, never `targetBranch`.
+- Rerun submission emits the new single-branch contract and must not depend on legacy `targetBranch`.
+
+### Legacy Branch Rerun Behavior
+
+Older executions may contain `startingBranch` and `targetBranch`.
+
+| Legacy shape | Rerun behavior |
+| --- | --- |
+| `startingBranch` only | Normalize to `branch`. |
+| `startingBranch == targetBranch` | Normalize the shared value to `branch`. |
+| PR publish snapshot with differing values | Normalize `branch` to old `startingBranch`, because it represented the PR base. Old `targetBranch` is retained only as historical metadata. |
+| Branch-publish snapshot with differing values | Show a user-facing warning that the previous two-branch intent cannot be preserved exactly. Rerun uses the normalized single `branch` only after operator review. |
+
+Rerun must not use `targetBranch` as executable intent under the new model.
 
 ## Rerun Request
 

--- a/specs/180-durable-task-edit-reconstruction/contracts/original-task-input-snapshot.md
+++ b/specs/180-durable-task-edit-reconstruction/contracts/original-task-input-snapshot.md
@@ -51,8 +51,7 @@ Minimal payload:
     "model": "gpt-5.4",
     "effort": "medium",
     "repository": "owner/repo",
-    "startingBranch": "main",
-    "targetBranch": "feature/example",
+    "branch": "main",
     "publish": {"mode": "pr"},
     "instructions": "",
     "primarySkill": {
@@ -93,8 +92,8 @@ Minimal payload:
 | Model | `requestedModel`, `model`, task runtime model | Requested is original; resolved is derived | Snapshot requested model; resolved model read-only display | Editable | Editable only before runtime dispatch |
 | Effort | execution `effort`, task runtime effort | Original | Snapshot `draft.effort` | Editable | Editable only before runtime dispatch |
 | Repository | payload repository, search attr `mm_repo` | Original plus presentation | Snapshot `draft.repository`; search attr display | Editable | Read-only after workspace materialization unless backend supports change |
-| Starting branch | task git, execution field | Original | Snapshot `draft.startingBranch` | Editable | Read-only after clone/checkout begins unless backend supports safe point |
-| Target branch | task git, execution field | Original | Snapshot `draft.targetBranch` | Editable | Editable before publish branch exists |
+| Branch | task git, execution field | Original/normalized | Snapshot `draft.branch` | Editable | Read-only after clone/checkout begins unless backend supports safe point |
+| Legacy target branch | old task git or execution field | Historical metadata only | Snapshot legacy metadata, if retained | Read-only audit/debug only | Not executable intent |
 | Publish settings | task publish, execution `publishMode` | Original/normalized | Snapshot `draft.publish` | Editable | Editable before publish/finalization |
 | Dependencies | `inputParameters.task.dependsOn`, dependency rows | Original plus normalized dependency graph | Snapshot selected IDs; dependency rows read-only audit | Editable on rerun | Read-only for active edit unless workflow supports dependency recalculation |
 | Attachments | artifact links `input.attachment`, step payload refs | Original refs and artifact metadata | Snapshot `attachmentRefs` plus artifact links | Editable by add/remove refs, subject to read validation | Editable by add/remove refs before consumed |
@@ -118,6 +117,20 @@ Minimal payload:
 
 4. Block submit for degraded drafts until the operator supplies replacement authoritative input.
 5. Do not call plan-artifact-derived instructions `taskInstructions` without marking their source as derived and read-only.
+
+## Legacy Branch Migration Matrix
+
+Reconstructed drafts expose only `branch`; they never surface `targetBranch` as an editable field.
+
+| Legacy snapshot shape | Reconstruction result | Warning |
+| --- | --- | --- |
+| `startingBranch` only | `draft.branch = startingBranch` | None. |
+| `startingBranch == targetBranch` | `draft.branch = startingBranch` | None. |
+| `publish.mode == "pr"` with differing `startingBranch` and `targetBranch` | `draft.branch = startingBranch`; retain `targetBranch` only as historical PR-head context. | None unless other required data is missing. |
+| `publish.mode == "branch"` with differing `startingBranch` and `targetBranch` | Non-round-trippable under the single-branch model. Operator must review and choose the one active `branch`. | Required. |
+| `targetBranch` only | Incomplete legacy branch metadata; operator must select `branch`. | Required. |
+
+Any retained legacy `targetBranch` is historical context only and must not be used as active submission logic for edit or rerun.
 
 ## Persistence Lifecycle
 

--- a/specs/180-durable-task-edit-reconstruction/data-model.md
+++ b/specs/180-durable-task-edit-reconstruction/data-model.md
@@ -50,8 +50,8 @@ Frontend state derived from `OriginalTaskInputSnapshot`.
 Fields:
 
 - `runtime`, `providerProfile`, `model`, `effort`.
-- `repository`, `startingBranch`, `targetBranch`.
-- `publishMode` and publish options supported by the current form.
+- `repository`, `branch`.
+- `publishMode` and publish options supported by the current form. `Publish Mode` remains submission data even when rendered inline with Branch.
 - `taskInstructions` and instruction refs where applicable.
 - `primarySkill`, `primarySkillArgs`, runtime command selection where applicable.
 - `steps` with stable order, IDs, titles, instructions, tool/skill overrides, inputs, attachments, and template binding metadata.
@@ -67,6 +67,20 @@ State transitions:
 - `degraded evidence -> read-only recovery preview`.
 - `read-only recovery preview + operator replacement -> editable draft`.
 - `editable draft submit -> new snapshot artifact + update/rerun payload ref`.
+
+## Legacy Branch Migration
+
+Older snapshots may contain `startingBranch` and `targetBranch`; reconstructed drafts surface only `branch`.
+
+| Legacy snapshot shape | Normalization | Warning requirement |
+| --- | --- | --- |
+| `startingBranch` only | `branch = startingBranch` | No warning. |
+| `startingBranch == targetBranch` | `branch = startingBranch` | No warning. |
+| PR publish with differing `startingBranch` and `targetBranch` | `branch = startingBranch`; old `targetBranch` may be retained as opaque PR-head history. | No warning unless other data is degraded. |
+| Branch publish with differing `startingBranch` and `targetBranch` | Cannot round-trip exactly. Operator must choose the single active `branch`. | Required warning. |
+| `targetBranch` only | Treat as incomplete legacy metadata and require operator branch selection. | Required warning. |
+
+Any retained legacy `targetBranch` is audit/debug context only. It is not executable intent and must not be submitted in edit or rerun payloads.
 
 ## Artifact Linkage
 


### PR DESCRIPTION
## Summary

Adds hover tooltip text to Create Page button controls so button intent is discoverable on hover, including step controls, Jira browser controls, preset actions, dependency actions, submit actions, and attachment retry/remove controls.

Updates the preset-save control to remain icon-only while using the concise accessible name `Save preset`; the tooltip explains that it saves the current steps as a reusable preset.

Aligns the follow-on Create Page strategy docs around the new single authored `branch` contract: removes active `targetBranch` authoring semantics, keeps `publishMode` in the task contract while documenting its inline Steps-card placement, adds MoonMind-owned GitHub branch lookup behavior, and records legacy two-branch normalization rules for edit/rerun/snapshot reconstruction.

## Validation

- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `npm run ui:typecheck`
- `npm run ui:lint`
- `git diff --check`
- Parsed updated OpenAPI YAML contracts with PyYAML