### PR TITLE
MM-405 Agent Skill Catalog and Source Policy

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/205-post-merge-jira-completion"
+  "feature_directory": "specs/206-agent-skill-catalog-source-policy"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,8 @@ Key diagnostics:
 - No new persistent storage; options are derived from configuration and best-effort GitHub API responses at runtime (203-repository-dropdown)
 - Python 3.12 + Pydantic v2, Temporal Python SDK, existing MoonMind Jira tool service, existing artifact and workflow activity catalogs (205-post-merge-jira-completion)
 - Existing Temporal workflow history, memo/search attributes, and artifact outputs; no new persistent database tables planned (205-post-merge-jira-completion)
+- Python 3.12 with Pydantic v2 models, SQLAlchemy async ORM, Temporal Python SDK activity boundaries + Pydantic v2, SQLAlchemy async session fixtures, Temporal activity wrappers, existing agent-skill resolver/materializer services (206-agent-skill-catalog-source-policy)
+- Existing agent skill tables and artifact-backed version content; no new persistent tables planned (206-agent-skill-catalog-source-policy)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-402",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1562"
+  "jira_issue_key": "MM-405",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1566"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md
@@ -1,0 +1,77 @@
+# MM-405 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-405
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Agent Skill Catalog and Source Policy
+- Labels: moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-405 from MM project
+Summary: Agent Skill Catalog and Source Policy
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-405 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-405: Agent Skill Catalog and Source Policy
+
+Source Reference
+- Source Document: docs/Tasks/AgentSkillSystem.md
+- Original Jira Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §1-§7
+  - AgentSkillSystem §9
+  - AgentSkillSystem §17
+  - SkillAndPlanContracts §1.1
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+
+User Story
+As a MoonMind operator, I can rely on agent skills being modeled as deployment-scoped, versioned instruction data with explicit source precedence and policy gates, so managed runs do not confuse instruction bundles with executable tools or silently trust repo-local content.
+
+Acceptance Criteria
+- Given executable tools and agent instruction bundles share the historical word skill, when contracts are validated, then ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet remain typed separately.
+- Given a deployment-stored skill is edited, when the change is saved, then a new immutable version is created instead of mutating the previous version.
+- Given built-in, deployment, repo, and local-only candidates exist, when policy allows them, then deterministic precedence selects the winner and records source provenance.
+- Given policy forbids repo or local-only skills, when those sources contain candidates, then they are excluded before precedence is applied and cannot silently affect the run.
+
+Requirements
+- Define or preserve concrete AgentSkillDefinition, AgentSkillVersion, SkillSet, and SkillSetEntry contracts with source kind and version metadata.
+- Keep executable ToolDefinition and runtime-native command contracts separate from agent-skill instruction bundles in validation and docs.
+- Apply deployment policy gates to repo and local-only skill sources before selection or materialization.
+- Treat repo-provided and local-only skill content as potentially untrusted input.
+- Preserve MM-405 in all downstream MoonSpec artifacts, verification output, commit text, and pull request metadata.
+
+Relevant Implementation Notes
+- The canonical agent-skill design lives in `docs/Tasks/AgentSkillSystem.md`; executable tool contracts live separately in `docs/Tasks/SkillAndPlanContracts.md`.
+- Agent skills are reusable instruction bundles and are not executable Temporal tools.
+- ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet should remain typed separately at validation and API boundaries.
+- Built-in, deployment-stored, repo-checked-in, and local-only skill candidates should be handled as distinct sources with explicit provenance.
+- Deployment policy should gate repo and local-only sources before selection, resolution, or materialization.
+- Runtime-visible `.agents/skills` should represent the active resolved skill set for a run, while `.agents/skills/local` remains a local-only overlay input.
+- Resolved skill sets should be immutable per run or step, and workflows should carry refs to snapshots rather than large skill bodies.
+- Runtime adapters own materialization of the resolved skill snapshot for each target runtime.
+- Checked-in skill folders should not be mutated in place during runtime setup.
+
+Verification
+- Verify executable tool contracts and agent-skill instruction-bundle contracts remain distinguishable in models, validation, tests, and docs touched by the change.
+- Verify deployment-backed skill edits create immutable versions rather than mutating previous versions.
+- Verify source precedence records provenance when built-in, deployment, repo, and local-only candidates are present.
+- Verify policy-denied repo and local-only skills are excluded before precedence is applied.
+- Verify trusted or untrusted skill source handling is covered at the workflow/activity or adapter boundary when runtime materialization is changed.
+- Preserve MM-405 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates MM-405 is blocked by MM-406.

--- a/moonmind/services/skill_resolution.py
+++ b/moonmind/services/skill_resolution.py
@@ -26,12 +26,14 @@ class SkillResolutionContext:
         snapshot_id: str,
         deployment_id: str | None = None,
         workspace_root: str | None = None,
+        allow_repo_skills: bool = False,
         allow_local_skills: bool = False,
         async_session_maker: Callable[[], typing.AsyncContextManager[AsyncSession]] | None = None,
     ) -> None:
         self.snapshot_id = snapshot_id
         self.deployment_id = deployment_id
         self.workspace_root = workspace_root
+        self.allow_repo_skills = allow_repo_skills
         self.allow_local_skills = allow_local_skills
         self.async_session_maker = async_session_maker
 
@@ -148,7 +150,7 @@ class RepoSkillLoader(SkillLoader):
     async def load_skills(
         self, selector: SkillSelector, context: SkillResolutionContext
     ) -> list[ResolvedSkillEntry]:
-        if not context.workspace_root:
+        if not context.allow_repo_skills or not context.workspace_root:
             return []
         skills_dir = Path(context.workspace_root) / ".agents" / "skills"
         return _scan_for_skills(skills_dir, AgentSkillSourceKind.REPO)
@@ -259,6 +261,7 @@ class AgentSkillResolver:
                 mode="json", exclude_none=True
             ),
             policy_summary={
+                "repo_skills_allowed": context.allow_repo_skills,
                 "local_skills_allowed": context.allow_local_skills,
                 "sources_merged": [
                     s.value for s in candidates_by_source.keys()

--- a/moonmind/workflows/agent_skills/agent_skills_activities.py
+++ b/moonmind/workflows/agent_skills/agent_skills_activities.py
@@ -32,6 +32,7 @@ class AgentSkillsActivities:
         run_id: str | None = None,
         workspace_root: str | None = None,
         allow_local_skills: bool = False,
+        allow_repo_skills: bool = False,
     ) -> ResolvedSkillSet:
         """Resolve a SkillSelector intent into a canonical ResolvedSkillSet."""
         
@@ -43,6 +44,7 @@ class AgentSkillsActivities:
             snapshot_id=snapshot_id,
             deployment_id=run_id,
             workspace_root=workspace_root,
+            allow_repo_skills=allow_repo_skills,
             allow_local_skills=allow_local_skills,
             async_session_maker=getattr(self, "_async_session_maker", None),
         )
@@ -140,4 +142,3 @@ class AgentSkillsActivities:
             runtime_id=runtime_id,
             mode=mode,
         )
-

--- a/specs/206-agent-skill-catalog-source-policy/checklists/requirements.md
+++ b/specs/206-agent-skill-catalog-source-policy/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Agent Skill Catalog and Source Policy
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Runtime mode selected because the request did not explicitly ask for docs-only work.
+- Source design mapping preserves MM-405 and maps all in-scope DESIGN-REQ-001 through DESIGN-REQ-004 requirements to functional requirements.

--- a/specs/206-agent-skill-catalog-source-policy/contracts/agent-skill-source-policy.md
+++ b/specs/206-agent-skill-catalog-source-policy/contracts/agent-skill-source-policy.md
@@ -1,0 +1,58 @@
+# Contract: Agent Skill Source Policy
+
+## Purpose
+
+This contract defines the observable resolver behavior for MM-405. It is intentionally runtime-facing: callers provide compact selection and source policy inputs, and the resolver returns an immutable ResolvedSkillSet snapshot containing only policy-allowed agent instruction bundles.
+
+## Inputs
+
+### SkillSelector
+
+- `sets`: optional skill-set slugs.
+- `include`: optional explicit skill names and version pins.
+- `exclude`: optional skill names to exclude.
+- `materialization_mode`: optional preferred runtime materialization mode.
+
+### SkillResolutionContext
+
+- `snapshot_id`: required snapshot identifier for the resolved output.
+- `deployment_id`: optional deployment identifier.
+- `workspace_root`: optional workspace root for repo/local candidate discovery.
+- `allow_repo_skills`: required effective policy decision for repo-checked-in skills.
+- `allow_local_skills`: required effective policy decision for local-only skills.
+- `async_session_maker`: optional deployment catalog session factory.
+
+## Source Policy Rules
+
+1. Built-in and deployment-stored sources may be considered when their loaders are configured.
+2. Repo-checked-in source candidates MUST NOT be loaded or returned when `allow_repo_skills` is false.
+3. Local-only source candidates MUST NOT be loaded or returned when `allow_local_skills` is false.
+4. Denied source candidates MUST be excluded before precedence, selector filtering, and materialization.
+5. A denied repo or local candidate MUST NOT appear in `ResolvedSkillSet.skills`, `source_trace`, or runtime materialization output as an active skill.
+6. Allowed source precedence remains built-in < deployment < repo < local.
+7. The final snapshot MUST record compact policy summary data sufficient to explain whether repo and local sources were allowed.
+
+## Outputs
+
+### ResolvedSkillSet
+
+The resolver returns:
+
+- `snapshot_id` matching the input context.
+- `resolved_at` set to resolution time.
+- `skills` containing only policy-allowed selections.
+- `resolution_inputs` containing compact selector data.
+- `policy_summary` containing `repo_skills_allowed`, `local_skills_allowed`, and loaded source information.
+
+## Error Behavior
+
+- Duplicate skill definitions within the same source fail resolution.
+- Pinned version mismatches fail resolution.
+- Unknown loader/source kinds fail resolution.
+- Unsupported or malformed policy state fails closed by excluding untrusted repo/local sources.
+
+## Non-Goals
+
+- This contract does not define executable ToolDefinition behavior.
+- This contract does not move raw skill body content into workflow history.
+- This contract does not mutate checked-in `.agents/skills` folders during runtime materialization.

