### PR TITLE
[codex] Fix merge automation hang handling

### DIFF
--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import re
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
@@ -568,7 +568,9 @@ class GitHubService:
         status_pending = status_state in {"pending", "expected"} and (
             has_commit_statuses or not has_check_runs
         )
-        status_failed = status_state in {"failure", "error"} and has_commit_statuses
+        status_failed = status_state in {"failure", "error"} and (
+            has_commit_statuses or not has_check_runs
+        )
         if status_pending or pending_runs:
             blockers.append(
                 {
@@ -640,7 +642,7 @@ class GitHubService:
                 ],
             }
 
-        latest_review_states: dict[str, str] = {}
+        latest_review_states: dict[str, tuple[str, bool]] = {}
         review_items = [
             (str(review.get("submitted_at") or ""), index, review)
             for index, review in enumerate(reviews)
@@ -649,14 +651,18 @@ class GitHubService:
         for _submitted_at, index, review in sorted(review_items):
             user = review.get("user") if isinstance(review.get("user"), dict) else {}
             reviewer = str(user.get("login") or review.get("user") or index)
-            latest_review_states[reviewer] = str(review.get("state") or "").upper()
+            latest_review_states[reviewer] = (
+                str(review.get("state") or "").upper(),
+                self._is_trusted_automation_reviewer(reviewer, user),
+            )
 
         review_completed = any(
-            state in {"APPROVED", "COMMENTED"}
-            for state in latest_review_states.values()
+            state == "APPROVED" or (state == "COMMENTED" and trusted_automation)
+            for state, trusted_automation in latest_review_states.values()
         )
         changes_requested = any(
-            state == "CHANGES_REQUESTED" for state in latest_review_states.values()
+            state == "CHANGES_REQUESTED"
+            for state, _trusted_automation in latest_review_states.values()
         )
         if review_completed and not changes_requested:
             return {"complete": True, "blockers": []}
@@ -683,6 +689,24 @@ class GitHubService:
                 }
             ],
         }
