### PR TITLE
Fix managed session GitHub auth

### DIFF
--- a/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_contract.py
@@ -25,6 +25,7 @@ NON_RETRYABLE_REASONS = {
     "comment_policy_not_enforced",
     "merge_not_ready",
     "pr_not_found",
+    "publish_unavailable",
     "already_merged",
 }
 
@@ -97,4 +98,6 @@ def remediation_next_step(reason: str) -> str:
         return "inspect_comment_policy"
     if normalized == "merge_not_ready":
         return "inspect_mergeability_state"
+    if normalized == "publish_unavailable":
+        return "manual_review"
     return "manual_review"

--- a/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_finalize.py
@@ -33,6 +33,15 @@ from pr_resolve_contract import (  # noqa: E402
 
 CONFLICTING_MERGEABLE = {"CONFLICTING", "DIRTY"}
 DIRECT_MERGE_STATE = {"CLEAN"}
+_GITHUB_AUTH_FAILURE_MARKERS = (
+    "not logged into any github hosts",
+    "gh auth login",
+    "populate the gh_token",
+    "populate the github_token",
+    "authentication required",
+    "could not read username for 'https://github.com'",
+    "could not read username for \"https://github.com\"",
+)
 
 
 def _check_pr_merged(selector: str | None) -> bool:
@@ -59,6 +68,23 @@ def _check_pr_merged(selector: str | None) -> bool:
         isinstance(payload, dict)
         and normalize_text(payload.get("state")).upper() == "MERGED"
     )
+
+
+def _called_process_detail(exc: subprocess.CalledProcessError) -> str:
+    parts = [
+        normalize_text(getattr(exc, "output", "")),
+        normalize_text(getattr(exc, "stdout", "")),
+        normalize_text(getattr(exc, "stderr", "")),
+        str(exc),
+    ]
+    return "\n".join(part for part in parts if part)
+
+
+def _snapshot_failed_reason(exc: subprocess.CalledProcessError) -> str:
+    detail = _called_process_detail(exc).lower()
+    if any(marker in detail for marker in _GITHUB_AUTH_FAILURE_MARKERS):
+        return "publish_unavailable"
+    return "pr_not_found"
 
 
 def _is_conflicting(pr: dict[str, Any]) -> bool:
@@ -237,15 +263,35 @@ def main() -> None:
                         )
                         print("PR is already merged (detected after snapshot failure).")
                         sys.exit(EXIT_CODE_MERGED)
+                    failure_reason = _snapshot_failed_reason(exc)
+                    if failure_reason == "publish_unavailable":
+                        _write_result(
+                            result_path,
+                            snapshot={"pr": {}},
+                            decision="blocked",
+                            merge_outcome="blocked",
+                            status="blocked",
+                            reason=failure_reason,
+                        )
+                        print(
+                            f"Blocked: {failure_reason}\n{_called_process_detail(exc)}",
+                            file=sys.stderr,
+                        )
+                        sys.exit(
+                            EXIT_CODE_BLOCKED if args.strict_exit_codes else 0
+                        )
                     _write_result(
                         result_path,
                         snapshot={"pr": {}},
                         decision="failed",
                         merge_outcome="failed",
                         status="failed",
-                        reason="pr_not_found",
+                        reason=failure_reason,
                     )
-                    print(f"Failed: pr_not_found\n{exc.stderr}", file=sys.stderr)
+                    print(
+                        f"Failed: {failure_reason}\n{_called_process_detail(exc)}",
+                        file=sys.stderr,
+                    )
                     sys.exit(EXIT_CODE_FAILED if args.strict_exit_codes else 0)
                 
                 # Snapshot refresh can fail transiently (network/auth/API blips).

--- a/moonmind/workflows/temporal/runtime/github_auth_broker.py
+++ b/moonmind/workflows/temporal/runtime/github_auth_broker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import shutil
 import socket
 import sys
 from dataclasses import dataclass
@@ -197,13 +198,30 @@ def request_github_token(socket_path: str, *, command: str = "github_token") -> 
         client.close()
 
 
