### PR TITLE
[codex] Fix agent skill resolver activity args

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3531,11 +3531,13 @@ class MoonMindRunWorkflow:
         route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("agent_skill.resolve")
         resolved = await workflow.execute_activity(
             "agent_skill.resolve",
-            selector,
-            self._principal(),
-            node_inputs.get("workspaceRoot"),
-            False,
-            False,
+            args=[
+                selector,
+                self._principal(),
+                node_inputs.get("workspaceRoot"),
+                False,
+                False,
+            ],
             **self._execute_kwargs_for_route(route),
         )
         manifest_ref = getattr(resolved, "manifest_ref", None)

--- a/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py
@@ -137,9 +137,12 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(ref, "artifact://skillsets/step-1")
         execute_activity.assert_awaited_once()
-        args, _kwargs = execute_activity.call_args
+        args, kwargs = execute_activity.call_args
         self.assertEqual(args[0], "agent_skill.resolve")
-        selector = args[1]
+        self.assertEqual(len(args), 1)
+        activity_args = kwargs["args"]
+        self.assertEqual(activity_args[1:], ["owner-1", None, False, False])
+        selector = activity_args[0]
         self.assertEqual(
             [(entry.name, entry.version) for entry in selector.include],
             [("baseline", "1.0.0"), ("step-only", None)],
@@ -176,8 +179,11 @@ class TestAgentSkillSnapshotResolution(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(ref, "artifact://skillsets/step-canonical")
-        args, _kwargs = execute_activity.call_args
-        selector = args[1]
+        args, kwargs = execute_activity.call_args
+        self.assertEqual(args, ("agent_skill.resolve",))
+        activity_args = kwargs["args"]
+        self.assertEqual(activity_args[1:], ["owner-1", None, False, False])
+        selector = activity_args[0]
         self.assertEqual(
             [(entry.name, entry.version) for entry in selector.include],
             [("baseline", None), ("canonical-step", None)],


### PR DESCRIPTION
## Summary

Fix the `MoonMind.Run` agent skill snapshot resolution path so `agent_skill.resolve` is invoked with Temporal's supported multi-argument activity shape.

## Root Cause

The workflow passed five activity inputs as positional Python arguments to `workflow.execute_activity()`. Temporal Python accepts the activity name plus at most one positional activity argument, so the workflow task failed before the Codex child runtime could bind. That made workflow queries such as `get_step_ledger` unavailable and surfaced in Mission Control as a 503 for `/api/executions/{workflowId}/steps`.

## Changes

- Pass the skill resolver inputs through `args=[...]` when invoking `agent_skill.resolve`.
- Tighten unit coverage to assert the resolver boundary uses `kwargs["args"]`, preventing a regression to unsupported positional activity inputs.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- Verified the affected workflow recovered after worker restart/reset and `/api/executions/mm:e88b72e9-e89d-4f04-83da-d38893ce4ea4/steps` returned `200 OK`.