### PR TITLE
[codex] Fix merge automation head SHA propagation

### DIFF
--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -31,6 +31,7 @@ class CreatePRResult(BaseModel):
     url: Optional[str] = Field(None, alias="url")
     created: bool = Field(..., alias="created")
     summary: str = Field(..., alias="summary")
+    head_sha: Optional[str] = Field(None, alias="headSha")
 
 
 class MergePRResult(BaseModel):
@@ -182,6 +183,7 @@ class GitHubService:
                     url=data.get("html_url"),
                     created=True,
                     summary=f"PR created successfully: {data.get('html_url')}",
+                    headSha=(data.get("head") or {}).get("sha"),
                 )
             except httpx.HTTPStatusError as exc:
                 status_code = exc.response.status_code

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -183,7 +183,7 @@ class GitHubService:
                     url=data.get("html_url"),
                     created=True,
                     summary=f"PR created successfully: {data.get('html_url')}",
-                    headSha=(data.get("head") or {}).get("sha"),
+                    head_sha=(data.get("head") or {}).get("sha"),
                 )
             except httpx.HTTPStatusError as exc:
                 status_code = exc.response.status_code

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2330,6 +2330,13 @@ class MoonMindRunWorkflow:
                         pr_url = self._get_from_result(create_result, "url")
                         created = self._get_from_result(create_result, "created")
                         summary = self._get_from_result(create_result, "summary") or ""
+                        created_head_sha = self._coerce_text(
+                            self._get_from_result(create_result, "headSha")
+                            or self._get_from_result(create_result, "head_sha"),
+                            max_chars=80,
+                        )
+                        if created_head_sha:
+                            self._publish_context["headSha"] = created_head_sha
                         if pr_url:
                             pull_request_url = pr_url
                             self._get_logger().info(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -2331,8 +2331,7 @@ class MoonMindRunWorkflow:
                         created = self._get_from_result(create_result, "created")
                         summary = self._get_from_result(create_result, "summary") or ""
                         created_head_sha = self._coerce_text(
-                            self._get_from_result(create_result, "headSha")
-                            or self._get_from_result(create_result, "head_sha"),
+                            self._get_from_result(create_result, "headSha"),
                             max_chars=80,
                         )
                         if created_head_sha:

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -50,7 +50,13 @@ async def test_create_pr_success(monkeypatch):
 
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(
-        return_value=_mock_response(201, {"html_url": "https://github.com/o/r/pull/42"})
+        return_value=_mock_response(
+            201,
+            {
+                "html_url": "https://github.com/o/r/pull/42",
+                "head": {"sha": "abc123"},
+            },
+        )
     )
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
@@ -64,6 +70,7 @@ async def test_create_pr_success(monkeypatch):
     assert isinstance(result, CreatePRResult)
     assert result.created is True
     assert result.url == "https://github.com/o/r/pull/42"
+    assert result.head_sha == "abc123"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_run_artifacts.py
+++ b/tests/unit/workflows/temporal/test_run_artifacts.py
@@ -1112,6 +1112,7 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
     workflow._owner_id = "owner-1"
     workflow._repo = "MoonLadderStudios/MoonMind"
     captured_create_payload: dict[str, Any] = {}
+    captured_merge_payload: dict[str, Any] = {}
 
     async def fake_execute_activity(
         activity_type: str,
@@ -1120,7 +1121,11 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
     ) -> object:
         if activity_type == "repo.create_pr":
             captured_create_payload["payload"] = _normalize_payload(payload)
-            return {"url": "https://github.com/MoonLadderStudios/MoonMind/pull/999", "created": True}
+            return {
+                "url": "https://github.com/MoonLadderStudios/MoonMind/pull/999",
+                "created": True,
+                "headSha": "created-head-sha",
+            }
 
         if activity_type == "artifact.read":
             if (payload.get("artifact_ref") if isinstance(payload, dict) else getattr(payload, "artifact_ref", None)) == "artifact://registry/1":
@@ -1186,6 +1191,13 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
         args: object,
         **_kwargs: object,
     ) -> object:
+        if workflow_type == "MoonMind.MergeAutomation":
+            captured_merge_payload["payload"] = _normalize_payload(args)
+            return {
+                "status": "merged",
+                "prNumber": 999,
+                "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/999",
+            }
         return {
             "summary": "Completed with status completed",
             "metadata": {"branch": "auto-0526d401", "push_status": "pushed"},
@@ -1214,6 +1226,7 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
             "repo": "MoonLadderStudios/MoonMind",
             "publishMode": "pr",
             "task": {
+                "mergeAutomation": {"enabled": True},
                 "publish": {
                     "prTitle": "OAuth redirect cleanup",
                     "prBody": "Adds regression coverage for callback URL selection.",
@@ -1227,6 +1240,9 @@ async def test_run_execution_stage_publish_mode_pr_uses_publish_overrides(
     assert (
         captured_create_payload["payload"]["body"]
         == "Adds regression coverage for callback URL selection."
+    )
+    assert captured_merge_payload["payload"]["pullRequest"]["headSha"] == (
+        "created-head-sha"
     )
 
 


### PR DESCRIPTION
## Summary

- Include the created pull request head SHA in `repo.create_pr` results.
- Persist that SHA into the parent run publish context before starting merge automation.
- Add regression coverage proving PR-mode merge automation starts with the created PR head SHA.

## Root Cause

A managed PR-publishing run with merge automation enabled created PR #1588, but `MoonMind.Run` skipped `MoonMind.MergeAutomation` because `_build_merge_gate_start_payload` requires a non-empty tracked head SHA. The managed push metadata did not include one, and `repo.create_pr` discarded GitHub's `head.sha`, so the gate payload returned `None` and no `pr-resolver` child was launched.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/workflows/adapters/test_github_service.py tests/unit/workflows/temporal/test_run_artifacts.py` -> 39 passed
- `./tools/test_unit.sh` -> 3619 passed, 1 xpassed, 16 subtests passed; frontend 10 files / 300 tests passed

## Operational Check

- Manually ran `pr-resolver` against stalled PR #1588 after addressing review feedback; it waited for CI and merged the PR successfully.