### PR TITLE
[codex] Pin merge resolver provider profile

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,27 @@
 [
   {
-    "id": 3114361904,
+    "id": 3115365887,
     "disposition": "addressed",
-    "rationale": "Updated deactivate_templates telemetry to increment the delete metric by the number of templates deactivated, with unit coverage for the bulk path."
+    "rationale": "Refactored resolver child request construction to consume a single canonical resolverTemplate.executionProfileRef key and write only task.runtime.executionProfileRef for the child run."
   },
   {
-    "id": 4144292983,
+    "id": 3115365890,
+    "disposition": "addressed",
+    "rationale": "Refactored merge automation resolver template construction to read the parent profile from the existing parameters.profileId source and emit only resolverTemplate.executionProfileRef."
+  },
+  {
+    "id": 4145395537,
+    "disposition": "addressed",
+    "rationale": "Removed redundant profile/model/effort alias propagation from the merge automation resolver template and child runtime payload."
+  },
+  {
+    "id": 3115378317,
+    "disposition": "addressed",
+    "rationale": "Removed the multiple-profile-field selection path so conflicting resolverTemplate aliases are no longer accepted or silently prioritized."
+  },
+  {
+    "id": 4145408425,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary only; the only concrete feedback item it referenced was addressed separately."
+    "rationale": "Informational Codex review wrapper with no actionable code feedback."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -445,6 +445,7 @@ class MoonMindMergeAutomationWorkflow:
                     pull_request=self._input.pull_request,
                     jira_issue_key=self._input.jira_issue_key,
                     merge_method=self._input.config.resolver.merge_method,
+                    resolver_template=self._input.resolver_template,
                 )
                 resolver_workflow_id = deterministic_resolver_idempotency_key(
                     parent_workflow_id=self._input.parent_workflow_id,

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -48,6 +48,11 @@ _TOKEN_ASSIGNMENT_PATTERN = re.compile(
 )
 
 
+def _compact_text(value: object) -> str | None:
+    candidate = str(value or "").strip()
+    return candidate or None
+
+
 def sanitize_blocker_summary(value: str | None) -> str:
     """Return a compact blocker summary safe for workflow state and UI."""
 
@@ -227,12 +232,32 @@ def build_resolver_run_request(
     pull_request: Mapping[str, Any] | PullRequestRefModel,
     jira_issue_key: str | None,
     merge_method: str,
+    resolver_template: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     pr = (
         pull_request
         if isinstance(pull_request, PullRequestRefModel)
         else PullRequestRefModel.model_validate(pull_request)
     )
+    template = resolver_template if isinstance(resolver_template, Mapping) else {}
+    target_runtime = _compact_text(template.get("targetRuntime")) or "codex"
+    provider_profile = (
+        _compact_text(template.get("executionProfileRef"))
+        or _compact_text(template.get("runtimeProviderProfile"))
+        or _compact_text(template.get("providerProfile"))
+        or _compact_text(template.get("profileId"))
+    )
+    runtime_model = _compact_text(template.get("runtimeModel")) or _compact_text(
+        template.get("model")
+    )
+    runtime_effort = _compact_text(template.get("runtimeEffort")) or _compact_text(
+        template.get("effort")
+    )
+    required_capabilities = [
+        str(item).strip()
+        for item in (template.get("requiredCapabilities") or [])
+        if str(item).strip()
+    ]
     args = {
         "repo": pr.repo,
         "pr": str(pr.number),
@@ -243,34 +268,55 @@ def build_resolver_run_request(
     if jira_issue_key:
         args["jiraIssueKey"] = jira_issue_key
     title = f"Resolve PR #{pr.number}"
+    runtime_payload: dict[str, Any] = {"mode": target_runtime}
+    if provider_profile:
+        runtime_payload["executionProfileRef"] = provider_profile
+        runtime_payload["providerProfile"] = provider_profile
+        runtime_payload["profileId"] = provider_profile
+    if runtime_model:
+        runtime_payload["model"] = runtime_model
+    if runtime_effort:
+        runtime_payload["effort"] = runtime_effort
+    initial_parameters: dict[str, Any] = {
+        "repo": pr.repo,
+        "repository": pr.repo,
+        "publishMode": "none",
+        "targetRuntime": target_runtime,
+        "task": {
+            "instructions": (
+                f"Resolve and merge pull request {pr.url}. "
+                "Use pr-resolver and do not create another pull request."
+            ),
+            "tool": {"type": "skill", "name": "pr-resolver", "version": "1.0"},
+            "skill": {"id": "pr-resolver", "args": args},
+            "runtime": runtime_payload,
+            "publish": {"mode": "none"},
+        },
+        "workspaceSpec": {
+            "repository": pr.repo,
+            "branch": pr.head_branch,
+            "startingBranch": pr.base_branch,
+            "targetBranch": pr.head_branch,
+        },
+        "mergeGate": {
+            "parentWorkflowId": parent_workflow_id,
+            "pullRequestUrl": pr.url,
+            "headSha": pr.head_sha,
+        },
+    }
+    if required_capabilities:
+        initial_parameters["requiredCapabilities"] = required_capabilities
+    if provider_profile:
+        initial_parameters["executionProfileRef"] = provider_profile
+        initial_parameters["profileId"] = provider_profile
+    if runtime_model:
+        initial_parameters["model"] = runtime_model
+    if runtime_effort:
+        initial_parameters["effort"] = runtime_effort
     return {
         "workflow_type": "MoonMind.Run",
         "title": title,
-        "initial_parameters": {
-            "repo": pr.repo,
-            "repository": pr.repo,
-            "publishMode": "none",
-            "task": {
-                "instructions": (
-                    f"Resolve and merge pull request {pr.url}. "
-                    "Use pr-resolver and do not create another pull request."
-                ),
-                "tool": {"type": "skill", "name": "pr-resolver", "version": "1.0"},
-                "skill": {"id": "pr-resolver", "args": args},
-                "publish": {"mode": "none"},
-            },
-            "workspaceSpec": {
-                "repository": pr.repo,
-                "branch": pr.head_branch,
-                "startingBranch": pr.base_branch,
-                "targetBranch": pr.head_branch,
-            },
-            "mergeGate": {
-                "parentWorkflowId": parent_workflow_id,
-                "pullRequestUrl": pr.url,
-                "headSha": pr.head_sha,
-            },
-        },
+        "initial_parameters": initial_parameters,
     }
 
 

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -241,18 +241,9 @@ def build_resolver_run_request(
     )
     template = resolver_template if isinstance(resolver_template, Mapping) else {}
     target_runtime = _compact_text(template.get("targetRuntime")) or "codex"
-    provider_profile = (
-        _compact_text(template.get("executionProfileRef"))
-        or _compact_text(template.get("runtimeProviderProfile"))
-        or _compact_text(template.get("providerProfile"))
-        or _compact_text(template.get("profileId"))
-    )
-    runtime_model = _compact_text(template.get("runtimeModel")) or _compact_text(
-        template.get("model")
-    )
-    runtime_effort = _compact_text(template.get("runtimeEffort")) or _compact_text(
-        template.get("effort")
-    )
+    provider_profile = _compact_text(template.get("executionProfileRef"))
+    runtime_model = _compact_text(template.get("model"))
+    runtime_effort = _compact_text(template.get("effort"))
     required_capabilities = [
         str(item).strip()
         for item in (template.get("requiredCapabilities") or [])
@@ -271,8 +262,6 @@ def build_resolver_run_request(
     runtime_payload: dict[str, Any] = {"mode": target_runtime}
     if provider_profile:
         runtime_payload["executionProfileRef"] = provider_profile
-        runtime_payload["providerProfile"] = provider_profile
-        runtime_payload["profileId"] = provider_profile
     if runtime_model:
         runtime_payload["model"] = runtime_model
     if runtime_effort:
@@ -306,13 +295,6 @@ def build_resolver_run_request(
     }
     if required_capabilities:
         initial_parameters["requiredCapabilities"] = required_capabilities
-    if provider_profile:
-        initial_parameters["executionProfileRef"] = provider_profile
-        initial_parameters["profileId"] = provider_profile
-    if runtime_model:
-        initial_parameters["model"] = runtime_model
-    if runtime_effort:
-        initial_parameters["effort"] = runtime_effort
     return {
         "workflow_type": "MoonMind.Run",
         "title": title,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3388,6 +3388,54 @@ class MoonMindRunWorkflow:
         timeouts: dict[str, Any] = {"fallbackPollSeconds": fallback_poll_seconds or 120}
         if expire_after_seconds is not None:
             timeouts["expireAfterSeconds"] = expire_after_seconds
+        task_payload = self._mapping_value(parameters, "task") or {}
+        task_runtime_payload = (
+            self._mapping_value(task_payload, "runtime")
+            if isinstance(task_payload, Mapping)
+            else {}
+        ) or {}
+        resolver_template: dict[str, Any] = {
+            "repository": repo,
+            "targetRuntime": (
+                self._coerce_text(
+                    parameters.get("targetRuntime")
+                    or task_runtime_payload.get("mode")
+                    or task_runtime_payload.get("targetRuntime"),
+                    max_chars=80,
+                )
+                or "codex"
+            ),
+            "requiredCapabilities": ["git", "gh"],
+        }
+        profile_id = self._coerce_text(
+            parameters.get("executionProfileRef")
+            or parameters.get("execution_profile_ref")
+            or parameters.get("profileId")
+            or parameters.get("providerProfile")
+            or task_runtime_payload.get("executionProfileRef")
+            or task_runtime_payload.get("execution_profile_ref")
+            or task_runtime_payload.get("profileId")
+            or task_runtime_payload.get("providerProfile"),
+            max_chars=160,
+        )
+        if profile_id:
+            resolver_template["executionProfileRef"] = profile_id
+            resolver_template["profileId"] = profile_id
+            resolver_template["providerProfile"] = profile_id
+        runtime_model = self._coerce_text(
+            parameters.get("requestedModel")
+            or task_runtime_payload.get("model")
+            or parameters.get("model"),
+            max_chars=160,
+        )
+        if runtime_model:
+            resolver_template["runtimeModel"] = runtime_model
+        runtime_effort = self._coerce_text(
+            task_runtime_payload.get("effort") or parameters.get("effort"),
+            max_chars=80,
+        )
+        if runtime_effort:
+            resolver_template["runtimeEffort"] = runtime_effort
         return {
             "workflowType": "MoonMind.MergeAutomation",
             "parentWorkflowId": parent_workflow_id,
@@ -3434,11 +3482,7 @@ class MoonMindRunWorkflow:
                 "timeouts": timeouts,
                 "postMergeJira": request.get("postMergeJira") or {},
             },
-            "resolverTemplate": {
-                "repository": repo,
-                "targetRuntime": "codex",
-                "requiredCapabilities": ["git", "gh"],
-            },
+            "resolverTemplate": resolver_template,
             "idempotencyKey": (
                 f"merge-automation:{parent_workflow_id}:{repo}:{pr_number}:{normalized_head_sha}"
             ),

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -3408,34 +3408,23 @@ class MoonMindRunWorkflow:
             "requiredCapabilities": ["git", "gh"],
         }
         profile_id = self._coerce_text(
-            parameters.get("executionProfileRef")
-            or parameters.get("execution_profile_ref")
-            or parameters.get("profileId")
-            or parameters.get("providerProfile")
-            or task_runtime_payload.get("executionProfileRef")
-            or task_runtime_payload.get("execution_profile_ref")
-            or task_runtime_payload.get("profileId")
-            or task_runtime_payload.get("providerProfile"),
+            parameters.get("profileId"),
             max_chars=160,
         )
         if profile_id:
             resolver_template["executionProfileRef"] = profile_id
-            resolver_template["profileId"] = profile_id
-            resolver_template["providerProfile"] = profile_id
         runtime_model = self._coerce_text(
-            parameters.get("requestedModel")
-            or task_runtime_payload.get("model")
-            or parameters.get("model"),
+            parameters.get("model"),
             max_chars=160,
         )
         if runtime_model:
-            resolver_template["runtimeModel"] = runtime_model
+            resolver_template["model"] = runtime_model
         runtime_effort = self._coerce_text(
-            task_runtime_payload.get("effort") or parameters.get("effort"),
+            parameters.get("effort"),
             max_chars=80,
         )
         if runtime_effort:
-            resolver_template["runtimeEffort"] = runtime_effort
+            resolver_template["effort"] = runtime_effort
         return {
             "workflowType": "MoonMind.MergeAutomation",
             "parentWorkflowId": parent_workflow_id,

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -185,6 +185,35 @@ def test_build_resolver_run_request_uses_pr_resolver_and_publish_none() -> None:
     assert request["initial_parameters"]["task"]["skill"]["args"]["pr"] == "341"
 
 
+def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
+    request = build_resolver_run_request(
+        parent_workflow_id="mm:parent",
+        pull_request=_pull_request(),
+        jira_issue_key=None,
+        merge_method="squash",
+        resolver_template={
+            "targetRuntime": "codex_cli",
+            "executionProfileRef": "codex_default",
+            "runtimeModel": "gpt-5.4",
+            "runtimeEffort": "high",
+            "requiredCapabilities": ["git", "gh"],
+        },
+    )
+
+    initial_parameters = request["initial_parameters"]
+    runtime = initial_parameters["task"]["runtime"]
+    assert initial_parameters["targetRuntime"] == "codex_cli"
+    assert initial_parameters["profileId"] == "codex_default"
+    assert initial_parameters["executionProfileRef"] == "codex_default"
+    assert initial_parameters["model"] == "gpt-5.4"
+    assert initial_parameters["effort"] == "high"
+    assert initial_parameters["requiredCapabilities"] == ["git", "gh"]
+    assert runtime["mode"] == "codex_cli"
+    assert runtime["executionProfileRef"] == "codex_default"
+    assert runtime["providerProfile"] == "codex_default"
+    assert runtime["profileId"] == "codex_default"
+
+
 def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:
     payload = build_continue_as_new_input(
         start_input={

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -194,8 +194,8 @@ def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
         resolver_template={
             "targetRuntime": "codex_cli",
             "executionProfileRef": "codex_default",
-            "runtimeModel": "gpt-5.4",
-            "runtimeEffort": "high",
+            "model": "gpt-5.4",
+            "effort": "high",
             "requiredCapabilities": ["git", "gh"],
         },
     )
@@ -203,15 +203,13 @@ def test_build_resolver_run_request_pins_parent_provider_profile() -> None:
     initial_parameters = request["initial_parameters"]
     runtime = initial_parameters["task"]["runtime"]
     assert initial_parameters["targetRuntime"] == "codex_cli"
-    assert initial_parameters["profileId"] == "codex_default"
-    assert initial_parameters["executionProfileRef"] == "codex_default"
-    assert initial_parameters["model"] == "gpt-5.4"
-    assert initial_parameters["effort"] == "high"
     assert initial_parameters["requiredCapabilities"] == ["git", "gh"]
     assert runtime["mode"] == "codex_cli"
     assert runtime["executionProfileRef"] == "codex_default"
-    assert runtime["providerProfile"] == "codex_default"
-    assert runtime["profileId"] == "codex_default"
+    assert runtime["model"] == "gpt-5.4"
+    assert runtime["effort"] == "high"
+    assert "profileId" not in runtime
+    assert "providerProfile" not in runtime
 
 
 def test_build_continue_as_new_input_preserves_compact_wait_state() -> None:

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -100,10 +100,10 @@ def test_build_merge_gate_start_payload_preserves_parent_runtime_profile() -> No
     resolver_template = payload["resolverTemplate"]
     assert resolver_template["targetRuntime"] == "codex_cli"
     assert resolver_template["executionProfileRef"] == "codex_default"
-    assert resolver_template["profileId"] == "codex_default"
-    assert resolver_template["providerProfile"] == "codex_default"
-    assert resolver_template["runtimeModel"] == "gpt-5.4"
-    assert resolver_template["runtimeEffort"] == "high"
+    assert resolver_template["model"] == "gpt-5.4"
+    assert resolver_template["effort"] == "high"
+    assert "profileId" not in resolver_template
+    assert "providerProfile" not in resolver_template
 
 
 def test_build_merge_gate_start_payload_normalizes_timeout_values() -> None:

--- a/tests/unit/workflows/temporal/test_run_merge_gate_start.py
+++ b/tests/unit/workflows/temporal/test_run_merge_gate_start.py
@@ -70,6 +70,42 @@ def test_build_merge_gate_start_payload_from_published_pr() -> None:
     assert payload["resolverTemplate"]["repository"] == "MoonLadderStudios/MoonMind"
 
 
+def test_build_merge_gate_start_payload_preserves_parent_runtime_profile() -> None:
+    workflow = MoonMindRunWorkflow()
+    workflow._repo = "MoonLadderStudios/MoonMind"
+
+    payload = workflow._build_merge_gate_start_payload(
+        parameters={
+            "publishMode": "pr",
+            "targetRuntime": "codex_cli",
+            "profileId": "codex_default",
+            "model": "gpt-5.4",
+            "effort": "high",
+            "task": {
+                "publish": {
+                    "mergeAutomation": {
+                        "enabled": True,
+                        "mergeMethod": "squash",
+                    }
+                }
+            },
+        },
+        pull_request_url="https://github.com/MoonLadderStudios/MoonMind/pull/341",
+        head_sha="abc123",
+        parent_workflow_id="mm:parent",
+        parent_run_id="run-1",
+    )
+
+    assert payload is not None
+    resolver_template = payload["resolverTemplate"]
+    assert resolver_template["targetRuntime"] == "codex_cli"
+    assert resolver_template["executionProfileRef"] == "codex_default"
+    assert resolver_template["profileId"] == "codex_default"
+    assert resolver_template["providerProfile"] == "codex_default"
+    assert resolver_template["runtimeModel"] == "gpt-5.4"
+    assert resolver_template["runtimeEffort"] == "high"
+
+
 def test_build_merge_gate_start_payload_normalizes_timeout_values() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._repo = "MoonLadderStudios/MoonMind"


### PR DESCRIPTION
## Summary
- propagate the parent runtime, provider profile, model, and effort into merge automation resolver templates
- stamp inherited resolver profile fields onto child MoonMind.Run requests so pr-resolver stays pinned to the parent profile
- add regression coverage for merge-gate payload construction and resolver child request generation

## Root Cause
Merge automation launched pr-resolver children with only targetRuntime=codex. When codex_default was cooling down, the provider-profile manager treated those children as unpinned codex_cli requests and could assign OpenRouter.

## Validation
- .venv/bin/pytest tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/test_run_merge_gate_start.py -q
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_merge_gate_workflow.py tests/unit/workflows/temporal/test_run_merge_gate_start.py (Python tests passed; existing unrelated Mission Control Vitest lazy-load test failed afterward)
