### PR TITLE
[codex] Harden provider profile manager sync

### DIFF
--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -283,6 +283,7 @@ class MoonMindProviderProfileManagerWorkflow:
         self._shutdown_requested: bool = False
         self._has_new_events: bool = False
         self._profile_refresh_requested: bool = False
+        self._has_db_profile_snapshot: bool = False
 
     # -- Signals ---------------------------------------------------------------
 
@@ -468,7 +469,7 @@ class MoonMindProviderProfileManagerWorkflow:
                     refresh_succeeded = await self._load_profiles_from_db(
                         prune_removed_profiles=True
                     )
-                    if not refresh_succeeded:
+                    if not refresh_succeeded and not self._has_db_profile_snapshot:
                         self._has_new_events = False
                         try:
                             await workflow.wait_condition(
@@ -477,6 +478,7 @@ class MoonMindProviderProfileManagerWorkflow:
                                 timeout=timedelta(seconds=60),
                             )
                         except TimeoutError:
+                            # Expected: retry the authoritative profile refresh on the next loop.
                             pass
                         continue
 
@@ -1029,6 +1031,7 @@ class MoonMindProviderProfileManagerWorkflow:
         self, *, prune_removed_profiles: bool = False
     ) -> bool:
         """Load provider profiles for this runtime from the database via activity."""
+        self._profile_refresh_requested = False
         try:
             result = await workflow.execute_activity(
                 "provider_profile.list",
@@ -1046,7 +1049,7 @@ class MoonMindProviderProfileManagerWorkflow:
             self._apply_profile_sync(profiles_data)
             if prune_removed_profiles:
                 self._prune_disabled_profiles_without_leases()
-            self._profile_refresh_requested = False
+            self._has_db_profile_snapshot = True
             return True
         except Exception:
             self._profile_refresh_requested = True

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -36,6 +36,9 @@ VERIFY_LEASE_HOLDERS_PATCH = "auth-profile-manager-verify-leases-v1"
 DB_LEASE_PERSISTENCE_PATCH = "provider-profile-manager-db-lease-persistence-v1"
 SLOT_HANDOFF_RESERVATION_PATCH = "provider-profile-manager-slot-handoff-v1"
 REFRESH_RESTORED_PROFILES_PATCH = "provider-profile-manager-refresh-restored-profiles-v1"
+DB_AUTHORITATIVE_PROFILE_SYNC_PATCH = (
+    "provider-profile-manager-db-authoritative-profile-sync-v1"
+)
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -279,6 +282,7 @@ class MoonMindProviderProfileManagerWorkflow:
         self._event_count: int = 0
         self._shutdown_requested: bool = False
         self._has_new_events: bool = False
+        self._profile_refresh_requested: bool = False
 
     # -- Signals ---------------------------------------------------------------
 
@@ -309,8 +313,12 @@ class MoonMindProviderProfileManagerWorkflow:
         for index, existing in enumerate(self._pending_requests):
             if existing.requester_workflow_id == request.requester_workflow_id:
                 self._pending_requests[index] = request
+                if workflow.patched(DB_AUTHORITATIVE_PROFILE_SYNC_PATCH):
+                    self._profile_refresh_requested = True
                 return
         self._pending_requests.append(request)
+        if workflow.patched(DB_AUTHORITATIVE_PROFILE_SYNC_PATCH):
+            self._profile_refresh_requested = True
 
     @workflow.signal
     async def release_slot(self, payload: dict[str, Any]) -> None:
@@ -365,9 +373,19 @@ class MoonMindProviderProfileManagerWorkflow:
 
     @workflow.signal
     def sync_profiles(self, payload: dict[str, Any]) -> None:
-        """Receive an updated profile list from the DB sync activity."""
+        """Request a provider-profile refresh from the authoritative DB snapshot.
+
+        The signal payload shape is preserved for in-flight workflow
+        compatibility, but new executions intentionally ignore embedded profile
+        rows. Profile existence and enabled/default state must come from the
+        provider_profile.list activity so stray or stale signal payloads cannot
+        poison slot assignment.
+        """
         self._event_count += 1
         self._has_new_events = True
+        if workflow.patched(DB_AUTHORITATIVE_PROFILE_SYNC_PATCH):
+            self._profile_refresh_requested = True
+            return
         profiles_data = payload.get("profiles", [])
         self._apply_profile_sync(profiles_data)
 
@@ -445,6 +463,23 @@ class MoonMindProviderProfileManagerWorkflow:
 
         # Main event loop: process signals, drain queue, clear cooldowns.
         while not self._shutdown_requested:
+            if workflow.patched(DB_AUTHORITATIVE_PROFILE_SYNC_PATCH):
+                if self._profile_refresh_requested:
+                    refresh_succeeded = await self._load_profiles_from_db(
+                        prune_removed_profiles=True
+                    )
+                    if not refresh_succeeded:
+                        self._has_new_events = False
+                        try:
+                            await workflow.wait_condition(
+                                lambda: self._has_new_events
+                                or self._shutdown_requested,
+                                timeout=timedelta(seconds=60),
+                            )
+                        except TimeoutError:
+                            pass
+                        continue
+
             # Drain pending requests against available profiles.
             await self._drain_queue()
 
@@ -606,6 +641,12 @@ class MoonMindProviderProfileManagerWorkflow:
             if pid not in seen:
                 self._profiles[pid].enabled = False
                 self._profiles[pid].is_default = False
+
+    def _prune_disabled_profiles_without_leases(self) -> None:
+        """Drop stale profile metadata that cannot still own runtime leases."""
+        for pid, profile in list(self._profiles.items()):
+            if not profile.enabled and not profile.current_leases:
+                self._profiles.pop(pid, None)
 
     @staticmethod
     def _normalize_optional_string(value: object) -> str | None:
@@ -984,7 +1025,9 @@ class MoonMindProviderProfileManagerWorkflow:
             },
         }
 
