### PR TITLE
With the adjustment of the mission control header to fill the full width of the screen, the card for Create task was also widened. This should not hav

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -3670,6 +3670,12 @@ describe("Task Create Entrypoint", () => {
   it("submits the Temporal task payload and redirects on success", async () => {
     renderWithClient(<TaskCreatePage payload={mockPayload} />);
 
+    expect(
+      (await screen.findByRole("heading", { name: "Create Task" })).closest(
+        ".task-create-page",
+      ),
+    ).not.toBeNull();
+
     const primaryStep = (await screen.findByText("Step 1 (Primary)")).closest(
       "section",
     );

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -5289,7 +5289,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
     (temporalDraftQuery.isLoading || Boolean(modeLoadError));
 
   return (
-    <div className="stack">
+    <div className="stack task-create-page">
       <section data-canonical-create-section="Header" aria-label="Header">
         <h2 className="page-title">{pageTitle}</h2>
       </section>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -374,6 +374,12 @@ h1 {
   box-shadow: none;
 }
 
+.panel:has(.task-create-page) {
+  max-width: min(72rem, calc(100vw - 2rem));
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .panel.panel--data-wide {
   max-width: min(112rem, calc(100vw - 2rem));
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -376,8 +376,6 @@ h1 {
 
 .panel:has(.task-create-page) {
   max-width: min(72rem, calc(100vw - 2rem));
-  margin-left: auto;
-  margin-right: auto;
 }
 
 .panel.panel--data-wide {


### PR DESCRIPTION
With the adjustment of the mission control header to fill the full width of the screen, the card for Create task was also widened. This should not have been done. The Create task card should still be restricted to a normal text page width that does not span the full width of the screen.