### PR TITLE
MM-408 Skill Runtime Observability and Verification

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/208-create-task-publish-controls"
+  "feature_directory": "specs/209-skill-runtime-observability"
 }

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -52,10 +52,15 @@ from moonmind.schemas.temporal_models import (
     ExecutionActionCapabilityModel,
     ExecutionDependencySummaryModel,
     ExecutionDebugFieldsModel,
+    ExecutionProjectionDiagnosticModel,
     ExecutionListResponse,
     ExecutionModel,
     ExecutionProgressModel,
     ExecutionRefreshEnvelope,
+    ExecutionSkillLifecycleIntentModel,
+    ExecutionSkillProvenanceModel,
+    ExecutionSkillRuntimeModel,
+    ExecutionSkillVersionSummaryModel,
     TaskInputSnapshotDescriptorModel,
     PollIntegrationRequest,
     RescheduleExecutionRequest,
@@ -248,6 +253,260 @@ def _coerce_temporal_scalar(value: object | None) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+def _dedupe_non_blank(items: list[str]) -> list[str]:
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        normalized = str(item or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _skill_selector_names(raw: object | None) -> list[str] | None:
+    if isinstance(raw, list):
+        return _dedupe_non_blank([_coerce_temporal_scalar(item) for item in raw]) or None
+    if not isinstance(raw, Mapping):
+        return None
+
+    names: list[str] = []
+    sets = raw.get("sets")
+    if isinstance(sets, list):
+        names.extend(_coerce_temporal_scalar(item) for item in sets)
+    include = raw.get("include")
+    if isinstance(include, list):
+        for item in include:
+            if isinstance(item, Mapping):
+                names.append(_coerce_temporal_scalar(item.get("name")))
+            else:
+                names.append(_coerce_temporal_scalar(item))
+    return _dedupe_non_blank(names) or None
+
+
+def _first_mapping(*candidates: object | None) -> Mapping[str, Any]:
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            return candidate
+    return {}
+
+
+def _coerce_skill_bool(value: object | None) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _selected_skill_versions(raw: object | None) -> list[ExecutionSkillVersionSummaryModel]:
+    if not isinstance(raw, list):
+        return []
+    versions: list[ExecutionSkillVersionSummaryModel] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            continue
+        name = _coerce_temporal_scalar(
+            item.get("name")
+            or item.get("skillName")
+            or item.get("skill_name")
+        )
+        if not name:
+            continue
+        versions.append(
+            ExecutionSkillVersionSummaryModel(
+                name=name,
+                version=_coerce_temporal_scalar(item.get("version")) or None,
+                sourceKind=(
+                    _coerce_temporal_scalar(
+                        item.get("sourceKind") or item.get("source_kind")
+                    )
+                    or None
+                ),
+                sourcePath=(
+                    _coerce_temporal_scalar(
+                        item.get("sourcePath") or item.get("source_path")
+                    )
+                    or None
+                ),
+                contentRef=(
+                    _coerce_temporal_scalar(
+                        item.get("contentRef") or item.get("content_ref")
+                    )
+                    or None
+                ),
+                contentDigest=(
+                    _coerce_temporal_scalar(
+                        item.get("contentDigest") or item.get("content_digest")
+                    )
+                    or None
+                ),
+            )
+        )
+    return versions
+
+
+def _skill_provenance_from_versions(
+    versions: list[ExecutionSkillVersionSummaryModel],
+) -> list[ExecutionSkillProvenanceModel]:
+    provenance: list[ExecutionSkillProvenanceModel] = []
+    for entry in versions:
+        if not entry.source_kind and not entry.source_path:
+            continue
+        provenance.append(
+            ExecutionSkillProvenanceModel(
+                name=entry.name,
+                sourceKind=entry.source_kind,
+                sourcePath=entry.source_path,
+            )
+        )
+    return provenance
+
+
+def _projection_diagnostic(raw: object | None) -> ExecutionProjectionDiagnosticModel | None:
+    if not isinstance(raw, Mapping):
+        return None
+    diagnostic = ExecutionProjectionDiagnosticModel(
+        path=_coerce_temporal_scalar(raw.get("path")) or None,
+        objectKind=(
+            _coerce_temporal_scalar(raw.get("objectKind") or raw.get("object_kind"))
+            or None
+        ),
+        attemptedAction=(
+            _coerce_temporal_scalar(
+                raw.get("attemptedAction") or raw.get("attempted_action")
+            )
+            or None
+        ),
+        remediation=_coerce_temporal_scalar(raw.get("remediation")) or None,
+        cause=_coerce_temporal_scalar(raw.get("cause")) or None,
+    )
+    if any(
+        [
+            diagnostic.path,
+            diagnostic.object_kind,
+            diagnostic.attempted_action,
+            diagnostic.remediation,
+            diagnostic.cause,
+        ]
+    ):
+        return diagnostic
+    return None
+
+
+def _skill_lifecycle_intent(
+    *,
+    params: Mapping[str, Any],
+    task_skills: list[str] | None,
+    resolved_skillset_ref: str | None,
+) -> ExecutionSkillLifecycleIntentModel | None:
+    raw = _first_mapping(params.get("skillLifecycleIntent"))
+    source = _coerce_temporal_scalar(raw.get("source")) or "run"
+    resolution_mode = _coerce_temporal_scalar(raw.get("resolutionMode"))
+    explanation = _coerce_temporal_scalar(raw.get("explanation"))
+    selectors = _skill_selector_names(raw.get("selectors")) or task_skills or []
+    lifecycle_ref = (
+        _coerce_temporal_scalar(
+            raw.get("resolvedSkillsetRef") or raw.get("resolved_skillset_ref")
+        )
+        or resolved_skillset_ref
+    )
+
+    if not resolution_mode:
+        resolution_mode = "snapshot-reuse" if lifecycle_ref else "selector-based"
+    if not explanation:
+        if resolution_mode == "snapshot-reuse":
+            explanation = (
+                "Execution reuses the resolved skill snapshot unless explicit "
+                "re-resolution is requested."
+            )
+        elif selectors:
+            explanation = "Execution resolves the selected skills when the run starts."
+        else:
+            explanation = "Execution inherits deployment skill defaults explicitly."
+
+    if not (selectors or lifecycle_ref or raw):
+        return None
+    return ExecutionSkillLifecycleIntentModel(
+        source=source,
+        selectors=selectors,
+        resolvedSkillsetRef=lifecycle_ref,
+        resolutionMode=resolution_mode,
+        explanation=explanation,
+    )
+
+
+def _skill_runtime_evidence(
+    *,
+    params: Mapping[str, Any],
+    task_payload: Mapping[str, Any],
+    task_skills: list[str] | None,
+    resolved_skillset_ref: str | None,
+) -> ExecutionSkillRuntimeModel | None:
+    materialized = _first_mapping(
+        params.get("skillRuntime"),
+        params.get("skillsMaterialized"),
+        task_payload.get("skillRuntime"),
+    )
+    selected_skills = _skill_selector_names(materialized.get("selectedSkills"))
+    if selected_skills is None:
+        selected_skills = _skill_selector_names(materialized.get("activeSkills"))
+    if selected_skills is None:
+        selected_skills = task_skills or []
+
+    versions = _selected_skill_versions(
+        materialized.get("selectedVersions") or materialized.get("skills")
+    )
+    provenance = _skill_provenance_from_versions(versions)
+    materialization_mode = (
+        _coerce_temporal_scalar(
+            materialized.get("materializationMode")
+            or materialized.get("materialization_mode")
+        )
+        or _coerce_temporal_scalar(
+            _first_mapping(task_payload.get("skills")).get("materializationMode")
+        )
+        or None
+    )
+    lifecycle_intent = _skill_lifecycle_intent(
+        params=params,
+        task_skills=task_skills,
+        resolved_skillset_ref=resolved_skillset_ref,
+    )
+    runtime_ref = (
+        _coerce_temporal_scalar(
+            materialized.get("resolvedSkillsetRef")
+            or materialized.get("resolved_skillset_ref")
+        )
+        or resolved_skillset_ref
+    )
+
+    if not any([runtime_ref, selected_skills, versions, materialized, lifecycle_intent]):
+        return None
+
+    return ExecutionSkillRuntimeModel(
+        resolvedSkillsetRef=runtime_ref,
+        selectedSkills=selected_skills,
+        selectedVersions=versions,
+        sourceProvenance=provenance,
+        materializationMode=materialization_mode,
+        visiblePath=_coerce_temporal_scalar(materialized.get("visiblePath")) or None,
+        backingPath=_coerce_temporal_scalar(materialized.get("backingPath")) or None,
+        readOnly=_coerce_skill_bool(materialized.get("readOnly")),
+        manifestRef=(
+            _coerce_temporal_scalar(
+                materialized.get("manifestRef") or materialized.get("manifestPath")
+            )
+            or None
+        ),
+        promptIndexRef=_coerce_temporal_scalar(materialized.get("promptIndexRef")) or None,
+        activationSummaryRef=(
+            _coerce_temporal_scalar(materialized.get("activationSummaryRef")) or None
+        ),
+        diagnostics=_projection_diagnostic(materialized.get("diagnostics")),
+        lifecycleIntent=lifecycle_intent,
+    )
 
 
 def _normalize_entry_value(value: object | None) -> str | None:
@@ -585,9 +844,13 @@ def _serialize_execution(
 
     resolved_skillset_ref = str(params.get("resolvedSkillsetRef") or params.get("resolved_skillset_ref") or "").strip() or None
     
-    # task_skills can be passed explicitly via task payload
-    raw_task_skills = task_payload.get("skills")
-    task_skills = raw_task_skills if isinstance(raw_task_skills, list) else None
+    task_skills = _skill_selector_names(task_payload.get("skills"))
+    skill_runtime = _skill_runtime_evidence(
+        params=params,
+        task_payload=task_payload,
+        task_skills=task_skills,
+        resolved_skillset_ref=resolved_skillset_ref,
+    )
 
     git_payload = task_payload.get("git")
     if not isinstance(git_payload, dict):
@@ -707,6 +970,7 @@ def _serialize_execution(
         merge_automation_selected=merge_automation_selected,
         resolved_skillset_ref=resolved_skillset_ref,
         task_skills=task_skills,
+        skill_runtime=skill_runtime,
         artifact_refs=(
             list(record.artifact_refs or []) if include_artifact_refs else []
         ),

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -300,6 +300,13 @@ def _coerce_skill_bool(value: object | None) -> bool | None:
     return None
 
 
+def _mapping_value(raw: Mapping[str, Any], *keys: str) -> object | None:
+    for key in keys:
+        if key in raw:
+            return raw[key]
+    return None
+
+
 def _selected_skill_versions(raw: object | None) -> list[ExecutionSkillVersionSummaryModel]:
     if not isinstance(raw, list):
         return []
@@ -364,6 +371,57 @@ def _skill_provenance_from_versions(
     return provenance
 
 
+def _skill_source_provenance(
+    raw: object | None,
+    versions: list[ExecutionSkillVersionSummaryModel],
+) -> list[ExecutionSkillProvenanceModel]:
+    provenance: list[ExecutionSkillProvenanceModel] = []
+    seen: set[tuple[str, str | None, str | None]] = set()
+
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                continue
+            name = _coerce_temporal_scalar(
+                item.get("name")
+                or item.get("skillName")
+                or item.get("skill_name")
+            )
+            if not name:
+                continue
+            source_kind = (
+                _coerce_temporal_scalar(
+                    item.get("sourceKind") or item.get("source_kind")
+                )
+                or None
+            )
+            source_path = (
+                _coerce_temporal_scalar(
+                    item.get("sourcePath") or item.get("source_path")
+                )
+                or None
+            )
+            key = (name, source_kind, source_path)
+            if key in seen:
+                continue
+            seen.add(key)
+            provenance.append(
+                ExecutionSkillProvenanceModel(
+                    name=name,
+                    sourceKind=source_kind,
+                    sourcePath=source_path,
+                )
+            )
+
+    for entry in _skill_provenance_from_versions(versions):
+        key = (entry.name, entry.source_kind, entry.source_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        provenance.append(entry)
+    return provenance
+
+
 def _projection_diagnostic(raw: object | None) -> ExecutionProjectionDiagnosticModel | None:
     if not isinstance(raw, Mapping):
         return None
@@ -402,7 +460,7 @@ def _skill_lifecycle_intent(
     resolved_skillset_ref: str | None,
 ) -> ExecutionSkillLifecycleIntentModel | None:
     raw = _first_mapping(params.get("skillLifecycleIntent"))
-    source = _coerce_temporal_scalar(raw.get("source")) or "run"
+    source = _coerce_temporal_scalar(raw.get("source")) or "proposal"
     resolution_mode = _coerce_temporal_scalar(raw.get("resolutionMode"))
     explanation = _coerce_temporal_scalar(raw.get("explanation"))
     selectors = _skill_selector_names(raw.get("selectors")) or task_skills or []
@@ -414,7 +472,12 @@ def _skill_lifecycle_intent(
     )
 
     if not resolution_mode:
-        resolution_mode = "snapshot-reuse" if lifecycle_ref else "selector-based"
+        if lifecycle_ref:
+            resolution_mode = "snapshot-reuse"
+        elif selectors:
+            resolution_mode = "selector-based"
+        else:
+            resolution_mode = "inherited-defaults"
     if not explanation:
         if resolution_mode == "snapshot-reuse":
             explanation = (
@@ -458,14 +521,22 @@ def _skill_runtime_evidence(
     versions = _selected_skill_versions(
         materialized.get("selectedVersions") or materialized.get("skills")
     )
-    provenance = _skill_provenance_from_versions(versions)
+    provenance = _skill_source_provenance(
+        materialized.get("sourceProvenance")
+        or materialized.get("source_provenance"),
+        versions,
+    )
+    task_skills_payload = _first_mapping(task_payload.get("skills"))
     materialization_mode = (
         _coerce_temporal_scalar(
             materialized.get("materializationMode")
             or materialized.get("materialization_mode")
         )
         or _coerce_temporal_scalar(
-            _first_mapping(task_payload.get("skills")).get("materializationMode")
+            task_skills_payload.get("materializationMode")
+            or task_skills_payload.get("materialization_mode")
+            or task_payload.get("materializationMode")
+            or task_payload.get("materialization_mode")
         )
         or None
     )
@@ -491,18 +562,43 @@ def _skill_runtime_evidence(
         selectedVersions=versions,
         sourceProvenance=provenance,
         materializationMode=materialization_mode,
-        visiblePath=_coerce_temporal_scalar(materialized.get("visiblePath")) or None,
-        backingPath=_coerce_temporal_scalar(materialized.get("backingPath")) or None,
-        readOnly=_coerce_skill_bool(materialized.get("readOnly")),
-        manifestRef=(
+        visiblePath=(
             _coerce_temporal_scalar(
-                materialized.get("manifestRef") or materialized.get("manifestPath")
+                materialized.get("visiblePath") or materialized.get("visible_path")
             )
             or None
         ),
-        promptIndexRef=_coerce_temporal_scalar(materialized.get("promptIndexRef")) or None,
+        backingPath=(
+            _coerce_temporal_scalar(
+                materialized.get("backingPath") or materialized.get("backing_path")
+            )
+            or None
+        ),
+        readOnly=_coerce_skill_bool(
+            _mapping_value(materialized, "readOnly", "read_only")
+        ),
+        manifestRef=(
+            _coerce_temporal_scalar(
+                materialized.get("manifestRef")
+                or materialized.get("manifest_ref")
+                or materialized.get("manifestPath")
+                or materialized.get("manifest_path")
+            )
+            or None
+        ),
+        promptIndexRef=(
+            _coerce_temporal_scalar(
+                materialized.get("promptIndexRef")
+                or materialized.get("prompt_index_ref")
+            )
+            or None
+        ),
         activationSummaryRef=(
-            _coerce_temporal_scalar(materialized.get("activationSummaryRef")) or None
+            _coerce_temporal_scalar(
+                materialized.get("activationSummaryRef")
+                or materialized.get("activation_summary_ref")
+            )
+            or None
         ),
         diagnostics=_projection_diagnostic(materialized.get("diagnostics")),
         lifecycleIntent=lifecycle_intent,

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-412",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1583"
+  "jira_issue_key": "MM-408",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1586"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-408-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-408-moonspec-orchestration-input.md
@@ -1,0 +1,69 @@
+# MM-408 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-408
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Skill Runtime Observability and Verification
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-408 from MM project
+Summary: Skill Runtime Observability and Verification
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-408 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-408: Skill Runtime Observability and Verification
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §18-§23
+  - SkillInjection §15, §18-§19
+  - docs/tmp/004-AgentSkillSystemPlan.md §2-§5
+- Coverage IDs:
+  - DESIGN-REQ-010
+  - DESIGN-REQ-018
+  - DESIGN-REQ-019
+  - DESIGN-REQ-020
+
+User Story
+As an operator or maintainer, I can inspect which skills were selected, where they came from, how they were materialized, and whether projection succeeded, with boundary tests proving the real adapter and activity behavior rather than isolated helper behavior only.
+
+Acceptance Criteria
+- Given a task detail view or API response for a run with skills, then it exposes resolved snapshot ID, selected skill versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs where appropriate.
+- Given a projection collision occurs, then operator-visible diagnostics include the path, object kind, attempted projection action, and remediation without dumping full skill bodies.
+- Given proposal, schedule, or rerun metadata is inspected, then skill intent or resolved snapshot reuse is explicit and re-resolution is never silent.
+- Given the skill injection implementation changes, then real adapter or activity boundary tests cover single-skill and multi-skill projections, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+
+Requirements
+- Surface resolved skill metadata in submit, detail, and debug contexts appropriate to operator permissions.
+- Record active backing path, visible path, projected skills and versions, read-only state, collision failures, and activation summary evidence.
+- Preserve artifact and payload discipline by linking manifests or prompt indexes instead of logging full bodies by default.
+- Add or maintain boundary-level tests for adapter and activity behavior when skill injection or resolution behavior changes.
+
+Relevant Implementation Notes
+- Keep skill observability focused on metadata and artifact refs rather than full skill body content.
+- Include selected skill versions, source provenance, materialization mode, runtime-visible path summary, active backing path, read-only state, and collision diagnostics where the existing submit, detail, debug, proposal, schedule, or rerun surfaces expose skill runtime state.
+- Treat projection failures as operator-visible diagnostics with path, object kind, attempted projection action, and remediation guidance.
+- Make skill intent or resolved snapshot reuse explicit for proposal, schedule, and rerun flows so re-resolution is not silent.
+- Cover real adapter or activity boundaries when skill injection or resolution behavior changes, including single-skill projection, multi-skill projection, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+
+Verification
+- Confirm task detail or API responses for runs with skills expose resolved snapshot ID, selected skill versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs where appropriate.
+- Confirm projection collision diagnostics include path, object kind, attempted projection action, and remediation without dumping full skill bodies.
+- Confirm proposal, schedule, and rerun metadata make skill intent or resolved snapshot reuse explicit and do not silently re-resolve.
+- Confirm boundary-level tests cover single-skill and multi-skill projections, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+- Preserve MM-408 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates MM-408 blocks MM-407.

--- a/frontend/src/components/skills/SkillProvenanceBadge.tsx
+++ b/frontend/src/components/skills/SkillProvenanceBadge.tsx
@@ -1,16 +1,78 @@
+type SkillRuntime = {
+  resolvedSkillsetRef?: string | null;
+  selectedSkills?: string[];
+  selectedVersions?: Array<{
+    name: string;
+    version?: string | null;
+    sourceKind?: string | null;
+    sourcePath?: string | null;
+    contentRef?: string | null;
+    contentDigest?: string | null;
+  }>;
+  sourceProvenance?: Array<{
+    name: string;
+    sourceKind?: string | null;
+    sourcePath?: string | null;
+  }>;
+  materializationMode?: string | null;
+  visiblePath?: string | null;
+  backingPath?: string | null;
+  readOnly?: boolean | null;
+  manifestRef?: string | null;
+  promptIndexRef?: string | null;
+  activationSummaryRef?: string | null;
+  diagnostics?: {
+    path?: string | null;
+    objectKind?: string | null;
+    attemptedAction?: string | null;
+    remediation?: string | null;
+    cause?: string | null;
+  } | null;
+  lifecycleIntent?: {
+    source: string;
+    selectors?: string[];
+    resolvedSkillsetRef?: string | null;
+    resolutionMode: string;
+    explanation: string;
+  } | null;
+};
+
 type SkillProvenanceBadgeProps = {
   resolvedSkillsetRef?: string | null | undefined;
   taskSkills?: string[] | null | undefined;
   targetSkill?: string | null | undefined;
+  skillRuntime?: SkillRuntime | null | undefined;
 };
 
 export function SkillProvenanceBadge({
   resolvedSkillsetRef,
   taskSkills,
   targetSkill,
+  skillRuntime,
 }: SkillProvenanceBadgeProps) {
   const hasExplicitSkills = Array.isArray(taskSkills) && taskSkills.length > 0;
-  
+  const runtimeRef = skillRuntime?.resolvedSkillsetRef || resolvedSkillsetRef;
+  const selectedVersions = skillRuntime?.selectedVersions ?? [];
+  const provenance = skillRuntime?.sourceProvenance ?? [];
+  const diagnostics = skillRuntime?.diagnostics;
+  const lifecycleIntent = skillRuntime?.lifecycleIntent;
+  const selectedVersionText = selectedVersions
+    .map((entry) => `${entry.name}${entry.version ? `@${entry.version}` : ''}`)
+    .join(', ');
+  const provenanceText = provenance
+    .map((entry) => [entry.name, entry.sourceKind, entry.sourcePath].filter(Boolean).join(' · '))
+    .join(', ');
+  const diagnosticText = diagnostics
+    ? [
+        diagnostics.path,
+        diagnostics.objectKind,
+        diagnostics.attemptedAction,
+        diagnostics.remediation,
+        diagnostics.cause,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    : '';
   
   return (
     <div className="card mt-4 bg-gray-50 border border-gray-200 p-4 rounded-lg">
@@ -27,15 +89,95 @@ export function SkillProvenanceBadge({
         <div>
           <dt>Resolved Snapshot Ref</dt>
           <dd>
-            {resolvedSkillsetRef ? (
-              <code className="small break-all">{resolvedSkillsetRef}</code>
+            {runtimeRef ? (
+              <code className="small break-all">{runtimeRef}</code>
             ) : (
               <span className="small text-muted">No snapshot bound for this run.</span>
             )}
           </dd>
         </div>
+        {selectedVersionText ? (
+          <div>
+            <dt>Selected Versions</dt>
+            <dd>{selectedVersionText}</dd>
+          </div>
+        ) : null}
+        {provenanceText ? (
+          <div>
+            <dt>Source Provenance</dt>
+            <dd>{provenanceText}</dd>
+          </div>
+        ) : null}
+        {skillRuntime?.materializationMode ? (
+          <div>
+            <dt>Materialization</dt>
+            <dd>{skillRuntime.materializationMode}</dd>
+          </div>
+        ) : null}
+        {skillRuntime?.visiblePath ? (
+          <div>
+            <dt>Visible Path</dt>
+            <dd>
+              <code className="small break-all">{skillRuntime.visiblePath}</code>
+            </dd>
+          </div>
+        ) : null}
+        {skillRuntime?.backingPath ? (
+          <div>
+            <dt>Backing Path</dt>
+            <dd>
+              <code className="small break-all">{skillRuntime.backingPath}</code>
+            </dd>
+          </div>
+        ) : null}
+        {typeof skillRuntime?.readOnly === 'boolean' ? (
+          <div>
+            <dt>Read Only</dt>
+            <dd>{skillRuntime.readOnly ? 'Yes' : 'No'}</dd>
+          </div>
+        ) : null}
+        {skillRuntime?.manifestRef ? (
+          <div>
+            <dt>Manifest Ref</dt>
+            <dd>
+              <code className="small break-all">{skillRuntime.manifestRef}</code>
+            </dd>
+          </div>
+        ) : null}
+        {skillRuntime?.promptIndexRef ? (
+          <div>
+            <dt>Prompt Index Ref</dt>
+            <dd>
+              <code className="small break-all">{skillRuntime.promptIndexRef}</code>
+            </dd>
+          </div>
+        ) : null}
+        {skillRuntime?.activationSummaryRef ? (
+          <div>
+            <dt>Activation Summary Ref</dt>
+            <dd>
+              <code className="small break-all">{skillRuntime.activationSummaryRef}</code>
+            </dd>
+          </div>
+        ) : null}
+        {lifecycleIntent ? (
+          <div>
+            <dt>Lifecycle Intent</dt>
+            <dd>
+              {[lifecycleIntent.source, lifecycleIntent.resolutionMode, lifecycleIntent.explanation]
+                .filter(Boolean)
+                .join(' · ')}
+            </dd>
+          </div>
+        ) : null}
+        {diagnosticText ? (
+          <div>
+            <dt>Projection Diagnostic</dt>
+            <dd>{diagnosticText}</dd>
+          </div>
+        ) : null}
       </dl>
-      {!resolvedSkillsetRef && (
+      {!runtimeRef && (
         <p className="small text-muted mt-2 mb-0">
           * Without a snapshot ref, the worker invokes standard legacy tools.
         </p>

--- a/frontend/src/components/skills/SkillProvenanceBadge.tsx
+++ b/frontend/src/components/skills/SkillProvenanceBadge.tsx
@@ -1,40 +1,40 @@
 type SkillRuntime = {
-  resolvedSkillsetRef?: string | null;
-  selectedSkills?: string[];
+  resolvedSkillsetRef?: string | null | undefined;
+  selectedSkills?: string[] | undefined;
   selectedVersions?: Array<{
     name: string;
-    version?: string | null;
-    sourceKind?: string | null;
-    sourcePath?: string | null;
-    contentRef?: string | null;
-    contentDigest?: string | null;
-  }>;
+    version?: string | null | undefined;
+    sourceKind?: string | null | undefined;
+    sourcePath?: string | null | undefined;
+    contentRef?: string | null | undefined;
+    contentDigest?: string | null | undefined;
+  }> | undefined;
   sourceProvenance?: Array<{
     name: string;
-    sourceKind?: string | null;
-    sourcePath?: string | null;
-  }>;
-  materializationMode?: string | null;
-  visiblePath?: string | null;
-  backingPath?: string | null;
-  readOnly?: boolean | null;
-  manifestRef?: string | null;
-  promptIndexRef?: string | null;
-  activationSummaryRef?: string | null;
+    sourceKind?: string | null | undefined;
+    sourcePath?: string | null | undefined;
+  }> | undefined;
+  materializationMode?: string | null | undefined;
+  visiblePath?: string | null | undefined;
+  backingPath?: string | null | undefined;
+  readOnly?: boolean | null | undefined;
+  manifestRef?: string | null | undefined;
+  promptIndexRef?: string | null | undefined;
+  activationSummaryRef?: string | null | undefined;
   diagnostics?: {
-    path?: string | null;
-    objectKind?: string | null;
-    attemptedAction?: string | null;
-    remediation?: string | null;
-    cause?: string | null;
-  } | null;
+    path?: string | null | undefined;
+    objectKind?: string | null | undefined;
+    attemptedAction?: string | null | undefined;
+    remediation?: string | null | undefined;
+    cause?: string | null | undefined;
+  } | null | undefined;
   lifecycleIntent?: {
     source: string;
-    selectors?: string[];
-    resolvedSkillsetRef?: string | null;
+    selectors?: string[] | undefined;
+    resolvedSkillsetRef?: string | null | undefined;
     resolutionMode: string;
     explanation: string;
-  } | null;
+  } | null | undefined;
 };
 
 type SkillProvenanceBadgeProps = {

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1272,6 +1272,33 @@ describe('Task Detail Entrypoint', () => {
       targetRuntime: 'gemini_cli',
       targetSkill: 'jira-pr-verify',
       taskSkills: ['jira-pr-verify', 'fix-comments'],
+      skillRuntime: {
+        resolvedSkillsetRef: 'artifact:resolved-skills-1',
+        selectedSkills: ['jira-pr-verify'],
+        selectedVersions: [
+          {
+            name: 'jira-pr-verify',
+            version: '1.2.0',
+            sourceKind: 'deployment',
+            contentRef: 'artifact:skill-body-1',
+            contentDigest: 'sha256:abc',
+          },
+        ],
+        sourceProvenance: [{ name: 'jira-pr-verify', sourceKind: 'deployment' }],
+        materializationMode: 'hybrid',
+        visiblePath: '.agents/skills',
+        backingPath: '../skills_active',
+        readOnly: true,
+        manifestRef: 'artifact:manifest-1',
+        promptIndexRef: 'artifact:prompt-index-1',
+        activationSummaryRef: 'artifact:activation-summary-1',
+        lifecycleIntent: {
+          source: 'run',
+          resolutionMode: 'snapshot-reuse',
+          explanation:
+            'Execution reuses the resolved skill snapshot unless explicit re-resolution is requested.',
+        },
+      },
       profileId: 'profile:gemini-default',
       providerId: 'google',
       providerLabel: 'Google',
@@ -1315,6 +1342,21 @@ describe('Task Detail Entrypoint', () => {
         'jira-pr-verify, fix-comments',
       );
       expect(screen.getByText('Delegated Skill').closest('div')?.textContent).toContain('jira-pr-verify');
+      expect(screen.getByText('Selected Versions').closest('div')?.textContent).toContain(
+        'jira-pr-verify@1.2.0',
+      );
+      expect(screen.getByText('Source Provenance').closest('div')?.textContent).toContain(
+        'deployment',
+      );
+      expect(screen.getByText('Materialization').closest('div')?.textContent).toContain('hybrid');
+      expect(screen.getByText('Visible Path').closest('div')?.textContent).toContain('.agents/skills');
+      expect(screen.getByText('Backing Path').closest('div')?.textContent).toContain('../skills_active');
+      expect(screen.getByText('Manifest Ref').closest('div')?.textContent).toContain('artifact:manifest-1');
+      expect(screen.getByText('Prompt Index Ref').closest('div')?.textContent).toContain(
+        'artifact:prompt-index-1',
+      );
+      expect(screen.getByText('Lifecycle Intent').closest('div')?.textContent).toContain('snapshot-reuse');
+      expect(screen.queryByText('FULL SKILL BODY SHOULD NOT LEAK')).toBeNull();
       expect(screen.getByText('Google')).toBeTruthy();
       expect(screen.getByText('profile:gemini-default')).toBeTruthy();
       expect(screen.getByRole('link', { name: 'https://github.com/MoonLadderStudios/MoonMind/pull/123' })).toBeTruthy();

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -143,6 +143,69 @@ const DependencySummarySchema = z
   })
   .passthrough();
 
+const SkillRuntimeSchema = z
+  .object({
+    resolvedSkillsetRef: z.string().nullable().optional(),
+    selectedSkills: z.array(z.string()).optional().default([]),
+    selectedVersions: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            version: z.string().nullable().optional(),
+            sourceKind: z.string().nullable().optional(),
+            sourcePath: z.string().nullable().optional(),
+            contentRef: z.string().nullable().optional(),
+            contentDigest: z.string().nullable().optional(),
+          })
+          .passthrough(),
+      )
+      .optional()
+      .default([]),
+    sourceProvenance: z
+      .array(
+        z
+          .object({
+            name: z.string(),
+            sourceKind: z.string().nullable().optional(),
+            sourcePath: z.string().nullable().optional(),
+          })
+          .passthrough(),
+      )
+      .optional()
+      .default([]),
+    materializationMode: z.string().nullable().optional(),
+    visiblePath: z.string().nullable().optional(),
+    backingPath: z.string().nullable().optional(),
+    readOnly: z.boolean().nullable().optional(),
+    manifestRef: z.string().nullable().optional(),
+    promptIndexRef: z.string().nullable().optional(),
+    activationSummaryRef: z.string().nullable().optional(),
+    diagnostics: z
+      .object({
+        path: z.string().nullable().optional(),
+        objectKind: z.string().nullable().optional(),
+        attemptedAction: z.string().nullable().optional(),
+        remediation: z.string().nullable().optional(),
+        cause: z.string().nullable().optional(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+    lifecycleIntent: z
+      .object({
+        source: z.string(),
+        selectors: z.array(z.string()).optional().default([]),
+        resolvedSkillsetRef: z.string().nullable().optional(),
+        resolutionMode: z.string(),
+        explanation: z.string(),
+      })
+      .passthrough()
+      .nullable()
+      .optional(),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string(),
@@ -186,6 +249,7 @@ const ExecutionDetailSchema = z
     prUrl: z.string().nullable().optional(),
     resolvedSkillsetRef: z.string().nullable().optional(),
     taskSkills: z.array(z.string()).nullable().optional(),
+    skillRuntime: SkillRuntimeSchema.nullable().optional(),
     publishMode: z.string().nullable().optional(),
     mergeAutomationSelected: z.boolean().optional().default(false),
     summaryArtifactRef: z.string().nullable().optional(),
@@ -3205,6 +3269,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
             resolvedSkillsetRef={execution.resolvedSkillsetRef}
             taskSkills={execution.taskSkills}
             targetSkill={execution.targetSkill}
+            skillRuntime={execution.skillRuntime}
           />
 
           <FactGroup title="Runtime">

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3454,6 +3454,7 @@ export interface components {
             resolvedSkillsetRef?: string | null;
             /** Taskskills */
             taskSkills?: string[] | null;
+            skillRuntime?: components["schemas"]["ExecutionSkillRuntimeModel"] | null;
             /** Artifactrefs */
             artifactRefs?: string[];
             actions?: components["schemas"]["ExecutionActionCapabilityModel"];
@@ -3617,6 +3618,22 @@ export interface components {
             updatedAt: string;
         };
         /**
+         * ExecutionProjectionDiagnosticModel
+         * @description Sanitized projection diagnostic for operator-visible skill failures.
+         */
+        ExecutionProjectionDiagnosticModel: {
+            /** Path */
+            path?: string | null;
+            /** Objectkind */
+            objectKind?: string | null;
+            /** Attemptedaction */
+            attemptedAction?: string | null;
+            /** Remediation */
+            remediation?: string | null;
+            /** Cause */
+            cause?: string | null;
+        };
+        /**
          * ExecutionRefreshEnvelope
          * @description Compatibility metadata for patching one acted-on row and refetching lists.
          */
@@ -3638,6 +3655,82 @@ export interface components {
              * Format: date-time
              */
             refreshedAt: string;
+        };
+        /**
+         * ExecutionSkillLifecycleIntentModel
+         * @description How skill intent or snapshot reuse is preserved across lifecycle paths.
+         */
+        ExecutionSkillLifecycleIntentModel: {
+            /** Source */
+            source: string;
+            /** Selectors */
+            selectors?: string[];
+            /** Resolvedskillsetref */
+            resolvedSkillsetRef?: string | null;
+            /** Resolutionmode */
+            resolutionMode: string;
+            /** Explanation */
+            explanation: string;
+        };
+        /**
+         * ExecutionSkillProvenanceModel
+         * @description Compact source provenance for one selected skill.
+         */
+        ExecutionSkillProvenanceModel: {
+            /** Name */
+            name: string;
+            /** Sourcekind */
+            sourceKind?: string | null;
+            /** Sourcepath */
+            sourcePath?: string | null;
+        };
+        /**
+         * ExecutionSkillRuntimeModel
+         * @description Compact skill runtime evidence exposed by execution detail APIs.
+         */
+        ExecutionSkillRuntimeModel: {
+            /** Resolvedskillsetref */
+            resolvedSkillsetRef?: string | null;
+            /** Selectedskills */
+            selectedSkills?: string[];
+            /** Selectedversions */
+            selectedVersions?: components["schemas"]["ExecutionSkillVersionSummaryModel"][];
+            /** Sourceprovenance */
+            sourceProvenance?: components["schemas"]["ExecutionSkillProvenanceModel"][];
+            /** Materializationmode */
+            materializationMode?: string | null;
+            /** Visiblepath */
+            visiblePath?: string | null;
+            /** Backingpath */
+            backingPath?: string | null;
+            /** Readonly */
+            readOnly?: boolean | null;
+            /** Manifestref */
+            manifestRef?: string | null;
+            /** Promptindexref */
+            promptIndexRef?: string | null;
+            /** Activationsummaryref */
+            activationSummaryRef?: string | null;
+            diagnostics?: components["schemas"]["ExecutionProjectionDiagnosticModel"] | null;
+            lifecycleIntent?: components["schemas"]["ExecutionSkillLifecycleIntentModel"] | null;
+        };
+        /**
+         * ExecutionSkillVersionSummaryModel
+         * @description Compact operator-safe summary of one selected skill version.
+         */
+        ExecutionSkillVersionSummaryModel: {
+            /** Name */
+            name: string;
+            /** Version */
+            version?: string | null;
+            /** Sourcekind */
+            sourceKind?: string | null;
+            /** Sourcepath */
+            sourcePath?: string | null;
+            /** Contentref */
+            contentRef?: string | null;
+            /** Contentdigest */
+            contentDigest?: string | null;
         };
         /**
          * GitHubCredentialStatus

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -704,6 +704,81 @@ class ExecutionDependencySummaryModel(BaseModel):
     workflow_type: Optional[str] = Field(None, alias="workflowType")
 
 
+class ExecutionSkillVersionSummaryModel(BaseModel):
+    """Compact operator-safe summary of one selected skill version."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., alias="name")
+    version: Optional[str] = Field(None, alias="version")
+    source_kind: Optional[str] = Field(None, alias="sourceKind")
+    source_path: Optional[str] = Field(None, alias="sourcePath")
+    content_ref: Optional[str] = Field(None, alias="contentRef")
+    content_digest: Optional[str] = Field(None, alias="contentDigest")
+
+
+class ExecutionSkillProvenanceModel(BaseModel):
+    """Compact source provenance for one selected skill."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(..., alias="name")
+    source_kind: Optional[str] = Field(None, alias="sourceKind")
+    source_path: Optional[str] = Field(None, alias="sourcePath")
+
+
+class ExecutionProjectionDiagnosticModel(BaseModel):
+    """Sanitized projection diagnostic for operator-visible skill failures."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    path: Optional[str] = Field(None, alias="path")
+    object_kind: Optional[str] = Field(None, alias="objectKind")
+    attempted_action: Optional[str] = Field(None, alias="attemptedAction")
+    remediation: Optional[str] = Field(None, alias="remediation")
+    cause: Optional[str] = Field(None, alias="cause")
+
+
+class ExecutionSkillLifecycleIntentModel(BaseModel):
+    """How skill intent or snapshot reuse is preserved across lifecycle paths."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source: str = Field(..., alias="source")
+    selectors: list[str] = Field(default_factory=list, alias="selectors")
+    resolved_skillset_ref: Optional[str] = Field(None, alias="resolvedSkillsetRef")
+    resolution_mode: str = Field(..., alias="resolutionMode")
+    explanation: str = Field(..., alias="explanation")
+
+
+class ExecutionSkillRuntimeModel(BaseModel):
+    """Compact skill runtime evidence exposed by execution detail APIs."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resolved_skillset_ref: Optional[str] = Field(None, alias="resolvedSkillsetRef")
+    selected_skills: list[str] = Field(default_factory=list, alias="selectedSkills")
+    selected_versions: list[ExecutionSkillVersionSummaryModel] = Field(
+        default_factory=list, alias="selectedVersions"
+    )
+    source_provenance: list[ExecutionSkillProvenanceModel] = Field(
+        default_factory=list, alias="sourceProvenance"
+    )
+    materialization_mode: Optional[str] = Field(None, alias="materializationMode")
+    visible_path: Optional[str] = Field(None, alias="visiblePath")
+    backing_path: Optional[str] = Field(None, alias="backingPath")
+    read_only: Optional[bool] = Field(None, alias="readOnly")
+    manifest_ref: Optional[str] = Field(None, alias="manifestRef")
+    prompt_index_ref: Optional[str] = Field(None, alias="promptIndexRef")
+    activation_summary_ref: Optional[str] = Field(None, alias="activationSummaryRef")
+    diagnostics: Optional[ExecutionProjectionDiagnosticModel] = Field(
+        None, alias="diagnostics"
+    )
+    lifecycle_intent: Optional[ExecutionSkillLifecycleIntentModel] = Field(
+        None, alias="lifecycleIntent"
+    )
+
+
 class ExecutionProgressModel(BaseModel):
     """Bounded latest-run progress summary derived from workflow-owned step state."""
 
@@ -943,6 +1018,9 @@ class ExecutionModel(BaseModel):
     merge_automation_selected: bool = Field(False, alias="mergeAutomationSelected")
     resolved_skillset_ref: Optional[str] = Field(None, alias="resolvedSkillsetRef")
     task_skills: Optional[list[str]] = Field(None, alias="taskSkills")
+    skill_runtime: Optional[ExecutionSkillRuntimeModel] = Field(
+        None, alias="skillRuntime"
+    )
     artifact_refs: list[str] = Field(default_factory=list, alias="artifactRefs")
     actions: ExecutionActionCapabilityModel = Field(
         default_factory=ExecutionActionCapabilityModel, alias="actions"

--- a/specs/209-skill-runtime-observability/checklists/requirements.md
+++ b/specs/209-skill-runtime-observability/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Skill Runtime Observability and Verification
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- PASS: The input is classified as a single-story runtime feature request from the preserved MM-408 Jira preset brief.
+- PASS: The historical `docs/Tools/SkillSystem.md` reference is unavailable in this checkout, and the spec records the current canonical source mapping instead of silently dropping source coverage.
+- PASS: In-scope DESIGN-REQ-010, DESIGN-REQ-018, DESIGN-REQ-019, and DESIGN-REQ-020 are mapped to functional requirements.

--- a/specs/209-skill-runtime-observability/contracts/skill-runtime-observability.md
+++ b/specs/209-skill-runtime-observability/contracts/skill-runtime-observability.md
@@ -1,0 +1,94 @@
+# Contract: Skill Runtime Observability
+
+## Execution Detail Payload
+
+Existing endpoint:
+- `GET /api/executions/{task_id}?source=temporal`
+
+The response may include a compact `skillRuntime` object.
+
+```json
+{
+  "resolvedSkillsetRef": "artifact:resolved-skillset-123",
+  "taskSkills": ["pr-resolver"],
+  "skillRuntime": {
+    "resolvedSkillsetRef": "artifact:resolved-skillset-123",
+    "selectedSkills": ["pr-resolver"],
+    "selectedVersions": [
+      {
+        "name": "pr-resolver",
+        "version": "1.2.0",
+        "sourceKind": "deployment",
+        "contentRef": "artifact:skill-body-123",
+        "contentDigest": "sha256:abc"
+      }
+    ],
+    "sourceProvenance": [
+      {
+        "name": "pr-resolver",
+        "sourceKind": "deployment"
+      }
+    ],
+    "materializationMode": "hybrid",
+    "visiblePath": ".agents/skills",
+    "backingPath": "../skills_active",
+    "readOnly": true,
+    "manifestRef": "artifact:manifest-123",
+    "promptIndexRef": "artifact:prompt-index-123",
+    "activationSummaryRef": "artifact:activation-summary-123"
+  }
+}
+```
+
+Rules:
+- `skillRuntime` is optional when no skill metadata exists.
+- `skillRuntime` must contain metadata and refs only.
+- Full skill bodies, full manifests, credentials, auth headers, and environment dumps must not appear.
+- Existing `resolvedSkillsetRef` and `taskSkills` remain available for current clients.
+
+## Projection Diagnostic Payload
+
+When a skill projection failure is surfaced, diagnostics use this shape when structured metadata is available.
+
+```json
+{
+  "diagnostics": {
+    "path": "/work/agent_jobs/example/repo/.agents/skills",
+    "objectKind": "directory",
+    "attemptedAction": "project active skill snapshot",
+    "remediation": "remove or relocate the existing path so MoonMind can create the canonical .agents/skills projection",
+    "cause": "existing non-symlink path present"
+  }
+}
+```
+
+Rules:
+- The diagnostic must include path, object kind, attempted action, and remediation.
+- `cause` is optional and must be sanitized.
+- Full skill bodies must not be included.
+
+## Lifecycle Intent Payload
+
+Lifecycle metadata should explain whether execution will resolve selectors, reuse a snapshot, inherit defaults, or explicitly re-resolve.
+
+```json
+{
+  "skillLifecycleIntent": {
+    "source": "rerun",
+    "resolvedSkillsetRef": "artifact:resolved-skillset-123",
+    "resolutionMode": "snapshot-reuse",
+    "explanation": "Rerun reuses the original resolved skill snapshot unless explicit re-resolution is requested."
+  }
+}
+```
+
+Allowed `resolutionMode` values:
+- `selector-based`
+- `snapshot-reuse`
+- `inherited-defaults`
+- `explicit-re-resolution`
+
+Rules:
+- Proposal metadata that relies on deployment defaults must say so explicitly.
+- Scheduled execution metadata must preserve selectors or explain default inheritance before launch and report the concrete snapshot after launch.
+- Rerun, retry, continue-as-new, and replay metadata must prefer `snapshot-reuse` when a `resolvedSkillsetRef` exists.

--- a/specs/209-skill-runtime-observability/data-model.md
+++ b/specs/209-skill-runtime-observability/data-model.md
@@ -1,0 +1,79 @@
+# Data Model: Skill Runtime Observability and Verification
+
+## SkillRuntimeEvidence
+
+Represents compact skill runtime metadata exposed on execution detail surfaces.
+
+Fields:
+- `resolvedSkillsetRef`: optional string identifying the immutable resolved skill snapshot.
+- `selectedSkills`: list of selected skill names from task selectors or materialization metadata.
+- `selectedVersions`: optional list of selected skill/version/source tuples when available.
+- `sourceProvenance`: optional list or summary of source kinds and source paths when available.
+- `materializationMode`: optional string describing how the runtime received the skill set.
+- `visiblePath`: optional canonical runtime-visible path summary.
+- `backingPath`: optional run-scoped active backing path summary.
+- `readOnly`: optional boolean indicating whether the projection or backing store was read-only where known.
+- `manifestRef`: optional artifact ref or path to the active manifest.
+- `promptIndexRef`: optional artifact ref or compact prompt-index ref.
+- `activationSummaryRef`: optional ref or safe summary label for the activation summary evidence.
+- `diagnostics`: optional `ProjectionDiagnostic` when materialization failed.
+
+Validation:
+- Must contain only metadata, paths, booleans, names, versions, source summaries, and refs.
+- Must not contain full `SKILL.md` bodies or large manifest content.
+- Empty or unknown values should be omitted or rendered as unavailable rather than guessed.
+
+## SkillVersionSummary
+
+Represents one selected skill entry in a compact operator-safe form.
+
+Fields:
+- `name`: skill name.
+- `version`: optional selected version.
+- `sourceKind`: optional source kind such as built-in, deployment, repo, or local.
+- `sourcePath`: optional source path summary when safe and available.
+- `contentRef`: optional artifact/content ref.
+- `contentDigest`: optional digest.
+
+Validation:
+- Full content is never included.
+- Source paths are metadata only and must not reveal credentials.
+
+## ProjectionDiagnostic
+
+Represents an operator-visible projection failure.
+
+Fields:
+- `path`: path involved in the failure.
+- `objectKind`: object kind such as file, directory, symlink, special, or missing.
+- `attemptedAction`: attempted projection/materialization action.
+- `remediation`: operator-safe remediation guidance.
+- `cause`: optional sanitized lower-level cause.
+
+Validation:
+- Must not include full skill bodies, raw credentials, or environment dumps.
+- Must be safe for standard operator-visible diagnostics.
+
+## SkillLifecycleIntent
+
+Represents how skill intent survives proposal, schedule, rerun, retry, and replay paths.
+
+Fields:
+- `source`: proposal, schedule, rerun, retry, continue-as-new, or replay.
+- `selectors`: optional selector summary for runs that should resolve at launch.
+- `resolvedSkillsetRef`: optional snapshot ref for runs that must reuse a previous snapshot.
+- `resolutionMode`: selector-based, snapshot-reuse, inherited-defaults, or explicit-re-resolution.
+- `explanation`: short operator-facing explanation of how the skill snapshot was or will be selected.
+
+Validation:
+- Rerun, retry, continue-as-new, and replay default to snapshot reuse when a resolved snapshot exists.
+- Inheriting deployment defaults must be explicit, not silent.
+- Explicit re-resolution must be distinguishable from snapshot reuse.
+
+## State Transitions
+
+- Submit-time selector -> unresolved skill intent.
+- Runtime resolution -> immutable `resolvedSkillsetRef` and selected skill summaries.
+- Runtime materialization -> `SkillRuntimeEvidence` with visible/backing paths, refs, and diagnostics.
+- Proposal/schedule -> preserved selector intent or explicit default-inheritance note.
+- Rerun/retry/replay -> original `resolvedSkillsetRef` reuse unless explicit re-resolution is requested.

--- a/specs/209-skill-runtime-observability/plan.md
+++ b/specs/209-skill-runtime-observability/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: Skill Runtime Observability and Verification
+
+**Branch**: `[209-skill-runtime-observability]` | **Date**: 2026-04-19 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `specs/209-skill-runtime-observability/spec.md`
+
+## Summary
+
+MM-408 requires operator-visible evidence for skill-enabled executions: selected skills, provenance, materialization mode, visible and backing paths, artifact refs, collision diagnostics, and lifecycle intent for proposal, schedule, rerun, retry, and replay paths. The repo already has resolved skill models, materialization metadata, projection diagnostics, task skill selector pass-through, and a basic task-detail skill badge, but the execution detail contract and UI only expose `resolvedSkillsetRef` and `taskSkills`. This story will add a compact `skillRuntime` execution-detail payload, render richer task-detail provenance, preserve full-body redaction, and add unit plus focused UI/API tests. Lifecycle intent surfaces will be verified through existing proposal/schedule/rerun payload paths first, with implementation contingency where metadata is missing.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `tests/unit/api/routers/test_executions.py` preserves `task.skills` selectors on create | add focused verification in final story tests if touched | unit |
+| FR-002 | partial | `ExecutionModel` exposes only `resolvedSkillsetRef` and `taskSkills`; `SkillProvenanceBadge` renders only explicit selection, delegated skill, and snapshot ref | add `skillRuntime` model/API fields and task-detail rendering for versions/provenance/mode/path refs | unit + UI |
+| FR-003 | partial | `RuntimeSkillMaterialization.metadata` includes `manifestPath`; execution detail does not expose manifest or prompt-index refs as skill refs | include manifest/prompt-index refs in compact `skillRuntime` payload | unit + UI |
+| FR-004 | partial | Standard views currently avoid bodies by omission, but no structured safe skill payload exists | ensure `skillRuntime` contains metadata/refs only and tests reject body leakage | unit + UI |
+| FR-005 | partial | Automation debug surfaces expose selected skill, adapter id, execution path, and flags; task debug surfaces lack raw skill materialization details | keep raw fields out of standard view and expose only safe compact debug-ready metadata | unit |
+| FR-006 | implemented_unverified | `AgentSkillMaterializer` records backing path, visible path, active skills, manifest path, and prompt index ref | wire existing materialization-shaped metadata into execution detail when present | unit |
+| FR-007 | implemented_verified | `AgentSkillMaterializer._projection_error_message` and unit tests include path, object kind, action, remediation, and preserve body redaction | no new implementation unless regression appears | final regression |
+| FR-008 | partial | `TaskProposalCreateRequest` includes `taskSkills`; proposal service tests cover task preview skills, but explicit selector/default-inheritance semantics are not fully documented in the execution detail contract | add lifecycle-intent contract and targeted test coverage where payload already supports it | unit |
+| FR-009 | missing | Schedule mapping tests do not show skill selector or snapshot intent metadata | add schedule/lifecycle metadata planning and focused tests or document unavailable source if blocked | unit |
+| FR-010 | partial | `resolvedSkillsetRef` exists in runtime request models; materializer consumes supplied snapshots; rerun/edit helpers pass task skills but not explicit reuse semantics | add rerun/replay metadata verification or minimal payload support for explicit snapshot reuse | unit |
+| FR-011 | partial | `tests/unit/services/test_skill_materialization.py` covers several boundary cases; exact replay and repo input without mutation need story-level verification across boundary surfaces | add targeted service/activity/API tests for remaining MM-408 evidence | unit |
+| FR-012 | implemented_verified | `spec.md` preserves MM-408 brief and this plan preserves traceability | no code work | final verification |
+| DESIGN-REQ-010 | partial | Task detail has a basic skill badge, create API preserves selectors | add richer operator-visible task detail fields | unit + UI |
+| DESIGN-REQ-018 | partial | Materialization records required evidence, but execution detail does not surface it | expose compact skill runtime evidence | unit + UI |
+| DESIGN-REQ-019 | partial | Existing models carry `resolvedSkillsetRef` and task skills; lifecycle semantics are not explicit enough | add lifecycle intent contract/tests for proposal, schedule, rerun/replay | unit |
+| DESIGN-REQ-020 | partial | Materializer tests cover projection, multi-skill, collision, and no-body behavior; exact-snapshot replay and repo input lifecycle evidence need targeted coverage | add boundary/lifecycle tests | unit |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for task-detail UI  
+**Primary Dependencies**: Pydantic v2, FastAPI, SQLAlchemy async ORM, existing Temporal execution router/service, React, Vitest, pytest  
+**Storage**: Existing Temporal execution records, input parameters, artifact refs, and materialization metadata only; no new persistent tables planned  
+**Unit Testing**: `./tools/test_unit.sh`; focused Python tests with `python -m pytest`; focused UI tests with `npm run ui:test -- <path>` or `./tools/test_unit.sh --ui-args <path>`  
+**Integration Testing**: Existing hermetic suite through `./tools/test_integration.sh`; no new compose service dependency expected  
+**Target Platform**: MoonMind API service, Mission Control task detail, and managed runtime execution metadata surfaces  
+**Project Type**: Web service plus frontend dashboard behavior  
+**Performance Goals**: Skill runtime metadata remains compact and does not require reading full skill bodies or dereferencing artifacts during task-detail render  
+**Constraints**: Preserve artifact-backed payload discipline; do not dump full skill bodies; preserve MM-408 traceability; add workflow/activity or adapter-boundary tests where runtime materialization semantics are affected  
+**Scale/Scope**: One execution detail payload extension, one task-detail UI component extension, lifecycle metadata tests, and focused boundary verification
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Principle I, Orchestrate Don't Recreate: PASS. The story exposes orchestration evidence and does not recreate agent behavior.
+- Principle IV, Own Your Data: PASS. Metadata and artifact refs remain operator-controlled and local to MoonMind surfaces.
+- Principle V, Skills Are First-Class: PASS. The story makes resolved skill state first-class in operator inspection and tests.
+- Principle VII, Powerful Runtime Configurability: PASS. Skill selector and lifecycle intent remains payload/config driven.
+- Principle VIII, Modular and Extensible Architecture: PASS. Changes are scoped to existing execution schemas, router serialization, task-detail UI, and boundary tests.
+- Principle IX, Resilient by Default: PASS. Projection diagnostics remain actionable and replay/rerun semantics are explicit.
+- Principle XII, Canonical Documentation Separates Desired State From Backlog: PASS. This feature uses `docs/tmp` planning artifacts for implementation details and does not rewrite canonical docs as migration trackers.
+- Principle XIII, Pre-Release Compatibility Policy: PASS. No compatibility aliases are planned; the internal execution-detail contract is extended directly.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/209-skill-runtime-observability/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── skill-runtime-observability.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+└── schemas/
+    └── temporal_models.py
+
+api_service/
+└── api/
+    └── routers/
+        └── executions.py
+
+frontend/
+└── src/
+    ├── components/
+    │   └── skills/
+    │       └── SkillProvenanceBadge.tsx
+    └── entrypoints/
+        ├── task-detail.tsx
+        └── task-detail.test.tsx
+
+tests/
+└── unit/
+    ├── api/
+    │   └── routers/
+    │       └── test_executions.py
+    ├── services/
+    │   └── test_skill_materialization.py
+    └── workflows/
+        └── temporal/
+            └── test_run_artifacts.py
+```
+
+**Structure Decision**: Extend existing execution detail and task-detail skill UI surfaces rather than creating a separate skill observability endpoint. Keep runtime materialization behavior in the existing service and tests unless lifecycle verification exposes a gap.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/209-skill-runtime-observability/quickstart.md
+++ b/specs/209-skill-runtime-observability/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Skill Runtime Observability and Verification
+
+## Focused Development Loop
+
+1. Run focused backend tests for execution detail serialization:
+
+```bash
+python -m pytest tests/unit/api/routers/test_executions.py -q
+```
+
+2. Run focused materialization regression tests:
+
+```bash
+python -m pytest tests/unit/services/test_skill_materialization.py -q
+```
+
+3. Run focused task-detail UI tests after JS dependencies are prepared:
+
+```bash
+npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
+```
+
+Or route the UI test through the repo unit runner:
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx
+```
+
+4. Final unit verification:
+
+```bash
+./tools/test_unit.sh
+```
+
+## End-to-End Story Check
+
+1. Submit or simulate a skill-enabled execution with task skill selectors and materialization metadata.
+2. Open the task detail API response or Mission Control task detail view.
+3. Confirm `MM-408` behavior:
+   - resolved snapshot ID is visible when present,
+   - selected skills and versions are visible when present,
+   - source provenance and materialization mode are visible when present,
+   - visible path, backing path, manifest ref, and prompt-index ref are visible when present,
+   - no full skill body text appears in the response or UI,
+   - projection diagnostics include path, object kind, attempted action, and remediation.
+4. Verify proposal, schedule, rerun, retry, or replay metadata makes skill intent or snapshot reuse explicit.
+5. Confirm boundary-level tests prove single-skill projection, multi-skill projection, read-only materialization, activation summary injection, collision failure, exact-snapshot replay, and repo-skill input without in-place mutation.
+
+## Integration Verification
+
+Run hermetic integration only if implementation changes cross a compose-backed route or Temporal worker boundary:
+
+```bash
+./tools/test_integration.sh
+```
+
+Provider verification is not required for this story.

--- a/specs/209-skill-runtime-observability/research.md
+++ b/specs/209-skill-runtime-observability/research.md
@@ -1,0 +1,65 @@
+# Research: Skill Runtime Observability and Verification
+
+## Input Classification
+
+Decision: Treat MM-408 as a single-story runtime feature request.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-408-moonspec-orchestration-input.md` contains one user story focused on operator/maintainer inspection and boundary verification.
+Rationale: The brief has one actor, one operational goal, and one coherent acceptance set. It references implementation documents, but the selected mode is runtime, so those documents are source requirements rather than docs-only targets.
+Alternatives considered: Route through story breakdown; rejected because no multiple independent stories are present.
+Test implications: Unit, UI, and focused boundary tests are required.
+
+## Existing Skill Runtime Evidence
+
+Decision: Reuse existing materialization metadata as the source for compact runtime evidence.
+Evidence: `moonmind/services/skill_materialization.py` returns `RuntimeSkillMaterialization` with `workspace_paths`, `prompt_index_ref`, and metadata such as `activeSkills`, `backingPath`, `visiblePath`, and `manifestPath`; `tests/unit/services/test_skill_materialization.py` verifies projection, manifest fields, no full body in hybrid metadata, and collision diagnostics.
+Rationale: The story asks to surface and verify existing runtime facts, not to create a parallel materialization model.
+Alternatives considered: Read `_manifest.json` during task detail serialization; rejected because task-detail render should remain compact and must not dereference full skill artifacts.
+Test implications: Unit tests should serialize metadata from execution params and assert no skill body leakage.
+
+## FR-001 Submit-Time Visibility
+
+Decision: Mark implemented_unverified and preserve existing create API behavior.
+Evidence: `tests/unit/api/routers/test_executions.py` verifies `task.skills` with sets, include, exclude, and materialization mode pass through create execution initial parameters.
+Rationale: The selector contract already exists. This story may add coverage only if touched by the task-detail payload extension.
+Alternatives considered: Add a new submit UI selector surface; rejected as outside MM-408's detail/lifecycle observability focus.
+Test implications: Existing unit coverage plus final verification.
+
+## FR-002 through FR-006 Task Detail Runtime Evidence
+
+Decision: Add a compact `skillRuntime` execution-detail payload and render it in the existing `SkillProvenanceBadge`.
+Evidence: `ExecutionModel` currently has `resolvedSkillsetRef` and `taskSkills`; `frontend/src/components/skills/SkillProvenanceBadge.tsx` renders explicit selection, delegated skill, and snapshot ref only. Materialization-shaped metadata may be present in execution input parameters as `skillsMaterialized` or related skill metadata.
+Rationale: Operators need one safe detail surface for selected versions, provenance, materialization mode, visible path, backing path, read-only state, and artifact refs. Extending the existing skill provenance UI keeps the feature discoverable.
+Alternatives considered: Add a separate debug-only route; rejected because standard task detail is explicitly in the acceptance criteria.
+Test implications: API serialization unit tests and task-detail Vitest coverage.
+
+## FR-007 Projection Diagnostics
+
+Decision: Treat projection diagnostics as implemented_verified and keep regression coverage.
+Evidence: `AgentSkillMaterializer._projection_error_message` includes path, object kind, attempted action, and remediation; `tests/unit/services/test_skill_materialization.py` verifies incompatible `.agents/skills` path failures preserve existing content and do not dump bodies.
+Rationale: The current behavior already matches the acceptance criterion. This story should not refactor projection failure mechanics unless tests expose a gap.
+Alternatives considered: Add a new diagnostic model; rejected because the existing message is already operator-visible and verified.
+Test implications: Final regression only unless related code changes.
+
+## FR-008 through FR-010 Lifecycle Intent
+
+Decision: Verify and minimally extend lifecycle metadata so proposal, schedule, rerun, retry, and replay paths do not silently lose skill intent or resolved snapshot reuse.
+Evidence: `moonmind/schemas/task_proposal_models.py` includes `taskSkills`; task editing helpers reconstruct `taskSkills`; runtime request models carry `resolvedSkillsetRef`; schedule mapping tests do not currently demonstrate skill intent. `AgentSkillMaterializer` consumes a supplied `ResolvedSkillSet` rather than re-resolving sources.
+Rationale: The source design requires lifecycle intent to be explicit. Where payload support exists, tests should prove it; where schedule metadata is missing, add the smallest explicit representation rather than relying on convention.
+Alternatives considered: Treat lifecycle behavior as documentation-only; rejected because selected mode is runtime and the acceptance criteria require inspectable metadata.
+Test implications: Unit tests for proposal preview skills, rerun/edit reconstruction, schedule payload skill intent, and no silent re-resolution.
+
+## FR-011 Boundary Verification
+
+Decision: Add focused unit and boundary tests only for gaps introduced or exposed by MM-408.
+Evidence: `tests/unit/services/test_skill_materialization.py` already covers single-skill projection, multi-skill projection, read-only-ish link metadata, collision failure, and no full-body hybrid metadata. Additional evidence is needed for execution-detail serialization and lifecycle reuse semantics.
+Rationale: The requirement is about proving real adapter/activity or API boundary behavior, not isolated helper behavior only.
+Alternatives considered: Broad end-to-end Temporal tests; rejected for this story because the required evidence can be covered by existing unit boundaries without adding slow time-skipping workflows.
+Test implications: Unit plus UI tests, with hermetic integration only if implementation crosses a compose-backed boundary.
+
+## Traceability
+
+Decision: Preserve MM-408 in all artifacts and final verification.
+Evidence: `spec.md` includes the full MM-408 brief and this plan names MM-408.
+Rationale: Jira, MoonSpec verification, commits, and PR metadata require source traceability.
+Alternatives considered: Preserve only the summary; rejected because final verification compares against the original brief.
+Test implications: Final verification traceability check.

--- a/specs/209-skill-runtime-observability/spec.md
+++ b/specs/209-skill-runtime-observability/spec.md
@@ -1,0 +1,168 @@
+# Feature Specification: Skill Runtime Observability and Verification
+
+**Feature Branch**: `[209-skill-runtime-observability]`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: User description: "Use the Jira preset brief for MM-408 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+
+Canonical Jira brief: docs/tmp/jira-orchestration-inputs/MM-408-moonspec-orchestration-input.md
+
+# MM-408 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-408
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Skill Runtime Observability and Verification
+- Labels: `moonmind-workflow-mm-84523417-cb8e-4e09-a152-7267f5d213c6`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-408 from MM project
+Summary: Skill Runtime Observability and Verification
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-408 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-408: Skill Runtime Observability and Verification
+
+Source Reference
+- Source Document: docs/Tools/SkillSystem.md
+- Source Title: MM-319: breakdown docs\Tools\SkillSystem.md
+- Source Sections:
+  - AgentSkillSystem §18-§23
+  - SkillInjection §15, §18-§19
+  - docs/tmp/004-AgentSkillSystemPlan.md §2-§5
+- Coverage IDs:
+  - DESIGN-REQ-010
+  - DESIGN-REQ-018
+  - DESIGN-REQ-019
+  - DESIGN-REQ-020
+
+User Story
+As an operator or maintainer, I can inspect which skills were selected, where they came from, how they were materialized, and whether projection succeeded, with boundary tests proving the real adapter and activity behavior rather than isolated helper behavior only.
+
+Acceptance Criteria
+- Given a task detail view or API response for a run with skills, then it exposes resolved snapshot ID, selected skill versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs where appropriate.
+- Given a projection collision occurs, then operator-visible diagnostics include the path, object kind, attempted projection action, and remediation without dumping full skill bodies.
+- Given proposal, schedule, or rerun metadata is inspected, then skill intent or resolved snapshot reuse is explicit and re-resolution is never silent.
+- Given the skill injection implementation changes, then real adapter or activity boundary tests cover single-skill and multi-skill projections, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+
+Requirements
+- Surface resolved skill metadata in submit, detail, and debug contexts appropriate to operator permissions.
+- Record active backing path, visible path, projected skills and versions, read-only state, collision failures, and activation summary evidence.
+- Preserve artifact and payload discipline by linking manifests or prompt indexes instead of logging full bodies by default.
+- Add or maintain boundary-level tests for adapter and activity behavior when skill injection or resolution behavior changes.
+
+Relevant Implementation Notes
+- Keep skill observability focused on metadata and artifact refs rather than full skill body content.
+- Include selected skill versions, source provenance, materialization mode, runtime-visible path summary, active backing path, read-only state, and collision diagnostics where the existing submit, detail, debug, proposal, schedule, or rerun surfaces expose skill runtime state.
+- Treat projection failures as operator-visible diagnostics with path, object kind, attempted projection action, and remediation guidance.
+- Make skill intent or resolved snapshot reuse explicit for proposal, schedule, and rerun flows so re-resolution is not silent.
+- Cover real adapter or activity boundaries when skill injection or resolution behavior changes, including single-skill projection, multi-skill projection, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+
+Verification
+- Confirm task detail or API responses for runs with skills expose resolved snapshot ID, selected skill versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs where appropriate.
+- Confirm projection collision diagnostics include path, object kind, attempted projection action, and remediation without dumping full skill bodies.
+- Confirm proposal, schedule, and rerun metadata make skill intent or resolved snapshot reuse explicit and do not silently re-resolve.
+- Confirm boundary-level tests cover single-skill and multi-skill projections, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+- Preserve MM-408 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Jira link metadata at fetch time indicates MM-408 blocks MM-407."
+
+## Classification
+
+- Input type: single-story feature request.
+- Selected mode: runtime.
+- Resume decision: no existing `MM-408` Moon Spec feature directory was present, so orchestration starts at `moonspec-specify`.
+- Source handling: the historical `docs/Tools/SkillSystem.md` source reference is absent in this checkout; the current canonical source is `docs/Tasks/AgentSkillSystem.md`, with `docs/Tools/SkillInjection.md` and `docs/tmp/004-AgentSkillSystemPlan.md` providing the referenced implementation-plan context.
+
+## User Story - Inspect Skill Runtime Evidence
+
+**Summary**: As an operator or maintainer, I want execution surfaces and verification evidence to show which skills were selected, how they were materialized, and whether projection succeeded, so I can audit skill-enabled runs without reading full skill bodies from logs or workflow history.
+
+**Goal**: Skill-enabled executions expose enough runtime metadata, diagnostics, and lifecycle intent to answer what skill set was selected and what skill view the runtime actually saw, while keeping large skill content behind artifact references and preserving boundary-level test evidence.
+
+**Independent Test**: Can be fully tested by creating or simulating skill-enabled executions, projection failures, rerun or scheduled metadata, and adapter/activity boundary cases, then verifying operator-visible metadata, redacted diagnostics, artifact references, and tests prove the real runtime boundary behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a run with resolved skills, **When** an operator inspects the task detail view or corresponding API response, **Then** the response exposes resolved snapshot ID, selected skill versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs where appropriate.
+2. **Given** skill projection collides with an incompatible path, **When** the failure is surfaced to an operator, **Then** diagnostics include the path, object kind, attempted projection action, and remediation without dumping full skill bodies.
+3. **Given** a proposal, schedule, or rerun references skill-enabled execution, **When** metadata is inspected, **Then** skill intent or resolved snapshot reuse is explicit and re-resolution is never silent.
+4. **Given** skill injection or resolution behavior changes, **When** the test suite runs, **Then** real adapter or activity boundary tests cover single-skill projection, multi-skill projection, read-only materialization, activation summary injection, collision failure, replay reuse, and repo-skill input without in-place mutation.
+
+### Edge Cases
+
+- A run has no selected skills and should show an explicit empty or default skill state rather than ambiguous missing metadata.
+- A manifest or prompt-index artifact ref exists but cannot be previewed by the current operator.
+- Projection fails before runtime launch and no active backing path exists yet.
+- A rerun uses a previously resolved snapshot while newer skill versions are available.
+- Scheduled execution stores skill selectors but resolves the concrete snapshot only when the run starts.
+- Debug surfaces may expose lower-level refs, but standard views must avoid full skill body dumps.
+
+## Assumptions
+
+- The historical `docs/Tools/SkillSystem.md` source reference maps to the current canonical agent-skill design in `docs/Tasks/AgentSkillSystem.md`.
+- `docs/Tools/SkillInjection.md` is the current repository source for manifest, observability, and boundary-test requirements referenced by the Jira brief's `SkillInjection` sections.
+- This story covers runtime observability, lifecycle metadata, and verification evidence; it does not redefine the skill catalog, resolution precedence, or projection mechanics already covered by earlier MM-405 through MM-407 stories.
+- MM-408 blocking MM-407 is preserved as Jira relationship context, but this spec covers only MM-408's selected single story.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-010**: Source `docs/Tasks/AgentSkillSystem.md` sections 18 through 18.3. Operator-facing submit, detail, and debug surfaces SHOULD expose selected skill sets, source provenance, materialization mode, resolved snapshot ID, selected versions, canonical path summary, and artifact refs appropriate to the surface. Scope: in scope. Maps to FR-001, FR-002, FR-003, FR-004, and FR-005.
+- **DESIGN-REQ-018**: Source `docs/Tools/SkillInjection.md` sections 15 and 18. Active projection observability SHOULD record resolved snapshot ref, backing path, visible path, projected skill names and versions, read-only state, collision or projection failures, and the activation summary while preserving manifest or prompt-index artifact discipline. Scope: in scope. Maps to FR-002, FR-003, FR-004, FR-006, and FR-007.
+- **DESIGN-REQ-019**: Source `docs/Tasks/AgentSkillSystem.md` sections 19 through 19.4 and `docs/tmp/004-AgentSkillSystemPlan.md` sections 2 through 5. Proposal, schedule, rerun, retry, and replay semantics MUST preserve skill intent or the original resolved snapshot explicitly; reruns and continuations must not silently re-resolve latest skills. Scope: in scope. Maps to FR-008, FR-009, and FR-010.
+- **DESIGN-REQ-020**: Source `docs/Tools/SkillInjection.md` section 19. Changes to skill injection SHOULD include real adapter or activity boundary tests covering single-skill projection, multi-skill projection, read-only materialization, activation-summary injection, collision failure, exact-snapshot replay, and repo-skill input without in-place mutation. Scope: in scope. Maps to FR-011 and FR-012.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose skill selection intent on submit-time or task-input surfaces when operators provide named skill sets, explicit includes or excludes, materialization mode, or repo/local overlay enablement.
+- **FR-002**: System MUST expose resolved skill runtime metadata on task detail or equivalent execution inspection surfaces for runs with skills, including resolved snapshot ID, selected skill versions, source provenance, materialization mode, and canonical runtime-visible path summary.
+- **FR-003**: System MUST expose manifest or prompt-index artifact refs for resolved skills where appropriate instead of embedding full skill bodies in standard operator-visible responses.
+- **FR-004**: System MUST keep standard operator-visible skill diagnostics scoped to metadata and artifact refs appropriate to the operator's permissions.
+- **FR-005**: System MAY expose raw resolved refs, raw manifest refs, source-trace details, or adapter materialization metadata only on advanced or debug surfaces intended for that level of detail.
+- **FR-006**: System MUST record active backing path, visible path, projected skill names and versions, read-only state, and activation summary evidence for skill materialization outcomes where that data exists.
+- **FR-007**: System MUST surface projection collision failures with path, object kind, attempted projection action, and remediation guidance without dumping full skill bodies.
+- **FR-008**: Proposal metadata for skill-enabled work MUST either preserve explicit skill selectors or explicitly state that deployment defaults will be inherited at promotion time.
+- **FR-009**: Scheduled execution metadata MUST preserve skill intent clearly and explain how the scheduled run's skill snapshot was selected when the run starts.
+- **FR-010**: Rerun, retry, continue-as-new, and replay semantics MUST reuse the original resolved snapshot unless an explicit new-resolution action is taken.
+- **FR-011**: Changes to skill injection or resolution behavior MUST include real adapter or activity boundary tests covering single-skill and multi-skill projection, read-only materialization, activation summary injection, collision failure, exact-snapshot replay, and repo-skill input without in-place mutation.
+- **FR-012**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata for this work MUST preserve Jira issue key `MM-408` and the original Jira preset brief.
+
+### Key Entities
+
+- **Skill Runtime Evidence**: Operator-visible and debug-safe metadata describing the resolved snapshot, selected skills, versions, provenance, materialization mode, visible path, backing path, read-only state, activation summary, and artifact refs.
+- **Projection Diagnostic**: A failure or warning record that identifies a projection path, object kind, attempted action, and remediation without exposing full skill content.
+- **Skill Lifecycle Intent**: Metadata carried by proposals, schedules, reruns, retries, and continuations that explains whether execution reuses a resolved snapshot, stores selectors, or inherits deployment defaults.
+- **Boundary Verification Evidence**: Unit or integration evidence proving the adapter or activity boundary behavior that selected, materialized, exposed, failed, or replayed skill runtime state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For at least one skill-enabled run, operator inspection can identify the resolved snapshot ID, selected skill names and versions, source provenance, materialization mode, visible path summary, and manifest or prompt-index artifact refs from a single task detail or equivalent API response.
+- **SC-002**: Projection collision diagnostics include all four required fields: path, object kind, attempted action, and remediation, with zero full skill bodies included in the diagnostic output.
+- **SC-003**: Proposal, schedule, and rerun metadata each make skill intent or resolved snapshot reuse explicit in verification evidence.
+- **SC-004**: Boundary-level tests cover all seven required cases: single-skill projection, multi-skill projection, read-only materialization, activation summary injection, collision failure, exact-snapshot replay, and repo-skill input without in-place mutation.
+- **SC-005**: Verification evidence preserves `MM-408` and the original Jira preset brief as the source for the feature.

--- a/specs/209-skill-runtime-observability/tasks.md
+++ b/specs/209-skill-runtime-observability/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Skill Runtime Observability and Verification
+
+**Input**: `specs/209-skill-runtime-observability/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-runtime-observability.md`, `quickstart.md`
+**Prerequisites**: Specify and plan artifacts complete; no unresolved clarification markers.
+**Unit Test Command**: `./tools/test_unit.sh`
+**Focused Backend Test Commands**: `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q`
+**Focused UI Test Command**: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx`
+**Integration Test Command**: `./tools/test_integration.sh` if implementation crosses compose-backed or Temporal worker boundaries.
+
+## Source Traceability
+
+- Original request: MM-408 Jira preset brief preserved in `spec.md`.
+- Story: Inspect Skill Runtime Evidence.
+- Acceptance scenarios: SCN-001 task detail/API evidence, SCN-002 projection collision diagnostics, SCN-003 lifecycle intent, SCN-004 boundary tests.
+- In-scope source IDs: DESIGN-REQ-010, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-020.
+- Requirement statuses from `plan.md`: implemented_unverified (FR-001, FR-006), partial (FR-002, FR-003, FR-004, FR-005, FR-008, FR-010, FR-011, DESIGN-REQ-010, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-020), missing (FR-009), implemented_verified (FR-007, FR-012).
+
+## Phase 1: Setup
+
+- [X] T001 Verify active feature artifacts exist in `specs/209-skill-runtime-observability/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/skill-runtime-observability.md`, and `quickstart.md`.
+- [X] T002 Confirm the focused backend and UI test commands from `specs/209-skill-runtime-observability/quickstart.md` are available in the current environment.
+
+## Phase 2: Foundational
+
+- [X] T003 Inspect current execution detail schema and serializer in `moonmind/schemas/temporal_models.py` and `api_service/api/routers/executions.py` for existing `resolvedSkillsetRef`, `taskSkills`, and input parameter metadata paths.
+- [X] T004 Inspect current task-detail skill UI in `frontend/src/components/skills/SkillProvenanceBadge.tsx` and `frontend/src/entrypoints/task-detail.tsx` to identify the minimum safe payload extension.
+
+## Phase 3: Story - Inspect Skill Runtime Evidence
+
+**Story Summary**: Operators and maintainers can inspect compact skill runtime evidence and lifecycle intent without full skill body leakage.
+**Independent Test**: Simulate skill-enabled execution detail payloads, projection failures, and lifecycle metadata, then verify API/UI output and boundary tests.
+**Traceability IDs**: FR-001 through FR-012, SCN-001 through SCN-004, SC-001 through SC-005, DESIGN-REQ-010, DESIGN-REQ-018, DESIGN-REQ-019, DESIGN-REQ-020.
+
+### Unit Test Plan
+
+- API serialization tests for `skillRuntime` metadata and no body leakage.
+- Existing materialization tests retained for projection diagnostics.
+- Lifecycle metadata tests for proposal/schedule/rerun intent where supported by current payload helpers.
+
+### Integration/UI Test Plan
+
+- Task-detail UI test rendering selected versions, provenance, materialization mode, paths, and refs from `skillRuntime`.
+- UI test confirming missing metadata remains stable and no full skill body appears.
+
+### Tests First
+
+- [X] T005 [P] Add failing API unit test for compact `skillRuntime` serialization from execution params in `tests/unit/api/routers/test_executions.py` covering FR-002, FR-003, FR-004, FR-006, SCN-001, DESIGN-REQ-010, and DESIGN-REQ-018.
+- [X] T006 [P] Add failing API unit test for lifecycle skill intent metadata in `tests/unit/api/routers/test_executions.py` covering FR-008, FR-009, FR-010, SCN-003, and DESIGN-REQ-019.
+- [X] T007 [P] Add failing UI test for rich skill provenance rendering in `frontend/src/entrypoints/task-detail.test.tsx` covering FR-002, FR-003, FR-004, SCN-001, and SC-001.
+- [X] T008 [P] Add or confirm projection diagnostic no-body regression coverage in `tests/unit/services/test_skill_materialization.py` covering FR-007 and SCN-002.
+- [X] T009 [P] Add or confirm boundary verification coverage for exact snapshot replay and repo-skill input without in-place mutation in `tests/unit/services/test_skill_materialization.py` or the closest existing activity-boundary test covering FR-011, SCN-004, and DESIGN-REQ-020.
+
+### Red-First Confirmation
+
+- [X] T010 Run `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q` and confirm new backend tests fail for missing `skillRuntime` and lifecycle metadata before production changes.
+- [X] T011 Run `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` and confirm the new UI test fails before frontend implementation.
+
+### Implementation
+
+- [X] T012 Add compact skill runtime Pydantic models to `moonmind/schemas/temporal_models.py` covering FR-002, FR-003, FR-004, FR-006, DESIGN-REQ-010, and DESIGN-REQ-018.
+- [X] T013 Implement skill runtime metadata extraction in `api_service/api/routers/executions.py` from existing execution params, task payload, and materialization-shaped metadata without dereferencing full skill bodies, covering FR-002, FR-003, FR-004, FR-006, SCN-001, and SC-001.
+- [X] T014 Implement lifecycle skill intent extraction in `api_service/api/routers/executions.py` using available selector and `resolvedSkillsetRef` metadata, covering FR-008, FR-009, FR-010, SCN-003, and DESIGN-REQ-019.
+- [X] T015 Extend task-detail parsing in `frontend/src/entrypoints/task-detail.tsx` to accept `skillRuntime` while preserving existing `resolvedSkillsetRef` and `taskSkills` behavior, covering FR-002 and FR-003.
+- [X] T016 Update `frontend/src/components/skills/SkillProvenanceBadge.tsx` to render compact selected versions, provenance, materialization mode, visible path, backing path, manifest ref, prompt-index ref, lifecycle intent, and diagnostics without full body content, covering FR-002 through FR-005 and SCN-001 through SCN-003.
+- [X] T017 Conditional fallback: if T009 exposes missing exact-snapshot or repo-input boundary behavior, update `moonmind/services/skill_materialization.py` or the closest activity-boundary implementation to preserve snapshot reuse evidence and repo input non-mutation, covering FR-011 and DESIGN-REQ-020.
+
+### Story Validation
+
+- [X] T018 Run focused backend tests `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q` and record PASS/FAIL evidence for FR-001 through FR-012.
+- [X] T019 Run focused UI tests `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` and record PASS/FAIL evidence for SCN-001 through SCN-003.
+- [X] T020 Verify `rg -n "MM-408|DESIGN-REQ-010|DESIGN-REQ-018|DESIGN-REQ-019|DESIGN-REQ-020" specs/209-skill-runtime-observability` preserves traceability for FR-012 and SC-005.
+
+## Final Phase: Polish and Verification
+
+- [X] T021 Review changed API/UI payloads for secret-like strings and full skill body leakage in `moonmind/schemas/temporal_models.py`, `api_service/api/routers/executions.py`, `frontend/src/components/skills/SkillProvenanceBadge.tsx`, and `frontend/src/entrypoints/task-detail.tsx`.
+- [X] T022 Run final unit verification with `./tools/test_unit.sh`.
+- [X] T023 Run `./tools/test_integration.sh` only if implementation changed compose-backed or Temporal worker boundary behavior; otherwise document why it was not required.
+- [X] T024 Run `/speckit.verify` via `moonspec-verify` against `specs/209-skill-runtime-observability/spec.md` after implementation and tests pass.
+
+## Dependencies and Execution Order
+
+1. T001-T004 complete setup and context.
+2. T005-T009 create tests before production code.
+3. T010-T011 confirm red-first behavior.
+4. T012-T017 implement only after red-first confirmation.
+5. T018-T020 validate the story.
+6. T021-T024 complete final verification.
+
+## Parallel Opportunities
+
+- T005, T007, T008, and T009 can be drafted in parallel because they touch different test concerns.
+- T012 and T015 can proceed in parallel after red-first confirmation because they touch backend schema and frontend parsing separately, but T016 depends on the final `skillRuntime` shape from T012/T015.
+- T020 can run in parallel with focused test validation after implementation is complete.
+
+## Implementation Strategy
+
+Use the existing `resolvedSkillsetRef` and `taskSkills` fields as compatibility anchors while adding a compact `skillRuntime` object for richer evidence. For partial requirements, add tests first, implement the smallest serializer/UI extension, and keep materialization behavior unchanged unless verification exposes a gap. For implemented-verified rows FR-007 and FR-012, preserve existing evidence and cover them in final verification rather than adding unnecessary implementation work.
+
+## Execution Notes
+
+- T010 red-first backend evidence: `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q` failed before implementation with missing `taskSkills` selector normalization and missing `skillRuntime`.
+- T011 red-first UI evidence: `npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx` was blocked by npm PATH bin lookup in the managed workspace path containing `:`; direct local Vitest invocation was used for focused UI verification after implementation.
+- T017 fallback was not needed; existing materialization tests already cover selected snapshot input, selected-only projection, incompatible source path non-mutation, and no body leakage.
+- T018 evidence: `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q` passed with 97 tests.
+- T019 evidence: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-detail.test.tsx` passed with 71 tests.
+- T022 evidence: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` passed with 3621 Python tests, 1 xpassed, 16 subtests, and 71 targeted UI tests.
+- T023 integration decision: not run because implementation stayed in execution-detail serialization, existing materialization unit boundaries, and task-detail rendering; no compose-backed or Temporal worker boundary behavior changed.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2177,13 +2177,84 @@ def test_serialize_execution_surfaces_compact_skill_runtime_metadata() -> None:
     assert skill_runtime["promptIndexRef"] == "artifact:prompt-index-1"
     assert skill_runtime["activationSummaryRef"] == "artifact:activation-summary-1"
     assert skill_runtime["lifecycleIntent"] == {
-        "source": "run",
+        "source": "proposal",
         "selectors": ["operator-default", "pr-resolver"],
         "resolvedSkillsetRef": "artifact:resolved-skills-1",
         "resolutionMode": "snapshot-reuse",
         "explanation": "Execution reuses the resolved skill snapshot unless explicit re-resolution is requested.",
     }
     assert "FULL SKILL BODY SHOULD NOT LEAK" not in str(dumped["skillRuntime"])
+
+
+def test_serialize_execution_preserves_direct_skill_source_provenance() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "task": {"instructions": "Inspect skill runtime evidence."},
+        "skillsMaterialized": {
+            "selectedSkills": ["pr-resolver", "fix-ci"],
+            "selectedVersions": [
+                {"name": "pr-resolver", "version": "1.2.0"},
+                {
+                    "name": "fix-ci",
+                    "version": "2.0.0",
+                    "source_kind": "deployment",
+                    "source_path": ".agents/skills/fix-ci",
+                },
+            ],
+            "sourceProvenance": [
+                {
+                    "name": "pr-resolver",
+                    "sourceKind": "repo",
+                    "sourcePath": ".agents/skills/pr-resolver",
+                }
+            ],
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    assert payload["skillRuntime"]["sourceProvenance"] == [
+        {
+            "name": "pr-resolver",
+            "sourceKind": "repo",
+            "sourcePath": ".agents/skills/pr-resolver",
+        },
+        {
+            "name": "fix-ci",
+            "sourceKind": "deployment",
+            "sourcePath": ".agents/skills/fix-ci",
+        },
+    ]
+
+
+def test_serialize_execution_accepts_snake_case_skill_materialization_metadata() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "task": {
+            "instructions": "Inspect skill runtime evidence.",
+            "skills": {"materialization_mode": "hybrid"},
+        },
+        "skillsMaterialized": {
+            "activeSkills": ["pr-resolver"],
+            "visible_path": ".agents/skills",
+            "backing_path": "../skills_active",
+            "read_only": False,
+            "manifest_ref": "artifact:manifest-1",
+            "prompt_index_ref": "artifact:prompt-index-1",
+            "activation_summary_ref": "artifact:activation-summary-1",
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+    skill_runtime = payload["skillRuntime"]
+
+    assert skill_runtime["materializationMode"] == "hybrid"
+    assert skill_runtime["visiblePath"] == ".agents/skills"
+    assert skill_runtime["backingPath"] == "../skills_active"
+    assert skill_runtime["readOnly"] is False
+    assert skill_runtime["manifestRef"] == "artifact:manifest-1"
+    assert skill_runtime["promptIndexRef"] == "artifact:prompt-index-1"
+    assert skill_runtime["activationSummaryRef"] == "artifact:activation-summary-1"
 
 
 def test_serialize_execution_surfaces_skill_lifecycle_intent_for_schedule_defaults() -> None:
@@ -2207,6 +2278,23 @@ def test_serialize_execution_surfaces_skill_lifecycle_intent_for_schedule_defaul
     assert lifecycle["selectors"] == ["nightly"]
     assert lifecycle["resolutionMode"] == "selector-based"
     assert lifecycle["explanation"] == "Scheduled run resolves selected skills when it starts."
+
+
+def test_serialize_execution_marks_lifecycle_defaults_as_inherited_defaults() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.SCHEDULED)
+    record.parameters = {
+        "task": {"instructions": "Run this later."},
+        "skillLifecycleIntent": {"source": "schedule"},
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    lifecycle = payload["skillRuntime"]["lifecycleIntent"]
+    assert lifecycle["source"] == "schedule"
+    assert lifecycle["selectors"] == []
+    assert lifecycle["resolvedSkillsetRef"] is None
+    assert lifecycle["resolutionMode"] == "inherited-defaults"
+    assert lifecycle["explanation"] == "Execution inherits deployment skill defaults explicitly."
 
 
 def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run(

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2115,6 +2115,100 @@ def test_serialize_execution_surfaces_runtime_fields_from_task_runtime_payload()
     assert dumped["profileId"] == "profile:claude-default"
 
 
+def test_serialize_execution_surfaces_compact_skill_runtime_metadata() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "resolvedSkillsetRef": "artifact:resolved-skills-1",
+        "task": {
+            "instructions": "Inspect skill runtime evidence.",
+            "skills": {
+                "sets": ["operator-default"],
+                "include": [{"name": "pr-resolver", "version": "1.2.0"}],
+                "materializationMode": "hybrid",
+            },
+        },
+        "skillsMaterialized": {
+            "activeSkills": ["pr-resolver"],
+            "skills": [
+                {
+                    "name": "pr-resolver",
+                    "version": "1.2.0",
+                    "source_kind": "deployment",
+                    "content_ref": "artifact:skill-body-1",
+                    "content_digest": "sha256:abc",
+                    "body": "FULL SKILL BODY SHOULD NOT LEAK",
+                }
+            ],
+            "materializationMode": "hybrid",
+            "visiblePath": ".agents/skills",
+            "backingPath": "../skills_active",
+            "readOnly": True,
+            "manifestPath": "artifact:manifest-1",
+            "promptIndexRef": "artifact:prompt-index-1",
+            "activationSummaryRef": "artifact:activation-summary-1",
+        },
+    }
+
+    payload = _serialize_execution(record)
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["taskSkills"] == ["operator-default", "pr-resolver"]
+    skill_runtime = dumped["skillRuntime"]
+    assert skill_runtime["resolvedSkillsetRef"] == "artifact:resolved-skills-1"
+    assert skill_runtime["selectedSkills"] == ["pr-resolver"]
+    assert skill_runtime["selectedVersions"][0] == {
+        "name": "pr-resolver",
+        "version": "1.2.0",
+        "sourceKind": "deployment",
+        "sourcePath": None,
+        "contentRef": "artifact:skill-body-1",
+        "contentDigest": "sha256:abc",
+    }
+    assert skill_runtime["sourceProvenance"][0] == {
+        "name": "pr-resolver",
+        "sourceKind": "deployment",
+        "sourcePath": None,
+    }
+    assert skill_runtime["materializationMode"] == "hybrid"
+    assert skill_runtime["visiblePath"] == ".agents/skills"
+    assert skill_runtime["backingPath"] == "../skills_active"
+    assert skill_runtime["readOnly"] is True
+    assert skill_runtime["manifestRef"] == "artifact:manifest-1"
+    assert skill_runtime["promptIndexRef"] == "artifact:prompt-index-1"
+    assert skill_runtime["activationSummaryRef"] == "artifact:activation-summary-1"
+    assert skill_runtime["lifecycleIntent"] == {
+        "source": "run",
+        "selectors": ["operator-default", "pr-resolver"],
+        "resolvedSkillsetRef": "artifact:resolved-skills-1",
+        "resolutionMode": "snapshot-reuse",
+        "explanation": "Execution reuses the resolved skill snapshot unless explicit re-resolution is requested.",
+    }
+    assert "FULL SKILL BODY SHOULD NOT LEAK" not in str(dumped["skillRuntime"])
+
+
+def test_serialize_execution_surfaces_skill_lifecycle_intent_for_schedule_defaults() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.SCHEDULED)
+    record.parameters = {
+        "task": {
+            "instructions": "Run this later.",
+            "skills": {"sets": ["nightly"], "materializationMode": "hybrid"},
+        },
+        "skillLifecycleIntent": {
+            "source": "schedule",
+            "resolutionMode": "selector-based",
+            "explanation": "Scheduled run resolves selected skills when it starts.",
+        },
+    }
+
+    payload = _serialize_execution(record).model_dump(by_alias=True)
+
+    lifecycle = payload["skillRuntime"]["lifecycleIntent"]
+    assert lifecycle["source"] == "schedule"
+    assert lifecycle["selectors"] == ["nightly"]
+    assert lifecycle["resolutionMode"] == "selector-based"
+    assert lifecycle["explanation"] == "Scheduled run resolves selected skills when it starts."
+
+
 def test_serialize_execution_ignores_stale_waiting_reason_for_executing_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Implements Jira issue MM-408 by adding compact skill runtime observability to execution detail surfaces and preserving the MoonSpec traceability for `specs/209-skill-runtime-observability`.

## Jira

- Jira issue key: MM-408

## MoonSpec

- Active feature path: `specs/209-skill-runtime-observability`
- Verification verdict: FULLY_IMPLEMENTED

## Tests Run

- `python -m pytest tests/unit/api/routers/test_executions.py tests/unit/services/test_skill_materialization.py -q` - PASS, 97 tests
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/task-detail.test.tsx` - PASS, 71 tests
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx` - PASS, 3621 Python tests, 1 xpassed, 16 subtests, and 71 targeted UI tests

## Remaining Risks

- `./tools/test_integration.sh` was not run because the change stayed within execution-detail serialization, existing materialization unit boundaries, and task-detail rendering. No compose-backed route or Temporal worker boundary behavior changed.
- Local Git metadata in this managed checkout has root-owned reflog/index files, so the remote branch push succeeded while the local remote-tracking reflog update reported a permission warning.