-def run_gh_wrapper(*, socket_path: str, real_gh_path: str) -> int:
+def _resolve_real_gh_path() -> str:
+    """Resolve gh from the container PATH without returning this wrapper."""
+
+    wrapper_path = Path(sys.argv[0]).resolve()
+    wrapper_dir = wrapper_path.parent
+    path_parts = [
+        item
+        for item in os.environ.get("PATH", "").split(os.pathsep)
+        if item and Path(item).resolve() != wrapper_dir
+    ]
+    resolved = shutil.which("gh", path=os.pathsep.join(path_parts))
+    if not resolved:
+        raise RuntimeError("Unable to locate real gh binary in managed session PATH")
+    return resolved
+
+
+def run_gh_wrapper(*, socket_path: str, real_gh_path: str | None = None) -> int:
     """Exec the real gh binary with a token fetched from the local broker."""
+    resolved_gh_path = str(real_gh_path or _resolve_real_gh_path())
     token = request_github_token(socket_path)
     env = dict(os.environ)
     env.pop("GH_TOKEN", None)
     env["GITHUB_TOKEN"] = token
-    os.execvpe(real_gh_path, [real_gh_path, *sys.argv[1:]], env)
+    os.execvpe(resolved_gh_path, [resolved_gh_path, *sys.argv[1:]], env)
     return 0
 
 

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -293,16 +293,14 @@ class DockerCodexManagedSessionController:
         return str(path)
 
     @staticmethod
-    def _render_gh_wrapper_script(*, socket_path: str, real_gh_path: str) -> str:
+    def _render_gh_wrapper_script(*, socket_path: str) -> str:
         return (
             "#!/usr/bin/env python3\n"
             "from moonmind.workflows.temporal.runtime.github_auth_broker "
             "import run_gh_wrapper\n"
             "\n"
             "if __name__ == \"__main__\":\n"
-            "    raise SystemExit(run_gh_wrapper("
-            f"socket_path={socket_path!r}, real_gh_path={real_gh_path!r}"
-            "))\n"
+            f"    raise SystemExit(run_gh_wrapper(socket_path={socket_path!r}))\n"
         )
 
     @staticmethod
@@ -321,19 +319,6 @@ class DockerCodexManagedSessionController:
         escaped = value.replace("\\", "\\\\").replace('"', '\\"')
         return f'"{escaped}"'
 
-    @staticmethod
-    def _best_effort_chown_managed_session_paths(paths: Sequence[Path]) -> None:
-        geteuid = getattr(os, "geteuid", None)
-        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
-            return
-        for path in paths:
-            try:
-                os.chown(path, _MANAGED_SESSION_CONTAINER_UID, _MANAGED_SESSION_CONTAINER_GID)
-            except FileNotFoundError:
-                continue
-            except OSError:
-                logger.debug("Failed to chown managed session support path %s", path, exc_info=True)
-
     @classmethod
     def _persist_brokered_github_config(
         cls,
@@ -342,14 +327,19 @@ class DockerCodexManagedSessionController:
         workspace_path: str,
         support_root: Path,
         github_socket_path: str,
-        real_gh_path: str | None,
     ) -> list[Path]:
         """Persist broker-backed git/gh config visible inside the session container."""
 
         bin_dir = support_root / "bin"
         git_config_path = support_root / "gitconfig"
         git_helper_path = bin_dir / "git-credential-moonmind"
-        touched_paths: list[Path] = [support_root, bin_dir, git_config_path, git_helper_path]
+        gh_wrapper_path = bin_dir / "gh"
+        touched_paths: list[Path] = [
+            support_root,
+            bin_dir,
+            git_config_path,
+            git_helper_path,
+        ]
 
         support_root.mkdir(parents=True, exist_ok=True)
         bin_dir.mkdir(parents=True, exist_ok=True)
@@ -357,31 +347,48 @@ class DockerCodexManagedSessionController:
             git_helper_path,
             cls._render_git_credential_helper_script(socket_path=github_socket_path),
         )