--- a/specs/206-agent-skill-catalog-source-policy/data-model.md
+++ b/specs/206-agent-skill-catalog-source-policy/data-model.md
@@ -1,0 +1,131 @@
+# Data Model: Agent Skill Catalog and Source Policy
+
+## AgentSkillDefinition
+
+Represents a reusable agent instruction bundle definition.
+
+Fields:
+- `id`: stable definition identity.
+- `slug`: unique human and API identifier.
+- `title`: operator-facing display title.
+- `description`: optional explanatory text.
+- `author`: optional author/provenance text.
+- `created_at`, `updated_at`: audit timestamps.
+- `versions`: ordered AgentSkillVersion records.
+
+Validation rules:
+- `slug` is unique.
+- A definition can have zero or more immutable versions.
+- Definition metadata may change, but version content is preserved by version rows.
+
+## AgentSkillVersion
+
+Represents one immutable content release for a deployment-stored agent skill.
+
+Fields:
+- `id`: stable version row identity.
+- `skill_id`: owning AgentSkillDefinition.
+- `version_string`: version label unique per skill.
+- `format`: markdown or bundle.
+- `artifact_ref`: artifact-backed content reference.
+- `content_digest`: content integrity digest.
+- `created_at`: immutable creation timestamp.
+
+Validation rules:
+- `(skill_id, version_string)` is unique.
+- Creating a later version does not mutate earlier versions.
+- Large content is stored by artifact reference rather than inline workflow payloads.
+
+## SkillSet
+
+Represents a named collection of agent-skill selections or rules.
+
+Fields:
+- `id`, `slug`, `title`, `description`.
+- `entries`: SkillSetEntry records.
+- `created_at`, `updated_at`.
+
+Validation rules:
+- `slug` is unique.
+- Skill sets reference AgentSkillDefinition records rather than executable ToolDefinition records.
+
+## SkillSetEntry
+
+Represents one selected skill inside a SkillSet.
+
+Fields:
+- `id`: stable entry identity.
+- `skill_set_id`: owning SkillSet.
+- `skill_id`: referenced AgentSkillDefinition.
+- `version_constraint`: optional version selector.
+- `created_at`: entry creation timestamp.
+
+Validation rules:
+- A SkillSet cannot include the same AgentSkillDefinition twice.
+- Version constraints select agent-skill versions, not executable tool contracts.
+
+## SkillResolutionContext
+
+Represents policy and runtime context used during source resolution.
+
+Fields:
+- `snapshot_id`: target ResolvedSkillSet identity.
+- `deployment_id`: optional deployment scope.
+- `workspace_root`: optional checked-out workspace root.
+- `allow_repo_skills`: whether repo-checked-in skills may participate in resolution.
+- `allow_local_skills`: whether local-only skills may participate in resolution.
+- `async_session_maker`: optional deployment catalog session factory.
+
+Validation rules:
+- Repo skill candidates are excluded when `allow_repo_skills` is false.
+- Local-only skill candidates are excluded when `allow_local_skills` is false.
+- Denied sources are excluded before precedence and materialization.
+
+## ResolvedSkillSet
+
+Represents the immutable resolved active skill set for a run or step.
+
+Fields:
+- `snapshot_id`: immutable snapshot identity.
+- `deployment_id`: optional deployment scope.
+- `resolved_at`: resolution timestamp.
+- `skills`: ordered ResolvedSkillEntry list.
+- `manifest_ref`: optional artifact reference.
+- `source_trace`: optional source diagnostics.
+- `resolution_inputs`: compact selector and policy input summary.
+- `policy_summary`: compact policy decision summary.
+
+Validation rules:
+- Entries are selected only from allowed source kinds.
+- Each entry records source provenance.
+- Runtime materialization consumes this snapshot rather than mutable source folders.
+
+## ResolvedSkillEntry
+
+Represents one selected skill in a resolved snapshot.
+
+Fields:
+- `skill_name`: selected skill identifier.
+- `version`: selected version or source-local version marker.
+- `format`: markdown or bundle.
+- `content_ref`: optional artifact/content reference.
+- `content_digest`: optional digest.
+- `provenance`: AgentSkillProvenance.
+
+Validation rules:
+- `provenance.source_kind` is required.
+- Denied source kinds cannot appear in final resolved entries.
+
+## AgentSkillProvenance
+
+Represents where a selected skill came from.
+
+Fields:
+- `source_kind`: built-in, deployment, repo, or local.
+- `original_version`: optional original source version.
+- `source_path`: optional repo/local source path.
+- `skill_set_name`: optional selection source.
+
+Validation rules:
+- Source kind must reflect the source that won resolution.
+- Repo/local path provenance is diagnostic only and must not make raw content trusted.

