### PR TITLE
[codex] Expose merge automation observability

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -10,7 +10,7 @@ import re
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
@@ -52,6 +52,8 @@ from moonmind.schemas.temporal_models import (
     ExecutionActionCapabilityModel,
     ExecutionDependencySummaryModel,
     ExecutionDebugFieldsModel,
+    ExecutionMergeAutomationModel,
+    ExecutionMergeAutomationResolverChildModel,
     ExecutionProjectionDiagnosticModel,
     ExecutionListResponse,
     ExecutionModel,
@@ -751,6 +753,71 @@ def _derive_full_task_instructions(task_payload: Mapping[str, Any]) -> str | Non
     return None
 
 
+def _normalize_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        candidate = str(item or "").strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized
+
+
+def _normalize_merge_automation_visibility_payload(
+    payload: Any,
+) -> ExecutionMergeAutomationModel | None:
+    if not isinstance(payload, Mapping):
+        return None
+    normalized = dict(payload)
+    workflow_id = (
+        _coerce_temporal_scalar(normalized.get("workflowId"))
+        or _coerce_temporal_scalar(normalized.get("childWorkflowId"))
+        or _coerce_temporal_scalar(normalized.get("mergeAutomationWorkflowId"))
+    )
+    if workflow_id:
+        normalized["workflowId"] = workflow_id
+        normalized["childWorkflowId"] = workflow_id
+
+    normalized["resolverChildWorkflowIds"] = _normalize_string_list(
+        normalized.get("resolverChildWorkflowIds")
+    )
+    blockers = normalized.get("blockers")
+    normalized["blockers"] = blockers if isinstance(blockers, list) else []
+    artifact_refs = normalized.get("artifactRefs")
+    if isinstance(artifact_refs, Mapping):
+        artifact_refs = dict(artifact_refs)
+        artifact_refs["gateSnapshots"] = _normalize_string_list(
+            artifact_refs.get("gateSnapshots")
+        )
+        artifact_refs["resolverAttempts"] = _normalize_string_list(
+            artifact_refs.get("resolverAttempts")
+        )
+        normalized["artifactRefs"] = artifact_refs
+    elif artifact_refs is not None:
+        normalized["artifactRefs"] = None
+
+    normalized["resolverChildren"] = (
+        normalized.get("resolverChildren")
+        if isinstance(normalized.get("resolverChildren"), list)
+        else []
+    )
+    normalized.setdefault("enabled", True)
+
+    try:
+        return ExecutionMergeAutomationModel.model_validate(normalized)
+    except ValidationError as exc:
+        logger.warning(
+            "Invalid merge automation visibility payload: %s",
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
 def _serialize_execution(
     record, *, include_artifact_refs: bool = True, user: Optional["User"] = None
 ) -> ExecutionModel:
@@ -1005,6 +1072,9 @@ def _serialize_execution(
     ).strip() or None
     publish_mode = raw_publish_mode if raw_publish_mode in _ALLOWED_PUBLISH_MODES else None
     merge_automation_selected = _merge_automation_selected_from_parameters(params)
+    merge_automation = _normalize_merge_automation_visibility_payload(
+        memo.get("merge_automation") or memo.get("mergeAutomation")
+    )
     pr_url = _extract_execution_pr_url(memo, search_attributes, params)
     is_admin = _is_execution_admin(user)
     steps_href = (
@@ -1064,6 +1134,7 @@ def _serialize_execution(
         pr_url=pr_url,
         publish_mode=publish_mode,
         merge_automation_selected=merge_automation_selected,
+        merge_automation=merge_automation,
         resolved_skillset_ref=resolved_skillset_ref,
         task_skills=task_skills,
         skill_runtime=skill_runtime,
@@ -1168,6 +1239,102 @@ async def _enrich_execution_dependencies(
             ],
         }
     )
+
+
+async def _resolver_child_observability(
+    *,
+    temporal_client: Client,
+    workflow_id: str,
+) -> ExecutionMergeAutomationResolverChildModel:
+    task_run_id: str | None = None
+    child_status: str | None = None
+    try:
+        payload = await query_workflow(
+            temporal_client,
+            workflow_id,
+            "get_step_ledger",
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed to query resolver child step ledger for %s: %s",
+            workflow_id,
+            exc,
+        )
+        payload = None
+    if isinstance(payload, Mapping):
+        steps = payload.get("steps")
+        if isinstance(steps, list):
+            for step in steps:
+                if not isinstance(step, Mapping):
+                    continue
+                if child_status is None:
+                    child_status = _coerce_temporal_scalar(step.get("status")) or None
+                refs = step.get("refs")
+                if not isinstance(refs, Mapping):
+                    continue
+                task_run_id = (
+                    _coerce_temporal_scalar(refs.get("taskRunId"))
+                    or _coerce_temporal_scalar(refs.get("task_run_id"))
+                    or None
+                )
+                if task_run_id:
+                    break
+    return ExecutionMergeAutomationResolverChildModel(
+        workflowId=workflow_id,
+        taskRunId=task_run_id,
+        status=child_status,
+        detailHref=f"/tasks/{quote(workflow_id, safe='')}?source=temporal",
+    )
+
+
+async def _enrich_execution_merge_automation(
+    execution: ExecutionModel,
+    *,
+    temporal_client: Client,
+) -> ExecutionModel:
+    merge_automation = execution.merge_automation
+    if merge_automation is None:
+        return execution
+    workflow_id = merge_automation.workflow_id or merge_automation.child_workflow_id
+    payload = merge_automation.model_dump(by_alias=True, exclude_none=True)
+    if workflow_id:
+        try:
+            live_payload = await query_workflow(
+                temporal_client,
+                workflow_id,
+                "summary",
+            )
+        except Exception as exc:
+            logger.debug(
+                "Failed to query merge automation summary for %s: %s",
+                workflow_id,
+                exc,
+            )
+        else:
+            if isinstance(live_payload, Mapping):
+                payload.update(dict(live_payload))
+                payload["workflowId"] = workflow_id
+                payload["childWorkflowId"] = workflow_id
+                payload["enabled"] = True
+
+    normalized = _normalize_merge_automation_visibility_payload(payload)
+    if normalized is None:
+        return execution
+
+    resolver_ids = list(normalized.resolver_child_workflow_ids)
+    if resolver_ids:
+        resolver_children = [
+            await _resolver_child_observability(
+                temporal_client=temporal_client,
+                workflow_id=child_workflow_id,
+            )
+            for child_workflow_id in resolver_ids[:10]
+        ]
+        normalized = normalized.model_copy(
+            update={"resolver_children": resolver_children}
+        )
+
+    return execution.model_copy(update={"merge_automation": normalized})
 
 
 async def _hydrate_provider_profile_metadata(
@@ -3534,6 +3701,10 @@ async def describe_execution(
             update["run_id"] = queried_run_id
             update["temporal_run_id"] = queried_run_id
         execution = execution.model_copy(update=update)
+        execution = await _enrich_execution_merge_automation(
+            execution,
+            temporal_client=temporal_client,
+        )
     if not execution.task_run_id:
         task_run_ids = await asyncio.to_thread(
             _resolve_task_run_ids_from_managed_store,

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1323,13 +1323,15 @@ async def _enrich_execution_merge_automation(
 
     resolver_ids = list(normalized.resolver_child_workflow_ids)
     if resolver_ids:
-        resolver_children = [
-            await _resolver_child_observability(
-                temporal_client=temporal_client,
-                workflow_id=child_workflow_id,
+        resolver_children = await asyncio.gather(
+            *(
+                _resolver_child_observability(
+                    temporal_client=temporal_client,
+                    workflow_id=child_workflow_id,
+                )
+                for child_workflow_id in resolver_ids[:10]
             )
-            for child_workflow_id in resolver_ids[:10]
-        ]
+        )
         normalized = normalized.model_copy(
             update={"resolver_children": resolver_children}
         )

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1646,6 +1646,71 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('renders live merge automation visibility from execution detail', async () => {
+    const mockExecution = {
+      taskId: 'test-live-merge-visibility',
+      workflowId: 'test-live-merge-visibility',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Live merge visibility task',
+      summary: 'Waiting on merge automation',
+      status: 'running',
+      state: 'awaiting_external',
+      rawState: 'awaiting_external',
+      temporalStatus: 'running',
+      closeStatus: null,
+      mergeAutomationSelected: true,
+      mergeAutomation: {
+        enabled: true,
+        workflowId: 'merge-automation:test-live-merge-visibility',
+        status: 'waiting',
+        prNumber: 1614,
+        prUrl: 'https://github.com/MoonLadderStudios/MoonMind/pull/1614',
+        latestHeadSha: 'abc123',
+        blockers: [{ kind: 'checks_failed', summary: 'Required checks are failing.', source: 'github' }],
+        resolverChildWorkflowIds: [],
+        artifactRefs: {
+          gateSnapshots: ['gate-snapshot-artifact'],
+          resolverAttempts: [],
+        },
+      },
+      createdAt: '2026-03-28T00:00:00Z',
+      startedAt: '2026-03-28T00:00:01Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      closedAt: null,
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Live merge visibility task')).toBeTruthy();
+      expect(screen.getByText('waiting')).toBeTruthy();
+      expect(screen.getByText('merge-automation:test-live-merge-visibility')).toBeTruthy();
+      expect(screen.getByText('Required checks are failing.')).toBeTruthy();
+      expect(screen.getByText('Waiting for required checks before launching pr-resolver.')).toBeTruthy();
+      expect(screen.getByText('gate-snapshot-artifact')).toBeTruthy();
+    });
+  });
+
   it('renders prerequisite and dependent panels for dependency-aware runs', async () => {
     const mockExecution = {
       taskId: 'mm:dependent-1',

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1711,6 +1711,61 @@ describe('Task Detail Entrypoint', () => {
     });
   });
 
+  it('accepts null merge automation artifact refs from execution detail', async () => {
+    const mockExecution = {
+      taskId: 'test-null-merge-artifact-refs',
+      workflowId: 'test-null-merge-artifact-refs',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Null merge artifact refs task',
+      summary: 'Waiting on merge automation',
+      status: 'running',
+      state: 'awaiting_external',
+      rawState: 'awaiting_external',
+      temporalStatus: 'running',
+      closeStatus: null,
+      mergeAutomationSelected: true,
+      mergeAutomation: {
+        enabled: true,
+        workflowId: 'merge-automation:test-null-merge-artifact-refs',
+        status: 'waiting',
+        resolverChildWorkflowIds: [],
+        artifactRefs: null,
+      },
+      createdAt: '2026-03-28T00:00:00Z',
+      startedAt: '2026-03-28T00:00:01Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      closedAt: null,
+      actions: {},
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Null merge artifact refs task')).toBeTruthy();
+      expect(screen.getByText('waiting')).toBeTruthy();
+      expect(screen.getByText('merge-automation:test-null-merge-artifact-refs')).toBeTruthy();
+    });
+  });
+
   it('renders prerequisite and dependent panels for dependency-aware runs', async () => {
     const mockExecution = {
       taskId: 'mm:dependent-1',

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -250,6 +250,7 @@ const MergeAutomationSchema = z
         resolverAttempts: z.array(z.string()).default([]).optional(),
       })
       .passthrough()
+      .nullable()
       .optional(),
   })
   .passthrough();

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -206,6 +206,54 @@ const SkillRuntimeSchema = z
   })
   .passthrough();
 
+const MergeAutomationSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    workflowId: z.string().nullable().optional(),
+    childWorkflowId: z.string().nullable().optional(),
+    status: z.string().nullable().optional(),
+    prNumber: z.union([z.number(), z.string()]).nullable().optional(),
+    prUrl: z.string().nullable().optional(),
+    latestHeadSha: z.string().nullable().optional(),
+    cycles: z.union([z.number(), z.string()]).nullable().optional(),
+    resolverChildWorkflowIds: z.array(z.string()).default([]).optional(),
+    resolverChildren: z
+      .array(
+        z
+          .object({
+            workflowId: z.string(),
+            taskRunId: z.string().nullable().optional(),
+            status: z.string().nullable().optional(),
+            detailHref: z.string().nullable().optional(),
+          })
+          .passthrough(),
+      )
+      .default([])
+      .optional(),
+    blockers: z
+      .array(
+        z
+          .object({
+            kind: z.string().nullable().optional(),
+            summary: z.string().nullable().optional(),
+            source: z.string().nullable().optional(),
+            retryable: z.boolean().nullable().optional(),
+          })
+          .passthrough(),
+      )
+      .default([])
+      .optional(),
+    artifactRefs: z
+      .object({
+        summary: z.string().nullable().optional(),
+        gateSnapshots: z.array(z.string()).default([]).optional(),
+        resolverAttempts: z.array(z.string()).default([]).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
 const ExecutionDetailSchema = z
   .object({
     taskId: z.string(),
@@ -252,6 +300,7 @@ const ExecutionDetailSchema = z
     skillRuntime: SkillRuntimeSchema.nullable().optional(),
     publishMode: z.string().nullable().optional(),
     mergeAutomationSelected: z.boolean().optional().default(false),
+    mergeAutomation: MergeAutomationSchema.nullable().optional(),
     summaryArtifactRef: z.string().nullable().optional(),
     summary_artifact_ref: z.string().nullable().optional(),
     scheduledFor: z.string().nullable().optional(),
@@ -609,39 +658,7 @@ const RunSummaryArtifactSchema = z
       })
       .passthrough()
       .optional(),
-    mergeAutomation: z
-      .object({
-        enabled: z.boolean().optional(),
-        status: z.string().nullable().optional(),
-        prNumber: z.union([z.number(), z.string()]).nullable().optional(),
-        prUrl: z.string().nullable().optional(),
-        latestHeadSha: z.string().nullable().optional(),
-        cycles: z.union([z.number(), z.string()]).nullable().optional(),
-        childWorkflowId: z.string().nullable().optional(),
-        resolverChildWorkflowIds: z.array(z.string()).default([]).optional(),
-        blockers: z
-          .array(
-            z
-              .object({
-                kind: z.string().nullable().optional(),
-                summary: z.string().nullable().optional(),
-                source: z.string().nullable().optional(),
-              })
-              .passthrough(),
-          )
-          .default([])
-          .optional(),
-        artifactRefs: z
-          .object({
-            summary: z.string().nullable().optional(),
-            gateSnapshots: z.array(z.string()).default([]).optional(),
-            resolverAttempts: z.array(z.string()).default([]).optional(),
-          })
-          .passthrough()
-          .optional(),
-      })
-      .passthrough()
-      .optional(),
+    mergeAutomation: MergeAutomationSchema.optional(),
   })
   .passthrough();
 
@@ -797,6 +814,123 @@ function formatDependencyResolution(value: string | null | undefined): string {
 
 function dependencyHref(workflowId: string): string {
   return `/tasks/${encodeURIComponent(workflowId)}?source=temporal`;
+}
+
+function MergeAutomationPanel({
+  mergeAutomation,
+}: {
+  mergeAutomation: z.infer<typeof MergeAutomationSchema>;
+}) {
+  const workflowId = mergeAutomation.workflowId || mergeAutomation.childWorkflowId || '';
+  const resolverChildren: Array<{
+    workflowId: string;
+    taskRunId?: string | null;
+    status?: string | null;
+    detailHref?: string | null;
+  }> = mergeAutomation.resolverChildren?.length
+    ? mergeAutomation.resolverChildren
+    : (mergeAutomation.resolverChildWorkflowIds || []).map((childWorkflowId) => ({
+        workflowId: childWorkflowId,
+      }));
+  const blockers = mergeAutomation.blockers || [];
+  const artifactRefs = mergeAutomation.artifactRefs;
+
+  return (
+    <section className="stack">
+      <h3>Merge Automation</h3>
+      <div className="grid-2">
+        <Card label="Status">{mergeAutomation.status || '—'}</Card>
+        {mergeAutomation.cycles !== undefined && mergeAutomation.cycles !== null ? (
+          <Card label="Cycles">{String(mergeAutomation.cycles)}</Card>
+        ) : null}
+        {mergeAutomation.prUrl ? (
+          <Card label="PR Link">
+            {(() => {
+              const normalizedUrl = normalizeGitHubPullRequestUrl(mergeAutomation.prUrl);
+              return normalizedUrl ? (
+                <a href={normalizedUrl} target="_blank" rel="noreferrer">
+                  {normalizedUrl}
+                </a>
+              ) : (
+                '—'
+              );
+            })()}
+          </Card>
+        ) : null}
+        {mergeAutomation.latestHeadSha ? (
+          <Card label="Latest Head SHA">
+            <code className="text-xs break-all">{mergeAutomation.latestHeadSha}</code>
+          </Card>
+        ) : null}
+        {workflowId ? (
+          <Card label="Child Workflow">
+            <code className="text-xs break-all">{workflowId}</code>
+          </Card>
+        ) : null}
+      </div>
+
+      {resolverChildren.length ? (
+        <div>
+          <strong>Resolver Children</strong>
+          <ul>
+            {resolverChildren.map((child) => (
+              <li key={child.workflowId}>
+                <a href={child.detailHref || dependencyHref(child.workflowId)}>
+                  <code className="text-xs break-all">{child.workflowId}</code>
+                </a>
+                {child.status ? <span className="small"> {child.status}</span> : null}
+                {child.taskRunId ? (
+                  <span className="small">
+                    {' '}
+                    logs: <code className="text-xs break-all">{child.taskRunId}</code>
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="small">Waiting for required checks before launching pr-resolver.</p>
+      )}
+
+      {blockers.length ? (
+        <div>
+          <strong>Blockers</strong>
+          <ul>
+            {blockers.map((blocker, index) => (
+              <li key={`${blocker.kind || 'blocker'}-${index}`}>
+                {blocker.summary || blocker.kind || 'Blocked'}
+                {blocker.source ? <span className="small"> ({blocker.source})</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {artifactRefs ? (
+        <div>
+          <strong>Artifacts</strong>
+          <ul>
+            {artifactRefs.summary ? (
+              <li>
+                Summary: <code className="text-xs break-all">{artifactRefs.summary}</code>
+              </li>
+            ) : null}
+            {artifactRefs.gateSnapshots?.map((artifactRef) => (
+              <li key={`gate-${artifactRef}`}>
+                Gate snapshot: <code className="text-xs break-all">{artifactRef}</code>
+              </li>
+            ))}
+            {artifactRefs.resolverAttempts?.map((artifactRef) => (
+              <li key={`resolver-${artifactRef}`}>
+                Resolver attempt: <code className="text-xs break-all">{artifactRef}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
 }
 
 function formatDebugValue(value: unknown): string {
@@ -2961,6 +3095,8 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     refetchInterval: liveUpdates && summaryArtifactRef ? detailPoll : false,
   });
   const runSummary = runSummaryQuery.data;
+  const displayedMergeAutomation =
+    execution?.mergeAutomation || runSummary?.mergeAutomation || null;
   const displayedSummary = runSummary?.operatorSummary || execution?.summary || '—';
   const prUrl =
     normalizeGitHubPullRequestUrl(execution?.prUrl) ||
@@ -3381,93 +3517,6 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
                   ) : null}
                 </div>
               ) : null}
-              {runSummary.mergeAutomation ? (
-                <section>
-                  <h3>Merge Automation</h3>
-                  <div className="grid-2">
-                    <Card label="Status">{runSummary.mergeAutomation.status || '—'}</Card>
-                    {runSummary.mergeAutomation.cycles !== undefined &&
-                    runSummary.mergeAutomation.cycles !== null ? (
-                      <Card label="Cycles">{String(runSummary.mergeAutomation.cycles)}</Card>
-                    ) : null}
-                    {runSummary.mergeAutomation.prUrl ? (
-                      <Card label="PR Link">
-                        {(() => {
-                          const normalizedUrl = normalizeGitHubPullRequestUrl(
-                            runSummary.mergeAutomation.prUrl,
-                          );
-                          return normalizedUrl ? (
-                            <a href={normalizedUrl} target="_blank" rel="noreferrer">
-                              {normalizedUrl}
-                            </a>
-                          ) : (
-                            '—'
-                          );
-                        })()}
-                      </Card>
-                    ) : null}
-                    {runSummary.mergeAutomation.latestHeadSha ? (
-                      <Card label="Latest Head SHA">
-                        <code className="text-xs break-all">{runSummary.mergeAutomation.latestHeadSha}</code>
-                      </Card>
-                    ) : null}
-                    {runSummary.mergeAutomation.childWorkflowId ? (
-                      <Card label="Child Workflow">
-                        <code className="text-xs break-all">{runSummary.mergeAutomation.childWorkflowId}</code>
-                      </Card>
-                    ) : null}
-                  </div>
-                  {runSummary.mergeAutomation.resolverChildWorkflowIds?.length ? (
-                    <div>
-                      <strong>Resolver Children</strong>
-                      <ul>
-                        {runSummary.mergeAutomation.resolverChildWorkflowIds.map((workflowId) => (
-                          <li key={workflowId}>
-                            <code className="text-xs break-all">{workflowId}</code>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-                  {runSummary.mergeAutomation.blockers?.length ? (
-                    <div>
-                      <strong>Blockers</strong>
-                      <ul>
-                        {runSummary.mergeAutomation.blockers.map((blocker, index) => (
-                          <li key={`${blocker.kind || 'blocker'}-${index}`}>
-                            {blocker.summary || blocker.kind || 'Blocked'}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-                  {runSummary.mergeAutomation.artifactRefs ? (
-                    <div>
-                      <strong>Artifacts</strong>
-                      <ul>
-                        {runSummary.mergeAutomation.artifactRefs.summary ? (
-                          <li>
-                            Summary:{' '}
-                            <code className="text-xs break-all">
-                              {runSummary.mergeAutomation.artifactRefs.summary}
-                            </code>
-                          </li>
-                        ) : null}
-                        {runSummary.mergeAutomation.artifactRefs.gateSnapshots?.map((artifactRef) => (
-                          <li key={`gate-${artifactRef}`}>
-                            Gate snapshot: <code className="text-xs break-all">{artifactRef}</code>
-                          </li>
-                        ))}
-                        {runSummary.mergeAutomation.artifactRefs.resolverAttempts?.map((artifactRef) => (
-                          <li key={`resolver-${artifactRef}`}>
-                            Resolver attempt: <code className="text-xs break-all">{artifactRef}</code>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-                </section>
-              ) : null}
               {runSummary.lastStep?.summary && runSummary.lastStep.summary !== displayedSummary ? (
                 <div>
                   <strong>Last Step</strong>
@@ -3483,6 +3532,10 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               <h3>Waiting Reason</h3>
               <p>{execution.waitingReason}</p>
             </section>
+          ) : null}
+
+          {displayedMergeAutomation ? (
+            <MergeAutomationPanel mergeAutomation={displayedMergeAutomation} />
           ) : null}
 
           {hasStepsEndpoint ? (

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3322,6 +3322,84 @@ export interface components {
             refreshedAt?: string | null;
         };
         /**
+         * ExecutionMergeAutomationArtifactRefsModel
+         * @description Artifact refs produced by merge automation.
+         */
+        ExecutionMergeAutomationArtifactRefsModel: {
+            /** Summary */
+            summary?: string | null;
+            /** Gatesnapshots */
+            gateSnapshots?: string[];
+            /** Resolverattempts */
+            resolverAttempts?: string[];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ExecutionMergeAutomationBlockerModel
+         * @description Operator-visible merge automation blocker.
+         */
+        ExecutionMergeAutomationBlockerModel: {
+            /** Kind */
+            kind?: string | null;
+            /** Summary */
+            summary?: string | null;
+            /** Retryable */
+            retryable?: boolean | null;
+            /** Source */
+            source?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ExecutionMergeAutomationModel
+         * @description Live or terminal merge automation visibility for an execution.
+         */
+        ExecutionMergeAutomationModel: {
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
+            /** Workflowid */
+            workflowId?: string | null;
+            /** Childworkflowid */
+            childWorkflowId?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Prnumber */
+            prNumber?: number | string | null;
+            /** Prurl */
+            prUrl?: string | null;
+            /** Latestheadsha */
+            latestHeadSha?: string | null;
+            /** Cycles */
+            cycles?: number | string | null;
+            /** Blockers */
+            blockers?: components["schemas"]["ExecutionMergeAutomationBlockerModel"][];
+            artifactRefs?: components["schemas"]["ExecutionMergeAutomationArtifactRefsModel"] | null;
+            /** Resolverchildworkflowids */
+            resolverChildWorkflowIds?: string[];
+            /** Resolverchildren */
+            resolverChildren?: components["schemas"]["ExecutionMergeAutomationResolverChildModel"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ExecutionMergeAutomationResolverChildModel
+         * @description Resolver child workflow reference plus observability binding when known.
+         */
+        ExecutionMergeAutomationResolverChildModel: {
+            /** Workflowid */
+            workflowId: string;
+            /** Taskrunid */
+            taskRunId?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Detailhref */
+            detailHref?: string | null;
+        };
+        /**
          * ExecutionModel
          * @description Materialized execution view returned by lifecycle APIs.
          */
@@ -3450,6 +3528,7 @@ export interface components {
              * @default false
              */
             mergeAutomationSelected: boolean;
+            mergeAutomation?: components["schemas"]["ExecutionMergeAutomationModel"] | null;
             /** Resolvedskillsetref */
             resolvedSkillsetRef?: string | null;
             /** Taskskills */

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -799,6 +799,77 @@ class ExecutionProgressModel(BaseModel):
     updated_at: datetime = Field(..., alias="updatedAt")
 
 
+class ExecutionMergeAutomationBlockerModel(BaseModel):
+    """Operator-visible merge automation blocker."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    kind: str | None = Field(None, alias="kind")
+    summary: str | None = Field(None, alias="summary")
+    retryable: bool | None = Field(None, alias="retryable")
+    source: str | None = Field(None, alias="source")
+
+
+class ExecutionMergeAutomationArtifactRefsModel(BaseModel):
+    """Artifact refs produced by merge automation."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    summary: str | None = Field(None, alias="summary")
+    gate_snapshots: list[str] = Field(default_factory=list, alias="gateSnapshots")
+    resolver_attempts: list[str] = Field(default_factory=list, alias="resolverAttempts")
+
+
+class ExecutionMergeAutomationResolverChildModel(BaseModel):
+    """Resolver child workflow reference plus observability binding when known."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    workflow_id: str = Field(..., alias="workflowId")
+    task_run_id: str | None = Field(None, alias="taskRunId")
+    status: str | None = Field(None, alias="status")
+    detail_href: str | None = Field(None, alias="detailHref")
+
+
+class ExecutionMergeAutomationModel(BaseModel):
+    """Live or terminal merge automation visibility for an execution."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    enabled: bool = Field(True, alias="enabled")
+    workflow_id: str | None = Field(None, alias="workflowId")
+    child_workflow_id: str | None = Field(None, alias="childWorkflowId")
+    status: str | None = Field(None, alias="status")
+    pr_number: int | str | None = Field(None, alias="prNumber")
+    pr_url: str | None = Field(None, alias="prUrl")
+    latest_head_sha: str | None = Field(None, alias="latestHeadSha")
+    cycles: int | str | None = Field(None, alias="cycles")
+    blockers: list[ExecutionMergeAutomationBlockerModel] = Field(
+        default_factory=list,
+        alias="blockers",
+    )
+    artifact_refs: ExecutionMergeAutomationArtifactRefsModel | None = Field(
+        None,
+        alias="artifactRefs",
+    )
+    resolver_child_workflow_ids: list[str] = Field(
+        default_factory=list,
+        alias="resolverChildWorkflowIds",
+    )
+    resolver_children: list[ExecutionMergeAutomationResolverChildModel] = Field(
+        default_factory=list,
+        alias="resolverChildren",
+    )
+
+    @model_validator(mode="after")
+    def _mirror_child_workflow_id(self) -> "ExecutionMergeAutomationModel":
+        if not self.workflow_id and self.child_workflow_id:
+            self.workflow_id = self.child_workflow_id
+        if not self.child_workflow_id and self.workflow_id:
+            self.child_workflow_id = self.workflow_id
+        return self
+
+
 class TaskInputSnapshotDescriptorModel(BaseModel):
     """Compact pointer to the authoritative original task input snapshot."""
 
@@ -1017,6 +1088,10 @@ class ExecutionModel(BaseModel):
     )
     publish_mode: Optional[str] = Field(None, alias="publishMode")
     merge_automation_selected: bool = Field(False, alias="mergeAutomationSelected")
+    merge_automation: ExecutionMergeAutomationModel | None = Field(
+        None,
+        alias="mergeAutomation",
+    )
     resolved_skillset_ref: Optional[str] = Field(None, alias="resolvedSkillsetRef")
     task_skills: Optional[list[str]] = Field(None, alias="taskSkills")
     skill_runtime: Optional[ExecutionSkillRuntimeModel] = Field(

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -208,7 +208,9 @@ def deterministic_resolver_idempotency_key(
     pr_number: int,
     head_sha: str,
 ) -> str:
-    return f"resolver:{parent_workflow_id}:{repo}:{pr_number}:{head_sha}"
+    # Keep repository identity in payload/search attributes, not workflow ids.
+    # Raw repo names contain "/" and make API/UI routing fragile.
+    return f"resolver:{parent_workflow_id}:pr:{pr_number}:head:{head_sha}"
 
 
 def build_resolver_run_request(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3516,8 +3516,12 @@ class MoonMindRunWorkflow:
         self._awaiting_external = True
         self._publish_context["mergeAutomationWorkflowId"] = workflow_id
         self._publish_context["mergeAutomationStatus"] = "awaiting_child"
-        self._update_search_attributes()
-        self._update_memo()
+        self._waiting_reason = "Waiting for PR merge automation."
+        self._attention_required = False
+        self._set_state(
+            STATE_AWAITING_EXTERNAL,
+            summary="Waiting for PR merge automation.",
+        )
         try:
             child_result = await workflow.execute_child_workflow(
                 "MoonMind.MergeAutomation",
@@ -3530,6 +3534,7 @@ class MoonMindRunWorkflow:
             )
         except CancelledError:
             self._awaiting_external = False
+            self._waiting_reason = None
             self._publish_context["mergeAutomationStatus"] = MERGE_AUTOMATION_CANCELED_STATUS
             self._publish_context["mergeAutomationSummary"] = (
                 "Merge automation canceled while parent was awaiting child workflow."
@@ -3539,11 +3544,13 @@ class MoonMindRunWorkflow:
             raise
         except Exception:
             self._awaiting_external = False
+            self._waiting_reason = None
             self._publish_context["mergeAutomationStatus"] = "failed"
             self._update_memo()
             self._update_search_attributes()
             raise
         self._awaiting_external = False
+        self._waiting_reason = None
         self._publish_context["mergeAutomationResult"] = (
             dict(child_result) if isinstance(child_result, Mapping) else child_result
         )
@@ -4811,6 +4818,9 @@ class MoonMindRunWorkflow:
             memo_dict["summary_artifact_ref"] = self._summary_ref
         if self._pull_request_url:
             memo_dict["pull_request_url"] = self._pull_request_url
+        merge_automation_summary = self._merge_automation_summary_from_context()
+        if merge_automation_summary:
+            memo_dict["merge_automation"] = merge_automation_summary
         memo_dict.update(self._dependency_metadata())
 
         try:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Iterator
@@ -33,6 +34,7 @@ from moonmind.workflows.temporal import (
     TemporalExecutionValidationError,
 )
 from moonmind.schemas.temporal_models import (
+    ExecutionMergeAutomationResolverChildModel,
     ExecutionProgressModel,
     StepLedgerSnapshotModel,
 )
@@ -2615,6 +2617,73 @@ def test_describe_execution_includes_live_merge_automation_summary() -> None:
             ),
         }
     ]
+
+
+def test_describe_execution_queries_resolver_children_concurrently() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    record.parameters = {
+        "publishMode": "pr",
+        "mergeAutomation": {"enabled": True},
+    }
+    record.memo = {
+        **record.memo,
+        "merge_automation": {
+            "enabled": True,
+            "status": "awaiting_child",
+            "childWorkflowId": "merge-automation:mm:wf-1:pr:1614:head:abc123",
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    resolver_ids = [
+        "resolver:mm:wf-1:pr:1614:head:abc123:1",
+        "resolver:mm:wf-1:pr:1614:head:abc123:2",
+        "resolver:mm:wf-1:pr:1614:head:abc123:3",
+    ]
+    _override_query_client(
+        app,
+        progress={"total": 1},
+        summary={
+            "status": "waiting",
+            "resolverChildWorkflowIds": resolver_ids,
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+
+    started: list[str] = []
+    all_started = asyncio.Event()
+
+    async def fake_child_observability(
+        *,
+        temporal_client,
+        workflow_id: str,
+    ) -> ExecutionMergeAutomationResolverChildModel:
+        started.append(workflow_id)
+        if len(started) == len(resolver_ids):
+            all_started.set()
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        return ExecutionMergeAutomationResolverChildModel(
+            workflow_id=workflow_id,
+            status="running",
+            detail_href=f"/tasks/{workflow_id}",
+        )
+
+    with patch(
+        "api_service.api.routers.executions._resolver_child_observability",
+        side_effect=fake_child_observability,
+    ):
+        with TestClient(app) as test_client:
+            response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    assert started == resolver_ids
+    assert [
+        child["workflowId"]
+        for child in response.json()["mergeAutomation"]["resolverChildren"]
+    ] == resolver_ids
 
 
 def test_describe_execution_prefers_progress_query_run_id_when_newer_latest_run() -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -55,9 +55,17 @@ class _ExecuteResult:
 
 
 class _QueryHandle:
-    def __init__(self, *, progress=None, ledger=None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        progress=None,
+        ledger=None,
+        summary=None,
+        error: Exception | None = None,
+    ) -> None:
         self._progress = progress
         self._ledger = ledger
+        self._summary = summary
         self._error = error
 
     async def query(self, name: str):
@@ -67,6 +75,8 @@ class _QueryHandle:
             return self._progress
         if name == "get_step_ledger":
             return self._ledger
+        if name == "summary":
+            return self._summary
         raise AssertionError(f"Unexpected query name: {name}")
 
 
@@ -75,10 +85,22 @@ def _override_query_client(
     *,
     progress=None,
     ledger=None,
+    summary=None,
     error: Exception | None = None,
 ) -> SimpleNamespace:
-    handle = _QueryHandle(progress=progress, ledger=ledger, error=error)
-    client = SimpleNamespace(get_workflow_handle=Mock(return_value=handle))
+    handles: dict[str, _QueryHandle] = {}
+
+    def get_workflow_handle(workflow_id: str) -> _QueryHandle:
+        if workflow_id not in handles:
+            handles[workflow_id] = _QueryHandle(
+                progress=progress,
+                ledger=ledger,
+                summary=summary,
+                error=error,
+            )
+        return handles[workflow_id]
+
+    client = SimpleNamespace(get_workflow_handle=Mock(side_effect=get_workflow_handle))
     app.dependency_overrides[get_temporal_client] = lambda: client
     return client
 
@@ -2491,6 +2513,108 @@ def test_describe_execution_includes_latest_run_progress() -> None:
         "currentStepTitle": "Run tests",
         "updatedAt": "2026-04-08T12:00:00Z",
     }
+
+
+def test_describe_execution_includes_live_merge_automation_summary() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record()
+    record.parameters = {
+        "publishMode": "pr",
+        "mergeAutomation": {"enabled": True},
+    }
+    record.memo = {
+        **record.memo,
+        "merge_automation": {
+            "enabled": True,
+            "status": "awaiting_child",
+            "childWorkflowId": "merge-automation:mm:wf-1:pr:1614:head:abc123",
+        },
+    }
+    mock_service.describe_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_query_client(
+        app,
+        progress={
+            "total": 1,
+            "pending": 0,
+            "ready": 0,
+            "running": 0,
+            "awaitingExternal": 1,
+            "reviewing": 0,
+            "succeeded": 0,
+            "failed": 0,
+            "skipped": 0,
+            "canceled": 0,
+            "currentStepTitle": None,
+            "updatedAt": "2026-04-08T12:00:00Z",
+        },
+        summary={
+            "status": "waiting",
+            "prNumber": 1614,
+            "prUrl": "https://github.com/MoonLadderStudios/MoonMind/pull/1614",
+            "latestHeadSha": "abc123",
+            "blockers": [
+                {
+                    "kind": "checks_failed",
+                    "summary": "Required checks are failing.",
+                    "source": "github",
+                    "retryable": True,
+                }
+            ],
+            "resolverChildWorkflowIds": [
+                "resolver:mm:wf-1:pr:1614:head:abc123:1"
+            ],
+            "artifactRefs": {
+                "gateSnapshots": ["gate-artifact"],
+                "resolverAttempts": None,
+            },
+        },
+        ledger={
+            "workflowId": "resolver:mm:wf-1:pr:1614:head:abc123:1",
+            "runId": "resolver-run",
+            "runScope": "latest",
+            "steps": [
+                {
+                    "logicalStepId": "node-1",
+                    "order": 1,
+                    "title": "codex_cli",
+                    "tool": {"type": "agent_runtime", "name": "codex_cli"},
+                    "dependsOn": [],
+                    "status": "running",
+                    "attempt": 1,
+                    "updatedAt": "2026-04-08T12:00:00Z",
+                    "refs": {"taskRunId": "resolver-task-run"},
+                    "artifacts": {},
+                    "checks": [],
+                }
+            ],
+        },
+    )
+    _override_user_dependencies(app, is_superuser=True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    merge_automation = response.json()["mergeAutomation"]
+    assert merge_automation["workflowId"] == "merge-automation:mm:wf-1:pr:1614:head:abc123"
+    assert merge_automation["status"] == "waiting"
+    assert merge_automation["blockers"][0]["summary"] == "Required checks are failing."
+    assert merge_automation["artifactRefs"]["gateSnapshots"] == ["gate-artifact"]
+    assert merge_automation["artifactRefs"]["resolverAttempts"] == []
+    assert merge_automation["resolverChildren"] == [
+        {
+            "workflowId": "resolver:mm:wf-1:pr:1614:head:abc123:1",
+            "taskRunId": "resolver-task-run",
+            "status": "running",
+            "detailHref": (
+                "/tasks/resolver%3Amm%3Awf-1%3Apr%3A1614%3Ahead%3Aabc123%3A1"
+                "?source=temporal"
+            ),
+        }
+    ]
 
 
 def test_describe_execution_prefers_progress_query_run_id_when_newer_latest_run() -> None:

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -136,7 +136,8 @@ def test_deterministic_resolver_idempotency_key_is_revision_scoped() -> None:
     )
 
     assert first != second
-    assert first == "resolver:mm:parent:MoonLadderStudios/MoonMind:341:abc123"
+    assert first == "resolver:mm:parent:pr:341:head:abc123"
+    assert "/" not in first
 
 
 def test_build_resolver_run_request_uses_pr_resolver_and_publish_none() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -221,8 +221,8 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
     assert result["status"] == "merged"
     assert result["cycles"] == 2
     assert child_workflow_ids == [
-        "resolver:wf-parent:MoonLadderStudios/MoonMind:350:abc123:1",
-        "resolver:wf-parent:MoonLadderStudios/MoonMind:350:def456:2",
+        "resolver:wf-parent:pr:350:head:abc123:1",
+        "resolver:wf-parent:pr:350:head:def456:2",
     ]
     assert child_payloads[0]["workflow_type"] == "MoonMind.Run"
     assert child_payloads[0]["initial_parameters"]["publishMode"] == "none"

--- a/tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py
@@ -45,6 +45,8 @@ async def test_parent_owned_merge_automation_awaits_child_success(
     ) -> dict[str, Any]:
         calls.append({"workflow_type": workflow_type, "payload": payload, "kwargs": kwargs})
         assert workflow._awaiting_external is True
+        assert workflow._state == "awaiting_external"
+        assert workflow._waiting_reason == "Waiting for PR merge automation."
         return {"status": "merged", "prNumber": 350, "prUrl": payload["pullRequest"]["url"]}
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- expose live merge automation state on execution detail responses, including PR blockers, artifact refs, and resolver child run bindings
- render a first-class Merge Automation panel in Mission Control before terminal summary artifacts exist
- make resolver child workflow IDs URL-safe by removing raw repository names from the ID shape

## Why
Merge Automation was running as a child workflow, but operators could only inspect it through Temporal CLI while the parent task was still active. This surfaces the active child state and resolver links directly on the task detail page.

## Validation
- pytest tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py tests/unit/workflows/temporal/workflows/test_run_parent_owned_merge_automation_boundary.py tests/unit/api/routers/test_executions.py -q
- npm run ui:test -- frontend/src/entrypoints/task-detail.test.tsx
- npm run api:types
- npm run ui:typecheck
- git diff --check