### PR TITLE
MM-406 Skill selection and snapshot resolution

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/206-agent-skill-catalog-source-policy"
+  "feature_directory": "specs/207-skill-selection-snapshot-resolution"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md
@@ -1,0 +1,76 @@
+# MM-406 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-406
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Skill Selection and Snapshot Resolution
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-406 from MM project
+Summary: Skill Selection and Snapshot Resolution
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-406 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-406: Skill Selection and Snapshot Resolution
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §10-§12
+  - AgentSkillSystem §15
+  - AgentSkillSystem §19
+  - ManagedAndExternalAgentExecutionModel §2.5
+- Coverage IDs:
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-019
+
+User Story
+As a task author, I can express task-wide and step-specific skill intent and have MoonMind resolve it into an immutable, artifact-backed snapshot before runtime launch, so retries, reruns, and audits reproduce the same skill set unless re-resolution is explicit.
+
+Acceptance Criteria
+- Given `task.skills` defines a baseline and `step.skills` excludes one inherited skill, when the step is prepared, then the resolved snapshot reflects the override without mutating task-level intent.
+- Given a pinned skill version cannot be resolved, when resolution runs, then the workflow fails before runtime launch with an actionable validation error.
+- Given a `ResolvedSkillSet` is produced, then workflow history contains only compact refs and metadata while large manifests, bodies, bundles, and source traces are artifact-backed.
+- Given a retry, continue-as-new, or ordinary rerun occurs, then the same resolved snapshot is reused unless the caller explicitly requests re-resolution.
+
+Requirements
+- Collect task and step skill selectors before runtime launch.
+- Resolve allowed source kinds through activity or service boundaries, not deterministic workflow code.
+- Pin exact skill versions and write resolved manifest artifacts.
+- Fail fast for missing required skills, unsatisfied pins, nondeterministic collisions, policy blocks, or runtime incompatibility.
+- Preserve proposal, schedule, retry, rerun, and replay semantics for skill intent and resolved snapshots.
+
+Relevant Implementation Notes
+- Keep `.agents/skills` as the canonical active runtime-visible path for the resolved active snapshot.
+- Treat checked-in repo skills and local-only skills as inputs to resolution, not as mutable runtime source-of-truth folders.
+- Keep `.agents/skills/local` as a local-only overlay source.
+- Do not embed large skill content in workflow history; workflows should carry compact refs and metadata while activities or services write artifact-backed manifests, bodies, bundles, and source traces.
+- Skill source loading, resolution, manifest generation, and materialization belong at activity or service boundaries, not deterministic workflow code.
+- Unsupported source kinds, missing required skills, unsatisfied pins, nondeterministic collisions, policy blocks, or runtime incompatibility should fail before runtime launch with actionable validation errors.
+
+Verification
+- Confirm task-level and step-level skill selector inputs are collected before runtime launch.
+- Confirm step-level exclusions can override inherited task-level skill intent without mutating the task-level intent.
+- Confirm pinned skill resolution failure stops before runtime launch with an actionable validation error.
+- Confirm `ResolvedSkillSet` output stores large skill manifests, bodies, bundles, and source traces as artifact-backed data while workflow history retains only compact refs and metadata.
+- Confirm retries, continue-as-new, and ordinary reruns reuse the same resolved snapshot unless explicit re-resolution is requested.
+- Preserve MM-406 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-407 blocks this issue.
+- MM-406 blocks MM-405.

--- a/moonmind/workflows/tasks/task_contract.py
+++ b/moonmind/workflows/tasks/task_contract.py
@@ -422,6 +422,90 @@ class TaskSkillSelectors(BaseModel):
         return lowered
 
 
