### PR TITLE
[codex] Add manual dependency wait override

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1429,6 +1429,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                     "cancel",
                     "reject",
                     "sendMessage",
+                    "skipDependencyWait",
                 )
             }
         )
@@ -1439,7 +1440,12 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
     state_actions = {
         "scheduled": {"can_set_title", "can_update_inputs", "can_cancel"},
         "initializing": {"can_set_title", "can_update_inputs", "can_cancel"},
-        "waiting_on_dependencies": {"can_set_title", "can_update_inputs", "can_cancel"},
+        "waiting_on_dependencies": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_cancel",
+            "can_skip_dependency_wait",
+        },
         "awaiting_slot": {"can_set_title", "can_update_inputs", "can_cancel"},
         "planning": {"can_set_title", "can_update_inputs", "can_cancel"},
         "executing": {
@@ -1483,6 +1489,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         "can_cancel": "canCancel",
         "can_reject": "canReject",
         "can_send_message": "canSendMessage",
+        "can_skip_dependency_wait": "canSkipDependencyWait",
     }
     disabled_reasons = {}
     for field_name, alias in capability_values.items():
@@ -1511,6 +1518,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         can_cancel="can_cancel" in enabled,
         can_reject="can_reject" in enabled,
         can_send_message="can_send_message" in enabled,
+        can_skip_dependency_wait="can_skip_dependency_wait" in enabled,
         disabled_reasons=disabled_reasons,
     )
 

--- a/docs/Tasks/TaskDependenciesOperatorGuide.md
+++ b/docs/Tasks/TaskDependenciesOperatorGuide.md
@@ -64,6 +64,7 @@ When a prerequisite fails, the dependent run records a structured `DependencyFai
 | Action | Effect |
 |---|---|
 | **Cancel** dependent run | Cancels only the dependent run. Prerequisites are untouched. |
+| **Skip dependency wait** | Manually clears the dependency gate and lets the dependent run continue even if one or more prerequisites are still unresolved. Prerequisites are untouched. |
 | **Pause** dependent run | Pauses progression through the dependency gate. Signals continue to be received and recorded; if a prerequisite failure is recorded while paused, the dependent run fails immediately. |
 | **Resume** dependent run | If all prerequisites resolved successfully while paused, proceeds normally. Any prerequisite failure recorded during pause would already have failed the dependent run before resume. |
 | Cancel/prerequisite run | **Never** affected by dependent run's state. |
@@ -74,6 +75,7 @@ When a prerequisite fails, the dependent run records a structured `DependencyFai
 - While paused, dependency outcomes continue to be recorded in local state.
 - Pausing does **not** defer dependency-failure propagation; a prerequisite failure recorded while paused fails the dependent run immediately.
 - While paused, the workflow does **not** leave the dependency gate and enter planning or execution unless it is failed by dependency resolution.
+- Skipping the dependency wait is an explicit operator override for cases where the remaining prerequisites are no longer required for reasons MoonMind cannot infer automatically. The run summary records dependency resolution as `manual_override`.
 
 ---
 
@@ -85,6 +87,7 @@ The following structured log events are emitted during dependency lifecycle:
 |---|---|---|---|
 | `dependency_gate_entered` | INFO | Workflow | `dependency_count`, `dependency_ids` |
 | `dependency_gate_satisfied` | INFO | Workflow | `dependency_count`, `wait_duration_ms` |
+| `dependency_gate_manual_override` | INFO | Workflow | `dependency_count`, `unresolved_dependency_count`, `wait_duration_ms` |
 | `dependency_gate_failed` | ERROR | Workflow | `failed_dependency_id`, `terminal_state`, `close_status`, `failure_category`, `wait_duration_ms` |
 | `dependency_signal_received` | INFO | Workflow | `prerequisite_workflow_id`, `terminal_state`, `close_status` |
 | `dependency_signal_failure` | WARNING | Workflow | `prerequisite_workflow_id`, `terminal_state`, `close_status`, `failure_category` |

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -2250,6 +2250,82 @@ describe('Task Detail Entrypoint', () => {
     confirmSpy.mockRestore();
   });
 
