### PR TITLE
The task details page should be constrained to a container with decent margins similar to the Create task page. This should be the default for any pag

### DIFF
--- a/frontend/src/entrypoints/mission-control-app.tsx
+++ b/frontend/src/entrypoints/mission-control-app.tsx
@@ -61,7 +61,9 @@ function AppShell({
 }) {
   return (
     <>
-      <div className="dashboard-shell-constrained">
+      <div
+        className={`dashboard-shell-constrained${dataWidePanel ? ' dashboard-shell-constrained--data-wide' : ''}`}
+      >
         <DashboardAlerts />
       </div>
       <section

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -88,7 +88,32 @@ describe('Mission Control shared entry', () => {
     expect(await screen.findByText(/First-Run Setup:/i)).toBeTruthy();
     await waitFor(() => {
       expect(document.querySelector('.panel--data-wide')).toBeTruthy();
+      expect(document.querySelector('.dashboard-shell-constrained--data-wide')).toBeTruthy();
     });
+  });
+
+  it('uses the constrained shell by default for non-table pages', async () => {
+    renderWithClient(<MissionControlApp payload={{ page: 'tasks-home', apiBase: '/api' }} />);
+
+    expect(await screen.findByText('Hello from Tasks Home!')).toBeTruthy();
+    expect(document.querySelector('.panel--data-wide')).toBeNull();
+    expect(document.querySelector('.dashboard-shell-constrained--data-wide')).toBeNull();
+    expect(document.querySelector('.dashboard-shell-constrained')).toBeTruthy();
+  });
+
+  it('keeps the default panel constrained and centered while data routes opt wider', async () => {
+    const { readFileSync } = await import('node:fs');
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      'utf8',
+    );
+
+    expect(missionControlCss).toMatch(
+      /\.panel\s*\{[^}]*margin-left:\s*auto;[^}]*margin-right:\s*auto;[^}]*max-width:\s*min\(72rem,\s*calc\(100vw - 2rem\)\)/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.panel\.panel--data-wide\s*\{[^}]*max-width:\s*min\(112rem,\s*calc\(100vw - 2rem\)\)/s,
+    );
   });
 
   it('renders an explicit error state for unknown pages', async () => {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -89,12 +89,16 @@ samp {
   container-type: inline-size;
 }
 
-/* Mission Control shell spans full width and left-aligns so content is not trapped in a narrow text column. */
+/* Most pages read best in a centered working container; data-table routes opt into wide. */
 .dashboard-shell-constrained {
-  max-width: 1800px;
-  margin-left: 0;
-  margin-right: 0;
+  max-width: min(72rem, calc(100vw - 2rem));
+  margin-left: auto;
+  margin-right: auto;
   width: 100%;
+}
+
+.dashboard-shell-constrained--data-wide {
+  max-width: min(112rem, calc(100vw - 2rem));
 }
 
 .masthead {
@@ -355,9 +359,9 @@ h1 {
 
 .panel {
   margin-top: 1rem;
-  margin-left: 0;
-  margin-right: 0;
-  max-width: none;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: min(72rem, calc(100vw - 2rem));
   width: 100%;
   border-radius: 1rem;
   border: 1px solid rgb(var(--mm-border) / 0.8);


### PR DESCRIPTION
The task details page should be constrained to a container with decent margins similar to the Create task page. This should be the default for any pages that do not require a large table view. So, Tasks List and Proposals will need the wide, but Settings, Create, Task Details, etc. can remain constrained to a central container with margins.