### PR TITLE
Remove this line from the Create Page UI: Leave blank to use default repository: MoonLadderStudios/MoonMind. Accepted formats: owner/repo, https://<ho

### DIFF
--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -5781,13 +5781,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                   placeholder="owner/repo"
                   onChange={(event) => setRepository(event.target.value)}
                 />
-                <span className="small">
-                  {defaultRepository
-                    ? `Leave blank to use default repository: ${defaultRepository}. `
-                    : "Set a repository in this form (no system default repository is configured). "}
-                  Accepted formats: owner/repo, https://&lt;host&gt;/&lt;path&gt;, or
-                  git@&lt;host&gt;:&lt;path&gt; (token-free).
-                </span>
               </label>
 
               <div className="queue-inline-selector-row">


### PR DESCRIPTION
Remove this line from the Create Page UI: Leave blank to use default repository: MoonLadderStudios/MoonMind. Accepted formats: owner/repo, https://<host>/<path>, or git@<host>:<path> (token-free).