--- a/specs/206-agent-skill-catalog-source-policy/plan.md
+++ b/specs/206-agent-skill-catalog-source-policy/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: Agent Skill Catalog and Source Policy
+
+**Branch**: `206-agent-skill-catalog-source-policy` | **Date**: 2026-04-18 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story feature specification from `specs/206-agent-skill-catalog-source-policy/spec.md`
+
+## Summary
+
+Implement MM-405 by closing the remaining policy gap in agent-skill source resolution while preserving the existing deployment-backed skill catalog, immutable skill versions, resolved skill set contracts, and runtime materialization behavior. Repo inspection shows the project already has AgentSkillDefinition, AgentSkillVersion, SkillSet, ResolvedSkillSet, source provenance, local-source gating, and materialization tests. The missing runtime behavior is an explicit repo-source policy gate before selection and materialization. The implementation approach is test-first: add focused resolver tests proving repo sources are excluded when policy forbids them and still participate in precedence when allowed, then update the resolver context and call sites to carry explicit repo-source policy.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `moonmind/schemas/agent_skill_models.py`; `docs/Tasks/SkillAndPlanContracts.md`; existing schema separation | no new implementation | final verify |
+| FR-002 | implemented_verified | `docs/Tasks/SkillAndPlanContracts.md` runtime command boundary; `moonmind/workflows/agent_skills/selection.py` | no new implementation | final verify |
+| FR-003 | implemented_verified | `api_service/db/models.py` AgentSkillDefinition and AgentSkillVersion models; `tests/unit/api/test_agent_skills_service.py` | no new implementation | final verify |
+| FR-004 | implemented_unverified | `AgentSkillsService.create_version()` creates distinct version rows and duplicate protection exists | add a focused immutability assertion that a second version preserves the first | unit |
+| FR-005 | implemented_verified | `AgentSkillSourceKind`; BuiltIn, Deployment, Repo, and Local loaders; resolver tests | no new implementation | final verify |
+| FR-006 | implemented_verified | `AgentSkillResolver` precedence order and `test_resolver_respects_precedence` | no new implementation | final verify |
+| FR-007 | implemented_verified | `ResolvedSkillEntry.provenance`; resolver and materializer tests assert source kind | no new implementation | final verify |
+| FR-008 | partial | local source policy exists through `allow_local_skills`; repo source policy is absent | add explicit repo-source policy flag and honor it before repo loading | unit + integration-style boundary |
+| FR-009 | partial | local denied candidates are excluded; repo denied candidates are not explicitly excluded | add repo-denied test and resolver behavior | unit |
+| FR-010 | partial | source kind and materialization boundaries exist, but repo/local validation is shallow | preserve fail-closed source gating and add coverage for denied untrusted repo input | unit |
+| FR-011 | implemented_verified | `ResolvedSkillSet`; `AgentSkillMaterializer`; `tests/unit/services/test_skill_materialization.py` | no new implementation | final verify |
+| FR-012 | implemented_verified | `spec.md`; Jira brief artifact | preserve through tasks, verification, commit, and PR metadata | traceability check |
+| DESIGN-REQ-001 | implemented_verified | source docs and schema separation | no new implementation | final verify |
+| DESIGN-REQ-002 | implemented_unverified | version rows are immutable by insert-only service path | add focused unit assertion for multi-version preservation | unit |
+| DESIGN-REQ-003 | implemented_verified | resolver source precedence and provenance tests | no new implementation | final verify |
+| DESIGN-REQ-004 | partial | local policy gate present; repo policy gate missing | add explicit repo policy gate and tests | unit + final verify |
+| SC-001 | implemented_verified | existing schemas and docs distinguish contract types | no new implementation | final verify |
+| SC-002 | implemented_unverified | service version creation exists | add two-version immutability test | unit |
+| SC-003 | implemented_verified | source precedence test covers built-in/deployment; add repo/local allowed coverage if touched | optional test hardening | unit |
+| SC-004 | partial | local denial covered; repo denial missing | add repo denial test | unit |
+| SC-005 | implemented_verified | provenance assertions in resolver/materializer tests | no new implementation | final verify |
+| SC-006 | implemented_verified | materializer writes `.agents/skills_active` and not `.agents/skills` | no new implementation | final verify |
+| SC-007 | implemented_verified | spec and Jira input preserve MM-405 | no new implementation | traceability check |
+
+## Technical Context
+
+**Language/Version**: Python 3.12 with Pydantic v2 models, SQLAlchemy async ORM, Temporal Python SDK activity boundaries  
+**Primary Dependencies**: Pydantic v2, SQLAlchemy async session fixtures, Temporal activity wrappers, existing agent-skill resolver/materializer services  
+**Storage**: Existing agent skill tables and artifact-backed version content; no new persistent tables planned  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py` for iteration; final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration checks when Docker is available; no provider verification required  
+**Target Platform**: MoonMind API service, Temporal worker activity runtime, managed runtime workspace preparation  
+**Project Type**: Python web service and Temporal workflow system  
+**Performance Goals**: Skill resolution remains deterministic and proportional to the number of candidate skill directories and deployment skill records; no additional network calls are introduced for repo/local policy gating  
+**Constraints**: Runtime mode; no raw credentials; no mutation of checked-in skill folders during materialization; large skill content stays out of workflow history; unsupported policy states fail closed rather than silently enabling untrusted sources; preserve MM-405 traceability  
+**Scale/Scope**: One agent-skill source-policy slice covering catalog contracts, immutable versions, source precedence, repo/local policy gates, and runtime materialization boundaries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The work keeps agent skills as adapter/materialization inputs and does not build a new cognitive engine.
+- **II. One-Click Agent Deployment**: PASS. No new required service, external dependency, or secret is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. The source-policy model is runtime-neutral and not provider-specific.
+- **IV. Own Your Data**: PASS. Skill catalog and resolved snapshots remain operator-controlled data/artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. This story strengthens skill contracts, source provenance, and policy gates.
+- **VI. Replaceability and Scientific Method**: PASS. The plan is test-first and narrows work to the missing policy behavior.
+- **VII. Runtime Configurability**: PASS. Policy gating is explicit input/config state, not hardcoded trust in repo content.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay in agent-skill resolver/service/activity boundaries.
+- **IX. Resilient by Default**: PASS. Denied or unsupported source policy fails closed for untrusted repo/local sources.
+- **X. Facilitate Continuous Improvement**: PASS. Verification records MM-405 traceability and policy evidence.
+- **XI. Spec-Driven Development**: PASS. Implementation proceeds from this spec/plan/tasks sequence.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Volatile orchestration input remains under `docs/tmp/`; no canonical migration narrative is added.
+- **XIII. Pre-release Compatibility Policy**: PASS. No compatibility aliases or semantic fallbacks are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/206-agent-skill-catalog-source-policy/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── agent-skill-source-policy.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/schemas/agent_skill_models.py
+moonmind/services/skill_resolution.py
+moonmind/workflows/agent_skills/agent_skills_activities.py
+api_service/services/agent_skills_service.py
+api_service/db/models.py
+tests/unit/services/test_skill_resolution.py
+tests/unit/api/test_agent_skills_service.py
+tests/unit/services/test_skill_materialization.py
+docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Use the existing agent-skill schema, resolver, service, and materialization modules. No new package or persistent table is planned. Add or update focused unit tests around existing resolver/service boundaries, and use final verification to confirm already-covered behavior remains intact.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| None | N/A | N/A |
+
+## Phase 0: Research Summary
+
+Research classifies MM-405 as a runtime feature. Existing code already implements the majority of the catalog and resolved-snapshot model. The repo policy gap is concrete: `SkillResolutionContext` has `allow_local_skills` but no equivalent explicit `allow_repo_skills`, while `RepoSkillLoader` loads `.agents/skills` whenever `workspace_root` is present. Implementation should add explicit repo-source policy and tests without changing the existing source precedence order when repo sources are allowed.
+
+## Phase 1: Design Artifact Summary
+
+- `research.md`: documents requirement status, repo evidence, and the missing repo-source policy gate.
+- `data-model.md`: records existing agent-skill entities and the added policy field semantics.
+- `contracts/agent-skill-source-policy.md`: defines resolver input/output behavior and policy decisions.
+- `quickstart.md`: defines test-first unit checks, final unit suite, integration command, and traceability checks.
+
+## Post-Design Constitution Re-Check
+
+PASS. The design artifacts preserve runtime mode, keep skill content out of workflow history, keep `.agents/skills` as runtime-visible active input only after resolution/materialization, and add explicit fail-closed policy handling for repo/local sources.
+
+## Managed Setup Note
+
+The active managed runtime branch is `mm-405-759fbff4`, which does not match the numbered feature directory. Use `SPECIFY_FEATURE=206-agent-skill-catalog-source-policy` when running Moon Spec helper scripts so they resolve this feature deterministically.

--- a/specs/206-agent-skill-catalog-source-policy/quickstart.md
+++ b/specs/206-agent-skill-catalog-source-policy/quickstart.md
@@ -1,0 +1,64 @@
+# Quickstart: Agent Skill Catalog and Source Policy
+
+## Focused Test-First Loop
+
+1. Add failing resolver tests for repo source policy:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py
+```
+
+Required failing coverage before implementation:
+- Repo skill candidates are excluded when repo sources are policy-denied.
+- Repo skill candidates participate in precedence when repo sources are policy-allowed.
+- Policy summary reports repo and local source decisions.
+
+2. Add or update focused service test coverage for immutable versions:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_agent_skills_service.py
+```
+
+Required coverage:
+- Creating a second version preserves the first version row and artifact metadata.
+
+3. Implement the minimum source-policy changes:
+- Add explicit repo-source policy to the skill resolution context.
+- Make repo source loading return no active candidates when repo sources are denied.
+- Preserve existing local-source denial behavior.
+- Keep source precedence unchanged when repo and local sources are allowed.
+
+4. Re-run focused unit tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py
+```
+
+## Final Verification Commands
+
+Run the required unit suite:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+Run required hermetic integration checks when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+Run traceability check:
+
+```bash
+rg -n "MM-405|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-003|DESIGN-REQ-004" specs/206-agent-skill-catalog-source-policy docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md
+```
+
+## End-to-End Story Validation
+
+The story is complete when:
+- Contract and service tests prove agent-skill instruction bundle contracts remain distinct from executable tool and runtime command contracts.
+- Versioning tests prove a deployment-stored skill edit creates a new immutable version without mutating previous versions.
+- Resolver tests prove source precedence for allowed sources and source exclusion for denied repo/local sources.
+- Materialization tests prove runtime-visible skill data comes from the resolved snapshot and not checked-in folder mutation.
+- Final verification preserves MM-405 and the original Jira preset brief.