+  it('supports manually skipping dependency waiting from the Intervention panel', async () => {
+    const actionPayload: BootPayload = {
+      ...mockPayload,
+      initialData: { dashboardConfig: { features: { temporalDashboard: { actionsEnabled: true } } } },
+    };
+    const mockExecution = {
+      taskId: 'test-123',
+      workflowId: 'test-123',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      title: 'Blocked dependent task',
+      summary: 'Waiting on prerequisites',
+      status: 'waiting',
+      state: 'waiting_on_dependencies',
+      rawState: 'waiting_on_dependencies',
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      blockedOnDependencies: true,
+      dependencies: [{ workflowId: 'dep-1', title: 'Prerequisite one', state: 'running' }],
+      dependents: [],
+      actions: {
+        canCancel: true,
+        canSkipDependencyWait: true,
+      },
+      interventionAudit: [],
+    };
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      if (url.endsWith('/signal')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ...mockExecution,
+            state: 'executing',
+            rawState: 'executing',
+            summary: 'Dependency wait skipped by operator.',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    renderWithClient(<TaskDetailPage payload={actionPayload} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Skip Dependency Wait' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/executions/test-123/signal',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            signalName: 'SkipDependencyWait',
+            payload: {},
+          }),
+        }),
+      );
+    });
+
+    confirmSpy.mockRestore();
+  });
+
   it('renders a Session Continuity panel for Codex managed-session task runs', async () => {
     const codexPayload: BootPayload = {
       ...mockPayload,

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -287,6 +287,7 @@ const ExecutionDetailSchema = z
         canCancel: z.boolean().optional(),
         canReject: z.boolean().optional(),
         canSendMessage: z.boolean().optional(),
+        canSkipDependencyWait: z.boolean().optional(),
         disabledReasons: z.record(z.string(), z.string()).optional(),
       })
       .passthrough()
@@ -2305,6 +2306,7 @@ function InterventionPanel({
   onCancel,
   onReject,
   onSendMessage,
+  onSkipDependencyWait,
 }: {
   actions: NonNullable<z.infer<typeof ExecutionDetailSchema>['actions']>;
   busy: boolean;
@@ -2321,6 +2323,7 @@ function InterventionPanel({
   onCancel: () => void;
   onReject: () => void;
   onSendMessage: (message: string) => void;
+  onSkipDependencyWait: () => void;
 }) {
   const [operatorMessage, setOperatorMessage] = useState('');
   const hasControls = Boolean(
@@ -2329,6 +2332,7 @@ function InterventionPanel({
       actions.canApprove ||
       actions.canCancel ||
       actions.canReject ||
+      actions.canSkipDependencyWait ||
       actions.canSendMessage,
   );
 
@@ -2373,6 +2377,11 @@ function InterventionPanel({
               onClick={onReject}
             >
               Reject
+            </button>
+          ) : null}
+          {actions.canSkipDependencyWait ? (
+            <button type="button" disabled={busy} className="secondary" onClick={onSkipDependencyWait}>
+              Skip Dependency Wait
             </button>
           ) : null}
           {actions.canCancel ? (
@@ -3098,6 +3107,12 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     signalMutation.mutate({ signalName: 'Approve', payload: {} });
   };
 
+  const onSkipDependencyWait = () => {
+    setActionError(null);
+    if (!window.confirm('Skip dependency waiting and continue this task?')) return;
+    signalMutation.mutate({ signalName: 'SkipDependencyWait', payload: {} });
+  };
+
   const onSendMessage = (message: string) => {
     setActionError(null);
     signalMutation.mutate({ signalName: 'SendMessage', payload: { message } });
@@ -3151,6 +3166,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
         actions.canCancel ||
         actions.canReject ||
         actions.canSendMessage ||
+        actions.canSkipDependencyWait ||
         (execution?.interventionAudit?.length ?? 0) > 0
       ),
   );
@@ -3662,6 +3678,7 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               onCancel={onCancel}
               onReject={onReject}
               onSendMessage={onSendMessage}
+              onSkipDependencyWait={onSkipDependencyWait}
             />
           ) : null}
 

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3198,6 +3198,11 @@ export interface components {
              * @default false
              */
             canSendMessage: boolean;
+            /**
+             * Canskipdependencywait
+             * @default false
+             */
+            canSkipDependencyWait: boolean;
             /** Disabledreasons */
             disabledReasons?: {
                 [key: string]: string;
@@ -5080,7 +5085,7 @@ export interface components {
              * Signalname
              * @enum {string}
              */
-            signalName: "ExternalEvent" | "Pause" | "Resume" | "Approve" | "SendMessage" | "DependencyResolved";
+            signalName: "ExternalEvent" | "Pause" | "Resume" | "Approve" | "SkipDependencyWait" | "SendMessage" | "DependencyResolved";
             /** Payload */
             payload?: {
                 [key: string]: unknown;

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -37,6 +37,7 @@ SUPPORTED_SIGNAL_NAMES = (
     "Pause",
     "Resume",
     "Approve",
+    "SkipDependencyWait",
     "SendMessage",
     "DependencyResolved",
 )
@@ -646,6 +647,7 @@ class ExecutionActionCapabilityModel(BaseModel):
     can_cancel: bool = Field(False, alias="canCancel")
     can_reject: bool = Field(False, alias="canReject")
     can_send_message: bool = Field(False, alias="canSendMessage")
+    can_skip_dependency_wait: bool = Field(False, alias="canSkipDependencyWait")
     disabled_reasons: dict[str, str] = Field(
         default_factory=dict, alias="disabledReasons"
     )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1193,7 +1193,7 @@ class TemporalExecutionService:
                 record.paused = False
                 self._clear_waiting_metadata(record)
                 self._clear_wait_metadata(record)
-                self._set_state(record, MoonMindWorkflowState.EXECUTING)
+                self._set_state(record, MoonMindWorkflowState.AWAITING_SLOT)
                 self._append_intervention_audit(
                     record,
                     action="skip_dependency_wait",

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1122,7 +1122,13 @@ class TemporalExecutionService:
             )
         record = await self._require_source_execution(workflow_id)
 
-        if signal_name in {"Pause", "Resume", "Approve", "SendMessage"}:
+        if signal_name in {
+            "Pause",
+            "Resume",
+            "Approve",
+            "SkipDependencyWait",
+            "SendMessage",
+        }:
             self._ensure_non_terminal(record)
             operator_message = self._extract_operator_message(payload)
             update_arg: dict[str, Any] = {}
@@ -1183,6 +1189,19 @@ class TemporalExecutionService:
                     self._update_summary(record, "Clarification reply sent to agent.")
                 else:
                     self._update_summary(record, "Execution resumed.")
+            elif signal_name == "SkipDependencyWait":
+                record.paused = False
+                self._clear_waiting_metadata(record)
+                self._clear_wait_metadata(record)
+                self._set_state(record, MoonMindWorkflowState.EXECUTING)
+                self._append_intervention_audit(
+                    record,
+                    action="skip_dependency_wait",
+                    transport="temporal_update",
+                    summary="Dependency wait skipped by operator.",
+                    detail=operator_message,
+                )
+                self._update_summary(record, "Dependency wait skipped by operator.")
             else:
                 if signal_name == "Approve":
                     record.paused = False

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -138,6 +138,7 @@ CLOSE_STATUS_FAILED = "failed"
 DEPENDENCY_RESOLUTION_NOT_APPLICABLE = "not_applicable"
 DEPENDENCY_RESOLUTION_SATISFIED = "satisfied"
 DEPENDENCY_RESOLUTION_FAILED = "dependency_failed"
+DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE = "manual_override"
 MERGE_AUTOMATION_SUCCESS_STATUSES = frozenset({"merged", "already_merged"})
 MERGE_AUTOMATION_FAILURE_STATUSES = frozenset({"blocked", "failed", "expired"})
 MERGE_AUTOMATION_CANCELED_STATUS = "canceled"
@@ -265,6 +266,7 @@ class MoonMindRunWorkflow:
         self._unresolved_dependency_ids: set[str] = set()
         self._dependency_wait_started_at: datetime | None = None
         self._dependency_failure: dict[str, Any] | None = None
+        self._dependency_manual_override_unresolved_count: int = 0
 
         # Artifact refs
         self._input_ref: Optional[str] = None
@@ -1279,11 +1281,23 @@ class MoonMindRunWorkflow:
                 self._dependency_failure is None
                 and self._close_status != CLOSE_STATUS_CANCELED
             ):
+                event = (
+                    "dependency_gate_manual_override"
+                    if self._dependency_resolution == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+                    else "dependency_gate_satisfied"
+                )
                 self._get_logger().info(
-                    "Dependency gate satisfied",
+                    "Dependency gate manually overridden"
+                    if event == "dependency_gate_manual_override"
+                    else "Dependency gate satisfied",
                     extra={
-                        "event": "dependency_gate_satisfied",
+                        "event": event,
                         "dependency_count": len(dependency_ids),
+                        "unresolved_dependency_count": (
+                            self._dependency_manual_override_unresolved_count
+                            if event == "dependency_gate_manual_override"
+                            else len(self._unresolved_dependency_ids)
+                        ),
                         "wait_duration_ms": self._dependency_wait_duration_ms,
                     },
                 )
@@ -4983,6 +4997,32 @@ class MoonMindRunWorkflow:
     def validate_approve(self, payload: dict[str, Any] | None = None) -> None:
         if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
             raise ValueError("Cannot approve a completed workflow.")
+
+    @workflow.update(name="SkipDependencyWait")
+    def skip_dependency_wait(self) -> None:
+        self._update_dependency_wait_duration()
+        self._dependency_manual_override_unresolved_count = len(
+            self._unresolved_dependency_ids
+        )
+        self._unresolved_dependency_ids.clear()
+        self._paused = False
+        self._dependency_failure = None
+        self._failed_dependency_id = None
+        self._dependency_resolution = DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+        self._summary = "Dependency wait skipped by operator."
+        self._update_search_attributes()
+        self._update_memo()
+
+    @skip_dependency_wait.validator
+    def validate_skip_dependency_wait(self) -> None:
+        if self._state in (STATE_COMPLETED, STATE_CANCELED, STATE_FAILED):
+            raise ValueError("Cannot skip dependency wait for a completed workflow.")
+        if self._state != STATE_WAITING_ON_DEPENDENCIES:
+            raise ValueError("Workflow is not waiting on dependencies.")
+        if self._dependency_failure is not None:
+            raise ValueError("Cannot skip dependency wait after dependency failure.")
+        if not self._unresolved_dependency_ids:
+            raise ValueError("Workflow has no unresolved dependencies.")
 
     @workflow.update(name="SendMessage")
     async def send_message(self, payload: dict[str, Any] | None = None) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1899,6 +1899,41 @@ def test_signal_execution_routes_send_message_and_serializes_audit(
     assert body["interventionAudit"][0]["detail"] == "Continue with provider profiles."
 
 
+def test_signal_execution_routes_skip_dependency_wait(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    record = _build_execution_record(state=MoonMindWorkflowState.WAITING_ON_DEPENDENCIES)
+    record.memo["intervention_audit"] = [
+        {
+            "action": "skip_dependency_wait",
+            "transport": "temporal_update",
+            "summary": "Dependency wait skipped by operator.",
+            "createdAt": "2026-03-31T01:02:03Z",
+        }
+    ]
+    mock_service.describe_execution.return_value = record
+    mock_service.signal_execution.return_value = record
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.post(
+            "/api/executions/mm:wf-1/signal",
+            json={"signalName": "SkipDependencyWait", "payload": {}},
+        )
+
+    assert response.status_code == 202
+    called = mock_service.signal_execution.await_args.kwargs
+    assert called["signal_name"] == "SkipDependencyWait"
+    assert called["payload"] == {}
+    body = response.json()
+    assert body["actions"]["canSkipDependencyWait"] is True
+    assert body["interventionAudit"][0]["action"] == "skip_dependency_wait"
+
+
 def test_cancel_execution_passes_reject_action_to_service() -> None:
     for test_client, service in _client_with_service():
         service.describe_execution.return_value = _build_execution_record(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1463,6 +1463,53 @@ async def test_signal_send_message_records_intervention_audit_without_state_chan
 
 
 @pytest.mark.asyncio
+async def test_signal_skip_dependency_wait_routes_update_and_records_audit(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        created.state = MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
+        await session.commit()
+
+        await service.signal_execution(
+            workflow_id=created.workflow_id,
+            signal_name="SkipDependencyWait",
+            payload={},
+            payload_artifact_ref=None,
+        )
+
+        service._client_adapter.update_workflow.assert_awaited_once_with(
+            created.workflow_id,
+            "SkipDependencyWait",
+        )
+        refreshed = await service.describe_execution(created.workflow_id)
+        assert refreshed.state is MoonMindWorkflowState.EXECUTING
+        assert refreshed.paused is False
+        assert (
+            refreshed.memo["intervention_audit"][-1]["action"]
+            == "skip_dependency_wait"
+        )
+        assert (
+            refreshed.memo["intervention_audit"][-1]["summary"]
+            == "Dependency wait skipped by operator."
+        )
+        assert refreshed.memo.get("waiting_reason") is None
+
+
+@pytest.mark.asyncio
 async def test_signal_send_message_rejects_noncanonical_payload(
     tmp_path, mock_client_adapter
 ):

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1496,7 +1496,7 @@ async def test_signal_skip_dependency_wait_routes_update_and_records_audit(
             "SkipDependencyWait",
         )
         refreshed = await service.describe_execution(created.workflow_id)
-        assert refreshed.state is MoonMindWorkflowState.EXECUTING
+        assert refreshed.state is MoonMindWorkflowState.AWAITING_SLOT
         assert refreshed.paused is False
         assert (
             refreshed.memo["intervention_audit"][-1]["action"]

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -10,6 +10,7 @@ from temporalio.worker import Worker, UnsandboxedWorkflowRunner
 from temporalio import workflow
 from moonmind.workflows.temporal.workflows.run import (
     DEPENDENCY_RECONCILE_INTERVAL,
+    DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE,
     STATE_AWAITING_SLOT,
     STATE_WAITING_ON_DEPENDENCIES,
     MoonMindRunWorkflow,
@@ -541,3 +542,48 @@ async def test_wait_for_dependencies_reconciles_again_after_timeout(monkeypatch)
 
     assert reconcile_calls == [["dep-1"], ["dep-1"]]
     assert wait_timeouts == [DEPENDENCY_RECONCILE_INTERVAL]
+
+
+@pytest.mark.asyncio
+async def test_skip_dependency_wait_unblocks_dependency_gate(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._owner_id = "owner-1"
+    workflow_instance._owner_type = "user"
+    memo_updates: list[dict[str, object]] = []
+
+    async def fake_reconcile(dependency_ids):
+        return None
+
+    async def fake_wait_condition(predicate, timeout=None):
+        workflow_instance.skip_dependency_wait()
+        assert predicate()
+
+    monkeypatch.setattr(workflow_instance, "_reconcile_dependencies", fake_reconcile)
+    monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
+    )
+    monkeypatch.setattr(workflow, "info", lambda: workflow_info())
+    monkeypatch.setattr(
+        workflow,
+        "logger",
+        type("Logger", (), {"warning": lambda *a, **k: None, "info": lambda *a, **k: None})(),
+    )
+
+    await workflow_instance._wait_for_dependencies(["dep-1", "dep-2"])
+
+    assert workflow_instance._dependency_resolution == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+    assert workflow_instance._dependency_manual_override_unresolved_count == 2
+    assert workflow_instance._unresolved_dependency_ids == set()
+    assert workflow_instance._failed_dependency_id is None
+    assert workflow_instance._waiting_reason is None
+    assert any(
+        (memo.get("dependencies") or {}).get("resolution")
+        == DEPENDENCY_RESOLUTION_MANUAL_OVERRIDE
+        for memo in memo_updates
+    )


### PR DESCRIPTION
## Summary

- Add a manual operator action to skip dependency waiting for eligible workflow runs.
- Wire the action through the execution signal API, Temporal service, workflow update path, OpenAPI types, and task detail intervention UI.
- Document the operator behavior and add API, workflow, service, and frontend coverage.

## Validation

- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
  - Python: 3638 passed, 1 xpassed, 110 warnings, 16 subtests passed
  - Frontend: 11 files passed, 317 tests passed
- ./node_modules/.bin/tsc --noEmit -p frontend/tsconfig.json
- Focused Python and frontend tests for the dependency-wait override
- git diff --check

## Notes

Recovered from MoonMind workflow mm:68ac8064-1e76-4913-af18-d3b32577882e after its original publish step failed because the natesticcog3 credential could not push to the repository.