+
+    @staticmethod
+    def _is_trusted_automation_reviewer(
+        reviewer: str,
+        user: Mapping[str, Any],
+    ) -> bool:
+        login = reviewer.strip().lower()
+        user_type = str(user.get("type") or "").strip().lower()
+        return (
+            user_type == "bot"
+            or login.endswith("[bot]")
+            or login
+            in {
+                "chatgpt-codex-connector",
+                "gemini-code-assist",
+                "github-actions",
+            }
+        )
 
 
 __all__ = [

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -510,6 +510,7 @@ class GitHubService:
             status_response.raise_for_status()
             status_data = status_response.json()
             status_state = str(status_data.get("state") or "").lower()
+            commit_statuses = status_data.get("statuses") or []
 
             checks_response = await client.get(
                 f"https://api.github.com/repos/{repo}/commits/{head_sha}/check-runs",
@@ -562,7 +563,13 @@ class GitHubService:
             if str(run.get("conclusion") or "").lower()
             not in {"", "success", "neutral", "skipped"}
         ]
-        if status_state in {"pending", "expected"} or pending_runs:
+        has_commit_statuses = bool(commit_statuses)
+        has_check_runs = bool(check_runs)
+        status_pending = status_state in {"pending", "expected"} and (
+            has_commit_statuses or not has_check_runs
+        )
+        status_failed = status_state in {"failure", "error"} and has_commit_statuses
+        if status_pending or pending_runs:
             blockers.append(
                 {
                     "kind": "checks_running",
@@ -571,7 +578,7 @@ class GitHubService:
                     "source": "github",
                 }
             )
-        elif status_state in {"failure", "error"} or failed_runs:
+        elif status_failed or failed_runs:
             blockers.append(
                 {
                     "kind": "checks_failed",
@@ -644,11 +651,14 @@ class GitHubService:
             reviewer = str(user.get("login") or review.get("user") or index)
             latest_review_states[reviewer] = str(review.get("state") or "").upper()
 
-        approved = any(state == "APPROVED" for state in latest_review_states.values())
+        review_completed = any(
+            state in {"APPROVED", "COMMENTED"}
+            for state in latest_review_states.values()
+        )
         changes_requested = any(
             state == "CHANGES_REQUESTED" for state in latest_review_states.values()
         )
-        if approved and not changes_requested:
+        if review_completed and not changes_requested:
             return {"complete": True, "blockers": []}
         if changes_requested:
             return {

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -430,7 +430,10 @@ class DockerCodexManagedSessionController:
         socket_path = self._build_github_socket_path(
             run_id=request.session_id,
             support_root=str(support_root),
+            socket_root=str(Path(self._workspace_root) / ".mm-gh"),
         )
+        socket_dir = Path(socket_path).parent
+        socket_dir.mkdir(parents=True, exist_ok=True)
         await self._github_auth_brokers.start(
             run_id=request.session_id,
             token=token,
@@ -442,6 +445,7 @@ class DockerCodexManagedSessionController:
             support_root=support_root,
             github_socket_path=socket_path,
         )
+        touched_paths.append(socket_dir)
         touched_paths.append(Path(socket_path))
         self._normalize_container_path_owners(touched_paths)
         # Codex shell tools can invoke nested `bash -lc` commands that bypass
@@ -451,17 +455,26 @@ class DockerCodexManagedSessionController:
         return {"GITHUB_TOKEN": token}
 
     @staticmethod
-    def _build_github_socket_path(*, run_id: str, support_root: str | None) -> str:
+    def _build_github_socket_path(
+        *,
+        run_id: str,
+        support_root: str | None,
+        socket_root: str | None = None,
+    ) -> str:
         """Keep broker sockets on a short path to avoid AF_UNIX length limits."""
-        socket_root = Path("/tmp")
-        if not socket_root.is_dir():
-            socket_root = Path(tempfile.gettempdir())
-        socket_root = socket_root / "mm-gh"
+        resolved_socket_root = Path(socket_root) if socket_root else Path("/tmp")
+        if not resolved_socket_root.is_dir() and socket_root is None:
+            resolved_socket_root = Path(tempfile.gettempdir())
+        resolved_socket_root = (
+            resolved_socket_root / "mm-gh"
+            if socket_root is None
+            else resolved_socket_root
+        )
         material = run_id
         if support_root:
             material = f"{Path(support_root).resolve()}::{run_id}"
         digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
-        return str(socket_root / f"{digest}.sock")
+        return str(resolved_socket_root / f"{digest}.sock")
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ import posixpath
 import re
 import shlex
 import shutil
+import tempfile
 import time
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -425,7 +427,10 @@ class DockerCodexManagedSessionController:
             return {}
 
         support_root = Path(request.session_workspace_path) / ".moonmind"
-        socket_path = str(support_root / "github-auth.sock")
+        socket_path = self._build_github_socket_path(
+            run_id=request.session_id,
+            support_root=str(support_root),
+        )
         await self._github_auth_brokers.start(
             run_id=request.session_id,
             token=token,
@@ -444,6 +449,19 @@ class DockerCodexManagedSessionController:
         # inherited environment (`-e GITHUB_TOKEN`) so it is not rendered into
         # the docker command line or the launch payload.
         return {"GITHUB_TOKEN": token}
+
+    @staticmethod
+    def _build_github_socket_path(*, run_id: str, support_root: str | None) -> str:
+        """Keep broker sockets on a short path to avoid AF_UNIX length limits."""
+        socket_root = Path("/tmp")
+        if not socket_root.is_dir():
+            socket_root = Path(tempfile.gettempdir())
+        socket_root = socket_root / "mm-gh"
+        material = run_id
+        if support_root:
+            material = f"{Path(support_root).resolve()}::{run_id}"
+        digest = hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+        return str(socket_root / f"{digest}.sock")
 
     @staticmethod
     def _record_status_from_handle_status(status: str) -> ManagedSessionRecordStatus:

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -133,6 +133,19 @@ class MoonMindMergeAutomationWorkflow:
             return "merge-automation"
         return self._input.principal or self._input.parent_workflow_id
 
+    def _resolver_owner_type(self) -> str:
+        return "system" if self._principal() == "system" else "user"
+
+    def _resolver_search_attributes(self) -> dict[str, list[str]]:
+        attributes = {
+            "mm_owner_type": [self._resolver_owner_type()],
+            "mm_owner_id": [self._principal()],
+            "mm_entry": ["run"],
+        }
+        if self._input is not None:
+            attributes["mm_repo"] = [self._input.pull_request.repo]
+        return attributes
+
     async def _write_json_artifact(self, *, name: str, payload: dict[str, Any]) -> str | None:
         try:
             artifact_ref, _upload_desc = await workflow.execute_activity(
@@ -449,6 +462,7 @@ class MoonMindMergeAutomationWorkflow:
                         resolver_request,
                         id=resolver_workflow_id,
                         task_queue=WORKFLOW_TASK_QUEUE,
+                        search_attributes=self._resolver_search_attributes(),
                         cancellation_type=ChildWorkflowCancellationType.TRY_CANCEL,
                         static_summary="Resolving pull request for merge automation",
                         static_details=f"Resolve {self._input.pull_request.url}",

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -234,9 +234,9 @@ def build_resolver_run_request(
         args["jiraIssueKey"] = jira_issue_key
     title = f"Resolve PR #{pr.number}"
     return {
-        "workflowType": "MoonMind.Run",
+        "workflow_type": "MoonMind.Run",
         "title": title,
-        "initialParameters": {
+        "initial_parameters": {
             "repo": pr.repo,
             "repository": pr.repo,
             "publishMode": "none",

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -35,6 +35,7 @@ WORKFLOW_ID_PREFIX = "provider-profile-manager"
 VERIFY_LEASE_HOLDERS_PATCH = "auth-profile-manager-verify-leases-v1"
 DB_LEASE_PERSISTENCE_PATCH = "provider-profile-manager-db-lease-persistence-v1"
 SLOT_HANDOFF_RESERVATION_PATCH = "provider-profile-manager-slot-handoff-v1"
+REFRESH_RESTORED_PROFILES_PATCH = "provider-profile-manager-refresh-restored-profiles-v1"
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -435,6 +436,13 @@ class MoonMindProviderProfileManagerWorkflow:
                 # This looks like a fresh start after a crash - try to restore leases from DB
                 await self._load_leases_from_db()
 
+        # Refresh restored state from the authoritative DB snapshot. This keeps
+        # continued-as-new managers from routing to profiles deleted or changed
+        # since the prior history payload was created. This patch is evaluated
+        # after older startup patch markers to preserve replay order.
+        if self._profiles and workflow.patched(REFRESH_RESTORED_PROFILES_PATCH):
+            await self._load_profiles_from_db()
+
         # Main event loop: process signals, drain queue, clear cooldowns.
         while not self._shutdown_requested:
             # Drain pending requests against available profiles.
@@ -597,6 +605,7 @@ class MoonMindProviderProfileManagerWorkflow:
         for pid in list(self._profiles.keys()):
             if pid not in seen:
                 self._profiles[pid].enabled = False
+                self._profiles[pid].is_default = False
 
     @staticmethod
     def _normalize_optional_string(value: object) -> str | None:

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -823,10 +823,13 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
             "socket_path": DockerCodexManagedSessionController._build_github_socket_path(
                 run_id=request.session_id,
                 support_root=str(Path(request.session_workspace_path) / ".moonmind"),
+                socket_root=str(workspace_root / ".mm-gh"),
             ),
         }
     ]
-    assert len(github_auth_brokers.starts[0]["socket_path"].encode("utf-8")) < 80
+    assert github_auth_brokers.starts[0]["socket_path"].startswith(
+        str(workspace_root / ".mm-gh")
+    )
     assert request.session_workspace_path not in github_auth_brokers.starts[0]["socket_path"]
     docker_run_text = " ".join(docker_commands[0])
     assert token not in docker_run_text

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -820,13 +820,14 @@ async def test_controller_clone_resolves_descriptor_for_git_without_container_to
         {
             "run_id": request.session_id,
             "token": token,
-            "socket_path": str(
-                Path(request.session_workspace_path)
-                / ".moonmind"
-                / "github-auth.sock"
+            "socket_path": DockerCodexManagedSessionController._build_github_socket_path(
+                run_id=request.session_id,
+                support_root=str(Path(request.session_workspace_path) / ".moonmind"),
             ),
         }
     ]
+    assert len(github_auth_brokers.starts[0]["socket_path"].encode("utf-8")) < 80
+    assert request.session_workspace_path not in github_auth_brokers.starts[0]["socket_path"]
     docker_run_text = " ".join(docker_commands[0])
     assert token not in docker_run_text
     assert "GITHUB_TOKEN=" not in docker_run_text

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -348,6 +348,40 @@ async def test_evaluate_pull_request_readiness_ignores_empty_combined_status_pen
 
 
 @pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_respects_failed_combined_status_without_check_runs(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _mock_get_response(200, {"state": "open", "head": {"sha": "abc123"}}),
+            _mock_get_response(200, {"state": "failure", "statuses": []}),
+            _mock_get_response(200, {"check_runs": []}),
+        ]
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "disabled"},
+        )
+
+    assert result.ready is False
+    assert result.checks_complete is True
+    assert result.checks_passing is False
+    assert result.blockers[0]["kind"] == "checks_failed"
+
+
+@pytest.mark.asyncio
 async def test_evaluate_pull_request_readiness_treats_commented_automated_review_as_complete(
     monkeypatch,
 ):
@@ -395,6 +429,56 @@ async def test_evaluate_pull_request_readiness_treats_commented_automated_review
     assert result.ready is True
     assert result.automated_review_complete is True
     assert result.blockers == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_waits_for_human_commented_review(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _mock_get_response(200, {"state": "open", "head": {"sha": "abc123"}}),
+            _mock_get_response(200, {"state": "success"}),
+            _mock_get_response(
+                200,
+                {
+                    "check_runs": [
+                        {"status": "completed", "conclusion": "success"},
+                    ]
+                },
+            ),
+            _mock_get_response(
+                200,
+                [
+                    {
+                        "state": "COMMENTED",
+                        "submitted_at": "2026-04-19T20:18:26Z",
+                        "user": {"login": "reviewer-a", "type": "User"},
+                    },
+                ],
+            ),
+        ]
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "required"},
+        )
+
+    assert result.ready is False
+    assert result.automated_review_complete is False
+    assert result.blockers[0]["kind"] == "automated_review_pending"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -307,6 +307,97 @@ async def test_evaluate_pull_request_readiness_opens_after_checks_and_review(mon
 
 
 @pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_ignores_empty_combined_status_pending_when_checks_pass(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _mock_get_response(200, {"state": "open", "head": {"sha": "abc123"}}),
+            _mock_get_response(200, {"state": "pending", "statuses": []}),
+            _mock_get_response(
+                200,
+                {
+                    "check_runs": [
+                        {"status": "completed", "conclusion": "success"},
+                    ]
+                },
+            ),
+        ]
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "disabled"},
+        )
+
+    assert result.ready is True
+    assert result.checks_complete is True
+    assert result.checks_passing is True
+    assert result.blockers == []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_pull_request_readiness_treats_commented_automated_review_as_complete(
+    monkeypatch,
+):
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _mock_get_response(200, {"state": "open", "head": {"sha": "abc123"}}),
+            _mock_get_response(200, {"state": "success"}),
+            _mock_get_response(
+                200,
+                {
+                    "check_runs": [
+                        {"status": "completed", "conclusion": "success"},
+                    ]
+                },
+            ),
+            _mock_get_response(
+                200,
+                [
+                    {
+                        "state": "COMMENTED",
+                        "submitted_at": "2026-04-19T20:18:26Z",
+                        "user": {"login": "chatgpt-codex-connector"},
+                    },
+                ],
+            ),
+        ]
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "moonmind.workflows.adapters.github_service.httpx.AsyncClient",
+        return_value=mock_client,
+    ):
+        result = await GitHubService().evaluate_pull_request_readiness(
+            repo="owner/repo",
+            pr_number=341,
+            head_sha="abc123",
+            policy={"checks": "required", "automatedReview": "required"},
+        )
+
+    assert result.ready is True
+    assert result.automated_review_complete is True
+    assert result.blockers == []
+
+
+@pytest.mark.asyncio
 async def test_evaluate_pull_request_readiness_reports_merged_closed_pr(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
 

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -147,13 +147,14 @@ def test_build_resolver_run_request_uses_pr_resolver_and_publish_none() -> None:
         merge_method="squash",
     )
 
-    assert request["initialParameters"]["task"]["skill"]["id"] == "pr-resolver"
-    assert request["initialParameters"]["task"]["publish"]["mode"] == "none"
-    assert request["initialParameters"]["task"]["tool"]["name"] == "pr-resolver"
-    assert request["initialParameters"]["task"]["tool"]["type"] == "skill"
-    assert request["initialParameters"]["task"]["tool"]["version"] == "1.0"
-    assert request["initialParameters"]["publishMode"] == "none"
-    assert request["initialParameters"]["task"]["skill"]["args"]["pr"] == "341"
+    assert request["workflow_type"] == "MoonMind.Run"
+    assert request["initial_parameters"]["task"]["skill"]["id"] == "pr-resolver"
+    assert request["initial_parameters"]["task"]["publish"]["mode"] == "none"
+    assert request["initial_parameters"]["task"]["tool"]["name"] == "pr-resolver"
+    assert request["initial_parameters"]["task"]["tool"]["type"] == "skill"
+    assert request["initial_parameters"]["task"]["tool"]["version"] == "1.0"
+    assert request["initial_parameters"]["publishMode"] == "none"
+    assert request["initial_parameters"]["task"]["skill"]["args"]["pr"] == "341"
 
 
 def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -233,11 +233,13 @@ class TestProviderProfileManagerHelpers:
             cooldown_after_429_seconds=300,
             rate_limit_policy="backoff",
             enabled=True,
+            is_default=True,
         )
         # Sync with empty list — p1 should be disabled but not deleted.
         wf._apply_profile_sync([])
         assert "p1" in wf._profiles
         assert not wf._profiles["p1"].enabled
