### PR TITLE
The Tasks List state dropdown does not align with any actual field name. It should now be labeled Status instead. Additionally, the options do not ali

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -124,6 +124,41 @@ describe('Tasks List Entrypoint', () => {
     expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
   });
 
+  it('labels the lifecycle filter as status and exposes canonical status options', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    const statusFilter = screen.getByLabelText('Status') as HTMLSelectElement;
+    const options = Array.from(statusFilter.options).map((option) => option.value);
+
+    expect(options).toEqual([
+      '',
+      'scheduled',
+      'initializing',
+      'waiting_on_dependencies',
+      'planning',
+      'awaiting_slot',
+      'executing',
+      'proposals',
+      'awaiting_external',
+      'finalizing',
+      'completed',
+      'failed',
+      'canceled',
+    ]);
+    expect(options).toContain('completed');
+    expect(options).not.toContain('succeeded');
+
+    const baselineCalls = fetchSpy.mock.calls.length;
+    fireEvent.change(statusFilter, { target: { value: 'completed' } });
+
+    await waitFor(() => {
+      expect(fetchSpy.mock.calls.length).toBe(baselineCalls + 1);
+    });
+    expect(fetchSpy.mock.calls.at(-1)?.[0]).toBe('/api/executions?source=temporal&pageSize=50&state=completed');
+  });
+
   it('renders pagination as arrow buttons beside the table summary', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -19,14 +19,17 @@ type ListDashboardConfig = {
 };
 
 const WORKFLOW_TYPES = ['MoonMind.Run', 'MoonMind.ManifestIngest'] as const;
-const TEMPORAL_STATES = [
+const TEMPORAL_STATUSES = [
+  'scheduled',
   'initializing',
-  'planning',
-  'executing',
-  'awaiting_external',
   'waiting_on_dependencies',
+  'planning',
+  'awaiting_slot',
+  'executing',
+  'proposals',
+  'awaiting_external',
   'finalizing',
-  'succeeded',
+  'completed',
   'failed',
   'canceled',
 ] as const;
@@ -362,7 +365,7 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
             </select>
           </label>
           <label>
-            State
+            Status
             <select
               value={temporalState}
               disabled={!listEnabled}
@@ -371,10 +374,10 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                 resetToFirstPage();
               }}
             >
-              <option value="">All States</option>
-              {TEMPORAL_STATES.map((state) => (
-                <option key={state} value={state}>
-                  {state}
+              <option value="">All Statuses</option>
+              {TEMPORAL_STATUSES.map((status) => (
+                <option key={status} value={status}>
+                  {status}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
The Tasks List state dropdown does not align with any actual field name. It should now be labeled Status instead. Additionally, the options do not align with the actual options now in all cases. For example, completed should be present instead of succeeded. Fix these issues.