--- a/specs/206-agent-skill-catalog-source-policy/research.md
+++ b/specs/206-agent-skill-catalog-source-policy/research.md
@@ -1,0 +1,65 @@
+# Research: Agent Skill Catalog and Source Policy
+
+## Classification
+
+Decision: MM-405 is a single-story runtime feature request.
+Evidence: `specs/206-agent-skill-catalog-source-policy/spec.md`; `docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md`.
+Rationale: The brief has one operator story and one validation surface: distinguish agent-skill instruction bundles from executable tools, preserve immutable versions, and enforce source policy before resolution/materialization.
+Alternatives considered: Documentation-only alignment was rejected because the user selected runtime mode and the brief describes system behavior.
+Test implications: Unit and adapter-boundary verification are required.
+
+## FR-001 and FR-002
+
+Decision: implemented_verified.
+Evidence: `moonmind/schemas/agent_skill_models.py`; `docs/Tasks/SkillAndPlanContracts.md`; `moonmind/workflows/agent_skills/selection.py`.
+Rationale: Agent-skill models and tool/runtime command docs use distinct contract names and categories.
+Alternatives considered: Renaming existing contracts was rejected because the current names already express the intended separation.
+Test implications: None beyond final verification and traceability checks.
+
+## FR-003 and FR-004
+
+Decision: implemented_unverified.
+Evidence: `api_service/db/models.py` defines `AgentSkillDefinition` and `AgentSkillVersion`; `api_service/services/agent_skills_service.py` creates version rows and blocks duplicate version strings; `tests/unit/api/test_agent_skills_service.py` covers successful and duplicate version creation.
+Rationale: The insert-only version path exists, but the test suite should explicitly prove that creating a later version preserves the earlier version and exposes both versions.
+Alternatives considered: Treating duplicate-version coverage as sufficient was rejected because MM-405 specifically calls for edit/new-version immutability.
+Test implications: Add a focused unit test in `tests/unit/api/test_agent_skills_service.py`.
+
+## FR-005, FR-006, and FR-007
+
+Decision: implemented_verified.
+Evidence: `AgentSkillSourceKind` includes built-in, deployment, repo, and local; `AgentSkillResolver` merges sources in deterministic order; `tests/unit/services/test_skill_resolution.py` covers source loaders, precedence, deterministic sorting, and provenance source kind.
+Rationale: Existing resolver behavior satisfies allowed-source precedence and provenance for covered cases.
+Alternatives considered: Reworking precedence was rejected because the current order matches the canonical source policy.
+Test implications: No implementation required; optional hardening may add repo/local precedence coverage if nearby tests are edited.
+
+## FR-008, FR-009, FR-010, and DESIGN-REQ-004
+
+Decision: partial.
+Evidence: `SkillResolutionContext.allow_local_skills` gates local sources; `LocalSkillLoader` returns no candidates when local is disallowed; `RepoSkillLoader` loads repo skills whenever `workspace_root` exists and has no explicit allow/deny policy.
+Rationale: The story requires policy gates for repo and local-only sources before selection or materialization. Local is gated; repo is not.
+Alternatives considered: Treating `workspace_root` as implicit repo permission was rejected because repo skill content is potentially untrusted and must not silently affect runs.
+Test implications: Add failing resolver tests first for repo-denied exclusion and repo-allowed precedence, then update `SkillResolutionContext` and `RepoSkillLoader` to honor explicit repo policy.
+
+## FR-011 and SC-006
+
+Decision: implemented_verified.
+Evidence: `ResolvedSkillSet` carries immutable snapshot metadata; `moonmind/services/skill_materialization.py` writes to `.agents/skills_active`; `tests/unit/services/test_skill_materialization.py` verifies materialization does not write to `.agents/skills`.
+Rationale: Runtime materialization already uses a resolved snapshot directory instead of mutating checked-in skill folders.
+Alternatives considered: No materializer rewrite is needed.
+Test implications: Existing test remains final verification evidence.
+
+## FR-012 and SC-007
+
+Decision: implemented_verified.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md`; `specs/206-agent-skill-catalog-source-policy/spec.md`.
+Rationale: MM-405 and the original Jira brief are preserved in the source artifact and spec.
+Alternatives considered: None.
+Test implications: Add traceability checks in quickstart/tasks and final verification.
+
+## Test Strategy
+
+Decision: Use focused unit tests for resolver/service behavior, then the full unit suite for final verification.
+Evidence: Existing test taxonomy in AGENTS instructions and local tests under `tests/unit/services/`, `tests/unit/api/`, and `tests/unit/workflows/agent_skills/`.
+Rationale: The required changes are hermetic Python logic and service behavior. Integration CI remains relevant for final regression confidence when Docker is available.
+Alternatives considered: Provider verification is unnecessary because this story has no external provider dependency.
+Test implications: Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` before finalizing.

