### PR TITLE
[codex] Fix provider profile slot sync ordering

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3114361904,
+    "id": 3115257689,
     "disposition": "addressed",
-    "rationale": "Updated deactivate_templates telemetry to increment the delete metric by the number of templates deactivated, with unit coverage for the bulk path."
+    "rationale": "Removed the unconditional provider_profile.ensure_manager activity from the request_slot=false path and moved auto-start to the sync_profiles signal retry only when ExternalWorkflowExecutionNotFound is observed."
   },
   {
-    "id": 4144292983,
+    "id": 4145277063,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; the only concrete feedback item it referenced was addressed separately."
+    "rationale": "Automated review summary; the actionable optimization it summarized is tracked by review comment 3115257689."
+  },
+  {
+    "id": 3115269139,
+    "disposition": "addressed",
+    "rationale": "Pre-slot manager startup is no longer a hard dependency; sync_profiles failures, including ensure_manager retry failures, remain best-effort and allow the run to continue to slot request."
+  },
+  {
+    "id": 4145288894,
+    "disposition": "not-applicable",
+    "rationale": "Automated review container/comment metadata; the actionable P1 item is tracked by review comment 3115269139."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -126,6 +126,9 @@ MANAGED_SESSION_PREPARE_TURN_INSTRUCTIONS_ACTIVITY_PATCH_ID = (
 )
 MANAGER_SLOT_WAIT_INSPECTION_PATCH_ID = "agent-run-slot-wait-manager-inspection-v1"
 SLOT_HANDOFF_PATCH_ID = "agent-run-slot-handoff-v1"
+SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID = (
+    "agent-run-sync-profiles-before-slot-request-v1"
+)
 
 # Module-level activity catalog — deterministic, safe for Temporal replay.
 # Mirrors the pattern used by MoonMind.Run (run.py:50).
@@ -662,7 +665,12 @@ class MoonMindAgentRun:
         if profile_selector:
             signal_payload["profile_selector"] = profile_selector
         if not request_slot:
-            return manager_handle
+            await self._execute_routed_activity(
+                "provider_profile.ensure_manager",
+                {"runtime_id": runtime_id},
+                cancellation_type=ActivityCancellationType.TRY_CANCEL,
+            )
+            return workflow.get_external_workflow_handle(manager_id)
 
         for attempt in range(2):
             try:
@@ -736,6 +744,20 @@ class MoonMindAgentRun:
             request_slot=True,
             execution_profile_ref=execution_profile_ref,
             profile_selector=profile_selector,
+        )
+
+    async def _ensure_manager_started(
+        self,
+        manager_id: str,
+        runtime_id: str,
+    ) -> workflow.ExternalWorkflowHandle:
+        """Ensure the provider-profile manager exists without requesting a slot."""
+        return await self._ensure_manager_and_signal(
+            manager_id,
+            runtime_id,
+            request_slot=False,
+            execution_profile_ref=None,
+            profile_selector=None,
         )
 
     async def _sync_manager_profiles(
@@ -1058,17 +1080,38 @@ class MoonMindAgentRun:
                     manager_id = self._manager_workflow_id(runtime_id)
 
                     self.slot_assigned_event.clear()
-                    manager_handle = await self._ensure_manager_and_signal(
-                        manager_id,
-                        runtime_id,
-                        request_slot=True,
-                        execution_profile_ref=request.execution_profile_ref,
-                        profile_selector=request.profile_selector.model_dump(by_alias=True, exclude_none=True),
+                    selector_payload = request.profile_selector.model_dump(
+                        by_alias=True,
+                        exclude_none=True,
                     )
-                    profile_count = await self._sync_manager_profiles(
-                        manager_handle=manager_handle,
-                        runtime_id=runtime_id,
-                    )
+                    if workflow.patched(SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID):
+                        manager_handle = await self._ensure_manager_started(
+                            manager_id,
+                            runtime_id,
+                        )
+                        profile_count = await self._sync_manager_profiles(
+                            manager_handle=manager_handle,
+                            runtime_id=runtime_id,
+                        )
+                        manager_handle = await self._ensure_manager_and_signal(
+                            manager_id,
+                            runtime_id,
+                            request_slot=True,
+                            execution_profile_ref=request.execution_profile_ref,
+                            profile_selector=selector_payload,
+                        )
+                    else:
+                        manager_handle = await self._ensure_manager_and_signal(
+                            manager_id,
+                            runtime_id,
+                            request_slot=True,
+                            execution_profile_ref=request.execution_profile_ref,
+                            profile_selector=selector_payload,
+                        )
+                        profile_count = await self._sync_manager_profiles(
+                            manager_handle=manager_handle,
+                            runtime_id=runtime_id,
+                        )
                     if profile_count == 0:
                         raise ApplicationError(
                             f"No enabled provider profiles found for runtime_id='{runtime_id}'",

--- a/moonmind/workflows/temporal/workflows/agent_run.py
+++ b/moonmind/workflows/temporal/workflows/agent_run.py
@@ -641,10 +641,13 @@ class MoonMindAgentRun:
         execution_profile_ref: str | None = None,
         profile_selector: dict | None = None,
     ) -> workflow.ExternalWorkflowHandle:
-        """Signal the ProviderProfileManager; auto-start it on first failure.
+        """Signal the ProviderProfileManager for slot requests; auto-start it on first failure.
 
         Tries the signal. If the manager workflow doesn't exist, starts it
         via the ``provider_profile.ensure_manager`` activity and retries once.
+        When ``request_slot`` is false this only returns the external handle;
+        pre-slot profile sync owns its own signal-with-start retry so an
+        already-running singleton does not pay an unconditional activity hop.
         
         Note: The Temporal Python SDK does not provide a `signal_with_start`
         method on `workflow.ExternalWorkflowHandle` objects for use inside a
@@ -665,12 +668,7 @@ class MoonMindAgentRun:
         if profile_selector:
             signal_payload["profile_selector"] = profile_selector
         if not request_slot:
-            await self._execute_routed_activity(
-                "provider_profile.ensure_manager",
-                {"runtime_id": runtime_id},
-                cancellation_type=ActivityCancellationType.TRY_CANCEL,
-            )
-            return workflow.get_external_workflow_handle(manager_id)
+            return manager_handle
 
         for attempt in range(2):
             try:
@@ -751,7 +749,7 @@ class MoonMindAgentRun:
         manager_id: str,
         runtime_id: str,
     ) -> workflow.ExternalWorkflowHandle:
-        """Ensure the provider-profile manager exists without requesting a slot."""
+        """Return a provider-profile manager handle without requesting a slot."""
         return await self._ensure_manager_and_signal(
             manager_id,
             runtime_id,
@@ -763,6 +761,7 @@ class MoonMindAgentRun:
     async def _sync_manager_profiles(
         self,
         *,
+        manager_id: str,
         manager_handle: workflow.ExternalWorkflowHandle,
         runtime_id: str,
     ) -> int:
@@ -783,7 +782,28 @@ class MoonMindAgentRun:
                 for profile in profiles
                 if isinstance(profile, dict) and str(profile.get("profile_id", "")).strip()
             }
-            await manager_handle.signal("sync_profiles", {"profiles": profiles})
+            signal_payload = {"profiles": profiles}
+            for attempt in range(2):
+                try:
+                    await manager_handle.signal("sync_profiles", signal_payload)
+                    break
+                except ApplicationError as exc:
+                    if "ExternalWorkflowExecutionNotFound" not in (
+                        getattr(exc, "type", None) or str(exc)
+                    ):
+                        raise
+                    if attempt > 0:
+                        raise
+                self._get_logger().warning(
+                    "ProviderProfileManager %s not found, auto-starting before profile sync",
+                    manager_id,
+                )
+                await self._execute_routed_activity(
+                    "provider_profile.ensure_manager",
+                    {"runtime_id": runtime_id},
+                    cancellation_type=ActivityCancellationType.TRY_CANCEL,
+                )
+                manager_handle = workflow.get_external_workflow_handle(manager_id)
             return len(profiles)
         except Exception:
             self._get_logger().warning(
@@ -1090,6 +1110,7 @@ class MoonMindAgentRun:
                             runtime_id,
                         )
                         profile_count = await self._sync_manager_profiles(
+                            manager_id=manager_id,
                             manager_handle=manager_handle,
                             runtime_id=runtime_id,
                         )
@@ -1109,6 +1130,7 @@ class MoonMindAgentRun:
                             profile_selector=selector_payload,
                         )
                         profile_count = await self._sync_manager_profiles(
+                            manager_id=manager_id,
                             manager_handle=manager_handle,
                             runtime_id=runtime_id,
                         )