-
-        if real_gh_path:
-            gh_wrapper_path = bin_dir / "gh"
-            touched_paths.append(gh_wrapper_path)
-            cls._write_executable_script(
-                gh_wrapper_path,
-                cls._render_gh_wrapper_script(
-                    socket_path=github_socket_path,
-                    real_gh_path=real_gh_path,
-                ),
-            )
+        touched_paths.append(gh_wrapper_path)
+        cls._write_executable_script(
+            gh_wrapper_path,
+            cls._render_gh_wrapper_script(socket_path=github_socket_path),
+        )
 
         git_config_lines = [
             "# moonmind-managed-git-config\n",
-            "[safe]\n",
-            f"\tdirectory = {cls._format_git_config_value(str(Path(workspace_path).resolve()))}\n",
-            "[credential]\n",
-            f"\thelper = !{shlex.quote(str(git_helper_path))}\n",
         ]
+        existing_global_git_config = str(
+            session_environment.get("GIT_CONFIG_GLOBAL") or ""
+        ).strip()
+        if (
+            existing_global_git_config
+            and Path(existing_global_git_config) != git_config_path
+        ):
+            git_config_lines.extend(
+                [
+                    "[include]\n",
+                    (
+                        "\tpath = "
+                        f"{cls._format_git_config_value(existing_global_git_config)}\n"
+                    ),
+                ]
+            )
+        git_config_lines.extend(
+            [
+                "[safe]\n",
+                f"\tdirectory = {cls._format_git_config_value(str(workspace_path))}\n",
+                "[credential]\n",
+                f"\thelper = !{shlex.quote(str(git_helper_path))}\n",
+            ]
+        )
         git_config_path.write_text("".join(git_config_lines), encoding="utf-8")
         git_config_path.chmod(0o600)
 
         existing_path = str(session_environment.get("PATH") or "").strip()
+        system_paths = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         session_environment["PATH"] = (
-            f"{bin_dir}{os.pathsep}{existing_path}" if existing_path else str(bin_dir)
+            f"{bin_dir}{os.pathsep}{existing_path}"
+            if existing_path
+            else f"{bin_dir}{os.pathsep}{system_paths}"
         )
         session_environment["GIT_CONFIG_GLOBAL"] = str(git_config_path)
         session_environment.setdefault("GIT_TERMINAL_PROMPT", "0")
@@ -400,6 +407,7 @@ class DockerCodexManagedSessionController:
                     existing_config + credential_section,
                     encoding="utf-8",
                 )
+                touched_paths.append(repo_git_config_path)
 
         return touched_paths
 
@@ -423,16 +431,14 @@ class DockerCodexManagedSessionController:
             token=token,
             socket_path=socket_path,
         )
-        real_gh_path = shutil.which("gh")
         touched_paths = self._persist_brokered_github_config(
             session_environment,
             workspace_path=request.workspace_path,
             support_root=support_root,
             github_socket_path=socket_path,
-            real_gh_path=real_gh_path,
         )
         touched_paths.append(Path(socket_path))
-        self._best_effort_chown_managed_session_paths(touched_paths)
+        self._normalize_container_path_owners(touched_paths)
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -8,6 +8,7 @@ import logging
 import os
 import posixpath
 import re
+import shlex
 import shutil
 import time
 from datetime import UTC, datetime
@@ -40,6 +41,7 @@ from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
 )
 from moonmind.utils.logging import SecretRedactor, scrub_github_tokens
 
+from .github_auth_broker import GitHubAuthBrokerManager
 from .managed_session_store import ManagedSessionStore
 from .managed_session_supervisor import ManagedSessionSupervisor
 
@@ -176,6 +178,7 @@ class DockerCodexManagedSessionController:
             DEFAULT_CODEX_TURN_COMPLETION_TIMEOUT_SECONDS
         ),
         command_runner: CommandRunner = _default_command_runner,
+        github_auth_brokers: GitHubAuthBrokerManager | Any | None = None,
     ) -> None:
         self._workspace_volume_name = workspace_volume_name
         self._codex_volume_name = codex_volume_name
