### PR TITLE
[codex] Fix merge automation child completion

### DIFF
--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -265,6 +265,7 @@ class ReadinessEvidenceModel(BaseModel):
     head_sha: str = Field(..., alias="headSha")
     ready: bool = Field(False, alias="ready")
     pull_request_open: bool | None = Field(None, alias="pullRequestOpen")
+    pull_request_merged: bool | None = Field(None, alias="pullRequestMerged")
     checks_complete: bool | None = Field(None, alias="checksComplete")
     checks_passing: bool | None = Field(None, alias="checksPassing")
     automated_review_complete: bool | None = Field(

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -53,6 +53,7 @@ class PullRequestReadinessResult(BaseModel):
     head_sha: str = Field(..., alias="headSha")
     ready: bool = Field(False, alias="ready")
     pull_request_open: bool | None = Field(None, alias="pullRequestOpen")
+    pull_request_merged: bool | None = Field(None, alias="pullRequestMerged")
     checks_complete: bool | None = Field(None, alias="checksComplete")
     checks_passing: bool | None = Field(None, alias="checksPassing")
     automated_review_complete: bool | None = Field(
@@ -406,6 +407,7 @@ class GitHubService:
         blockers: list[dict[str, Any]] = []
         observed_head_sha = head_sha
         pr_open: bool | None = None
+        pr_merged: bool | None = None
         checks_complete: bool | None = None
         checks_passing: bool | None = None
         automated_review_complete: bool | None = None
@@ -419,6 +421,7 @@ class GitHubService:
                 pr_response.raise_for_status()
                 pr_data = pr_response.json()
                 pr_open = pr_data.get("state") == "open"
+                pr_merged = bool(pr_data.get("merged"))
                 head = pr_data.get("head") if isinstance(pr_data, dict) else {}
                 if isinstance(head, dict):
                     observed_head_sha = str(head.get("sha") or head_sha)
@@ -447,7 +450,7 @@ class GitHubService:
                     }
                 )
 
-            if pr_open is False:
+            if pr_open is False and pr_merged is not True:
                 blockers.append(
                     {
                         "kind": "pull_request_closed",
@@ -457,7 +460,7 @@ class GitHubService:
                     }
                 )
 
