### PR TITLE
[codex] Fix Jira breakdown orchestrate defaults

### DIFF
--- a/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-breakdown-orchestrate.yaml
@@ -100,6 +100,7 @@ steps:
       Return the created Jira issue keys, URLs, dependency mode, and created/reused/failed link results.
     storyOutput:
       mode: jira
+      fallback: fail
       jira:
         projectKey: "{{ inputs.jira_project_key }}"
         issueTypeName: "{{ inputs.jira_issue_type }}"

--- a/api_service/services/task_templates/catalog.py
+++ b/api_service/services/task_templates/catalog.py
@@ -50,6 +50,10 @@ _SUPPORTED_INPUT_TYPES = frozenset(
     {"text", "textarea", "markdown", "enum", "boolean", "user", "team", "repo_path"}
 )
 _JIRA_BREAKDOWN_SLUG = "jira-breakdown"
+_JIRA_BREAKDOWN_ORCHESTRATE_SLUG = "jira-breakdown-orchestrate"
+_JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS = frozenset(
+    {_JIRA_BREAKDOWN_SLUG, _JIRA_BREAKDOWN_ORCHESTRATE_SLUG}
+)
 _JIRA_BREAKDOWN_PROJECT_INPUT = "jira_project_key"
 _SLUG_PATTERN = re.compile(r"[^a-z0-9-]+")
 _UNRESOLVED_PLACEHOLDER_PATTERN = re.compile(r"{{\s*[^}]+\s*}}")
@@ -313,7 +317,7 @@ def _effective_inputs_schema(
 ) -> list[dict[str, Any]]:
     """Apply runtime-derived defaults without mutating stored template versions."""
 
-    if slug != _JIRA_BREAKDOWN_SLUG:
+    if slug not in _JIRA_BREAKDOWN_PROJECT_DEFAULT_SLUGS:
         return inputs_schema
 
     project_key = _first_allowed_jira_project_key()

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -990,6 +990,69 @@ async def test_jira_breakdown_uses_first_allowed_project_as_runtime_default(
             assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
 
 
+async def test_jira_breakdown_orchestrate_uses_first_allowed_project_as_runtime_default(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(settings.atlassian.jira, "jira_allowed_projects", "MM,OPS")
+    seed_dir = (
+        Path(__file__).resolve().parents[3]
+        / "api_service"
+        / "data"
+        / "task_step_templates"
+    )
+
+    async with template_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            service = TaskTemplateCatalogService(session)
+            await service.sync_seed_templates(seed_dir=seed_dir)
+
+            template = await service.get_template(
+                slug="jira-breakdown-orchestrate",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+            )
+            project_input = next(
+                item
+                for item in template["inputs"]
+                if item["name"] == "jira_project_key"
+            )
+            assert project_input["default"] == "MM"
+
+            expanded = await service.expand_template(
+                slug="jira-breakdown-orchestrate",
+                scope="global",
+                scope_ref=None,
+                version="1.0.0",
+                inputs={
+                    "feature_request": "docs/Designs/RuntimeTypes.md",
+                    "jira_issue_type": "Story",
+                    "jira_dependency_mode": "linear_blocker_chain",
+                    "repository": "MoonLadderStudios/MoonMind",
+                    "orchestration_mode": "runtime",
+                    "runtime_mode": "codex_cli",
+                    "publish_mode": "pr",
+                    "source_issue_key": "MM-404",
+                },
+                context={},
+            )
+
+            assert "Jira Story issue in project MM" in expanded["steps"][1][
+                "instructions"
+            ]
+            assert expanded["steps"][1]["storyOutput"] == {
+                "mode": "jira",
+                "fallback": "fail",
+                "jira": {
+                    "projectKey": "MM",
+                    "issueTypeName": "Story",
+                    "dependencyMode": "linear_blocker_chain",
+                },
+            }
+            assert expanded["appliedTemplate"]["inputs"]["jira_project_key"] == "MM"
+
+
 async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
     seed_dir = (
         Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary

Fixes the Jira Breakdown and Orchestrate preset so it honors the deployment's allowed Jira project default and fails loudly when required Jira story creation cannot produce issue mappings.

## Root Cause

The completed breakdown workflow used the composite `jira-breakdown-orchestrate` preset with the seeded `TOOL` project default. The deployment allows Jira project `MM`, so the trusted Jira tool rejected `TOOL`. `story.create_jira_issues` then fell back to docs output, and the downstream task-creation step had zero Jira issue mappings to convert into MoonMind tasks.

## Changes

- Apply the existing allowed-project runtime defaulting to both `jira-breakdown` and `jira-breakdown-orchestrate`.
- Set `storyOutput.fallback: fail` for `jira-breakdown-orchestrate` because downstream orchestration requires actual Jira issue mappings.
- Add regression coverage for the composite preset default and fail-fast story output contract.

## Verification

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/test_task_step_templates_service.py tests/integration/test_startup_task_template_seeding.py tests/unit/workflows/temporal/test_story_output_tools.py tests/unit/workflows/temporal/test_temporal_worker_runtime.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`

Full unit result: Python `3625 passed, 1 xpassed`; frontend `10 files passed, 301 tests passed`.