### PR TITLE
[codex] fix codex session github auth

### DIFF
--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -439,7 +439,6 @@ class DockerCodexManagedSessionController:
         )
         touched_paths.append(Path(socket_path))
         self._normalize_container_path_owners(touched_paths)
-        session_environment.setdefault("GIT_TERMINAL_PROMPT", "0")
         # Codex shell tools can invoke nested `bash -lc` commands that bypass
         # the workspace-local gh wrapper. Bind the token through Docker's
         # inherited environment (`-e GITHUB_TOKEN`) so it is not rendered into

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -415,14 +415,14 @@ class DockerCodexManagedSessionController:
         self,
         request: LaunchCodexManagedSessionRequest,
         session_environment: dict[str, str],
-    ) -> None:
+    ) -> dict[str, str]:
         token = await resolve_github_token_for_launch(
             request.environment,
             github_credential=request.github_credential,
         )
         token = str(token or "").strip()
         if not token:
-            return
+            return {}
 
         support_root = Path(request.session_workspace_path) / ".moonmind"
         socket_path = str(support_root / "github-auth.sock")
@@ -439,6 +439,12 @@ class DockerCodexManagedSessionController:
         )
         touched_paths.append(Path(socket_path))
         self._normalize_container_path_owners(touched_paths)
+        session_environment.setdefault("GIT_TERMINAL_PROMPT", "0")
+        # Codex shell tools can invoke nested `bash -lc` commands that bypass
+        # the workspace-local gh wrapper. Bind the token through Docker's
+        # inherited environment (`-e GITHUB_TOKEN`) so it is not rendered into
+        # the docker command line or the launch payload.
+        return {"GITHUB_TOKEN": token}
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:
@@ -1551,8 +1557,12 @@ class DockerCodexManagedSessionController:
             if existing_moonmind_url is None or not str(existing_moonmind_url).strip():
                 session_environment["MOONMIND_URL"] = self._moonmind_url
         github_broker_started = False
+        container_secret_environment: dict[str, str] = {}
         try:
-            await self._configure_session_github_auth(request, session_environment)
+            container_secret_environment = await self._configure_session_github_auth(
+                request,
+                session_environment,
+            )
             github_broker_started = "GIT_CONFIG_GLOBAL" in session_environment
         except Exception:
             await self._github_auth_brokers.stop(request.session_id)
@@ -1593,6 +1603,8 @@ class DockerCodexManagedSessionController:
             )
         for key, value in sorted(session_environment.items()):
             run_command.extend(["-e", f"{key}={value}"])
+        for key in sorted(container_secret_environment):
+            run_command.extend(["-e", key])
         run_command.extend(
             [
                 request.image_ref,
@@ -1603,7 +1615,10 @@ class DockerCodexManagedSessionController:
             ]
         )
         try:
-            stdout, _stderr = await self._run(run_command)
+            stdout, _stderr = await self._run(
+                run_command,
+                extra_env=container_secret_environment or None,
+            )
             container_id = stdout.strip()
             if not container_id:
                 raise RuntimeError("docker run returned a blank container id")

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -739,6 +739,7 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
     )
     git_envs: list[dict[str, str] | None] = []
     docker_commands: list[tuple[str, ...]] = []
+    docker_envs: list[dict[str, str] | None] = []
     container_payloads: list[str | None] = []
 
     class _FakeGitHubAuthBrokers:
@@ -779,6 +780,7 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
             return 1, "", "No such container"
         if command[:2] == ("docker", "run"):
             docker_commands.append(command)
+            docker_envs.append(env)
             return 0, "ctr-1\n", ""
         if "ready" in command:
             return 0, '{"ready": true}\n', ""
@@ -828,11 +830,16 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
     docker_run_text = " ".join(docker_commands[0])
     assert token not in docker_run_text
     assert "GITHUB_TOKEN=" not in docker_run_text
+    assert "GITHUB_TOKEN" in docker_commands[0]
+    assert docker_envs[0] is not None
+    assert docker_envs[0]["GITHUB_TOKEN"] == token
     assert "GIT_CONFIG_GLOBAL=" in docker_run_text
+    assert "GIT_TERMINAL_PROMPT=0" in docker_run_text
     assert ".moonmind/bin" in docker_run_text
     assert container_payloads
     assert token not in str(container_payloads[0])
     assert "githubCredential" in str(container_payloads[0])
+    assert '"environment": {"GITHUB_TOKEN"' not in str(container_payloads[0])
     assert "GIT_CONFIG_GLOBAL" in str(container_payloads[0])
     assert (Path(request.session_workspace_path) / ".moonmind" / "bin" / "gh").exists()
     assert (
@@ -1068,6 +1075,11 @@ async def test_controller_launch_redacts_github_token_from_command_failures(
         if command[:3] == ("docker", "rm", "-f"):
             return 1, "", "No such container"
         if command[:2] == ("docker", "run"):
+            assert "GITHUB_TOKEN=ghp_inline_secret_token_12345678901234567890" not in " ".join(
+                command
+            )
+            assert env is not None
+            assert env["GITHUB_TOKEN"] == "ghp_inline_secret_token_12345678901234567890"
             return (
                 1,
                 "",


### PR DESCRIPTION
## Summary

Fix task-scoped Codex managed sessions so GitHub authentication is available to nested shell commands that invoke `gh`.

## Root Cause

Task-scoped Codex sessions mounted the brokered `gh` wrapper and git credential helper, but Codex shell tool execution can run nested `bash -lc` commands that bypass the wrapper. The local `pr-resolver` command then saw unauthenticated `gh` and reported `pr_not_found`, even when the PR was resolvable and merged through the GitHub connector.

## Changes

- Bind `GITHUB_TOKEN` into the session container through Docker's inherited environment using `-e GITHUB_TOKEN`, without rendering the secret value into the `docker run` command or launch payload.
- Preserve the brokered git/gh configuration and set `GIT_TERMINAL_PROMPT=0` for the session environment.
- Extend managed-session controller tests to verify container auth availability and secret redaction boundaries.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Python unit suite: 3544 passed, 1 xpassed, 16 subtests passed
- Frontend unit suite: 10 files passed, 276 tests passed