-            if checks_required and not blockers:
+            if checks_required and pr_merged is not True and not blockers:
                 check_evidence = await self._evaluate_github_checks(
                     client=client,
                     repo=repo,
@@ -468,7 +471,7 @@ class GitHubService:
                 checks_passing = check_evidence["passing"]
                 blockers.extend(check_evidence["blockers"])
 
-            if review_required and not blockers:
+            if review_required and pr_merged is not True and not blockers:
                 review_evidence = await self._evaluate_automated_review(
                     client=client,
                     repo=repo,
@@ -480,8 +483,9 @@ class GitHubService:
 
         return PullRequestReadinessResult(
             headSha=observed_head_sha,
-            ready=not blockers,
+            ready=not blockers and pr_merged is not True,
             pullRequestOpen=pr_open,
+            pullRequestMerged=pr_merged,
             checksComplete=checks_complete,
             checksPassing=checks_passing,
             automatedReviewComplete=automated_review_complete,

--- a/moonmind/workflows/temporal/worker_runtime.py
+++ b/moonmind/workflows/temporal/worker_runtime.py
@@ -84,6 +84,9 @@ from moonmind.workflows.temporal.workflows.agent_run import (
 from moonmind.workflows.temporal.workflows.oauth_session import (
     MoonMindOAuthSessionWorkflow as MoonMindOAuthSession,
 )
+from moonmind.workflows.temporal.workflows.merge_automation import (
+    MoonMindMergeAutomationWorkflow as MoonMindMergeAutomation,
+)
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workflows.temporal.runtime.launcher import ManagedRuntimeLauncher
 from moonmind.workflows.temporal.runtime.log_streamer import RuntimeLogStreamer
@@ -1299,6 +1302,7 @@ async def main_async() -> None:
             MoonMindManagedSessionReconcile,
             MoonMindAgentRun,
             MoonMindOAuthSession,
+            MoonMindMergeAutomation,
         ]
         activities = [
             resolve_adapter_metadata,

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -415,6 +415,15 @@ class MoonMindMergeAutomationWorkflow:
                     )
             self._blockers = list(evidence.blockers)
             await self._write_gate_snapshot(evidence_ready=evidence.ready)
+            if evidence.pull_request_merged:
+                self._refresh_tracked_head_sha(evaluation)
+                if not await self._complete_post_merge_jira(
+                    resolver_disposition=DISPOSITION_ALREADY_MERGED
+                ):
+                    return await self._finish()
+                self._status = STATE_ALREADY_MERGED
+                self._publish_visibility()
+                return await self._finish()
             if evidence.ready:
                 self._status = STATE_EXECUTING
                 self._publish_visibility()

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -87,8 +87,12 @@ def classify_readiness(
     """Normalize provider readiness evidence into bounded merge-gate evidence."""
 
     head_sha = str(payload.get("headSha") or payload.get("head_sha") or "").strip()
+    pull_request_merged = (
+        payload.get("pullRequestMerged") is True
+        or payload.get("pull_request_merged") is True
+    )
     blockers: list[ReadinessBlockerModel] = []
-    if head_sha != str(tracked_head_sha).strip():
+    if not pull_request_merged and head_sha != str(tracked_head_sha).strip():
         blockers.append(
             ReadinessBlockerModel(
                 kind="stale_revision",
@@ -102,7 +106,10 @@ def classify_readiness(
         if isinstance(raw, Mapping):
             blockers.append(_blocker_from_mapping(raw))
 
-    if payload.get("pullRequestOpen") is False or payload.get("pull_request_open") is False:
+    if not pull_request_merged and (
+        payload.get("pullRequestOpen") is False
+        or payload.get("pull_request_open") is False
+    ):
         blockers.append(
             ReadinessBlockerModel.model_validate(
                 _default_blocker(
@@ -181,13 +188,14 @@ def classify_readiness(
         seen.add(key)
         deduped.append(blocker)
 
-    explicit_ready = bool(payload.get("ready", False))
+    explicit_ready = bool(payload.get("ready", False)) and not pull_request_merged
     ready = explicit_ready and not deduped
     return ReadinessEvidenceModel.model_validate(
         {
             **dict(payload),
             "headSha": head_sha,
             "ready": ready,
+            "pullRequestMerged": pull_request_merged,
             "blockers": [b.model_dump(by_alias=True) for b in deduped],
         }
     )

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -307,6 +307,39 @@ async def test_evaluate_pull_request_readiness_opens_after_checks_and_review(mon
 
 
 @pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_reports_merged_closed_pr(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        return_value=_mock_get_response(
+            200,
+            {"state": "closed", "merged": True, "head": {"sha": "def456"}},
+        )
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "required"},
+        )
+
+    assert result.ready is False
+    assert result.pull_request_open is False
+    assert result.pull_request_merged is True
+    assert result.head_sha == "def456"
+    assert result.blockers == []
+    mock_client.get.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_evaluate_pull_request_readiness_blocks_changes_requested_review(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
 

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -55,6 +55,27 @@ def test_classify_readiness_marks_stale_revision_terminal() -> None:
     assert evidence.blockers[0].retryable is False
 
 
+def test_classify_readiness_treats_merged_pr_as_terminal_success_evidence() -> None:
+    evidence = classify_readiness(
+        {
+            "headSha": "def456",
+            "ready": False,
+            "pullRequestOpen": False,
+            "pullRequestMerged": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+            "policyAllowed": True,
+        },
+        tracked_head_sha="abc123",
+    )
+
+    assert evidence.pull_request_merged is True
+    assert evidence.ready is False
+    assert evidence.blockers == []
+
+
 def test_classify_readiness_sanitizes_secret_like_blocker_summary() -> None:
     evidence = classify_readiness(
         {

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -1149,6 +1149,9 @@ async def test_main_async_workflow_fleet(
     )
     from moonmind.workflows.temporal.workflows.provider_profile_manager import MoonMindProviderProfileManagerWorkflow
     from moonmind.workflows.temporal.workflows.oauth_session import MoonMindOAuthSessionWorkflow as MoonMindOAuthSession
+    from moonmind.workflows.temporal.workflows.merge_automation import (
+        MoonMindMergeAutomationWorkflow,
+    )
     from moonmind.workflows.temporal.workflows.managed_session_reconcile import (
         MoonMindManagedSessionReconcileWorkflow,
     )
@@ -1160,6 +1163,7 @@ async def test_main_async_workflow_fleet(
         MoonMindManagedSessionReconcileWorkflow,
         MoonMindAgentRun,
         MoonMindOAuthSession,
+        MoonMindMergeAutomationWorkflow,
     ]
     assert kwargs["activities"] == [
         resolve_adapter_metadata,

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -292,6 +292,63 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
 
 
 @pytest.mark.asyncio
+async def test_merge_automation_finishes_already_merged_without_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        assert activity_type == "merge_automation.evaluate_readiness"
+        readiness_calls += 1
+        return {
+            "headSha": "def456",
+            "ready": False,
+            "pullRequestOpen": False,
+            "pullRequestMerged": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("already-merged PRs must not launch pr-resolver")
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 1
+    assert result["status"] == "already_merged"
+    assert result["latestHeadSha"] == "def456"
+    assert result["blockers"] == []
+    assert result["resolverChildWorkflowIds"] == []
+
+
+@pytest.mark.asyncio
 async def test_merge_automation_runs_post_merge_jira_before_merged_success(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes merge automation child workflows failing to start and improves terminal handling when a pull request is already merged.

## Root Cause

The active Temporal worker process uses `worker_runtime.py`, but that runtime did not include `MoonMind.MergeAutomation` in the workflow fleet registration list. Merge automation children could be scheduled, then repeatedly fail workflow activation as an unregistered workflow type.

After registration was fixed, readiness evaluation also treated an already-merged PR as a closed/stale PR, which caused merge automation to report a blocked result instead of `already_merged`.

## Changes

- Register `MoonMind.MergeAutomation` in the active workflow worker runtime.
- Add `pullRequestMerged` readiness evidence from the GitHub adapter.
- Treat merged PRs as terminal success evidence instead of stale/closed blockers.
- Finish merge automation as `already_merged` without launching a resolver when GitHub reports the PR is already merged.
- Add regression coverage for worker registration, merged-PR readiness evidence, classifier behavior, and the merge automation already-merged path.

## Validation

Ran:

```bash
MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh \
  tests/unit/workflows/temporal/test_temporal_worker_runtime.py \
  tests/unit/workflows/temporal/test_temporal_workers.py \
  tests/unit/workflows/temporal/test_merge_gate_workflow.py \
  tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py \
  tests/unit/workflows/adapters/test_github_service.py
```

Result: backend tests passed (`90 passed`), and the wrapper frontend phase passed (`10 passed`, `301 passed`).