### PR TITLE
MM-412 Create Task Publish Controls

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/207-visible-step-attachments"
+  "feature_directory": "specs/208-create-task-publish-controls"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-410",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1572"
+  "jira_issue_key": "MM-412",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1583"
 }

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -99,7 +99,7 @@ The page is a single composition form with these canonical sections, in this ord
 | 2 | Steps | Author the execution plan directly, including step-scoped image inputs, repository selection, GitHub-backed branch selection, inline publish mode, and the primary create/add-step actions |
 | 3 | Task Presets | Apply reusable step blueprints and define preset objective text and objective-scoped image inputs |
 | 4 | Dependencies | Block the new run on existing `MoonMind.Run` executions |
-| 5 | Execution context | Runtime, provider, model, effort, and merge automation eligibility |
+| 5 | Execution context | Runtime, provider, model, and effort |
 | 6 | Execution controls | Priority, max attempts, propose tasks |
 | 7 | Schedule | Immediate, once, deferred minutes, recurring |
 | 8 | Submit | Display submission status and error messages |
@@ -451,7 +451,6 @@ The Create page preserves these execution-context controls:
 - `Provider profile` when profiles exist for the selected runtime
 - `Model`
 - `Effort`
-- `Enable merge automation` when publish mode is `pr` for an ordinary task
 
 Rules:
 
@@ -462,7 +461,10 @@ Rules:
 - repository branch lookup uses MoonMind API surfaces and is unaffected by attachments or Jira
 - publish mode is authored in the Steps card and must not be duplicated here
 - resolver-style skills may still force publish mode to `none`
-- merge automation is available only for ordinary PR-publishing tasks
+- merge automation is authored as a PR-specific `Publish Mode` choice in the
+  Steps card, not as a standalone Execution context checkbox
+- the PR-specific merge automation choice is available only for ordinary
+  PR-publishing tasks
 - when merge automation is selected, the submitted task creation payload must
   preserve `publishMode=pr`, preserve `task.publish.mode=pr`, and include
   `mergeAutomation.enabled=true`
@@ -817,6 +819,8 @@ The Create page test suite should cover:
 24. the submit payload maps the single browser-authored branch into canonical `startingBranch` and `targetBranch` fields without exposing a `Target Branch` control
 25. `Publish Mode` renders adjacent to `Branch` in the Steps card control group and does not render a visible label above the compact dropdown
 26. edit/rerun correctly normalize legacy starting/target branch data into the single authored `branch` field, including the explicit migration warning for legacy cross-branch publish snapshots
+27. `Publish Mode` exposes the PR-specific merge automation choice for eligible ordinary PR-publishing tasks and the page does not render a standalone `Enable merge automation` checkbox
+28. create/edit/rerun correctly normalize stored PR publishing plus merge automation into the combined Publish Mode choice where allowed
 
 ---
 

--- a/docs/tmp/jira-orchestration-inputs/MM-412-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-412-moonspec-orchestration-input.md
@@ -1,0 +1,216 @@
+# MM-412 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-412
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Create Task Publish Controls
+- Labels: none
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-412 from MM project
+Summary: Create Task Publish Controls
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-412 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-412: Create Task Publish Controls
+
+User Story
+As a task author, I can author publish intent from one compact control group in the Create Task Steps card, with merge automation presented as a PR-specific publish choice, so repository, branch, publish mode, and merge automation intent are grouped where task execution intent is defined.
+
+Summary
+Update the Create Task UI so publishing controls are authored together in the Steps card instead of being split across multiple sections.
+
+Specifically:
+- Move Publish Mode so it appears next to Branch within the Steps card footer/control bar.
+- Remove the separate Enable merge automation checkbox from Execution context.
+- Expose merge automation through the Publish Mode UI as a PR-specific option, for example:
+  - None
+  - Branch
+  - PR
+  - PR with Merge Automation
+- Keep this as a UI and authoring-layer change, not a worker contract rewrite.
+- Preserve the existing backend and runtime payload shape.
+
+Current State
+The current frontend implementation is still split in a way that does not match desired-state authoring:
+- The Steps section still contains separate Starting Branch and Target Branch text inputs.
+- Publish Mode is rendered later in Execution context.
+- Merge automation is rendered as a separate checkbox.
+
+That creates several problems:
+- Publish-related choices are not grouped where the user is thinking about repo and branch intent.
+- Merge automation looks like a separate orthogonal feature when it only makes sense for PR publishing.
+- The Create page feels larger and more fragmented than necessary.
+- The implementation is drifting from the desired-state Create Page contract.
+
+Desired Outcome
+The Create page should author publish intent from one compact control group in the Steps card.
+
+Target UX:
+- GitHub Repo
+- Branch
+- Publish Mode
+
+Publish Mode should sit immediately to the right of Branch when there is room, and wrap responsively on narrower widths while staying within the same Steps-card control group.
+
+The merge automation checkbox should be removed and represented as a Publish Mode choice instead.
+
+Recommended Publish Mode options:
+- None
+- Branch
+- PR
+- PR with Merge Automation
+
+Important Contract Decision
+Do not introduce a new backend publish-mode enum just to support this UI.
+
+Keep the existing runtime contract and treat the combined option as a UI projection:
+- None -> `publishMode=none`
+- Branch -> `publishMode=branch`
+- PR -> `publishMode=pr`
+- PR with Merge Automation -> `publishMode=pr` plus `mergeAutomation.enabled=true`
+
+This keeps workflow and worker-side merge automation behavior stable while simplifying the Create page.
+
+Scope
+
+In scope:
+- Move Publish Mode into the Steps card next to Branch.
+- Remove the separate merge automation checkbox from Execution context.
+- Represent merge automation as a PR-specific Publish Mode option.
+- Preserve existing submission payload semantics.
+- Update edit/rerun reconstruction so legacy drafts still hydrate correctly.
+- Update Create Page docs and tests to match the new UI contract.
+- Ensure resolver-style skills still constrain publishing correctly.
+
+Out of scope:
+- Redesigning merge automation behavior or merge gating logic.
+- Changing worker-side merge automation orchestration semantics.
+- Introducing a brand-new public API contract for publish mode.
+- Broader PR resolver redesign.
+
+Proposed UI Behavior
+
+1. Steps card control group
+- The Steps footer/control bar should own publish authoring.
+- It should render compact inline controls for repository, branch, and publish mode.
+
+2. Publish Mode values
+- Suggested visible values:
+  - None
+  - Branch
+  - PR
+  - PR with Merge Automation
+- The exact label can be adjusted slightly for brevity, such as PR + Merge Automation, but the behavior must be unambiguous.
+
+3. Merge automation availability rules
+- PR with Merge Automation should only be available when merge automation is semantically allowed.
+- At minimum:
+  - Ordinary task authoring may use it.
+  - Direct pr-resolver / batch-pr-resolver tasks must not surface it.
+  - If current runtime or skill constraints force publish mode to none, the combined PR+merge option must not remain selected silently.
+
+4. Accessible labeling
+- The compact inline controls may omit large visible labels above the chrome, but they must still expose accessible names.
+
+5. Responsive behavior
+- On wide layouts, Branch and Publish Mode should appear side-by-side.
+- On narrow layouts, they may wrap, but must remain in the same Steps-card control group.
+
+Edit / Rerun / Migration Behavior
+This story must handle existing state safely.
+
+Existing create/edit states to normalize:
+- `publishMode=none` -> None
+- `publishMode=branch` -> Branch
+- `publishMode=pr` and no merge automation -> PR
+- `publishMode=pr` and `mergeAutomation.enabled=true` -> PR with Merge Automation
+
+This should apply consistently for:
+- Fresh create.
+- Edit.
+- Rerun.
+- Legacy snapshots reconstructed into the Create page.
+
+Technical Work Breakdown
+
+1. Update Create page state model
+- Refactor the Create page UI state so Publish Mode can represent the combined PR+merge choice without changing the worker payload contract.
+- Keep internal submission logic capable of emitting `publishMode` and `mergeAutomation.enabled`.
+- Add a UI-layer derived enum/value for the combined picker state.
+- Centralize mapping between UI selection and submission payload.
+- Centralize mapping between stored payload and hydrated UI selection.
+
+2. Move Publish Mode rendering into the Steps card
+- Update the Steps-card footer/control group so Publish Mode is rendered adjacent to Branch.
+- Relocate the control from Execution context.
+- Remove the old duplicate control placement.
+- Ensure layout, spacing, and wrapping are intentional.
+
+3. Remove separate merge automation checkbox
+- Delete the separate checkbox from Execution context and replace its behavior with the combined Publish Mode option.
+
+4. Preserve submission semantics
+- Submission logic must continue to emit the existing payload shape:
+  - `publishMode`
+  - `task.publish.mode`
+  - optional `mergeAutomation.enabled=true`
+- No worker-side API churn should be required for this story.
+
+5. Preserve gating behavior for resolver skills
+- Current safeguards that force or constrain publish mode for resolver-style skills must continue to work with the new UI representation.
+
+6. Update tests
+- Add or update Create page tests for inline Publish Mode rendering in the Steps card.
+- Confirm there is no standalone merge automation checkbox.
+- Cover correct payload mapping for all Publish Mode choices.
+- Cover correct edit/rerun hydration for existing task inputs.
+- Cover behavior when resolver skills or other constraints disallow PR publish choices.
+
+7. Update docs
+- Update desired-state docs so implementation and docs stay aligned.
+- At minimum, update `docs/UI/CreatePage.md`.
+- If needed, also update related UI/test contract docs that still describe the old placement.
+
+Likely File Targets
+
+Frontend / tests:
+- `frontend/src/entrypoints/task-create.tsx`
+- `frontend/src/entrypoints/task-create.test.tsx`
+
+Docs:
+- `docs/UI/CreatePage.md`
+
+Potential supporting areas if needed:
+- Create-page styling assets used by `task-create.tsx`.
+- Task editing draft reconstruction helpers if hydration logic needs a shared normalization path.
+
+Acceptance Criteria
+- Publish Mode is rendered in the Steps card next to Branch rather than in Execution context.
+- The separate Enable merge automation checkbox is removed.
+- The Publish Mode UI includes a PR-specific merge automation option.
+- Selecting the merge automation option still submits `publishMode=pr` plus `mergeAutomation.enabled=true` rather than introducing a new backend publish-mode contract.
+- Edit/rerun hydration maps existing PR + merge automation task inputs back to the combined Publish Mode selection correctly.
+- Resolver-style skills and similar guardrails still prevent invalid publish selections.
+- Responsive layout keeps Branch and Publish Mode grouped within the Steps card.
+- Accessibility names remain correct for the compact controls.
+- Tests cover both submission mapping and reconstruction behavior.
+- `docs/UI/CreatePage.md` reflects the new control placement and semantics.
+
+Implementation Notes
+- This story is intentionally about Create-page authoring UX alignment, not merge automation orchestration changes.
+- Merge automation is not a separate publish category at the backend contract layer, but it should be presented as a first-class PR publishing choice in the UI.
+- Keep workflow and worker-side merge automation behavior stable.
+- Preserve MM-412 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates no issue links for MM-412.

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -765,6 +765,40 @@ describe("Task Create Entrypoint", () => {
             }),
           } as Response);
         }