--- a/specs/206-agent-skill-catalog-source-policy/spec.md
+++ b/specs/206-agent-skill-catalog-source-policy/spec.md
@@ -1,0 +1,220 @@
+# Feature Specification: Agent Skill Catalog and Source Policy
+
+**Feature Branch**: `206-agent-skill-catalog-source-policy`  
+**Created**: 2026-04-18  
+**Status**: Draft  
+**Input**: User description:
+
+```text
+Jira issue: MM-405 from MM project
+Summary: Agent Skill Catalog and Source Policy
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-405 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-405: Agent Skill Catalog and Source Policy
+
+Source Reference
+- Source Document: docs/Tasks/AgentSkillSystem.md
+- Original Jira Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §1-§7
+  - AgentSkillSystem §9
+  - AgentSkillSystem §17
+  - SkillAndPlanContracts §1.1
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+
+User Story
+As a MoonMind operator, I can rely on agent skills being modeled as deployment-scoped, versioned instruction data with explicit source precedence and policy gates, so managed runs do not confuse instruction bundles with executable tools or silently trust repo-local content.
+
+Acceptance Criteria
+- Given executable tools and agent instruction bundles share the historical word skill, when contracts are validated, then ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet remain typed separately.
+- Given a deployment-stored skill is edited, when the change is saved, then a new immutable version is created instead of mutating the previous version.
+- Given built-in, deployment, repo, and local-only candidates exist, when policy allows them, then deterministic precedence selects the winner and records source provenance.
+- Given policy forbids repo or local-only skills, when those sources contain candidates, then they are excluded before precedence is applied and cannot silently affect the run.
+
+Requirements
+- Define or preserve concrete AgentSkillDefinition, AgentSkillVersion, SkillSet, and SkillSetEntry contracts with source kind and version metadata.
+- Keep executable ToolDefinition and runtime-native command contracts separate from agent-skill instruction bundles in validation and docs.
+- Apply deployment policy gates to repo and local-only skill sources before selection or materialization.
+- Treat repo-provided and local-only skill content as potentially untrusted input.
+- Preserve MM-405 in all downstream MoonSpec artifacts, verification output, commit text, and pull request metadata.
+
+Relevant Implementation Notes
+- The canonical agent-skill design lives in `docs/Tasks/AgentSkillSystem.md`; executable tool contracts live separately in `docs/Tasks/SkillAndPlanContracts.md`.
+- Agent skills are reusable instruction bundles and are not executable Temporal tools.
+- ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet should remain typed separately at validation and API boundaries.
+- Built-in, deployment-stored, repo-checked-in, and local-only skill candidates should be handled as distinct sources with explicit provenance.
+- Deployment policy should gate repo and local-only sources before selection, resolution, or materialization.
+- Runtime-visible `.agents/skills` should represent the active resolved skill set for a run, while `.agents/skills/local` remains a local-only overlay input.
+- Resolved skill sets should be immutable per run or step, and workflows should carry refs to snapshots rather than large skill bodies.
+- Runtime adapters own materialization of the resolved skill snapshot for each target runtime.
+- Checked-in skill folders should not be mutated in place during runtime setup.
+
+Verification
+- Verify executable tool contracts and agent-skill instruction-bundle contracts remain distinguishable in models, validation, tests, and docs touched by the change.
+- Verify deployment-backed skill edits create immutable versions rather than mutating previous versions.
+- Verify source precedence records provenance when built-in, deployment, repo, and local-only candidates are present.
+- Verify policy-denied repo and local-only skills are excluded before precedence is applied.
+- Verify trusted or untrusted skill source handling is covered at the workflow/activity or adapter boundary when runtime materialization is changed.
+- Preserve MM-405 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates MM-405 is blocked by MM-406.
+```
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-405 from MM project
+Summary: Agent Skill Catalog and Source Policy
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-405 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-405: Agent Skill Catalog and Source Policy
+
+Source Reference
+- Source Document: docs/Tasks/AgentSkillSystem.md
+- Original Jira Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §1-§7
+  - AgentSkillSystem §9
+  - AgentSkillSystem §17
+  - SkillAndPlanContracts §1.1
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+
+User Story
+As a MoonMind operator, I can rely on agent skills being modeled as deployment-scoped, versioned instruction data with explicit source precedence and policy gates, so managed runs do not confuse instruction bundles with executable tools or silently trust repo-local content.
+
+Acceptance Criteria
+- Given executable tools and agent instruction bundles share the historical word skill, when contracts are validated, then ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet remain typed separately.
+- Given a deployment-stored skill is edited, when the change is saved, then a new immutable version is created instead of mutating the previous version.
+- Given built-in, deployment, repo, and local-only candidates exist, when policy allows them, then deterministic precedence selects the winner and records source provenance.
+- Given policy forbids repo or local-only skills, when those sources contain candidates, then they are excluded before precedence is applied and cannot silently affect the run.
+
+Requirements
+- Define or preserve concrete AgentSkillDefinition, AgentSkillVersion, SkillSet, and SkillSetEntry contracts with source kind and version metadata.
+- Keep executable ToolDefinition and runtime-native command contracts separate from agent-skill instruction bundles in validation and docs.
+- Apply deployment policy gates to repo and local-only skill sources before selection or materialization.
+- Treat repo-provided and local-only skill content as potentially untrusted input.
+- Preserve MM-405 in all downstream MoonSpec artifacts, verification output, commit text, and pull request metadata.
+
+Relevant Implementation Notes
+- The canonical agent-skill design lives in `docs/Tasks/AgentSkillSystem.md`; executable tool contracts live separately in `docs/Tasks/SkillAndPlanContracts.md`.
+- Agent skills are reusable instruction bundles and are not executable Temporal tools.
+- ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet should remain typed separately at validation and API boundaries.
+- Built-in, deployment-stored, repo-checked-in, and local-only skill candidates should be handled as distinct sources with explicit provenance.
+- Deployment policy should gate repo and local-only sources before selection, resolution, or materialization.
+- Runtime-visible `.agents/skills` should represent the active resolved skill set for a run, while `.agents/skills/local` remains a local-only overlay input.
+- Resolved skill sets should be immutable per run or step, and workflows should carry refs to snapshots rather than large skill bodies.
+- Runtime adapters own materialization of the resolved skill snapshot for each target runtime.
+- Checked-in skill folders should not be mutated in place during runtime setup.
+
+Verification
+- Verify executable tool contracts and agent-skill instruction-bundle contracts remain distinguishable in models, validation, tests, and docs touched by the change.
+- Verify deployment-backed skill edits create immutable versions rather than mutating previous versions.
+- Verify source precedence records provenance when built-in, deployment, repo, and local-only candidates are present.
+- Verify policy-denied repo and local-only skills are excluded before precedence is applied.
+- Verify trusted or untrusted skill source handling is covered at the workflow/activity or adapter boundary when runtime materialization is changed.
+- Preserve MM-405 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates MM-405 is blocked by MM-406.
+
+<!-- Moon Spec specs contain exactly one independently testable user story. Use /speckit.breakdown for technical designs that contain multiple stories. -->
+
+## Classification
+
+Single-story runtime feature request. The brief defines one operator-facing behavior slice: agent-skill catalog and source-policy contracts must model instruction bundles separately from executable tools, preserve immutable versioned skill data, and enforce source precedence and policy gates.
+
+## User Story - Agent Skill Catalog and Source Policy
+
+**Summary**: As a MoonMind operator, I want agent skills modeled as deployment-scoped, versioned instruction data with explicit source precedence and policy gates so managed runs do not confuse instruction bundles with executable tools or silently trust repo-local content.
+
+**Goal**: Operators can trust that managed runs use clearly typed, policy-filtered, provenance-recorded agent-skill selections without mutating skill versions or treating instruction bundles as executable tools.
+
+**Independent Test**: Create or inspect skill catalog entries, skill-set selections, and mixed built-in, deployment, repo, and local-only candidates under both allowed and denied policy settings. The story passes when contracts keep executable tools, runtime commands, agent skills, skill sets, and resolved skill sets distinct; deployment-backed edits create immutable versions; allowed candidates resolve with source provenance; and denied repo or local-only sources cannot affect the resolved run input.
+
+**Acceptance Scenarios**:
+
+1. **Given** executable tools and agent instruction bundles both use the historical word skill, **when** contracts are validated, **then** ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet remain typed separately.
+2. **Given** a deployment-stored agent skill exists, **when** an operator saves an edit to it, **then** the system creates a new immutable version instead of mutating the previous version.
+3. **Given** built-in, deployment, repo, and local-only skill candidates exist and policy allows them, **when** skill selection is resolved, **then** deterministic precedence selects the winner and records source provenance.
+4. **Given** policy forbids repo or local-only skill sources, **when** those sources contain skill candidates, **then** they are excluded before precedence is applied and cannot silently affect the run.
+5. **Given** a run or step receives a resolved agent-skill set, **when** the runtime adapter materializes it, **then** the runtime-visible skill data comes from the resolved snapshot rather than mutating checked-in skill folders in place.
+
+### Edge Cases
+
+- A repo-checked-in skill has the same name as a deployment-stored skill.
+- A local-only skill is present while local-only sources are disabled by policy.
+- An existing run is retried after a newer deployment-backed skill version is created.
+- A runtime command is displayed near agent skills but must not be stored as an agent skill or resolved skill-set member.
+- A skill source contains untrusted or malformed metadata.
+
+## Assumptions
+
+- Runtime mode is required; this story must be validated through system behavior, not documentation-only edits.
+- The canonical runtime source requirements are `docs/Tasks/AgentSkillSystem.md` and `docs/Tasks/SkillAndPlanContracts.md`.
+- Existing checked-in repo skill folders and local-only overlays are valid inputs, not authoritative durable storage.
+- The Jira dependency note for MM-406 is preserved as source context but does not broaden this spec beyond MM-405's selected single story.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (Source: MM-405 brief, Acceptance Criteria; `docs/Tasks/AgentSkillSystem.md` sections 1-3; `docs/Tasks/SkillAndPlanContracts.md` section 1.1): Executable tools, runtime commands, agent skill definitions, skill sets, and resolved skill sets remain typed separately. Scope: in scope. Maps to FR-001 and FR-002.
+- **DESIGN-REQ-002** (Source: MM-405 brief, Acceptance Criteria; `docs/Tasks/AgentSkillSystem.md` sections 2, 4, and 6): Deployment-stored agent skills are versioned, and edits create new immutable versions rather than mutating previous versions. Scope: in scope. Maps to FR-003 and FR-004.
+- **DESIGN-REQ-003** (Source: MM-405 brief, Acceptance Criteria; `docs/Tasks/AgentSkillSystem.md` sections 2, 5, and 6): Built-in, deployment, repo, and local-only skill candidates resolve through deterministic precedence and record source provenance when policy allows them. Scope: in scope. Maps to FR-005, FR-006, and FR-007.
+- **DESIGN-REQ-004** (Source: MM-405 brief, Acceptance Criteria and Requirements; `docs/Tasks/AgentSkillSystem.md` sections 5 and 7): Policy gates exclude forbidden repo and local-only skill sources before selection or materialization, and repo/local skill content is treated as potentially untrusted. Scope: in scope. Maps to FR-008, FR-009, and FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST represent executable ToolDefinition contracts separately from agent instruction bundle contracts.
+- **FR-002**: System MUST represent runtime-native commands separately from AgentSkillDefinition, SkillSet, and ResolvedSkillSet entries.
+- **FR-003**: System MUST represent deployment-stored agent skills with stable definition identity and version metadata.
+- **FR-004**: System MUST create a new immutable version when a deployment-stored agent skill is edited, preserving previous versions unchanged.
+- **FR-005**: System MUST support built-in, deployment-stored, repo-checked-in, and local-only agent-skill source kinds as distinct candidate sources.
+- **FR-006**: System MUST apply deterministic source precedence when multiple allowed candidates match the same skill selection.
+- **FR-007**: System MUST record source kind and selected version provenance for resolved agent-skill entries.
+- **FR-008**: System MUST apply deployment policy gates to repo and local-only skill sources before selection, resolution, or materialization.
+- **FR-009**: System MUST exclude policy-denied repo or local-only skill candidates from resolved skill sets.
+- **FR-010**: System MUST treat repo-provided and local-only skill content as untrusted input during validation and materialization.
+- **FR-011**: System MUST expose a resolved agent-skill set for a run or step as an immutable snapshot or reference, not as mutable checked-in source content.
+- **FR-012**: System MUST preserve MM-405 and the original Jira preset brief in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **AgentSkillDefinition**: A reusable instruction-bundle definition with identity, source kind, metadata, and version history.
+- **AgentSkillVersion**: An immutable version of a deployment-stored agent skill.
+- **SkillSet**: A named collection of agent-skill selections or rules.
+- **SkillSetEntry**: A member or selector inside a skill set, including source and version targeting information where applicable.
+- **ResolvedSkillSet**: The immutable, exact run or step skill selection after policy gates and precedence resolution.
+- **Source Policy**: The rules that allow or deny skill sources before selection, resolution, and materialization.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Contract validation distinguishes ToolDefinition, runtime command, AgentSkillDefinition, SkillSet, and ResolvedSkillSet in 100% of covered contract cases.
+- **SC-002**: Editing a deployment-stored agent skill preserves 100% of previously existing versions and creates a distinct new version.
+- **SC-003**: Source precedence verification resolves 100% of mixed built-in, deployment, repo, and local-only candidate cases to the expected candidate when all relevant sources are policy-allowed.
+- **SC-004**: Policy verification excludes 100% of repo and local-only candidates when those source kinds are denied.
+- **SC-005**: Provenance verification records source kind and selected version metadata for 100% of resolved skill-set entries in covered cases.
+- **SC-006**: Runtime materialization verification confirms resolved skill snapshots are exposed without mutating checked-in skill folders in 100% of covered adapter-boundary cases.
+- **SC-007**: Verification evidence preserves MM-405 and the original Jira preset brief as the source for the feature.

