### PR TITLE
[codex] Fix PR branch publish defaults

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4831,9 +4831,12 @@ class TemporalAgentRuntimeActivities:
         raw_ref = stdout.decode("utf-8", errors="replace").strip()
         if raw_ref.startswith("origin/"):
             branch = raw_ref.removeprefix("origin/").strip()
-            if branch:
+            if branch and branch != "HEAD":
                 return branch
-        return raw_ref or "main"
+            return "main"
+        if raw_ref and raw_ref != "HEAD":
+            return raw_ref
+        return "main"
 
     async def _count_branch_commits_ahead(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4685,7 +4685,15 @@ class TemporalAgentRuntimeActivities:
                 and bool(target_branch_name)
                 and current_branch == target_branch_name
             )
-            base_ref = f"origin/{target_branch_name or 'main'}"
+            base_branch_name = (
+                target_branch_name
+                or await self._resolve_workspace_default_branch(
+                    workspace=workspace,
+                    run_id=run_id,
+                    env=command_env,
+                )
+            )
+            base_ref = f"origin/{base_branch_name}"
             commit_count: int | None = None
             if same_branch_publish:
                 commit_count = await self._count_branch_commits_ahead(
@@ -4708,7 +4716,10 @@ class TemporalAgentRuntimeActivities:
                 push_proc.communicate(), timeout=120,
             )
             if push_proc.returncode != 0:
-                error_detail = push_stderr.decode("utf-8", errors="replace").strip() or "(no stderr)"
+                error_detail = (
+                    push_stderr.decode("utf-8", errors="replace").strip()
+                    or "(no stderr)"
+                )
                 logger.error(
                     "Post-agent git push FAILED for run %s "
                     "(branch=%s, rc=%d): %s",
@@ -4747,6 +4758,7 @@ class TemporalAgentRuntimeActivities:
                 return {
                     "push_status": "no_commits",
                     "push_branch": current_branch,
+                    "push_base_branch": base_branch_name,
                     "push_base_ref": base_ref,
                     "push_commit_count": 0,
                 }
@@ -4759,6 +4771,7 @@ class TemporalAgentRuntimeActivities:
             result: dict[str, Any] = {
                 "push_status": "pushed",
                 "push_branch": current_branch,
+                "push_base_branch": base_branch_name,
                 "push_base_ref": base_ref,
             }
             result.update(commit_info)
@@ -4775,6 +4788,52 @@ class TemporalAgentRuntimeActivities:
                 "push_status": "failed",
                 "push_error": str(exc),
             }