+def _coerce_task_skill_selectors(
+    value: TaskSkillSelectors | Mapping[str, Any] | None,
+    *,
+    field_name: str,
+) -> TaskSkillSelectors | None:
+    if value is None:
+        return None
+    if isinstance(value, TaskSkillSelectors):
+        return value
+    if isinstance(value, Mapping):
+        return TaskSkillSelectors.model_validate(dict(value))
+    raise TaskContractError(f"{field_name} must be an object")
+
+
+def build_effective_task_skill_selectors(
+    task_skills: TaskSkillSelectors | Mapping[str, Any] | None,
+    step_skills: TaskSkillSelectors | Mapping[str, Any] | None,
+) -> TaskSkillSelectors | None:
+    """Merge task-level and step-level agent skill selectors for one step.
+
+    Step selectors refine inherited task intent. Exclusions are retained in the
+    effective selector and also remove matching includes so downstream
+    resolution receives deterministic input without mutating the task selector.
+    """
+
+    task = _coerce_task_skill_selectors(
+        task_skills, field_name="task.skills"
+    )
+    step = _coerce_task_skill_selectors(
+        step_skills, field_name="task.steps[].skills"
+    )
+    if task is None and step is None:
+        return None
+
+    sets: list[str] = []
+    seen_sets: set[str] = set()
+    for source in (task, step):
+        for item in (source.sets if source is not None else None) or []:
+            if item not in seen_sets:
+                sets.append(item)
+                seen_sets.add(item)
+
+    excludes: list[str] = []
+    seen_excludes: set[str] = set()
+    for source in (task, step):
+        for item in (source.exclude if source is not None else None) or []:
+            if item not in seen_excludes:
+                excludes.append(item)
+                seen_excludes.add(item)
+
+    include_by_name: dict[str, TaskSkillSelectorExact] = {}
+    for source in (task, step):
+        for item in (source.include if source is not None else None) or []:
+            include_by_name[item.name] = TaskSkillSelectorExact(
+                name=item.name,
+                version=item.version,
+            )
+    for item in excludes:
+        include_by_name.pop(item, None)
+
+    materialization_mode = (
+        step.materialization_mode
+        if step is not None and step.materialization_mode is not None
+        else task.materialization_mode if task is not None else None
+    )
+
+    payload: dict[str, Any] = {}
+    if sets:
+        payload["sets"] = sets
+    if include_by_name:
+        payload["include"] = [
+            item.model_dump(mode="json", by_alias=True, exclude_none=True)
+            for item in include_by_name.values()
+        ]
+    if excludes:
+        payload["exclude"] = excludes
+    if materialization_mode is not None:
+        payload["materializationMode"] = materialization_mode
+
+    if not payload:
+        return None
+    return TaskSkillSelectors.model_validate(payload)
+
+
 class TaskSkillSelection(BaseModel):
     """Selected skill and optional skill argument object."""
 

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1792,9 +1792,16 @@ class MoonMindRunWorkflow:
                             resolved_skillset_ref = (
                                 await self._resolve_agent_node_skillset_ref(
                                     task_skills=task_skills,
+                                    node_skills=node.get("skills"),
                                     node_inputs=node_inputs,
                                     node_id=node_id,
-                                    existing_skillset_ref=registry_snapshot_ref,
+                                    existing_skillset_ref=(
+                                        self._existing_agent_skillset_ref(
+                                            parameters=parameters,
+                                            node=node,
+                                            node_inputs=node_inputs,
+                                        )
+                                    ),
                                 )
                             )
                             request = self._build_agent_execution_request(
@@ -3493,6 +3500,7 @@ class MoonMindRunWorkflow:
         self,
         *,
         task_skills: Mapping[str, Any] | Any | None,
+        node_skills: Mapping[str, Any] | Any | None = None,
         node_inputs: Mapping[str, Any],
         node_id: str,
         existing_skillset_ref: str | None,
@@ -3504,7 +3512,7 @@ class MoonMindRunWorkflow:
 
         effective = build_effective_task_skill_selectors(
             task_skills,
-            node_inputs.get("skills"),
+            node_skills if node_skills is not None else node_inputs.get("skills"),
         )
         if effective is None:
             return None
@@ -3530,6 +3538,22 @@ class MoonMindRunWorkflow:
             return str(manifest_ref)
         snapshot_id = getattr(resolved, "snapshot_id", None)
         return str(snapshot_id) if snapshot_id else None
+
+    @staticmethod
+    def _existing_agent_skillset_ref(
+        *,
+        parameters: Mapping[str, Any],
+        node: Mapping[str, Any],
+        node_inputs: Mapping[str, Any],
+    ) -> str | None:
+        for source in (node_inputs, node, parameters):
+            for key in ("resolvedSkillsetRef", "resolved_skillset_ref"):
+                value = source.get(key)
+                if value is not None:
+                    candidate = str(value).strip()
+                    if candidate:
+                        return candidate
+        return None
 
     def _build_agent_execution_request(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -15,6 +15,7 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.schemas.agent_runtime_models import (
         AgentExecutionRequest,
     )
+    from moonmind.schemas.agent_skill_models import SkillSelector
     from moonmind.schemas.managed_session_models import (
         CodexManagedSessionBinding,
         CodexManagedSessionSnapshot,
@@ -37,6 +38,9 @@ with workflow.unsafe.imports_passed_through():
     from moonmind.config.settings import settings
     from moonmind.utils.logging import scrub_github_tokens
     from moonmind.workflows.temporal.typed_execution import execute_typed_activity
+    from moonmind.workflows.tasks.task_contract import (
+        build_effective_task_skill_selectors,
+    )
     from moonmind.workflows.temporal.workflows.provider_profile_manager import (
         workflow_id_for_runtime,
     )
@@ -1667,6 +1671,12 @@ class MoonMindRunWorkflow:
         )
 
         registry_snapshot_ref = plan_definition.metadata.registry_snapshot.artifact_ref
+        task_payload = parameters.get("task")
+        task_skills = (
+            task_payload.get("skills")
+            if isinstance(task_payload, Mapping)
+            else parameters.get("skills")
+        )
         failure_mode = plan_definition.policy.failure_mode
         publish_mode = self._publish_mode(parameters)
         pr_publish_optional = self._pr_publish_optional_for_plan(ordered_nodes)
@@ -1779,11 +1789,19 @@ class MoonMindRunWorkflow:
                     if tool_type == "agent_runtime":
                         # --- Agent dispatch: child workflow ---
                         try:
+                            resolved_skillset_ref = (
+                                await self._resolve_agent_node_skillset_ref(
+                                    task_skills=task_skills,
+                                    node_inputs=node_inputs,
+                                    node_id=node_id,
+                                    existing_skillset_ref=registry_snapshot_ref,
+                                )
+                            )
                             request = self._build_agent_execution_request(
                                 node_inputs=node_inputs,
                                 node_id=node_id,
                                 tool_name=tool_name,
-                                resolved_skillset_ref=registry_snapshot_ref,
+                                resolved_skillset_ref=resolved_skillset_ref,
                             )
                             if workflow.patched(RUN_SLOT_CONTINUITY_PATCH):
                                 self._mark_slot_continuity_for_next_step(
@@ -3470,6 +3488,48 @@ class MoonMindRunWorkflow:
             return
         if not self._merge_automation_child_succeeded(child_result):
             raise ValueError(reason or "merge automation failed")
+
+    async def _resolve_agent_node_skillset_ref(
+        self,
+        *,
+        task_skills: Mapping[str, Any] | Any | None,
+        node_inputs: Mapping[str, Any],
+        node_id: str,
+        existing_skillset_ref: str | None,
+    ) -> str | None:
+        """Resolve effective task/step skill intent before AgentRun launch."""
+
+        if existing_skillset_ref:
+            return existing_skillset_ref
+
+        effective = build_effective_task_skill_selectors(
+            task_skills,
+            node_inputs.get("skills"),
+        )
+        if effective is None:
+            return None
+
+        selector = SkillSelector.model_validate(
+            effective.model_dump(mode="json", exclude_none=True)
+        )
+        if not selector.sets and not selector.include and not selector.exclude:
+            return None
+
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("agent_skill.resolve")
+        resolved = await workflow.execute_activity(
+            "agent_skill.resolve",
+            selector,
+            self._principal(),
+            node_inputs.get("workspaceRoot"),
+            False,
+            False,
+            **self._execute_kwargs_for_route(route),
+        )
+        manifest_ref = getattr(resolved, "manifest_ref", None)
+        if manifest_ref:
+            return str(manifest_ref)
+        snapshot_id = getattr(resolved, "snapshot_id", None)
+        return str(snapshot_id) if snapshot_id else None
 
     def _build_agent_execution_request(
         self,

--- a/specs/207-skill-selection-snapshot-resolution/checklists/requirements.md
+++ b/specs/207-skill-selection-snapshot-resolution/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Skill Selection and Snapshot Resolution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request from `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`.
+- Historical source path `docs/Tools/SkillSystem.md` was mapped to the current canonical source documents `docs/Tasks/AgentSkillSystem.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- No clarification markers remain.

--- a/specs/207-skill-selection-snapshot-resolution/contracts/skill-snapshot-resolution.md
+++ b/specs/207-skill-selection-snapshot-resolution/contracts/skill-snapshot-resolution.md
@@ -1,0 +1,60 @@
+# Contract: Skill Snapshot Resolution
+
+## Scope
+
+This contract defines observable runtime behavior for MM-406. It covers effective task/step skill selector construction, pre-launch snapshot resolution, artifact-backed payload discipline, and runtime launch ref propagation.
+
+## Inputs
+
+### Task Skill Selector
+
+Optional task-level object:
+
+```json
+{
+  "sets": ["default"],
+  "include": [{"name": "pr-resolver", "version": "1.0.0"}],
+  "exclude": ["legacy"],
+  "materializationMode": "hybrid"
+}
+```
+
+### Step Skill Selector
+
+Optional step-level object with the same shape. Step-level values refine the inherited task-level selector for one step.
+
+## Effective Selector Rules
+
+1. The effective selector MUST start from task-level skill intent.
+2. Step-level `sets` and `include` MUST be additive.
+3. Step-level `exclude` MUST remove matching inherited and step-local skills.
+4. Step-level `materializationMode` MUST override task-level `materializationMode` for that step only.
+5. The original task selector MUST remain unchanged after effective selector construction.
+
+## Resolution Rules
+
+1. MoonMind MUST call the trusted agent-skill resolution activity or service before runtime launch when an effective selector is non-empty.
+2. Source loading, source policy filtering, manifest generation, and materialization MUST happen outside deterministic workflow code.
+3. Source policy MUST be applied before precedence.
+4. Missing required skills, unsatisfied pins, nondeterministic same-source collisions, policy blocks, and runtime incompatibility MUST fail before runtime launch.
+5. Successful resolution MUST return a compact `ResolvedSkillSet` ref and metadata for the downstream runtime request.
+
+## Artifact Discipline
+
+1. Large skill bodies, resolved manifests, materialization bundles, and source traces MUST be artifact-backed.
+2. Workflow payloads MUST carry compact refs and metadata only.
+3. The resolved snapshot manifest ref MUST be sufficient for audit and rerun reasoning without embedding full skill bodies in workflow history.
+
+## Runtime Launch Rules
+
+1. `MoonMind.AgentRun` requests MUST receive `resolvedSkillsetRef` when a pre-launch skill snapshot was resolved.
+2. Runtime adapters MUST consume the immutable ref and MUST NOT independently re-resolve skill sources.
+3. Retries, continue-as-new, and ordinary reruns MUST reuse the same resolved snapshot unless explicit re-resolution is requested.
+
+## Failure Output
+
+Resolution failure before launch MUST include:
+- the failing selector context,
+- the validation reason,
+- whether the failure was caused by missing skill, pin mismatch, policy, collision, or runtime incompatibility,
+- no raw skill body content or secret material.

--- a/specs/207-skill-selection-snapshot-resolution/data-model.md
+++ b/specs/207-skill-selection-snapshot-resolution/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Skill Selection and Snapshot Resolution
+
+## Skill Selector
+
+Represents task-wide or step-specific agent skill intent.
+
+Fields:
+- `sets`: Optional named skill sets to activate.
+- `include`: Optional exact skill names and versions.
+- `exclude`: Optional skill names to remove from inherited or resolved intent.
+- `materializationMode`: Optional requested delivery mode for the runtime.
+
+Validation:
+- Selector arrays must be lists.
+- Include entries require non-blank names and may include pinned versions.
+- Invalid materialization modes fail validation before execution.
+
+## Effective Skill Selector
+
+Represents the deterministic merge of task-level and step-level selector intent.
+
+Rules:
+- Task-level `sets` and `include` provide inherited baseline intent.
+- Step-level `sets` and `include` are additive.
+- Step-level `exclude` removes matching inherited or step-level selections.
+- Step-level `materializationMode`, when present, overrides the task-level mode for that step.
+- Merging must not mutate the original task-level selector object.
+
+## Source Policy
+
+Represents which skill sources may contribute candidates during resolution.
+
+Fields:
+- `allow_repo_skills`: Whether repo-checked-in skills may be loaded.
+- `allow_local_skills`: Whether `.agents/skills/local` skills may be loaded.
+- Deployment and built-in source availability are determined by configured loader context.
+
+Validation:
+- Disallowed source candidates are excluded before precedence is applied.
+- Unsupported or missing policy inputs fail closed for untrusted repo and local sources.
+
+## ResolvedSkillSet
+
+Immutable snapshot of selected skills for a run or step.
+
+Fields:
+- `snapshot_id`: Stable snapshot identity.
+- `deployment_id`: Optional run or deployment context.
+- `resolved_at`: Resolution timestamp.
+- `skills`: Exact active skill entries with names, versions, provenance, and content refs.
+- `manifest_ref`: Artifact-backed manifest reference when persisted.
+- `source_trace`: Artifact-backed or compact provenance summary.
+- `resolution_inputs`: Compact serialized selector inputs.
+- `policy_summary`: Compact policy decisions used during resolution.
+
+Validation:
+- Resolved skills are sorted deterministically.
+- Pinned versions must match exactly.
+- Duplicate same-source names fail resolution.
+- Missing required or pinned skills fail before runtime launch.
+
+## Runtime Skill Materialization
+
+Runtime-facing rendering of a `ResolvedSkillSet`.
+
+Fields:
+- `runtime_id`: Target runtime identity.
+- `materialization_mode`: Prompt-bundled, workspace-mounted, hybrid, or retrieval mode.
+- `workspace_paths`: Paths to materialized active skill snapshot data.
+- `prompt_index_ref`: Optional prompt bundle or index ref.
+- `retrieval_manifest_ref`: Optional retrieval manifest ref.
+- `metadata`: Compact metadata for observability.
+
+State transitions:
+- `requested` -> `resolved` once `ResolvedSkillSet` is created.
+- `resolved` -> `persisted` once manifest artifact refs are written.
+- `persisted` -> `materialized` when runtime-facing content is prepared.
+- Any resolution validation failure transitions to `failed_before_launch`.

--- a/specs/207-skill-selection-snapshot-resolution/plan.md
+++ b/specs/207-skill-selection-snapshot-resolution/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Skill Selection and Snapshot Resolution
+
+**Branch**: `207-skill-selection-snapshot-resolution` | **Date**: 2026-04-18 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story runtime feature specification from `specs/207-skill-selection-snapshot-resolution/spec.md`
+
+## Summary
+
+Implement MM-406 by wiring task-wide and step-specific agent skill intent into the runtime preparation path so MoonMind resolves one immutable, artifact-backed skill snapshot before managed or external runtime launch. Repo inspection shows schemas, resolver services, source policy gates, materialization, activity registration, manifest artifacts, and adapter propagation already exist. The remaining work is to merge task and step selectors deterministically, call `agent_skill.resolve` before launch, thread the compact `ResolvedSkillSet` ref to `MoonMind.AgentRun`, and add boundary tests proving inheritance, pinned failures, artifact discipline, and retry/rerun snapshot reuse.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `TaskExecutionSpec.skills`, `TaskStepSpec.skills`; no runtime pre-launch resolution from task/step selectors found | collect effective selector during run preparation and resolve before launch | unit + workflow boundary |
+| FR-002 | missing | task and step selector schemas exist; no selector merge helper found | add deterministic task/step selector merge with exclusions preserving task intent | unit |
+| FR-003 | implemented_unverified | `AgentSkillResolver.resolve()` returns `ResolvedSkillSet`; pinned mismatch test exists | verify through pre-launch workflow boundary and pinned failure path | unit + workflow boundary |
+| FR-004 | implemented_verified | `SkillResolutionContext.allow_repo_skills`; `allow_local_skills`; resolver policy summary tests | no new implementation | final verify |
+| FR-005 | implemented_unverified | resolver rejects duplicate same-source entries and pinned mismatches | add or extend pre-launch error propagation coverage | unit + workflow boundary |
+| FR-006 | implemented_unverified | `ResolvedSkillSet`; `agent_skill.resolve`; manifest ref persistence | thread manifest/ref through runtime request from task/step selectors | workflow boundary |
+| FR-007 | implemented_unverified | `agent_skill.resolve` writes manifest artifact; materializer writes active manifest | assert compact payload and artifact ref behavior at activity/workflow boundary | unit + workflow boundary |
+| FR-008 | implemented_verified | `AgentSkillsActivities.resolve_skills`; `AgentSkillResolver`; materializer service | no new implementation beyond workflow call site | final verify |
+| FR-009 | implemented_unverified | integration tests cover plan registry snapshot retry/rerun reuse; not task/step resolved snapshots | extend boundary coverage for resolved task/step snapshot reuse | workflow boundary |
+| FR-010 | implemented_unverified | `_build_agent_execution_request` propagates `resolved_skillset_ref`; adapter metadata propagation exists | verify launch path receives resolved ref from new pre-launch resolution | unit + workflow boundary |
+| FR-011 | implemented_verified | `AgentSkillMaterializer` writes `.agents/skills_active`; test asserts `.agents/skills` is not mutated | no new implementation | final verify |
+| FR-012 | implemented_verified | `spec.md`; `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md` | preserve through tasks, verification, commit, and PR metadata | traceability check |
+| DESIGN-REQ-006 | partial | resolver creates immutable snapshot; pre-launch task/step call missing | add pre-launch resolution | unit + workflow boundary |
+| DESIGN-REQ-007 | implemented_unverified | manifest artifact persistence exists | assert manifest ref remains compact in launch path | unit + workflow boundary |
+| DESIGN-REQ-008 | missing | task and step selectors parse; merge semantics absent | add merge helper and tests | unit |
+| DESIGN-REQ-009 | partial | activity/service boundary exists; workflow does not yet invoke it for task/step intent | invoke activity from workflow preparation | workflow boundary |
+| DESIGN-REQ-010 | implemented_unverified | resolver fail-fast and snapshot reuse evidence exists in adjacent plan registry path | add selected story coverage | unit + workflow boundary |
+| DESIGN-REQ-019 | implemented_unverified | `MoonMind.AgentRun` request carries `resolvedSkillsetRef` | prove new resolved snapshot ref reaches AgentRun without re-resolution | workflow boundary |
+| SC-001 | missing | no effective selector merge test | add unit test | unit |
+| SC-002 | implemented_unverified | pinned mismatch unit test exists; not pre-launch | add workflow-boundary failure coverage | unit + workflow boundary |
+| SC-003 | implemented_unverified | artifact manifest creation exists | add boundary assertion for compact ref | workflow boundary |
+| SC-004 | implemented_unverified | existing integration tests cover plan registry snapshot reuse | extend or add focused coverage for resolved task/step snapshot | workflow boundary |
+| SC-005 | implemented_unverified | request and adapter propagation tests exist | add launch-path test from selector to request ref | unit + workflow boundary |
+| SC-006 | implemented_verified | spec and Jira input preserve MM-406 and source IDs | preserve through tasks and verification | traceability check |
+
+## Technical Context
+
+**Language/Version**: Python 3.12 with Pydantic v2 models and Temporal Python SDK activity boundaries  
+**Primary Dependencies**: Pydantic v2, Temporal activity wrappers, existing agent-skill resolver/materializer services, existing task contract models  
+**Storage**: Existing artifact-backed skill snapshot manifests; no new persistent database tables planned  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` for focused iteration; final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration checks when Docker is available; targeted Temporal workflow-boundary tests should be unit or local integration where practical  
+**Target Platform**: MoonMind API service, Temporal orchestration workflow, `MoonMind.AgentRun`, managed and external runtime adapters  
+**Project Type**: Python web service and Temporal workflow system  
+**Performance Goals**: Resolve at most once per task step preparation unless explicit re-resolution is requested; workflow payload carries compact refs only  
+**Constraints**: Runtime mode; no raw credentials; do not mutate checked-in skill folders; keep large skill bodies and source traces out of workflow history; preserve MM-406 traceability; source loading stays outside deterministic workflow code  
+**Scale/Scope**: One runtime story covering task/step selector inheritance, pre-launch snapshot resolution, artifact discipline, and runtime launch ref propagation
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The work strengthens orchestration around existing agent runtimes.
+- **II. One-Click Agent Deployment**: PASS. No new required external service or secret is introduced.
+- **III. Avoid Vendor Lock-In**: PASS. Skill snapshot refs are runtime-neutral and adapter-consumed.
+- **IV. Own Your Data**: PASS. Resolved skill manifests stay in operator-controlled artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The story completes first-class selector and snapshot behavior.
+- **VI. Replaceability and Scientific Method**: PASS. Work is test-first with boundary verification.
+- **VII. Runtime Configurability**: PASS. Existing source policy flags remain explicit inputs.
+- **VIII. Modular and Extensible Architecture**: PASS. Changes stay in task contract, resolver, workflow, and adapter boundaries.
+- **IX. Resilient by Default**: PASS. Fail-fast resolution prevents runtime launch with invalid skill intent.
+- **X. Facilitate Continuous Improvement**: PASS. Final verification will preserve structured outcome evidence.
+- **XI. Spec-Driven Development**: PASS. Implementation proceeds from spec, plan, and tasks.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. Jira input remains under `docs/tmp/`; canonical docs are source requirements only.
+- **XIII. Pre-release Compatibility Policy**: PASS. Internal contract changes should update all callers without compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/207-skill-selection-snapshot-resolution/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── skill-snapshot-resolution.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/workflows/tasks/task_contract.py
+moonmind/services/skill_resolution.py
+moonmind/workflows/agent_skills/agent_skills_activities.py
+moonmind/workflows/temporal/workflows/run.py
+moonmind/workflows/temporal/workflows/agent_run.py
+moonmind/workflows/adapters/codex_session_adapter.py
+tests/unit/workflows/tasks/test_task_contract.py
+tests/unit/services/test_skill_resolution.py
+tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py
+docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Use existing task selector contracts, resolver services, activities, and AgentRun request fields. Add a narrow selector-merge helper and workflow call-site coverage rather than introducing a new persistent model or parallel skill-resolution path.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| None | N/A | N/A |
+
+## Phase 0: Research Summary
+
+Research classifies MM-406 as a single-story runtime feature. Existing code already validates task and step skill selector shapes, resolves skills through services and activities, writes manifest artifacts, materializes to `.agents/skills_active`, and propagates `resolvedSkillsetRef` into AgentRun requests. The missing runtime behavior is the deterministic merge of task and step selectors plus a workflow preparation call that resolves the effective selector before launch and reuses that compact snapshot ref across retries and reruns.
+
+## Phase 1: Design Artifact Summary
+
+- `research.md`: requirement-by-requirement repo evidence, current gaps, and planned test-first work.
+- `data-model.md`: selector, source policy, `ResolvedSkillSet`, and materialization entities.
+- `contracts/skill-snapshot-resolution.md`: observable merge, resolution, failure, artifact, and launch-ref behavior.
+- `quickstart.md`: focused red-first tests, unit suite, integration command, and traceability checks.
+
+## Post-Design Constitution Re-Check
+
+PASS. The planned design preserves runtime mode, keeps skill content out of workflow history, keeps source loading at activity/service boundaries, and keeps `.agents/skills` as the runtime-visible active path after snapshot materialization.
+
+## Managed Setup Note
+
+The standard `.specify/scripts/bash/setup-plan.sh --json` helper could not be used because the managed runtime branch is `mm-406-29677dad`, not a numbered Moon Spec branch. The feature directory is resolved through `.specify/feature.json` as `specs/207-skill-selection-snapshot-resolution`.

--- a/specs/207-skill-selection-snapshot-resolution/plan.md
+++ b/specs/207-skill-selection-snapshot-resolution/plan.md
@@ -1,6 +1,6 @@
 # Implementation Plan: Skill Selection and Snapshot Resolution
 
-**Branch**: `207-skill-selection-snapshot-resolution` | **Date**: 2026-04-18 | **Spec**: [spec.md](spec.md)  
+**Branch**: `207-skill-selection-snapshot-resolution` | **Date**: 2026-04-18 | **Spec**: [spec.md](spec.md)
 **Input**: Single-story runtime feature specification from `specs/207-skill-selection-snapshot-resolution/spec.md`
 
 ## Summary
@@ -38,15 +38,15 @@ Implement MM-406 by wiring task-wide and step-specific agent skill intent into t
 
 ## Technical Context
 
-**Language/Version**: Python 3.12 with Pydantic v2 models and Temporal Python SDK activity boundaries  
-**Primary Dependencies**: Pydantic v2, Temporal activity wrappers, existing agent-skill resolver/materializer services, existing task contract models  
-**Storage**: Existing artifact-backed skill snapshot manifests; no new persistent database tables planned  
-**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` for focused iteration; final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
-**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration checks when Docker is available; targeted Temporal workflow-boundary tests should be unit or local integration where practical  
-**Target Platform**: MoonMind API service, Temporal orchestration workflow, `MoonMind.AgentRun`, managed and external runtime adapters  
-**Project Type**: Python web service and Temporal workflow system  
-**Performance Goals**: Resolve at most once per task step preparation unless explicit re-resolution is requested; workflow payload carries compact refs only  
-**Constraints**: Runtime mode; no raw credentials; do not mutate checked-in skill folders; keep large skill bodies and source traces out of workflow history; preserve MM-406 traceability; source loading stays outside deterministic workflow code  
+**Language/Version**: Python 3.12 with Pydantic v2 models and Temporal Python SDK activity boundaries
+**Primary Dependencies**: Pydantic v2, Temporal activity wrappers, existing agent-skill resolver/materializer services, existing task contract models
+**Storage**: Existing artifact-backed skill snapshot manifests; no new persistent database tables planned
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` for focused iteration; final `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+**Integration Testing**: `./tools/test_integration.sh` for required hermetic integration checks when Docker is available; targeted Temporal workflow-boundary tests should be unit or local integration where practical
+**Target Platform**: MoonMind API service, Temporal orchestration workflow, `MoonMind.AgentRun`, managed and external runtime adapters
+**Project Type**: Python web service and Temporal workflow system
+**Performance Goals**: Resolve at most once per task step preparation unless explicit re-resolution is requested; workflow payload carries compact refs only
+**Constraints**: Runtime mode; no raw credentials; do not mutate checked-in skill folders; keep large skill bodies and source traces out of workflow history; preserve MM-406 traceability; source loading stays outside deterministic workflow code
 **Scale/Scope**: One runtime story covering task/step selector inheritance, pre-launch snapshot resolution, artifact discipline, and runtime launch ref propagation
 
 ## Constitution Check

--- a/specs/207-skill-selection-snapshot-resolution/quickstart.md
+++ b/specs/207-skill-selection-snapshot-resolution/quickstart.md
@@ -1,0 +1,66 @@
+# Quickstart: Skill Selection and Snapshot Resolution
+
+## Focused Test-First Flow
+
+1. Add failing unit coverage for effective task/step selector merging:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py
+```
+
+Expected red cases before implementation:
+- step-level exclusion removes inherited task-level include,
+- step materialization mode overrides task mode for one step,
+- original task selector remains unchanged.
+
+2. Add failing workflow-boundary coverage for pre-launch resolution:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+```
+
+Expected red cases before implementation:
+- effective selector invokes `agent_skill.resolve` or the equivalent boundary before runtime launch,
+- `resolvedSkillsetRef` from the manifest/ref reaches the AgentRun request,
+- pinned resolution failure stops before AgentRun launch.
+
+3. Verify existing resolver and activity behavior stays green:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py
+```
+
+4. Run source traceability check:
+
+```bash
+rg -n "MM-406|DESIGN-REQ-006|DESIGN-REQ-007|DESIGN-REQ-008|DESIGN-REQ-009|DESIGN-REQ-010|DESIGN-REQ-019" specs/207-skill-selection-snapshot-resolution docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md
+```
+
+5. Run final unit verification:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+6. Run hermetic integration verification when Docker is available:
+
+```bash
+./tools/test_integration.sh
+```
+
+If Docker is unavailable in the managed runtime, record the exact blocker and rely on focused unit/workflow-boundary evidence plus final MoonSpec verification.
+
+## Story Validation
+
+Submit or simulate a task with:
+- task-level skills including at least one pinned include,
+- one step-level exclusion,
+- one step-level materialization mode override.
+
+Validate that:
+- the effective selector reflects step override behavior,
+- the original task-level selector is preserved,
+- snapshot resolution happens before runtime launch,
+- the launch request carries a compact `resolvedSkillsetRef`,
+- large skill content remains in artifacts,
+- retries/reruns use the same snapshot ref unless explicit re-resolution is requested.

--- a/specs/207-skill-selection-snapshot-resolution/research.md
+++ b/specs/207-skill-selection-snapshot-resolution/research.md
@@ -1,0 +1,89 @@
+# Research: Skill Selection and Snapshot Resolution
+
+## Classification
+
+Decision: Treat MM-406 as a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`; `specs/207-skill-selection-snapshot-resolution/spec.md`.
+Rationale: The Jira brief contains one actor, one operational goal, and one independently testable behavior: resolve task/step skill intent into an immutable snapshot before runtime launch.
+Alternatives considered: Treating `docs/Tasks/AgentSkillSystem.md` as a broad design was rejected because the Jira brief selected a bounded story from that design.
+Test implications: Unit and workflow-boundary tests are required.
+
+## FR-001 / DESIGN-REQ-006
+
+Decision: Partial; selector schemas exist but runtime pre-launch collection and resolution from task/step intent is not complete.
+Evidence: `TaskExecutionSpec.skills` and `TaskStepSpec.skills` in `moonmind/workflows/tasks/task_contract.py`; `tests/unit/workflows/tasks/test_task_contract.py`; no `agent_skill.resolve` invocation was found in `moonmind/workflows/temporal/workflows/run.py`.
+Rationale: Input normalization is present, but the story requires resolution before runtime launch.
+Alternatives considered: Rely on existing plan `registry_snapshot` behavior; rejected because the Jira brief specifically concerns task and step skill intent.
+Test implications: Add workflow-boundary coverage that task/step skill intent triggers pre-launch resolution.
+
+## FR-002 / DESIGN-REQ-008 / SC-001
+
+Decision: Missing; task-level and step-level skill selectors parse independently, but no deterministic inheritance/override merge helper was found.
+Evidence: `TaskSkillSelectors` validation exists in `task_contract.py`; no merge helper appeared in repo search for task/step skill selectors.
+Rationale: The acceptance scenario requires step exclusions to override inherited task skills without mutating the task-level intent.
+Alternatives considered: Put merge behavior inline in the workflow; rejected because focused helper tests are simpler and keep workflow code smaller.
+Test implications: Add unit tests for include union, set union, step exclusion, materialization mode override, and unchanged task selector input.
+
+## FR-003 / FR-005 / DESIGN-REQ-010 / SC-002
+
+Decision: Implemented but not fully verified through the launch path.
+Evidence: `AgentSkillResolver.resolve()` returns `ResolvedSkillSet`; `tests/unit/services/test_skill_resolution.py` covers pinned version mismatch and duplicate same-source failure.
+Rationale: Resolver fail-fast behavior exists, but the selected story also needs proof that such failures stop before runtime launch.
+Alternatives considered: Add only resolver tests; rejected because the story is about orchestration before launch.
+Test implications: Add workflow-boundary failure coverage proving pinned failure prevents AgentRun launch.
+
+## FR-004
+
+Decision: Implemented and verified.
+Evidence: `SkillResolutionContext.allow_repo_skills`, `allow_local_skills`; `RepoSkillLoader` and `LocalSkillLoader`; tests for allowed and denied repo/local sources in `tests/unit/services/test_skill_resolution.py`.
+Rationale: Source policy is explicit and deny-by-default for repo/local sources.
+Alternatives considered: Add new source policy model; rejected because current context already supports the required policy inputs.
+Test implications: None beyond final verification.
+
+## FR-006 / FR-007 / DESIGN-REQ-007 / SC-003
+
+Decision: Implemented but needs selected-story boundary proof.
+Evidence: `ResolvedSkillSet` in `moonmind/schemas/agent_skill_models.py`; `AgentSkillsActivities.resolve_skills()` writes the resolved set as an artifact and sets `manifest_ref`; `AgentSkillMaterializer` writes `active_manifest.json`.
+Rationale: Artifact discipline exists, but runtime preparation must prove it threads compact refs rather than large payloads.
+Alternatives considered: Treat activity artifact persistence as sufficient; rejected because the workflow launch path remains unverified.
+Test implications: Add boundary assertions for manifest ref and compact `resolvedSkillsetRef`.
+
+## FR-008 / DESIGN-REQ-009
+
+Decision: Partial; activity/service boundaries exist, but the workflow is not yet invoking them for task/step intent.
+Evidence: `AgentSkillsActivities.resolve_skills`; `AgentSkillResolver`; `AgentSkillMaterializer`; activity catalog entries for `agent_skill.resolve`, `agent_skill.build_prompt_index`, and `agent_skill.materialize`.
+Rationale: The architectural boundary is ready, but the selected runtime path needs to call it.
+Alternatives considered: Resolve inside deterministic workflow code; rejected by source requirements and Temporal constraints.
+Test implications: Workflow-boundary test should observe an `agent_skill.resolve` activity call or equivalent wrapper invocation before launch.
+
+## FR-009 / SC-004
+
+Decision: Implemented for plan registry snapshots, unverified for task/step resolved snapshots.
+Evidence: `tests/integration/workflows/temporal/workflows/test_run_agent_dispatch.py` covers retry/rerun reuse of `registry_snapshot_ref`.
+Rationale: Adjacent snapshot-pinning behavior exists, but MM-406 requires the resolved skill snapshot produced from task/step intent.
+Alternatives considered: Reuse the existing tests unchanged; rejected because they use plan registry snapshots rather than task/step selectors.
+Test implications: Add focused coverage that the new resolved snapshot ref is reused.
+
+## FR-010 / DESIGN-REQ-019 / SC-005
+
+Decision: Implemented but not verified from the new resolution source.
+Evidence: `_build_agent_execution_request(..., resolved_skillset_ref=...)` propagates the ref; `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` covers direct propagation; adapter code preserves `resolved_skillset_ref`.
+Rationale: The request field exists, but new tests must prove the resolved snapshot ref from task/step intent reaches the request.
+Alternatives considered: Add adapter-only tests; rejected because propagation from the resolution call is the missing behavior.
+Test implications: Add launch-path unit or workflow-boundary coverage.
+
+## FR-011
+
+Decision: Implemented and verified.
+Evidence: `AgentSkillMaterializer` writes `.agents/skills_active`; `tests/unit/services/test_skill_materialization.py` asserts `.agents/skills` is not written.
+Rationale: This preserves the canonical active snapshot path without mutating checked-in skill folders.
+Alternatives considered: Change materializer output to `.agents/skills`; rejected because runtime adapters map active snapshots to canonical paths separately.
+Test implications: None beyond final verification.
+
+## FR-012 / SC-006
+
+Decision: Implemented and verified at Specify/Plan stages.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`; `specs/207-skill-selection-snapshot-resolution/spec.md`; this plan.
+Rationale: MM-406 and source coverage IDs are preserved.
+Alternatives considered: Link only to Jira; rejected because downstream verification needs local artifact traceability.
+Test implications: Traceability `rg` check.

--- a/specs/207-skill-selection-snapshot-resolution/spec.md
+++ b/specs/207-skill-selection-snapshot-resolution/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Skill Selection and Snapshot Resolution
+
+**Feature Branch**: `[207-skill-selection-snapshot-resolution]`
+**Created**: 2026-04-18
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-406 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira brief: docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md
+
+# MM-406 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-406
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Skill Selection and Snapshot Resolution
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-406 from MM project
+Summary: Skill Selection and Snapshot Resolution
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-406 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-406: Skill Selection and Snapshot Resolution
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §10-§12
+  - AgentSkillSystem §15
+  - AgentSkillSystem §19
+  - ManagedAndExternalAgentExecutionModel §2.5
+- Coverage IDs:
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-008
+  - DESIGN-REQ-009
+  - DESIGN-REQ-010
+  - DESIGN-REQ-019
+
+User Story
+As a task author, I can express task-wide and step-specific skill intent and have MoonMind resolve it into an immutable, artifact-backed snapshot before runtime launch, so retries, reruns, and audits reproduce the same skill set unless re-resolution is explicit.
+
+Acceptance Criteria
+- Given `task.skills` defines a baseline and `step.skills` excludes one inherited skill, when the step is prepared, then the resolved snapshot reflects the override without mutating task-level intent.
+- Given a pinned skill version cannot be resolved, when resolution runs, then the workflow fails before runtime launch with an actionable validation error.
+- Given a `ResolvedSkillSet` is produced, then workflow history contains only compact refs and metadata while large manifests, bodies, bundles, and source traces are artifact-backed.
+- Given a retry, continue-as-new, or ordinary rerun occurs, then the same resolved snapshot is reused unless the caller explicitly requests re-resolution.
+
+Requirements
+- Collect task and step skill selectors before runtime launch.
+- Resolve allowed source kinds through activity or service boundaries, not deterministic workflow code.
+- Pin exact skill versions and write resolved manifest artifacts.
+- Fail fast for missing required skills, unsatisfied pins, nondeterministic collisions, policy blocks, or runtime incompatibility.
+- Preserve proposal, schedule, retry, rerun, and replay semantics for skill intent and resolved snapshots.
+
+Relevant Implementation Notes
+- Keep `.agents/skills` as the canonical active runtime-visible path for the resolved active snapshot.
+- Treat checked-in repo skills and local-only skills as inputs to resolution, not as mutable runtime source-of-truth folders.
+- Keep `.agents/skills/local` as a local-only overlay source.
+- Do not embed large skill content in workflow history; workflows should carry compact refs and metadata while activities or services write artifact-backed manifests, bodies, bundles, and source traces.
+- Skill source loading, resolution, manifest generation, and materialization belong at activity or service boundaries, not deterministic workflow code.
+- Unsupported source kinds, missing required skills, unsatisfied pins, nondeterministic collisions, policy blocks, or runtime incompatibility should fail before runtime launch with actionable validation errors.
+
+Verification
+- Confirm task-level and step-level skill selector inputs are collected before runtime launch.
+- Confirm step-level exclusions can override inherited task-level skill intent without mutating the task-level intent.
+- Confirm pinned skill resolution failure stops before runtime launch with an actionable validation error.
+- Confirm `ResolvedSkillSet` output stores large skill manifests, bodies, bundles, and source traces as artifact-backed data while workflow history retains only compact refs and metadata.
+- Confirm retries, continue-as-new, and ordinary reruns reuse the same resolved snapshot unless explicit re-resolution is requested.
+- Preserve MM-406 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-407 blocks this issue.
+- MM-406 blocks MM-405."
+
+## User Story - Resolve Skill Snapshots Before Runtime Launch
+
+**Summary**: As a task author, I want task-wide and step-specific skill intent resolved into an immutable snapshot before runtime launch so retries, reruns, and audits reproduce the same skill set unless re-resolution is explicit.
+
+**Goal**: MoonMind resolves applicable agent instruction bundles for each run or step before launching a managed or external runtime, records compact snapshot metadata, stores large resolved skill content in artifacts, and presents the same resolved active skill set to downstream adapters through the canonical workspace-facing path.
+
+**Independent Test**: Can be tested by submitting task and step skill selections that include inheritance, exclusion, pinned versions, and policy-gated sources, then validating the resolved snapshot, artifact refs, workflow payload shape, and retry/rerun behavior without launching a full agent runtime.
+
+**Acceptance Scenarios**:
+
+1. **Given** `task.skills` defines a baseline and `step.skills` excludes one inherited skill, **When** the step is prepared for execution, **Then** the resolved snapshot reflects the override without mutating task-level intent.
+2. **Given** a selected skill version is pinned but cannot be resolved, **When** snapshot resolution runs, **Then** MoonMind fails before runtime launch with an actionable validation error.
+3. **Given** a `ResolvedSkillSet` is produced, **When** workflow payloads and execution metadata are inspected, **Then** workflow history contains only compact refs and metadata while large manifests, bodies, bundles, and source traces are artifact-backed.
+4. **Given** a retry, continue-as-new, or ordinary rerun occurs, **When** MoonMind prepares skill context again, **Then** the same resolved snapshot is reused unless the caller explicitly requests re-resolution.
+5. **Given** a runtime adapter launches a managed or external agent, **When** it receives the resolved skill context, **Then** it consumes immutable snapshot refs and does not independently re-resolve skill sources.
+
+### Edge Cases
+
+- A required skill is missing from all allowed sources.
+- A pinned version exists in a disallowed source but not in any allowed source.
+- Two allowed sources provide the same canonical skill name and precedence determines a winner.
+- Source policy forbids repo or local-only skills that would otherwise match a selector.
+- Large skill bodies, source traces, or materialized bundles exceed safe workflow payload size.
+- A task is rerun after source skill content has changed since the original run.
+- A workflow continues as new after snapshot resolution but before runtime launch.
+
+## Assumptions
+
+- The active runtime-visible path remains `.agents/skills`, with `.agents/skills/local` treated as a local-only overlay input rather than authoritative durable storage.
+- The historical `docs/Tools/SkillSystem.md` source reference maps to the canonical current repo documents `docs/Tasks/AgentSkillSystem.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- The Jira dependency note for MM-407 is preserved as source context, but this spec covers only MM-406's selected single story.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-006**: Source `docs/Tasks/AgentSkillSystem.md` sections 10 and 12. Each resolved skill set MUST be immutable, pin exact selected versions, and be created before runtime launch. Scope: in scope. Maps to FR-001, FR-003, FR-004, FR-005, and FR-006.
+- **DESIGN-REQ-007**: Source `docs/Tasks/AgentSkillSystem.md` sections 10, 12, and 15. Large skill bodies, manifests, materialization bundles, and source traces MUST live in artifacts or equivalent blob storage while workflow payloads carry compact refs and metadata. Scope: in scope. Maps to FR-006 and FR-007.
+- **DESIGN-REQ-008**: Source `docs/Tasks/AgentSkillSystem.md` section 11. Task-level and step-level skill selectors MUST support inheritance and explicit step overrides without mutating task-level intent. Scope: in scope. Maps to FR-001 and FR-002.
+- **DESIGN-REQ-009**: Source `docs/Tasks/AgentSkillSystem.md` sections 12 and 15. Candidate source loading, policy filtering, resolution, manifest writing, and materialization MUST happen at activity or service boundaries, not deterministic workflow code. Scope: in scope. Maps to FR-004, FR-005, FR-006, and FR-008.
+- **DESIGN-REQ-010**: Source `docs/Tasks/AgentSkillSystem.md` sections 12 and 19. Resolution MUST fail before runtime launch for missing required skills, unsatisfied pins, nondeterministic collisions, policy blocks, or runtime incompatibility, and reruns or continuations MUST reuse the original snapshot unless explicit re-resolution is requested. Scope: in scope. Maps to FR-005 and FR-009.
+- **DESIGN-REQ-019**: Source `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` section 2.5. `MoonMind.AgentRun` and runtime adapters MUST consume immutable resolved skill refs and must not re-resolve skill sources ad hoc during retry, rerun, or launch. Scope: in scope. Maps to FR-006, FR-008, and FR-010.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST collect task-level and step-level agent skill selectors before preparing a runtime launch.
+- **FR-002**: System MUST apply step-level skill overrides, including exclusions, to inherited task-level intent without mutating the original task-level intent.
+- **FR-003**: System MUST resolve selected skills to exact immutable versions before runtime launch.
+- **FR-004**: System MUST apply configured source policy before source precedence so disallowed built-in, deployment, repo, or local-only candidates cannot enter the active snapshot.
+- **FR-005**: System MUST fail before runtime launch with an actionable validation error when required skills, pins, source policy, collisions, or runtime compatibility prevent deterministic resolution.
+- **FR-006**: System MUST produce a compact `ResolvedSkillSet` reference and metadata for downstream workflow and adapter use.
+- **FR-007**: System MUST store large resolved manifests, bodies, materialization bundles, and source traces outside workflow history as artifact-backed data.
+- **FR-008**: System MUST perform source loading, policy filtering, manifest generation, and materialization through activity or service boundaries rather than deterministic workflow code.
+- **FR-009**: System MUST reuse the same resolved snapshot across retries, continue-as-new, and ordinary reruns unless explicit re-resolution is requested.
+- **FR-010**: System MUST ensure managed and external runtime adapters consume the immutable resolved snapshot refs without independently re-resolving skill sources.
+- **FR-011**: System MUST expose the active resolved skill set through `.agents/skills` while keeping `.agents/skills/local` as a local-only overlay input.
+- **FR-012**: System MUST preserve Jira issue key MM-406 and the canonical Jira preset brief in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Skill Selector**: Task-level or step-level declaration of requested agent instruction bundles, including includes, excludes, and pinned versions.
+- **Source Policy**: The allowed skill source kinds and shadowing rules that determine which candidates may participate in resolution.
+- **ResolvedSkillSet**: Immutable snapshot containing selected skills, versions, source provenance, compact metadata, and artifact refs.
+- **Runtime Skill Materialization**: Runtime-facing rendering of a `ResolvedSkillSet` through workspace files, prompt bundles, retrieval manifests, or equivalent adapter-specific delivery.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A task with inherited skill intent and one step-level exclusion resolves to the expected active skill set in deterministic unit or workflow-boundary coverage.
+- **SC-002**: A pinned missing skill version fails before runtime launch with an actionable validation error in deterministic coverage.
+- **SC-003**: Boundary coverage proves workflow payloads carry only compact `ResolvedSkillSet` refs and metadata while large manifests, bodies, bundles, and source traces are artifact-backed.
+- **SC-004**: Retry, continue-as-new, and rerun coverage proves the original resolved snapshot is reused unless explicit re-resolution is requested.
+- **SC-005**: Adapter-boundary coverage proves runtime launch consumes resolved snapshot refs and does not perform ad hoc source re-resolution.
+- **SC-006**: Source traceability checks confirm MM-406, DESIGN-REQ-006 through DESIGN-REQ-010, and DESIGN-REQ-019 remain present in MoonSpec artifacts and verification output.

--- a/specs/207-skill-selection-snapshot-resolution/tasks.md
+++ b/specs/207-skill-selection-snapshot-resolution/tasks.md
@@ -1,9 +1,9 @@
 # Tasks: Skill Selection and Snapshot Resolution
 
-**Input**: `specs/207-skill-selection-snapshot-resolution/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-snapshot-resolution.md`, `quickstart.md`  
-**Prerequisites**: `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`; existing agent-skill resolver/activity/materializer services  
-**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py`  
-**Integration Test Command**: `./tools/test_integration.sh` when Docker is available  
+**Input**: `specs/207-skill-selection-snapshot-resolution/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-snapshot-resolution.md`, `quickstart.md`
+**Prerequisites**: `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`; existing agent-skill resolver/activity/materializer services
+**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py`
+**Integration Test Command**: `./tools/test_integration.sh` when Docker is available
 **Source Traceability**: FR-001 through FR-012; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-019; Jira issue MM-406.
 
 ## Phase 1: Setup
@@ -18,8 +18,8 @@
 
 ## Phase 3: Story - Resolve Skill Snapshots Before Runtime Launch
 
-**Story Summary**: Resolve task-wide and step-specific skill intent into an immutable, artifact-backed snapshot before runtime launch.  
-**Independent Test**: Validate selector merge behavior, pre-launch resolution, compact `resolvedSkillsetRef` propagation, fail-fast pinned errors, and snapshot reuse without requiring a full external provider run.  
+**Story Summary**: Resolve task-wide and step-specific skill intent into an immutable, artifact-backed snapshot before runtime launch.
+**Independent Test**: Validate selector merge behavior, pre-launch resolution, compact `resolvedSkillsetRef` propagation, fail-fast pinned errors, and snapshot reuse without requiring a full external provider run.
 **Traceability**: FR-001-FR-012; acceptance scenarios 1-5; SC-001-SC-006; DESIGN-REQ-006-DESIGN-REQ-010; DESIGN-REQ-019.
 
 ### Unit Test Plan

--- a/specs/207-skill-selection-snapshot-resolution/tasks.md
+++ b/specs/207-skill-selection-snapshot-resolution/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Skill Selection and Snapshot Resolution
+
+**Input**: `specs/207-skill-selection-snapshot-resolution/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-snapshot-resolution.md`, `quickstart.md`  
+**Prerequisites**: `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`; existing agent-skill resolver/activity/materializer services  
+**Unit Test Command**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py`  
+**Integration Test Command**: `./tools/test_integration.sh` when Docker is available  
+**Source Traceability**: FR-001 through FR-012; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-019; Jira issue MM-406.
+
+## Phase 1: Setup
+
+- [X] T001 Confirm active feature locator in `.specify/feature.json` points to `specs/207-skill-selection-snapshot-resolution` and MM-406 source input exists in `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md` (FR-012, SC-006)
+- [X] T002 Inspect existing selector, resolver, activity, materializer, and AgentRun request code in `moonmind/workflows/tasks/task_contract.py`, `moonmind/services/skill_resolution.py`, `moonmind/workflows/agent_skills/agent_skills_activities.py`, `moonmind/services/skill_materialization.py`, and `moonmind/workflows/temporal/workflows/run.py` (FR-001-FR-011)
+
+## Phase 2: Foundational
+
+- [X] T003 Add or confirm test helper fixtures for effective skill selector assertions in `tests/unit/workflows/tasks/test_task_contract.py` (FR-001, FR-002, DESIGN-REQ-008)
+- [X] T004 Add or confirm workflow-boundary test helpers for observing resolved skillset refs before AgentRun launch in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` (FR-006, FR-010, DESIGN-REQ-019)
+
+## Phase 3: Story - Resolve Skill Snapshots Before Runtime Launch
+
+**Story Summary**: Resolve task-wide and step-specific skill intent into an immutable, artifact-backed snapshot before runtime launch.  
+**Independent Test**: Validate selector merge behavior, pre-launch resolution, compact `resolvedSkillsetRef` propagation, fail-fast pinned errors, and snapshot reuse without requiring a full external provider run.  
+**Traceability**: FR-001-FR-012; acceptance scenarios 1-5; SC-001-SC-006; DESIGN-REQ-006-DESIGN-REQ-010; DESIGN-REQ-019.
+
+### Unit Test Plan
+
+- Selector merge unit tests in `tests/unit/workflows/tasks/test_task_contract.py`.
+- Resolver/activity regression tests in `tests/unit/services/test_skill_resolution.py` and `tests/unit/workflows/agent_skills/test_agent_skills_activities.py`.
+
+### Integration / Boundary Test Plan
+
+- Workflow-boundary tests in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`.
+- Existing Temporal integration snapshot tests remain supporting evidence where Docker/time-skipping is available.
+
+### Tests First
+
+- [X] T005 Add failing unit tests for effective task/step skill selector merging in `tests/unit/workflows/tasks/test_task_contract.py`, covering inherited includes, step exclusions, materialization override, and non-mutating task intent (FR-001, FR-002, SC-001, DESIGN-REQ-008)
+- [X] T006 Add failing workflow-boundary test that task/step skill intent triggers pre-launch skill resolution and passes compact `resolvedSkillsetRef` into the AgentRun request in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` (FR-001, FR-006, FR-010, SC-003, SC-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-009, DESIGN-REQ-019)
+- [X] T007 Add failing workflow-boundary test that a pinned resolution failure stops before AgentRun launch in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` (FR-003, FR-005, SC-002, DESIGN-REQ-010)
+- [X] T008 Add failing workflow-boundary or unit test proving retry/rerun uses the original resolved skillset ref unless explicit re-resolution is requested in `tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` or existing Temporal integration tests (FR-009, SC-004, DESIGN-REQ-010, DESIGN-REQ-019)
+- [X] T009 Run focused red-first command `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` and confirm new tests fail for the expected missing behavior (FR-001, FR-002, FR-006, FR-009, FR-010)
+
+### Implementation
+
+- [X] T010 Implement effective task/step skill selector merge helper in `moonmind/workflows/tasks/task_contract.py` without mutating task-level intent (FR-001, FR-002, DESIGN-REQ-008)
+- [X] T011 Wire runtime preparation in `moonmind/workflows/temporal/workflows/run.py` to resolve the effective selector through the agent-skill activity/service boundary before AgentRun launch (FR-001, FR-003, FR-005, FR-006, FR-008, DESIGN-REQ-006, DESIGN-REQ-009, DESIGN-REQ-010)
+- [X] T012 Thread the returned compact resolved snapshot ref into the AgentRun request in `moonmind/workflows/temporal/workflows/run.py` without embedding large skill content in workflow payloads (FR-006, FR-007, FR-010, DESIGN-REQ-007, DESIGN-REQ-019)
+- [X] T013 Preserve existing source policy, artifact persistence, and `.agents/skills_active` materialization behavior in `moonmind/services/skill_resolution.py`, `moonmind/workflows/agent_skills/agent_skills_activities.py`, and `moonmind/services/skill_materialization.py` while adapting call sites if needed (FR-004, FR-007, FR-008, FR-011)
+- [X] T014 Ensure resolution failures surface as pre-launch validation failures with actionable context and no raw skill body or secret material in `moonmind/workflows/temporal/workflows/run.py` (FR-005, DESIGN-REQ-010)
+
+### Story Validation
+
+- [X] T015 Run focused tests `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py` and confirm pass (FR-001-FR-011, SC-001-SC-005)
+- [X] T016 Run traceability check `rg -n "MM-406|DESIGN-REQ-006|DESIGN-REQ-007|DESIGN-REQ-008|DESIGN-REQ-009|DESIGN-REQ-010|DESIGN-REQ-019" specs/207-skill-selection-snapshot-resolution docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md` (FR-012, SC-006)
+
+## Final Phase: Polish And Verification
+
+- [X] T017 Run final unit verification `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` or document the exact local blocker if unavailable (FR-001-FR-012)
+- [X] T018 Run hermetic integration verification `./tools/test_integration.sh` when Docker is available, or document the exact Docker/runtime blocker (acceptance scenarios 1-5)
+- [X] T019 Run `/moonspec-verify` equivalent against `specs/207-skill-selection-snapshot-resolution/spec.md` and write `specs/207-skill-selection-snapshot-resolution/verification.md` after implementation and tests pass (FR-001-FR-012, SC-001-SC-006)
+
+## Dependencies and Execution Order
+
+1. T001-T004 establish feature context and helpers.
+2. T005-T009 create and confirm failing tests before production changes.
+3. T010-T014 implement the missing selector merge and pre-launch resolution path.
+4. T015-T016 validate focused behavior and traceability.
+5. T017-T019 complete full verification.
+
+## Parallel Examples
+
+- T005 can run in parallel with T006 and T007 because they touch different test areas.
+- T010 can run after T005, while T011 and T012 must wait for T006/T007 red-first coverage.
+- T016 can run independently after artifacts exist.
+
+## Implementation Strategy
+
+Start with the smallest deterministic unit: effective selector merging. Then wire the workflow boundary so the runtime path consumes the existing resolver activity and passes only compact refs to AgentRun. Preserve already-verified source policy and materialization behavior; do not introduce a parallel skill source loader, new storage table, or workflow-history skill body payload.

--- a/specs/207-skill-selection-snapshot-resolution/verification.md
+++ b/specs/207-skill-selection-snapshot-resolution/verification.md
@@ -1,9 +1,9 @@
 # MoonSpec Verification Report
 
-**Feature**: Skill Selection and Snapshot Resolution  
-**Spec**: `/work/agent_jobs/mm:a5ced108-472d-4af5-b351-41150acbaf00/repo/specs/207-skill-selection-snapshot-resolution/spec.md`  
-**Original Request Source**: `spec.md` `Input`, preserving Jira issue `MM-406` and `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`  
-**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Feature**: Skill Selection and Snapshot Resolution
+**Spec**: `/work/agent_jobs/mm:a5ced108-472d-4af5-b351-41150acbaf00/repo/specs/207-skill-selection-snapshot-resolution/spec.md`
+**Original Request Source**: `spec.md` `Input`, preserving Jira issue `MM-406` and `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`
+**Verdict**: ADDITIONAL_WORK_NEEDED
 **Confidence**: MEDIUM
 
 ## Test Results

--- a/specs/207-skill-selection-snapshot-resolution/verification.md
+++ b/specs/207-skill-selection-snapshot-resolution/verification.md
@@ -1,0 +1,77 @@
+# MoonSpec Verification Report
+
+**Feature**: Skill Selection and Snapshot Resolution  
+**Spec**: `/work/agent_jobs/mm:a5ced108-472d-4af5-b351-41150acbaf00/repo/specs/207-skill-selection-snapshot-resolution/spec.md`  
+**Original Request Source**: `spec.md` `Input`, preserving Jira issue `MM-406` and `docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md`  
+**Verdict**: ADDITIONAL_WORK_NEEDED  
+**Confidence**: MEDIUM
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Red-first focused unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py` | PASS after implementation | The same command failed before implementation because the selector merge helper and workflow resolver method were missing. |
+| Focused unit regression | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py` | PASS | 72 Python tests and 286 frontend tests passed. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | 3589 Python tests passed, 1 xpassed, 16 subtests passed; 286 frontend tests passed. |
+| Traceability | `rg -n "MM-406|DESIGN-REQ-006|DESIGN-REQ-007|DESIGN-REQ-008|DESIGN-REQ-009|DESIGN-REQ-010|DESIGN-REQ-019" specs/207-skill-selection-snapshot-resolution docs/tmp/jira-orchestration-inputs/MM-406-moonspec-orchestration-input.md` | PASS | Jira key and source IDs remain present. |
+| Hermetic integration | `./tools/test_integration.sh` | NOT RUN | Docker socket unavailable in the managed runtime: `dial unix /var/run/docker.sock: connect: no such file or directory`. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `task_contract.py` effective selector helper; `run.py` pre-launch resolver call; focused tests | VERIFIED | Task and step selectors are collected before launch. |
+| FR-002 | `tests/unit/workflows/tasks/test_task_contract.py` selector merge tests | VERIFIED | Step exclusions remove inherited includes and task intent remains unchanged. |
+| FR-003 | Existing resolver pinning tests plus workflow failure propagation test | VERIFIED | Pinned resolution failures occur before launch. |
+| FR-004 | Existing repo/local source policy code and tests in `tests/unit/services/test_skill_resolution.py` | VERIFIED | Source policy remains explicit and deny-by-default for repo/local sources. |
+| FR-005 | Workflow failure propagation test and resolver duplicate/pin tests | VERIFIED | Resolution errors stop launch with actionable validation context. |
+| FR-006 | `run.py` `_resolve_agent_node_skillset_ref`; workflow tests | VERIFIED | Compact resolved snapshot refs are produced for downstream launch. |
+| FR-007 | `agent_skill.resolve` artifact behavior remains covered; launch path passes ref only | VERIFIED | Large skill content is not embedded in workflow launch payloads. |
+| FR-008 | `run.py` calls `agent_skill.resolve` activity boundary | VERIFIED | Source loading and resolution stay outside deterministic workflow code. |
+| FR-009 | New reuse test plus existing snapshot-pinning evidence | VERIFIED | Existing snapshot refs are reused without ad hoc re-resolution. |
+| FR-010 | `AgentExecutionRequest.resolved_skillset_ref`; workflow launch-boundary test | VERIFIED | AgentRun consumes immutable refs. |
+| FR-011 | Existing materializer tests verify `.agents/skills_active` and no `.agents/skills` mutation | VERIFIED | Active snapshot materialization behavior remains intact. |
+| FR-012 | Spec, tasks, plan, verification, and Jira input artifact | VERIFIED | MM-406 is preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| Task baseline plus step exclusion | `test_effective_task_step_skills_apply_exclusions_without_mutating_task` | VERIFIED | Effective selector matches expected override. |
+| Pinned skill cannot resolve | `test_agent_node_pinned_resolution_failure_happens_before_launch` | VERIFIED | Failure occurs before launch. |
+| ResolvedSkillSet is compact/artifact-backed | `test_agent_node_resolves_effective_task_and_step_skills_before_launch`; existing activity/materializer tests | VERIFIED | Manifest ref reaches launch path. |
+| Retry/rerun snapshot reuse | `test_agent_node_reuses_existing_skillset_ref_without_reresolution`; existing Temporal snapshot-pinning tests | VERIFIED | Existing ref is reused without activity call. |
+| Adapter consumes immutable refs | `test_agent_node_resolves_effective_task_and_step_skills_before_launch`; existing request propagation test | VERIFIED | Launch request carries `resolvedSkillsetRef`. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-006 | `run.py` pre-launch resolution; focused tests | VERIFIED | Skill snapshots are resolved before launch. |
+| DESIGN-REQ-007 | Activity/materializer artifact behavior; compact launch ref | VERIFIED | Large content remains artifact-backed. |
+| DESIGN-REQ-008 | Selector merge helper and tests | VERIFIED | Task/step inheritance and override semantics are implemented. |
+| DESIGN-REQ-009 | `agent_skill.resolve` activity call from workflow | VERIFIED | Resolution stays at activity/service boundary. |
+| DESIGN-REQ-010 | Resolver fail-fast behavior and pre-launch failure test | VERIFIED | Invalid resolution prevents launch; reuse behavior is covered. |
+| DESIGN-REQ-019 | AgentRun request ref propagation and no re-resolution test | VERIFIED | Runtime launch consumes immutable refs. |
+| Constitution IX | Unit and workflow-boundary tests | VERIFIED | Fail-fast resolution avoids invalid runtime launches. |
+| Constitution XI | MoonSpec artifacts and tasks | VERIFIED | Spec/plan/tasks/verification traceability is preserved. |
+
+## Original Request Alignment
+
+- PASS: The input was classified as a single-story runtime feature request.
+- PASS: The canonical Jira preset brief for MM-406 is preserved.
+- PASS: Existing artifacts were inspected before creating `207-skill-selection-snapshot-resolution`.
+- PASS: Implementation resumed from the first incomplete stage and did not regenerate unrelated valid artifacts.
+
+## Gaps
+
+- Hermetic integration verification could not run because the managed runtime has no Docker socket. This is a validation-environment gap, not a known implementation failure.
+
+## Remaining Work
+
+1. Run `./tools/test_integration.sh` in an environment with Docker access.
+
+## Decision
+
+- Implementation and unit/workflow-boundary evidence satisfy the MM-406 story.
+- Final verdict remains `ADDITIONAL_WORK_NEEDED` until required hermetic integration verification is executed or explicitly waived for this managed runtime.

--- a/tests/unit/workflows/tasks/test_task_contract.py
+++ b/tests/unit/workflows/tasks/test_task_contract.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from moonmind.workflows.tasks.task_contract import (
     build_canonical_task_view,
+    build_effective_task_skill_selectors,
     TaskExecutionSpec,
     TaskStepSpec,
 )
@@ -84,6 +85,54 @@ def test_task_step_spec_with_step_skills() -> None:
     assert spec.skills is not None
     assert spec.skills.exclude == ["bad-skill"]
     assert spec.skills.materialization_mode == "none"
+
+
+def test_effective_task_step_skills_apply_exclusions_without_mutating_task() -> None:
+    task_skills = TaskExecutionSpec.model_validate(
+        {
+            "repository": "test/repo",
+            "instructions": "execute",
+            "skills": {
+                "sets": ["default"],
+                "include": [
+                    {"name": "baseline", "version": "1.0.0"},
+                    {"name": "remove-me", "version": "2.0.0"},
+                ],
+                "exclude": ["legacy"],
+                "materializationMode": "hybrid",
+            },
+        }
+    ).skills
+    step_skills = TaskStepSpec.model_validate(
+        {
+            "id": "step1",
+            "skills": {
+                "sets": ["python"],
+                "include": [{"name": "step-only"}],
+                "exclude": ["remove-me"],
+                "materializationMode": "none",
+            },
+        }
+    ).skills
+
+    effective = build_effective_task_skill_selectors(task_skills, step_skills)
+
+    assert effective is not None
+    assert effective.sets == ["default", "python"]
+    assert [(item.name, item.version) for item in effective.include or []] == [
+        ("baseline", "1.0.0"),
+        ("step-only", None),
+    ]
+    assert effective.exclude == ["legacy", "remove-me"]
+    assert effective.materialization_mode == "none"
+    assert [item.name for item in task_skills.include or []] == [
+        "baseline",
+        "remove-me",
+    ]
+
+
+def test_effective_task_step_skills_returns_none_for_empty_intent() -> None:
+    assert build_effective_task_skill_selectors(None, None) is None
 
 
 def test_task_input_attachments_preserve_objective_and_step_targets() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -146,6 +146,44 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(selector.exclude, ["remove-me"])
 
+    async def test_agent_node_reads_canonical_node_skills_before_inputs_skills(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/step-canonical",
+            skills=[],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills={"include": [{"name": "baseline"}]},
+                node_skills={
+                    "include": [{"name": "canonical-step"}],
+                    "exclude": ["legacy-input-step"],
+                },
+                node_inputs={
+                    "skills": {
+                        "include": [{"name": "legacy-input-step"}],
+                    }
+                },
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/step-canonical")
+        args, _kwargs = execute_activity.call_args
+        selector = args[1]
+        self.assertEqual(
+            [(entry.name, entry.version) for entry in selector.include],
+            [("baseline", None), ("canonical-step", None)],
+        )
+        self.assertEqual(selector.exclude, ["legacy-input-step"])
+
     async def test_agent_node_pinned_resolution_failure_happens_before_launch(self) -> None:
         wf = MoonMindRunWorkflow()
         wf._owner_id = "owner-1"
@@ -181,6 +219,51 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(ref, "artifact://skillsets/original")
         execute_activity.assert_not_called()
+
+    async def test_agent_node_does_not_reuse_registry_snapshot_as_skillset_ref(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/resolved-from-intent",
+            skills=[],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            existing = wf._existing_agent_skillset_ref(
+                parameters={},
+                node={
+                    "metadata": {
+                        "registry_snapshot": {
+                            "artifact_ref": "artifact://registry/not-a-skillset"
+                        }
+                    }
+                },
+                node_inputs={"skills": {"include": [{"name": "baseline"}]}},
+            )
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills=None,
+                node_inputs={"skills": {"include": [{"name": "baseline"}]}},
+                node_id="step-1",
+                existing_skillset_ref=existing,
+            )
+
+        self.assertIsNone(existing)
+        self.assertEqual(ref, "artifact://skillsets/resolved-from-intent")
+        execute_activity.assert_awaited_once()
+
+    def test_existing_agent_skillset_ref_accepts_explicit_refs_only(self) -> None:
+        ref = MoonMindRunWorkflow._existing_agent_skillset_ref(
+            parameters={"resolvedSkillsetRef": "artifact://skillsets/from-task"},
+            node={"resolvedSkillsetRef": "artifact://skillsets/from-node"},
+            node_inputs={"resolved_skillset_ref": "artifact://skillsets/from-input"},
+        )
+
+        self.assertEqual(ref, "artifact://skillsets/from-input")
 
 
 class TestJiraAgentPublishHelpers(unittest.TestCase):

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -4,13 +4,16 @@ Pure unit tests — no Temporal test server needed.
 """
 
 import unittest
+from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 pytest.importorskip("temporalio")
 
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.schemas.agent_skill_models import ResolvedSkillSet
 from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
 
 
@@ -97,6 +100,87 @@ class TestSlotContinuityMetadata(unittest.TestCase):
         )
 
         self.assertEqual(request.parameters, {})
+
+
+class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
+    async def test_agent_node_resolves_effective_task_and_step_skills_before_launch(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+        resolved = ResolvedSkillSet(
+            snapshot_id="skillset-wf-step-1",
+            resolved_at=datetime.now(UTC),
+            manifest_ref="artifact://skillsets/step-1",
+            skills=[],
+        )
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(return_value=resolved),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills={
+                    "include": [
+                        {"name": "baseline", "version": "1.0.0"},
+                        {"name": "remove-me"},
+                    ],
+                    "materializationMode": "hybrid",
+                },
+                node_inputs={
+                    "skills": {
+                        "include": [{"name": "step-only"}],
+                        "exclude": ["remove-me"],
+                    }
+                },
+                node_id="step-1",
+                existing_skillset_ref=None,
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/step-1")
+        execute_activity.assert_awaited_once()
+        args, _kwargs = execute_activity.call_args
+        self.assertEqual(args[0], "agent_skill.resolve")
+        selector = args[1]
+        self.assertEqual(
+            [(entry.name, entry.version) for entry in selector.include],
+            [("baseline", "1.0.0"), ("step-only", None)],
+        )
+        self.assertEqual(selector.exclude, ["remove-me"])
+
+    async def test_agent_node_pinned_resolution_failure_happens_before_launch(self) -> None:
+        wf = MoonMindRunWorkflow()
+        wf._owner_id = "owner-1"
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(side_effect=ValueError("Could not resolve pinned version")),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "Could not resolve pinned version",
+            ):
+                await wf._resolve_agent_node_skillset_ref(
+                    task_skills={"include": [{"name": "baseline", "version": "9.9.9"}]},
+                    node_inputs={},
+                    node_id="step-1",
+                    existing_skillset_ref=None,
+                )
+
+    async def test_agent_node_reuses_existing_skillset_ref_without_reresolution(self) -> None:
+        wf = MoonMindRunWorkflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.run.workflow.execute_activity",
+            new=AsyncMock(),
+        ) as execute_activity:
+            ref = await wf._resolve_agent_node_skillset_ref(
+                task_skills={"include": [{"name": "baseline"}]},
+                node_inputs={"skills": {"exclude": ["baseline"]}},
+                node_id="step-1",
+                existing_skillset_ref="artifact://skillsets/original",
+            )
+
+        self.assertEqual(ref, "artifact://skillsets/original")
+        execute_activity.assert_not_called()
 
 
 class TestJiraAgentPublishHelpers(unittest.TestCase):


### PR DESCRIPTION
## Jira
MM-406

## Active MoonSpec Feature
specs/207-skill-selection-snapshot-resolution

## Verification Verdict
ADDITIONAL_WORK_NEEDED

## Tests Run
- PASS: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py`
- PASS: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/tasks/test_task_contract.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/services/test_skill_resolution.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/services/test_skill_materialization.py`
- PASS: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- NOT RUN: `./tools/test_integration.sh` because Docker socket `/var/run/docker.sock` is unavailable in this managed container.

## Remaining Risks
- Hermetic integration verification still needs to run in an environment with Docker access.
