### PR TITLE
[codex] Surface preset as primary skill

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -304,7 +304,7 @@ def _task_template_primary_skill_name(task_payload: Mapping[str, Any]) -> str | 
         "applied_step_templates"
     )
     if isinstance(applied_templates, list):
-        for item in applied_templates:
+        for item in reversed(applied_templates):
             if not isinstance(item, Mapping):
                 continue
             candidate = _coerce_temporal_scalar(

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -287,6 +287,35 @@ def _skill_selector_names(raw: object | None) -> list[str] | None:
     return _dedupe_non_blank(names) or None
 
 
+def _task_template_primary_skill_name(task_payload: Mapping[str, Any]) -> str | None:
+    task_template = task_payload.get("taskTemplate") or task_payload.get(
+        "task_template"
+    )
+    if isinstance(task_template, Mapping):
+        candidate = _coerce_temporal_scalar(
+            task_template.get("slug")
+            or task_template.get("name")
+            or task_template.get("id")
+        )
+        if candidate:
+            return candidate
+
+    applied_templates = task_payload.get("appliedStepTemplates") or task_payload.get(
+        "applied_step_templates"
+    )
+    if isinstance(applied_templates, list):
+        for item in applied_templates:
+            if not isinstance(item, Mapping):
+                continue
+            candidate = _coerce_temporal_scalar(
+                item.get("slug") or item.get("name") or item.get("id")
+            )
+            if candidate:
+                return candidate
+
+    return None
+
+
 def _first_mapping(*candidates: object | None) -> Mapping[str, Any]:
     for candidate in candidates:
         if isinstance(candidate, Mapping):
@@ -852,14 +881,33 @@ def _serialize_execution(
         ) or None
 
     task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
-    tool_params = task_params.get("tool") if isinstance(task_params.get("tool"), dict) else {}
-    skill_params = task_params.get("skill") if isinstance(task_params.get("skill"), dict) else {}
+    tool_params = (
+        task_params.get("tool") if isinstance(task_params.get("tool"), dict) else {}
+    )
+    skill_params = (
+        task_params.get("skill") if isinstance(task_params.get("skill"), dict) else {}
+    )
     target_skill = (
-        str(tool_params.get("name") or skill_params.get("name") or "").strip() or None
+        str(
+            tool_params.get("name")
+            or tool_params.get("id")
+            or skill_params.get("name")
+            or skill_params.get("id")
+            or ""
+        ).strip()
+        or None
     )
     if not target_skill:
+        target_skill = _task_template_primary_skill_name(task_params)
+    if not target_skill:
         target_skill = (
-            _coerce_temporal_scalar(search_attributes.get("mm_target_skill"))
+            _coerce_temporal_scalar(params.get("targetSkill"))
+            or _coerce_temporal_scalar(params.get("target_skill"))
+            or _coerce_temporal_scalar(params.get("skillId"))
+            or _coerce_temporal_scalar(params.get("skill"))
+            or _coerce_temporal_scalar(params.get("selectedSkill"))
+            or _coerce_temporal_scalar(params.get("selected_skill"))
+            or _coerce_temporal_scalar(search_attributes.get("mm_target_skill"))
             or _coerce_temporal_scalar(search_attributes.get("mm_skill_id"))
             or _coerce_temporal_scalar(search_attributes.get("mm_skill"))
             or _coerce_temporal_scalar(search_attributes.get("skillId"))
@@ -938,9 +986,20 @@ def _serialize_execution(
         else []
     )
 
-    resolved_skillset_ref = str(params.get("resolvedSkillsetRef") or params.get("resolved_skillset_ref") or "").strip() or None
-    
+    resolved_skillset_ref = (
+        str(
+            params.get("resolvedSkillsetRef")
+            or params.get("resolved_skillset_ref")
+            or ""
+        ).strip()
+        or None
+    )
+
     task_skills = _skill_selector_names(task_payload.get("skills"))
+    if task_skills is None:
+        template_primary_skill = _task_template_primary_skill_name(task_payload)
+        if template_primary_skill:
+            task_skills = [template_primary_skill]
     skill_runtime = _skill_runtime_evidence(
         params=params,
         task_payload=task_payload,

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -3212,13 +3212,13 @@ describe("Task Create Entrypoint", () => {
           proposeTasks: true,
           tool: {
             type: "skill",
-            name: "speckit-implement",
+            name: "speckit-demo",
           },
           skill: {
-            id: "speckit-implement",
+            id: "speckit-demo",
           },
           skills: {
-            include: [{ name: "speckit-implement" }],
+            include: [{ name: "speckit-demo" }],
           },
           runtime: {
             mode: "gemini_cli",
@@ -6390,14 +6390,14 @@ describe("Task Create Entrypoint", () => {
     const request = JSON.parse(String(executionCall?.[1]?.body));
     expect(request.payload.task.instructions).toBe('Task Create');
     // Address: Copilot r3034495957 — assert skills and derived title in preset-submit.
-    // The first template step has an explicit skill (speckit-clarify), so effectiveSkillId
-    // stays as that explicit skill rather than the template slug.
+    // The applied preset slug is the workflow-level primary skill even when
+    // the first preset step has its own explicit execution skill.
     expect(request.payload.task.skills).toEqual({
-      include: [{ name: "speckit-clarify" }],
+      include: [{ name: "speckit-demo" }],
     });
     expect(request.payload.task.title).toBe('Task Create');
-    expect(request.payload.task.tool.name).toBe('speckit-clarify');
-    expect(request.payload.task.skill.id).toBe('speckit-clarify');
+    expect(request.payload.task.tool.name).toBe('speckit-demo');
+    expect(request.payload.task.skill.id).toBe('speckit-demo');
     expect(request.payload.task.steps).toEqual([
       {
         id: "tpl:speckit-demo:1.2.3:01",

--- a/frontend/src/entrypoints/task-create.tsx
+++ b/frontend/src/entrypoints/task-create.tsx
@@ -957,12 +957,12 @@ function resolveEffectiveSkillId(
   primarySkillId: string,
   appliedTemplates: AppliedTemplateState[],
 ): string {
-  if (hasExplicitSkillSelection(primarySkillId)) {
-    return primarySkillId;
-  }
   if (appliedTemplates.length > 0) {
     const lastTemplate = appliedTemplates[appliedTemplates.length - 1];
     return lastTemplate?.slug ?? primarySkillId;
+  }
+  if (hasExplicitSkillSelection(primarySkillId)) {
+    return primarySkillId;
   }
   return primarySkillId;
 }
@@ -5042,7 +5042,7 @@ export function TaskCreatePage({ payload }: { payload: BootPayload }) {
         : cleaned;
     })();
 
-    // Determine skill: use template slug when a preset is applied without explicit skill selection.
+    // Determine skill: applied presets define the workflow-level primary skill.
     const effectiveSubmissionSkillId = resolveEffectiveSkillId(
       primarySkillId,
       appliedTemplates,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2162,6 +2162,35 @@ def test_serialize_execution_surfaces_applied_template_slug_as_primary_skill() -
     assert dumped["taskSkills"] == ["jira-orchestrate"]
 
 
+def test_serialize_execution_uses_latest_applied_template_as_primary_skill() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "targetRuntime": "codex_cli",
+        "task": {
+            "instructions": "Run the latest applied preset.",
+            "appliedStepTemplates": [
+                {
+                    "slug": "initial-preset",
+                    "version": "1.0.0",
+                    "stepIds": ["tpl:initial-preset:1"],
+                },
+                {
+                    "slug": "latest-preset",
+                    "version": "1.0.0",
+                    "stepIds": ["tpl:latest-preset:1"],
+                },
+            ],
+        },
+    }
+
+    payload = _serialize_execution(record)
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["targetSkill"] == "latest-preset"
+    assert dumped["taskSkills"] == ["latest-preset"]
+    assert dumped["skillRuntime"]["selectedSkills"] == ["latest-preset"]
+
+
 def test_serialize_execution_surfaces_compact_skill_runtime_metadata() -> None:
     record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
     record.parameters = {

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2115,6 +2115,53 @@ def test_serialize_execution_surfaces_runtime_fields_from_task_runtime_payload()
     assert dumped["profileId"] == "profile:claude-default"
 
 
+def test_serialize_execution_surfaces_task_template_slug_as_primary_skill() -> None:
+    record = _build_execution_record(
+        state=MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
+    )
+    record.parameters = {
+        "targetRuntime": "codex_cli",
+        "task": {
+            "title": "Run Jira Orchestrate for MM-501",
+            "instructions": "Use the existing Jira Orchestrate workflow.",
+            "taskTemplate": {
+                "slug": "jira-orchestrate",
+                "version": "1.0.0",
+            },
+        },
+    }
+
+    payload = _serialize_execution(record)
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["targetSkill"] == "jira-orchestrate"
+    assert dumped["taskSkills"] == ["jira-orchestrate"]
+    assert dumped["skillRuntime"]["selectedSkills"] == ["jira-orchestrate"]
+
+
+def test_serialize_execution_surfaces_applied_template_slug_as_primary_skill() -> None:
+    record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
+    record.parameters = {
+        "targetRuntime": "codex_cli",
+        "task": {
+            "instructions": "Run the applied preset.",
+            "appliedStepTemplates": [
+                {
+                    "slug": "jira-orchestrate",
+                    "version": "1.0.0",
+                    "stepIds": ["tpl:jira-orchestrate:1"],
+                }
+            ],
+        },
+    }
+
+    payload = _serialize_execution(record)
+    dumped = payload.model_dump(by_alias=True)
+
+    assert dumped["targetSkill"] == "jira-orchestrate"
+    assert dumped["taskSkills"] == ["jira-orchestrate"]
+
+
 def test_serialize_execution_surfaces_compact_skill_runtime_metadata() -> None:
     record = _build_execution_record(state=MoonMindWorkflowState.EXECUTING)
     record.parameters = {


### PR DESCRIPTION
## Summary

This change makes applied presets the workflow-level primary skill for Mission Control execution rows and submission payloads.

## What changed

- Execution API projection now derives `targetSkill` and `taskSkills` from `task.taskTemplate.slug` or applied template metadata when no explicit workflow tool/skill is present.
- Task creation now prioritizes the applied preset slug over Step 1's explicit skill for workflow-level `task.tool`, `task.skill`, and `task.skills` selection.
- Added backend and frontend tests covering preset-derived primary skill behavior.

## Why

Jira Orchestrate child workflows were created with preset metadata but no explicit workflow-level skill, so the Skill column displayed `—`. Preset-applied workflows should list the applied preset, such as `jira-orchestrate`, as the primary skill even when the first execution step has its own skill.

## Validation

- `./tools/test_unit.sh --python-only tests/unit/api/routers/test_executions.py`
- `npm run ui:test -- frontend/src/entrypoints/task-create.test.tsx`

Note: A prior full unit-run attempt reached unrelated Mission Control frontend coverage and failed on an existing OAuth terminal assertion outside this change.