### PR TITLE
The task list page does not look like when a workflow launched with a child workflow that gets shown in the ID column for some reason. The table shoul

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -252,4 +252,39 @@ describe('Tasks List Entrypoint', () => {
     expect((await screen.findAllByText('Readable runtime task'))[0]).toBeTruthy();
     expect((await screen.findAllByText('Codex CLI'))[0]).toBeTruthy();
   });
+
+  it('renders the desktop table with constrained columns for long workflow IDs', async () => {
+    const longWorkflowId =
+      'mm:run:child-workflow:01HTESTVERYVERYLONGCHILDWORKFLOWIDENTIFIERWITHOUTBREAKS';
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            taskId: longWorkflowId,
+            source: 'temporal',
+            targetRuntime: 'codex_cli',
+            targetSkill: 'pr-resolver',
+            repository: 'MoonLadderStudios/MoonMind',
+            title: 'Long child workflow id task',
+            status: 'running',
+            state: 'executing',
+            rawState: 'executing',
+            createdAt: '2026-03-28T00:00:00Z',
+          },
+        ],
+      }),
+    } as Response);
+
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    const titleMatches = await screen.findAllByText('Long child workflow id task');
+    const table = titleMatches
+      .map((element) => element.closest('table'))
+      .find((candidate): candidate is HTMLTableElement => Boolean(candidate));
+    expect(table?.querySelectorAll('col.queue-table-column-id')).toHaveLength(1);
+    expect(table?.querySelectorAll('col.queue-table-column-date')).toHaveLength(4);
+    const idCell = table?.querySelector('td.queue-table-cell-id');
+    expect(idCell?.textContent).toBe(longWorkflowId);
+  });
 });

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -462,6 +462,18 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
             <>
               <div className="queue-table-wrapper" data-layout="table">
                 <table>
+                  <colgroup>
+                    <col className="queue-table-column-id" />
+                    <col className="queue-table-column-runtime" />
+                    <col className="queue-table-column-skill" />
+                    <col className="queue-table-column-repository" />
+                    <col className="queue-table-column-status" />
+                    <col className="queue-table-column-title" />
+                    <col className="queue-table-column-date" />
+                    <col className="queue-table-column-date" />
+                    <col className="queue-table-column-date" />
+                    <col className="queue-table-column-date" />
+                  </colgroup>
                   <thead>
                     <tr>
                       {TABLE_COLUMNS.map(([field, label]) => {
@@ -487,31 +499,33 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                     {sortedItems.map((row) => {
                       const depsSummary = dependencyListSummary(row);
                       return (
-                      <tr key={row.taskId}>
-                        <td>
-                          <a href={`/tasks/${encodeURIComponent(row.taskId)}?source=temporal`}>
-                            <code>{row.taskId}</code>
-                          </a>
-                        </td>
-                        <td>{formatRuntimeLabel(row.targetRuntime)}</td>
-                        <td>{formatTaskSkills(row.taskSkills, row.targetSkill)}</td>
-                        <td>{row.repository || '—'}</td>
-                        <td>
-                          <span className={executionStatusPillClasses(row.rawState || row.state || row.status)}>
-                            {row.rawState || row.state || row.status || '—'}
-                          </span>
-                        </td>
-                        <td>
-                          <div>{row.title}</div>
-                          {depsSummary ? (
-                            <div className="small">{depsSummary}</div>
-                          ) : null}
-                        </td>
-                        <td>{formatWhen(row.scheduledFor)}</td>
-                        <td>{formatWhen(row.createdAt)}</td>
-                        <td>{formatWhen(row.startedAt)}</td>
-                        <td>{formatWhen(row.closedAt)}</td>
-                      </tr>
+                        <tr key={row.taskId}>
+                          <td className="queue-table-cell-id">
+                            <a href={`/tasks/${encodeURIComponent(row.taskId)}?source=temporal`}>
+                              <code>{row.taskId}</code>
+                            </a>
+                          </td>
+                          <td className="queue-table-cell-compact">{formatRuntimeLabel(row.targetRuntime)}</td>
+                          <td className="queue-table-cell-compact">
+                            {formatTaskSkills(row.taskSkills, row.targetSkill)}
+                          </td>
+                          <td className="queue-table-cell-compact">{row.repository || '—'}</td>
+                          <td className="queue-table-cell-status">
+                            <span className={executionStatusPillClasses(row.rawState || row.state || row.status)}>
+                              {row.rawState || row.state || row.status || '—'}
+                            </span>
+                          </td>
+                          <td className="queue-table-cell-title">
+                            <div>{row.title}</div>
+                            {depsSummary ? (
+                              <div className="small">{depsSummary}</div>
+                            ) : null}
+                          </td>
+                          <td className="queue-table-cell-date">{formatWhen(row.scheduledFor)}</td>
+                          <td className="queue-table-cell-date">{formatWhen(row.createdAt)}</td>
+                          <td className="queue-table-cell-date">{formatWhen(row.startedAt)}</td>
+                          <td className="queue-table-cell-date">{formatWhen(row.closedAt)}</td>
+                        </tr>
                       );
                     })}
                   </tbody>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -575,6 +575,69 @@ tbody tr:hover {
 
 .queue-table-wrapper {
   display: block;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.queue-table-wrapper table {
+  table-layout: fixed;
+  max-width: 100%;
+}
+
+.queue-table-wrapper th,
+.queue-table-wrapper td {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
+
+.queue-table-wrapper code {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.queue-table-column-id {
+  width: 13%;
+}
+
+.queue-table-column-runtime {
+  width: 8%;
+}
+
+.queue-table-column-skill {
+  width: 9%;
+}
+
+.queue-table-column-repository {
+  width: 10%;
+}
+
+.queue-table-column-status {
+  width: 10%;
+}
+
+.queue-table-column-title {
+  width: 18%;
+}
+
+.queue-table-column-date {
+  width: 8%;
+}
+
+.queue-table-cell-id,
+.queue-table-cell-compact,
+.queue-table-cell-date {
+  font-size: 0.82rem;
+}
+
+.queue-table-cell-status .status {
+  max-width: 100%;
+  white-space: normal;
+}
+
+.queue-table-cell-title {
+  font-weight: 500;
 }
 
 .queue-card-list {


### PR DESCRIPTION
The task list page does not look like when a workflow launched with a child workflow that gets shown in the ID column for some reason. The table should not spill outside the bands of a normal desktop width view due to the workflow run ID column behaving like this (or any other column).