### PR TITLE
There is wasted space on the right side of the github repo in the floating bar of the create page. The 3 dropdowns should take up the available space.

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,12 @@
 [
   {
-    "id": 3114361904,
+    "id": 3114793791,
     "disposition": "addressed",
-    "rationale": "Updated deactivate_templates telemetry to increment the delete metric by the number of templates deactivated, with unit coverage for the bulk path."
+    "rationale": "Updated the mobile floating bar grid to preserve the publish-mode minimum width while the repository control spans the full row, and added CSS regression coverage."
   },
   {
-    "id": 4144292983,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; the only concrete feedback item it referenced was addressed separately."
+    "id": 4144781567,
+    "disposition": "addressed",
+    "rationale": "The review summary identified the same mobile grid issue as the inline comment; the CSS fix and regression test address it."
   }
 ]

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5664,7 +5664,7 @@ describe("Task Create Entrypoint", () => {
     expect(LIQUID_GL_OPTIONS.reveal).toBe(false);
   });
 
-  it("gives repository, branch, and publish controls equal desktop space in the floating bar", async () => {
+  it("lets repository, branch, and publish controls fill the floating bar on desktop", async () => {
     const { readFileSync } = await import("node:fs");
     const missionControlCss = readFileSync(
       `${process.cwd()}/frontend/src/styles/mission-control.css`,
@@ -5672,7 +5672,10 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)\s*auto/s,
+      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
     );
   });
 

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5677,6 +5677,9 @@ describe("Task Create Entrypoint", () => {
     expect(missionControlCss).toMatch(
       /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
     );
+    expect(missionControlCss).toMatch(
+      /@media \(max-width:\s*640px\)\s*\{[^}]*\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
+    );
   });
 
   it("centers the constrained create page panel with equal side margins", async () => {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1877,7 +1877,7 @@ button.secondary:hover {
   bottom: 1.1rem;
   transform: translateX(-50%);
   z-index: 40;
-  width: min(100% - 1.5rem, 64rem);
+  width: min(100% - 1.5rem, 72rem);
   padding: 0.55rem 0.7rem;
   border-radius: 1.5rem;
   background: var(--mm-glass-fill);
@@ -1900,7 +1900,11 @@ button.secondary:hover {
 
 .queue-floating-bar-row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  grid-template-columns:
+    minmax(0, 1.35fr)
+    minmax(0, 1.35fr)
+    minmax(9.5rem, 0.8fr)
+    auto;
   gap: 0.5rem;
   align-items: center;
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1942,7 +1942,7 @@ button.secondary:hover {
 
 @media (max-width: 640px) {
   .queue-floating-bar-row {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) minmax(9.5rem, 0.8fr) auto;
   }
 
   .queue-floating-bar-row .queue-inline-selector--repo {


### PR DESCRIPTION
There is wasted space on the right side of the github repo in the floating bar of the create page. The 3 dropdowns should take up the available space. The publish mode dropdown can be shorter than the other 2 if that's easy to keep consistent since it will usually not be as long.