### PR TITLE
[codex] Fix Codex home seeding retries

### DIFF
--- a/moonmind/workflows/temporal/runtime/codex_session_runtime.py
+++ b/moonmind/workflows/temporal/runtime/codex_session_runtime.py
@@ -48,7 +48,7 @@ _DEFAULT_TURN_COMPLETION_TIMEOUT_SECONDS = (
     float(DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS)
 )
 _STDOUT_EOF = object()
-_AUTH_SEED_EXCLUDED_NAMES = frozenset({"config.toml", "sessions"})
+_AUTH_SEED_EXCLUDED_NAMES = frozenset({".tmp", "config.toml", "sessions"})
 _AUTH_SEED_EXCLUDED_PREFIXES: tuple[str, ...] = ("logs_", "state_")
 _ROLLOUT_RECOVERY_MAX_BYTES = 4 * 1024 * 1024
 _ROLLOUT_RECOVERY_TIMESTAMP_SKEW_SECONDS = 5.0
@@ -378,6 +378,22 @@ class CodexManagedSessionRuntime:
             return False
         return not any(name.startswith(prefix) for prefix in _AUTH_SEED_EXCLUDED_PREFIXES)
 
+    @staticmethod
+    def _copy_auth_seed_file(
+        source: str | os.PathLike[str],
+        destination: str | os.PathLike[str],
+    ) -> None:
+        destination_path = Path(destination)
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        if destination_path.is_symlink() or destination_path.exists():
+            if destination_path.is_dir() and not destination_path.is_symlink():
+                raise RuntimeError(
+                    "cannot overwrite auth seed directory with file: "
+                    f"{destination_path}"
+                )
+            destination_path.unlink()
+        shutil.copy2(source, destination_path)
+
     def _seed_codex_home_from_auth_volume(self) -> None:
         if self._auth_volume_path is None:
             return
@@ -407,10 +423,14 @@ class CodexManagedSessionRuntime:
             if source_path.is_symlink():
                 continue
             if source_path.is_dir():
-                shutil.copytree(source_path, destination, dirs_exist_ok=True)
+                shutil.copytree(
+                    source_path,
+                    destination,
+                    dirs_exist_ok=True,
+                    copy_function=self._copy_auth_seed_file,
+                )
                 continue
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_path, destination)
+            self._copy_auth_seed_file(source_path, destination)
 
     def _append_spool(self, stream_name: str, text: str) -> None:
         if stream_name not in {"stdout", "stderr"}:

--- a/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
+++ b/tests/unit/services/temporal/runtime/test_codex_session_runtime.py
@@ -2203,6 +2203,9 @@ def test_runtime_launch_session_seeds_auth_directories_and_excludes_sessions(
     sessions_dir = auth_volume_path / "sessions"
     sessions_dir.mkdir()
     (sessions_dir / "rollout.jsonl").write_text("secret transcript", encoding="utf-8")
+    tmp_dir = auth_volume_path / ".tmp" / "plugins" / ".git" / "objects" / "pack"
+    tmp_dir.mkdir(parents=True)
+    (tmp_dir / "pack-readonly.pack").write_text("plugin cache", encoding="utf-8")
     symlink_path = auth_volume_path / "linked-auth.json"
     symlink_path.symlink_to(auth_volume_path / "auth.json")
 
@@ -2223,7 +2226,47 @@ def test_runtime_launch_session_seeds_auth_directories_and_excludes_sessions(
     assert Path(request.codex_home_path, "auth.json").is_file()
     assert Path(request.codex_home_path, "accounts", "default.json").is_file()
     assert not Path(request.codex_home_path, "sessions").exists()
+    assert not Path(request.codex_home_path, ".tmp").exists()
     assert not Path(request.codex_home_path, "linked-auth.json").exists()
+
+
+def test_runtime_launch_session_auth_seed_overwrites_read_only_files_on_retry(
+    tmp_path: Path,
+) -> None:
+    script = write_fake_app_server(tmp_path)
+    request = launch_request(tmp_path)
+    auth_volume_path = tmp_path / "auth-volume"
+    auth_volume_path.mkdir()
+    source_auth = auth_volume_path / "auth.json"
+    source_auth.write_text('{"token":"oauth"}', encoding="utf-8")
+    source_auth.chmod(0o444)
+
+    runtime = CodexManagedSessionRuntime(
+        workspace_path=request.workspace_path,
+        session_workspace_path=request.session_workspace_path,
+        artifact_spool_path=request.artifact_spool_path,
+        codex_home_path=request.codex_home_path,
+        auth_volume_path=str(auth_volume_path),
+        image_ref=request.image_ref,
+        control_url="docker-exec://mm-codex-session-sess-1",
+        container_id="ctr-1",
+        app_server_command=("python3", str(script)),
+    )
+
+    runtime.launch_session(request)
+    destination_auth = Path(request.codex_home_path, "auth.json")
+    assert destination_auth.stat().st_mode & 0o777 == 0o444
+
+    source_auth.chmod(0o644)
+    source_auth.write_text('{"token":"oauth-refresh"}', encoding="utf-8")
+    source_auth.chmod(0o444)
+
+    runtime.launch_session(request)
+
+    assert destination_auth.read_text(encoding="utf-8") == (
+        '{"token":"oauth-refresh"}'
+    )
+    assert destination_auth.stat().st_mode & 0o777 == 0o444
 
 
 def test_runtime_launch_session_rejects_missing_auth_volume_path(


### PR DESCRIPTION
## Summary

- Exclude Codex `.tmp` plugin/cache state from auth-volume seeding into per-run `codex-home`.
- Make auth seed file copying retry-safe by unlinking existing destination files before copying.
- Add regression coverage for `.tmp` exclusion and read-only destination overwrite on launch retry.

## Root Cause

A cancelled or timed-out managed Codex session launch could leave read-only Git pack/index files under the per-run `codex-home/.tmp` tree. A later launch retry attempted to copy over those files from the auth volume and failed with `Errno 13 Permission denied` before the agent session started.

## Validation

- `./tools/test_unit.sh tests/unit/services/temporal/runtime/test_codex_session_runtime.py`
- `./tools/test_unit.sh`