@@ -191,6 +194,7 @@ class DockerCodexManagedSessionController:
         self._turn_poll_interval_seconds = turn_poll_interval_seconds
         self._turn_poll_timeout_seconds = turn_poll_timeout_seconds
         self._command_runner = command_runner
+        self._github_auth_brokers = github_auth_brokers or GitHubAuthBrokerManager()
 
     @staticmethod
     def _managed_session_user_command_kwargs() -> dict[str, int]:
@@ -280,6 +284,155 @@ class DockerCodexManagedSessionController:
     @staticmethod
     def _volume_mount(volume_name: str, target_path: str) -> str:
         return f"type=volume,src={volume_name},dst={target_path}"
+
+    @staticmethod
+    def _write_executable_script(path: Path, content: str) -> str:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o700)
+        return str(path)
+
+    @staticmethod
+    def _render_gh_wrapper_script(*, socket_path: str, real_gh_path: str) -> str:
+        return (
+            "#!/usr/bin/env python3\n"
+            "from moonmind.workflows.temporal.runtime.github_auth_broker "
+            "import run_gh_wrapper\n"
+            "\n"
+            "if __name__ == \"__main__\":\n"
+            "    raise SystemExit(run_gh_wrapper("
+            f"socket_path={socket_path!r}, real_gh_path={real_gh_path!r}"
+            "))\n"
+        )
+
+    @staticmethod
+    def _render_git_credential_helper_script(*, socket_path: str) -> str:
+        return (
+            "#!/usr/bin/env python3\n"
+            "from moonmind.workflows.temporal.runtime.github_auth_broker "
+            "import run_git_credential_helper\n"
+            "\n"
+            "if __name__ == \"__main__\":\n"
+            f"    raise SystemExit(run_git_credential_helper(socket_path={socket_path!r}))\n"
+        )
+
+    @staticmethod
+    def _format_git_config_value(value: str) -> str:
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+
+    @staticmethod
+    def _best_effort_chown_managed_session_paths(paths: Sequence[Path]) -> None:
+        geteuid = getattr(os, "geteuid", None)
+        if os.name != "posix" or not callable(geteuid) or geteuid() != 0:
+            return
+        for path in paths:
+            try:
+                os.chown(path, _MANAGED_SESSION_CONTAINER_UID, _MANAGED_SESSION_CONTAINER_GID)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                logger.debug("Failed to chown managed session support path %s", path, exc_info=True)
+
+    @classmethod
+    def _persist_brokered_github_config(
+        cls,
+        session_environment: dict[str, str],
+        *,
+        workspace_path: str,
+        support_root: Path,
+        github_socket_path: str,
+        real_gh_path: str | None,
+    ) -> list[Path]:
+        """Persist broker-backed git/gh config visible inside the session container."""
+
+        bin_dir = support_root / "bin"
+        git_config_path = support_root / "gitconfig"
+        git_helper_path = bin_dir / "git-credential-moonmind"
+        touched_paths: list[Path] = [support_root, bin_dir, git_config_path, git_helper_path]
+
+        support_root.mkdir(parents=True, exist_ok=True)
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        cls._write_executable_script(
+            git_helper_path,
+            cls._render_git_credential_helper_script(socket_path=github_socket_path),
+        )
+
+        if real_gh_path:
+            gh_wrapper_path = bin_dir / "gh"
+            touched_paths.append(gh_wrapper_path)
+            cls._write_executable_script(
+                gh_wrapper_path,
+                cls._render_gh_wrapper_script(
+                    socket_path=github_socket_path,
+                    real_gh_path=real_gh_path,
+                ),
+            )
+
+        git_config_lines = [
+            "# moonmind-managed-git-config\n",
+            "[safe]\n",
+            f"\tdirectory = {cls._format_git_config_value(str(Path(workspace_path).resolve()))}\n",
+            "[credential]\n",
+            f"\thelper = !{shlex.quote(str(git_helper_path))}\n",
+        ]
+        git_config_path.write_text("".join(git_config_lines), encoding="utf-8")
+        git_config_path.chmod(0o600)
+
+        existing_path = str(session_environment.get("PATH") or "").strip()
+        session_environment["PATH"] = (
+            f"{bin_dir}{os.pathsep}{existing_path}" if existing_path else str(bin_dir)
+        )
+        session_environment["GIT_CONFIG_GLOBAL"] = str(git_config_path)
+        session_environment.setdefault("GIT_TERMINAL_PROMPT", "0")
+
+        repo_git_config_path = Path(workspace_path) / ".git" / "config"
+        if repo_git_config_path.exists():
+            marker = "# moonmind-credential-helper"
+            existing_config = repo_git_config_path.read_text(encoding="utf-8")
+            if marker not in existing_config:
+                credential_section = (
+                    f"\n{marker}\n"
+                    "[credential]\n"
+                    f"\thelper = !{shlex.quote(str(git_helper_path))}\n"
+                )
+                repo_git_config_path.write_text(
+                    existing_config + credential_section,
+                    encoding="utf-8",
+                )
+
+        return touched_paths
+
+    async def _configure_session_github_auth(
+        self,
+        request: LaunchCodexManagedSessionRequest,
+        session_environment: dict[str, str],
+    ) -> None:
+        token = await resolve_github_token_for_launch(
+            request.environment,
+            github_credential=request.github_credential,
+        )
+        token = str(token or "").strip()
+        if not token:
+            return
+
+        support_root = Path(request.session_workspace_path) / ".moonmind"
+        socket_path = str(support_root / "github-auth.sock")
+        await self._github_auth_brokers.start(
+            run_id=request.session_id,
+            token=token,
+            socket_path=socket_path,
+        )
+        real_gh_path = shutil.which("gh")
+        touched_paths = self._persist_brokered_github_config(
+            session_environment,
+            workspace_path=request.workspace_path,
+            support_root=support_root,
+            github_socket_path=socket_path,
+            real_gh_path=real_gh_path,
+        )
+        touched_paths.append(Path(socket_path))
+        self._best_effort_chown_managed_session_paths(touched_paths)
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:
@@ -1391,6 +1544,13 @@ class DockerCodexManagedSessionController:
             existing_moonmind_url = session_environment.get("MOONMIND_URL")
             if existing_moonmind_url is None or not str(existing_moonmind_url).strip():
                 session_environment["MOONMIND_URL"] = self._moonmind_url
