### PR TITLE
I believe the following document updates have already been made. Now update the UI to match:

### DIFF
--- a/api_service/api/routers/task_dashboard.py
+++ b/api_service/api/routers/task_dashboard.py
@@ -17,7 +17,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.base import get_async_session
-from api_service.api.routers.task_dashboard_view_model import build_runtime_config
+from api_service.api.routers.task_dashboard_view_model import (
+    build_repository_branch_options,
+    build_runtime_config,
+)
 from api_service.auth_providers import get_current_user
 from api_service.db.models import User
 from moonmind.config.settings import settings
@@ -99,6 +102,21 @@ class DashboardSkillListResponse(BaseModel):
     legacy_items: list[DashboardSkillOption] = Field(
         default_factory=list, alias="legacyItems"
     )
+
+
+class DashboardBranchOption(BaseModel):
+    """Serializable Git branch option exposed to dashboard clients."""
+
+    value: str = Field(description="Branch name")
+    label: str = Field(description="Display label")
+    source: str = Field(description="Branch option source")
+
+
+class DashboardBranchListResponse(BaseModel):
+    """Dashboard response containing branch options for one repository."""
+
+    items: list[DashboardBranchOption] = Field(default_factory=list)
+    error: str | None = Field(None)
 
 
 class DashboardTaskSourceResponse(BaseModel):
@@ -482,6 +500,17 @@ async def list_dashboard_skills(
         },
         legacyItems=legacy_items,
     )
+
+
+@router.get("/api/github/branches", response_model=DashboardBranchListResponse)
+async def list_dashboard_github_branches(
+    repository: str = Query(..., min_length=1),
+    _user: User = Depends(get_current_user()),
+) -> DashboardBranchListResponse:
+    """List GitHub branches through MoonMind so browsers never call GitHub directly."""
+
+    payload = build_repository_branch_options(repository)
+    return DashboardBranchListResponse(**payload)
 
 
 @router.post(

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -35,10 +35,14 @@ _SSH_GIT_RE = re.compile(
     r"([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git)?/?$"
 )
 _GITHUB_REPOSITORY_DISCOVERY_URL = "https://api.github.com/user/repos"
+_GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE = "https://api.github.com/repos/{repository}/branches"
 _GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS = 5.0
 _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS = 60.0
 _GITHUB_REPOSITORY_OPTIONS_CACHE: dict[
     str, tuple[float, tuple["RepositoryOption", ...], str | None]
+] = {}
+_GITHUB_BRANCH_OPTIONS_CACHE: dict[
+    str, tuple[float, tuple["BranchOption", ...], str | None]
 ] = {}
 
 _JIRA_CREATE_PAGE_SOURCES = {
@@ -77,6 +81,22 @@ _validate_jira_source_templates(_JIRA_CREATE_PAGE_SOURCES)
 @dataclass(frozen=True, slots=True)
 class RepositoryOption:
     """Browser-safe repository suggestion for the Create page."""
+
+    value: str
+    label: str
+    source: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {
+            "value": self.value,
+            "label": self.label,
+            "source": self.source,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BranchOption:
+    """Browser-safe branch suggestion for the Create page."""
 
     value: str
     label: str
@@ -190,8 +210,60 @@ def _fetch_github_repository_options(
     return options, None
 
 
+def _fetch_github_branch_options(
+    token: str,
+    repository: str,
+) -> tuple[list[BranchOption], str | None]:
+    """Fetch credential-visible GitHub branches without exposing secrets."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not token or not normalized_repository:
+        return [], None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        with httpx.Client(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            response = client.get(
+                _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
+                    repository=normalized_repository
+                ),
+                headers=headers,
+                params={"per_page": 100},
+            )
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.HTTPError, ValueError):
+        return [], "GitHub branch lookup is unavailable."
+
+    options: list[BranchOption] = []
+    seen: set[str] = set()
+    if isinstance(data, list):
+        for item in data:
+            if not isinstance(item, Mapping):
+                continue
+            branch_name = str(item.get("name") or "").strip()
+            if not branch_name or branch_name in seen:
+                continue
+            seen.add(branch_name)
+            options.append(
+                BranchOption(value=branch_name, label=branch_name, source="github")
+            )
+    return options, None
+
+
 def _github_repository_options_cache_key(token: str) -> str:
     return sha256(token.encode("utf-8")).hexdigest()
+
+
+def _github_branch_options_cache_key(token: str, repository: str) -> str:
+    normalized_repository = _normalize_repository_value(repository) or ""
+    raw_key = f"{token}:{normalized_repository.lower()}"
+    return sha256(raw_key.encode("utf-8")).hexdigest()
 
 
 def _get_cached_github_repository_options(
@@ -207,6 +279,23 @@ def _get_cached_github_repository_options(
 
     options, error = _fetch_github_repository_options(token)
     _GITHUB_REPOSITORY_OPTIONS_CACHE[cache_key] = (now, tuple(options), error)
+    return options, error
+
+
+def _get_cached_github_branch_options(
+    token: str,
+    repository: str,
+) -> tuple[list[BranchOption], str | None]:
+    now = time.monotonic()
+    cache_key = _github_branch_options_cache_key(token, repository)
+    cached = _GITHUB_BRANCH_OPTIONS_CACHE.get(cache_key)
+    if cached:
+        cached_at, cached_options, cached_error = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            return list(cached_options), cached_error
+
+    options, error = _fetch_github_branch_options(token, repository)
+    _GITHUB_BRANCH_OPTIONS_CACHE[cache_key] = (now, tuple(options), error)
     return options, error
 
 
@@ -254,6 +343,36 @@ def _build_repository_options(
     return {
         "items": [option.to_payload() for option in options],
         "error": discovery_error,
+    }
+
+
+def build_repository_branch_options(repository: str) -> dict[str, Any]:
+    """Build Create-page branch suggestions through MoonMind-owned GitHub lookup."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not normalized_repository:
+        return {
+            "items": [],
+            "error": "Repository must be owner/repo before branches can be loaded.",
+        }
+
+    github_enabled = bool(getattr(settings.github, "github_enabled", True))
+    github_token = str(getattr(settings.github, "github_token", "") or "").strip()
+    if not github_enabled or not github_token:
+        return {
+            "items": [],
+            "error": "GitHub branch lookup is unavailable.",
+        }
+
+    options, error = _get_cached_github_branch_options(
+        github_token,
+        normalized_repository,
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    return {
+        "items": [option.to_payload() for option in options],
+        "error": error,
     }
 
 
@@ -502,6 +621,9 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
                 "artifactSessionControl": "/api/task-runs/{taskRunId}/artifact-sessions/{sessionId}/control",
             },
             **jira_sources,
+            "github": {
+                "branches": "/api/github/branches?repository={repository}",
+            },
 
         },
         "features": {
@@ -569,8 +691,10 @@ def build_runtime_config(initial_path: str) -> dict[str, Any]:
 
 __all__ = [
     "build_live_logs_feature_config",
+    "build_repository_branch_options",
     "build_runtime_config",
     "normalize_status",
+    "BranchOption",
     "RepositoryOption",
     "status_maps",
 ]

--- a/api_service/api/routers/task_dashboard_view_model.py
+++ b/api_service/api/routers/task_dashboard_view_model.py
@@ -224,35 +224,44 @@ def _fetch_github_branch_options(
         "Authorization": f"Bearer {token}",
         "X-GitHub-Api-Version": "2022-11-28",
     }
+    options: list[BranchOption] = []
+    seen: set[str] = set()
+    next_url: str | None = _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
+        repository=normalized_repository
+    )
+    params: dict[str, int] | None = {"per_page": 100}
     try:
         with httpx.Client(
             timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
         ) as client:
-            response = client.get(
-                _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
-                    repository=normalized_repository
-                ),
-                headers=headers,
-                params={"per_page": 100},
-            )
-            response.raise_for_status()
-            data = response.json()
+            while next_url:
+                response = client.get(
+                    next_url,
+                    headers=headers,
+                    params=params,
+                )
+                params = None
+                response.raise_for_status()
+                data = response.json()
+                if isinstance(data, list):
+                    for item in data:
+                        if not isinstance(item, Mapping):
+                            continue
+                        branch_name = str(item.get("name") or "").strip()
+                        if not branch_name or branch_name in seen:
+                            continue
+                        seen.add(branch_name)
+                        options.append(
+                            BranchOption(
+                                value=branch_name,
+                                label=branch_name,
+                                source="github",
+                            )
+                        )
+                next_url = response.links.get("next", {}).get("url")
     except (httpx.HTTPError, ValueError):
         return [], "GitHub branch lookup is unavailable."
 
-    options: list[BranchOption] = []
-    seen: set[str] = set()
-    if isinstance(data, list):
-        for item in data:
-            if not isinstance(item, Mapping):
-                continue
-            branch_name = str(item.get("name") or "").strip()
-            if not branch_name or branch_name in seen:
-                continue
-            seen.add(branch_name)
-            options.append(
-                BranchOption(value=branch_name, label=branch_name, source="github")
-            )
     return options, None
 
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -181,6 +181,30 @@ function withRepositoryOptions(payload: BootPayload = mockPayload): BootPayload 
   };
 }
 
