### PR TITLE
Remove the "started" column from the tasks list page. This can purely be part of task details.

### DIFF
--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -27,6 +27,7 @@ describe('Tasks List Entrypoint', () => {
             status: 'completed',
             state: 'succeeded',
             rawState: 'succeeded',
+            startedAt: '2026-03-28T00:00:01Z',
             createdAt: '2026-03-28T00:00:00Z',
           },
         ],
@@ -55,6 +56,15 @@ describe('Tasks List Entrypoint', () => {
         'Runtime. Sorted ascending. Activate to sort descending.',
       );
     });
+  });
+
+  it('keeps started time out of the task list presentation', async () => {
+    renderWithClient(<TasksListPage payload={mockPayload} />);
+
+    await screen.findAllByText('Example task');
+
+    expect(screen.queryByRole('button', { name: /^Started\./i })).toBeNull();
+    expect(screen.queryByText('Started')).toBeNull();
   });
 
   it('orders scheduled rows by latest scheduled time before created time by default', async () => {
@@ -341,7 +351,7 @@ describe('Tasks List Entrypoint', () => {
       .map((element) => element.closest('table'))
       .find((candidate): candidate is HTMLTableElement => Boolean(candidate));
     expect(table?.querySelectorAll('col.queue-table-column-id')).toHaveLength(1);
-    expect(table?.querySelectorAll('col.queue-table-column-date')).toHaveLength(4);
+    expect(table?.querySelectorAll('col.queue-table-column-date')).toHaveLength(3);
     const idCell = table?.querySelector('td.queue-table-cell-id');
     expect(idCell?.textContent).toBe(longWorkflowId);
   });

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -65,7 +65,6 @@ const ExecutionRowSchema = z
     rawState: z.string().optional(),
     temporalStatus: z.string().optional(),
     scheduledFor: z.string().nullable().optional(),
-    startedAt: z.string().nullable().optional(),
     closedAt: z.string().nullable().optional(),
     createdAt: z.string(),
     entry: z.string().optional(),

--- a/frontend/src/entrypoints/tasks-list.tsx
+++ b/frontend/src/entrypoints/tasks-list.tsx
@@ -35,7 +35,7 @@ const TEMPORAL_STATUSES = [
 ] as const;
 const ENTRY_OPTIONS = ['run', 'manifest'] as const;
 
-const TIMESTAMP_SORT_FIELDS = new Set(['scheduledFor', 'createdAt', 'startedAt', 'closedAt']);
+const TIMESTAMP_SORT_FIELDS = new Set(['scheduledFor', 'createdAt', 'closedAt']);
 const TABLE_COLUMNS = [
   ['taskId', 'ID'],
   ['targetRuntime', 'Runtime'],
@@ -45,7 +45,6 @@ const TABLE_COLUMNS = [
   ['title', 'Title'],
   ['scheduledFor', 'Scheduled'],
   ['createdAt', 'Created'],
-  ['startedAt', 'Started'],
   ['closedAt', 'Finished'],
 ] as const;
 const VALID_TABLE_SORT_FIELDS = new Set<string>([...TABLE_COLUMNS.map((column) => column[0]), 'integration']);
@@ -475,7 +474,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                     <col className="queue-table-column-date" />
                     <col className="queue-table-column-date" />
                     <col className="queue-table-column-date" />
-                    <col className="queue-table-column-date" />
                   </colgroup>
                   <thead>
                     <tr>
@@ -526,7 +524,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                           </td>
                           <td className="queue-table-cell-date">{formatWhen(row.scheduledFor)}</td>
                           <td className="queue-table-cell-date">{formatWhen(row.createdAt)}</td>
-                          <td className="queue-table-cell-date">{formatWhen(row.startedAt)}</td>
                           <td className="queue-table-cell-date">{formatWhen(row.closedAt)}</td>
                         </tr>
                       );
@@ -588,10 +585,6 @@ export function TasksListPage({ payload }: { payload: BootPayload }) {
                       <div>
                         <dt>Created</dt>
                         <dd>{formatWhen(row.createdAt)}</dd>
-                      </div>
-                      <div>
-                        <dt>Started</dt>
-                        <dd>{formatWhen(row.startedAt)}</dd>
                       </div>
                       <div>
                         <dt>Finished</dt>


### PR DESCRIPTION
Remove the "started" column from the tasks list page. This can purely be part of task details.