+        github_broker_started = False
+        try:
+            await self._configure_session_github_auth(request, session_environment)
+            github_broker_started = "GIT_CONFIG_GLOBAL" in session_environment
+        except Exception:
+            await self._github_auth_brokers.stop(request.session_id)
+            raise
         docker_network = self._network_name or _managed_session_docker_network(
             session_environment
         )
@@ -1436,10 +1596,15 @@ class DockerCodexManagedSessionController:
                 "serve",
             ]
         )
-        stdout, _stderr = await self._run(run_command)
-        container_id = stdout.strip()
-        if not container_id:
-            raise RuntimeError("docker run returned a blank container id")
+        try:
+            stdout, _stderr = await self._run(run_command)
+            container_id = stdout.strip()
+            if not container_id:
+                raise RuntimeError("docker run returned a blank container id")
+        except Exception:
+            if github_broker_started:
+                await self._github_auth_brokers.stop(request.session_id)
+            raise
         try:
             await self._wait_ready(container_id=container_id)
             container_request = request.model_copy(
@@ -1457,6 +1622,8 @@ class DockerCodexManagedSessionController:
             )
         except Exception:
             await self._remove_container(container_id, ignore_failure=True)
+            if github_broker_started:
+                await self._github_auth_brokers.stop(request.session_id)
             raise
         handle = CodexManagedSessionHandle.model_validate(payload)
         if self._session_store is not None:
@@ -1719,6 +1886,7 @@ class DockerCodexManagedSessionController:
             if record is not None and record.status == "terminated":
                 self._matches_locator(record, request)
                 await self._remove_container(record.container_id, ignore_failure=True)
