### PR TITLE
There should be a manual way in the UI to stop a workflow from waiting on dependencies if we realize we no longer need to wait for some reason that ca

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -1488,6 +1488,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
                     "cancel",
                     "reject",
                     "sendMessage",
+                    "bypassDependencies",
                 )
             }
         )
@@ -1498,7 +1499,12 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
     state_actions = {
         "scheduled": {"can_set_title", "can_update_inputs", "can_cancel"},
         "initializing": {"can_set_title", "can_update_inputs", "can_cancel"},
-        "waiting_on_dependencies": {"can_set_title", "can_update_inputs", "can_cancel"},
+        "waiting_on_dependencies": {
+            "can_set_title",
+            "can_update_inputs",
+            "can_cancel",
+            "can_bypass_dependencies",
+        },
         "awaiting_slot": {"can_set_title", "can_update_inputs", "can_cancel"},
         "planning": {"can_set_title", "can_update_inputs", "can_cancel"},
         "executing": {
@@ -1542,6 +1548,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         "can_cancel": "canCancel",
         "can_reject": "canReject",
         "can_send_message": "canSendMessage",
+        "can_bypass_dependencies": "canBypassDependencies",
     }
     disabled_reasons = {}
     for field_name, alias in capability_values.items():
@@ -1570,6 +1577,7 @@ def _build_action_capabilities(record) -> ExecutionActionCapabilityModel:
         can_cancel="can_cancel" in enabled,
         can_reject="can_reject" in enabled,
         can_send_message="can_send_message" in enabled,
+        can_bypass_dependencies="can_bypass_dependencies" in enabled,
         disabled_reasons=disabled_reasons,
     )
 

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -116,6 +116,18 @@ describe('Task Detail Entrypoint', () => {
     page: 'task-detail',
     apiBase: '/api',
   };
+  const actionsPayload: BootPayload = {
+    ...mockPayload,
+    initialData: {
+      dashboardConfig: {
+        features: {
+          temporalDashboard: {
+            actionsEnabled: true,
+          },
+        },
+      },
+    },
+  };
   const stepsPayload: BootPayload = {
     page: 'task-detail',
     apiBase: '/api',
@@ -282,7 +294,6 @@ describe('Task Detail Entrypoint', () => {
       updatedAt: '2026-04-09T00:00:04Z',
       actions: {},
     };
-
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/executions/test-123/steps')) {
@@ -1713,6 +1724,81 @@ describe('Task Detail Entrypoint', () => {
       expect(screen.getByText(/Blocked on prerequisites/i)).toBeTruthy();
       expect(screen.getByText('Build shared schema')).toBeTruthy();
       expect(screen.getByText('Run UI smoke tests')).toBeTruthy();
+    });
+  });
+
+  it('signals a manual dependency wait bypass from the dependency panel', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const signalBodies: unknown[] = [];
+    const mockExecution = {
+      taskId: 'mm:dependent-1',
+      workflowId: 'mm:dependent-1',
+      namespace: 'default',
+      temporalRunId: '01-run',
+      runId: '01-run',
+      source: 'temporal',
+      workflowType: 'MoonMind.Run',
+      entry: 'run',
+      title: 'Dependent task',
+      summary: 'Waiting on upstream work',
+      status: 'waiting',
+      state: 'waiting_on_dependencies',
+      rawState: 'waiting_on_dependencies',
+      temporalStatus: 'running',
+      dependsOn: ['mm:dep-1'],
+      hasDependencies: true,
+      blockedOnDependencies: true,
+      dependencyResolution: 'not_applicable',
+      prerequisites: [
+        {
+          workflowId: 'mm:dep-1',
+          title: 'Build shared schema',
+          summary: 'Finishing migrations',
+          state: 'executing',
+          closeStatus: null,
+          workflowType: 'MoonMind.Run',
+        },
+      ],
+      dependents: [],
+      createdAt: '2026-03-28T00:00:00Z',
+      updatedAt: '2026-03-28T00:00:02Z',
+      actions: { canBypassDependencies: true },
+    };
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/artifacts')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ artifacts: [] }),
+        } as Response);
+      }
+      if (url.endsWith('/api/executions/mm%3Adependent-1/signal')) {
+        signalBodies.push(JSON.parse(String(init?.body || '{}')));
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ ...mockExecution, blockedOnDependencies: false }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => mockExecution,
+      } as Response);
+    });
+
+    window.history.pushState({}, 'Test', '/tasks/mm%3Adependent-1?source=temporal');
+    renderWithClient(<TaskDetailPage payload={actionsPayload} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Bypass Dependency Wait' }));
+
+    await waitFor(() => {
+      expect(confirmSpy).toHaveBeenCalledWith('Bypass dependency waiting for this task?');
+      expect(signalBodies).toEqual([
+        {
+          signalName: 'BypassDependencies',
+          payload: { reason: 'Dependency wait bypassed by operator from Mission Control.' },
+        },
+      ]);
     });
   });
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -287,6 +287,7 @@ const ExecutionDetailSchema = z
         canCancel: z.boolean().optional(),
         canReject: z.boolean().optional(),
         canSendMessage: z.boolean().optional(),