+        if (url === "/api/executions/mm%3Amerge-automation-edit?source=temporal") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              workflowId: "mm:merge-automation-edit",
+              workflowType: "MoonMind.Run",
+              state: "executing",
+              targetRuntime: "codex_cli",
+              profileId: "profile:codex-default",
+              model: "gpt-5.4",
+              effort: "medium",
+              repository: "MoonLadderStudios/MoonMind",
+              publishMode: "pr",
+              inputParameters: {
+                targetRuntime: "codex_cli",
+                mergeAutomation: { enabled: true },
+                task: {
+                  instructions: "Update an existing automated PR task.",
+                  runtime: {
+                    mode: "codex_cli",
+                    model: "gpt-5.4",
+                    effort: "medium",
+                    profileId: "profile:codex-default",
+                  },
+                  publish: { mode: "pr" },
+                },
+              },
+              actions: {
+                canUpdateInputs: true,
+                canRerun: false,
+              },
+            }),
+          } as Response);
+        }
         if (url === "/api/executions/mm%3Amulti-step-edit?source=temporal") {
           return Promise.resolve({
             ok: true,
@@ -1205,6 +1239,17 @@ describe("Task Create Entrypoint", () => {
               applied: "immediate",
               message: "Inputs updated.",
               execution: { workflowId: "mm:edit-123" },
+            }),
+          } as Response);
+        }
+        if (url === "/api/executions/mm%3Amerge-automation-edit/update") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              accepted: true,
+              applied: "immediate",
+              message: "Inputs updated.",
+              execution: { workflowId: "mm:merge-automation-edit" },
             }),
           } as Response);
         }
@@ -3234,6 +3279,40 @@ describe("Task Create Entrypoint", () => {
     window.removeEventListener("moonmind:temporal-task-editing", onTelemetry);
   });
 
