### PR TITLE
MM-407 Managed Runtime Skill Projection

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/207-visible-step-attachments"
+  "feature_directory": "specs/208-managed-runtime-skill-projection"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-407-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-407-moonspec-orchestration-input.md
@@ -1,0 +1,82 @@
+# MM-407 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-407
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Managed Runtime Skill Projection
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-407 from MM project
+Summary: Managed Runtime Skill Projection
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-407 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-407: Managed Runtime Skill Projection
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §8
+  - AgentSkillSystem §13-§16
+  - SkillInjection §2-§16
+  - ManagedAndExternalAgentExecutionModel §1-§2.5
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-011
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-016
+  - DESIGN-REQ-017
+  - DESIGN-REQ-021
+
+User Story
+As a managed runtime adapter, I can materialize a pinned skill snapshot into a run-scoped active backing store and expose exactly that selected set at .agents/skills with a compact activation summary, so agents see the expected path without MoonMind rewriting checked-in skill folders.
+
+Acceptance Criteria
+- Given a resolved snapshot with one skill, when the adapter prepares the runtime, then .agents/skills contains a full active root with _manifest.json and that skill's SKILL.md.
+- Given a resolved snapshot with multiple skills, then only selected skills appear in the active projection and unselected repo skills are absent.
+- Given a checked-in .agents/skills directory exists, then MoonMind may use it as a resolution input but does not rewrite it in place during runtime setup.
+- Given .agents or .agents/skills is an incompatible file or unprojectable path, then preparation fails before runtime launch with path, object kind, attempted action, and remediation guidance.
+- Given the runtime starts, then the instruction payload includes a compact activation summary and full skill bodies are available on disk, not duplicated inline.
+
+Requirements
+- Materialize the active skill bundle into a MoonMind-owned run-scoped backing directory exactly once per snapshot.
+- Project the active backing store at .agents/skills for managed runtimes using adapter-compatible mechanics.
+- Include only selected skills and a MoonMind-owned active manifest in the runtime-visible tree.
+- Inject a compact activation summary naming active skills, visible path, hard rules, and first-read hints.
+- Do not use retrieval-first loading, custom visible paths, or per-skill leaf mounting as the canonical managed-runtime path.
+
+Relevant Implementation Notes
+- Keep `.agents/skills` as the canonical runtime-visible path for the resolved active snapshot.
+- Materialize the selected skill set into a MoonMind-owned run-scoped backing store before managed runtime launch.
+- Expose exactly the selected active skill set at `.agents/skills`; unselected repo skills must be absent from the runtime-visible projection.
+- Treat checked-in `.agents/skills` folders as resolution inputs only and do not rewrite them in place during runtime setup.
+- Include a MoonMind-owned active manifest in the runtime-visible projection.
+- Keep full skill bodies on disk and avoid duplicating large skill content inline in the instruction payload.
+- Inject only a compact activation summary that names active skills, visible path, hard rules, and first-read hints.
+- Fail before runtime launch when `.agents` or `.agents/skills` is an incompatible file or unprojectable path, with path, object kind, attempted action, and remediation guidance.
+
+Verification
+- Confirm a resolved snapshot with one skill materializes a full `.agents/skills` active root containing `_manifest.json` and that skill's `SKILL.md`.
+- Confirm a resolved snapshot with multiple skills projects only selected skills and omits unselected repo skills.
+- Confirm checked-in `.agents/skills` can be used as a resolution input without being rewritten in place during runtime setup.
+- Confirm incompatible `.agents` or `.agents/skills` paths fail before runtime launch with actionable diagnostics.
+- Confirm runtime instructions include a compact activation summary while full skill bodies are available on disk and not duplicated inline.
+- Preserve MM-407 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-408 blocks this issue.
+- MM-407 blocks MM-406.

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -106,6 +106,7 @@ class AgentSkillMaterializer:
                 links = ensure_shared_skill_links(
                     run_root=self.workspace_root,
                     skills_active_path=active_dir,
+                    require_gemini_link=False,
                 )
             except (OSError, SkillWorkspaceError) as ex:
                 raise RuntimeError(
@@ -113,15 +114,19 @@ class AgentSkillMaterializer:
                 ) from ex
 
             result.workspace_paths.append(str(links.agents_skills_path))