+
+    async def _resolve_workspace_default_branch(
+        self,
+        *,
+        workspace: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> str:
+        """Resolve the remote default branch for branchless PR publishing."""
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(
+                    workspace,
+                    "symbolic-ref",
+                    "--quiet",
+                    "--short",
+                    "refs/remotes/origin/HEAD",
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except Exception:
+            logger.debug(
+                "Could not resolve remote default branch for run %s; using main",
+                run_id,
+                exc_info=True,
+            )
+            return "main"
+
+        if proc.returncode != 0:
+            logger.debug(
+                "Could not resolve remote default branch for run %s: %s",
+                run_id,
+                stderr.decode("utf-8", errors="replace").strip(),
+            )
+            return "main"
+
+        raw_ref = stdout.decode("utf-8", errors="replace").strip()
+        if raw_ref.startswith("origin/"):
+            branch = raw_ref.removeprefix("origin/").strip()
+            if branch:
+                return branch
+        return raw_ref or "main"
 
     async def _count_branch_commits_ahead(
         self,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -565,7 +565,12 @@ def _build_runtime_planner():
             and isinstance(publish_mode, str)
             and publish_mode.strip().lower() == "pr"
         ):
-            if not node_inputs.get("targetBranch") and not node_inputs.get("branch"):
+            # In the single authored branch model, ``branch`` is the PR base,
+            # not the work/head branch. Always resolve a distinct head branch
+            # for PR publishing when one was not explicitly provided.
+            if node_inputs.get("branch") and not node_inputs.get("startingBranch"):
+                node_inputs["startingBranch"] = node_inputs["branch"]
+            if not node_inputs.get("targetBranch"):
                 prefix = _derive_pr_branch_prefix(
                     task_payload=task_payload,
                     publish_payload=publish_payload,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -172,6 +172,8 @@ RUN_CONDITIONAL_REGISTRY_READ_PATCH = "run-conditional-registry-read-v1"
 RUN_PROVIDER_PROFILE_MANAGER_ID_PATCH = "provider-profile-manager-id-v1"
 DEPENDENCY_GATE_PATCH = "dependency-gate-v1"
 NATIVE_PR_CREATE_PAYLOAD_PATCH = "native-pr-create-payload-v1"
+NATIVE_PR_BRANCH_DEFAULTS_PATCH = "native-pr-branch-defaults-v1"
+NATIVE_PR_PUSH_STATUS_GATE_PATCH = "native-pr-push-status-gate-v1"
 RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 RUN_FETCH_PROFILE_SNAPSHOTS_PATCH = "fetch-profile-snapshots-v1"
 RUN_SLOT_CONTINUITY_PATCH = "run-slot-continuity-v1"
@@ -2265,43 +2267,17 @@ class MoonMindRunWorkflow:
                 last_node_inputs = (
                     ordered_nodes[-1].get("inputs", {}) if ordered_nodes else {}
                 )
-                head_branch = (
-                    agent_outputs.get("push_branch")
-                    or agent_outputs.get("branch")
-                    or agent_outputs.get("targetBranch")
-                    or ws.get("targetBranch")
-                    or parameters.get("targetBranch")
-                    or last_node_inputs.get("targetBranch")
-                    or ""
-                )
                 publish_payload = self._resolve_publish_payload(parameters)
-                base_branch = self._resolve_publish_base_branch(publish_payload) or (
-                    agent_outputs.get("push_base_branch")
-                    or agent_outputs.get("baseBranch")
-                    or agent_outputs.get("base_branch")
-                    or ws.get("startingBranch")
-                    or ws.get("branch")
-                    or last_node_inputs.get("startingBranch")
-                    or last_node_inputs.get("branch")
-                    or "main"
+                head_branch, base_branch = self._resolve_native_pr_branches(
+                    parameters=parameters,
+                    agent_outputs=agent_outputs,
+                    workspace_spec=ws,
+                    last_node_inputs=last_node_inputs,
+                    publish_payload=publish_payload,
                 )
                 pr_title = self._title or "Automated changes by MoonMind"
                 pr_body = self._summary or "Automated changes by MoonMind."
                 if workflow.patched(NATIVE_PR_CREATE_PAYLOAD_PATCH):
-                    publish_payload = self._resolve_publish_payload(parameters)
-                    base_branch = (
-                        self._resolve_publish_base_branch(publish_payload)
-                        or (
-                            agent_outputs.get("push_base_branch")
-                            or agent_outputs.get("baseBranch")
-                            or agent_outputs.get("base_branch")
-                            or ws.get("startingBranch")
-                            or ws.get("branch")
-                            or last_node_inputs.get("startingBranch")
-                            or last_node_inputs.get("branch")
-                            or "main"
-                        )
-                    )
                     task_payload = self._mapping_value(parameters, "task")
                     pr_title = self._resolve_native_pr_title(
                         publish_payload=publish_payload,
@@ -2319,7 +2295,7 @@ class MoonMindRunWorkflow:
                         "on branch '%s'.",
                         agent_outputs.get("push_branch") or head_branch,
                     )
-                elif push_status in {"failed", "protected_branch", "skipped"}:
+                elif self._native_pr_push_status_blocks_creation(push_status):
                     self._get_logger().info(
                         "Skipping native PR creation: publish push already "
                         "failed with status '%s'.",
@@ -2772,6 +2748,83 @@ class MoonMindRunWorkflow:
             raw_base = publish_payload.get("baseBranch")
         return self._coerce_text(raw_base)
 
+    def _resolve_native_pr_branches(
+        self,
+        *,
+        parameters: Mapping[str, Any],
+        agent_outputs: Mapping[str, Any],
+        workspace_spec: Mapping[str, Any],
+        last_node_inputs: Mapping[str, Any],
+        publish_payload: Mapping[str, Any],
+    ) -> tuple[str, str]:
+        if workflow.patched(NATIVE_PR_BRANCH_DEFAULTS_PATCH):
+            head_candidates = (
+                agent_outputs.get("push_branch"),
+                agent_outputs.get("branch"),
+                agent_outputs.get("targetBranch"),
+                workspace_spec.get("targetBranch"),
+                parameters.get("targetBranch"),
+                last_node_inputs.get("targetBranch"),
+            )
+            base_candidates = (
+                self._resolve_publish_base_branch(publish_payload),
+                agent_outputs.get("push_base_branch"),
+                agent_outputs.get("baseBranch"),
+                agent_outputs.get("base_branch"),
+                workspace_spec.get("startingBranch"),
+                last_node_inputs.get("startingBranch"),
+                "main",
+            )
+        else:
+            head_candidates = (
+                agent_outputs.get("push_branch"),
+                agent_outputs.get("branch"),
+                agent_outputs.get("targetBranch"),
+                workspace_spec.get("targetBranch"),
+                parameters.get("targetBranch"),
+                last_node_inputs.get("targetBranch"),
+                workspace_spec.get("branch"),
+                last_node_inputs.get("branch"),
+            )
+            base_candidates = (
+                agent_outputs.get("baseBranch"),
+                agent_outputs.get("base_branch"),
+                workspace_spec.get("startingBranch"),
+                workspace_spec.get("branch"),
+                last_node_inputs.get("startingBranch"),
+                last_node_inputs.get("branch"),
+                "main",
+            )
+        head_branch = next(
+            (
+                candidate
+                for candidate in (
+                    self._coerce_text(value) for value in head_candidates
+                )
+                if candidate
+            ),
+            "",
+        )
+        base_branch = next(
+            (
+                candidate
+                for candidate in (
+                    self._coerce_text(value) for value in base_candidates
+                )
+                if candidate
+            ),
+            "main",
+        )
+        return head_branch, base_branch
+
+    def _native_pr_push_status_blocks_creation(self, push_status: Any) -> bool:
+        status = self._coerce_text(push_status)
+        if status in {"failed", "skipped"}:
+            return True
+        if status == "protected_branch":
+            return workflow.patched(NATIVE_PR_PUSH_STATUS_GATE_PATCH)
+        return False
+
     def _extract_pull_request_url(self, result: Any) -> str | None:
         outputs = self._get_from_result(result, "outputs")
         if not isinstance(outputs, Mapping):
@@ -2837,6 +2890,8 @@ class MoonMindRunWorkflow:
             return
 
         if push_status == "protected_branch":
+            if not workflow.patched(NATIVE_PR_PUSH_STATUS_GATE_PATCH):
+                return
             push_branch = self._coerce_text(outputs.get("push_branch"), max_chars=120)
             self._publish_status = "failed"
             if push_branch:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2270,16 +2270,19 @@ class MoonMindRunWorkflow:
                     or agent_outputs.get("branch")
                     or agent_outputs.get("targetBranch")
                     or ws.get("targetBranch")
-                    or ws.get("branch")
                     or parameters.get("targetBranch")
                     or last_node_inputs.get("targetBranch")
-                    or last_node_inputs.get("branch")
                     or ""
                 )
                 publish_payload = self._resolve_publish_payload(parameters)
                 base_branch = self._resolve_publish_base_branch(publish_payload) or (
-                    ws.get("startingBranch")
+                    agent_outputs.get("push_base_branch")
+                    or agent_outputs.get("baseBranch")
+                    or agent_outputs.get("base_branch")
+                    or ws.get("startingBranch")
+                    or ws.get("branch")
                     or last_node_inputs.get("startingBranch")
+                    or last_node_inputs.get("branch")
                     or "main"
                 )
                 pr_title = self._title or "Automated changes by MoonMind"
@@ -2289,8 +2292,13 @@ class MoonMindRunWorkflow:
                     base_branch = (
                         self._resolve_publish_base_branch(publish_payload)
                         or (
-                            ws.get("startingBranch")
+                            agent_outputs.get("push_base_branch")
+                            or agent_outputs.get("baseBranch")
+                            or agent_outputs.get("base_branch")
+                            or ws.get("startingBranch")
+                            or ws.get("branch")
                             or last_node_inputs.get("startingBranch")
+                            or last_node_inputs.get("branch")
                             or "main"
                         )
                     )
@@ -2310,6 +2318,12 @@ class MoonMindRunWorkflow:
                         "Skipping native PR creation: agent made no commits "
                         "on branch '%s'.",
                         agent_outputs.get("push_branch") or head_branch,
+                    )
+                elif push_status in {"failed", "protected_branch", "skipped"}:
+                    self._get_logger().info(
+                        "Skipping native PR creation: publish push already "
+                        "failed with status '%s'.",
+                        push_status,
                     )
                 elif not self._repo or not head_branch:
                     raise ValueError(

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -347,7 +347,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # push
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/trunk\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -359,6 +362,8 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "feature/delete-spec-048"
+        assert result["push_base_branch"] == "trunk"
+        assert result["push_base_ref"] == "origin/trunk"
         assert "push_error" not in result
 
     @pytest.mark.asyncio
@@ -380,7 +385,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # push
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count
@@ -392,7 +400,7 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
 
         assert result["push_status"] == "pushed"
-        assert len(recorded_calls) == 4
+        assert len(recorded_calls) == 5
         for call in recorded_calls:
             command = list(call)
             assert command[:5] == [
@@ -820,7 +828,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # push
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count — simulate failure
@@ -850,7 +861,10 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # push
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
             else:  # rev-list --count — non-zero exit with empty stdout

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -367,6 +367,30 @@ class TestPushWorkspaceBranch:
         assert "push_error" not in result
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw_ref", [b"origin/\n", b"origin/HEAD\n", b"HEAD\n"])
+    async def test_resolve_workspace_default_branch_rejects_non_branch_refs(
+        self,
+        raw_ref: bytes,
+    ):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+
+        async def _mock_exec(*args, **kwargs):
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(raw_ref, b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_mock_exec):
+            result = await activities._resolve_workspace_default_branch(
+                workspace="/work/agent_jobs/run-1/repo",
+                run_id="run-1",
+                env={},
+            )
+
+        assert result == "main"
+
+    @pytest.mark.asyncio
     async def test_push_marks_workspace_safe_for_git_commands(self):
         store = _make_mock_store()
         activities = TemporalAgentRuntimeActivities(run_store=store)

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1778,6 +1778,131 @@ async def test_run_execution_stage_non_jules_agent_with_session_id_creates_nativ
         "even when child result metadata contains jules_session_id"
     )
 
+
+@pytest.mark.asyncio
+async def test_run_execution_stage_skips_native_pr_after_push_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    wf = MoonMindRunWorkflow()
+    wf._owner_id = "owner-1"
+    wf._repo = "MoonLadderStudios/MoonMind"
+    create_pr_called = False
+
+    async def fake_execute_activity(
+        activity_type: str,
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> object:
+        nonlocal create_pr_called
+        if activity_type == "repo.create_pr":
+            create_pr_called = True
+            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999"}
+
+        if activity_type == "artifact.read":
+            artifact_ref = (
+                payload.get("artifact_ref")
+                if isinstance(payload, dict)
+                else getattr(payload, "artifact_ref", None)
+            )
+            if artifact_ref == "artifact://registry/1":
+                return json.dumps(
+                    {
+                        "skills": [
+                            {
+                                "name": "auto",
+                                "version": "1.0",
+                                "description": "Auto",
+                                "inputs": {"schema": {"type": "object"}},
+                                "outputs": {"schema": {"type": "object"}},
+                                "executor": {
+                                    "activity_type": "mm.tool.execute",
+                                    "selector": {"mode": "by_capability"},
+                                },
+                                "requirements": {"capabilities": ["sandbox"]},
+                                "policies": {
+                                    "timeouts": {
+                                        "start_to_close_seconds": 1800,
+                                        "schedule_to_close_seconds": 3600,
+                                    },
+                                    "retries": {"max_attempts": 1},
+                                },
+                            }
+                        ]
+                    }
+                ).encode("utf-8")
+            return json.dumps(
+                {
+                    "plan_version": "1.0",
+                    "metadata": {
+                        "title": "Test Plan",
+                        "created_at": "2026-03-12T00:00:00Z",
+                        "registry_snapshot": {
+                            "digest": "reg:sha256:" + ("a" * 64),
+                            "artifact_ref": "artifact://registry/1",
+                        },
+                    },
+                    "policy": {"failure_mode": "FAIL_FAST", "max_concurrency": 1},
+                    "nodes": [
+                        {
+                            "id": "node-1",
+                            "tool": {
+                                "type": "agent_runtime",
+                                "name": "auto",
+                                "version": "1.0",
+                            },
+                            "inputs": {
+                                "runtime": {"mode": "claude"},
+                                "instructions": "Do work",
+                            },
+                            "options": {},
+                        }
+                    ],
+                    "edges": [],
+                }
+            ).encode("utf-8")
+        return {"status": "COMPLETED", "outputs": {}}
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        args: object,
+        **_kwargs: object,
+    ) -> object:
+        return {
+            "summary": "Completed with status completed",
+            "metadata": {
+                "push_status": "protected_branch",
+                "push_branch": "main",
+            },
+            "output_refs": [],
+        }
+
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(run_workflow_module.workflow, "execute_child_workflow", fake_execute_child_workflow)
+    monkeypatch.setattr(run_workflow_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        run_workflow_module.workflow,
+        "upsert_search_attributes",
+        lambda _attributes: None,
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1"},
+    )
+    monkeypatch.setattr(run_workflow_module.workflow, "info", workflow_info)
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda patch_id: True)
+
+    await wf._run_execution_stage(
+        parameters={"repo": "MoonLadderStudios/MoonMind", "publishMode": "pr"},
+        plan_ref="art_plan_1",
+    )
+
+    assert not create_pr_called
+    assert wf._publish_status == "failed"
+    assert wf._publish_reason == "publish failed: working branch 'main' is protected"
+
+
 @pytest.mark.asyncio
 async def test_run_proposals_stage_global_disable_halts_execution(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1001,6 +1001,32 @@ def test_runtime_planner_publish_pr_uses_task_title_for_target_branch_prefix():
     assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", target)
 
 
+def test_runtime_planner_publish_pr_treats_authored_branch_as_base():
+    planner = _build_runtime_planner()
+    snapshot = _make_snapshot()
+
+    plan = planner(
+        inputs={
+            "task": {
+                "instructions": "Do work",
+                "title": "Fix create branch publish",
+                "git": {"branch": "main"},
+                "runtime": {"mode": "codex_cli"},
+                "publish": {"mode": "pr"},
+            }
+        },
+        parameters={},
+        snapshot=snapshot,
+    )
+
+    node_inputs = plan["nodes"][-1]["inputs"]
+    assert node_inputs["branch"] == "main"
+    assert node_inputs["startingBranch"] == "main"
+    assert node_inputs["targetBranch"] != "main"
+    assert node_inputs["targetBranch"].startswith("fix-create-branch-publish-")
+    assert re.fullmatch(r"[a-z0-9-]+-[0-9a-f]{8}", node_inputs["targetBranch"])
+
+
 def test_runtime_planner_publish_pr_uses_step_title_for_target_branch_prefix():
     planner = _build_runtime_planner()
     snapshot = _make_snapshot()

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -9,6 +9,8 @@ pytest.importorskip("temporalio")
 from moonmind.workflows.temporal.workflows import run as run_workflow_module
 from moonmind.workflows.temporal.workflows.run import (
     INTEGRATION_POLL_LOOP_PATCH,
+    NATIVE_PR_BRANCH_DEFAULTS_PATCH,
+    NATIVE_PR_PUSH_STATUS_GATE_PATCH,
     MoonMindRunWorkflow,
 )
 from moonmind.workloads.tool_bridge import build_dood_tool_definition_payload
@@ -863,6 +865,93 @@ def test_determine_publish_completion_fails_for_no_commit_pr_publish(
     assert "0 commits ahead" not in message
     assert "Files edited in this run: none." in message
     assert publish_failure is True
+
+
+def test_native_pr_branch_resolution_keeps_legacy_branch_only_replay_shape(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={"push_base_branch": "trunk"},
+        workspace_spec={"branch": "feature/existing"},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "release"},
+    )
+
+    assert head_branch == "feature/existing"
+    assert base_branch == "feature/existing"
+
+
+def test_native_pr_branch_resolution_uses_patched_publish_defaults(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_BRANCH_DEFAULTS_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    head_branch, base_branch = mock_run_workflow._resolve_native_pr_branches(
+        parameters={},
+        agent_outputs={"push_base_branch": "trunk"},
+        workspace_spec={"branch": "feature/existing"},
+        last_node_inputs={},
+        publish_payload={"prBaseBranch": "release"},
+    )
+
+    assert head_branch == ""
+    assert base_branch == "release"
+
+
+def test_native_pr_push_status_gate_preserves_legacy_protected_branch_fallback(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", lambda _patch_id: False)
+
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={
+            "outputs": {
+                "push_status": "protected_branch",
+                "push_branch": "feature/existing",
+            }
+        },
+    )
+
+    assert mock_run_workflow._native_pr_push_status_blocks_creation(
+        "protected_branch"
+    ) is False
+    assert mock_run_workflow._publish_status is None
+
+
+def test_native_pr_push_status_gate_blocks_protected_branch_when_patched(
+    mock_run_workflow: MoonMindRunWorkflow,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_patched(patch_id: str) -> bool:
+        return patch_id == NATIVE_PR_PUSH_STATUS_GATE_PATCH
+
+    monkeypatch.setattr(run_workflow_module.workflow, "patched", fake_patched)
+
+    mock_run_workflow._record_publish_result(
+        parameters={"publishMode": "pr"},
+        execution_result={
+            "outputs": {
+                "push_status": "protected_branch",
+                "push_branch": "feature/existing",
+            }
+        },
+    )
+
+    assert mock_run_workflow._native_pr_push_status_blocks_creation(
+        "protected_branch"
+    ) is True
+    assert mock_run_workflow._publish_status == "failed"
+    assert "feature/existing" in (mock_run_workflow._publish_reason or "")
 
 
 def test_record_execution_context_resets_last_step_fields_when_current_node_has_no_summary(


### PR DESCRIPTION
## Summary
- Treat the single authored branch as the PR base and always generate a distinct PR head branch when publishing in PR mode.
- Stop native PR creation from using the authored base branch as the head branch after publish failures.
- Resolve the remote default branch for branchless PR publishing instead of assuming `main`.

## Validation
- `./tools/test_unit.sh --python-only tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py tests/unit/workflows/temporal/workflows/test_run_agent_dispatch.py tests/unit/workflows/temporal/test_run_artifacts.py`
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`
- Full `./tools/test_unit.sh` ran all Python unit tests successfully, then failed on the existing frontend live-log test `entrypoints/task-detail.test.tsx > LiveLogsPanel > shows artifact tail content before SSE connects`.