### PR TITLE
Remove the line "PR with Merge Automation uses pr-resolver after the PR readiness gate opens; it does not bypass resolver handling." from the UI. This

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5584,8 +5584,9 @@ describe("Task Create Entrypoint", () => {
       const datalist = document.querySelector<HTMLDataListElement>(
         "#queue-branch-options",
       );
+      expect(datalist).not.toBeNull();
       expect(
-        Array.from(datalist?.querySelectorAll("option") || []).some(
+        Array.from(datalist?.querySelectorAll("option") ?? []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);
@@ -5669,8 +5670,9 @@ describe("Task Create Entrypoint", () => {
       const datalist = document.querySelector<HTMLDataListElement>(
         "#queue-branch-options",
       );
+      expect(datalist).not.toBeNull();
       expect(
-        Array.from(datalist?.querySelectorAll("option") || []).some(
+        Array.from(datalist?.querySelectorAll("option") ?? []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);
@@ -5707,8 +5709,9 @@ describe("Task Create Entrypoint", () => {
       const datalist = document.querySelector<HTMLDataListElement>(
         "#queue-branch-options",
       );
+      expect(datalist).not.toBeNull();
       expect(
-        Array.from(datalist?.querySelectorAll("option") || []).some(
+        Array.from(datalist?.querySelectorAll("option") ?? []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -2711,7 +2711,7 @@ describe("Task Create Entrypoint", () => {
         (screen.getByLabelText(/GitHub Repo/) as HTMLInputElement).value,
       ).toBe("MoonLadderStudios/MoonMind");
       expect(
-        (screen.getByLabelText("Branch") as HTMLSelectElement).value,
+        (screen.getByLabelText("Branch") as HTMLInputElement).value,
       ).toBe("main");
       expect(
         (screen.getByLabelText("Publish Mode") as HTMLSelectElement).value,
@@ -4895,7 +4895,7 @@ describe("Task Create Entrypoint", () => {
       ),
     ).toBe(true);
     expect(screen.queryByLabelText("Enable merge automation")).toBeNull();
-    expect(screen.getByText(/uses pr-resolver/i)).toBeTruthy();
+    expect(screen.queryByText(/uses pr-resolver/i)).toBeNull();
     expect(screen.queryByText(/direct auto-merge/i)).toBeNull();
 
     fireEvent.change(screen.getByLabelText("Publish Mode"), {
@@ -5578,10 +5578,14 @@ describe("Task Create Entrypoint", () => {
   it("loads branches through MoonMind and submits one authored branch", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const branchSelect = await screen.findByLabelText("Branch");
+    const branchInput = await screen.findByLabelText("Branch");
+    expect(branchInput.getAttribute("list")).toBe("queue-branch-options");
     await waitFor(() => {
+      const datalist = document.querySelector<HTMLDataListElement>(
+        "#queue-branch-options",
+      );
       expect(
-        Array.from((branchSelect as HTMLSelectElement).options).some(
+        Array.from(datalist?.querySelectorAll("option") || []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);
@@ -5594,7 +5598,7 @@ describe("Task Create Entrypoint", () => {
       ),
     ).toBe(true);
 
-    fireEvent.change(branchSelect, {
+    fireEvent.change(branchInput, {
       target: { value: "feature/create-page" },
     });
     fireEvent.change(screen.getByLabelText("Instructions"), {
@@ -5628,14 +5632,12 @@ describe("Task Create Entrypoint", () => {
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const branchSelect = (await screen.findByLabelText(
+    const branchInput = (await screen.findByLabelText(
       "Branch",
-    )) as HTMLSelectElement;
+    )) as HTMLInputElement;
 
     await waitFor(() => {
-      expect(branchSelect.selectedOptions[0]?.textContent).toBe(
-        "Loading branches...",
-      );
+      expect(branchInput.getAttribute("placeholder")).toBe("Loading branches...");
     });
     expect(
       Array.from(document.querySelectorAll("p")).some(
@@ -5660,18 +5662,21 @@ describe("Task Create Entrypoint", () => {
 
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
-    const branchSelect = (await screen.findByLabelText(
+    const branchInput = (await screen.findByLabelText(
       "Branch",
-    )) as HTMLSelectElement;
+    )) as HTMLInputElement;
     await waitFor(() => {
+      const datalist = document.querySelector<HTMLDataListElement>(
+        "#queue-branch-options",
+      );
       expect(
-        Array.from(branchSelect.options).some(
+        Array.from(datalist?.querySelectorAll("option") || []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);
     });
 
-    fireEvent.change(branchSelect, {
+    fireEvent.change(branchInput, {
       target: { value: "feature/create-page" },
     });
     fireEvent.change(screen.getByLabelText(/GitHub Repo/), {
@@ -5696,10 +5701,14 @@ describe("Task Create Entrypoint", () => {
       />,
     );
 
-    const branchSelect = await screen.findByLabelText("Branch");
+    const branchInput = await screen.findByLabelText("Branch");
+    expect(branchInput.getAttribute("list")).toBe("queue-branch-options");
     await waitFor(() => {
+      const datalist = document.querySelector<HTMLDataListElement>(
+        "#queue-branch-options",
+      );
       expect(
-        Array.from((branchSelect as HTMLSelectElement).options).some(
+        Array.from(datalist?.querySelectorAll("option") || []).some(
           (option) => option.value === "feature/create-page",
         ),
       ).toBe(true);

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -3784,7 +3784,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
   const branchOptions = useMemo(() => {
     const items = branchOptionsQuery.data || [];
     const seen = new Set<string>();
-    const options = items.filter((item) => {
+    return items.filter((item) => {
       const key = item.value;
       if (!key || seen.has(key)) {
         return false;
@@ -3792,19 +3792,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
       seen.add(key);
       return true;
     });
-    const selected = branch.trim();
-    if (selected && !seen.has(selected)) {
-      return [
-        {
-          value: selected,
-          label: `${selected} (not in latest branch list)`,
-          source: "stale",
-        },
-        ...options,
-      ];
-    }
-    return options;
-  }, [branch, branchOptionsQuery.data]);
+  }, [branchOptionsQuery.data]);
   const selectedBranchIsStale = Boolean(
     branch.trim() &&
       branchOptionsQuery.isSuccess &&

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -20,6 +20,7 @@ const SKILL_OPTIONS_DATALIST_ID = "queue-skill-options";
 const MODEL_OPTIONS_DATALIST_ID = "queue-model-options";
 const EFFORT_OPTIONS_DATALIST_ID = "queue-effort-options";
 const REPOSITORY_OPTIONS_DATALIST_ID = "queue-repository-options";
+const BRANCH_OPTIONS_DATALIST_ID = "queue-branch-options";
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const PR_RESOLVER_SKILLS = new Set(["pr-resolver", "batch-pr-resolver"]);
 const JIRA_BREAKDOWN_PRESET_SLUG = "jira-breakdown";
@@ -5557,6 +5558,13 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
                 </option>
               ))}
             </datalist>
+            <datalist id={BRANCH_OPTIONS_DATALIST_ID}>
+              {branchOptions.map((item) => (
+                <option key={`${item.source}:${item.value}`} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </datalist>
 
             {steps.map((step, index) => {
               const isPrimaryStep = index === 0;
@@ -6545,24 +6553,17 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
             </div>
             <div className="queue-inline-selector queue-inline-selector--branch">
               <BranchIcon />
-              <select
+              <input
                 name="branch"
                 aria-label="Branch"
+                list={BRANCH_OPTIONS_DATALIST_ID}
                 value={branch}
+                placeholder={
+                  branchOptionsQuery.isLoading ? "Loading branches..." : "Branch"
+                }
                 disabled={branchControlDisabled}
                 onChange={(event) => setBranch(event.target.value)}
-              >
-                <option value="">
-                  {branchOptionsQuery.isLoading
-                    ? "Loading branches..."
-                    : "Branch"}
-                </option>
-                {branchOptions.map((item) => (
-                  <option key={`${item.source}:${item.value}`} value={item.value}>
-                    {item.label}
-                  </option>
-                ))}
-              </select>
+              />
             </div>
             <div className="queue-inline-selector queue-inline-selector--publish">
               <PublishIcon />
@@ -6608,12 +6609,6 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
               )}
             </button>
           </div>
-          {mergeAutomationAvailable ? (
-            <p className="small">
-              PR with Merge Automation uses pr-resolver after the PR readiness
-              gate opens; it does not bypass resolver handling.
-            </p>
-          ) : null}
         </div>
         </section>
         </fieldset>


### PR DESCRIPTION
Remove the line "PR with Merge Automation uses pr-resolver after the PR readiness gate opens; it does not bypass resolver handling." from the UI. This does not need to be stated explicitly.

The Branch dropdown UI should use the same dropdown logic that the github repo dropdown now uses where you can type a snippet of text and it will just show you the applicable matches to that snippet.