+        canBypassDependencies: z.boolean().optional(),
         disabledReasons: z.record(z.string(), z.string()).optional(),
       })
       .passthrough()
@@ -3103,6 +3104,15 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
     signalMutation.mutate({ signalName: 'SendMessage', payload: { message } });
   };
 
+  const onBypassDependencies = () => {
+    setActionError(null);
+    if (!window.confirm('Bypass dependency waiting for this task?')) return;
+    signalMutation.mutate({
+      signalName: 'BypassDependencies',
+      payload: { reason: 'Dependency wait bypassed by operator from Mission Control.' },
+    });
+  };
+
   const onCancel = () => {
     setActionError(null);
     if (!window.confirm('Cancel this task?')) return;
@@ -3556,6 +3566,18 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
               {execution.blockedOnDependencies ? (
                 <div className="notice">
                   <strong>Blocked on prerequisites.</strong> This run will not advance until every prerequisite reaches <code>completed</code>.
+                  {actionsOn && actions?.canBypassDependencies ? (
+                    <div className="actions" style={{ marginTop: '0.75rem' }}>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        className="queue-action queue-action-danger"
+                        onClick={onBypassDependencies}
+                      >
+                        Bypass Dependency Wait
+                      </button>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
               <div className="stack">

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -3199,6 +3199,11 @@ export interface components {
              */
             canSendMessage: boolean;
             /**
+             * Canbypassdependencies
+             * @default false
+             */
+            canBypassDependencies: boolean;
+            /**
              * Canskipdependencywait
              * @default false
              */
@@ -5164,7 +5169,7 @@ export interface components {
              * Signalname
              * @enum {string}
              */
-            signalName: "ExternalEvent" | "Pause" | "Resume" | "Approve" | "SkipDependencyWait" | "SendMessage" | "DependencyResolved";
+            signalName: "ExternalEvent" | "Pause" | "Resume" | "Approve" | "SkipDependencyWait" | "SendMessage" | "DependencyResolved" | "BypassDependencies";
             /** Payload */
             payload?: {
                 [key: string]: unknown;

--- a/moonmind/schemas/temporal_models.py
+++ b/moonmind/schemas/temporal_models.py
@@ -39,6 +39,7 @@ SUPPORTED_SIGNAL_NAMES = (
     "Approve",
     "SendMessage",
     "DependencyResolved",
+    "BypassDependencies",
 )
 TASK_RUN_ID_MEMO_KEYS = ("taskRunId", "task_run_id")
 TASK_RUN_ID_SEARCH_ATTR_KEYS = ("mm_task_run_id",)
@@ -646,6 +647,7 @@ class ExecutionActionCapabilityModel(BaseModel):
     can_cancel: bool = Field(False, alias="canCancel")
     can_reject: bool = Field(False, alias="canReject")
     can_send_message: bool = Field(False, alias="canSendMessage")
+    can_bypass_dependencies: bool = Field(False, alias="canBypassDependencies")
     disabled_reasons: dict[str, str] = Field(
         default_factory=dict, alias="disabledReasons"
     )

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1225,7 +1225,19 @@ class TemporalExecutionService:
             ) from exc
 
         signal_payload = dict(payload or {})
-        if signal_name == "ExternalEvent":
+        if signal_name == "BypassDependencies":
+            self._append_intervention_audit(
+                record,
+                action="bypass_dependencies",
+                transport="temporal_signal",
+                summary="Dependency wait bypass requested.",
+                detail=str(signal_payload.get("reason") or "").strip() or None,
+            )
+            self._clear_waiting_metadata(record)
+            self._clear_wait_metadata(record)
+            self._set_state(record, MoonMindWorkflowState.INITIALIZING)
+            self._update_summary(record, "Dependency wait bypass requested.")
+        elif signal_name == "ExternalEvent":
             source_raw = signal_payload.get("source")
             event_type_raw = signal_payload.get("event_type")
             if not source_raw or not event_type_raw:

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1226,17 +1226,24 @@ class TemporalExecutionService:
 
         signal_payload = dict(payload or {})
         if signal_name == "BypassDependencies":
-            self._append_intervention_audit(
-                record,
-                action="bypass_dependencies",
-                transport="temporal_signal",
-                summary="Dependency wait bypass requested.",
-                detail=str(signal_payload.get("reason") or "").strip() or None,
-            )
-            self._clear_waiting_metadata(record)
-            self._clear_wait_metadata(record)
-            self._set_state(record, MoonMindWorkflowState.INITIALIZING)
-            self._update_summary(record, "Dependency wait bypass requested.")
+            bypass_reason = str(signal_payload.get("reason") or "").strip() or None
+            if record.state == MoonMindWorkflowState.WAITING_ON_DEPENDENCIES:
+                self._append_intervention_audit(
+                    record,
+                    action="bypass_dependencies",
+                    transport="temporal_signal",
+                    summary="Dependency wait bypass requested.",
+                    detail=bypass_reason,
+                )
+                self._update_summary(record, "Dependency wait bypass requested.")
+            else:
+                self._append_intervention_audit(
+                    record,
+                    action="bypass_dependencies",
+                    transport="temporal_signal",
+                    summary="Dependency wait bypass ignored outside dependency wait.",
+                    detail=bypass_reason,
+                )
         elif signal_name == "ExternalEvent":
             source_raw = signal_payload.get("source")
             event_type_raw = signal_payload.get("event_type")

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -1148,7 +1148,7 @@ class MoonMindRunWorkflow:
             reason = "Dependency wait bypassed by operator."
 
         self._update_dependency_wait_duration()
-        bypassed_at = workflow.now().isoformat()
+        bypassed_at = workflow.now().isoformat().replace("+00:00", "Z")
         for prerequisite_workflow_id in list(self._unresolved_dependency_ids):
             self._dependency_outcomes_by_id[prerequisite_workflow_id] = {
                 "workflowId": prerequisite_workflow_id,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -138,6 +138,7 @@ CLOSE_STATUS_FAILED = "failed"
 DEPENDENCY_RESOLUTION_NOT_APPLICABLE = "not_applicable"
 DEPENDENCY_RESOLUTION_SATISFIED = "satisfied"
 DEPENDENCY_RESOLUTION_FAILED = "dependency_failed"
+DEPENDENCY_RESOLUTION_BYPASSED = "bypassed"
 MERGE_AUTOMATION_SUCCESS_STATUSES = frozenset({"merged", "already_merged"})
 MERGE_AUTOMATION_FAILURE_STATUSES = frozenset({"blocked", "failed", "expired"})
 MERGE_AUTOMATION_CANCELED_STATUS = "canceled"
@@ -1124,6 +1125,52 @@ class MoonMindRunWorkflow:
             resolved_at=signal.resolved_at.isoformat(),
             failure_category=signal.failure_category,
             message=signal.message,
+        )
+        self._update_search_attributes()
+        self._update_memo()
+
+    def _bypass_dependencies(self, payload: dict[str, Any] | None = None) -> None:
+        if self._state != STATE_WAITING_ON_DEPENDENCIES:
+            self._get_logger().warning(
+                "Ignoring BypassDependencies signal outside dependency wait",
+                extra={
+                    "event": "dependency_bypass_ignored",
+                    "state": self._state,
+                },
+            )
+            return
+
+        envelope = payload if isinstance(payload, dict) else {}
+        signal_payload = envelope.get("payload")
+        details = signal_payload if isinstance(signal_payload, dict) else envelope
+        reason = str(details.get("reason") or "").strip()
+        if not reason:
+            reason = "Dependency wait bypassed by operator."
+
+        self._update_dependency_wait_duration()
+        bypassed_at = workflow.now().isoformat()
+        for prerequisite_workflow_id in list(self._unresolved_dependency_ids):
+            self._dependency_outcomes_by_id[prerequisite_workflow_id] = {
+                "workflowId": prerequisite_workflow_id,
+                "terminalState": "bypassed",
+                "closeStatus": None,
+                "resolvedAt": bypassed_at,
+                "failureCategory": None,
+                "message": reason,
+            }
+
+        self._unresolved_dependency_ids.clear()
+        self._dependency_failure = None
+        self._failed_dependency_id = None
+        self._dependency_resolution = DEPENDENCY_RESOLUTION_BYPASSED
+        self._summary = reason
+        self._get_logger().warning(
+            "Dependency gate bypassed by operator",
+            extra={
+                "event": "dependency_gate_bypassed",
+                "dependency_count": len(self._declared_dependencies),
+                "wait_duration_ms": self._dependency_wait_duration_ms,
+            },
         )
         self._update_search_attributes()
         self._update_memo()
@@ -4862,6 +4909,10 @@ class MoonMindRunWorkflow:
     @workflow.signal(name="DependencyResolved")
     def dependency_resolved(self, payload: dict[str, Any]) -> None:
         self._record_dependency_signal(payload)
+
+    @workflow.signal(name="BypassDependencies")
+    def bypass_dependencies(self, payload: dict[str, Any] | None = None) -> None:
+        self._bypass_dependencies(payload)
 
     def _release_slot_defensive(self) -> None:
         """Release the provider-profile slot defensively when a child exits.

--- a/specs/213-manual-dependency-bypass/plan.md
+++ b/specs/213-manual-dependency-bypass/plan.md
@@ -1,0 +1,44 @@
+# Implementation Plan: Manual Dependency Wait Bypass
+
+**Branch**: `213-manual-dependency-bypass` | **Date**: 2026-04-20 | **Spec**: `specs/213-manual-dependency-bypass/spec.md`
+
+## Summary
+
+Add an operator-confirmed `BypassDependencies` signal for `MoonMind.Run`, expose a matching action capability from the execution detail API only while a run is blocked on dependencies, and render the control in the task detail Dependencies panel.
+
+## Technical Context
+
+**Language/Version**: Python 3.12, TypeScript/React  
+**Primary Dependencies**: Pydantic v2, Temporal Python SDK, FastAPI, React, Vitest, pytest  
+**Storage**: Existing workflow memo/search attributes and execution projection only; no new tables.  
+**Testing**: Focused workflow unit tests, Temporal service tests, execution API serialization tests, and task-detail Vitest coverage.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. Adds a Temporal signal to existing orchestration.
+- II. One-Click Agent Deployment: PASS. No new deployment dependency.
+- III. Avoid Vendor Lock-In: PASS. Workflow-level behavior is provider-neutral.
+- IV. Own Your Data: PASS. Bypass metadata stays in local workflow state/projections.
+- V. Skills Are First-Class: PASS. No skill contract changes.
+- VI. Replaceable Scaffolding: PASS. Small signal/action surface with focused tests.
+- VII. Runtime Configurability: PASS. Respects the existing dashboard actions flag.
+- VIII. Modular Architecture: PASS. Changes stay within schema, service, workflow, and detail UI boundaries.
+- IX. Resilient by Default: PASS. Manual bypass is explicit, recorded, and does not pretend prerequisites succeeded.
+- X. Continuous Improvement: PASS. Operator action is auditable.
+- XI. Spec-Driven Development: PASS. This spec covers the change.
+- XII. Canonical Documentation Separation: PASS. No canonical docs needed for this narrow runtime addition.
+- XIII. Pre-Release Compatibility Policy: PASS. Adds one explicit signal name without hidden aliases.
+
+## Project Structure
+
+```text
+moonmind/schemas/temporal_models.py
+moonmind/workflows/temporal/workflows/run.py
+moonmind/workflows/temporal/service.py
+api_service/api/routers/executions.py
+frontend/src/entrypoints/task-detail.tsx
+frontend/src/entrypoints/task-detail.test.tsx
+tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+tests/unit/workflows/temporal/test_temporal_service.py
+tests/unit/api/routers/test_executions.py
+```

--- a/specs/213-manual-dependency-bypass/spec.md
+++ b/specs/213-manual-dependency-bypass/spec.md
@@ -1,0 +1,31 @@
+# Feature Specification: Manual Dependency Wait Bypass
+
+**Feature Branch**: `213-manual-dependency-bypass`  
+**Created**: 2026-04-20  
+**Status**: Draft  
+**Input**: User request: "There should be a manual way in the UI to stop a workflow from waiting on dependencies if we realize we no longer need to wait for some reason that cannot be automatically discovered."
+
+## User Story
+
+As a MoonMind operator, I can manually release a `MoonMind.Run` that is waiting on declared dependencies so an operator-discovered exception can let the run proceed without canceling or recreating it.
+
+## Acceptance Scenarios
+
+1. **Given** a run is in `waiting_on_dependencies`, **when** the task detail page renders, **then** the Dependencies panel offers an explicit dependency-wait bypass action.
+2. **Given** the operator confirms the bypass, **when** Mission Control submits the action, **then** the backend signals the workflow with `BypassDependencies`.
+3. **Given** the workflow receives `BypassDependencies` while waiting on dependencies, **when** unresolved prerequisites remain, **then** the dependency gate records a `bypassed` resolution, records bypass outcomes for unresolved prerequisites, and allows the run to proceed.
+4. **Given** a workflow is not waiting on dependencies, **when** `BypassDependencies` is received, **then** the signal is ignored without changing dependency state.
+
+## Requirements
+
+- **FR-001**: The execution detail API MUST expose a dependency bypass capability only for `waiting_on_dependencies` runs when actions are enabled.
+- **FR-002**: The UI MUST render the manual bypass action in the dependency wait context, not as a generic task action.
+- **FR-003**: The UI MUST require explicit operator confirmation before sending the bypass signal.
+- **FR-004**: `MoonMind.Run` MUST support a `BypassDependencies` signal that releases the dependency wait without fabricating prerequisite completion.
+- **FR-005**: The bypass MUST be visible in dependency metadata as a `bypassed` resolution with operator-readable outcome messages.
+
+## Out Of Scope
+
+- Editing dependency edges after run creation.
+- Automatically deciding when dependencies are no longer needed.
+- Bypassing other wait types such as provider slots, approvals, or merge gates.

--- a/specs/213-manual-dependency-bypass/tasks.md
+++ b/specs/213-manual-dependency-bypass/tasks.md
@@ -1,0 +1,19 @@
+# Tasks: Manual Dependency Wait Bypass
+
+**Input**: `specs/213-manual-dependency-bypass/spec.md`
+
+## Implementation
+
+- [X] T001 Add `BypassDependencies` to the supported Temporal signal contract.
+- [X] T002 Expose `canBypassDependencies` only for runs in `waiting_on_dependencies`.
+- [X] T003 Implement `MoonMind.Run` dependency bypass handling that records `bypassed` metadata and clears unresolved prerequisites.
+- [X] T004 Record an operator intervention audit entry when the bypass signal is submitted through the execution service.
+- [X] T005 Render an explicit confirmed Dependency panel action in task detail.
+
+## Verification
+
+- [X] T006 Add workflow-level unit coverage for bypassing an active dependency wait.
+- [X] T007 Add service coverage for sending the bypass signal and recording audit metadata.
+- [X] T008 Add API serialization coverage for `canBypassDependencies`.
+- [X] T009 Add task-detail UI coverage for the bypass signal request.
+- [X] T010 Run focused tests and final unit verification.

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3344,9 +3344,33 @@ def test_describe_execution_includes_actions_and_debug_fields(
     assert body["actions"]["canApprove"] is True
     assert body["actions"]["canResume"] is True
     assert body["actions"]["canCancel"] is True
+    assert body["actions"]["canBypassDependencies"] is False
     assert body["actions"]["canUpdateInputs"] is False
     assert body["debugFields"]["workflowId"] == "mm:wf-1"
     assert body["redirectPath"] == "/tasks/mm:wf-1?source=temporal"
+
+
+def test_describe_execution_exposes_dependency_bypass_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    mock_service = AsyncMock()
+    mock_service.describe_execution.return_value = _build_execution_record(
+        state=MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
+    )
+    app.dependency_overrides[_get_service] = lambda: mock_service
+    _override_temporal_client(app)
+    _override_user_dependencies(app, is_superuser=True)
+    monkeypatch.setattr(settings.temporal_dashboard, "actions_enabled", True)
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/api/executions/mm:wf-1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["actions"]["canBypassDependencies"] is True
+    assert "canBypassDependencies" not in body["actions"]["disabledReasons"]
 
 
 def test_describe_execution_exposes_temporal_task_editing_contract(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1495,6 +1495,52 @@ async def test_signal_send_message_rejects_noncanonical_payload(
 
 
 @pytest.mark.asyncio
+async def test_signal_bypass_dependencies_records_operator_audit(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={"task": {"dependsOn": []}},
+            idempotency_key=None,
+        )
+        service._set_state(created, MoonMindWorkflowState.WAITING_ON_DEPENDENCIES)
+        await session.commit()
+
+        await service.signal_execution(
+            workflow_id=created.workflow_id,
+            signal_name="BypassDependencies",
+            payload={"reason": "No longer needs the upstream task."},
+            payload_artifact_ref=None,
+        )
+
+        mock_client_adapter.signal_workflow.assert_awaited_once_with(
+            created.workflow_id,
+            "BypassDependencies",
+            {
+                "payload": {"reason": "No longer needs the upstream task."},
+                "payload_artifact_ref": None,
+            },
+        )
+        refreshed = await service.describe_execution(created.workflow_id)
+        assert refreshed.state is MoonMindWorkflowState.INITIALIZING
+        assert refreshed.memo["intervention_audit"][-1]["action"] == "bypass_dependencies"
+        assert (
+            refreshed.memo["intervention_audit"][-1]["detail"]
+            == "No longer needs the upstream task."
+        )
+
+
+@pytest.mark.asyncio
 async def test_signal_execution_rejects_unknown_signal_name(tmp_path):
     async with temporal_db(tmp_path) as session:
         service = TemporalExecutionService(session)

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1513,7 +1513,8 @@ async def test_signal_bypass_dependencies_records_operator_audit(
             initial_parameters={"task": {"dependsOn": []}},
             idempotency_key=None,
         )
-        service._set_state(created, MoonMindWorkflowState.WAITING_ON_DEPENDENCIES)
+        source = await service._require_source_execution(created.workflow_id)
+        service._set_state(source, MoonMindWorkflowState.WAITING_ON_DEPENDENCIES)
         await session.commit()
 
         await service.signal_execution(
@@ -1532,11 +1533,53 @@ async def test_signal_bypass_dependencies_records_operator_audit(
             },
         )
         refreshed = await service.describe_execution(created.workflow_id)
-        assert refreshed.state is MoonMindWorkflowState.INITIALIZING
+        assert refreshed.state is MoonMindWorkflowState.WAITING_ON_DEPENDENCIES
+        assert refreshed.memo["summary"] == "Dependency wait bypass requested."
         assert refreshed.memo["intervention_audit"][-1]["action"] == "bypass_dependencies"
         assert (
             refreshed.memo["intervention_audit"][-1]["detail"]
             == "No longer needs the upstream task."
+        )
+
+
+@pytest.mark.asyncio
+async def test_signal_bypass_dependencies_outside_wait_does_not_mutate_projection(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+
+        created = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=uuid4(),
+            title=None,
+            input_artifact_ref=None,
+            plan_artifact_ref="artifact://plan/1",
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={"task": {"dependsOn": []}},
+            idempotency_key=None,
+        )
+        source = await service._require_source_execution(created.workflow_id)
+        service._set_state(source, MoonMindWorkflowState.EXECUTING)
+        service._update_summary(source, "Execution in progress.")
+        await session.commit()
+
+        await service.signal_execution(
+            workflow_id=created.workflow_id,
+            signal_name="BypassDependencies",
+            payload={"reason": "Operator clicked bypass from stale UI."},
+            payload_artifact_ref=None,
+        )
+
+        refreshed = await service.describe_execution(created.workflow_id)
+        assert refreshed.state is MoonMindWorkflowState.EXECUTING
+        assert refreshed.memo["summary"] == "Execution in progress."
+        assert refreshed.memo["intervention_audit"][-1]["action"] == "bypass_dependencies"
+        assert (
+            refreshed.memo["intervention_audit"][-1]["summary"]
+            == "Dependency wait bypass ignored outside dependency wait."
         )
 
 

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -494,6 +494,68 @@ async def test_wait_for_dependencies_raises_dependency_specific_failure(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_wait_for_dependencies_can_be_bypassed_by_operator_signal(monkeypatch):
+    workflow_instance = MoonMindRunWorkflow()
+    workflow_instance._owner_id = "owner-1"
+    workflow_instance._owner_type = "user"
+    memo_updates: list[dict[str, object]] = []
+
+    async def fake_reconcile(dependency_ids):
+        return None
+
+    async def fake_wait_condition(predicate, timeout=None):
+        workflow_instance._bypass_dependencies(
+            {"payload": {"reason": "No longer needed."}}
+        )
+        assert predicate()
+
+    monkeypatch.setattr(workflow_instance, "_reconcile_dependencies", fake_reconcile)
+    monkeypatch.setattr(workflow, "wait_condition", fake_wait_condition)
+    monkeypatch.setattr(workflow, "upsert_search_attributes", lambda attr: None)
+    monkeypatch.setattr(workflow, "upsert_memo", lambda memo: memo_updates.append(memo))
+    monkeypatch.setattr(workflow, "now", lambda: datetime.now(timezone.utc))
+    workflow_info = type(
+        "WorkflowInfo",
+        (),
+        {"namespace": "default", "workflow_id": "wf-1", "run_id": "run-1", "search_attributes": {}},
+    )
+    monkeypatch.setattr(workflow, "info", lambda: workflow_info())
+    monkeypatch.setattr(
+        workflow,
+        "logger",
+        type("Logger", (), {"warning": lambda *a, **k: None, "info": lambda *a, **k: None})(),
+    )
+
+    await workflow_instance._wait_for_dependencies(["dep-1", "dep-2"])
+
+    assert workflow_instance._dependency_resolution == "bypassed"
+    assert workflow_instance._unresolved_dependency_ids == set()
+    assert workflow_instance._failed_dependency_id is None
+    assert workflow_instance._dependency_outcomes() == [
+        {
+            "workflowId": "dep-1",
+            "terminalState": "bypassed",
+            "closeStatus": None,
+            "resolvedAt": workflow_instance._dependency_outcomes_by_id["dep-1"]["resolvedAt"],
+            "failureCategory": None,
+            "message": "No longer needed.",
+        },
+        {
+            "workflowId": "dep-2",
+            "terminalState": "bypassed",
+            "closeStatus": None,
+            "resolvedAt": workflow_instance._dependency_outcomes_by_id["dep-2"]["resolvedAt"],
+            "failureCategory": None,
+            "message": "No longer needed.",
+        },
+    ]
+    assert any(
+        (memo.get("dependencies") or {}).get("resolution") == "bypassed"
+        for memo in memo_updates
+    )
+
+
+@pytest.mark.asyncio
 async def test_wait_for_dependencies_reconciles_again_after_timeout(monkeypatch):
     workflow_instance = MoonMindRunWorkflow()
     workflow_instance._owner_id = "owner-1"

--- a/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_signals_updates.py
@@ -549,6 +549,10 @@ async def test_wait_for_dependencies_can_be_bypassed_by_operator_signal(monkeypa
             "message": "No longer needed.",
         },
     ]
+    assert all(
+        workflow_instance._dependency_outcomes_by_id[dependency_id]["resolvedAt"].endswith("Z")
+        for dependency_id in ("dep-1", "dep-2")
+    )
     assert any(
         (memo.get("dependencies") or {}).get("resolution") == "bypassed"
         for memo in memo_updates


### PR DESCRIPTION
There should be a manual way in the UI to stop a workflow from waiting on dependencies if we realize we no longer need to wait for some reason that cannot be automatically discovered.