--- a/specs/206-agent-skill-catalog-source-policy/tasks.md
+++ b/specs/206-agent-skill-catalog-source-policy/tasks.md
@@ -1,0 +1,166 @@
+# Tasks: Agent Skill Catalog and Source Policy
+
+**Input**: Design documents from `specs/206-agent-skill-catalog-source-policy/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/agent-skill-source-policy.md, quickstart.md
+
+**Tests**: Unit tests and boundary/integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-405 story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: Coverage includes FR-001 through FR-012, acceptance scenarios 1-5, edge cases, SC-001 through SC-007, and DESIGN-REQ-001 through DESIGN-REQ-004 from `spec.md`.
+
+**Requirement Status Summary**: FR-008, FR-009, FR-010, DESIGN-REQ-004, and SC-004 require code-and-test work. FR-004, DESIGN-REQ-002, and SC-002 require verification tests with conditional fallback only if existing behavior fails. FR-001, FR-002, FR-003, FR-005, FR-006, FR-007, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-003, SC-001, SC-003, SC-005, SC-006, and SC-007 are already implemented or verified and remain covered by final validation.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py`
+- Integration tests: `./tools/test_integration.sh` when Docker is available
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing feature structure and test surfaces before touching behavior.
+
+- [X] T001 Confirm feature artifacts are present in `specs/206-agent-skill-catalog-source-policy/spec.md`, `specs/206-agent-skill-catalog-source-policy/plan.md`, `specs/206-agent-skill-catalog-source-policy/research.md`, `specs/206-agent-skill-catalog-source-policy/data-model.md`, `specs/206-agent-skill-catalog-source-policy/contracts/agent-skill-source-policy.md`, and `specs/206-agent-skill-catalog-source-policy/quickstart.md` for MM-405 traceability.
+- [X] T002 Inspect existing agent-skill resolver, service, materializer, and activity test files in `moonmind/services/skill_resolution.py`, `api_service/services/agent_skills_service.py`, `moonmind/services/skill_materialization.py`, `moonmind/workflows/agent_skills/agent_skills_activities.py`, `tests/unit/services/test_skill_resolution.py`, `tests/unit/api/test_agent_skills_service.py`, `tests/unit/services/test_skill_materialization.py`, and `tests/unit/workflows/agent_skills/test_agent_skills_activities.py`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the exact existing behavior and policy gap before story tests and implementation.
+
+**CRITICAL**: No production implementation work can begin until this phase is complete.
+
+- [X] T003 Map current resolver policy inputs in `moonmind/services/skill_resolution.py` against `specs/206-agent-skill-catalog-source-policy/contracts/agent-skill-source-policy.md` for FR-008, FR-009, FR-010, and DESIGN-REQ-004.
+- [X] T004 Confirm existing immutable version and materialization evidence in `tests/unit/api/test_agent_skills_service.py` and `tests/unit/services/test_skill_materialization.py` for FR-004, FR-011, DESIGN-REQ-002, and SC-006.
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Agent Skill Catalog and Source Policy
+
+**Summary**: As a MoonMind operator, I want agent skills modeled as deployment-scoped, versioned instruction data with explicit source precedence and policy gates so managed runs do not confuse instruction bundles with executable tools or silently trust repo-local content.
+
+**Independent Test**: Resolve agent-skill selections with mixed built-in, deployment, repo, and local candidates under allowed and denied policies, then verify the output contains only policy-allowed entries with provenance and immutable snapshot behavior.
+
+**Traceability**: FR-001 through FR-012, acceptance scenarios 1-5, edge cases, SC-001 through SC-007, DESIGN-REQ-001 through DESIGN-REQ-004, MM-405.
+
+**Test Plan**:
+
+- Unit: resolver source policy gates, source precedence, immutable version preservation, materialization snapshot path.
+- Boundary/Integration: activity-level resolution preserves policy decisions and produces compact resolved snapshots; final hermetic integration suite runs when Docker is available.
+
+### Unit Tests (write first)
+
+> NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T005 [P] Add failing unit test proving repo skill candidates are excluded when repo sources are policy-denied in `tests/unit/services/test_skill_resolution.py` covering FR-008, FR-009, FR-010, SC-004, and DESIGN-REQ-004.
+- [X] T006 [P] Add failing unit test proving repo skill candidates participate in precedence when repo sources are policy-allowed in `tests/unit/services/test_skill_resolution.py` covering FR-005, FR-006, FR-007, SC-003, SC-005, and DESIGN-REQ-003.
+- [X] T007 [P] Add failing unit test proving resolver policy summary reports repo and local source policy decisions in `tests/unit/services/test_skill_resolution.py` covering FR-007, FR-008, FR-009, and DESIGN-REQ-004.
+- [X] T008 [P] Add verification unit test proving creating a later deployment skill version preserves the earlier version row and artifact metadata in `tests/unit/api/test_agent_skills_service.py` covering FR-004, SC-002, and DESIGN-REQ-002.
+- [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py` and confirm T005-T007 fail for missing repo policy behavior while T008 either passes or identifies a real immutability gap.
+
+### Boundary and Integration Tests (write first)
+
+- [X] T010 [P] Add failing activity-boundary test proving `agent_skill.resolve` carries repo/local policy into `ResolvedSkillSet.policy_summary` in `tests/unit/workflows/agent_skills/test_agent_skills_activities.py` covering acceptance scenarios 3-5, FR-008, FR-009, FR-010, and DESIGN-REQ-004.
+- [X] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/agent_skills/test_agent_skills_activities.py` and confirm T010 fails for the expected missing policy propagation reason before production implementation.
+
+### Implementation
+
+- [X] T012 Add explicit repo-source policy input to `SkillResolutionContext` in `moonmind/services/skill_resolution.py` covering FR-008, FR-009, FR-010, and DESIGN-REQ-004.
+- [X] T013 Update `RepoSkillLoader` in `moonmind/services/skill_resolution.py` so repo candidates are not loaded when repo sources are denied, while preserving existing allowed-source precedence for FR-005, FR-006, FR-008, FR-009, and SC-004.
+- [X] T014 Update resolver `policy_summary` in `moonmind/services/skill_resolution.py` to record repo and local source policy decisions for FR-007, FR-008, FR-009, and SC-005.
+- [X] T015 Update `AgentSkillsActivities.resolve_skills` in `moonmind/workflows/agent_skills/agent_skills_activities.py` to pass explicit repo/local policy into `SkillResolutionContext` without embedding large skill content in workflow history, covering FR-008, FR-010, FR-011, and DESIGN-REQ-004.
+- [X] T016 Conditional fallback: if T008 exposes an immutability gap, update `api_service/services/agent_skills_service.py` so creating a new version preserves previous AgentSkillVersion rows and artifact metadata for FR-004 and DESIGN-REQ-002.
+- [X] T017 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py` and fix only MM-405-scoped failures.
+
+### Story Validation
+
+- [X] T018 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py` to validate FR-001 through FR-012, SC-001 through SC-007, and DESIGN-REQ-001 through DESIGN-REQ-004.
+- [X] T019 Run `rg -n "MM-405|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-003|DESIGN-REQ-004" specs/206-agent-skill-catalog-source-policy docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md` to validate source traceability for FR-012 and SC-007.
+
+**Checkpoint**: The story is fully functional, covered by focused tests and traceability checks, and testable independently.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without changing its core scope.
+
+- [X] T020 Review `docs/Tasks/AgentSkillSystem.md` and `docs/Tasks/SkillAndPlanContracts.md` for consistency with implemented MM-405 behavior; update only if the runtime behavior reveals a mismatch, covering FR-001, FR-002, DESIGN-REQ-001, and DESIGN-REQ-004.
+- [X] T021 Run final unit suite `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and fix only MM-405-scoped failures.
+- [X] T022 Run required hermetic integration suite `./tools/test_integration.sh` when Docker is available; if unavailable, record the exact Docker availability blocker in `specs/206-agent-skill-catalog-source-policy/verification.md`.
+- [X] T023 Run `/speckit.verify` against `specs/206-agent-skill-catalog-source-policy/spec.md` after implementation and tests pass, then record the final verdict and evidence in `specs/206-agent-skill-catalog-source-policy/verification.md`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story work.
+- **Story (Phase 3)**: Depends on Foundational completion.
+- **Polish (Phase 4)**: Depends on the story being functionally complete and tests passing.
+
+### Within The Story
+
+- T005-T008 must be written before T009.
+- T009 and T011 red-first confirmations must complete before T012-T016.
+- T012-T015 implement the missing repo policy behavior and activity-boundary propagation.
+- T016 runs only if T008 exposes a real immutability gap.
+- T017-T019 validate the story before Phase 4.
+
+### Parallel Opportunities
+
+- T005, T006, T007, and T008 can be authored in parallel if contributors coordinate changes to `tests/unit/services/test_skill_resolution.py`.
+- T010 can be authored in parallel with T005-T008 because it touches `tests/unit/workflows/agent_skills/test_agent_skills_activities.py`.
+- T020 can run after story validation and does not block T021 unless it changes documentation.
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch independent test authoring together:
+Task: "Add repo policy resolver tests in tests/unit/services/test_skill_resolution.py"
+Task: "Add activity-boundary policy test in tests/unit/workflows/agent_skills/test_agent_skills_activities.py"
+Task: "Add immutable version preservation test in tests/unit/api/test_agent_skills_service.py"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete Phase 1 and Phase 2 inspection.
+2. Write resolver and service tests first.
+3. Confirm repo policy tests fail for the expected missing behavior.
+4. Add explicit repo-source policy to resolver context and repo loader behavior.
+5. Propagate policy through the activity boundary.
+6. Re-run focused tests until they pass.
+7. Run final unit, integration when available, traceability, and `/speckit.verify`.
+
+### Requirement Status Handling
+
+- Code-and-test work: FR-008, FR-009, FR-010, DESIGN-REQ-004, SC-004.
+- Verification-only with conditional fallback: FR-004, DESIGN-REQ-002, SC-002.
+- Already verified, preserved by final validation: FR-001, FR-002, FR-003, FR-005, FR-006, FR-007, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-003, SC-001, SC-003, SC-005, SC-006, SC-007.
+
+---
+
+## Notes
+
+- This task list covers exactly one story: MM-405 Agent Skill Catalog and Source Policy.
+- Preserve MM-405 in implementation notes, verification output, commit text, and pull request metadata.
+- Do not add compatibility aliases or hidden fallbacks for source policy decisions.
+- Do not mutate checked-in `.agents/skills` folders during runtime materialization.

--- a/specs/206-agent-skill-catalog-source-policy/tasks.md
+++ b/specs/206-agent-skill-catalog-source-policy/tasks.md
@@ -15,7 +15,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py`
 - Integration tests: `./tools/test_integration.sh` when Docker is available
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -98,7 +98,7 @@
 - [X] T020 Review `docs/Tasks/AgentSkillSystem.md` and `docs/Tasks/SkillAndPlanContracts.md` for consistency with implemented MM-405 behavior; update only if the runtime behavior reveals a mismatch, covering FR-001, FR-002, DESIGN-REQ-001, and DESIGN-REQ-004.
 - [X] T021 Run final unit suite `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` and fix only MM-405-scoped failures.
 - [X] T022 Run required hermetic integration suite `./tools/test_integration.sh` when Docker is available; if unavailable, record the exact Docker availability blocker in `specs/206-agent-skill-catalog-source-policy/verification.md`.
-- [X] T023 Run `/speckit.verify` against `specs/206-agent-skill-catalog-source-policy/spec.md` after implementation and tests pass, then record the final verdict and evidence in `specs/206-agent-skill-catalog-source-policy/verification.md`.
+- [X] T023 Run `/moonspec-verify` against `specs/206-agent-skill-catalog-source-policy/spec.md` after implementation and tests pass, then record the final verdict and evidence in `specs/206-agent-skill-catalog-source-policy/verification.md`.
 
 ---
 
@@ -148,7 +148,7 @@ Task: "Add immutable version preservation test in tests/unit/api/test_agent_skil
 4. Add explicit repo-source policy to resolver context and repo loader behavior.
 5. Propagate policy through the activity boundary.
 6. Re-run focused tests until they pass.
-7. Run final unit, integration when available, traceability, and `/speckit.verify`.
+7. Run final unit, integration when available, traceability, and `/moonspec-verify`.
 
 ### Requirement Status Handling
 

--- a/specs/206-agent-skill-catalog-source-policy/verification.md
+++ b/specs/206-agent-skill-catalog-source-policy/verification.md
@@ -1,0 +1,75 @@
+# MoonSpec Verification Report
+
+**Feature**: Agent Skill Catalog and Source Policy  
+**Spec**: `/work/agent_jobs/mm:61d42f2c-add6-4b41-bc47-3287d3b88ad1/repo/specs/206-agent-skill-catalog-source-policy/spec.md`  
+**Original Request Source**: `spec.md` Input and `docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md`  
+**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Confidence**: MEDIUM
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Red-first focused unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py` | PASS after implementation | First run failed with missing `allow_repo_skills` context/activity support; second focused run passed with 29 tests. |
+| Focused unit plus materialization | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py` | PASS | 29 focused Python tests passed; the runner also executed frontend tests as part of its normal flow. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3584 Python tests passed, 1 xpassed, 16 subtests passed; frontend suite passed with 10 files and 286 tests. |
+| Integration | `./tools/test_integration.sh` | NOT RUN | Blocked by missing Docker socket: `unix:///var/run/docker.sock` was unavailable in this managed container. |
+| Traceability | `rg -n "MM-405|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-003|DESIGN-REQ-004" specs/206-agent-skill-catalog-source-policy docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md` | PASS | MM-405 and all in-scope source design IDs are preserved. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/schemas/agent_skill_models.py`; `docs/Tasks/SkillAndPlanContracts.md` | VERIFIED | Executable tools and agent instruction bundles remain separate contracts. |
+| FR-002 | `docs/Tasks/SkillAndPlanContracts.md`; `moonmind/workflows/agent_skills/selection.py` | VERIFIED | Runtime commands remain separate from AgentSkillDefinition, SkillSet, and ResolvedSkillSet. |
+| FR-003 | `api_service/db/models.py`; `api_service/services/agent_skills_service.py` | VERIFIED | Deployment-stored skill definitions and version rows exist. |
+| FR-004 | `tests/unit/api/test_agent_skills_service.py:116`; full unit PASS | VERIFIED | Second-version test proves earlier version row and metadata are preserved. |
+| FR-005 | `moonmind/schemas/agent_skill_models.py`; `moonmind/services/skill_resolution.py` | VERIFIED | Built-in, deployment, repo, and local source kinds are represented. |
+| FR-006 | `tests/unit/services/test_skill_resolution.py` existing precedence tests; focused PASS | VERIFIED | Source precedence remains deterministic when sources are allowed. |
+| FR-007 | `moonmind/services/skill_resolution.py:263`; `tests/unit/services/test_skill_resolution.py:219` | VERIFIED | Resolved entries and policy summary record source/policy provenance. |
+| FR-008 | `moonmind/services/skill_resolution.py:29`; `moonmind/services/skill_resolution.py:153`; `tests/unit/services/test_skill_resolution.py:177` | VERIFIED | Repo source policy gate is explicit and denies repo candidates before selection. |
+| FR-009 | `tests/unit/services/test_skill_resolution.py:177`; focused PASS | VERIFIED | Policy-denied repo candidates are excluded from resolved output. |
+| FR-010 | `moonmind/services/skill_resolution.py:153`; `moonmind/workflows/agent_skills/agent_skills_activities.py:43`; `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:44` | VERIFIED | Untrusted repo/local source policy is carried through resolver and activity boundary. |
+| FR-011 | `tests/unit/services/test_skill_materialization.py:18`; full unit PASS | VERIFIED | Materialization writes to active snapshot path and not checked-in `.agents/skills`. |
+| FR-012 | Traceability command PASS | VERIFIED | MM-405 and the original Jira brief are preserved in MoonSpec artifacts. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Scenario 1 | Contract/model docs and full unit PASS | VERIFIED | Contract types remain separate. |
+| Scenario 2 | `tests/unit/api/test_agent_skills_service.py:116` | VERIFIED | New version creation preserves existing versions. |
+| Scenario 3 | `tests/unit/services/test_skill_resolution.py:197` and existing precedence tests | VERIFIED | Allowed repo candidates participate in resolution and provenance. |
+| Scenario 4 | `tests/unit/services/test_skill_resolution.py:177` | VERIFIED | Denied repo candidates do not affect resolved output. |
+| Scenario 5 | `moonmind/workflows/agent_skills/agent_skills_activities.py:43`; `tests/unit/services/test_skill_materialization.py:18` | VERIFIED | Runtime boundary receives resolved policy context and materialization uses active snapshot path. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Tasks/SkillAndPlanContracts.md`; schema separation | VERIFIED | Tool, runtime command, and agent-skill contracts remain typed separately. |
+| DESIGN-REQ-002 | `tests/unit/api/test_agent_skills_service.py:116` | VERIFIED | Deployment-stored skill versions are insert-only and preserved. |
+| DESIGN-REQ-003 | resolver precedence/provenance tests | VERIFIED | Allowed source precedence and provenance are covered. |
+| DESIGN-REQ-004 | `moonmind/services/skill_resolution.py:153`; `tests/unit/services/test_skill_resolution.py:177`; `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:44` | VERIFIED | Repo/local policy gates are enforced before active resolution output. |
+| Constitution XI | Spec, plan, tasks, and verification artifacts under `specs/206-agent-skill-catalog-source-policy/` | VERIFIED | Work proceeded from MoonSpec artifacts. |
+| Agent Skill System Coverage | Activity-boundary test in `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:44` | VERIFIED | Adapter/activity-boundary policy propagation is covered. |
+
+## Original Request Alignment
+
+- PASS: The implementation uses the MM-405 Jira brief as the canonical MoonSpec input.
+- PASS: Runtime mode was used; docs-only mode was not selected.
+- PASS: The input was classified as a single-story feature request.
+- PASS: Existing artifacts were inspected before creating new numbered artifacts; no prior MM-405 feature directory existed.
+- PASS: Repo/local skill sources are now explicitly policy-gated rather than silently trusted.
+
+## Gaps
+
+- Hermetic integration CI evidence is unavailable in this environment because Docker is not available at `/var/run/docker.sock`.
+
+## Remaining Work
+
+- Re-run `./tools/test_integration.sh` in an environment with Docker access and record the result.
+
+## Decision
+
+- Implementation and unit/boundary evidence satisfy MM-405, but the final MoonSpec verdict remains `ADDITIONAL_WORK_NEEDED` until required hermetic integration evidence can be collected.

--- a/tests/unit/api/test_agent_skills_service.py
+++ b/tests/unit/api/test_agent_skills_service.py
@@ -114,6 +114,41 @@ async def test_create_version_success(tmp_path, mock_artifact_service: AsyncMock
 
 
 @pytest.mark.asyncio
+async def test_create_second_version_preserves_first_version(
+    tmp_path, mock_artifact_service: AsyncMock
+):
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as db_session:
+            svc = AgentSkillsService(
+                session=db_session, artifact_service=mock_artifact_service
+            )
+            await svc.create_skill(slug="versioned-skill", title="Versioned")
+
+            first = await svc.create_version(
+                skill_slug="versioned-skill",
+                version_string="1.0.0",
+                content="first markdown content",
+            )
+            second = await svc.create_version(
+                skill_slug="versioned-skill",
+                version_string="1.1.0",
+                content="second markdown content",
+            )
+
+            fetched = await svc.require_skill("versioned-skill")
+
+            assert first.id != second.id
+            assert [version.version_string for version in fetched.versions] == [
+                "1.0.0",
+                "1.1.0",
+            ]
+            assert fetched.versions[0].artifact_ref == first.artifact_ref
+            assert fetched.versions[0].content_digest == first.content_digest
+            assert fetched.versions[1].artifact_ref == second.artifact_ref
+            assert fetched.versions[1].content_digest == second.content_digest
+
+
+@pytest.mark.asyncio
 async def test_create_version_duplicate(tmp_path, mock_artifact_service: AsyncMock):
     async with template_db(tmp_path) as session_maker:
         async with session_maker() as db_session:

--- a/tests/unit/services/test_skill_resolution.py
+++ b/tests/unit/services/test_skill_resolution.py
@@ -125,6 +125,7 @@ async def test_resolver_resolves_repo_skills_when_workspace_provided():
     context = SkillResolutionContext(
         snapshot_id="snap-123",
         workspace_root="/tmp/workspace",
+        allow_repo_skills=True,
         allow_local_skills=False
     )
     selector = SkillSelector(
@@ -173,6 +174,63 @@ async def test_resolver_ignores_repo_skills_when_no_workspace():
     assert len(result.skills) == 0
 
 
+async def test_resolver_filters_repo_skills_when_not_allowed(tmp_path):
+    skills_dir = tmp_path / ".agents" / "skills"
+    skill_dir = skills_dir / "repo_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Repo Skill\n", encoding="utf-8")
+
+    resolver = AgentSkillResolver(loaders=[RepoSkillLoader()])
+    context = SkillResolutionContext(
+        snapshot_id="snap-123",
+        workspace_root=str(tmp_path),
+        allow_repo_skills=False,
+    )
+    selector = SkillSelector(include=[{"name": "repo_skill"}])
+
+    result = await resolver.resolve(selector, context)
+
+    assert result.skills == []
+    assert result.policy_summary["repo_skills_allowed"] is False
+
+
+async def test_resolver_resolves_repo_skills_when_allowed(tmp_path):
+    skills_dir = tmp_path / ".agents" / "skills"
+    skill_dir = skills_dir / "repo_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Repo Skill\n", encoding="utf-8")
+
+    resolver = AgentSkillResolver(loaders=[RepoSkillLoader()])
+    context = SkillResolutionContext(
+        snapshot_id="snap-123",
+        workspace_root=str(tmp_path),
+        allow_repo_skills=True,
+    )
+    selector = SkillSelector(include=[{"name": "repo_skill"}])
+
+    result = await resolver.resolve(selector, context)
+
+    assert len(result.skills) == 1
+    assert result.skills[0].skill_name == "repo_skill"
+    assert result.skills[0].provenance.source_kind == AgentSkillSourceKind.REPO
+    assert result.policy_summary["repo_skills_allowed"] is True
+
+
+async def test_resolver_policy_summary_reports_repo_and_local_policy():
+    resolver = AgentSkillResolver(loaders=[])
+    context = SkillResolutionContext(
+        snapshot_id="snap-123",
+        allow_repo_skills=False,
+        allow_local_skills=True,
+    )
+    selector = SkillSelector(include=[])
+
+    result = await resolver.resolve(selector, context)
+
+    assert result.policy_summary["repo_skills_allowed"] is False
+    assert result.policy_summary["local_skills_allowed"] is True
+
+
 async def test_repo_skill_loader_scans_fs(tmp_path):
     loader = RepoSkillLoader()
     skills_dir = tmp_path / ".agents" / "skills"
@@ -190,7 +248,11 @@ async def test_repo_skill_loader_scans_fs(tmp_path):
     skill3 = skills_dir / "not_a_skill"
     skill3.mkdir(parents=True)
     
-    context = SkillResolutionContext(snapshot_id="snap", workspace_root=str(tmp_path))
+    context = SkillResolutionContext(
+        snapshot_id="snap",
+        workspace_root=str(tmp_path),
+        allow_repo_skills=True,
+    )
     selector = SkillSelector(include=[{"name": "skill1"}])
     
     results = await loader.load_skills(selector, context)
@@ -208,7 +270,12 @@ async def test_local_skill_loader_scans_fs(tmp_path):
     skill1.mkdir(parents=True)
     (skill1 / "SKILL.md").touch()
     
-    context = SkillResolutionContext(snapshot_id="snap", workspace_root=str(tmp_path), allow_local_skills=True)
+    context = SkillResolutionContext(
+        snapshot_id="snap",
+        workspace_root=str(tmp_path),
+        allow_repo_skills=True,
+        allow_local_skills=True,
+    )
     selector = SkillSelector(include=[])
     
     results = await loader.load_skills(selector, context)

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -24,7 +24,7 @@ async def test_resolve_skills_activity_returns_expected_payload():
     with patch("moonmind.workflows.agent_skills.agent_skills_activities.AgentSkillResolver.resolve") as mock_resolve:
         mock_resolve.return_value = ResolvedSkillSet(
             snapshot_id="skillset_test_abc123",
-            resolved_at=datetime.utcnow(),
+            resolved_at=datetime.now(UTC),
             skills=[
                 ResolvedSkillEntry(
                     skill_name="read_file",
@@ -39,6 +39,40 @@ async def test_resolve_skills_activity_returns_expected_payload():
     assert len(result.skills) == 1
     assert result.skills[0].skill_name == "read_file"
     assert result.skills[0].provenance.source_kind == AgentSkillSourceKind.BUILT_IN
+
+
+async def test_resolve_skills_activity_passes_repo_and_local_policy():
+    activities = AgentSkillsActivities()
+    env = ActivityEnvironment()
+
+    selector = SkillSelector(include=[{"name": "repo_skill"}])
+    with patch(
+        "moonmind.workflows.agent_skills.agent_skills_activities.AgentSkillResolver.resolve"
+    ) as mock_resolve:
+        mock_resolve.return_value = ResolvedSkillSet(
+            snapshot_id="skillset_test_abc123",
+            resolved_at=datetime.now(UTC),
+            skills=[],
+            policy_summary={
+                "repo_skills_allowed": False,
+                "local_skills_allowed": True,
+            },
+        )
+
+        result = await env.run(
+            activities.resolve_skills,
+            selector,
+            "run-1",
+            "/tmp/workspace",
+            True,
+            False,
+        )
+
+    context = mock_resolve.call_args.args[1]
+    assert context.allow_repo_skills is False
+    assert context.allow_local_skills is True
+    assert result.policy_summary["repo_skills_allowed"] is False
+    assert result.policy_summary["local_skills_allowed"] is True
 
 async def test_build_prompt_index_activity_returns_bundle():
     activities = AgentSkillsActivities()


### PR DESCRIPTION
## Jira

- Jira issue key: MM-405

## MoonSpec

- Active feature path: `specs/206-agent-skill-catalog-source-policy/`
- Verification verdict: `ADDITIONAL_WORK_NEEDED`

## Summary

Implements the MM-405 agent skill catalog/source policy slice by adding an explicit repo-skill source policy gate, preserving separate agent-skill and executable-tool contract boundaries, and adding tests for immutable deployment skill versions plus resolver/activity policy propagation.

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/api/test_agent_skills_service.py tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py` - PASS
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS
- `./tools/test_integration.sh` - NOT RUN; blocked by missing Docker socket `/var/run/docker.sock` in the managed container
- `git diff --check` - PASS
- `rg -n "MM-405|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-003|DESIGN-REQ-004" specs/206-agent-skill-catalog-source-policy docs/tmp/jira-orchestration-inputs/MM-405-moonspec-orchestration-input.md` - PASS

## Remaining Risks

- Hermetic integration coverage still needs to be run in an environment with Docker access.
- Jira link metadata collected during orchestration indicated MM-405 was blocked by MM-406 at fetch time; this PR preserves that context in the MoonSpec artifacts.