-    async def _load_profiles_from_db(self) -> None:
+    async def _load_profiles_from_db(
+        self, *, prune_removed_profiles: bool = False
+    ) -> bool:
         """Load provider profiles for this runtime from the database via activity."""
         try:
             result = await workflow.execute_activity(
@@ -1001,9 +1044,17 @@ class MoonMindProviderProfileManagerWorkflow:
             )
             profiles_data = result.get("profiles", []) if result else []
             self._apply_profile_sync(profiles_data)
+            if prune_removed_profiles:
+                self._prune_disabled_profiles_without_leases()
+            self._profile_refresh_requested = False
+            return True
         except Exception:
-            # If we can't load profiles, we'll wait for a sync_profiles signal.
-            pass
+            self._profile_refresh_requested = True
+            self._get_logger().warning(
+                "Failed to refresh provider profiles from DB for runtime %s",
+                self._runtime_id,
+            )
+            return False
 
     async def _sync_leases_to_db(self) -> None:
         """Persist current lease state to the database for crash recovery."""

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -401,6 +401,69 @@ class TestProviderProfileManagerHelpers:
             "resolver-run:agent:node-1"
         ]
 
+    @pytest.mark.asyncio
+    async def test_profile_refresh_preserves_signal_that_arrives_during_activity(
+        self,
+    ):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._profile_refresh_requested = True
+
+        async def fake_execute_activity(*_: object, **__: object) -> dict:
+            wf._profile_refresh_requested = True
+            return {
+                "profiles": [
+                    {
+                        "profile_id": "codex_default",
+                        "max_parallel_runs": 1,
+                        "cooldown_after_429_seconds": 900,
+                        "rate_limit_policy": "backoff",
+                        "enabled": True,
+                        "is_default": True,
+                    }
+                ]
+            }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+
+            assert await wf._load_profiles_from_db() is True
+
+        assert wf._has_db_profile_snapshot is True
+        assert wf._profile_refresh_requested is True
+
+    @pytest.mark.asyncio
+    async def test_failed_profile_refresh_keeps_known_good_snapshot_available(
+        self,
+    ):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        wf._has_db_profile_snapshot = True
+        wf._profiles["codex_default"] = ProfileSlotState(
+            profile_id="codex_default",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=900,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+        )
+
+        async def fake_execute_activity(*_: object, **__: object) -> dict:
+            raise RuntimeError("temporary DB outage")
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+
+            assert await wf._load_profiles_from_db() is False
+
+        assert wf._has_db_profile_snapshot is True
+        assert wf._profile_refresh_requested is True
+        assert wf._profiles["codex_default"].enabled is True
+
     def test_find_available_profile_picks_most_free(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from moonmind.workflows.temporal.workflows.provider_profile_manager import (
+    DB_AUTHORITATIVE_PROFILE_SYNC_PATCH,
     HandoffReservation,
     PendingRequest,
     SLOT_HANDOFF_RESERVATION_PATCH,
@@ -225,7 +226,7 @@ class TestProviderProfileManagerHelpers:
         # Leases should be preserved across sync.
         assert wf._profiles["p1"].current_leases == ["wf1"]
 
-    def test_apply_profile_sync_disables_removed(self):
+    def test_apply_profile_sync_disables_removed_profiles_without_leases(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(
             profile_id="p1",
@@ -235,11 +236,170 @@ class TestProviderProfileManagerHelpers:
             enabled=True,
             is_default=True,
         )
-        # Sync with empty list — p1 should be disabled but not deleted.
+        # Legacy sync merge keeps the row but makes it unavailable.
         wf._apply_profile_sync([])
         assert "p1" in wf._profiles
         assert not wf._profiles["p1"].enabled
         assert not wf._profiles["p1"].is_default
+
+    def test_prune_disabled_profiles_without_leases_removes_dead_state(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=False,
+            is_default=False,
+        )
+
+        wf._prune_disabled_profiles_without_leases()
+
+        assert "p1" not in wf._profiles
+
+    def test_apply_profile_sync_disables_removed_profiles_with_leases(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=1,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            current_leases=["wf1"],
+        )
+
+        wf._apply_profile_sync([])
+
+        assert "p1" in wf._profiles
+        assert not wf._profiles["p1"].enabled
+        assert not wf._profiles["p1"].is_default
+
+    def test_sync_profiles_legacy_payload_path_before_db_authoritative_patch(self):
+        wf = self._make_workflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.return_value = False
+            wf.sync_profiles(
+                {
+                    "profiles": [
+                        {
+                            "profile_id": "payload_profile",
+                            "max_parallel_runs": 1,
+                            "rate_limit_policy": "backoff",
+                            "enabled": True,
+                        }
+                    ]
+                }
+            )
+
+        assert "payload_profile" in wf._profiles
+        assert wf._profile_refresh_requested is False
+
+    def test_sync_profiles_requests_db_refresh_after_authoritative_patch(self):
+        wf = self._make_workflow()
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = (
+                lambda patch_id: patch_id == DB_AUTHORITATIVE_PROFILE_SYNC_PATCH
+            )
+            wf.sync_profiles(
+                {
+                    "profiles": [
+                        {
+                            "profile_id": "polluted_profile",
+                            "max_parallel_runs": 1,
+                            "rate_limit_policy": "backoff",
+                            "enabled": True,
+                        }
+                    ]
+                }
+            )
+
+        assert "polluted_profile" not in wf._profiles
+        assert wf._profile_refresh_requested is True
+
+    @pytest.mark.asyncio
+    async def test_polluted_sync_payload_does_not_assign_missing_profile(self):
+        wf = self._make_workflow()
+        wf._runtime_id = "codex_cli"
+        assigned: list[tuple[str, str]] = []
+
+        async def fake_signal(requester_workflow_id: str, profile_id: str) -> None:
+            assigned.append((requester_workflow_id, profile_id))
+
+        async def fake_execute_activity(
+            activity_name: str,
+            payload: dict,
+            **_: object,
+        ) -> dict:
+            assert activity_name == "provider_profile.list"
+            assert payload == {"runtime_id": "codex_cli"}
+            return {
+                "profiles": [
+                    {
+                        "profile_id": "codex_default",
+                        "max_parallel_runs": 1,
+                        "cooldown_after_429_seconds": 900,
+                        "rate_limit_policy": "backoff",
+                        "enabled": True,
+                        "is_default": True,
+                        "provider_id": "openai",
+                        "runtime_materialization_mode": "oauth_home",
+                    }
+                ]
+            }
+
+        wf._signal_slot_assigned = fake_signal  # type: ignore[method-assign]
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.patched.side_effect = lambda patch_id: patch_id in {
+                SLOT_HANDOFF_RESERVATION_PATCH,
+                DB_AUTHORITATIVE_PROFILE_SYNC_PATCH,
+            }
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            mock_wf.now.return_value = datetime(2026, 4, 20, tzinfo=timezone.utc)
+
+            wf.sync_profiles(
+                {
+                    "profiles": [
+                        {
+                            "profile_id": "runtime_default_second",
+                            "max_parallel_runs": 1,
+                            "cooldown_after_429_seconds": 900,
+                            "rate_limit_policy": "backoff",
+                            "enabled": True,
+                            "is_default": True,
+                        }
+                    ]
+                }
+            )
+            wf.request_slot(
+                {
+                    "requester_workflow_id": "resolver-run:agent:node-1",
+                    "runtime_id": "codex_cli",
+                    "lease_group_id": "resolver-run",
+                    "profile_selector": {"tagsAny": [], "tagsAll": []},
+                }
+            )
+
+            assert (
+                await wf._load_profiles_from_db(prune_removed_profiles=True)
+                is True
+            )
+            await wf._drain_queue()
+
+        assert assigned == [("resolver-run:agent:node-1", "codex_default")]
+        assert "runtime_default_second" not in wf._profiles
+        assert wf._profiles["codex_default"].current_leases == [
+            "resolver-run:agent:node-1"
+        ]
 
     def test_find_available_profile_picks_most_free(self):
         wf = self._make_workflow()


### PR DESCRIPTION
## Summary
- Treat ProviderProfileManager `sync_profiles` as a DB refresh trigger instead of trusting embedded signal profile rows.
- Refresh provider profiles from `provider_profile.list` before assigning new slots under a Temporal patch marker.
- Add regression coverage for polluted sync payloads assigning stale profile IDs.

## Root Cause
A stray or stale `sync_profiles` signal could inject profile IDs into the live manager state. The manager could assign one of those IDs before a later DB-backed sync corrected the profile list, causing AgentRun startup to fail when the adapter could not resolve the assigned profile.

## Validation
- `.venv/bin/pytest tests/unit/workflows/temporal/test_provider_profile_manager.py -q` passed: 61 tests.
- `git diff --check` passed.
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_provider_profile_manager.py` passed the targeted Python tests, then failed later in unrelated frontend test `entrypoints/mission-control.test.tsx` while waiting for `Hello from Tasks Home!`, with jsdom canvas `getContext()` warnings.