@@ -1211,6 +1233,7 @@ class MoonMindAgentRun:
                                                 manager_id
                                             )
                                             await self._sync_manager_profiles(
+                                                manager_id=manager_id,
                                                 manager_handle=manager_handle,
                                                 runtime_id=runtime_id,
                                             )
@@ -1228,6 +1251,7 @@ class MoonMindAgentRun:
                                             profile_selector=selector_payload,
                                         )
                                         await self._sync_manager_profiles(
+                                            manager_id=manager_id,
                                             manager_handle=manager_handle,
                                             runtime_id=runtime_id,
                                         )
@@ -1240,6 +1264,7 @@ class MoonMindAgentRun:
                                     profile_selector=selector_payload,
                                 )
                                 await self._sync_manager_profiles(
+                                    manager_id=manager_id,
                                     manager_handle=manager_handle,
                                     runtime_id=runtime_id,
                                 )

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -812,13 +812,14 @@ async def test_agent_run_clears_auto_profile_after_provider_cooldown_retry(
         execution_profile_ref: str | None,
         profile_selector: dict[str, Any],
     ) -> _FakeManagerHandle:
-        ensure_profile_refs.append(execution_profile_ref)
-        run.slot_assigned_event.set()
-        run._assigned_profile_id = (
-            "codex_openrouter_qwen36_plus"
-            if len(ensure_profile_refs) == 1
-            else "codex-default"
-        )
+        if request_slot:
+            ensure_profile_refs.append(execution_profile_ref)
+            run.slot_assigned_event.set()
+            run._assigned_profile_id = (
+                "codex_openrouter_qwen36_plus"
+                if len(ensure_profile_refs) == 1
+                else "codex-default"
+            )
         return _FakeManagerHandle()
 
     async def fake_sync_manager_profiles(

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_codex_session_execution.py
@@ -214,6 +214,7 @@ async def test_agent_run_uses_codex_session_adapter_for_managed_codex_session(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -355,6 +356,7 @@ async def test_agent_run_keeps_managed_adapter_for_non_session_managed_request(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -474,6 +476,7 @@ async def test_agent_run_managed_session_passes_publish_branch_context_to_fetch_
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -606,6 +609,7 @@ async def test_agent_run_managed_session_start_runtime_error_returns_failed_resu
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -715,6 +719,7 @@ async def test_agent_run_managed_session_start_runtime_error_truncates_summary(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -824,6 +829,7 @@ async def test_agent_run_clears_auto_profile_after_provider_cooldown_retry(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -952,6 +958,7 @@ async def test_agent_run_keeps_legacy_session_fetch_path_when_patch_unset(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -1050,6 +1057,7 @@ async def test_agent_run_keeps_legacy_instruction_preparation_for_pre_patch_hist
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -113,15 +113,14 @@ class TestEnsureManagerAutoStart:
             "manager assignments."
         )
 
-    def test_ensure_manager_without_slot_starts_manager_activity(self):
-        """The helper must auto-start the manager before the pre-slot sync signal."""
+    def test_ensure_manager_without_slot_does_not_start_manager_activity(self):
+        """The pre-slot path must not start the singleton manager unconditionally."""
         source = textwrap.dedent(
             inspect.getsource(MoonMindAgentRun._ensure_manager_and_signal)
         )
         tree = ast.parse(source)
 
         found_no_slot_branch = False
-        found_ensure_activity = False
         for node in ast.walk(tree):
             if not isinstance(node, ast.If):
                 continue
@@ -138,15 +137,59 @@ class TestEnsureManagerAutoStart:
                 if not isinstance(child, ast.Constant):
                     continue
                 if child.value == "provider_profile.ensure_manager":
-                    found_ensure_activity = True
-                    break
+                    raise AssertionError(
+                        "request_slot=False must not call provider_profile.ensure_manager "
+                        "unless a later signal observes ExternalWorkflowExecutionNotFound."
+                    )
 
         assert found_no_slot_branch, (
             "_ensure_manager_and_signal must handle request_slot=False"
         )
+
+    def test_profile_sync_auto_starts_manager_only_after_not_found(self):
+        """Profile sync must use signal-with-start fallback without hard startup dependency."""
+        source = textwrap.dedent(
+            inspect.getsource(MoonMindAgentRun._sync_manager_profiles)
+        )
+        tree = ast.parse(source)
+
+        found_sync_signal = False
+        found_not_found_guard = False
+        found_ensure_activity = False
+        found_retry_handle = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if (
+                    node.func.attr == "signal"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and node.args[0].value == "sync_profiles"
+                ):
+                    found_sync_signal = True
+                if (
+                    node.func.attr == "get_external_workflow_handle"
+                    and node.args
+                    and isinstance(node.args[0], ast.Name)
+                    and node.args[0].id == "manager_id"
+                ):
+                    found_retry_handle = True
+            if isinstance(node, ast.Constant):
+                if node.value == "ExternalWorkflowExecutionNotFound":
+                    found_not_found_guard = True
+                if node.value == "provider_profile.ensure_manager":
+                    found_ensure_activity = True
+
+        assert found_sync_signal, "_sync_manager_profiles must signal sync_profiles"
+        assert found_not_found_guard, (
+            "_sync_manager_profiles must only start the manager after "
+            "ExternalWorkflowExecutionNotFound."
+        )
         assert found_ensure_activity, (
-            "request_slot=False must call provider_profile.ensure_manager before "
-            "returning a manager handle."
+            "_sync_manager_profiles must auto-start the manager before retrying "
+            "a missing-manager sync signal."
+        )
+        assert found_retry_handle, (
+            "_sync_manager_profiles must reacquire the manager handle before retrying."
         )
 
     def test_no_bare_request_slot_signal_after_ensure_manager(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_ensure_manager.py
@@ -24,7 +24,7 @@ class TestEnsureManagerAutoStart:
         source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
         tree = ast.parse(source)
 
-        found_ensure_manager_call = False
+        found_request_slot_call = False
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -35,7 +35,6 @@ class TestEnsureManagerAutoStart:
                 and func.attr == "_ensure_manager_and_signal"
             ):
                 continue
-            found_ensure_manager_call = True
 
             # Find the request_slot keyword arg
             request_slot_kw = [
@@ -45,16 +44,109 @@ class TestEnsureManagerAutoStart:
                 "_ensure_manager_and_signal must have exactly one request_slot kwarg"
             )
             kw_value = request_slot_kw[0].value
-            # Must be True (ast.Constant with value True)
-            assert isinstance(kw_value, ast.Constant) and kw_value.value is True, (
-                "_ensure_manager_and_signal must be called with request_slot=True "
-                "so the auto-start fallback fires when the ProviderProfileManager "
-                "doesn't exist. Using request_slot=False bypasses auto-start "
-                "and causes ExternalWorkflowExecutionNotFound crashes."
-            )
+            if isinstance(kw_value, ast.Constant) and kw_value.value is True:
+                found_request_slot_call = True
 
-        assert found_ensure_manager_call, (
-            "Could not find _ensure_manager_and_signal call in MoonMindAgentRun.run"
+        assert found_request_slot_call, (
+            "Could not find a _ensure_manager_and_signal(..., request_slot=True) "
+            "call in MoonMindAgentRun.run"
+        )
+
+    def test_profile_sync_happens_before_slot_request_on_new_patch_path(self):
+        """New managed runs must refresh manager profiles before requesting a slot."""
+        source = textwrap.dedent(inspect.getsource(MoonMindAgentRun.run))
+        tree = ast.parse(source)
+
+        patched_block: ast.If | None = None
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            test = node.test
+            if not (
+                isinstance(test, ast.Call)
+                and isinstance(test.func, ast.Attribute)
+                and test.func.attr == "patched"
+                and test.args
+                and isinstance(test.args[0], ast.Name)
+                and test.args[0].id == "SYNC_PROFILES_BEFORE_SLOT_REQUEST_PATCH_ID"
+            ):
+                continue
+            patched_block = node
+            break
+
+        assert patched_block is not None, (
+            "MoonMindAgentRun.run must patch-gate sync-before-slot ordering"
+        )
+
+        sync_line = None
+        request_line = None
+        for statement in patched_block.body:
+            nodes = ast.walk(statement)
+            for node in nodes:
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not isinstance(func, ast.Attribute):
+                    continue
+                if func.attr == "_sync_manager_profiles":
+                    sync_line = node.lineno
+                if func.attr != "_ensure_manager_and_signal":
+                    continue
+                request_slot_kw = [
+                    kw for kw in node.keywords if kw.arg == "request_slot"
+                ]
+                if (
+                    request_slot_kw
+                    and isinstance(request_slot_kw[0].value, ast.Constant)
+                    and request_slot_kw[0].value.value is True
+                ):
+                    request_line = node.lineno
+            if sync_line is not None and request_line is not None:
+                break
+
+        assert sync_line is not None, "Patched path must call _sync_manager_profiles"
+        assert request_line is not None, (
+            "Patched path must request a slot through _ensure_manager_and_signal"
+        )
+        assert sync_line < request_line, (
+            "Provider profiles must sync before request_slot to avoid stale "
+            "manager assignments."
+        )
+
+    def test_ensure_manager_without_slot_starts_manager_activity(self):
+        """The helper must auto-start the manager before the pre-slot sync signal."""
+        source = textwrap.dedent(
+            inspect.getsource(MoonMindAgentRun._ensure_manager_and_signal)
+        )
+        tree = ast.parse(source)
+
+        found_no_slot_branch = False
+        found_ensure_activity = False
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            test = node.test
+            if not (
+                isinstance(test, ast.UnaryOp)
+                and isinstance(test.op, ast.Not)
+                and isinstance(test.operand, ast.Name)
+                and test.operand.id == "request_slot"
+            ):
+                continue
+            found_no_slot_branch = True
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Constant):
+                    continue
+                if child.value == "provider_profile.ensure_manager":
+                    found_ensure_activity = True
+                    break
+
+        assert found_no_slot_branch, (
+            "_ensure_manager_and_signal must handle request_slot=False"
+        )
+        assert found_ensure_activity, (
+            "request_slot=False must call provider_profile.ensure_manager before "
+            "returning a manager handle."
         )
 
     def test_no_bare_request_slot_signal_after_ensure_manager(self):

--- a/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
+++ b/tests/unit/workflows/temporal/workflows/test_agent_run_jules_execution.py
@@ -276,6 +276,7 @@ async def test_agent_run_managed_passes_commit_message_override_to_fetch_result(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:
@@ -416,6 +417,7 @@ async def test_agent_run_managed_preserves_task_scoped_session_metadata(
 
     async def fake_sync_manager_profiles(
         *,
+        manager_id: str,
         manager_handle: object,
         runtime_id: str,
     ) -> int:


### PR DESCRIPTION
## Summary
- refresh ProviderProfileManager profiles from the DB before requesting a managed runtime slot
- keep manager auto-start behavior available for the pre-slot sync path
- add workflow-boundary coverage for sync-before-slot ordering and cooldown retry accounting

## Root Cause
A managed AgentRun could request a provider-profile slot before the singleton manager had consumed the current DB-backed provider profile snapshot. A stale continued manager could then assign a removed profile, causing adapter startup to fail when it resolved profiles from the fresh DB list.

## Validation
- ./tools/test_unit.sh
- npm run ui:test -- entrypoints/mission-control.test.tsx -t "renders the OAuth terminal page and attaches through the session bridge"