+                await self._github_auth_brokers.stop(request.session_id)
                 return CodexManagedSessionHandle(
                     sessionState=record.session_state(),
                     status="terminated",
@@ -1726,6 +1894,7 @@ class DockerCodexManagedSessionController:
                     controlUrl=record.control_url,
                 )
         await self._remove_container(request.container_id, ignore_failure=True)
+        await self._github_auth_brokers.stop(request.session_id)
         handle = CodexManagedSessionHandle(
             sessionState={
                 "sessionId": request.session_id,

--- a/tests/unit/services/temporal/runtime/test_github_auth_broker.py
+++ b/tests/unit/services/temporal/runtime/test_github_auth_broker.py
@@ -75,3 +75,50 @@ def test_run_gh_wrapper_clears_ambient_gh_token(
     assert isinstance(env, dict)
     assert env["GITHUB_TOKEN"] == "broker-issued-token"
     assert "GH_TOKEN" not in env
+
+
+def test_run_gh_wrapper_resolves_real_gh_after_wrapper_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wrapper_dir = tmp_path / "wrapper-bin"
+    real_dir = tmp_path / "real-bin"
+    wrapper_dir.mkdir()
+    real_dir.mkdir()
+    wrapper_path = wrapper_dir / "gh"
+    real_gh_path = real_dir / "gh"
+    wrapper_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_gh_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    wrapper_path.chmod(0o700)
+    real_gh_path.chmod(0o700)
+    monkeypatch.setenv("PATH", f"{wrapper_dir}{os.pathsep}{real_dir}")
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.request_github_token",
+        lambda _socket_path: "broker-issued-token",
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.sys.argv",
+        [str(wrapper_path), "auth", "status"],
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_execvpe(path: str, args: list[str], env: dict[str, str]) -> None:
+        captured["path"] = path
+        captured["args"] = args
+        captured["env"] = env
+        raise SystemExit(0)
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.github_auth_broker.os.execvpe",
+        _fake_execvpe,
+    )
+
+    with pytest.raises(SystemExit):
+        run_gh_wrapper(socket_path="/tmp/github-auth.sock")
+
+    assert captured["path"] == str(real_gh_path)
+    assert captured["args"] == [str(real_gh_path), "auth", "status"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["GITHUB_TOKEN"] == "broker-issued-token"

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -740,6 +740,20 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
     docker_commands: list[tuple[str, ...]] = []
     container_payloads: list[str | None] = []
 
+    class _FakeGitHubAuthBrokers:
+        def __init__(self) -> None:
+            self.starts: list[dict[str, str]] = []
+            self.stops: list[str] = []
+
+        async def start(self, *, run_id: str, token: str, socket_path: str) -> None:
+            self.starts.append(
+                {"run_id": run_id, "token": token, "socket_path": socket_path}
+            )
+
+        async def stop(self, run_id: str) -> None:
+            self.stops.append(run_id)
+
+    github_auth_brokers = _FakeGitHubAuthBrokers()
     monkeypatch.setenv("MM320_GITHUB_TOKEN", token)
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.geteuid",
@@ -748,6 +762,10 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
     monkeypatch.setattr(
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
         lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller.shutil.which",
+        lambda command: "/usr/bin/gh" if command == "gh" else None,
     )
 
     async def _fake_runner(
@@ -790,21 +808,59 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
         workspace_root=str(workspace_root),
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
+        github_auth_brokers=github_auth_brokers,
     )
 
-    await controller.launch_session(request)
+    handle = await controller.launch_session(request)
 
     assert git_envs
     assert git_envs[0] is not None
     assert git_envs[0]["GITHUB_TOKEN"] == token
     assert git_envs[0]["GIT_TERMINAL_PROMPT"] == "0"
     assert 'password="$GITHUB_TOKEN"' in git_envs[0]["GIT_CONFIG_VALUE_1"]
+    assert github_auth_brokers.starts == [
+        {
+            "run_id": request.session_id,
+            "token": token,
+            "socket_path": str(
+                Path(request.session_workspace_path)
+                / ".moonmind"
+                / "github-auth.sock"
+            ),
+        }
+    ]
     docker_run_text = " ".join(docker_commands[0])
     assert token not in docker_run_text
     assert "GITHUB_TOKEN=" not in docker_run_text
+    assert "GIT_CONFIG_GLOBAL=" in docker_run_text
+    assert ".moonmind/bin" in docker_run_text
     assert container_payloads
     assert token not in str(container_payloads[0])
     assert "githubCredential" in str(container_payloads[0])
+    assert "GIT_CONFIG_GLOBAL" in str(container_payloads[0])
+    assert (Path(request.session_workspace_path) / ".moonmind" / "bin" / "gh").exists()
+    assert (
+        Path(request.session_workspace_path)
+        / ".moonmind"
+        / "bin"
+        / "git-credential-moonmind"
+    ).exists()
+    git_config_text = (
+        Path(request.session_workspace_path) / ".moonmind" / "gitconfig"
+    ).read_text(encoding="utf-8")
+    assert "moonmind-managed-git-config" in git_config_text
+    assert "git-credential-moonmind" in git_config_text
+
+    await controller.terminate_session(
+        TerminateCodexManagedSessionRequest(
+            sessionId=handle.session_state.session_id,
+            sessionEpoch=handle.session_state.session_epoch,
+            containerId=handle.session_state.container_id,
+            threadId=handle.session_state.thread_id,
+            reason="test cleanup",
+        )
+    )
+    assert github_auth_brokers.stops == [request.session_id]
 
 
 @pytest.mark.asyncio
@@ -976,12 +1032,20 @@ async def test_controller_launch_redacts_github_token_from_command_failures(
             )
         raise AssertionError(f"unexpected command: {command}")
 
+    class _FakeGitHubAuthBrokers:
+        async def start(self, *, run_id: str, token: str, socket_path: str) -> None:
+            return None
+
+        async def stop(self, run_id: str) -> None:
+            return None
+
     controller = DockerCodexManagedSessionController(
         workspace_volume_name="agent_workspaces",
         codex_volume_name="codex_auth_volume",
         workspace_root=str(workspace_root),
         command_runner=_fake_runner,
         ready_poll_interval_seconds=0,
+        github_auth_brokers=_FakeGitHubAuthBrokers(),
     )
 
     with pytest.raises(RuntimeError) as exc_info:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
@@ -763,11 +764,6 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
         "moonmind.workflows.temporal.runtime.managed_session_controller.os.chown",
         lambda *_args, **_kwargs: None,
     )
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_session_controller.shutil.which",
-        lambda command: "/usr/bin/gh" if command == "gh" else None,
-    )
-
     async def _fake_runner(
         command: tuple[str, ...],
         *,
@@ -861,6 +857,53 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
         )
     )
     assert github_auth_brokers.stops == [request.session_id]
