### PR TITLE
There is wasted space to the right of the github repo in the floating bar on desktop. This space should be used to allow GitHub Repo, Branch, and publ

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5659,6 +5659,18 @@ describe("Task Create Entrypoint", () => {
     );
   });
 
+  it("gives repository, branch, and publish controls equal desktop space in the floating bar", async () => {
+    const { readFileSync } = await import("node:fs");
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      "utf8",
+    );
+
+    expect(missionControlCss).toMatch(
+      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)\s*auto/s,
+    );
+  });
+
   it("centers the constrained create page panel with equal side margins", async () => {
     const { readFileSync } = await import("node:fs");
     const missionControlCss = readFileSync(

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1877,7 +1877,7 @@ button.secondary:hover {
 
 .queue-floating-bar-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr) minmax(0, 0.7fr) auto;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
   gap: 0.5rem;
   align-items: center;
 }


### PR DESCRIPTION
There is wasted space to the right of the github repo in the floating bar on desktop. This space should be used to allow GitHub Repo, Branch, and publish mode more space and roughly equal sizes.