+  it("clears persisted merge automation when edit mode deselects the combined publish mode", async () => {
+    renderForEdit("mm:merge-automation-edit");
+
+    const publishSelect = (await screen.findByLabelText(
+      "Publish Mode",
+    )) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(publishSelect.value).toBe("pr_with_merge_automation");
+    });
+    fireEvent.change(publishSelect, { target: { value: "pr" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/executions/mm%3Amerge-automation-edit/update",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const updateCall = fetchSpy.mock.calls
+      .filter(
+        ([url]) =>
+          String(url) === "/api/executions/mm%3Amerge-automation-edit/update",
+      )
+      .at(-1);
+    const request = JSON.parse(String(updateCall?.[1]?.body));
+    expect(request.parametersPatch).not.toHaveProperty("mergeAutomation");
+    expect(request.parametersPatch).toMatchObject({
+      publishMode: "pr",
+      task: {
+        publish: { mode: "pr" },
+      },
+    });
+  });
+
   it("shows continue-as-new success copy and redirects to the returned execution context", async () => {
     renderForEdit("mm:continue-edit");
 
@@ -4963,7 +5042,7 @@ describe("Task Create Entrypoint", () => {
     await waitFor(() => {
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
-      ).toBe("pr");
+      ).toBe("none");
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
@@ -4977,8 +5056,9 @@ describe("Task Create Entrypoint", () => {
 
     const payload = latestCreateRequest().payload as Record<string, unknown>;
     const task = payload.task as Record<string, unknown>;
-    expect(payload.publishMode).toBe("pr");
+    expect(payload.publishMode).toBe("none");
     expect(payload).not.toHaveProperty("mergeAutomation");
+    expect(task.publish).toMatchObject({ mode: "none" });
     expect(task.skills).toEqual({ include: [{ name: "pr-resolver" }] });
   });
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2030,6 +2030,26 @@ describe("Task Create Entrypoint", () => {
     ]);
   });
 
+  it("reconstructs pr publish with merge automation into draft state", () => {
+    const draft = buildTemporalSubmissionDraftFromExecution({
+      workflowId: "mm:merge-edit",
+      workflowType: "MoonMind.Run",
+      targetRuntime: "codex_cli",
+      repository: "MoonLadderStudios/MoonMind",
+      publishMode: "pr",
+      inputParameters: {
+        mergeAutomation: { enabled: true },
+        task: {
+          instructions: "Preserve PR merge automation state.",
+          publish: { mode: "pr" },
+        },
+      },
+    });
+
+    expect(draft.publishMode).toBe("pr");
+    expect(draft.mergeAutomationEnabled).toBe(true);
+  });
+
   it("reconstructs a draft from an artifact-backed execution contract", () => {
     const draft = buildTemporalSubmissionDraftFromExecution(
       {
@@ -4780,12 +4800,20 @@ describe("Task Create Entrypoint", () => {
     });
   });
 
-  it("shows merge automation only for ordinary pr-publishing tasks", async () => {
+  it("shows merge automation as a publish mode choice only for ordinary pr-publishing tasks", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
+    const publishModeSelect = (await screen.findByLabelText(
+      "Publish Mode",
+    )) as HTMLSelectElement;
     expect(
-      await screen.findByLabelText("Enable merge automation"),
-    ).toBeTruthy();
+      Array.from(publishModeSelect.options).some(
+        (option) =>
+          option.value === "pr_with_merge_automation" &&
+          /merge automation/i.test(option.text),
+      ),
+    ).toBe(true);
+    expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
     expect(screen.getByText(/uses pr-resolver/i)).toBeTruthy();
     expect(screen.queryByText(/direct auto-merge/i)).toBeNull();
 
@@ -4793,7 +4821,11 @@ describe("Task Create Entrypoint", () => {
       target: { value: "branch" },
     });
     await waitFor(() => {
-      expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
+      expect(
+        Array.from(
+          (screen.getByLabelText("Publish Mode") as HTMLSelectElement).options,
+        ).some((option) => option.value === "pr_with_merge_automation"),
+      ).toBe(true);
     });
 
     fireEvent.change(screen.getByLabelText("Publish Mode"), {
@@ -4806,16 +4838,22 @@ describe("Task Create Entrypoint", () => {
     fireEvent.change(screen.getByLabelText("Publish Mode"), {
       target: { value: "pr" },
     });
-    expect(await screen.findByLabelText("Enable merge automation")).toBeTruthy();
+    expect(
+      Array.from(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).options,
+      ).some((option) => option.value === "pr_with_merge_automation"),
+    ).toBe(true);
   });
 
   it("submits merge automation with the existing pr publish contracts", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
     fireEvent.change(await screen.findByLabelText("Instructions"), {
-      target: { value: "Implement MM-365." },
+      target: { value: "Implement MM-412." },
     });
-    fireEvent.click(await screen.findByLabelText("Enable merge automation"));
+    fireEvent.change(await screen.findByLabelText("Publish Mode"), {
+      target: { value: "pr_with_merge_automation" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
     await waitFor(() => {
@@ -4863,7 +4901,9 @@ describe("Task Create Entrypoint", () => {
       "section",
     );
     expect(primaryStep).not.toBeNull();
-    fireEvent.click(await screen.findByLabelText("Enable merge automation"));
+    fireEvent.change(await screen.findByLabelText("Publish Mode"), {
+      target: { value: "pr_with_merge_automation" },
+    });
     fireEvent.change(
       within(primaryStep as HTMLElement).getByLabelText(/Skill \(optional\)/),
       {
@@ -4871,7 +4911,9 @@ describe("Task Create Entrypoint", () => {
       },
     );
     await waitFor(() => {
-      expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("none");
     });
     fireEvent.change(
       within(primaryStep as HTMLElement).getByLabelText("Instructions"),
@@ -4897,7 +4939,12 @@ describe("Task Create Entrypoint", () => {
   it("hides merge automation when the effective template skill is a resolver", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    expect(await screen.findByLabelText("Enable merge automation")).toBeTruthy();
+    fireEvent.change(await screen.findByLabelText("Publish Mode"), {
+      target: { value: "pr_with_merge_automation" },
+    });
+    expect(
+      (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+    ).toBe("pr_with_merge_automation");
 
     const presetSelect = await screen.findByLabelText("Preset");
     await waitFor(() => {
@@ -4914,7 +4961,9 @@ describe("Task Create Entrypoint", () => {
 
     await screen.findByDisplayValue("Resolve the current branch PR.");
     await waitFor(() => {
-      expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
+      expect(
+        (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
+      ).toBe("pr");
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
@@ -5391,6 +5440,7 @@ describe("Task Create Entrypoint", () => {
     expect(
       publishModeSelect.closest('[data-canonical-create-section="Execution context"]'),
     ).toBeNull();
+    expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
     expect(screen.queryByLabelText("Target Branch (optional)")).toBeNull();
     expect(
       primaryStepLabel.compareDocumentPosition(repoInput) &

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -620,6 +620,9 @@ function buildEditParametersPatch({
     ...submittedPayload,
     task: mergedTask,
   };
+  if (!("mergeAutomation" in submittedPayload)) {
+    delete parametersPatch.mergeAutomation;
+  }
   delete parametersPatch.startingBranch;
   delete parametersPatch.targetBranch;
   return parametersPatch;
@@ -3012,12 +3015,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
 
   useEffect(() => {
     if (!mergeAutomationAvailable && isMergeAutomationPublishMode(publishMode)) {
-      const primarySkill = String(steps[0]?.skillId || "")
-        .trim()
-        .toLowerCase();
-      setPublishMode(isResolverSkill(primarySkill) ? "none" : "pr");
+      setPublishMode(isResolverSkill(effectiveSkillId) ? "none" : "pr");
     }
-  }, [mergeAutomationAvailable, publishMode, steps[0]?.skillId]);
+  }, [effectiveSkillId, mergeAutomationAvailable, publishMode]);
 
   const availableDependencyOptions = useMemo(
     () =>

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -1382,6 +1382,19 @@ function deriveRequiredCapabilities(args: {
   );
 }
 
+const PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE = "pr_with_merge_automation";
+
+function normalizePublishModeForSubmit(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return normalized === PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE
+    ? "pr"
+    : normalized;
+}
+
+function isMergeAutomationPublishMode(value: string): boolean {
+  return value.trim().toLowerCase() === PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE;
+}
+
 function mapExpandedStepToState(
   index: number,
   step: ExpandedStepPayload,
@@ -2210,8 +2223,9 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const [repository, setRepository] = useState(defaultRepository);
   const [providerProfile, setProviderProfile] = useState("");
   const [branch, setBranch] = useState("");
-  const [publishMode, setPublishMode] = useState(defaultPublishMode);
-  const [mergeAutomationEnabled, setMergeAutomationEnabled] = useState(false);
+  const [publishMode, setPublishMode] = useState(
+    normalizePublishModeForSubmit(defaultPublishMode),
+  );
   const [priority, setPriority] = useState(0);
   const [maxAttempts, setMaxAttempts] = useState(3);
   const [proposeTasks, setProposeTasks] = useState(() =>
@@ -2553,7 +2567,14 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       setSubmitMessage(draft.legacyBranchWarning);
     }
     if (draft.publishMode) {
-      setPublishMode(draft.publishMode);
+      const normalizedDraftPublishMode = normalizePublishModeForSubmit(
+        draft.publishMode,
+      );
+      setPublishMode(
+        normalizedDraftPublishMode === "pr" && draft.mergeAutomationEnabled
+          ? PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE
+          : normalizedDraftPublishMode,
+      );
     }
     const reconstructedSteps = createStepStateEntriesFromTemporalDraft(draft);
     setSteps(reconstructedSteps);
@@ -2987,16 +3008,16 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     }
   }, [pageMode.mode, selectedPreset?.slug]);
 
-  const mergeAutomationAvailable =
-    pageMode.mode === "create" &&
-    publishMode.trim().toLowerCase() === "pr" &&
-    !isResolverSkill(effectiveSkillId);
+  const mergeAutomationAvailable = !isResolverSkill(effectiveSkillId);
 
   useEffect(() => {
-    if (!mergeAutomationAvailable && mergeAutomationEnabled) {
-      setMergeAutomationEnabled(false);
+    if (!mergeAutomationAvailable && isMergeAutomationPublishMode(publishMode)) {
+      const primarySkill = String(steps[0]?.skillId || "")
+        .trim()
+        .toLowerCase();
+      setPublishMode(isResolverSkill(primarySkill) ? "none" : "pr");
     }
-  }, [mergeAutomationAvailable, mergeAutomationEnabled]);
+  }, [mergeAutomationAvailable, publishMode, steps[0]?.skillId]);
 
   const availableDependencyOptions = useMemo(
     () =>
@@ -4486,7 +4507,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       return;
     }
 
-    const normalizedPublishMode = publishMode.trim().toLowerCase();
+    const normalizedPublishMode = normalizePublishModeForSubmit(publishMode);
     if (!["none", "branch", "pr"].includes(normalizedPublishMode)) {
       setSubmitMessage("Publish mode must be one of: none, branch, pr.");
       return;
@@ -5003,8 +5024,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       : primaryStepSkill;
 
     const shouldSubmitMergeAutomation =
-      mergeAutomationEnabled &&
-      pageMode.mode === "create" &&
+      isMergeAutomationPublishMode(publishMode) &&
       normalizedPublishMode === "pr" &&
       !isResolverSkill(effectiveSubmissionSkillId);
 
@@ -5968,12 +5988,23 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                     value={publishMode}
                     onChange={(event) => setPublishMode(event.target.value)}
                   >
-                    <option value="pr">pr</option>
-                    <option value="branch">branch</option>
-                    <option value="none">none</option>
+                    <option value="none">None</option>
+                    <option value="branch">Branch</option>
+                    <option value="pr">PR</option>
+                    {mergeAutomationAvailable ? (
+                      <option value={PR_WITH_MERGE_AUTOMATION_PUBLISH_MODE}>
+                        PR with Merge Automation
+                      </option>
+                    ) : null}
                   </select>
                 </div>
               </div>
+              {mergeAutomationAvailable ? (
+                <p className="small">
+                  PR with Merge Automation uses pr-resolver after the PR
+                  readiness gate opens; it does not bypass resolver handling.
+                </p>
+              ) : null}
               {branchStatusMessage ? (
                 <p
                   className={
@@ -6388,24 +6419,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
           </label>
         </div>
 
-        {mergeAutomationAvailable ? (
-          <label className="checkbox">
-            <input
-              type="checkbox"
-              name="mergeAutomationEnabled"
-              aria-label="Enable merge automation"
-              checked={mergeAutomationEnabled}
-              onChange={(event) =>
-                setMergeAutomationEnabled(event.target.checked)
-              }
-            />
-            Enable merge automation
-            <span className="small">
-              Uses pr-resolver after the PR readiness gate opens; it does not
-              bypass resolver handling.
-            </span>
-          </label>
-        ) : null}
         </section>
 
         <section

--- a/frontend/src/lib/temporalTaskEditing.ts
+++ b/frontend/src/lib/temporalTaskEditing.ts
@@ -61,6 +61,7 @@ export type TemporalSubmissionDraft = {
   branch: string | null;
   legacyBranchWarning: string | null;
   publishMode: string | null;
+  mergeAutomationEnabled: boolean;
   taskInstructions: string;
   primarySkill: string | null;
   inputAttachments: TemporalTaskInputAttachmentRef[];
@@ -659,6 +660,10 @@ export function buildTemporalSubmissionDraftFromExecution(
   const artifactGit = objectValue(artifactTask.git);
   const publish = objectValue(task.publish);
   const artifactPublish = objectValue(artifactTask.publish);
+  const mergeAutomation = objectValue(params.mergeAutomation);
+  const artifactMergeAutomation = objectValue(artifactParams.mergeAutomation);
+  const taskMergeAutomation = objectValue(task.mergeAutomation);
+  const artifactTaskMergeAutomation = objectValue(artifactTask.mergeAutomation);
   const tool = objectValue(task.tool);
   const skill = objectValue(task.skill);
   const artifactTool = objectValue(artifactTask.tool);
@@ -759,6 +764,12 @@ export function buildTemporalSubmissionDraftFromExecution(
     branch: legacyBranchDraft.branch,
     legacyBranchWarning: legacyBranchDraft.warning,
     publishMode,
+    mergeAutomationEnabled: Boolean(
+      mergeAutomation.enabled ||
+        artifactMergeAutomation.enabled ||
+        taskMergeAutomation.enabled ||
+        artifactTaskMergeAutomation.enabled,
+    ),
     taskInstructions:
       Object.keys(snapshotDraft).length > 0
         ? taskInstructionsFrom(artifactTask, task)

--- a/specs/208-create-task-publish-controls/checklists/requirements.md
+++ b/specs/208-create-task-publish-controls/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Create Task Publish Controls
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Input classified as a single-story runtime feature request.
+- Existing artifacts were inspected; no existing MM-412 spec directory was found, so orchestration resumed at the specify stage.
+- Source design requirements from `docs/UI/CreatePage.md` sections 5, 7.6, 10, 13, 14, 16, 17, and 18 are mapped to functional requirements.

--- a/specs/208-create-task-publish-controls/contracts/create-page-publish-controls.md
+++ b/specs/208-create-task-publish-controls/contracts/create-page-publish-controls.md
@@ -1,0 +1,57 @@
+# UI Contract: Create Page Publish Controls
+
+## Publish Mode Options
+
+The Create page exposes one compact `Publish Mode` control in the Steps card control group.
+
+Required visible options:
+- None
+- Branch
+- PR
+- PR with Merge Automation
+
+The final label for the combined option may be shortened, but it must be accessible and unambiguous.
+
+## Availability Rules
+
+- None, Branch, and PR remain available according to existing publish constraints.
+- PR with Merge Automation is available only when:
+  - page mode is create,
+  - the effective publish behavior is PR publishing,
+  - the effective task skill is not `pr-resolver` or `batch-pr-resolver`,
+  - no preset or runtime constraint forces publishing to None.
+- If constraints change while PR with Merge Automation is selected, the page must clear or normalize the selection visibly before submit.
+
+## Submission Contract
+
+The UI-only combined choice must normalize before request submission.
+
+| Visible selection | Top-level `publishMode` | `task.publish.mode` | Top-level `mergeAutomation` |
+| --- | --- | --- | --- |
+| None | `none` | `none` | omitted |
+| Branch | `branch` | `branch` | omitted |
+| PR | `pr` | `pr` | omitted |
+| PR with Merge Automation | `pr` | `pr` | `{ "enabled": true }` |
+
+The request must not submit `pr_with_merge_automation` or any other new backend publish-mode value.
+
+## Edit And Rerun Hydration
+
+The page must normalize stored state into the visible control:
+- stored None -> None
+- stored Branch -> Branch
+- stored PR and no merge automation -> PR
+- stored PR and merge automation enabled -> PR with Merge Automation, when currently allowed
+
+When currently disallowed, merge automation must not remain selected silently.
+
+## Accessibility And Layout
+
+- Branch and Publish Mode must expose accessible names.
+- Publish Mode appears next to Branch when space allows.
+- Branch and Publish Mode remain in the same Steps card control group when wrapping.
+- Execution context must not expose a separate Enable merge automation checkbox.
+
+## Copy
+
+When the combined PR with Merge Automation choice is available or selected, the UI must explain that MoonMind waits for PR readiness and uses pr-resolver behavior. It must not imply direct auto-merge or bypass resolver handling.

--- a/specs/208-create-task-publish-controls/data-model.md
+++ b/specs/208-create-task-publish-controls/data-model.md
@@ -1,0 +1,65 @@
+# Data Model: Create Task Publish Controls
+
+## Publish Mode Selection
+
+Represents the visible Create-page publish choice.
+
+Values:
+- `none`: no publishing after task execution.
+- `branch`: publish work back to the selected branch.
+- `pr`: create or update a pull request without merge automation.
+- `pr_with_merge_automation`: create or update a pull request and enable existing MoonMind merge automation behavior.
+
+Validation:
+- `pr_with_merge_automation` is valid only for ordinary PR-publishing task authoring.
+- Resolver-style tasks and constrained presets must not keep `pr_with_merge_automation` selected.
+- The visible value is UI-only; it must normalize before submission.
+
+Submission mapping:
+- `none` -> `publishMode=none`, `task.publish.mode=none`, no `mergeAutomation`.
+- `branch` -> `publishMode=branch`, `task.publish.mode=branch`, no `mergeAutomation`.
+- `pr` -> `publishMode=pr`, `task.publish.mode=pr`, no `mergeAutomation`.
+- `pr_with_merge_automation` -> `publishMode=pr`, `task.publish.mode=pr`, `mergeAutomation.enabled=true`.
+
+## Merge Automation Intent
+
+Represents the existing runtime behavior request to let MoonMind wait for PR readiness and use resolver handling.
+
+Fields:
+- `enabled`: boolean submitted only when the visible publish selection is PR with Merge Automation and current task constraints allow it.
+
+Validation:
+- Must be omitted for None and Branch.
+- Must be omitted for direct `pr-resolver` and `batch-pr-resolver` tasks.
+- Must be omitted or cleared when runtime or preset constraints force publish mode to None.
+- Must not imply direct auto-merge or bypass resolver behavior.
+
+## Stored Publish State
+
+Represents publish state reconstructed from create, edit, or rerun input snapshots.
+
+Inputs:
+- stored publish mode from top-level payload and/or nested task publish object.
+- stored merge automation enabled flag, when present.
+- runtime, selected skill, and preset constraints.
+
+State transitions:
+- Stored None -> visible None.
+- Stored Branch -> visible Branch.
+- Stored PR without merge automation -> visible PR.
+- Stored PR with merge automation enabled -> visible PR with Merge Automation when currently allowed.
+- Stored PR with merge automation enabled but currently disallowed -> visible PR or None according to existing publish constraints, with merge automation not submitted.
+
+## Steps Card Publish Control Group
+
+Represents the visible authoring group in the Steps card footer.
+
+Members:
+- GitHub Repo.
+- Branch.
+- Publish Mode.
+
+Validation:
+- Branch and Publish Mode expose accessible names even when compact styling omits visible labels above the controls.
+- Publish Mode stays adjacent to Branch when room allows and remains in the same control group when wrapping.
+- Execution context must not contain duplicate Publish Mode or standalone Enable merge automation controls.

--- a/specs/208-create-task-publish-controls/plan.md
+++ b/specs/208-create-task-publish-controls/plan.md
@@ -7,7 +7,9 @@
 
 Implement MM-412 by converting merge automation from a separate Execution context checkbox into a PR-specific Publish Mode choice inside the existing Steps-card publish control group. The code already has repository, Branch, and Publish Mode in the Steps card, so the remaining runtime work is to introduce a UI-layer combined publish selection, preserve existing submission semantics, update edit/rerun hydration, remove the standalone checkbox, and update focused Create-page tests plus the desired-state Create Page doc.
 
-## Requirement Status
+## Initial Requirement Gap Analysis
+
+This table records the pre-implementation repository state used to generate `tasks.md`. Current implementation verification is recorded in `verification.md`.
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |

--- a/specs/208-create-task-publish-controls/plan.md
+++ b/specs/208-create-task-publish-controls/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Create Task Publish Controls
+
+**Branch**: `208-create-task-publish-controls` | **Date**: 2026-04-18 | **Spec**: `specs/208-create-task-publish-controls/spec.md`  
+**Input**: Single-story feature specification from `specs/208-create-task-publish-controls/spec.md`
+
+## Summary
+
+Implement MM-412 by converting merge automation from a separate Execution context checkbox into a PR-specific Publish Mode choice inside the existing Steps-card publish control group. The code already has repository, Branch, and Publish Mode in the Steps card, so the remaining runtime work is to introduce a UI-layer combined publish selection, preserve existing submission semantics, update edit/rerun hydration, remove the standalone checkbox, and update focused Create-page tests plus the desired-state Create Page doc.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `frontend/src/entrypoints/task-create.tsx` renders GitHub Repo, Branch, and Publish Mode in Steps card | keep behavior and add MM-412-specific placement test | unit/integration-style UI |
+| FR-002 | partial | `frontend/src/entrypoints/task-create.tsx` still renders `Enable merge automation` in Execution context | remove standalone checkbox and test absence | unit/integration-style UI |
+| FR-003 | implemented_unverified | `frontend/src/entrypoints/task-create.tsx` places Publish Mode after Branch in `.queue-inline-selector-row` | preserve responsive grouping and update test coverage | unit/integration-style UI |
+| FR-004 | missing | Publish Mode options are only `pr`, `branch`, `none` | add PR-with-merge visible choice for ordinary eligible tasks | unit/integration-style UI |
+| FR-005 | partial | submission already sends `mergeAutomation.enabled=true` from checkbox | map combined selection to existing PR + merge payload | integration-style request-shape UI |
+| FR-006 | implemented_unverified | submission already preserves none/branch/pr publish modes | add coverage proving non-merge choices omit merge automation | integration-style request-shape UI |
+| FR-007 | partial | resolver constraints clear checkbox state through `mergeAutomationAvailable` | apply constraints to combined selection and clear invalid PR+merge visibly | unit/integration-style UI |
+| FR-008 | implemented_unverified | direct resolver skill tests exist for checkbox hiding | update coverage to prove PR+merge option is unavailable or cleared | unit/integration-style UI |
+| FR-009 | implemented_unverified | Branch and Publish Mode selects have `aria-label` values | preserve accessible names and add combined option coverage | unit UI |
+| FR-010 | implemented_verified | Existing copy says uses pr-resolver after PR readiness and not bypassing resolver handling | move/retain copy near combined option if needed | unit UI |
+| FR-011 | implemented_verified | Jira Orchestrate behavior is separate from Create-page publish option | no implementation change unless tests expose coupling | final verify |
+| FR-012 | partial | edit/rerun hydration maps stored publish mode, but merge automation state is not represented in Publish Mode | add stored-state normalization for PR-with-merge | unit/integration-style UI |
+| FR-013 | missing | MM-412-specific combined-option tests absent | add focused tests and preserve MM-412 traceability | unit/integration-style UI |
+| DESIGN-REQ-001 | implemented_unverified | Steps-card publish placement exists | preserve and verify | unit UI |
+| DESIGN-REQ-002 | partial | compact controls exist, combined PR+merge option absent | add combined option while preserving compact controls | unit UI |
+| DESIGN-REQ-003 | implemented_unverified | existing publish submit contract maps none/branch/pr | preserve contract while adding combined UI state | integration-style UI |
+| DESIGN-REQ-004 | partial | merge automation eligibility exists as checkbox gating | move eligibility into Publish Mode choices | unit/integration-style UI |
+| DESIGN-REQ-005 | implemented_verified | merge automation copy already references PR readiness and pr-resolver | keep or relocate copy with no direct auto-merge implication | unit UI |
+| DESIGN-REQ-006 | partial | publish mode hydrates; merge automation combined state does not | normalize stored PR+merge state | unit UI |
+| DESIGN-REQ-007 | implemented_unverified | submit payload preserves publish fields | verify through request-shape tests | integration-style UI |
+| DESIGN-REQ-008 | partial | invalid merge checkbox is cleared; combined value needs equivalent clearing | clear invalid combined selection and preserve draft state | unit UI |
+| DESIGN-REQ-009 | implemented_unverified | compact controls have aria labels | preserve in tests | unit UI |
+| DESIGN-REQ-010 | partial | existing tests cover placement and branch mapping, but old checkbox tests remain | update tests for combined Publish Mode semantics | unit/integration-style UI |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present for backend but not expected in this story  
+**Primary Dependencies**: React, TanStack Query, existing Create page entrypoint, existing MoonMind REST execution create/edit/rerun surfaces, Vitest and Testing Library  
+**Storage**: Existing execution payload snapshots only; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`  
+**Integration Testing**: Focused Create page request-shape tests in `frontend/src/entrypoints/task-create.test.tsx`; no compose-backed service integration is required for this UI state story  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web UI  
+**Performance Goals**: Publish selection changes remain immediate and do not add network calls or submission latency  
+**Constraints**: Preserve existing backend/runtime publish contract, preserve resolver-style restrictions, keep Jira Orchestrate behavior unchanged, and preserve MM-412 traceability  
+**Scale/Scope**: One Create page entrypoint, focused Create page tests, and desired-state Create Page documentation
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story preserves existing MoonMind task submission and pr-resolver behavior.
+- II. One-Click Agent Deployment: PASS. No new services, secrets, or deployment prerequisites.
+- III. Avoid Vendor Lock-In: PASS. Publish controls remain MoonMind-native UI state and do not introduce provider-specific browser calls.
+- IV. Own Your Data: PASS. Existing task payload snapshots remain the data boundary.
+- V. Skills Are First-Class and Easy to Add: PASS. Resolver-style skill restrictions remain explicit.
+- VI. Replaceable Scaffolding: PASS. Adds focused UI state and tests without new orchestration scaffolding.
+- VII. Runtime Configurability: PASS. Runtime and skill constraints continue to drive availability.
+- VIII. Modular Architecture: PASS. Work stays in existing Create page surfaces.
+- IX. Resilient by Default: PASS. Invalid combined selections are cleared instead of silently submitting stale merge automation.
+- X. Continuous Improvement: PASS. Verification evidence will be recorded in feature artifacts.
+- XI. Spec-Driven Development: PASS. Runtime changes follow this one-story Moon Spec.
+- XII. Canonical Documentation Separation: PASS. Desired-state docs stay declarative; implementation notes remain in `specs/` and `docs/tmp/`.
+- XIII. Pre-Release Compatibility Policy: PASS. No compatibility alias or backend enum is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/208-create-task-publish-controls/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── create-page-publish-controls.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── task-create.tsx
+└── task-create.test.tsx
+
+docs/UI/
+└── CreatePage.md
+
+docs/tmp/jira-orchestration-inputs/
+└── MM-412-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Preserve the existing Create page implementation surface. Add a small UI-layer publish selection mapping in `task-create.tsx`, update focused tests in the existing test file, and update the declarative Create Page doc to remove the standalone checkbox contract.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/208-create-task-publish-controls/quickstart.md
+++ b/specs/208-create-task-publish-controls/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart: Create Task Publish Controls
+
+## Focused Test Command
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx
+```
+
+## Final Unit Command
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Test-First Validation Scenarios
+
+1. Render the Create page and confirm GitHub Repo, Branch, and Publish Mode are in the Steps card control group.
+2. Confirm Execution context has no standalone `Enable merge automation` checkbox.
+3. Confirm ordinary PR-publishing tasks expose a Publish Mode option for PR with Merge Automation.
+4. Select None, Branch, PR, and PR with Merge Automation and submit each draft; inspect request payload mapping.
+5. Select PR with Merge Automation, then select a direct resolver skill; confirm the combined merge choice is unavailable or cleared and submission omits merge automation.
+6. Hydrate edit/rerun snapshots with None, Branch, PR, and PR plus merge automation; confirm the visible Publish Mode selection matches stored state.
+7. Confirm Branch and Publish Mode controls expose accessible names.
+8. Confirm `docs/UI/CreatePage.md` describes merge automation as a Publish Mode choice rather than a standalone Execution context checkbox.
+
+## Expected End State
+
+- No backend publish enum changes.
+- No worker contract changes.
+- Existing payload shape is preserved.
+- MM-412 remains traceable through spec, plan, tasks, verification, commits, and PR metadata.

--- a/specs/208-create-task-publish-controls/research.md
+++ b/specs/208-create-task-publish-controls/research.md
@@ -1,5 +1,7 @@
 # Research: Create Task Publish Controls
 
+This research records the pre-implementation repository inspection and decisions that shaped the MM-412 task plan. Current completion evidence is recorded in `verification.md`.
+
 ## Input Classification
 
 Decision: Single-story runtime feature request.

--- a/specs/208-create-task-publish-controls/research.md
+++ b/specs/208-create-task-publish-controls/research.md
@@ -1,0 +1,57 @@
+# Research: Create Task Publish Controls
+
+## Input Classification
+
+Decision: Single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-412-moonspec-orchestration-input.md`, `specs/208-create-task-publish-controls/spec.md`.
+Rationale: The brief asks for one independently testable Create-page authoring change: represent merge automation as a PR-specific Publish Mode choice in the Steps card while preserving existing runtime contracts.
+Alternatives considered: Broad design classification was rejected because the brief identifies one primary UI/runtime behavior story and explicit file targets.
+Test implications: Unit and integration-style UI tests are required.
+
+## Existing Create Page Placement
+
+Decision: Repository, Branch, and Publish Mode placement is implemented but needs MM-412 regression coverage.
+Evidence: `frontend/src/entrypoints/task-create.tsx` renders GitHub Repo plus Branch and Publish Mode controls in the Steps card footer; existing tests assert Branch and Publish Mode belong to `data-canonical-create-section="Steps"`.
+Rationale: Placement work should be preserved, not rewritten.
+Alternatives considered: Moving controls again was rejected because current placement already matches the desired-state structure.
+Test implications: Update/extend placement test to include absence of standalone merge automation.
+
+## Merge Automation UI Shape
+
+Decision: Current standalone checkbox is partial and must be replaced by a combined Publish Mode option.
+Evidence: `frontend/src/entrypoints/task-create.tsx` renders a checkbox labeled `Enable merge automation` in Execution context when `mergeAutomationAvailable` is true; tests cover checkbox visibility and payload behavior.
+Rationale: MM-412 requires merge automation to be authored through Publish Mode, not as a separate control.
+Alternatives considered: Keeping the checkbox and adding explanatory copy was rejected because it violates the brief and source design alignment.
+Test implications: Add failing tests proving the checkbox is absent and the select includes a PR-specific merge automation option when eligible.
+
+## Publish Selection Mapping
+
+Decision: Add a UI-layer combined publish selection that maps to existing payload semantics.
+Evidence: Submission currently validates `publishMode` against `none`, `branch`, `pr` and conditionally emits `mergeAutomation.enabled=true` from checkbox state.
+Rationale: The backend contract must remain unchanged, so the combined UI value should not be submitted as a new publish mode.
+Alternatives considered: Adding a backend publish enum was rejected by MM-412.
+Test implications: Request-shape tests must cover None, Branch, PR, and PR with Merge Automation.
+
+## Resolver And Runtime Constraints
+
+Decision: Existing resolver constraints must be applied to the combined UI value.
+Evidence: `isResolverSkill(effectiveSkillId)` currently hides and clears the standalone checkbox, while Jira breakdown preset can force publish mode to `none`.
+Rationale: A stale combined value must not silently submit merge automation when skill or preset constraints disallow it.
+Alternatives considered: Relying only on submission-time omission was rejected because the UI must not leave invalid selections active silently.
+Test implications: Add coverage for direct resolver skill and template resolver cases.
+
+## Edit And Rerun Hydration
+
+Decision: Draft reconstruction needs a visible PR-with-merge state when stored task input has PR publishing and merge automation enabled.
+Evidence: Current hydration sets `publishMode` from reconstructed draft state but does not represent merge automation as a Publish Mode value.
+Rationale: MM-412 explicitly requires legacy edit/rerun states to map deterministically into the combined selection.
+Alternatives considered: Showing PR and separately hiding merge automation was rejected because it loses visible authored intent.
+Test implications: Add hydration tests for stored PR-with-merge, PR without merge, Branch, and None.
+
+## Documentation Alignment
+
+Decision: Update `docs/UI/CreatePage.md` to describe merge automation as a Publish Mode choice rather than a standalone Execution context checkbox.
+Evidence: Section 10 still lists `Enable merge automation` under Execution context, while sections 5 and 7.6 already place Publish Mode in Steps.
+Rationale: Canonical docs must describe desired-state behavior and not retain the old split UI.
+Alternatives considered: Leaving docs unchanged was rejected by MM-412 acceptance criteria.
+Test implications: Documentation is checked by final review, not executable tests.

--- a/specs/208-create-task-publish-controls/spec.md
+++ b/specs/208-create-task-publish-controls/spec.md
@@ -1,0 +1,169 @@
+# Feature Specification: Create Task Publish Controls
+
+**Feature Branch**: `208-create-task-publish-controls`
+**Created**: 2026-04-18
+**Status**: Draft
+**Input**:
+
+```text
+Use the Jira preset brief for MM-412 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira preset brief:
+
+# MM-412 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-412
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Create Task Publish Controls
+- Labels: none
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-412 from MM project
+Summary: Create Task Publish Controls
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-412 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-412: Create Task Publish Controls
+
+User Story
+As a task author, I can author publish intent from one compact control group in the Create Task Steps card, with merge automation presented as a PR-specific publish choice, so repository, branch, publish mode, and merge automation intent are grouped where task execution intent is defined.
+
+Summary
+Update the Create Task UI so publishing controls are authored together in the Steps card instead of being split across multiple sections.
+
+Specifically:
+- Move Publish Mode so it appears next to Branch within the Steps card footer/control bar.
+- Remove the separate Enable merge automation checkbox from Execution context.
+- Expose merge automation through the Publish Mode UI as a PR-specific option.
+- Keep this as a UI and authoring-layer change, not a worker contract rewrite.
+- Preserve the existing backend and runtime payload shape.
+
+Recommended Publish Mode options:
+- None
+- Branch
+- PR
+- PR with Merge Automation
+
+The combined merge automation option is a UI projection:
+- None -> publishMode=none
+- Branch -> publishMode=branch
+- PR -> publishMode=pr
+- PR with Merge Automation -> publishMode=pr plus mergeAutomation.enabled=true
+
+Scope includes moving Publish Mode into the Steps card next to Branch, removing the separate merge automation checkbox from Execution context, representing merge automation as a PR-specific Publish Mode option, preserving submission payload semantics, updating edit/rerun reconstruction, updating Create Page docs and tests, and preserving resolver-style publishing constraints.
+
+Out of scope: redesigning merge automation behavior or merge gating logic, changing worker-side merge automation orchestration semantics, introducing a brand-new public API contract for publish mode, or broader PR resolver redesign.
+
+Likely file targets include frontend/src/entrypoints/task-create.tsx, frontend/src/entrypoints/task-create.test.tsx, docs/UI/CreatePage.md, and supporting Create-page styling or draft reconstruction helpers if needed.
+
+Acceptance criteria include rendering Publish Mode in the Steps card next to Branch, removing the separate Enable merge automation checkbox, including a PR-specific merge automation option, preserving publishMode=pr plus mergeAutomation.enabled=true for the combined option, correctly hydrating edit/rerun drafts, preserving resolver-style guardrails, keeping responsive grouping, preserving accessibility names, updating tests, and keeping docs/UI/CreatePage.md aligned.
+```
+
+**Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.
+
+## User Story - Consolidate Publish Controls
+
+**Summary**: As a task author, I want repository, branch, publish mode, and merge automation intent authored together in the Steps card so that publishing choices are grouped with the execution plan they affect.
+
+**Goal**: Task authors can choose a publish mode, including a PR-specific merge automation choice, from the Steps card without a separate merge automation checkbox or duplicate execution-context publish controls, while existing runtime submission semantics remain unchanged.
+
+**Independent Test**: Open the Create page for create, edit, and rerun flows; select each publish option from the Steps card control group; verify the page exposes no separate merge automation checkbox, preserves resolver-style restrictions, hydrates legacy PR-with-merge drafts into the combined option, and submits the existing publish and merge automation payload semantics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a task author is creating an ordinary task, **when** the Steps card footer renders repository publishing controls, **then** GitHub Repo, Branch, and Publish Mode appear together in one compact control group.
+2. **Given** there is room in the Steps footer, **when** Branch and Publish Mode render, **then** Publish Mode appears immediately to the right of Branch; on narrow layouts it may wrap while remaining in the same control group.
+3. **Given** the task is an ordinary PR-publishing task, **when** the author opens Publish Mode, **then** a PR-specific merge automation choice is available alongside None, Branch, and PR.
+4. **Given** the author selects the PR-specific merge automation choice, **when** the task is submitted, **then** the runtime request preserves PR publishing and includes merge automation enabled without creating a new backend publish category.
+5. **Given** publish mode is None or Branch, **when** the task is submitted, **then** merge automation is not submitted.
+6. **Given** a direct pr-resolver or batch-pr-resolver task constrains publishing, **when** Publish Mode renders, **then** invalid PR or merge automation choices are not surfaced or cannot remain selected silently.
+7. **Given** edit or rerun reconstructs a legacy task with PR publishing and merge automation enabled, **when** the Create page hydrates the draft, **then** Publish Mode displays the combined PR-with-merge selection.
+8. **Given** edit or rerun reconstructs legacy publish states without merge automation, **when** the draft hydrates, **then** None, Branch, and PR states map deterministically to their visible Publish Mode choices.
+9. **Given** the Execution context section renders, **when** the author reviews runtime options, **then** it does not contain a separate Enable merge automation checkbox or duplicate Publish Mode control.
+10. **Given** compact publishing controls omit large visible labels above the dropdown chrome, **when** assistive technology inspects them, **then** Branch and Publish Mode still expose clear accessible names.
+
+### Edge Cases
+
+- The selected runtime or task skill can force publish mode to None.
+- A stored draft can contain PR publishing with merge automation enabled from a previous UI shape.
+- A stored draft can contain merge automation enabled while the current publish choice or skill constraints no longer allow it.
+- The Steps footer can be too narrow for all publishing controls to fit on one row.
+- Repository or branch values can be absent while the author is still drafting a text-only task.
+- Jira Orchestrate preset behavior remains separate from this Create-page publish option.
+
+## Assumptions
+
+- Runtime mode is selected; this story changes Create-page behavior and tests rather than only documentation.
+- The existing backend/runtime publish and merge automation contract is still the source of truth for task submission.
+- The visible label for the combined choice may be `PR with Merge Automation` or a shorter equivalent such as `PR + Merge Automation` if behavior and accessibility remain unambiguous.
+- The existing desired-state Create Page document is a runtime source requirement because the Jira brief points at it.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/UI/CreatePage.md`, section 5): Branch and publish authoring lives in the Steps card, is not duplicated in Execution context, and the Create page exposes no separate target branch field. Scope: in scope. Mapped to FR-001, FR-002, FR-008.
+- **DESIGN-REQ-002** (`docs/UI/CreatePage.md`, section 7.6): The Steps footer contains GitHub Repo, Branch, and Publish Mode; Branch and Publish Mode use compact inline controls with accessible names; Publish Mode appears immediately to the right of Branch when possible. Scope: in scope. Mapped to FR-001, FR-002, FR-003, FR-009.
+- **DESIGN-REQ-003** (`docs/UI/CreatePage.md`, section 7.6): Create-page authoring must not require a user-authored target branch and submit logic must preserve the canonical publishing contract for none, branch, and PR publishing. Scope: in scope as a contract preservation guardrail. Mapped to FR-004, FR-006.
+- **DESIGN-REQ-004** (`docs/UI/CreatePage.md`, section 10): Publish mode is authored in the Steps card, resolver-style skills may force publish mode to None, merge automation is available only for ordinary PR-publishing tasks, and merge automation must not be submitted for Branch, None, direct pr-resolver, or batch-pr-resolver tasks. Scope: in scope. Mapped to FR-004, FR-005, FR-007, FR-008.
+- **DESIGN-REQ-005** (`docs/UI/CreatePage.md`, section 10): Merge automation copy must explain that MoonMind waits for PR readiness and uses pr-resolver, must not imply direct auto-merge, and Jira Orchestrate behavior remains unchanged by this option. Scope: in scope. Mapped to FR-010, FR-011.
+- **DESIGN-REQ-006** (`docs/UI/CreatePage.md`, section 13): Edit and rerun reconstruct runtime, repository, branch, and publish settings from authoritative task input snapshots. Scope: in scope. Mapped to FR-012.
+- **DESIGN-REQ-007** (`docs/UI/CreatePage.md`, section 14): Create-page submission maps authored branch and publish intent into canonical task publishing fields before runtime launch. Scope: in scope. Mapped to FR-004, FR-006.
+- **DESIGN-REQ-008** (`docs/UI/CreatePage.md`, section 16): Repository, branch, and legacy publish migration failures must preserve unrelated draft state and fail explicitly rather than silently rewriting semantics. Scope: in scope. Mapped to FR-007, FR-012.
+- **DESIGN-REQ-009** (`docs/UI/CreatePage.md`, section 17): Compact Branch and Publish Mode controls must have accessible names even without visible labels above the dropdown chrome. Scope: in scope. Mapped to FR-009.
+- **DESIGN-REQ-010** (`docs/UI/CreatePage.md`, section 18): Create-page tests should cover a single Branch dropdown, no Target Branch control, branch mapping, Publish Mode adjacent to Branch, and edit/rerun normalization. Scope: in scope. Mapped to FR-013.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Create page MUST render repository, Branch, and Publish Mode authoring controls together in the Steps card footer/control group.
+- **FR-002**: The Create page MUST NOT render a duplicate Publish Mode control or a separate Enable merge automation checkbox in Execution context.
+- **FR-003**: Publish Mode MUST appear immediately to the right of Branch when layout space allows and MUST remain in the same responsive Steps-card control group when wrapping is needed.
+- **FR-004**: Publish Mode MUST include a PR-specific merge automation choice for ordinary PR-publishing tasks where merge automation is semantically allowed.
+- **FR-005**: Selecting the PR-specific merge automation choice MUST preserve PR publish behavior and submit merge automation as enabled without introducing a new backend publish category.
+- **FR-006**: None, Branch, and PR choices MUST continue to submit the existing publishing semantics without merge automation unless the PR-specific merge automation choice is selected.
+- **FR-007**: If runtime, skill, or task constraints disallow PR publishing or merge automation, the UI MUST hide, disable, or clear invalid choices visibly rather than leaving an invalid combined selection active.
+- **FR-008**: Direct pr-resolver and batch-pr-resolver task authoring MUST NOT surface merge automation as an available publish choice.
+- **FR-009**: Compact Branch and Publish Mode controls MUST expose clear accessible names even when visible labels above the dropdown chrome are omitted.
+- **FR-010**: Merge automation copy MUST explain that MoonMind waits for PR readiness and uses pr-resolver behavior rather than direct auto-merge.
+- **FR-011**: Jira Orchestrate preset behavior MUST remain unchanged by this Create-page publish control change.
+- **FR-012**: Create, edit, and rerun draft hydration MUST deterministically map stored publish and merge automation state into the visible Publish Mode selection, including PR-with-merge legacy states.
+- **FR-013**: Automated coverage MUST preserve MM-412 traceability and validate Steps-card placement, absence of the standalone checkbox, all publish-choice submission mappings, edit/rerun hydration, resolver-style restrictions, responsive grouping, and accessible names.
+
+### Key Entities
+
+- **Publish Mode Selection**: The visible authoring choice that represents None, Branch, PR, or PR with Merge Automation.
+- **Merge Automation Intent**: A PR-specific task authoring choice that enables MoonMind's existing PR readiness and resolver flow without changing publish category.
+- **Steps Card Publish Control Group**: The compact group in the Steps card footer that owns repository, Branch, and Publish Mode authoring.
+- **Stored Publish State**: Existing task input state reconstructed during create, edit, and rerun flows and normalized into a visible Publish Mode selection.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Automated Create-page tests find exactly one Publish Mode control and it is located in the Steps card control group for 100% of covered create/edit/rerun render paths.
+- **SC-002**: Automated tests confirm the separate Enable merge automation checkbox is absent in 100% of covered ordinary and constrained task render paths.
+- **SC-003**: Automated request-shape tests cover all four visible Publish Mode choices and confirm 100% of submissions preserve the expected publish and merge automation semantics.
+- **SC-004**: Automated hydration tests cover stored None, Branch, PR, and PR-with-merge states and map each to the correct visible Publish Mode selection.
+- **SC-005**: Automated constrained-task tests confirm direct pr-resolver and batch-pr-resolver tasks cannot submit merge automation.
+- **SC-006**: Accessibility tests confirm Branch and Publish Mode each expose an accessible name in the compact Steps-card control group.
+- **SC-007**: The desired-state Create Page documentation reflects the new control placement and semantics with no remaining statement that merge automation is a standalone Execution context checkbox.

--- a/specs/208-create-task-publish-controls/spec.md
+++ b/specs/208-create-task-publish-controls/spec.md
@@ -54,9 +54,37 @@ Update the Create Task UI so publishing controls are authored together in the St
 Specifically:
 - Move Publish Mode so it appears next to Branch within the Steps card footer/control bar.
 - Remove the separate Enable merge automation checkbox from Execution context.
-- Expose merge automation through the Publish Mode UI as a PR-specific option.
+- Expose merge automation through the Publish Mode UI as a PR-specific option, for example:
+  - None
+  - Branch
+  - PR
+  - PR with Merge Automation
 - Keep this as a UI and authoring-layer change, not a worker contract rewrite.
 - Preserve the existing backend and runtime payload shape.
+
+Current State
+The current frontend implementation is still split in a way that does not match desired-state authoring:
+- The Steps section still contains separate Starting Branch and Target Branch text inputs.
+- Publish Mode is rendered later in Execution context.
+- Merge automation is rendered as a separate checkbox.
+
+That creates several problems:
+- Publish-related choices are not grouped where the user is thinking about repo and branch intent.
+- Merge automation looks like a separate orthogonal feature when it only makes sense for PR publishing.
+- The Create page feels larger and more fragmented than necessary.
+- The implementation is drifting from the desired-state Create Page contract.
+
+Desired Outcome
+The Create page should author publish intent from one compact control group in the Steps card.
+
+Target UX:
+- GitHub Repo
+- Branch
+- Publish Mode
+
+Publish Mode should sit immediately to the right of Branch when there is room, and wrap responsively on narrower widths while staying within the same Steps-card control group.
+
+The merge automation checkbox should be removed and represented as a Publish Mode choice instead.
 
 Recommended Publish Mode options:
 - None
@@ -64,19 +92,150 @@ Recommended Publish Mode options:
 - PR
 - PR with Merge Automation
 
-The combined merge automation option is a UI projection:
-- None -> publishMode=none
-- Branch -> publishMode=branch
-- PR -> publishMode=pr
-- PR with Merge Automation -> publishMode=pr plus mergeAutomation.enabled=true
+Important Contract Decision
+Do not introduce a new backend publish-mode enum just to support this UI.
 
-Scope includes moving Publish Mode into the Steps card next to Branch, removing the separate merge automation checkbox from Execution context, representing merge automation as a PR-specific Publish Mode option, preserving submission payload semantics, updating edit/rerun reconstruction, updating Create Page docs and tests, and preserving resolver-style publishing constraints.
+Keep the existing runtime contract and treat the combined option as a UI projection:
+- None -> `publishMode=none`
+- Branch -> `publishMode=branch`
+- PR -> `publishMode=pr`
+- PR with Merge Automation -> `publishMode=pr` plus `mergeAutomation.enabled=true`
 
-Out of scope: redesigning merge automation behavior or merge gating logic, changing worker-side merge automation orchestration semantics, introducing a brand-new public API contract for publish mode, or broader PR resolver redesign.
+This keeps workflow and worker-side merge automation behavior stable while simplifying the Create page.
 
-Likely file targets include frontend/src/entrypoints/task-create.tsx, frontend/src/entrypoints/task-create.test.tsx, docs/UI/CreatePage.md, and supporting Create-page styling or draft reconstruction helpers if needed.
+Scope
 
-Acceptance criteria include rendering Publish Mode in the Steps card next to Branch, removing the separate Enable merge automation checkbox, including a PR-specific merge automation option, preserving publishMode=pr plus mergeAutomation.enabled=true for the combined option, correctly hydrating edit/rerun drafts, preserving resolver-style guardrails, keeping responsive grouping, preserving accessibility names, updating tests, and keeping docs/UI/CreatePage.md aligned.
+In scope:
+- Move Publish Mode into the Steps card next to Branch.
+- Remove the separate merge automation checkbox from Execution context.
+- Represent merge automation as a PR-specific Publish Mode option.
+- Preserve existing submission payload semantics.
+- Update edit/rerun reconstruction so legacy drafts still hydrate correctly.
+- Update Create Page docs and tests to match the new UI contract.
+- Ensure resolver-style skills still constrain publishing correctly.
+
+Out of scope:
+- Redesigning merge automation behavior or merge gating logic.
+- Changing worker-side merge automation orchestration semantics.
+- Introducing a brand-new public API contract for publish mode.
+- Broader PR resolver redesign.
+
+Proposed UI Behavior
+
+1. Steps card control group
+- The Steps footer/control bar should own publish authoring.
+- It should render compact inline controls for repository, branch, and publish mode.
+
+2. Publish Mode values
+- Suggested visible values:
+  - None
+  - Branch
+  - PR
+  - PR with Merge Automation
+- The exact label can be adjusted slightly for brevity, such as PR + Merge Automation, but the behavior must be unambiguous.
+
+3. Merge automation availability rules
+- PR with Merge Automation should only be available when merge automation is semantically allowed.
+- At minimum:
+  - Ordinary task authoring may use it.
+  - Direct pr-resolver / batch-pr-resolver tasks must not surface it.
+  - If current runtime or skill constraints force publish mode to none, the combined PR+merge option must not remain selected silently.
+
+4. Accessible labeling
+- The compact inline controls may omit large visible labels above the chrome, but they must still expose accessible names.
+
+5. Responsive behavior
+- On wide layouts, Branch and Publish Mode should appear side-by-side.
+- On narrow layouts, they may wrap, but must remain in the same Steps-card control group.
+
+Edit / Rerun / Migration Behavior
+This story must handle existing state safely.
+
+Existing create/edit states to normalize:
+- `publishMode=none` -> None
+- `publishMode=branch` -> Branch
+- `publishMode=pr` and no merge automation -> PR
+- `publishMode=pr` and `mergeAutomation.enabled=true` -> PR with Merge Automation
+
+This should apply consistently for:
+- Fresh create.
+- Edit.
+- Rerun.
+- Legacy snapshots reconstructed into the Create page.
+
+Technical Work Breakdown
+
+1. Update Create page state model
+- Refactor the Create page UI state so Publish Mode can represent the combined PR+merge choice without changing the worker payload contract.
+- Keep internal submission logic capable of emitting `publishMode` and `mergeAutomation.enabled`.
+- Add a UI-layer derived enum/value for the combined picker state.
+- Centralize mapping between UI selection and submission payload.
+- Centralize mapping between stored payload and hydrated UI selection.
+
+2. Move Publish Mode rendering into the Steps card
+- Update the Steps-card footer/control group so Publish Mode is rendered adjacent to Branch.
+- Relocate the control from Execution context.
+- Remove the old duplicate control placement.
+- Ensure layout, spacing, and wrapping are intentional.
+
+3. Remove separate merge automation checkbox
+- Delete the separate checkbox from Execution context and replace its behavior with the combined Publish Mode option.
+
+4. Preserve submission semantics
+- Submission logic must continue to emit the existing payload shape:
+  - `publishMode`
+  - `task.publish.mode`
+  - optional `mergeAutomation.enabled=true`
+- No worker-side API churn should be required for this story.
+
+5. Preserve gating behavior for resolver skills
+- Current safeguards that force or constrain publish mode for resolver-style skills must continue to work with the new UI representation.
+
+6. Update tests
+- Add or update Create page tests for inline Publish Mode rendering in the Steps card.
+- Confirm there is no standalone merge automation checkbox.
+- Cover correct payload mapping for all Publish Mode choices.
+- Cover correct edit/rerun hydration for existing task inputs.
+- Cover behavior when resolver skills or other constraints disallow PR publish choices.
+
+7. Update docs
+- Update desired-state docs so implementation and docs stay aligned.
+- At minimum, update `docs/UI/CreatePage.md`.
+- If needed, also update related UI/test contract docs that still describe the old placement.
+
+Likely File Targets
+
+Frontend / tests:
+- `frontend/src/entrypoints/task-create.tsx`
+- `frontend/src/entrypoints/task-create.test.tsx`
+
+Docs:
+- `docs/UI/CreatePage.md`
+
+Potential supporting areas if needed:
+- Create-page styling assets used by `task-create.tsx`.
+- Task editing draft reconstruction helpers if hydration logic needs a shared normalization path.
+
+Acceptance Criteria
+- Publish Mode is rendered in the Steps card next to Branch rather than in Execution context.
+- The separate Enable merge automation checkbox is removed.
+- The Publish Mode UI includes a PR-specific merge automation option.
+- Selecting the merge automation option still submits `publishMode=pr` plus `mergeAutomation.enabled=true` rather than introducing a new backend publish-mode contract.
+- Edit/rerun hydration maps existing PR + merge automation task inputs back to the combined Publish Mode selection correctly.
+- Resolver-style skills and similar guardrails still prevent invalid publish selections.
+- Responsive layout keeps Branch and Publish Mode grouped within the Steps card.
+- Accessibility names remain correct for the compact controls.
+- Tests cover both submission mapping and reconstruction behavior.
+- `docs/UI/CreatePage.md` reflects the new control placement and semantics.
+
+Implementation Notes
+- This story is intentionally about Create-page authoring UX alignment, not merge automation orchestration changes.
+- Merge automation is not a separate publish category at the backend contract layer, but it should be presented as a first-class PR publishing choice in the UI.
+- Keep workflow and worker-side merge automation behavior stable.
+- Preserve MM-412 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates no issue links for MM-412.
 ```
 
 **Implementation Intent**: Runtime implementation. Required deliverables include production behavior changes plus validation tests.

--- a/specs/208-create-task-publish-controls/tasks.md
+++ b/specs/208-create-task-publish-controls/tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Create Task Publish Controls
+
+**Input**: Design documents from `specs/208-create-task-publish-controls/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style Create page tests are REQUIRED. Write tests first, confirm they fail for the intended reason when implementation is absent, then implement production code until they pass.
+
+**Source Traceability**: MM-412, original Jira preset brief preserved in `spec.md`, FR-001 through FR-013, acceptance scenarios 1-10, SC-001 through SC-007, DESIGN-REQ-001 through DESIGN-REQ-010.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Phase 1: Setup
+
+- [X] T001 Confirm the canonical MM-412 Jira preset brief is preserved in `docs/tmp/jira-orchestration-inputs/MM-412-moonspec-orchestration-input.md` and `specs/208-create-task-publish-controls/spec.md` (MM-412, SC-007)
+- [X] T002 Confirm Moon Spec artifact set exists in `specs/208-create-task-publish-controls/` with spec, plan, research, data model, UI contract, quickstart, and tasks
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect current publish controls in `frontend/src/entrypoints/task-create.tsx` and existing tests in `frontend/src/entrypoints/task-create.test.tsx` before story work (FR-001 through FR-013, DESIGN-REQ-001 through DESIGN-REQ-010)
+
+## Phase 3: Story - Consolidate Publish Controls
+
+**Summary**: As a task author, I want repository, branch, publish mode, and merge automation intent authored together in the Steps card so publishing choices are grouped with the execution plan they affect.
+
+**Independent Test**: Open the Create page for create, edit, and rerun flows; select each publish option from the Steps card control group; verify there is no separate merge automation checkbox, resolver-style restrictions hold, legacy PR-with-merge drafts hydrate to the combined option, and submitted payloads preserve existing publish and merge automation semantics.
+
+**Traceability**: MM-412; FR-001 through FR-013; acceptance scenarios 1-10; SC-001 through SC-007; DESIGN-REQ-001 through DESIGN-REQ-010.
+
+### Unit Tests
+
+- [X] T004 Add failing UI test in `frontend/src/entrypoints/task-create.test.tsx` proving Execution context has no standalone `Enable merge automation` checkbox and Publish Mode remains in the Steps card (FR-001, FR-002, FR-003, SC-001, SC-002, DESIGN-REQ-001, DESIGN-REQ-002)
+- [X] T005 Add failing UI test in `frontend/src/entrypoints/task-create.test.tsx` proving ordinary PR-publishing tasks expose a visible PR-with-merge Publish Mode option with accessible copy (FR-004, FR-009, FR-010, SC-006, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-009)
+- [X] T006 Add failing UI tests in `frontend/src/entrypoints/task-create.test.tsx` proving resolver-style skill and preset constraints hide or clear the PR-with-merge Publish Mode option (FR-007, FR-008, SC-005, DESIGN-REQ-004, DESIGN-REQ-008)
+- [X] T007 Add failing hydration tests in `frontend/src/entrypoints/task-create.test.tsx` proving edit/rerun stored None, Branch, PR, and PR-with-merge states map to visible Publish Mode selections (FR-012, SC-004, DESIGN-REQ-006)
+
+### Integration Tests
+
+- [X] T008 Add failing request-shape tests in `frontend/src/entrypoints/task-create.test.tsx` proving None, Branch, PR, and PR with Merge Automation submit the exact existing publish and merge automation payload semantics (FR-005, FR-006, SC-003, DESIGN-REQ-003, DESIGN-REQ-007)
+- [X] T009 Add failing request-shape tests in `frontend/src/entrypoints/task-create.test.tsx` proving invalid or constrained combined selections omit merge automation and do not change Jira Orchestrate behavior (FR-007, FR-008, FR-011, SC-005, DESIGN-REQ-004, DESIGN-REQ-005)
+
+### Red-First Confirmation
+
+- [X] T010 Run focused tests with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and record that new MM-412 tests fail for the expected missing combined-option behavior before production edits
+
+### Implementation
+
+- [X] T011 Implement a UI-layer Publish Mode selection mapping in `frontend/src/entrypoints/task-create.tsx` so PR with Merge Automation is visible but submits existing PR publish plus merge automation semantics (FR-004, FR-005, FR-006, DESIGN-REQ-003, DESIGN-REQ-007)
+- [X] T012 Remove the standalone Execution context merge automation checkbox from `frontend/src/entrypoints/task-create.tsx` and keep explanatory merge automation copy attached to the combined Publish Mode behavior (FR-002, FR-010, DESIGN-REQ-005)
+- [X] T013 Apply resolver-style and preset publish constraints to the combined Publish Mode selection in `frontend/src/entrypoints/task-create.tsx`, including clearing invalid stale PR-with-merge selections visibly (FR-007, FR-008, DESIGN-REQ-004, DESIGN-REQ-008)
+- [X] T014 Update edit/rerun hydration in `frontend/src/entrypoints/task-create.tsx` so stored PR publishing plus merge automation reconstructs to PR with Merge Automation when allowed (FR-012, DESIGN-REQ-006)
+- [X] T015 Preserve compact Steps-card Branch and Publish Mode accessibility and responsive grouping in `frontend/src/entrypoints/task-create.tsx` (FR-001, FR-003, FR-009, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-009)
+
+### Story Validation
+
+- [X] T016 Run focused validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` and fix failures until MM-412 story coverage passes
+
+## Phase 4: Polish And Verification
+
+- [X] T017 Update `docs/UI/CreatePage.md` so merge automation is described as a PR-specific Publish Mode choice rather than a standalone Execution context checkbox (FR-013, SC-007, DESIGN-REQ-010)
+- [X] T018 Run final unit validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- [X] T019 Run final `/speckit.verify` work and record verification in `specs/208-create-task-publish-controls/verification.md`
+
+## Dependencies & Execution Order
+
+- T001-T003 must complete before story tests.
+- T004-T009 must be written before T011-T015 production implementation.
+- T010 records red-first evidence before production edits.
+- T011-T015 implement the UI behavior.
+- T016 validates the story before documentation polish and final verification.
+- T017 updates canonical desired-state docs after behavior is implemented.
+- T018 and T019 are final verification gates.
+
+## Parallel Examples
+
+- T004 and T005 can be drafted together only if edits remain in separate test blocks and are reconciled before T010.
+- T017 can be prepared after implementation behavior is clear, but it should not replace the required production tests.
+
+## Notes
+
+- This task list covers one story only.
+- MM-412 and the original Jira preset brief are preserved as canonical source input.
+- The implementation must not introduce a new backend publish-mode enum or worker contract.

--- a/specs/208-create-task-publish-controls/tasks.md
+++ b/specs/208-create-task-publish-controls/tasks.md
@@ -11,7 +11,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
 - Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Phase 1: Setup
 
@@ -62,7 +62,7 @@
 
 - [X] T017 Update `docs/UI/CreatePage.md` so merge automation is described as a PR-specific Publish Mode choice rather than a standalone Execution context checkbox (FR-013, SC-007, DESIGN-REQ-010)
 - [X] T018 Run final unit validation `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
-- [X] T019 Run final `/speckit.verify` work and record verification in `specs/208-create-task-publish-controls/verification.md`
+- [X] T019 Run final `/moonspec-verify` work and record verification in `specs/208-create-task-publish-controls/verification.md`
 
 ## Dependencies & Execution Order
 

--- a/specs/208-create-task-publish-controls/verification.md
+++ b/specs/208-create-task-publish-controls/verification.md
@@ -1,0 +1,75 @@
+# MoonSpec Verification Report
+
+**Feature**: Create Task Publish Controls  
+**Spec**: `specs/208-create-task-publish-controls/spec.md`  
+**Original Request Source**: `spec.md` `Input` preserving MM-412  
+**Verdict**: FULLY_IMPLEMENTED  
+**Confidence**: HIGH
+
+## Test Results
+
+| Suite | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Red-first focused UI | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` | FAIL first, expected | New MM-412 tests failed before production edits on missing `mergeAutomationEnabled` draft state, missing combined Publish Mode option, old checkbox, and old request mapping. |
+| Focused UI | `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` | PASS | 173 tests passed after implementation. |
+| Unit | `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` | PASS | Python unit suite passed: 3604 passed, 1 xpassed, 16 subtests passed. Frontend Vitest suite passed: 10 files, 299 tests. |
+
+## Requirement Coverage
+
+| Requirement | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| FR-001 | `frontend/src/entrypoints/task-create.tsx` Steps footer controls; `frontend/src/entrypoints/task-create.test.tsx` shared Steps card test | VERIFIED | Repo, Branch, and Publish Mode remain together in the Steps card. |
+| FR-002 | `frontend/src/entrypoints/task-create.tsx` Execution context no longer renders merge checkbox; test asserts checkbox absence | VERIFIED | Standalone `Enable merge automation` is removed. |
+| FR-003 | `frontend/src/entrypoints/task-create.tsx` Branch and Publish Mode remain in `.queue-inline-selector-row`; shared Steps card test checks order | VERIFIED | Responsive grouping is preserved. |
+| FR-004 | `frontend/src/entrypoints/task-create.tsx` adds `PR with Merge Automation` option when eligible; UI test checks option | VERIFIED | Combined option exists for ordinary eligible tasks. |
+| FR-005 | `frontend/src/entrypoints/task-create.tsx` normalizes combined value to `pr` and submits `mergeAutomation.enabled=true`; request-shape test verifies | VERIFIED | No backend publish category added. |
+| FR-006 | Request-shape tests for Branch and PR-without-merge paths | VERIFIED | Non-merge choices omit merge automation. |
+| FR-007 | `frontend/src/entrypoints/task-create.tsx` clears invalid combined selections; resolver tests verify | VERIFIED | Direct resolver tasks become `none`; template resolver clears merge component to PR. |
+| FR-008 | Resolver skill and template tests | VERIFIED | Resolver-style authoring cannot submit merge automation. |
+| FR-009 | Branch and Publish Mode keep `aria-label` values; tests query by accessible label | VERIFIED | Compact controls remain accessible. |
+| FR-010 | `frontend/src/entrypoints/task-create.tsx` explanatory copy near Publish Mode; tests check pr-resolver copy and no direct auto-merge copy | VERIFIED | Copy preserves resolver semantics. |
+| FR-011 | No Jira Orchestrate code path changed; constrained request-shape tests still pass | VERIFIED | Jira Orchestrate behavior remains separate. |
+| FR-012 | `frontend/src/lib/temporalTaskEditing.ts` reconstructs `mergeAutomationEnabled`; test verifies PR+merge draft state | VERIFIED | Edit/rerun draft state can hydrate combined selection. |
+| FR-013 | Tests, docs, and MM-412 artifacts updated | VERIFIED | MM-412 traceability preserved. |
+
+## Acceptance Scenario Coverage
+
+| Scenario | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| 1-2 | Shared Steps card test and UI implementation | VERIFIED | Controls are grouped and ordered in Steps. |
+| 3-5 | Publish option and request-shape tests | VERIFIED | PR with Merge Automation is available when eligible and maps to existing payload semantics. |
+| 6 | Resolver skill and template tests | VERIFIED | Invalid combined selections are cleared and not submitted. |
+| 7-8 | Draft reconstruction test and TaskCreatePage hydration mapping | VERIFIED | PR+merge stored state is captured and mapped to combined selection. |
+| 9 | Checkbox absence tests and docs update | VERIFIED | Execution context no longer owns merge automation UI. |
+| 10 | Accessible label queries and compact control preservation | VERIFIED | Branch and Publish Mode are accessible by name. |
+
+## Constitution And Source Design Coverage
+
+| Item | Evidence | Status | Notes |
+| --- | --- | --- | --- |
+| DESIGN-REQ-001 - DESIGN-REQ-003 | `task-create.tsx`, request-shape tests | VERIFIED | Steps-card publishing and existing publish contract preserved. |
+| DESIGN-REQ-004 - DESIGN-REQ-005 | Combined option gating, copy, resolver tests | VERIFIED | Merge automation is PR-specific and resolver-mediated. |
+| DESIGN-REQ-006 - DESIGN-REQ-008 | `temporalTaskEditing.ts`, hydration and resolver tests | VERIFIED | Stored state and invalid selection handling are covered. |
+| DESIGN-REQ-009 - DESIGN-REQ-010 | Accessible label tests and `docs/UI/CreatePage.md` | VERIFIED | Compact accessibility and docs alignment are covered. |
+| Constitution XI | Moon Spec artifacts and TDD evidence | VERIFIED | Spec, plan, tasks, tests, implementation, and verification are present. |
+| Constitution XII | `docs/UI/CreatePage.md` remains desired-state; implementation notes stay in `specs/` and `docs/tmp/` | VERIFIED | Canonical/tmp separation preserved. |
+| Constitution XIII | No backend enum compatibility layer introduced | VERIFIED | UI-only value normalizes before submission. |
+
+## Original Request Alignment
+
+- PASS: MM-412 is preserved in the orchestration input, spec, tasks, and verification artifact.
+- PASS: Runtime mode was used; behavior and tests were implemented.
+- PASS: Publish Mode is authored in the Steps card, includes a PR-specific merge automation option, and no standalone Execution context checkbox remains.
+- PASS: Existing backend/runtime payload shape is preserved.
+
+## Gaps
+
+- None.
+
+## Remaining Work
+
+- None.
+
+## Decision
+
+- FULLY_IMPLEMENTED. The implementation satisfies MM-412 with production behavior, focused UI/request-shape coverage, final repository unit validation, and updated canonical documentation.


### PR DESCRIPTION
## Summary

Implements MM-412 Create Task Publish Controls.

- Moves publish authoring into the Create Task Steps card control group.
- Represents merge automation as a PR-specific Publish Mode choice.
- Preserves the existing backend/runtime publish contract by submitting `publishMode=pr` plus `mergeAutomation.enabled=true` for the combined option.
- Updates edit/rerun hydration, Create page tests, docs, and MoonSpec artifacts.

## Jira

- Jira issue key: MM-412

## MoonSpec

- Active feature path: `specs/208-create-task-publish-controls`
- Verification verdict: FULLY_IMPLEMENTED

## Tests Run

- Red-first focused UI: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-create.test.tsx` failed before production edits for the expected missing behavior.
- Focused UI: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-create.test.tsx` passed, 173 tests.
- Unit suite: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` passed, including Python 3604 passed, 1 xpassed, 16 subtests passed, and frontend Vitest 10 files / 299 tests passed.
- Final read-only verification: existing MoonSpec verification report confirmed current code and artifacts as FULLY_IMPLEMENTED.

## Remaining Risks

- None identified.