+
+
+def test_persist_brokered_github_config_preserves_container_visible_paths(
+    tmp_path: Path,
+) -> None:
+    workspace_target = tmp_path / "workspace-target"
+    workspace_target.mkdir()
+    workspace_path = tmp_path / "workspace-link"
+    workspace_path.symlink_to(workspace_target, target_is_directory=True)
+    repo_git_config_path = workspace_path / ".git" / "config"
+    repo_git_config_path.parent.mkdir()
+    repo_git_config_path.write_text(
+        "[core]\n\trepositoryformatversion = 0\n",
+        encoding="utf-8",
+    )
+    existing_global_config = tmp_path / "existing.gitconfig"
+    existing_global_config.write_text(
+        "[user]\n\tname = Existing User\n",
+        encoding="utf-8",
+    )
+    support_root = tmp_path / "session" / ".moonmind"
+    session_environment = {
+        "GIT_CONFIG_GLOBAL": str(existing_global_config),
+    }
+
+    touched_paths = DockerCodexManagedSessionController._persist_brokered_github_config(
+        session_environment,
+        workspace_path=str(workspace_path),
+        support_root=support_root,
+        github_socket_path="/tmp/github-auth.sock",
+    )
+
+    git_config_text = (support_root / "gitconfig").read_text(encoding="utf-8")
+    assert f"\tpath = \"{existing_global_config}\"" in git_config_text
+    assert f"\tdirectory = \"{workspace_path}\"" in git_config_text
+    assert f"\tdirectory = \"{workspace_target}\"" not in git_config_text
+    assert session_environment["GIT_CONFIG_GLOBAL"] == str(support_root / "gitconfig")
+    assert session_environment["PATH"] == (
+        f"{support_root / 'bin'}{os.pathsep}"
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    )
+    assert repo_git_config_path in touched_paths
+    assert "# moonmind-credential-helper" in repo_git_config_path.read_text(
+        encoding="utf-8"
+    )
+    gh_wrapper_text = (support_root / "bin" / "gh").read_text(encoding="utf-8")
+    assert "real_gh_path" not in gh_wrapper_text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -920,6 +920,73 @@ def test_finalize_snapshot_refresh_failure_is_blocked_retryable(
     assert int(raised_strict.value.code) == int(exit_code_blocked)
 
 
+def test_finalize_snapshot_auth_failure_reports_publish_unavailable(
+    pr_resolve_finalize_module: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import subprocess
+
+    main = pr_resolve_finalize_module["main"]
+    globals_dict = main.__globals__
+    exit_code_blocked = pr_resolve_finalize_module["EXIT_CODE_BLOCKED"]
+
+    def _boom(
+        _snapshot_script: Path,
+        _pr: str | None,
+        _snapshot_path: Path,
+    ) -> None:
+        raise subprocess.CalledProcessError(
+            returncode=pr_resolve_finalize_module["EXIT_CODE_FAILED"],
+            cmd=["python3", "pr_resolve_snapshot.py"],
+            stderr=(
+                "You are not logged into any GitHub hosts. "
+                "Run gh auth login to authenticate."
+            ),
+        )
+
+    monkeypatch.setitem(globals_dict, "_run_snapshot", _boom)
+    monkeypatch.setitem(globals_dict, "_check_pr_merged", lambda _selector: False)
+
+    result_path = tmp_path / "pr_resolver_result.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--pr",
+            "feature/branch",
+            "--result-path",
+            str(result_path),
+        ],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+    assert int(raised.value.code) == 0
+
+    import json
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "blocked"
+    assert payload["reason"] == "publish_unavailable"
+    assert payload["next_step"] == "manual_review"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "pr_resolve_finalize.py",
+            "--strict-exit-codes",
+            "--pr",
+            "feature/branch",
+            "--result-path",
+            str(result_path),
+        ],
+    )
+    with pytest.raises(SystemExit) as raised_strict:
+        main()
+    assert int(raised_strict.value.code) == int(exit_code_blocked)
+
+
 def test_summarize_ci_treats_stale_rollup_as_running(
     pr_resolve_snapshot_module: dict[str, Any],
 ) -> None:


### PR DESCRIPTION
## Summary

- Add broker-backed GitHub auth setup for Docker-managed Codex sessions so in-session `gh` and `git` commands can authenticate without receiving raw credential values in Docker command arguments or launch payloads.
- Stop the broker on launch failures and session termination.
- Classify pr-resolver GitHub auth failures as `publish_unavailable` instead of misleading `pr_not_found`.

## Root Cause

The failed workflow had a GitHub credential available at the worker boundary, but the Docker-managed session stripped the credential from the container environment and did not provide a reachable brokered auth path for `gh` or `git push`. The resolver then treated the resulting GitHub CLI auth failure as a missing PR.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py tests/unit/services/temporal/runtime/test_managed_session_controller.py`
- Focused regression rerun: `pytest -q tests/unit/services/temporal/runtime/test_managed_session_controller.py::test_controller_clone_resolves_descriptor_for_git_without_container_token tests/unit/test_pr_resolver_tools.py::test_finalize_snapshot_auth_failure_reports_publish_unavailable`
- `git diff --check`