### PR TITLE
When full screen and there's enough space, I want the Mission Control title text to be close to the left side of the screen. The navigation tabs:

### DIFF
--- a/api_service/templates/react_dashboard.html
+++ b/api_service/templates/react_dashboard.html
@@ -64,7 +64,9 @@
           <span class="nav-hamburger-icon" aria-hidden="true"></span>
         </button>
 
-        {% include "_navigation.html" %}
+        <div class="masthead-nav">
+          {% include "_navigation.html" %}
+        </div>
 
         {% if build_id %}
         <div class="masthead-title-meta">

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -134,6 +134,27 @@ describe('Mission Control shared entry', () => {
     );
   });
 
+  it('keeps the masthead brand left, navigation centered, and version aligned right on desktop', async () => {
+    const { readFileSync } = await import('node:fs');
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      'utf8',
+    );
+
+    expect(missionControlCss).toMatch(
+      /\.masthead\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto\s+minmax\(0,\s*1fr\);/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.masthead-brand\s*\{[^}]*justify-self:\s*start;/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.masthead-nav\s*\{[^}]*justify-content:\s*center;[^}]*justify-self:\s*center;/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.masthead-title-meta\s*\{[^}]*justify-self:\s*end;[^}]*justify-content:\s*flex-end;/s,
+    );
+  });
+
   it('renders an explicit error state for unknown pages', async () => {
     renderWithClient(
       <MissionControlApp payload={{ page: 'not-a-page', apiBase: '/api' }} />,

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -155,6 +155,29 @@ describe('Mission Control shared entry', () => {
     );
   });
 
+  it('keeps the wider masthead breakpoint isolated from the shared mobile layout rules', async () => {
+    const { readFileSync } = await import('node:fs');
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      'utf8',
+    );
+
+    const mastheadBreakpointStart = missionControlCss.indexOf('@media (max-width: 1180px)');
+    const sharedMobileStart = missionControlCss.indexOf('@media (max-width: 900px)');
+    const mastheadResponsive = missionControlCss.slice(
+      mastheadBreakpointStart,
+      sharedMobileStart,
+    );
+    const sharedMobile = missionControlCss.slice(sharedMobileStart);
+
+    expect(mastheadBreakpointStart).toBeGreaterThanOrEqual(0);
+    expect(sharedMobileStart).toBeGreaterThan(mastheadBreakpointStart);
+    expect(mastheadResponsive).toContain('.masthead {');
+    expect(mastheadResponsive).not.toContain('.grid-2 {');
+    expect(sharedMobile).toContain('.grid-2 {');
+    expect(sharedMobile).toContain('.queue-submit-form {');
+  });
+
   it('renders an explicit error state for unknown pages', async () => {
     renderWithClient(
       <MissionControlApp payload={{ page: 'not-a-page', apiBase: '/api' }} />,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -112,7 +112,6 @@ samp {
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   column-gap: 1rem;
-  row-gap: 0.55rem;
   padding: 0.65rem 1rem 0.62rem;
 }
 
@@ -2333,7 +2332,9 @@ button.secondary:hover {
     text-align: left;
     background: transparent;
   }
+}
 
+@media (max-width: 900px) {
   .grid-2 {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -108,12 +108,12 @@ samp {
 .masthead {
   position: relative;
   isolation: isolate;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
-  justify-content: flex-start;
-  gap: 1.25rem;
+  column-gap: 1rem;
+  row-gap: 0.55rem;
   padding: 0.65rem 1rem 0.62rem;
-  flex-wrap: wrap;
 }
 
 .masthead::before {
@@ -140,6 +140,7 @@ samp {
 .masthead-brand {
   display: inline-flex;
   align-items: center;
+  justify-self: start;
   gap: 0.55rem;
   min-width: 0;
 }
@@ -159,11 +160,11 @@ samp {
 }
 
 .masthead-title-meta {
-  margin-left: auto;
   display: flex;
   align-items: center;
+  justify-self: end;
   justify-content: flex-end;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.4rem;
   row-gap: 0.25rem;
   min-width: 0;
@@ -269,6 +270,13 @@ h1 {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.55rem;
+}
+
+.masthead-nav {
+  display: flex;
+  justify-content: center;
+  justify-self: center;
+  min-width: 0;
 }
 
 .nav-hamburger {
@@ -2266,7 +2274,14 @@ button.secondary:hover {
   align-items: center;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1180px) {
+  .masthead {
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+  }
+
   .masthead-brand {
     flex: 1 1 auto;
     min-width: 0;
@@ -2284,6 +2299,10 @@ button.secondary:hover {
 
   .version-badge {
     margin-left: 0;
+  }
+
+  .masthead-nav {
+    display: contents;
   }
 
   .route-nav {

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -280,6 +280,21 @@ def test_navigation_exposes_single_manifest_destination(client: TestClient) -> N
     assert 'href="/tasks/manifests/new"' not in response.text
 
 
+def test_react_shell_wraps_navigation_in_centered_masthead_slot(
+    client: TestClient,
+) -> None:
+    response = client.get("/tasks/list")
+
+    assert response.status_code == 200
+    assert '<div class="masthead-nav">' in response.text
+    assert response.text.index('<div class="masthead-nav">') < response.text.index(
+        'id="mission-control-nav"'
+    )
+    assert response.text.index('id="mission-control-nav"') < response.text.index(
+        '<div class="masthead-title-meta">'
+    )
+
+
 def test_trailing_slash_alias_routes_return_404_not_detail_page(client: TestClient) -> None:
     """Trailing-slash variants /tasks/create/ and /tasks/tasks-list/ must not render a detail shell."""
     for path in ("/tasks/create/", "/tasks/tasks-list/"):

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -290,9 +290,12 @@ def test_react_shell_wraps_navigation_in_centered_masthead_slot(
     assert response.text.index('<div class="masthead-nav">') < response.text.index(
         'id="mission-control-nav"'
     )
-    assert response.text.index('id="mission-control-nav"') < response.text.index(
-        '<div class="masthead-title-meta">'
-    )
+
+    title_meta_marker = '<div class="masthead-title-meta">'
+    if title_meta_marker in response.text:
+        assert response.text.index('id="mission-control-nav"') < response.text.index(
+            title_meta_marker
+        )
 
 
 def test_trailing_slash_alias_routes_return_404_not_detail_page(client: TestClient) -> None:


### PR DESCRIPTION
When full screen and there's enough space, I want the Mission Control title text to be close to the left side of the screen. The navigation tabs:
 🛰️ Tasks
🚀 Create
💽 Manifests
🌒 Schedules
🔭 Proposals
🛠️ Skills
⚙️ Settings

Should be in a div that's centered. The version, e.g. "v20260420.2060" should be on the far right and still in the same row unless there's not enough space.