+            compatibility_paths = {
+                "geminiSkillsAvailable": links.gemini_skills_available,
+                "geminiSkillsPath": str(links.gemini_skills_path),
+            }
+            if links.gemini_skills_error:
+                compatibility_paths["geminiSkillsError"] = links.gemini_skills_error
             result.metadata.update(
                 {
                     "activeSkills": [
                         skill.skill_name for skill in resolved_skillset.skills
                     ],
                     "backingPath": str(active_dir),
-                    "compatibilityPaths": {
-                        "geminiSkillsPath": str(links.gemini_skills_path),
-                    },
+                    "compatibilityPaths": compatibility_paths,
                     "manifestPath": str(links.agents_skills_path / "_manifest.json"),
                     "visiblePath": str(links.agents_skills_path),
                 }

--- a/moonmind/services/skill_materialization.py
+++ b/moonmind/services/skill_materialization.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -7,6 +8,10 @@ from moonmind.schemas.agent_skill_models import (
     ResolvedSkillSet,
     RuntimeMaterializationMode,
     RuntimeSkillMaterialization,
+)
+from moonmind.workflows.skills.workspace_links import (
+    SkillWorkspaceError,
+    ensure_shared_skill_links,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,35 +39,22 @@ class AgentSkillMaterializer:
             materialization_mode=mode,
         )
         
-        if mode in (RuntimeMaterializationMode.WORKSPACE_MOUNTED, RuntimeMaterializationMode.HYBRID):
-            active_dir = self.workspace_root / ".agents" / "skills_active"
-            
+        if mode in (
+            RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+            RuntimeMaterializationMode.HYBRID,
+        ):
+            active_dir = self.workspace_root / "skills_active"
+            visible_dir = self.workspace_root / ".agents" / "skills"
+            manifest_path = active_dir / "_manifest.json"
+
+            self._validate_projection_path(visible_dir)
+
             try:
                 active_dir.mkdir(parents=True, exist_ok=True)
+                self._clear_directory(active_dir)
             except OSError as ex:
-                raise RuntimeError(f"Failed to create skills_active directory: {ex}") from ex
+                raise RuntimeError(f"Failed to prepare skills_active directory: {ex}") from ex
 
-            manifest_path = active_dir / "active_manifest.json"
-            
-            manifest_content = {
-                "snapshot_id": resolved_skillset.snapshot_id,
-                "resolved_at": resolved_skillset.resolved_at.isoformat(),
-                "skills": [
-                    {
-                        "name": entry.skill_name,
-                        "version": entry.version,
-                        "source_kind": entry.provenance.source_kind.value,
-                    }
-                    for entry in resolved_skillset.skills
-                ]
-            }
-            
-            try:
-                manifest_path.write_text(json.dumps(manifest_content, indent=2), encoding="utf-8")
-                result.workspace_paths.append(str(active_dir))
-            except OSError as ex:
-                raise RuntimeError(f"AgentSkillMaterializer failed to write active_manifest.json: {ex}") from ex
-            
             for skill in resolved_skillset.skills:
                 if skill.content_ref and self._artifact_service:
                     try:
@@ -75,7 +67,65 @@ class AgentSkillMaterializer:
                         skill_dir.mkdir(parents=True, exist_ok=True)
                         (skill_dir / "SKILL.md").write_bytes(payload)
                     except Exception as ex:
-                        logger.warning("Failed to materialize content for skill %s: %s", skill.skill_name, ex)
+                        logger.warning(
+                            "Failed to materialize content for skill %s: %s",
+                            skill.skill_name,
+                            ex,
+                        )
+
+            manifest_content = {
+                "backing_path": str(active_dir),
+                "materialization_mode": mode.value,
+                "resolved_at": resolved_skillset.resolved_at.isoformat(),
+                "runtime_id": runtime_id,
+                "skills": [
+                    {
+                        "content_digest": entry.content_digest,
+                        "content_ref": entry.content_ref,
+                        "name": entry.skill_name,
+                        "source_kind": entry.provenance.source_kind.value,
+                        "version": entry.version,
+                    }
+                    for entry in resolved_skillset.skills
+                ],
+                "snapshot_id": resolved_skillset.snapshot_id,
+                "visible_path": str(visible_dir),
+            }
+
+            try:
+                manifest_path.write_text(
+                    json.dumps(manifest_content, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
+            except OSError as ex:
+                raise RuntimeError(
+                    f"AgentSkillMaterializer failed to write _manifest.json: {ex}"
+                ) from ex
+
+            try:
+                links = ensure_shared_skill_links(
+                    run_root=self.workspace_root,
+                    skills_active_path=active_dir,
+                )
+            except (OSError, SkillWorkspaceError) as ex:
+                raise RuntimeError(
+                    self._projection_error_message(visible_dir, cause=str(ex))
+                ) from ex
+
+            result.workspace_paths.append(str(links.agents_skills_path))
+            result.metadata.update(
+                {
+                    "activeSkills": [
+                        skill.skill_name for skill in resolved_skillset.skills
+                    ],
+                    "backingPath": str(active_dir),
+                    "compatibilityPaths": {
+                        "geminiSkillsPath": str(links.gemini_skills_path),
+                    },
+                    "manifestPath": str(links.agents_skills_path / "_manifest.json"),
+                    "visiblePath": str(links.agents_skills_path),
+                }
+            )
 
         # Ensure compatibility paths or index refs are filled depending on mode.
         if mode in (RuntimeMaterializationMode.PROMPT_BUNDLED, RuntimeMaterializationMode.HYBRID):
@@ -84,3 +134,44 @@ class AgentSkillMaterializer:
             result.prompt_index_ref = f"index_{resolved_skillset.snapshot_id}"
             
         return result
+
+    @staticmethod
+    def _clear_directory(path: Path) -> None:
+        for child in path.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+    def _validate_projection_path(self, visible_dir: Path) -> None:
+        agents_dir = visible_dir.parent
+        if agents_dir.exists() and not agents_dir.is_dir():
+            raise RuntimeError(self._projection_error_message(agents_dir))
+        if visible_dir.exists() and not visible_dir.is_symlink():
+            raise RuntimeError(self._projection_error_message(visible_dir))
+
+    @staticmethod
+    def _path_kind(path: Path) -> str:
+        if path.is_symlink():
+            return "symlink"
+        if path.is_dir():
+            return "directory"
+        if path.is_file():
+            return "file"
+        if path.exists():
+            return "special"
+        return "missing"
+
+    def _projection_error_message(self, path: Path, *, cause: str | None = None) -> str:
+        message = (
+            "skill projection failed before runtime launch: "
+            f"path: {path}; "
+            f"object kind: {self._path_kind(path)}; "
+            "attempted action: project active skill snapshot; "
+            "remediation: remove or relocate the existing path so MoonMind can "
+            "create the canonical .agents/skills projection to the run-scoped "
+            "active skill backing store"
+        )
+        if cause:
+            message += f"; cause: {cause}"
+        return message

--- a/moonmind/workflows/skills/workspace_links.py
+++ b/moonmind/workflows/skills/workspace_links.py
@@ -18,13 +18,20 @@ class SkillWorkspaceLinks:
     skills_active_path: Path
     agents_skills_path: Path
     gemini_skills_path: Path
+    gemini_skills_available: bool = True
+    gemini_skills_error: str | None = None
 
     def to_payload(self) -> dict[str, str]:
-        return {
+        payload = {
             "skillsActivePath": str(self.skills_active_path),
             "agentsSkillsPath": str(self.agents_skills_path),
             "geminiSkillsPath": str(self.gemini_skills_path),
         }
+        if not self.gemini_skills_available:
+            payload["geminiSkillsAvailable"] = "false"
+            if self.gemini_skills_error:
+                payload["geminiSkillsError"] = self.gemini_skills_error
+        return payload
 
 
 def _replace_link(path: Path, *, target: Path) -> None:
@@ -48,6 +55,7 @@ def ensure_shared_skill_links(
     *,
     run_root: Path,
     skills_active_path: Path,
+    require_gemini_link: bool = True,
 ) -> SkillWorkspaceLinks:
     """Create `.agents/skills` and `.gemini/skills` links to `skills_active`."""
 
@@ -60,19 +68,36 @@ def ensure_shared_skill_links(
     gemini_skills = run_root / ".gemini" / "skills"
 
     _replace_link(agents_skills, target=skills_active_path)
-    _replace_link(gemini_skills, target=skills_active_path)
+    gemini_skills_available = True
+    gemini_skills_error = None
+    try:
+        _replace_link(gemini_skills, target=skills_active_path)
+    except SkillWorkspaceError as ex:
+        if require_gemini_link:
+            raise
+        gemini_skills_available = False
+        gemini_skills_error = str(ex)
 
     links = SkillWorkspaceLinks(
         skills_active_path=skills_active_path,
         agents_skills_path=agents_skills,
         gemini_skills_path=gemini_skills,
+        gemini_skills_available=gemini_skills_available,
+        gemini_skills_error=gemini_skills_error,
     )
-    validate_shared_skill_links(links)
+    validate_shared_skill_links(links, require_gemini_link=require_gemini_link)
     return links
 
 
-def validate_shared_skill_links(links: SkillWorkspaceLinks) -> None:
+def validate_shared_skill_links(
+    links: SkillWorkspaceLinks,
+    *,
+    require_gemini_link: bool | None = None,
+) -> None:
     """Validate adapter symlink invariants for a run workspace."""
+
+    if require_gemini_link is None:
+        require_gemini_link = links.gemini_skills_available
 
     if not links.skills_active_path.exists() or not links.skills_active_path.is_dir():
         raise SkillWorkspaceError(
@@ -83,19 +108,22 @@ def validate_shared_skill_links(links: SkillWorkspaceLinks) -> None:
         raise SkillWorkspaceError(
             f"Expected symlink at {links.agents_skills_path}, found non-symlink"
         )
-    if not links.gemini_skills_path.is_symlink():
+    if require_gemini_link and not links.gemini_skills_path.is_symlink():
         raise SkillWorkspaceError(
             f"Expected symlink at {links.gemini_skills_path}, found non-symlink"
         )
 
     agents_resolved = links.agents_skills_path.resolve(strict=True)
-    gemini_resolved = links.gemini_skills_path.resolve(strict=True)
     active_resolved = links.skills_active_path.resolve(strict=True)
 
     if agents_resolved != active_resolved:
         raise SkillWorkspaceError(
             f".agents/skills does not resolve to skills_active ({agents_resolved} != {active_resolved})"
         )
+    if not require_gemini_link:
+        return
+
+    gemini_resolved = links.gemini_skills_path.resolve(strict=True)
     if gemini_resolved != active_resolved:
         raise SkillWorkspaceError(
             f".gemini/skills does not resolve to skills_active ({gemini_resolved} != {active_resolved})"

--- a/specs/208-managed-runtime-skill-projection/checklists/requirements.md
+++ b/specs/208-managed-runtime-skill-projection/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Managed Runtime Skill Projection
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Classification: single-story runtime feature request.
+- Existing artifacts: no prior `specs/*managed-runtime-skill-projection*` or MM-407 spec existed; started at specify stage.
+- Source design mapping uses canonical current documents because the historical `docs/Tools/SkillSystem.md` source path is not present in the repository.

--- a/specs/208-managed-runtime-skill-projection/contracts/runtime-skill-projection.md
+++ b/specs/208-managed-runtime-skill-projection/contracts/runtime-skill-projection.md
@@ -1,0 +1,68 @@
+# Contract: Runtime Skill Projection
+
+## Boundary
+
+The materialization boundary accepts an already resolved skill snapshot and prepares runtime-visible files for a managed runtime. It must not resolve skills, reload source directories, or mutate checked-in skill sources.
+
+## Input
+
+```text
+ResolvedSkillSet
+- snapshot_id
+- resolved_at
+- skills[]
+  - skill_name
+  - version
+  - content_ref
+  - content_digest
+  - provenance.source_kind
+
+runtime_id
+materialization_mode
+workspace_root
+```
+
+## Output
+
+```text
+RuntimeSkillMaterialization
+- runtime_id
+- materialization_mode
+- workspace_paths includes .agents/skills
+- prompt_index_ref when mode is hybrid or prompt_bundled
+- metadata
+  - visiblePath
+  - backingPath
+  - manifestPath
+  - activeSkills[]
+```
+
+## Filesystem Contract
+
+- `.agents/skills` is the canonical runtime-visible active skill path.
+- `.agents/skills/_manifest.json` must exist for `workspace_mounted` and `hybrid` modes.
+- `.agents/skills/<skill>/SKILL.md` must exist when the selected skill content is available.
+- Unselected repo or local skills must not appear under `.agents/skills`.
+- Compatibility links may exist, but they must target the same backing store as `.agents/skills`.
+
+## Failure Contract
+
+When projection cannot be established before runtime launch, the error must include:
+
+- path
+- object kind
+- attempted action
+- remediation guidance
+
+Examples:
+
+- `.agents` exists as a file.
+- `.agents/skills` exists as a non-symlink directory.
+- `.agents/skills` is a symlink that cannot be corrected or validated.
+
+## Non-Goals
+
+- Resolving skill selectors.
+- Changing source precedence.
+- Creating new persistent storage.
+- Prompt-bundling full `SKILL.md` bodies for managed runtimes.

--- a/specs/208-managed-runtime-skill-projection/data-model.md
+++ b/specs/208-managed-runtime-skill-projection/data-model.md
@@ -1,0 +1,76 @@
+# Data Model: Managed Runtime Skill Projection
+
+## Resolved Skill Snapshot
+
+- **Represents**: Immutable selected skill set supplied to materialization.
+- **Key fields**:
+  - `snapshot_id`: stable snapshot identity.
+  - `resolved_at`: timestamp for the resolved snapshot.
+  - `skills[]`: selected skill entries only.
+  - `manifest_ref`: optional artifact ref for the resolved manifest.
+- **Validation rules**:
+  - Materialization must not add unselected skills.
+  - Materialization must not re-resolve source folders.
+  - Snapshot identity must be preserved in `_manifest.json`.
+
+## Resolved Skill Entry
+
+- **Represents**: One selected skill in the snapshot.
+- **Key fields**:
+  - `skill_name`
+  - `version`
+  - `content_ref`
+  - `content_digest`
+  - `provenance.source_kind`
+- **Validation rules**:
+  - Skill names become path components only after existing model validation and safe materialization.
+  - Missing content payloads must not produce misleading full skill bodies.
+
+## Active Backing Store
+
+- **Represents**: MoonMind-owned run-scoped directory containing the active materialized snapshot.
+- **Key fields / paths**:
+  - backing directory path
+  - `_manifest.json`
+  - selected skill directories
+- **Validation rules**:
+  - Directory is owned by runtime setup, not by checked-in repo content.
+  - Contents are derived from the supplied snapshot only.
+  - Unselected repo/local skills are absent.
+
+## Runtime-Visible Projection
+
+- **Represents**: `.agents/skills` path visible to the managed runtime.
+- **Key fields / paths**:
+  - visible path: `.agents/skills`
+  - target/backing path: active backing store
+  - compatibility mirrors, when present, target the same backing path
+- **Validation rules**:
+  - Existing non-symlink path fails before runtime launch.
+  - Drifted links are corrected or rejected by validation.
+  - Projection must be established before runtime launch.
+
+## Active Manifest
+
+- **Represents**: Compact runtime-visible summary of active skill projection.
+- **Required fields**:
+  - `snapshot_id`
+  - `runtime_id`
+  - `materialization_mode`
+  - `visible_path`
+  - `backing_path`
+  - `resolved_at`
+  - `skills[]` with `name`, `version`, `source_kind`, `content_ref`, and `content_digest`
+- **Validation rules**:
+  - Lives at `.agents/skills/_manifest.json`.
+  - Does not embed full skill bodies.
+  - Lists only selected skills.
+
+## State Transitions
+
+1. `ResolvedSkillSet` supplied to materialization.
+2. Active backing store is created or refreshed for the run.
+3. `_manifest.json` and selected skill files are written into the active store.
+4. `.agents/skills` is projected to the active store.
+5. Runtime instruction summary references the active visible path.
+6. Incompatible path or unreadable skill content fails before runtime launch.

--- a/specs/208-managed-runtime-skill-projection/plan.md
+++ b/specs/208-managed-runtime-skill-projection/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Managed Runtime Skill Projection
+
+**Branch**: `[208-managed-runtime-skill-projection]` | **Date**: 2026-04-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/208-managed-runtime-skill-projection/spec.md`
+
+## Summary
+
+MM-407 requires managed runtime preparation to project an immutable resolved skill snapshot into the canonical `.agents/skills` path while keeping the backing store MoonMind-owned and run-scoped. The repo already has two relevant materialization paths: `moonmind/workflows/skills/materializer.py` plus `workspace_links.py` for managed Codex task jobs, and `moonmind/services/skill_materialization.py` for Temporal `agent_skill.materialize`. The service path still writes `.agents/skills_active/active_manifest.json` and explicitly avoids `.agents/skills`; this story will align it with the canonical runtime-visible projection by using shared link validation, writing `_manifest.json`, and adding focused unit and activity-boundary coverage. Existing Codex worker instruction behavior already exposes compact skill-location guidance and will be verified rather than broadly refactored.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `moonmind/workflows/skills/workspace_links.py` projects `.agents/skills`; `moonmind/services/skill_materialization.py` does not | align service materializer projection | unit + activity boundary |
+| FR-002 | partial | shared link helper validates symlink target; service path bypasses it | use shared link helper from service materializer | unit |
+| FR-003 | implemented_unverified | `workspace_links.py` rejects existing non-symlink path; service lacks coverage | add service test preserving source directories and rejecting incompatible path | unit |
+| FR-004 | implemented_unverified | both materializers use run-scoped roots | verify service writes backing store once per call and exposes projection | unit |
+| FR-005 | missing | service writes `active_manifest.json`, not `_manifest.json`, and lacks visible-path/backing-path fields | write `_manifest.json` with required metadata | unit |
+| FR-006 | implemented_unverified | run materializer links only selected skills; service needs multi-skill proof | add multi-skill selected-only projection test | unit |
+| FR-007 | implemented_verified | `workspace_links.py` points `.agents/skills` and `.gemini/skills` to same active store with tests | no new implementation | final regression |
+| FR-008 | partial | shared helper reports non-symlink path, but service does not use it and message lacks full remediation | route service through helper and normalize diagnostics | unit |
+| FR-009 | implemented_unverified | `worker.py` compact instruction lines mention `.agents/skills` and selected skill path | add/retain focused instruction assertion | unit |
+| FR-010 | implemented_unverified | service writes bodies to disk from artifact refs; prompt index only returns refs | verify no full body appears in prompt index/activity output | unit |
+| FR-011 | implemented_unverified | service materializes from supplied `ResolvedSkillSet`; no runtime re-resolution in service | add activity-boundary test that materialize consumes supplied snapshot | unit |
+| FR-012 | implemented_verified | `spec.md` preserves MM-407 brief and traceability | no code work | final verification |
+| DESIGN-REQ-005 | partial | service still exposes `.agents/skills_active`, not canonical `.agents/skills` | align service visible path | unit |
+| DESIGN-REQ-011 | implemented_unverified | hybrid mode sets prompt index ref and workspace files | verify hybrid returns prompt ref plus visible workspace | unit |
+| DESIGN-REQ-012 | missing | active manifest lacks required visible path, backing path, and source contribution fields | add `_manifest.json` fields | unit |
+| DESIGN-REQ-013 | implemented_unverified | local overlay convention exists in resolver tests | ensure runtime projection does not rewrite existing source input dirs | unit |
+| DESIGN-REQ-014 | implemented_verified | `.agents/skills` and `.gemini/skills` link to same active store | no new implementation | final regression |
+| DESIGN-REQ-015 | implemented_unverified | service boundary exists; workflow payload carries compact refs | add activity-boundary materialization test | unit |
+| DESIGN-REQ-016 | partial | activity accepts resolved snapshot and materializes it, but projection is noncanonical | align service materializer | unit |
+| DESIGN-REQ-017 | partial | adapter responsibility is documented and Codex worker uses shared links; service path needs canonical projection | align service path and tests | unit |
+| DESIGN-REQ-021 | implemented_unverified | materialization takes supplied snapshot | test no resolver call in materialize boundary | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK activity wrappers, pytest, existing artifact service interfaces  
+**Storage**: Filesystem workspace projection and artifact-backed skill content refs; no new persistent storage  
+**Unit Testing**: pytest via `./tools/test_unit.sh`; focused iteration with `python -m pytest` for affected tests  
+**Integration Testing**: Existing hermetic integration suite via `./tools/test_integration.sh`; no new compose dependency expected for this story  
+**Target Platform**: Linux managed agent worker environments  
+**Project Type**: Python service/runtime orchestration code  
+**Performance Goals**: Materialization remains bounded to selected skill count and writes only selected skill files plus one manifest per snapshot  
+**Constraints**: Do not rewrite checked-in skill folders; fail before runtime launch for unprojectable paths; keep large skill bodies out of workflow history and inline instructions  
+**Scale/Scope**: One service materializer path, one activity boundary, existing managed runtime instruction coverage
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle I, Orchestrate Don't Recreate: PASS. The work stays in adapter/service boundaries and does not add agent cognition.
+- Principle V, Skills Are First-Class: PASS. The feature strengthens skill materialization contracts and tests.
+- Principle VIII, Modular and Extensible Architecture: PASS. Changes are scoped to `moonmind/services/skill_materialization.py` and boundary tests.
+- Principle IX, Resilient by Default: PASS. Incompatible workspace paths fail before runtime launch with actionable diagnostics.
+- Principle XI, Spec-Driven Development: PASS. Specification, plan, tasks, implementation, and verification artifacts are produced before completion.
+- Principle XII, Canonical Documentation Separates Desired State From Backlog: PASS. Migration notes remain in `docs/tmp` and this runtime work does not rewrite canonical docs.
+- Principle XIII, Pre-Release Compatibility Policy: PASS. No compatibility aliases are introduced; existing internal service semantics are aligned to the canonical path.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/208-managed-runtime-skill-projection/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── runtime-skill-projection.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+├── services/
+│   └── skill_materialization.py
+├── workflows/
+│   ├── agent_skills/
+│   │   └── agent_skills_activities.py
+│   └── skills/
+│       └── workspace_links.py
+
+tests/
+└── unit/
+    ├── services/
+    │   └── test_skill_materialization.py
+    └── workflows/
+        ├── agent_skills/
+        │   └── test_agent_skills_activities.py
+        └── test_workspace_links.py
+```
+
+**Structure Decision**: Keep materialization behavior in the existing service and shared workspace-link helper. Add tests at the service and Temporal activity boundary rather than introducing a new runtime subsystem.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/208-managed-runtime-skill-projection/quickstart.md
+++ b/specs/208-managed-runtime-skill-projection/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Managed Runtime Skill Projection
+
+## Classification
+
+- Input type: single-story feature request.
+- Intent: runtime.
+- Active feature directory: `specs/208-managed-runtime-skill-projection`.
+- Resume decision: no existing MM-407 spec artifacts were found, so orchestration started at specify.
+
+## Test-First Validation
+
+1. Add focused unit coverage for `AgentSkillMaterializer`:
+
+```bash
+python -m pytest tests/unit/services/test_skill_materialization.py -q
+```
+
+Expected red cases before implementation:
+
+- `.agents/skills/_manifest.json` does not exist.
+- service materializer does not expose `.agents/skills`.
+- incompatible `.agents/skills` paths are not rejected through shared projection validation.
+
+2. Add activity-boundary coverage for `agent_skill.materialize`:
+
+```bash
+python -m pytest tests/unit/workflows/agent_skills/test_agent_skills_activities.py -q
+```
+
+Expected red case before implementation:
+
+- activity materialization output does not report canonical visible path metadata.
+
+3. Final unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## Integration Verification
+
+This story does not require live provider credentials. If filesystem projection changes touch managed worker prepare behavior, run:
+
+```bash
+./tools/test_integration.sh
+```
+
+If Docker is unavailable in the managed agent environment, record the exact Docker/socket blocker and rely on unit plus activity-boundary evidence.
+
+## End-to-End Story Check
+
+- Materialize a one-skill snapshot into a temporary workspace.
+- Confirm `.agents/skills/_manifest.json` exists and lists MM-407-required metadata.
+- Confirm `.agents/skills/<skill>/SKILL.md` is available when content is readable.
+- Confirm multi-skill projection omits unselected repo skills.
+- Confirm existing checked-in source directories are not rewritten.
+- Confirm incompatible projection paths fail before runtime launch.

--- a/specs/208-managed-runtime-skill-projection/research.md
+++ b/specs/208-managed-runtime-skill-projection/research.md
@@ -53,5 +53,5 @@ Test implications: Existing instruction tests plus focused prompt-index/no-body 
 Decision: Preserve MM-407 in all MoonSpec artifacts and final verification output.
 Evidence: `spec.md` includes the full MM-407 canonical input and traceability.
 Rationale: Downstream PR and verification automation needs Jira traceability.
-Alternatives considered: Reference only the summary; rejected because the original request must remain available to `/speckit.verify`.
+Alternatives considered: Reference only the summary; rejected because the original request must remain available to `/moonspec-verify`.
 Test implications: Final verification traceability check.

--- a/specs/208-managed-runtime-skill-projection/research.md
+++ b/specs/208-managed-runtime-skill-projection/research.md
@@ -1,0 +1,57 @@
+# Research: Managed Runtime Skill Projection
+
+## FR-001 / FR-002 / DESIGN-REQ-005 / DESIGN-REQ-012
+
+Decision: Align the service materializer with the shared run workspace projection model so `.agents/skills` is the canonical visible path and the backing store remains MoonMind-owned.
+Evidence: `moonmind/workflows/skills/workspace_links.py` already creates and validates `.agents/skills -> skills_active`; `moonmind/services/skill_materialization.py` currently writes `.agents/skills_active` and explicitly avoids `.agents/skills`.
+Rationale: There should be one canonical managed-runtime visible path. Reusing the shared link helper avoids introducing a second projection rule.
+Alternatives considered: Keep service output at `.agents/skills_active`; rejected because MM-407 and canonical docs require `.agents/skills`.
+Test implications: Unit tests for visible path projection and activity-boundary coverage.
+
+## FR-003 / FR-008 / DESIGN-REQ-013
+
+Decision: Treat existing non-symlink `.agents/skills` paths as unprojectable and fail before runtime launch with path, object kind, attempted action, and remediation guidance.
+Evidence: `workspace_links.py` already rejects existing non-symlink paths, but the service materializer does not use it.
+Rationale: A checked-in `.agents/skills` directory is a source input, not mutable runtime state. The service must not merge or overwrite it.
+Alternatives considered: Rename or move the checked-in directory automatically; rejected because it mutates user-authored repo content.
+Test implications: Unit test for incompatible path failure and source directory preservation.
+
+## FR-004 / FR-006 / FR-011 / DESIGN-REQ-016 / DESIGN-REQ-021
+
+Decision: Materialize from the supplied `ResolvedSkillSet` only, using selected entries to populate the backing store and manifest.
+Evidence: `AgentSkillMaterializer.materialize` already accepts `ResolvedSkillSet` directly and does not call the resolver.
+Rationale: Runtime projection is downstream of snapshot resolution and must preserve retry/rerun semantics.
+Alternatives considered: Let materializer reload or re-resolve sources; rejected because it breaks immutable snapshot semantics.
+Test implications: Multi-skill selected-only projection test and activity-boundary test using a supplied snapshot.
+
+## FR-005 / DESIGN-REQ-012
+
+Decision: Write `_manifest.json` into the runtime-visible active tree with snapshot identity, runtime id, materialization mode, visible path, backing path, and per-skill name/version/source fields.
+Evidence: Service currently writes `active_manifest.json` with only snapshot, resolved time, and skills.
+Rationale: The active manifest must be owned by MoonMind and useful to agents, operators, and tests at the visible path.
+Alternatives considered: Keep `active_manifest.json`; rejected because Jira acceptance criteria name `_manifest.json`.
+Test implications: Unit assertion on exact manifest location and required fields.
+
+## FR-007 / DESIGN-REQ-014
+
+Decision: Preserve existing compatibility-link behavior where `.gemini/skills` may mirror the same active backing store, while `.agents/skills` remains canonical.
+Evidence: `workspace_links.py` and `tests/unit/workflows/test_workspace_links.py` already verify both links resolve to the same backing store.
+Rationale: No additional compatibility surface is required for this story.
+Alternatives considered: Remove `.gemini/skills`; rejected as unrelated and already covered.
+Test implications: Existing regression coverage is sufficient.
+
+## FR-009 / FR-010 / DESIGN-REQ-011 / DESIGN-REQ-015
+
+Decision: Keep instruction payload compact and file-oriented: mention active skill names and paths, but do not inline full skill bodies.
+Evidence: `moonmind/agents/codex_worker/worker.py` already emits compact workspace guidance for selected skills and prompt-index activity emits metadata rather than bodies.
+Rationale: Agents need the stable path and first-read hints; large skill bodies belong on disk/artifacts.
+Alternatives considered: Prompt-bundle full `SKILL.md` bodies for managed runtimes; rejected because hybrid workspace materialization is the desired default.
+Test implications: Existing instruction tests plus focused prompt-index/no-body test if needed.
+
+## FR-012
+
+Decision: Preserve MM-407 in all MoonSpec artifacts and final verification output.
+Evidence: `spec.md` includes the full MM-407 canonical input and traceability.
+Rationale: Downstream PR and verification automation needs Jira traceability.
+Alternatives considered: Reference only the summary; rejected because the original request must remain available to `/speckit.verify`.
+Test implications: Final verification traceability check.

--- a/specs/208-managed-runtime-skill-projection/spec.md
+++ b/specs/208-managed-runtime-skill-projection/spec.md
@@ -1,0 +1,180 @@
+# Feature Specification: Managed Runtime Skill Projection
+
+**Feature Branch**: `[208-managed-runtime-skill-projection]`
+**Created**: 2026-04-18
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-407 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira brief: docs/tmp/jira-orchestration-inputs/MM-407-moonspec-orchestration-input.md
+
+# MM-407 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-407
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Managed Runtime Skill Projection
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-407 from MM project
+Summary: Managed Runtime Skill Projection
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-407 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-407: Managed Runtime Skill Projection
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §8
+  - AgentSkillSystem §13-§16
+  - SkillInjection §2-§16
+  - ManagedAndExternalAgentExecutionModel §1-§2.5
+- Coverage IDs:
+  - DESIGN-REQ-005
+  - DESIGN-REQ-011
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-015
+  - DESIGN-REQ-016
+  - DESIGN-REQ-017
+  - DESIGN-REQ-021
+
+User Story
+As a managed runtime adapter, I can materialize a pinned skill snapshot into a run-scoped active backing store and expose exactly that selected set at .agents/skills with a compact activation summary, so agents see the expected path without MoonMind rewriting checked-in skill folders.
+
+Acceptance Criteria
+- Given a resolved snapshot with one skill, when the adapter prepares the runtime, then .agents/skills contains a full active root with _manifest.json and that skill's SKILL.md.
+- Given a resolved snapshot with multiple skills, then only selected skills appear in the active projection and unselected repo skills are absent.
+- Given a checked-in .agents/skills directory exists, then MoonMind may use it as a resolution input but does not rewrite it in place during runtime setup.
+- Given .agents or .agents/skills is an incompatible file or unprojectable path, then preparation fails before runtime launch with path, object kind, attempted action, and remediation guidance.
+- Given the runtime starts, then the instruction payload includes a compact activation summary and full skill bodies are available on disk, not duplicated inline.
+
+Requirements
+- Materialize the active skill bundle into a MoonMind-owned run-scoped backing directory exactly once per snapshot.
+- Project the active backing store at .agents/skills for managed runtimes using adapter-compatible mechanics.
+- Include only selected skills and a MoonMind-owned active manifest in the runtime-visible tree.
+- Inject a compact activation summary naming active skills, visible path, hard rules, and first-read hints.
+- Do not use retrieval-first loading, custom visible paths, or per-skill leaf mounting as the canonical managed-runtime path.
+
+Relevant Implementation Notes
+- Keep `.agents/skills` as the canonical runtime-visible path for the resolved active snapshot.
+- Materialize the selected skill set into a MoonMind-owned run-scoped backing store before managed runtime launch.
+- Expose exactly the selected active skill set at `.agents/skills`; unselected repo skills must be absent from the runtime-visible projection.
+- Treat checked-in `.agents/skills` folders as resolution inputs only and do not rewrite them in place during runtime setup.
+- Include a MoonMind-owned active manifest in the runtime-visible projection.
+- Keep full skill bodies on disk and avoid duplicating large skill content inline in the instruction payload.
+- Inject only a compact activation summary that names active skills, visible path, hard rules, and first-read hints.
+- Fail before runtime launch when `.agents` or `.agents/skills` is an incompatible file or unprojectable path, with path, object kind, attempted action, and remediation guidance.
+
+Verification
+- Confirm a resolved snapshot with one skill materializes a full `.agents/skills` active root containing `_manifest.json` and that skill's `SKILL.md`.
+- Confirm a resolved snapshot with multiple skills projects only selected skills and omits unselected repo skills.
+- Confirm checked-in `.agents/skills` can be used as a resolution input without being rewritten in place during runtime setup.
+- Confirm incompatible `.agents` or `.agents/skills` paths fail before runtime launch with actionable diagnostics.
+- Confirm runtime instructions include a compact activation summary while full skill bodies are available on disk and not duplicated inline.
+- Preserve MM-407 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- MM-408 blocks this issue.
+- MM-407 blocks MM-406."
+
+## User Story - Project Active Skill Snapshot Into Managed Runtime
+
+**Summary**: As a managed runtime adapter, I want a pinned skill snapshot projected into the canonical `.agents/skills` path so the launched agent sees exactly the selected skill set without MoonMind rewriting checked-in skill sources.
+
+**Goal**: Managed runtime preparation exposes a run-scoped, immutable active skill projection at the stable workspace path agents already know, while retaining a MoonMind-owned backing store, compact activation metadata, and fail-fast diagnostics for unprojectable paths.
+
+**Independent Test**: Can be fully tested by materializing one or more resolved skill snapshots into a temporary managed runtime workspace, then validating the visible `.agents/skills` tree, manifest, absent unselected skills, source-folder immutability, instruction summary, and failure behavior before any real provider runtime launches.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resolved snapshot with one selected skill, **When** the managed runtime workspace is prepared, **Then** `.agents/skills` exposes a complete active root containing `_manifest.json` and that skill's `SKILL.md`.
+2. **Given** a resolved snapshot with multiple selected skills and additional repo skills exist outside the snapshot, **When** the active projection is created, **Then** only selected skills appear under `.agents/skills` and unselected repo skills are absent.
+3. **Given** a checked-in `.agents/skills` directory exists as a source input, **When** runtime materialization runs, **Then** MoonMind does not rewrite that checked-in folder in place and instead uses a MoonMind-owned run-scoped active backing store for the runtime-visible path.
+4. **Given** `.agents` or `.agents/skills` is an incompatible file or otherwise unprojectable path, **When** managed runtime preparation attempts projection, **Then** preparation fails before runtime launch with the path, object kind, attempted action, and remediation guidance.
+5. **Given** a runtime starts with an active snapshot, **When** the instruction payload is inspected, **Then** it includes a compact activation summary naming active skills, the visible path, hard rules, and first-read hints while full skill bodies remain available on disk and are not duplicated inline.
+
+### Edge Cases
+
+- A snapshot contains zero skills and still needs a stable empty active root or prompt summary.
+- A stale `.agents/skills` symlink from an earlier preparation points at the wrong backing store.
+- A checked-in `.agents/skills/local` overlay exists and must remain an input convention rather than the active runtime projection.
+- A selected skill content artifact cannot be read before projection.
+- The runtime-visible manifest and backing store disagree about selected skill names or versions.
+- A workspace cannot create symlinks and must fail clearly rather than silently exposing the wrong source tree.
+
+## Assumptions
+
+- The historical `docs/Tools/SkillSystem.md` source reference maps to the canonical current repo documents `docs/Tasks/AgentSkillSystem.md` and `docs/Temporal/ManagedAndExternalAgentExecutionModel.md`.
+- The optional `SkillInjection` source section maps to the compact activation summary requirements in the MM-407 Jira brief and the canonical Agent Skill System path policy.
+- MM-408 is preserved as dependency context from Jira links, but this spec covers only MM-407's selected single story.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-005**: Source `docs/Tasks/AgentSkillSystem.md` section 8. The runtime-visible skill set MUST be the resolved active snapshot exposed through `.agents/skills`, not a mutable merge into user-authored checked-in folders. Scope: in scope. Maps to FR-001, FR-002, FR-003, and FR-008.
+- **DESIGN-REQ-011**: Source `docs/Tasks/AgentSkillSystem.md` section 13. Managed runtimes SHOULD use hybrid materialization, combining a compact prompt index with full content materialized into workspace files. Scope: in scope. Maps to FR-004 and FR-009.
+- **DESIGN-REQ-012**: Source `docs/Tasks/AgentSkillSystem.md` section 14. For managed runtimes, the active resolved skill set MUST be visible through `.agents/skills`, and the active manifest SHOULD identify active skills, where they are available, and contributing sources. Scope: in scope. Maps to FR-001, FR-002, FR-005, and FR-006.
+- **DESIGN-REQ-013**: Source `docs/Tasks/AgentSkillSystem.md` section 14.2. `.agents/skills/local` MUST remain a local-only overlay input area and must not become the runtime-visible active set. Scope: in scope. Maps to FR-003 and FR-008.
+- **DESIGN-REQ-014**: Source `docs/Tasks/AgentSkillSystem.md` section 14.4. Runtime-specific compatibility links MAY be created, but `.agents/skills` remains the canonical workspace-facing path. Scope: in scope. Maps to FR-001, FR-002, and FR-007.
+- **DESIGN-REQ-015**: Source `docs/Tasks/AgentSkillSystem.md` section 15. Runtime-facing materialization MUST happen through activity or service boundaries and workflow payloads MUST keep large skill bodies out of history. Scope: in scope. Maps to FR-004, FR-009, and FR-010.
+- **DESIGN-REQ-016**: Source `docs/Tasks/AgentSkillSystem.md` section 16. The agent-run path receives compact resolved skill refs and the runtime adapter materializes the snapshot so the underlying runtime sees a stable active skill view through `.agents/skills`. Scope: in scope. Maps to FR-001, FR-004, FR-005, and FR-009.
+- **DESIGN-REQ-017**: Source `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` section 6.3. Managed runtime adapters are responsible for preparing local runtime context and materializing any active skill snapshot into the managed runtime environment before launch. Scope: in scope. Maps to FR-001, FR-004, FR-007, and FR-010.
+- **DESIGN-REQ-021**: Source `docs/Temporal/ManagedAndExternalAgentExecutionModel.md` sections 1 through 2.5. Managed runtime skill projection must preserve retry and rerun boundaries by treating the resolved snapshot as an input contract rather than re-resolving sources during runtime launch. Scope: in scope. Maps to FR-004 and FR-011.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose the run-scoped active resolved skill set at `.agents/skills` for managed runtimes.
+- **FR-002**: System MUST project the active backing store through adapter-compatible mechanics so `.agents/skills` resolves to the selected active snapshot before runtime launch.
+- **FR-003**: System MUST treat checked-in `.agents/skills` and `.agents/skills/local` folders as source inputs only and MUST NOT rewrite them in place during runtime setup.
+- **FR-004**: System MUST materialize the selected skill snapshot into a MoonMind-owned run-scoped backing store exactly once for the snapshot before managed runtime launch.
+- **FR-005**: System MUST include a MoonMind-owned `_manifest.json` in the runtime-visible active tree that lists active skills, versions, source kinds, visible path, backing path, and snapshot identity.
+- **FR-006**: System MUST ensure only selected skills and the MoonMind-owned manifest appear in the active projection; unselected repo skills MUST be absent.
+- **FR-007**: System MAY create runtime-specific compatibility links or mirrors, but those links MUST target the same active snapshot as `.agents/skills`.
+- **FR-008**: System MUST fail before runtime launch when `.agents` or `.agents/skills` is an incompatible file, non-link directory, or otherwise unprojectable path, and the failure MUST include the path, object kind, attempted action, and remediation guidance.
+- **FR-009**: System MUST provide a compact activation summary naming active skills, visible path, hard rules, and first-read hints without duplicating full skill bodies inline.
+- **FR-010**: System MUST keep full skill bodies, bundles, and large manifests on disk or artifact-backed storage rather than embedding them in workflow history or instruction payloads.
+- **FR-011**: System MUST preserve immutable resolved snapshot semantics across retries and reruns by materializing from the supplied snapshot input rather than ad hoc re-resolving skill sources at runtime launch.
+- **FR-012**: System MUST preserve Jira issue key MM-407 and the canonical Jira preset brief in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Key Entities
+
+- **Resolved Skill Snapshot**: Immutable selected skill set with snapshot identity, versions, provenance, and compact metadata.
+- **Active Backing Store**: MoonMind-owned run-scoped directory containing the materialized selected skills and active manifest.
+- **Runtime-Visible Projection**: The `.agents/skills` path exposed to managed runtimes, resolving to the active backing store.
+- **Activation Summary**: Compact instruction payload section that tells the agent which skills are active, where to read them, and which path rules apply.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Unit coverage proves a one-skill snapshot produces `.agents/skills/_manifest.json` and `.agents/skills/<skill>/SKILL.md` before runtime launch.
+- **SC-002**: Unit coverage proves a multi-skill snapshot exposes only selected skills under `.agents/skills` and omits unselected repo skills.
+- **SC-003**: Boundary coverage proves checked-in skill source folders are not modified during runtime setup.
+- **SC-004**: Failure coverage proves incompatible `.agents` or `.agents/skills` paths fail before runtime launch with path, object kind, attempted action, and remediation guidance.
+- **SC-005**: Instruction coverage proves active skills, visible path, hard rules, and first-read hints appear in compact form without embedding full `SKILL.md` bodies inline.
+- **SC-006**: Source traceability checks confirm MM-407 and DESIGN-REQ-005, DESIGN-REQ-011 through DESIGN-REQ-017, and DESIGN-REQ-021 remain present in MoonSpec artifacts and verification output.

--- a/specs/208-managed-runtime-skill-projection/tasks.md
+++ b/specs/208-managed-runtime-skill-projection/tasks.md
@@ -1,0 +1,124 @@
+# Tasks: Managed Runtime Skill Projection
+
+**Input**: Design documents from `/specs/208-managed-runtime-skill-projection/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/runtime-skill-projection.md
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single MM-407 story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: FR-001 through FR-012, acceptance scenarios 1-5, edge cases, SC-001 through SC-006, DESIGN-REQ-005, DESIGN-REQ-011 through DESIGN-REQ-017, DESIGN-REQ-021.
+
+**Test Commands**:
+
+- Unit tests: `python -m pytest tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q`
+- Integration tests: `./tools/test_integration.sh` when Docker is available; otherwise record the Docker/socket blocker because this story is covered by service and activity-boundary unit tests.
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the active MoonSpec artifacts and test surfaces.
+
+- [X] T001 Confirm MM-407 is classified as a single-story runtime feature and active artifacts live under `specs/208-managed-runtime-skill-projection/` (FR-012, SC-006)
+- [X] T002 Confirm existing runtime skill materialization surfaces in `moonmind/services/skill_materialization.py`, `moonmind/workflows/agent_skills/agent_skills_activities.py`, and `moonmind/workflows/skills/workspace_links.py` (FR-001 through FR-011)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No new infrastructure is required; existing service and shared link helper are the foundation.
+
+- [X] T003 Confirm `workspace_links.py` already owns shared `.agents/skills` and `.gemini/skills` link validation in `tests/unit/workflows/test_workspace_links.py` (FR-007, DESIGN-REQ-014)
+- [X] T004 Confirm no database migrations or new persistent storage are needed in `specs/208-managed-runtime-skill-projection/data-model.md` (FR-010, DESIGN-REQ-015)
+
+**Checkpoint**: Foundation ready - story test and implementation work can begin.
+
+---
+
+## Phase 3: Story - Project Active Skill Snapshot Into Managed Runtime
+
+**Summary**: As a managed runtime adapter, I want a pinned skill snapshot projected into the canonical `.agents/skills` path so the launched agent sees exactly the selected skill set without MoonMind rewriting checked-in skill sources.
+
+**Independent Test**: Materialize one-skill and multi-skill snapshots into temporary managed runtime workspaces, then validate `.agents/skills`, `_manifest.json`, selected skill files, absent unselected skills, source-folder immutability, activity output metadata, and fail-fast incompatible path handling.
+
+**Traceability**: FR-001 through FR-012; acceptance scenarios 1-5; SC-001 through SC-006; DESIGN-REQ-005, DESIGN-REQ-011 through DESIGN-REQ-017, DESIGN-REQ-021.
+
+**Test Plan**:
+
+- Unit: service materialization path, manifest content, selected-only projection, incompatible path diagnostics, prompt summary compactness.
+- Integration: Temporal activity boundary through `AgentSkillsActivities.materialize` using supplied `ResolvedSkillSet`; hermetic integration suite only if Docker is available and worker wiring changes.
+
+### Unit Tests (write first) ⚠️
+
+> **NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.**
+
+- [X] T005 [P] Add failing unit tests proving one-skill and multi-skill snapshots expose `.agents/skills/_manifest.json`, selected skill directories, and no unselected repo skills in `tests/unit/services/test_skill_materialization.py` (FR-001, FR-002, FR-005, FR-006, SC-001, SC-002, DESIGN-REQ-005, DESIGN-REQ-012)
+- [X] T006 [P] Add failing unit test proving existing checked-in `.agents/skills` source directory is not rewritten and incompatible path diagnostics include path, object kind, attempted action, and remediation in `tests/unit/services/test_skill_materialization.py` (FR-003, FR-008, SC-003, SC-004, DESIGN-REQ-013)
+- [X] T007 [P] Add failing unit test proving hybrid materialization returns compact prompt metadata and does not inline full `SKILL.md` bodies in `tests/unit/services/test_skill_materialization.py` (FR-009, FR-010, DESIGN-REQ-011, DESIGN-REQ-015)
+- [X] T008 Run `python -m pytest tests/unit/services/test_skill_materialization.py -q` to confirm T005-T007 fail for the expected pre-implementation reasons.
+
+### Integration / Boundary Tests (write first) ⚠️
+
+- [X] T009 [P] Add failing activity-boundary unit test proving `AgentSkillsActivities.materialize` consumes the supplied `ResolvedSkillSet` and returns canonical `.agents/skills` metadata in `tests/unit/workflows/agent_skills/test_agent_skills_activities.py` (FR-004, FR-011, SC-005, DESIGN-REQ-016, DESIGN-REQ-017, DESIGN-REQ-021)
+- [X] T010 Run `python -m pytest tests/unit/workflows/agent_skills/test_agent_skills_activities.py -q` to confirm T009 fails for the expected pre-implementation reason.
+
+### Implementation
+
+- [X] T011 Update `moonmind/services/skill_materialization.py` so workspace-mounted and hybrid modes materialize a run-scoped backing store and project it through canonical `.agents/skills` using the shared link helper (FR-001, FR-002, FR-004, FR-007, DESIGN-REQ-005, DESIGN-REQ-014, DESIGN-REQ-016)
+- [X] T012 Update `moonmind/services/skill_materialization.py` to write `_manifest.json` with snapshot identity, runtime id, materialization mode, visible path, backing path, resolved time, and selected skill metadata (FR-005, FR-006, DESIGN-REQ-012)
+- [X] T013 Update `moonmind/services/skill_materialization.py` failure handling to include path, object kind, attempted action, and remediation for incompatible `.agents` or `.agents/skills` paths (FR-003, FR-008, SC-004, DESIGN-REQ-013)
+- [X] T014 Update `moonmind/services/skill_materialization.py` output metadata and workspace paths to report `.agents/skills`, backing store, manifest path, and active skill names without embedding full skill bodies (FR-009, FR-010, FR-011, DESIGN-REQ-011, DESIGN-REQ-015, DESIGN-REQ-021)
+- [X] T015 Update `moonmind/workflows/agent_skills/agent_skills_activities.py` only if needed so activity materialization returns the service metadata unchanged and remains resolver-free (FR-004, FR-011, DESIGN-REQ-017, DESIGN-REQ-021)
+- [X] T016 Run `python -m pytest tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q` and fix failures until the story passes.
+
+**Checkpoint**: The story is fully functional, covered by service and activity-boundary tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without changing its core scope.
+
+- [X] T017 Run `git diff --check` for changed files and fix formatting issues.
+- [X] T018 Run `./tools/test_unit.sh` for final unit verification or record the exact blocker if the managed environment cannot complete it.
+- [X] T019 Run `./tools/test_integration.sh` if Docker is available; otherwise record the Docker/socket blocker because no compose-backed code path changed.
+- [X] T020 Run `/speckit.verify` by producing `specs/208-managed-runtime-skill-projection/verification.md` against the original MM-407 request, spec, plan, tasks, and test evidence.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: Complete.
+- **Foundational (Phase 2)**: Complete; no migrations or new infrastructure.
+- **Story (Phase 3)**: Tests first, red-first confirmation, then implementation.
+- **Polish (Phase 4)**: Runs after story tests pass.
+
+### Within The Story
+
+- T005-T007 must be written before T008.
+- T009 must be written before T010.
+- T011-T015 start only after red-first confirmation in T008 and T010.
+- T016 validates implementation.
+- T020 is final verification after tests and quickstart evidence.
+
+### Parallel Opportunities
+
+- T005, T006, and T007 touch the same test file and should be sequenced by one editor, but their test concerns are independent.
+- T009 can be authored in parallel with service test additions because it touches a separate test file.
+- T017 and documentation review can run after T016 while final suite commands are prepared.
+
+## Implementation Strategy
+
+1. Preserve the MM-407 source brief and existing spec artifacts.
+2. Add failing service and activity-boundary tests for canonical `.agents/skills` projection.
+3. Align the service materializer with the shared workspace-link helper and `_manifest.json` contract.
+4. Keep existing Codex worker compatibility-link behavior intact.
+5. Run focused tests, final unit verification, and final MoonSpec verification.

--- a/specs/208-managed-runtime-skill-projection/tasks.md
+++ b/specs/208-managed-runtime-skill-projection/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `python -m pytest tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q`
 - Integration tests: `./tools/test_integration.sh` when Docker is available; otherwise record the Docker/socket blocker because this story is covered by service and activity-boundary unit tests.
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -88,7 +88,7 @@
 - [X] T017 Run `git diff --check` for changed files and fix formatting issues.
 - [X] T018 Run `./tools/test_unit.sh` for final unit verification or record the exact blocker if the managed environment cannot complete it.
 - [X] T019 Run `./tools/test_integration.sh` if Docker is available; otherwise record the Docker/socket blocker because no compose-backed code path changed.
-- [X] T020 Run `/speckit.verify` by producing `specs/208-managed-runtime-skill-projection/verification.md` against the original MM-407 request, spec, plan, tasks, and test evidence.
+- [X] T020 Run `/moonspec-verify` by producing `specs/208-managed-runtime-skill-projection/verification.md` against the original MM-407 request, spec, plan, tasks, and test evidence.
 
 ---
 

--- a/specs/208-managed-runtime-skill-projection/verification.md
+++ b/specs/208-managed-runtime-skill-projection/verification.md
@@ -1,0 +1,81 @@
+# MoonSpec Verification Report
+
+**Feature**: Managed Runtime Skill Projection  
+**Spec**: `/work/agent_jobs/mm:4361c6a4-184d-486b-bfd8-5bb78b998107/repo/specs/208-managed-runtime-skill-projection/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving MM-407 canonical Jira preset brief  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Red-first service unit | `python -m pytest tests/unit/services/test_skill_materialization.py -q` | PASS after implementation | Confirmed pre-implementation failures for canonical `.agents/skills`, `_manifest.json`, incompatible path, and compact metadata gaps. Final result: 5 passed. |
+| Red-first activity boundary | `python -m pytest tests/unit/workflows/agent_skills/test_agent_skills_activities.py -q` | PASS after implementation | Confirmed pre-implementation failure for canonical materialization metadata. Final result: 5 passed. |
+| Story regression | `python -m pytest tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q` | PASS | 13 passed. Covers service, Temporal activity boundary, and shared adapter link invariants. |
+| Full unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python: 3608 passed, 1 xpassed, 16 subtests passed. Frontend: 10 files passed, 298 tests passed. |
+| Diff check | `git diff --check` | PASS | No whitespace errors. |
+| Compose integration | `./tools/test_integration.sh` | NOT RUN | Docker unavailable in managed container: `docker info` failed because `/var/run/docker.sock` does not exist. No compose-backed code path changed; service and activity-boundary unit tests cover the MM-407 runtime projection contract. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `moonmind/services/skill_materialization.py:46-48`, `moonmind/services/skill_materialization.py:105-127`, `tests/unit/services/test_skill_materialization.py:17-83` | VERIFIED | Workspace-mounted and hybrid materialization expose `.agents/skills`. |
+| FR-002 | `moonmind/services/skill_materialization.py:105-115`, `moonmind/workflows/skills/workspace_links.py:47-71` | VERIFIED | Shared link helper projects the active backing store through `.agents/skills`. |
+| FR-003 | `moonmind/services/skill_materialization.py:146-151`, `tests/unit/services/test_skill_materialization.py:127-152` | VERIFIED | Existing non-symlink source paths are not rewritten. |
+| FR-004 | `moonmind/services/skill_materialization.py:46-56`, `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Materialization consumes supplied snapshot and prepares the run-scoped backing store before launch. |
+| FR-005 | `moonmind/services/skill_materialization.py:76-99`, `tests/unit/services/test_skill_materialization.py:48-83` | VERIFIED | `_manifest.json` includes snapshot, runtime, mode, visible path, backing path, and selected skill metadata. |
+| FR-006 | `moonmind/services/skill_materialization.py:81-90`, `tests/unit/services/test_skill_materialization.py:86-124` | VERIFIED | Multi-skill projection lists only selected skills and omits unselected repo skill. |
+| FR-007 | `moonmind/workflows/skills/workspace_links.py:59-71`, `tests/unit/workflows/test_workspace_links.py` | VERIFIED | `.gemini/skills` compatibility link targets the same backing store. |
+| FR-008 | `moonmind/services/skill_materialization.py:146-177`, `tests/unit/services/test_skill_materialization.py:127-152` | VERIFIED | Failure includes path, object kind, attempted action, and remediation. |
+| FR-009 | `moonmind/services/skill_materialization.py:116-134`, `tests/unit/services/test_skill_materialization.py:155-179` | VERIFIED | Hybrid output carries compact metadata and prompt index ref. |
+| FR-010 | `moonmind/services/skill_materialization.py:58-74`, `tests/unit/services/test_skill_materialization.py:155-179` | VERIFIED | Full skill body is written to disk when available and not included in materialization payload. |
+| FR-011 | `moonmind/workflows/agent_skills/agent_skills_activities.py`, `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Activity boundary materializes supplied `ResolvedSkillSet` and does not perform resolver calls. |
+| FR-012 | `specs/208-managed-runtime-skill-projection/spec.md`, this report | VERIFIED | MM-407 is preserved in spec, plan, tasks, and verification. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| One selected skill appears at `.agents/skills` with `_manifest.json` and `SKILL.md` | `tests/unit/services/test_skill_materialization.py:17-83` | VERIFIED | Covers acceptance scenario 1 and SC-001. |
+| Multiple selected skills appear while unselected repo skills are absent | `tests/unit/services/test_skill_materialization.py:86-124` | VERIFIED | Covers acceptance scenario 2 and SC-002. |
+| Checked-in `.agents/skills` source directory is not rewritten | `tests/unit/services/test_skill_materialization.py:127-152` | VERIFIED | Covers acceptance scenario 3 and SC-003. |
+| Incompatible path fails before runtime launch with diagnostics | `moonmind/services/skill_materialization.py:146-177`, `tests/unit/services/test_skill_materialization.py:127-152` | VERIFIED | Covers acceptance scenario 4 and SC-004. |
+| Runtime output contains compact activation metadata without inline full bodies | `tests/unit/services/test_skill_materialization.py:155-179`, `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Covers acceptance scenario 5 and SC-005. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-005 | `moonmind/services/skill_materialization.py:46-50`, `moonmind/services/skill_materialization.py:105-127` | VERIFIED | Resolved active snapshot is exposed through `.agents/skills`. |
+| DESIGN-REQ-011 | `moonmind/services/skill_materialization.py:130-134`, `tests/unit/services/test_skill_materialization.py:155-179` | VERIFIED | Hybrid keeps prompt metadata compact while content lives on disk. |
+| DESIGN-REQ-012 | `moonmind/services/skill_materialization.py:76-99`, `tests/unit/services/test_skill_materialization.py:62-83` | VERIFIED | Active manifest identifies active skills, source kinds, visible path, and backing path. |
+| DESIGN-REQ-013 | `moonmind/services/skill_materialization.py:146-151`, `tests/unit/services/test_skill_materialization.py:127-152` | VERIFIED | Local/source path is not overwritten by runtime projection. |
+| DESIGN-REQ-014 | `moonmind/workflows/skills/workspace_links.py:47-71`, `tests/unit/workflows/test_workspace_links.py` | VERIFIED | Compatibility links preserve `.agents/skills` as canonical target. |
+| DESIGN-REQ-015 | `moonmind/services/skill_materialization.py:29-136`, `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Materialization occurs at service/activity boundary and returns compact refs. |
+| DESIGN-REQ-016 | `moonmind/workflows/agent_skills/agent_skills_activities.py`, `moonmind/services/skill_materialization.py:29-136` | VERIFIED | Agent-run materialization consumes snapshot input and projects stable active view. |
+| DESIGN-REQ-017 | `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Managed runtime activity boundary returns canonical `.agents/skills` metadata before launch. |
+| DESIGN-REQ-021 | `moonmind/services/skill_materialization.py:29-36`, `tests/unit/workflows/agent_skills/test_agent_skills_activities.py:126-156` | VERIFIED | Runtime projection uses supplied snapshot and preserves retry/rerun boundaries. |
+| Constitution I / V / VIII / IX / XI / XII / XIII | `specs/208-managed-runtime-skill-projection/plan.md`, tests above | VERIFIED | Work remains in adapter/service boundaries, fails fast, is spec-driven, and does not add compatibility aliases. |
+
+## Original Request Alignment
+
+- The MM-407 Jira preset brief is the canonical MoonSpec orchestration input.
+- The input was classified as a single-story runtime feature request.
+- No existing MM-407 spec artifacts were found, so orchestration started at specify and proceeded through plan, tasks, implementation, and verification.
+- The implementation exposes the selected active skill snapshot at `.agents/skills`, writes `_manifest.json`, avoids rewriting source folders, fails before launch for incompatible projection paths, and keeps activation metadata compact.
+
+## Gaps
+
+- Compose-backed integration was not run because Docker is unavailable in this managed container. The activity-boundary and service tests cover the changed runtime projection contract.
+- `.specify/scripts/bash/update-agent-context.sh` could not update context because this checkout's branch-derived helper expected `specs/mm-407-ac8b072c/plan.md` rather than the globally numbered `specs/208-managed-runtime-skill-projection/plan.md`.
+
+## Remaining Work
+
+- None required for MM-407 completion.
+- Optional operator-side validation: run `./tools/test_integration.sh` in an environment with Docker available.
+
+## Decision
+
+- MM-407 is fully implemented with unit and activity-boundary verification. The only unrun suite is compose-backed integration, blocked by missing Docker in this managed workspace.

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -1,78 +1,224 @@
-import pytest
-import tempfile
 import json
-from pathlib import Path
 from datetime import datetime, UTC
+from pathlib import Path
+
+import pytest
 
 from moonmind.schemas.agent_skill_models import (
-    ResolvedSkillSet,
-    ResolvedSkillEntry,
-    AgentSkillProvenance,
     AgentSkillSourceKind,
+    AgentSkillProvenance,
+    ResolvedSkillEntry,
+    ResolvedSkillSet,
     RuntimeMaterializationMode,
 )
 from moonmind.services.skill_materialization import AgentSkillMaterializer
 
 
 @pytest.mark.asyncio
-async def test_materializer_writes_files_to_skills_active():
-    with tempfile.TemporaryDirectory() as tempdir:
-        workspace_root = Path(tempdir)
-        materializer = AgentSkillMaterializer(str(workspace_root))
+async def test_materializer_projects_selected_skill_to_agents_skills(tmp_path: Path):
+    artifact_service = _StaticArtifactService(
+        {"artifact-my-skill": b"---\nname: my_skill\ndescription: test\n---\n"}
+    )
+    materializer = AgentSkillMaterializer(
+        str(tmp_path), artifact_service=artifact_service
+    )
 
-        skillset = ResolvedSkillSet(
-            snapshot_id="test_snap_123",
-            resolved_at=datetime.now(tz=UTC),
-            skills=[
-                ResolvedSkillEntry(
-                    skill_name="my_skill",
-                    version="1.0.0",
-                    provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT)
-                )
-            ]
-        )
+    skillset = ResolvedSkillSet(
+        snapshot_id="test_snap_123",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="my_skill",
+                version="1.0.0",
+                content_ref="artifact-my-skill",
+                content_digest="sha256:abc123",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.DEPLOYMENT
+                ),
+            )
+        ],
+    )
 
-        result = await materializer.materialize(
-            resolved_skillset=skillset,
-            runtime_id="test_runtime",
-            mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED
-        )
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
 
-        assert result.runtime_id == "test_runtime"
-        assert result.materialization_mode == RuntimeMaterializationMode.WORKSPACE_MOUNTED
-        
-        # Ensure it didn't write to .agents/skills but to .agents/skills_active
-        active_dir = workspace_root / ".agents" / "skills_active"
-        assert active_dir.exists()
-        assert not (workspace_root / ".agents" / "skills").exists()
-        
-        manifest_path = active_dir / "active_manifest.json"
-        assert manifest_path.exists()
-        
-        content = json.loads(manifest_path.read_text(encoding="utf-8"))
-        assert content["snapshot_id"] == "test_snap_123"
-        assert len(content["skills"]) == 1
-        assert content["skills"][0]["name"] == "my_skill"
+    visible_dir = tmp_path / ".agents" / "skills"
+    backing_dir = tmp_path / "skills_active"
+    manifest_path = visible_dir / "_manifest.json"
+
+    assert result.runtime_id == "test_runtime"
+    assert result.materialization_mode == RuntimeMaterializationMode.WORKSPACE_MOUNTED
+    assert visible_dir.is_symlink()
+    assert visible_dir.resolve() == backing_dir.resolve()
+    assert manifest_path.exists()
+    assert (visible_dir / "my_skill" / "SKILL.md").read_text(
+        encoding="utf-8"
+    ).startswith("---\nname: my_skill")
+    assert str(visible_dir) in result.workspace_paths
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest == {
+        "backing_path": str(backing_dir),
+        "materialization_mode": "workspace_mounted",
+        "resolved_at": skillset.resolved_at.isoformat(),
+        "runtime_id": "test_runtime",
+        "skills": [
+            {
+                "content_digest": "sha256:abc123",
+                "content_ref": "artifact-my-skill",
+                "name": "my_skill",
+                "source_kind": "deployment",
+                "version": "1.0.0",
+            }
+        ],
+        "snapshot_id": "test_snap_123",
+        "visible_path": str(visible_dir),
+    }
+    assert result.metadata["visiblePath"] == str(visible_dir)
+    assert result.metadata["backingPath"] == str(backing_dir)
+    assert result.metadata["manifestPath"] == str(manifest_path)
+    assert result.metadata["activeSkills"] == ["my_skill"]
+
 
 @pytest.mark.asyncio
-async def test_materializer_prompt_bundle_mode():
-    with tempfile.TemporaryDirectory() as tempdir:
-        workspace_root = Path(tempdir)
-        materializer = AgentSkillMaterializer(str(workspace_root))
+async def test_materializer_projects_only_selected_skills(tmp_path: Path):
+    repo_skill = tmp_path / "repo" / ".agents" / "skills" / "unselected_skill"
+    repo_skill.mkdir(parents=True)
+    (repo_skill / "SKILL.md").write_text(
+        "---\nname: unselected_skill\ndescription: repo\n---\n",
+        encoding="utf-8",
+    )
+    artifact_service = _StaticArtifactService(
+        {
+            "artifact-alpha": b"---\nname: alpha\ndescription: test\n---\n",
+            "artifact-beta": b"---\nname: beta\ndescription: test\n---\n",
+        }
+    )
+    materializer = AgentSkillMaterializer(
+        str(tmp_path), artifact_service=artifact_service
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="multi_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[
+            _skill("alpha", "artifact-alpha"),
+            _skill("beta", "artifact-beta"),
+        ],
+    )
 
-        skillset = ResolvedSkillSet(
-            snapshot_id="snap_prompt",
-            resolved_at=datetime.now(tz=UTC),
-            skills=[]
-        )
+    await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
 
-        result = await materializer.materialize(
+    visible_dir = tmp_path / ".agents" / "skills"
+    assert sorted(path.name for path in visible_dir.iterdir()) == [
+        "_manifest.json",
+        "alpha",
+        "beta",
+    ]
+    assert not (visible_dir / "unselected_skill").exists()
+
+
+@pytest.mark.asyncio
+async def test_materializer_rejects_incompatible_agents_skills_path(tmp_path: Path):
+    source_dir = tmp_path / ".agents" / "skills"
+    source_dir.mkdir(parents=True)
+    source_file = source_dir / "SKILL.md"
+    source_file.write_text("do not rewrite", encoding="utf-8")
+    materializer = AgentSkillMaterializer(str(tmp_path))
+    skillset = ResolvedSkillSet(
+        snapshot_id="blocked_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await materializer.materialize(
             resolved_skillset=skillset,
             runtime_id="test_runtime",
-            mode=RuntimeMaterializationMode.PROMPT_BUNDLED
+            mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
         )
 
-        assert result.materialization_mode == RuntimeMaterializationMode.PROMPT_BUNDLED
-        active_dir = workspace_root / ".agents" / "skills_active"
-        assert not active_dir.exists()
-        assert result.prompt_index_ref == "index_snap_prompt"
+    message = str(exc_info.value)
+    assert str(source_dir) in message
+    assert "object kind: directory" in message
+    assert "attempted action: project active skill snapshot" in message
+    assert "remediation:" in message
+    assert source_file.read_text(encoding="utf-8") == "do not rewrite"
+
+
+@pytest.mark.asyncio
+async def test_materializer_hybrid_returns_compact_metadata_without_skill_body(
+    tmp_path: Path,
+):
+    body = b"---\nname: compact_skill\ndescription: test\n---\nFULL BODY CONTENT\n"
+    materializer = AgentSkillMaterializer(
+        str(tmp_path),
+        artifact_service=_StaticArtifactService({"artifact-compact": body}),
+    )
+    skillset = ResolvedSkillSet(
+        snapshot_id="snap_hybrid",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[_skill("compact_skill", "artifact-compact")],
+    )
+
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.HYBRID,
+    )
+
+    assert result.prompt_index_ref == "index_snap_hybrid"
+    serialized = result.model_dump_json()
+    assert "compact_skill" in serialized
+    assert "FULL BODY CONTENT" not in serialized
+
+@pytest.mark.asyncio
+async def test_materializer_prompt_bundle_mode(tmp_path: Path):
+    materializer = AgentSkillMaterializer(str(tmp_path))
+
+    skillset = ResolvedSkillSet(
+        snapshot_id="snap_prompt",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[],
+    )
+
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="test_runtime",
+        mode=RuntimeMaterializationMode.PROMPT_BUNDLED,
+    )
+
+    assert result.materialization_mode == RuntimeMaterializationMode.PROMPT_BUNDLED
+    active_dir = tmp_path / "skills_active"
+    assert not active_dir.exists()
+    assert result.prompt_index_ref == "index_snap_prompt"
+
+
+def _skill(name: str, content_ref: str) -> ResolvedSkillEntry:
+    return ResolvedSkillEntry(
+        skill_name=name,
+        version="1.0.0",
+        content_ref=content_ref,
+        provenance=AgentSkillProvenance(source_kind=AgentSkillSourceKind.DEPLOYMENT),
+    )
+
+
+class _StaticArtifactService:
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+
+    async def read(
+        self,
+        *,
+        artifact_id: str,
+        principal: str,
+        allow_restricted_raw: bool,
+    ) -> tuple[object, bytes]:
+        del principal, allow_restricted_raw
+        return object(), self._payloads[artifact_id]

--- a/tests/unit/services/test_skill_materialization.py
+++ b/tests/unit/services/test_skill_materialization.py
@@ -153,6 +153,38 @@ async def test_materializer_rejects_incompatible_agents_skills_path(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_materializer_does_not_block_on_incompatible_gemini_skills_path(
+    tmp_path: Path,
+):
+    gemini_skill = tmp_path / ".gemini" / "skills"
+    gemini_skill.mkdir(parents=True)
+    (gemini_skill / "SKILL.md").write_text("local gemini skill", encoding="utf-8")
+    materializer = AgentSkillMaterializer(str(tmp_path))
+    skillset = ResolvedSkillSet(
+        snapshot_id="optional_gemini_snap",
+        resolved_at=datetime.now(tz=UTC),
+        skills=[],
+    )
+
+    result = await materializer.materialize(
+        resolved_skillset=skillset,
+        runtime_id="codex",
+        mode=RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+    )
+
+    visible_dir = tmp_path / ".agents" / "skills"
+    assert visible_dir.is_symlink()
+    assert result.workspace_paths == [str(visible_dir)]
+    compatibility = result.metadata["compatibilityPaths"]
+    assert compatibility["geminiSkillsPath"] == str(gemini_skill)
+    assert compatibility["geminiSkillsAvailable"] is False
+    assert "existing non-symlink path present" in compatibility["geminiSkillsError"]
+    assert (
+        gemini_skill / "SKILL.md"
+    ).read_text(encoding="utf-8") == "local gemini skill"
+
+
+@pytest.mark.asyncio
 async def test_materializer_hybrid_returns_compact_metadata_without_skill_body(
     tmp_path: Path,
 ):

--- a/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
+++ b/tests/unit/workflows/agent_skills/test_agent_skills_activities.py
@@ -9,6 +9,7 @@ from moonmind.schemas.agent_skill_models import (
     AgentSkillSourceKind,
     ResolvedSkillEntry,
     ResolvedSkillSet,
+    RuntimeMaterializationMode,
     SkillSelector,
 )
 from moonmind.workflows.agent_skills.agent_skills_activities import AgentSkillsActivities
@@ -97,7 +98,6 @@ async def test_build_prompt_index_activity_returns_bundle():
 
 
 async def test_materialize_activity_returns_materialization():
-    from moonmind.schemas.agent_skill_models import RuntimeMaterializationMode
     import tempfile
     
     activities = AgentSkillsActivities()
@@ -118,7 +118,39 @@ async def test_materialize_activity_returns_materialization():
             tempdir
         )
         
-        assert result.metadata == {}
         assert result.runtime_id == "test_runtime"
         assert result.materialization_mode == RuntimeMaterializationMode.WORKSPACE_MOUNTED
         assert len(result.workspace_paths) == 1
+
+
+async def test_materialize_activity_returns_canonical_agents_skills_metadata(
+    tmp_path,
+):
+    activities = AgentSkillsActivities()
+    env = ActivityEnvironment()
+    snapshot = ResolvedSkillSet(
+        snapshot_id="snap-canonical",
+        resolved_at=datetime.now(UTC),
+        skills=[
+            ResolvedSkillEntry(
+                skill_name="read_file",
+                provenance=AgentSkillProvenance(
+                    source_kind=AgentSkillSourceKind.BUILT_IN
+                ),
+            )
+        ],
+    )
+
+    result = await env.run(
+        activities.materialize,
+        snapshot,
+        "codex",
+        RuntimeMaterializationMode.WORKSPACE_MOUNTED,
+        str(tmp_path),
+    )
+
+    visible_path = tmp_path / ".agents" / "skills"
+    assert result.workspace_paths == [str(visible_path)]
+    assert result.metadata["visiblePath"] == str(visible_path)
+    assert result.metadata["manifestPath"] == str(visible_path / "_manifest.json")
+    assert result.metadata["activeSkills"] == ["read_file"]

--- a/tests/unit/workflows/test_workspace_links.py
+++ b/tests/unit/workflows/test_workspace_links.py
@@ -44,6 +44,27 @@ def test_ensure_shared_skill_links_rejects_existing_non_symlink(tmp_path):
         ensure_shared_skill_links(run_root=run_root, skills_active_path=skills_active)
 
 
+def test_ensure_shared_skill_links_can_treat_gemini_link_as_optional(tmp_path):
+    run_root = tmp_path / "runs" / "run-optional-gemini"
+    skills_active = run_root / "skills_active"
+    skills_active.mkdir(parents=True)
+    (run_root / ".gemini" / "skills").mkdir(parents=True)
+
+    links = ensure_shared_skill_links(
+        run_root=run_root,
+        skills_active_path=skills_active,
+        require_gemini_link=False,
+    )
+
+    assert links.agents_skills_path.is_symlink()
+    assert links.agents_skills_path.resolve() == skills_active.resolve()
+    assert not links.gemini_skills_path.is_symlink()
+    assert links.gemini_skills_available is False
+    assert links.gemini_skills_error is not None
+    assert "existing non-symlink path present" in links.gemini_skills_error
+    validate_shared_skill_links(links, require_gemini_link=False)
+
+
 def test_validate_shared_skill_links_detects_target_drift(tmp_path):
     run_root = tmp_path / "runs" / "run-3"
     skills_active = run_root / "skills_active"


### PR DESCRIPTION
## Jira

- Issue: MM-407

## MoonSpec

- Active feature path: `specs/208-managed-runtime-skill-projection`
- Verification verdict: `FULLY_IMPLEMENTED`

## Summary

- Projects managed runtime skill snapshots through canonical `.agents/skills`.
- Writes runtime-visible `_manifest.json` with snapshot, visible path, backing path, runtime, and selected skill metadata.
- Rejects incompatible `.agents/skills` paths before runtime launch with actionable diagnostics.
- Adds service and Temporal activity-boundary coverage for the projection contract.

## Tests Run

- `python -m pytest tests/unit/services/test_skill_materialization.py -q` - PASS, 5 passed
- `python -m pytest tests/unit/workflows/agent_skills/test_agent_skills_activities.py -q` - PASS, 5 passed
- `python -m pytest tests/unit/services/test_skill_materialization.py tests/unit/workflows/agent_skills/test_agent_skills_activities.py tests/unit/workflows/test_workspace_links.py -q` - PASS, 13 passed
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS, Python 3608 passed, 1 xpassed, 16 subtests passed; frontend 298 passed
- `git diff --check` - PASS

## Remaining Risks

- `./tools/test_integration.sh` was not run because Docker is unavailable in the managed container (`/var/run/docker.sock` missing). The changed runtime projection contract is covered by service and activity-boundary unit tests.
- `.specify/scripts/bash/update-agent-context.sh` could not update context in this checkout because the branch-derived helper expected `specs/mm-407-ac8b072c/plan.md`, while the repo numbering rule required `specs/208-managed-runtime-skill-projection/plan.md`.