+        assert not wf._profiles["p1"].is_default
 
     def test_find_available_profile_picks_most_free(self):
         wf = self._make_workflow()

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -224,10 +224,11 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         "resolver:wf-parent:MoonLadderStudios/MoonMind:350:abc123:1",
         "resolver:wf-parent:MoonLadderStudios/MoonMind:350:def456:2",
     ]
-    assert child_payloads[0]["initialParameters"]["publishMode"] == "none"
-    assert child_payloads[0]["initialParameters"]["task"]["publish"]["mode"] == "none"
-    assert child_payloads[0]["initialParameters"]["task"]["skill"]["id"] == "pr-resolver"
-    assert child_payloads[0]["initialParameters"]["task"]["tool"] == {
+    assert child_payloads[0]["workflow_type"] == "MoonMind.Run"
+    assert child_payloads[0]["initial_parameters"]["publishMode"] == "none"
+    assert child_payloads[0]["initial_parameters"]["task"]["publish"]["mode"] == "none"
+    assert child_payloads[0]["initial_parameters"]["task"]["skill"]["id"] == "pr-resolver"
+    assert child_payloads[0]["initial_parameters"]["task"]["tool"] == {
         "type": "skill",
         "name": "pr-resolver",
         "version": "1.0",
@@ -289,6 +290,10 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
 
     assert result["status"] == "merged"
     assert child_kwargs["cancellation_type"] == ChildWorkflowCancellationType.TRY_CANCEL
+    search_attributes = child_kwargs["search_attributes"]
+    assert search_attributes["mm_owner_type"] == ["user"]
+    assert search_attributes["mm_owner_id"] == ["wf-parent"]
+    assert search_attributes["mm_repo"] == ["MoonLadderStudios/MoonMind"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the merge automation path that made workflow `mm:6e2a5641-df5b-4ef9-8ec8-305fe4e9c4d1` appear stuck even after GitHub checks and bot reviews had completed.

## Root Cause

The merge gate treated GitHub's empty legacy combined commit status as pending even when check-runs were successful, and automated review completion only accepted `APPROVED` states. Once the gate advanced, several resolver launch issues surfaced: camelCase child payload keys for `MoonMind.Run`, missing trusted owner search attributes, stale restored provider-profile defaults, and an overlong AF_UNIX socket path for GitHub auth broker setup on long workflow IDs.

## Changes

- Ignore empty legacy combined commit statuses when check-runs are present and successful.
- Treat bot `COMMENTED` reviews as completed automated review evidence while still blocking on `CHANGES_REQUESTED`.
- Send snake_case resolver child payloads and trusted owner search attributes.
- Refresh restored provider-profile manager state from the DB and clear defaults for removed profiles.
- Use short hashed GitHub auth broker socket paths for managed Codex sessions.
- Add regression coverage for the gate, resolver launch payload, profile sync, and socket path behavior.

## Validation

Targeted unit suites passed with `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh ...` for the changed areas:

- `tests/unit/workflows/adapters/test_github_service.py`
- `tests/unit/workflows/temporal/test_merge_gate_workflow.py`
- `tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`
- `tests/unit/workflows/temporal/test_provider_profile_manager.py`
- `tests/unit/services/temporal/runtime/test_managed_session_controller.py`

The live workflow was reset after the fix and advanced past the original merge gate into an active resolver `MoonMind.AgentRun` with a heartbeating `agent_runtime.send_turn` activity.