### PR TITLE
The Mission Control header contents should span the full width of the page. The Create Task region should be restricted to margins. This is a common p

### DIFF
--- a/api_service/templates/react_dashboard.html
+++ b/api_service/templates/react_dashboard.html
@@ -41,7 +41,7 @@
       </p>
     </section>
 
-    <div class="dashboard-shell-constrained">
+    <div class="dashboard-shell-full">
       <header class="masthead">
         <div class="masthead-brand">
           <img

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -116,13 +116,16 @@ describe('Mission Control shared entry', () => {
     );
   });
 
-  it('lets masthead chrome span the viewport while content stays constrained', async () => {
+  it('lets masthead content and chrome span the page while panels stay constrained', async () => {
     const { readFileSync } = await import('node:fs');
     const missionControlCss = readFileSync(
       `${process.cwd()}/frontend/src/styles/mission-control.css`,
       'utf8',
     );
 
+    expect(missionControlCss).toMatch(
+      /\.dashboard-shell-full\s*\{[^}]*width:\s*100%/s,
+    );
     expect(missionControlCss).toMatch(
       /\.masthead::before\s*\{[^}]*left:\s*calc\(50% - 50cqw - 1rem\);[^}]*right:\s*calc\(50% - 50cqw - 1rem\);/s,
     );

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -101,6 +101,10 @@ samp {
   max-width: min(112rem, calc(100vw - 2rem));
 }
 
+.dashboard-shell-full {
+  width: 100%;
+}
+
 .masthead {
   position: relative;
   isolation: isolate;

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -186,6 +186,7 @@ def test_static_sub_routes_render_react_shell(client: TestClient) -> None:
         assert "moonmind-ui-boot" in response.text
         assert 'type="module"' in response.text
         assert "/static/task_dashboard/dist/assets/" in response.text
+        assert 'class="dashboard-shell-full"' in response.text
         assert 'class="masthead-brand"' in response.text
         assert 'src="/static/task_dashboard/moonmindlogo.webp"' in response.text
         assert "MOONMIND OPERATIONS" not in response.text


### PR DESCRIPTION
The Mission Control header contents should span the full width of the page. The Create Task region should be restricted to margins. This is a common pattern with sites like GitHub and we also want to use it here. It seems like it gets switched back and forth because for some reason the assumption is that they should match, which is not what is seen with sites like GitHub.