+function withDefaultRepository(
+  defaultRepository: string,
+  payload: BootPayload = mockPayload,
+): BootPayload {
+  const initialData = payload.initialData as {
+    dashboardConfig: {
+      system?: Record<string, unknown>;
+    };
+  };
+  return {
+    ...payload,
+    initialData: {
+      ...initialData,
+      dashboardConfig: {
+        ...initialData.dashboardConfig,
+        system: {
+          ...initialData.dashboardConfig.system,
+          defaultRepository,
+        },
+      },
+    },
+  };
+}
+
 function withImageOnlyAttachmentPolicy(
   payload: BootPayload = mockPayload,
 ): BootPayload {
@@ -1937,7 +1961,6 @@ describe("Task Create Entrypoint", () => {
       effort: "high",
       repository: "MoonLadderStudios/MoonMind",
       branch: "main",
-      legacyBranchWarning: null,
       publishMode: "branch",
       targetSkill: "speckit-implement",
       inputParameters: {
@@ -5134,20 +5157,9 @@ describe("Task Create Entrypoint", () => {
   it("loads branches for URL repository values accepted by submission", async () => {
     renderWithClient(
       <TaskCreatePage
-        payload={{
-          ...mockPayload,
-          initialData: {
-            ...mockPayload.initialData,
-            dashboardConfig: {
-              ...mockPayload.initialData.dashboardConfig,
-              system: {
-                ...mockPayload.initialData.dashboardConfig.system,
-                defaultRepository:
-                  "https://github.com/MoonLadderStudios/MoonMind.git",
-              },
-            },
-          },
-        }}
+        payload={withDefaultRepository(
+          "https://github.com/MoonLadderStudios/MoonMind.git",
+        )}
       />,
     );
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -38,6 +38,9 @@ const mockPayload: BootPayload = {
           create: "/api/executions",
           artifactCreate: "/api/artifacts",
         },
+        github: {
+          branches: "/api/github/branches?repository={repository}",
+        },
       },
       system: {
         defaultRepository: "MoonLadderStudios/MoonMind",
@@ -393,6 +396,22 @@ describe("Task Create Entrypoint", () => {
             ok: true,
             json: async () => ({
               items: { worker: ["speckit-orchestrate", "pr-resolver"] },
+            }),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              items: [
+                { value: "main", label: "main", source: "github" },
+                {
+                  value: "feature/create-page",
+                  label: "feature/create-page",
+                  source: "github",
+                },
+              ],
+              error: null,
             }),
           } as Response);
         }
@@ -1915,8 +1934,8 @@ describe("Task Create Entrypoint", () => {
       model: "gemini-2.5-pro",
       effort: "high",
       repository: "MoonLadderStudios/MoonMind",
-      startingBranch: "main",
-      targetBranch: "task-editing-phase-2",
+      branch: "main",
+      legacyBranchWarning: null,
       publishMode: "branch",
       targetSkill: "speckit-implement",
       inputParameters: {
@@ -1942,8 +1961,8 @@ describe("Task Create Entrypoint", () => {
       model: "gemini-2.5-pro",
       effort: "high",
       repository: "MoonLadderStudios/MoonMind",
-      startingBranch: "main",
-      targetBranch: "task-editing-phase-2",
+      branch: "main",
+      legacyBranchWarning: null,
       publishMode: "branch",
       taskInstructions: "Rebuild the Temporal task draft.",
       primarySkill: "speckit-implement",
@@ -1999,8 +2018,8 @@ describe("Task Create Entrypoint", () => {
       model: "gpt-5.4",
       effort: "medium",
       repository: "MoonLadderStudios/MoonMind",
-      startingBranch: "main",
-      targetBranch: "rerun-target",
+      branch: "main",
+      legacyBranchWarning: null,
       publishMode: "pr",
       taskInstructions: "Rerun from immutable artifact input.",
       primarySkill: "speckit-orchestrate",
@@ -2286,8 +2305,9 @@ describe("Task Create Entrypoint", () => {
       model: "gpt-5.4",
       effort: "medium",
       repository: "MoonLadderStudios/MoonMind",
-      startingBranch: "main",
-      targetBranch: "durable-task-edit-reconstruction",
+      branch: "main",
+      legacyBranchWarning:
+        "This older task used separate starting and target branches. The new form submits one branch, so review it before saving or rerunning.",
       publishMode: "none",
       taskInstructions: "",
       primarySkill: "moonspec-orchestrate",
@@ -2513,8 +2533,8 @@ describe("Task Create Entrypoint", () => {
       model: null,
       effort: null,
       repository: null,
-      startingBranch: null,
-      targetBranch: null,
+      branch: null,
+      legacyBranchWarning: null,
       publishMode: null,
       primarySkill: null,
       taskInstructions: "Only instructions are available.",
@@ -2570,13 +2590,8 @@ describe("Task Create Entrypoint", () => {
         (screen.getByLabelText(/GitHub Repo/) as HTMLInputElement).value,
       ).toBe("MoonLadderStudios/MoonMind");
       expect(
-        (screen.getByLabelText("Starting Branch (optional)") as HTMLInputElement)
-          .value,
+        (screen.getByLabelText("Branch") as HTMLSelectElement).value,
       ).toBe("main");
-      expect(
-        (screen.getByLabelText("Target Branch (optional)") as HTMLInputElement)
-          .value,
-      ).toBe("task-editing-phase-2");
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
       ).toBe("branch");
@@ -3091,8 +3106,7 @@ describe("Task Create Entrypoint", () => {
             profileId: "profile:gemini-default",
           },
           git: {
-            startingBranch: "main",
-            targetBranch: "task-editing-phase-2",
+            branch: "main",
           },
           publish: {
             mode: "branch",
@@ -4760,11 +4774,8 @@ describe("Task Create Entrypoint", () => {
     expect(
       await screen.findByLabelText("Feature Request / Initial Instructions"),
     ).not.toBeNull();
-    expect(
-      await screen.findByPlaceholderText(
-        "auto-generated unless starting branch is non-default",
-      ),
-    ).not.toBeNull();
+    expect(await screen.findByLabelText("Branch")).not.toBeNull();
+    expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
     expect(await screen.findByDisplayValue("3")).not.toBeNull();
     expect(screen.getByText("Task Presets (optional)")).not.toBeNull();
     expect(screen.getByText("Schedule (optional)")).not.toBeNull();
@@ -5027,8 +5038,8 @@ describe("Task Create Entrypoint", () => {
     const addStepButton = screen.getByRole("button", { name: "Add Step" });
     const createButton = screen.getByRole("button", { name: "Create" });
     const repoInput = screen.getByLabelText(/GitHub Repo/);
-    const startingBranchInput = screen.getByLabelText("Starting Branch (optional)");
-    const targetBranchInput = screen.getByLabelText("Target Branch (optional)");
+    const branchSelect = screen.getByLabelText("Branch");
+    const publishModeSelect = screen.getByLabelText("Publish Mode");
     const stepActionRow = addStepButton.closest(".queue-step-actions");
 
     expect(stepActionRow).not.toBeNull();
@@ -5040,11 +5051,15 @@ describe("Task Create Entrypoint", () => {
       stepsSection,
     );
     expect(
-      startingBranchInput.closest('[data-canonical-create-section="Steps"]'),
+      branchSelect.closest('[data-canonical-create-section="Steps"]'),
     ).toBe(stepsSection);
     expect(
-      targetBranchInput.closest('[data-canonical-create-section="Steps"]'),
+      publishModeSelect.closest('[data-canonical-create-section="Steps"]'),
     ).toBe(stepsSection);
+    expect(
+      publishModeSelect.closest('[data-canonical-create-section="Execution context"]'),
+    ).toBeNull();
+    expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
     expect(Array.from(stepActionRow?.children || [])).toEqual([
       addStepButton,
       createButton,
@@ -5054,21 +5069,62 @@ describe("Task Create Entrypoint", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      repoInput.compareDocumentPosition(startingBranchInput) &
+      repoInput.compareDocumentPosition(branchSelect) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      startingBranchInput.compareDocumentPosition(targetBranchInput) &
+      branchSelect.compareDocumentPosition(publishModeSelect) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      targetBranchInput.compareDocumentPosition(addStepButton) &
+      publishModeSelect.compareDocumentPosition(addStepButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       addStepButton.compareDocumentPosition(createButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("loads branches through MoonMind and submits one authored branch", async () => {
+    renderWithClient(<TaskCreatePage payload={mockPayload} />);
+
+    const branchSelect = await screen.findByLabelText("Branch");
+    await waitFor(() => {
+      expect(
+        Array.from((branchSelect as HTMLSelectElement).options).some(
+          (option) => option.value === "feature/create-page",
+        ),
+      ).toBe(true);
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).startsWith(
+          "/api/github/branches?repository=MoonLadderStudios%2FMoonMind",
+        ),
+      ),
+    ).toBe(true);
+
+    fireEvent.change(branchSelect, {
+      target: { value: "feature/create-page" },
+    });
+    fireEvent.change(screen.getByLabelText("Instructions"), {
+      target: { value: "Implement single branch create page." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    const payload = latestCreateRequest().payload as Record<string, unknown>;
+    const task = payload.task as Record<string, unknown>;
+    expect(task.git).toEqual({ branch: "feature/create-page" });
+    expect(JSON.stringify(task)).not.toContain("targetBranch");
+    expect(JSON.stringify(task)).not.toContain("startingBranch");
   });
 
   it("uses only MoonMind REST endpoints while submitting a manually authored task", async () => {

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -676,6 +676,8 @@ describe("Task Create Entrypoint", () => {
               inputParameters: {
                 targetRuntime: "gemini_cli",
                 operatorNote: "Keep this unedited top-level value.",
+                startingBranch: "stale-legacy-source",
+                targetBranch: "stale-legacy-target",
                 task: {
                   instructions: "Rebuild the Temporal task draft.",
                   proposeTasks: true,
@@ -3123,6 +3125,8 @@ describe("Task Create Entrypoint", () => {
         },
       },
     });
+    expect(request.parametersPatch).not.toHaveProperty("startingBranch");
+    expect(request.parametersPatch).not.toHaveProperty("targetBranch");
     expect(request.inputArtifactRef).toBeUndefined();
     await waitFor(() => {
       expect(navigateTo).toHaveBeenCalledWith(
@@ -5125,6 +5129,46 @@ describe("Task Create Entrypoint", () => {
     expect(task.git).toEqual({ branch: "feature/create-page" });
     expect(JSON.stringify(task)).not.toContain("targetBranch");
     expect(JSON.stringify(task)).not.toContain("startingBranch");
+  });
+
+  it("loads branches for URL repository values accepted by submission", async () => {
+    renderWithClient(
+      <TaskCreatePage
+        payload={{
+          ...mockPayload,
+          initialData: {
+            ...mockPayload.initialData,
+            dashboardConfig: {
+              ...mockPayload.initialData.dashboardConfig,
+              system: {
+                ...mockPayload.initialData.dashboardConfig.system,
+                defaultRepository:
+                  "https://github.com/MoonLadderStudios/MoonMind.git",
+              },
+            },
+          },
+        }}
+      />,
+    );
+
+    const branchSelect = await screen.findByLabelText("Branch");
+    await waitFor(() => {
+      expect(
+        Array.from((branchSelect as HTMLSelectElement).options).some(
+          (option) => option.value === "feature/create-page",
+        ),
+      ).toBe(true);
+    });
+    expect(
+      fetchSpy.mock.calls.some(([url]) =>
+        String(url).startsWith(
+          "/api/github/branches?repository=https%3A%2F%2Fgithub.com%2FMoonLadderStudios%2FMoonMind.git",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      screen.queryByText("Branch lookup requires a valid GitHub repository value."),
+    ).toBeNull();
   });
 
   it("uses only MoonMind REST endpoints while submitting a manually authored task", async () => {

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -100,6 +100,9 @@ interface DashboardConfig {
       detail?: string;
       list?: string;
     };
+    github?: {
+      branches?: string;
+    };
     jira?: {
       connections?: string;
       projects?: string;
@@ -273,6 +276,21 @@ interface ProviderProfile {
   account_label?: string | null;
   default_model?: string | null;
   is_default?: boolean;
+}
+
+interface BranchOption {
+  value: string;
+  label: string;
+  source: string;
+}
+
+interface BranchListResponse {
+  items?: Array<{
+    value?: string | null;
+    label?: string | null;
+    source?: string | null;
+  }>;
+  error?: string | null;
 }
 
 function resolveDefaultProviderProfileId(
@@ -502,6 +520,13 @@ function configuredTemporalUpdateUrl(
   return interpolatePath(updateTemplate, { workflowId });
 }
 
+function configuredBranchLookupUrl(
+  branchTemplate: string,
+  repository: string,
+): string {
+  return interpolatePath(branchTemplate, { repository });
+}
+
 function configuredArtifactDownloadUrl(
   downloadTemplate: string,
   artifactId: string,
@@ -581,6 +606,14 @@ function buildEditParametersPatch({
       recordValue(editTask.publish),
     ),
   };
+  const mergedGit = recordValue(mergedTask.git);
+  delete mergedGit.startingBranch;
+  delete mergedGit.targetBranch;
+  if (Object.keys(mergedGit).length > 0) {
+    mergedTask.git = mergedGit;
+  } else {
+    delete mergedTask.git;
+  }
 
   return {
     ...baseParameters,
@@ -1071,6 +1104,10 @@ function isValidRepositoryInput(value: string): boolean {
   return candidate.startsWith("git@");
 }
 
+function canLookupRepositoryBranches(value: string): boolean {
+  return OWNER_REPO_PATTERN.test(value.trim());
+}
+
 function scopeLabel(scope: TemplateScope): string {
   return scope === "personal" ? "Personal" : "Global";
 }
@@ -1436,6 +1473,38 @@ async function responseErrorMessage(
   fallback: string,
 ): Promise<string> {
   return (await responseErrorDetail(response, fallback)).message;
+}
+
+async function readBranchOptions(
+  branchLookupEndpoint: string,
+  repository: string,
+): Promise<BranchOption[]> {
+  const response = await fetch(
+    configuredBranchLookupUrl(branchLookupEndpoint, repository),
+    { headers: { Accept: "application/json" } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      await responseErrorMessage(response, "Failed to load branches."),
+    );
+  }
+  const payload = (await response.json()) as BranchListResponse;
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+  return (payload.items || [])
+    .map((item) => {
+      const value = String(item.value || "").trim();
+      if (!value) {
+        return null;
+      }
+      return {
+        value,
+        label: String(item.label || value).trim() || value,
+        source: String(item.source || "github").trim() || "github",
+      };
+    })
+    .filter((item): item is BranchOption => item !== null);
 }
 
 function localJiraErrorMessage(error: unknown, fallback: string): string {
@@ -1921,6 +1990,27 @@ function ArrowRightIcon() {
   );
 }
 
+function BranchIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M7 5v10a4 4 0 0 0 4 4h6" />
+      <path d="M7 5a2 2 0 1 0-2 2 2 2 0 0 0 2-2z" />
+      <path d="M17 19a2 2 0 1 0 2-2 2 2 0 0 0-2 2z" />
+      <path d="M11 9h2a4 4 0 0 0 4-4" />
+    </svg>
+  );
+}
+
+function PublishIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M12 18V6" />
+      <path d="M8 10l4-4 4 4" />
+      <path d="M6 18h12" />
+    </svg>
+  );
+}
+
 function CloseIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -2076,8 +2166,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   );
   const [repository, setRepository] = useState(defaultRepository);
   const [providerProfile, setProviderProfile] = useState("");
-  const [startingBranch, setStartingBranch] = useState("");
-  const [targetBranch, setTargetBranch] = useState("");
+  const [branch, setBranch] = useState("");
   const [publishMode, setPublishMode] = useState(defaultPublishMode);
   const [mergeAutomationEnabled, setMergeAutomationEnabled] = useState(false);
   const [priority, setPriority] = useState(0);
@@ -2413,11 +2502,11 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     if (draft.repository) {
       setRepository(draft.repository);
     }
-    if (draft.startingBranch) {
-      setStartingBranch(draft.startingBranch);
+    if (draft.branch) {
+      setBranch(draft.branch);
     }
-    if (draft.targetBranch) {
-      setTargetBranch(draft.targetBranch);
+    if (draft.legacyBranchWarning) {
+      setSubmitMessage(draft.legacyBranchWarning);
     }
     if (draft.publishMode) {
       setPublishMode(draft.publishMode);
@@ -3584,6 +3673,82 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         return true;
       });
   }, [dashboardConfig.system?.repositoryOptions?.items]);
+
+  const branchLookupEndpoint = normalizeMoonMindApiPath(
+    dashboardConfig.sources?.github?.branches,
+  );
+  const selectedRepositoryForBranchLookup =
+    repository.trim() || defaultRepository;
+  const branchLookupRepository = canLookupRepositoryBranches(
+    selectedRepositoryForBranchLookup,
+  )
+    ? selectedRepositoryForBranchLookup.trim()
+    : "";
+  const branchOptionsQuery = useQuery({
+    queryKey: ["task-create", "github-branches", branchLookupRepository],
+    enabled: Boolean(branchLookupEndpoint && branchLookupRepository),
+    queryFn: async () =>
+      readBranchOptions(branchLookupEndpoint || "", branchLookupRepository),
+  });
+  const branchOptions = useMemo(() => {
+    const items = branchOptionsQuery.data || [];
+    const seen = new Set<string>();
+    const options = items.filter((item) => {
+      const key = item.value;
+      if (!key || seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+    const selected = branch.trim();
+    if (selected && !seen.has(selected)) {
+      return [
+        {
+          value: selected,
+          label: `${selected} (not in latest branch list)`,
+          source: "stale",
+        },
+        ...options,
+      ];
+    }
+    return options;
+  }, [branch, branchOptionsQuery.data]);
+  const selectedBranchIsStale = Boolean(
+    branch.trim() &&
+      branchOptionsQuery.isSuccess &&
+      !(branchOptionsQuery.data || []).some((item) => item.value === branch.trim()),
+  );
+  const branchControlDisabled =
+    !selectedRepositoryForBranchLookup.trim() ||
+    !branchLookupEndpoint ||
+    !branchLookupRepository ||
+    branchOptionsQuery.isLoading;
+  const branchStatusMessage = (() => {
+    if (!selectedRepositoryForBranchLookup.trim()) {
+      return "Select a repository to load branches.";
+    }
+    if (!branchLookupEndpoint) {
+      return "Branch lookup is not configured.";
+    }
+    if (!branchLookupRepository) {
+      return "Branch lookup requires an owner/repo repository value.";
+    }
+    if (branchOptionsQuery.isLoading || branchOptionsQuery.isFetching) {
+      return "Loading branches...";
+    }
+    if (branchOptionsQuery.isError) {
+      const error = branchOptionsQuery.error;
+      return error instanceof Error ? error.message : "Failed to load branches.";
+    }
+    if (selectedBranchIsStale) {
+      return "Selected branch is not in the latest list for this repository.";
+    }
+    if (branchOptionsQuery.isSuccess && branchOptions.length === 0) {
+      return "No branches returned for this repository.";
+    }
+    return "";
+  })();
 
   const presetStatusText = useMemo(() => {
     if (presetReapplyNeeded) {
@@ -4757,15 +4922,10 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       publish: {
         mode: normalizedPublishMode,
       },
-      ...(startingBranch.trim() || targetBranch.trim()
+      ...(branch.trim()
         ? {
             git: {
-              ...(startingBranch.trim()
-                ? { startingBranch: startingBranch.trim() }
-                : {}),
-              ...(targetBranch.trim()
-                ? { targetBranch: targetBranch.trim() }
-                : {}),
+              branch: branch.trim(),
             },
           }
         : {}),
@@ -5634,26 +5794,53 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 </span>
               </label>
 
-              <div className="grid-2">
-                <label>
-                  Starting Branch (optional)
-                  <input
-                    name="startingBranch"
-                    value={startingBranch}
-                    placeholder="repo default branch"
-                    onChange={(event) => setStartingBranch(event.target.value)}
-                  />
-                </label>
-                <label>
-                  Target Branch (optional)
-                  <input
-                    name="targetBranch"
-                    value={targetBranch}
-                    placeholder="auto-generated unless starting branch is non-default"
-                    onChange={(event) => setTargetBranch(event.target.value)}
-                  />
-                </label>
+              <div className="queue-inline-selector-row">
+                <div className="queue-inline-selector queue-inline-selector--branch">
+                  <BranchIcon />
+                  <select
+                    name="branch"
+                    aria-label="Branch"
+                    value={branch}
+                    disabled={branchControlDisabled}
+                    onChange={(event) => setBranch(event.target.value)}
+                  >
+                    <option value="">
+                      {branchOptionsQuery.isLoading
+                        ? "Loading branches..."
+                        : "Branch"}
+                    </option>
+                    {branchOptions.map((item) => (
+                      <option key={`${item.source}:${item.value}`} value={item.value}>
+                        {item.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="queue-inline-selector queue-inline-selector--publish">
+                  <PublishIcon />
+                  <select
+                    name="publishMode"
+                    aria-label="Publish Mode"
+                    value={publishMode}
+                    onChange={(event) => setPublishMode(event.target.value)}
+                  >
+                    <option value="pr">pr</option>
+                    <option value="branch">branch</option>
+                    <option value="none">none</option>
+                  </select>
+                </div>
               </div>
+              {branchStatusMessage ? (
+                <p
+                  className={
+                    branchOptionsQuery.isError || selectedBranchIsStale
+                      ? "notice error"
+                      : "small"
+                  }
+                >
+                  {branchStatusMessage}
+                </p>
+              ) : null}
             </div>
 
             <div className="actions queue-step-add queue-step-actions">
@@ -6047,19 +6234,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             />
           </label>
         </div>
-
-        <label>
-          Publish Mode
-          <select
-            name="publishMode"
-            value={publishMode}
-            onChange={(event) => setPublishMode(event.target.value)}
-          >
-            <option value="pr">pr</option>
-            <option value="branch">branch</option>
-            <option value="none">none</option>
-          </select>
-        </label>
 
         {mergeAutomationAvailable ? (
           <label className="checkbox">

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -615,11 +615,14 @@ function buildEditParametersPatch({
     delete mergedTask.git;
   }
 
-  return {
+  const parametersPatch: Record<string, unknown> = {
     ...baseParameters,
     ...submittedPayload,
     task: mergedTask,
   };
+  delete parametersPatch.startingBranch;
+  delete parametersPatch.targetBranch;
+  return parametersPatch;
 }
 
 function readJiraItems<T>(data: unknown): T[] {
@@ -1105,7 +1108,7 @@ function isValidRepositoryInput(value: string): boolean {
 }
 
 function canLookupRepositoryBranches(value: string): boolean {
-  return OWNER_REPO_PATTERN.test(value.trim());
+  return isValidRepositoryInput(value);
 }
 
 function scopeLabel(scope: TemplateScope): string {
@@ -3732,7 +3735,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return "Branch lookup is not configured.";
     }
     if (!branchLookupRepository) {
-      return "Branch lookup requires an owner/repo repository value.";
+      return "Branch lookup requires a valid GitHub repository value.";
     }
     if (branchOptionsQuery.isLoading || branchOptionsQuery.isFetching) {
       return "Loading branches...";

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1800,6 +1800,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/github/branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Dashboard Github Branches
+         * @description List GitHub branches through MoonMind so browsers never call GitHub directly.
+         */
+        get: operations["list_dashboard_github_branches_api_github_branches_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/task-step-templates": {
         parameters: {
             query?: never;
@@ -3061,6 +3081,37 @@ export interface components {
              * @description The markdown content of the new skill
              */
             markdown: string;
+        };
+        /**
+         * DashboardBranchListResponse
+         * @description Dashboard response containing branch options for one repository.
+         */
+        DashboardBranchListResponse: {
+            /** Items */
+            items?: components["schemas"]["DashboardBranchOption"][];
+            /** Error */
+            error?: string | null;
+        };
+        /**
+         * DashboardBranchOption
+         * @description Serializable Git branch option exposed to dashboard clients.
+         */
+        DashboardBranchOption: {
+            /**
+             * Value
+             * @description Branch name
+             */
+            value: string;
+            /**
+             * Label
+             * @description Display label
+             */
+            label: string;
+            /**
+             * Source
+             * @description Branch option source
+             */
+            source: string;
         };
         /**
          * DashboardSkillListResponse
@@ -9719,6 +9770,37 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_dashboard_github_branches_api_github_branches_get: {
+        parameters: {
+            query: {
+                repository: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardBranchListResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -36,6 +36,7 @@ export type TemporalTaskEditingExecutionContract = {
   resolvedModel?: string | null;
   effort?: string | null;
   repository?: string | null;
+  branch?: string | null;
   startingBranch?: string | null;
   targetBranch?: string | null;
   publishMode?: string | null;
@@ -57,8 +58,8 @@ export type TemporalSubmissionDraft = {
   model: string | null;
   effort: string | null;
   repository: string | null;
-  startingBranch: string | null;
-  targetBranch: string | null;
+  branch: string | null;
+  legacyBranchWarning: string | null;
   publishMode: string | null;
   taskInstructions: string;
   primarySkill: string | null;
@@ -579,10 +580,12 @@ function snapshotDraftTask(
       : {}),
     ...(Array.isArray(snapshotDraft.steps) ? { steps: snapshotDraft.steps } : {}),
   };
+  const branch = stringValue(snapshotDraft.branch);
   const startingBranch = stringValue(snapshotDraft.startingBranch);
   const targetBranch = stringValue(snapshotDraft.targetBranch);
-  if (startingBranch || targetBranch) {
+  if (branch || startingBranch || targetBranch) {
     task.git = {
+      ...(branch ? { branch } : {}),
       ...(startingBranch ? { startingBranch } : {}),
       ...(targetBranch ? { targetBranch } : {}),
     };
@@ -600,6 +603,43 @@ function snapshotDraftTask(
     };
   }
   return task;
+}
+
+function normalizeLegacyBranchDraft({
+  publishMode,
+  branch,
+  startingBranch,
+  targetBranch,
+}: {
+  publishMode: string | null;
+  branch: string | null;
+  startingBranch: string | null;
+  targetBranch: string | null;
+}): { branch: string | null; warning: string | null } {
+  if (branch) {
+    return { branch, warning: null };
+  }
+  if (startingBranch && (!targetBranch || targetBranch === startingBranch)) {
+    return { branch: startingBranch, warning: null };
+  }
+  if (!startingBranch && targetBranch) {
+    return {
+      branch: targetBranch,
+      warning:
+        "This older task only stored a target branch. Review the reconstructed branch before submitting.",
+    };
+  }
+  if (startingBranch && targetBranch && publishMode === "pr") {
+    return { branch: startingBranch, warning: null };
+  }
+  if (startingBranch && targetBranch) {
+    return {
+      branch: startingBranch,
+      warning:
+        "This older task used separate starting and target branches. The new form submits one branch, so review it before saving or rerunning.",
+    };
+  }
+  return { branch: null, warning: null };
 }
 
 export function buildTemporalSubmissionDraftFromExecution(
@@ -637,6 +677,42 @@ export function buildTemporalSubmissionDraftFromExecution(
     ? execution.taskSkills
     : [];
   const artifactTaskSkills = skillSelectorNames(artifactTask.skills);
+  const publishMode = nullableStringValue(
+    execution.publishMode,
+    params.publishMode,
+    publish.mode,
+    artifactPublish.mode,
+  );
+  const legacyBranchDraft = normalizeLegacyBranchDraft({
+    publishMode,
+    branch: nullableStringValue(
+      snapshotDraft.branch,
+      execution.branch,
+      task.branch,
+      git.branch,
+      params.branch,
+      artifactTask.branch,
+      artifactGit.branch,
+    ),
+    startingBranch: nullableStringValue(
+      snapshotDraft.startingBranch,
+      execution.startingBranch,
+      task.startingBranch,
+      git.startingBranch,
+      params.startingBranch,
+      artifactTask.startingBranch,
+      artifactGit.startingBranch,
+    ),
+    targetBranch: nullableStringValue(
+      snapshotDraft.targetBranch,
+      execution.targetBranch,
+      task.targetBranch,
+      git.targetBranch,
+      params.targetBranch,
+      artifactTask.targetBranch,
+      artifactGit.targetBranch,
+    ),
+  });
 
   const draft: TemporalSubmissionDraft = {
     runtime: nullableStringValue(
@@ -680,30 +756,9 @@ export function buildTemporalSubmissionDraftFromExecution(
       artifactTask.repository,
       artifactGit.repository,
     ),
-    startingBranch: nullableStringValue(
-      snapshotDraft.startingBranch,
-      execution.startingBranch,
-      task.startingBranch,
-      git.startingBranch,
-      params.startingBranch,
-      artifactTask.startingBranch,
-      artifactGit.startingBranch,
-    ),
-    targetBranch: nullableStringValue(
-      snapshotDraft.targetBranch,
-      execution.targetBranch,
-      task.targetBranch,
-      git.targetBranch,
-      params.targetBranch,
-      artifactTask.targetBranch,
-      artifactGit.targetBranch,
-    ),
-    publishMode: nullableStringValue(
-      execution.publishMode,
-      params.publishMode,
-      publish.mode,
-      artifactPublish.mode,
-    ),
+    branch: legacyBranchDraft.branch,
+    legacyBranchWarning: legacyBranchDraft.warning,
+    publishMode,
     taskInstructions:
       Object.keys(snapshotDraft).length > 0
         ? taskInstructionsFrom(artifactTask, task)

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1564,6 +1564,35 @@ button.secondary:hover {
   margin-top: 0.2rem;
 }
 
+.queue-inline-selector-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(10rem, 0.9fr);
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.queue-inline-selector {
+  display: grid;
+  grid-template-columns: 1.35rem minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.queue-inline-selector svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  color: rgb(var(--mm-muted));
+}
+
+.queue-inline-selector select {
+  width: 100%;
+  min-height: 2.35rem;
+}
+
 .queue-step-header {
   display: flex;
   justify-content: space-between;
@@ -1923,6 +1952,10 @@ button.secondary:hover {
   }
 
   .grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .queue-inline-selector-row {
     grid-template-columns: 1fr;
   }
 

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -95,6 +95,9 @@ def test_build_runtime_config_contains_expected_keys(monkeypatch) -> None:
         config["sources"]["temporal"]["artifactDownload"]
         == "/api/artifacts/{artifactId}/download"
     )
+    assert config["sources"]["github"]["branches"] == (
+        "/api/github/branches?repository={repository}"
+    )
     assert config["sources"]["taskRuns"]["observabilitySummary"] == "/api/task-runs/{taskRunId}/observability-summary"
     assert config["sources"]["taskRuns"]["observabilityEvents"] == "/api/task-runs/{taskRunId}/observability/events"
     assert config["sources"]["taskRuns"]["logsStream"] == "/api/task-runs/{taskRunId}/logs/stream"
@@ -477,6 +480,63 @@ def test_build_runtime_config_sanitizes_repository_options_and_errors(
         {"value": "Another/Repo", "label": "Another/Repo", "source": "configured"},
     ]
     assert "ghp_secret_token" not in config["system"]["repositoryOptions"]["error"]
+
+
+def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None:
+    monkeypatch.setattr(settings.github, "github_token", "ghp_test_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_get_cached_github_branch_options",
+        lambda token, repository: (
+            [
+                dashboard_view_model.BranchOption(
+                    value="main",
+                    label="main",
+                    source="github",
+                ),
+                dashboard_view_model.BranchOption(
+                    value="feature/create-page",
+                    label="feature/create-page",
+                    source="github",
+                ),
+            ],
+            None,
+        ),
+    )
+
+    payload = dashboard_view_model.build_repository_branch_options("Octo/Repo")
+
+    assert payload == {
+        "items": [
+            {"value": "main", "label": "main", "source": "github"},
+            {
+                "value": "feature/create-page",
+                "label": "feature/create-page",
+                "source": "github",
+            },
+        ],
+        "error": None,
+    }
+
+
+def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
+    monkeypatch.setattr(settings.github, "github_token", "ghp_secret_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_get_cached_github_branch_options",
+        lambda token, repository: (
+            [],
+            "GitHub failed with ghp_secret_token",
+        ),
+    )
+
+    payload = dashboard_view_model.build_repository_branch_options("Octo/Repo")
+
+    assert payload["items"] == []
+    assert payload["error"] == "GitHub branch lookup is unavailable."
+    assert "ghp_secret_token" not in payload["error"]
 
 
 def test_build_runtime_config_uses_repo_runtime_model_defaults(monkeypatch) -> None:

--- a/tests/unit/api/routers/test_task_dashboard_view_model.py
+++ b/tests/unit/api/routers/test_task_dashboard_view_model.py
@@ -520,6 +520,85 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
     }
 
 
+def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
+    responses = [
+        {
+            "json": [{"name": "main"}, {"name": "feature/page-one"}],
+            "links": {"next": {"url": "https://api.github.com/page/2"}},
+        },
+        {
+            "json": [{"name": "feature/page-two"}, {"name": "main"}],
+            "links": {},
+        },
+    ]
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+            self.links = payload["links"]
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return self._payload["json"]
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            calls.append({"url": url, "headers": headers, "params": params})
+            return FakeResponse(responses[len(calls) - 1])
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    options, error = dashboard_view_model._fetch_github_branch_options(
+        "ghp_test_token",
+        "Octo/Repo",
+    )
+
+    assert error is None
+    assert [option.value for option in options] == [
+        "main",
+        "feature/page-one",
+        "feature/page-two",
+    ]
+    assert calls == [
+        {
+            "url": "https://api.github.com/repos/Octo/Repo/branches",
+            "headers": {
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer ghp_test_token",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            "params": {"per_page": 100},
+        },
+        {
+            "url": "https://api.github.com/page/2",
+            "headers": {
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer ghp_test_token",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            "params": None,
+        },
+    ]
+
+
 def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
     monkeypatch.setattr(settings.github, "github_token", "ghp_secret_token")
     monkeypatch.setattr(settings.github, "github_enabled", True)


### PR DESCRIPTION
I believe the following document updates have already been made. Now update the UI to match:

I’d treat this as the priority changelist after `CreatePage.md`.

The reason these are the key follow-ons is that the current contract still encodes a two-branch model: `CreatePage.md` carries both `startingBranch` and `targetBranch`, the frontend still stores and renders both fields as separate labeled inputs, `Publish Mode` still sits in the Execution context section, `TaskPublishing.md` still defines `startingBranch` as base and `targetBranch` as head, and the runtime-config builder does not yet expose a GitHub branch source for the Create page.    

## P0: must-update contract docs

### `docs/Tasks/TaskPublishing.md`

Changelist:

* Rewrite the “Branch Fields” section around a single authored field: `branch`.
* Remove `targetBranch` as an authored/operator-facing field.
* Change `pr` semantics to:

  * authored `branch` = selected repo branch / PR base
  * PR head branch = runtime-generated work branch, not user-authored
* Change `branch` publish semantics to:

  * authored `branch` = branch to update/push
  * no separate “clone from X, push to Y” operator model
* Delete examples showing `startingBranch` + `targetBranch`.
* Add a short “legacy migration” note:

  * old snapshots may still contain `startingBranch` / `targetBranch`
  * new authored submissions must not
  * legacy `targetBranch` may be retained only as historical metadata, never as active submission logic
* Update “Branch Resolution” so resolution starts from `branch`, not `startingBranch`/`targetBranch`. 

### `specs/045-submit-runtime-selector/contracts/submit-work-form.md`

Changelist:

* Remove the `Target Branch` control entirely.
* Rename `Starting Branch` to `Branch`.
* Move `Publish Mode` into the same inline control row as `Branch`, inside the Steps card.
* Document the compact control treatment:

  * no label above either control
  * Codex-like inline dropdown styling
  * use a different icon than the Codex screenshot
* Add GitHub-backed dropdown behavior:

  * disabled until repo is selected
  * fetches branches through a MoonMind API
  * loading, empty, and error states
  * stale selection handling when repo changes
* Document branch-option source as runtime-config/API-driven, not hardcoded.

### `docs/UI/MissionControlArchitecture.md`

Changelist:

* Add the new Create-page data dependency: MoonMind-owned GitHub branch lookup.
* State explicitly that the browser still talks only to MoonMind APIs, never directly to GitHub.
* Add the boot/runtime-config source for branch lookup.
* Document the repo → branch dependency chain:

  * repo chosen
  * branch list fetched
  * branch dropdown populated
  * publish mode rendered alongside it in the Steps card
* Note that `Publish Mode` changed visual placement only; it remains part of task submission semantics. The “browser talks only to MoonMind APIs” rule is already part of the Create page contract, so this architecture doc should mirror that posture.  

### `specs/161-temporal-task-drafts/contracts/temporal-task-drafts.openapi.yaml`

### `specs/161-temporal-task-drafts/data-model.md`

Changelist:

* Replace `startingBranch` + `targetBranch` in the draft shape with a single `branch`.
* Remove any draft write-path that expects both branches.
* Keep `publishMode` in the schema, but stop implying it lives in a separate Execution context card.
* Add a legacy-normalization section:

  * `startingBranch` only → normalize to `branch`
  * `startingBranch == targetBranch` → normalize to `branch`
  * legacy PR snapshot with differing values → normalize authored `branch` to the old base branch
  * legacy branch-publish snapshot with differing values → mark as non-round-trippable under the new model and require a warning on reconstruction
* Preserve old `targetBranch` only as opaque legacy metadata if needed for audit/debug, not for active draft logic. The current Create page draft model still carries both fields, so this is one of the most important contract updates. 

### `specs/157-temporal-task-editing/contracts/temporal-task-editing.openapi.yaml`

### `specs/157-temporal-task-editing/data-model.md`

Changelist:

* Mirror the same schema change from `startingBranch`/`targetBranch` to `branch`.
* State that edit flows must never reintroduce a visible `Target Branch` field.
* Add compatibility rules for loading older executions into the new UI.
* Clarify that saving an edited task always emits the new single-branch contract.

### `specs/169-temporal-rerun-submit/contracts/temporal-rerun-submit.openapi.yaml`

### `specs/169-temporal-rerun-submit/data-model.md`

Changelist:

* Same field migration as edit/draft docs.
* Clarify rerun behavior for legacy two-branch executions:

  * rerun uses the normalized single `branch`
  * rerun must not depend on `targetBranch`
* Add user-facing warning requirements for legacy runs whose old two-branch intent cannot be preserved exactly.

### `specs/180-durable-task-edit-reconstruction/contracts/original-task-input-snapshot.md`

### `specs/180-durable-task-edit-reconstruction/data-model.md`

Changelist:

* Add the canonical migration matrix for old snapshots.
* Define which legacy cases are silently normalized and which require warnings.
* Require reconstructed drafts to surface only `branch`, never `targetBranch`.
* Clarify that any retained legacy `targetBranch` is historical context only, not executable intent.

## P1: important supporting docs

### `docs/Tasks/TaskArchitecture.md`

Changelist:

* Update all task payload examples and field descriptions to use `branch`.
* Remove any create/edit/rerun examples that show `targetBranch`.
* Align the page-level execution-context description with the new Create page layout:

  * repo + branch + publish mode live together in the Steps card
  * publish mode is still submission data, even though it moved visually

### `specs/105-jules-provider-adapter/contracts/jules-bundle-runtime-contract.md`

### `docs/ExternalAgents/JulesAdapter.md`

Changelist:

* Remove any assumption that authored inputs provide both a base and target branch.
* State that Jules receives a single authored `branch` reference.
* For PR mode, clarify that work/head branch creation is provider/runtime-managed.
* Keep provider-specific publish behavior, but align the authored contract with the new single-branch model.

### `docs/UI/MissionControlStyleGuide.md`

Changelist:

* Add an inline selector-row pattern for compact dropdowns inside cards.
* Document “no label above the control” treatment for this specific pattern.
* Add guidance for the branch icon:

  * branch-like affordance
  * not the exact Codex icon
* Add spacing/alignment guidance for a two-control row: `Branch` on the left, `Publish Mode` on the right.

## One nuance to document everywhere

I would make this explicit in all of the above:

* `Publish Mode` is **not** being removed from the task contract.
* Only its **UI placement** changes.
* The real contract change is the removal of `Target Branch` and the collapse to a single authored `branch`.

That distinction matters because the frontend currently mixes both kinds of change: it still has two branch fields and it still renders Publish Mode in a separate section.