### PR TITLE
MM-419 Run manifest page form

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/215-mission-control-interaction-language"
+  "feature_directory": "specs/216-run-manifest-page-form"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,27 @@
 [
   {
-    "id": 3114948062,
+    "id": 3115399905,
     "disposition": "addressed",
-    "rationale": "Changed the provider profiles table divider utility to md:divide-y so the hidden mobile header does not leave an extra top border above the card list."
+    "rationale": "Secret validation now checks only fields submitted by the active source mode."
   },
   {
-    "id": 3114948072,
-    "disposition": "addressed",
-    "rationale": "Added explicit table, rowgroup, row, columnheader, and cell roles plus stable header associations for the responsive table/card layout."
-  },
-  {
-    "id": 4144944042,
-    "disposition": "addressed",
-    "rationale": "Review summary covered the same divider and accessibility feedback, both of which were addressed in this change."
-  },
-  {
-    "id": 3114948151,
-    "disposition": "addressed",
-    "rationale": "Replaced display:none on the mobile table header with visually-hidden styling and added headers mappings so header context remains available to assistive technologies."
-  },
-  {
-    "id": 4144944133,
+    "id": 4145431398,
     "disposition": "not-applicable",
-    "rationale": "Automated review wrapper text only; it contained no separate actionable request beyond the linked review comments."
+    "rationale": "Review summary; its single actionable point is tracked by review comments 3115399905 and 3115404834."
+  },
+  {
+    "id": 3115404834,
+    "disposition": "addressed",
+    "rationale": "Registry submissions now ignore stale inactive inline YAML while preserving validation for active registry input."
+  },
+  {
+    "id": 3115404837,
+    "disposition": "addressed",
+    "rationale": "Max Docs validation now rejects non-safe or non-finite numeric conversions before request payload construction."
+  },
+  {
+    "id": 4145436869,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper with no separate actionable feedback beyond the inline comments already addressed."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-419-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-419-moonspec-orchestration-input.md
@@ -1,0 +1,80 @@
+# MM-419 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-419
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Run registry or inline manifests from the Manifests page
+- Labels: moonmind-workflow-mm-f78d0769-fb1e-4712-a140-47c34e83cc3f
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-419 from MM project
+Summary: Run registry or inline manifests from the Manifests page
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-419 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-419: Run registry or inline manifests from the Manifests page
+
+Source Reference
+- Source Document: docs/UI/ManifestsPage.md
+- Source Title: Manifests Page
+- Source Sections:
+  - Page structure
+  - Run Manifest card
+  - Source type toggle
+  - Fields
+  - Validation rules
+  - Responsive behavior
+  - Accessibility
+  - Why inline form is preferred over a drawer/modal
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-016
+  - DESIGN-REQ-018
+
+User Story
+As a dashboard user, I want a compact Run Manifest form on the Manifests page that supports registry names and inline YAML so I can start either kind of manifest run from the same context.
+
+Acceptance Criteria
+- Given /tasks/manifests loads, then a Run Manifest card is visible above Recent Runs and advanced options are collapsed by default.
+- Given Registry Manifest mode is active, then manifest name and action are required and inline YAML is not required.
+- Given Inline YAML mode is active, then non-empty YAML and action are required and registry manifest name is not required.
+- Given a user switches between source modes, then values entered in each mode are preserved independently for the current session.
+- Given max docs is provided, then non-positive or non-integer values are rejected before submit.
+- Given submitted content or helper fields contain raw secret-style entries, then the UI rejects them or requires env/Vault references instead.
+- Given the page is used with keyboard or assistive technology, then the source toggle, validation messages, YAML fallback, and primary action have accessible labels and field associations.
+- Given the viewport narrows, then form controls stack in a clear form-first flow without hiding the primary Run Manifest action behind advanced options.
+
+Requirements
+- The Run Manifest card must be available directly on /tasks/manifests.
+- Registry Manifest mode must accept a required manifest name and existing supported action values.
+- Inline YAML mode must accept required YAML content and existing supported action values.
+- Advanced options must include supported dry run, force full sync, max docs, and priority controls where those controls already exist or are backend-supported.
+- The primary action label must be Run Manifest and must disable while submission is in progress.
+- The implementation must not introduce raw secret entry into the UI.
+- Autocomplete from /api/manifests may be added only as progressive enhancement with free-text fallback.
+
+Implementation Notes
+- This story is about adding compact Manifests-page authoring for manifest runs, not replacing the existing manifest execution contract.
+- The UI must support both registry manifest names and inline YAML as separate source modes.
+- Mode switching must preserve the entered values independently for the current session.
+- Validation must happen before submit for required source fields, supported actions, max docs, and raw secret-style values.
+- Preserve MM-419 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-419 is blocked by MM-420, whose embedded status is Done.
+- Trusted Jira link metadata also shows MM-419 blocks MM-418, which is not a blocker for MM-419 and is ignored for dependency gating.

--- a/frontend/src/entrypoints/manifests.test.tsx
+++ b/frontend/src/entrypoints/manifests.test.tsx
@@ -243,6 +243,77 @@ describe('Manifests Entrypoint', () => {
     });
   });
 
+  it('rejects invalid max docs before calling manifest APIs', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    fireEvent.change(screen.getByLabelText('Registry Manifest Name'), {
+      target: { value: 'docs-registry' },
+    });
+    fireEvent.click(screen.getByText('Advanced options'));
+    fireEvent.change(screen.getByLabelText('Max Docs'), {
+      target: { value: '1.5' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Max Docs must be a positive whole number.')).toBeTruthy();
+    });
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/api/manifests/docs-registry'))).toBe(false);
+  });
+
+  it('rejects raw secret-shaped values before calling manifest APIs', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    fireEvent.change(screen.getByLabelText('Source Kind'), {
+      target: { value: 'inline' },
+    });
+    fireEvent.change(screen.getByLabelText('Manifest Name'), {
+      target: { value: 'nightly-docs' },
+    });
+    fireEvent.change(screen.getByLabelText('Inline YAML'), {
+      target: { value: 'kind: docs\nauth:\n  token=example\n' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Raw secret-like values are not allowed. Use env or Vault references instead.')).toBeTruthy();
+    });
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/api/manifests/nightly-docs'))).toBe(false);
+  });
+
+  it('allows env-style secret references in inline YAML', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    fireEvent.change(screen.getByLabelText('Source Kind'), {
+      target: { value: 'inline' },
+    });
+    fireEvent.change(screen.getByLabelText('Manifest Name'), {
+      target: { value: 'nightly-docs' },
+    });
+    fireEvent.change(screen.getByLabelText('Inline YAML'), {
+      target: { value: 'kind: docs\nauth:\n  token: ${GITHUB_TOKEN}\n' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/manifests/nightly-docs',
+        expect.objectContaining({
+          method: 'PUT',
+        }),
+      );
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/manifests/nightly-docs/runs',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+  });
+
   it('styles submit failures as errors', async () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);

--- a/frontend/src/entrypoints/manifests.test.tsx
+++ b/frontend/src/entrypoints/manifests.test.tsx
@@ -243,6 +243,63 @@ describe('Manifests Entrypoint', () => {
     });
   });
 
+  it('ignores inactive inline secrets when running a registry manifest', async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/executions?entry=manifest&limit=200') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [] }),
+        } as Response);
+      }
+      if (url === '/api/manifests/docs-registry/runs') {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            execution: {
+              workflowId: 'mm:manifest-123',
+            },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: async () => 'Unhandled fetch',
+      } as Response);
+    });
+
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    fireEvent.change(screen.getByLabelText('Source Kind'), {
+      target: { value: 'inline' },
+    });
+    fireEvent.change(screen.getByLabelText('Manifest Name'), {
+      target: { value: 'inline-draft' },
+    });
+    fireEvent.change(screen.getByLabelText('Inline YAML'), {
+      target: { value: 'kind: docs\nauth:\n  token=stale-draft\n' },
+    });
+    fireEvent.change(screen.getByLabelText('Source Kind'), {
+      target: { value: 'registry' },
+    });
+    fireEvent.change(screen.getByLabelText('Registry Manifest Name'), {
+      target: { value: 'docs-registry' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/manifests/docs-registry/runs',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+    expect(screen.queryByText('Raw secret-like values are not allowed. Use env or Vault references instead.')).toBeNull();
+  });
+
   it('rejects invalid max docs before calling manifest APIs', async () => {
     renderWithClient(<ManifestsPage payload={mockPayload} />);
 
@@ -252,6 +309,25 @@ describe('Manifests Entrypoint', () => {
     fireEvent.click(screen.getByText('Advanced options'));
     fireEvent.change(screen.getByLabelText('Max Docs'), {
       target: { value: '1.5' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Max Docs must be a positive whole number.')).toBeTruthy();
+    });
+    expect(fetchSpy.mock.calls.some(([url]) => String(url).includes('/api/manifests/docs-registry'))).toBe(false);
+  });
+
+  it('rejects overflowed max docs before building a request body', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    fireEvent.change(screen.getByLabelText('Registry Manifest Name'), {
+      target: { value: 'docs-registry' },
+    });
+    fireEvent.click(screen.getByText('Advanced options'));
+    fireEvent.change(screen.getByLabelText('Max Docs'), {
+      target: { value: '9'.repeat(400) },
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Run Manifest' }));

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -80,13 +80,9 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
       setNotice({ level: 'error', text: 'Manifest YAML is required.' });
       return;
     }
-    if (
-      hasRawSecretLikeValue([
-        trimmedManifestName,
-        trimmedRegistryName,
-        manifestContent,
-      ])
-    ) {
+    const secretCheckValues =
+      sourceKind === 'registry' ? [trimmedRegistryName] : [trimmedManifestName, manifestContent];
+    if (hasRawSecretLikeValue(secretCheckValues)) {
       setNotice({
         level: 'error',
         text: 'Raw secret-like values are not allowed. Use env or Vault references instead.',
@@ -94,7 +90,13 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
       return;
     }
     const trimmedMaxDocs = maxDocs.trim();
-    if (trimmedMaxDocs && !/^[1-9]\d*$/.test(trimmedMaxDocs)) {
+    const parsedMaxDocs = trimmedMaxDocs ? Number(trimmedMaxDocs) : undefined;
+    if (
+      trimmedMaxDocs &&
+      (!/^[1-9]\d*$/.test(trimmedMaxDocs) ||
+        !Number.isSafeInteger(parsedMaxDocs) ||
+        parsedMaxDocs <= 0)
+    ) {
       setNotice({ level: 'error', text: 'Max Docs must be a positive whole number.' });
       return;
     }
@@ -108,8 +110,8 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
     if (forceFull) {
       options.forceFull = true;
     }
-    if (trimmedMaxDocs) {
-      options.maxDocs = Number(trimmedMaxDocs);
+    if (parsedMaxDocs !== undefined) {
+      options.maxDocs = parsedMaxDocs;
     }
 
     try {

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -90,15 +90,18 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
       return;
     }
     const trimmedMaxDocs = maxDocs.trim();
-    const parsedMaxDocs = trimmedMaxDocs ? Number(trimmedMaxDocs) : undefined;
-    if (
-      trimmedMaxDocs &&
-      (!/^[1-9]\d*$/.test(trimmedMaxDocs) ||
-        !Number.isSafeInteger(parsedMaxDocs) ||
-        parsedMaxDocs <= 0)
-    ) {
-      setNotice({ level: 'error', text: 'Max Docs must be a positive whole number.' });
-      return;
+    let parsedMaxDocs: number | undefined;
+    if (trimmedMaxDocs) {
+      const maxDocsCandidate = Number(trimmedMaxDocs);
+      if (
+        !/^[1-9]\d*$/.test(trimmedMaxDocs) ||
+        !Number.isSafeInteger(maxDocsCandidate) ||
+        maxDocsCandidate <= 0
+      ) {
+        setNotice({ level: 'error', text: 'Max Docs must be a positive whole number.' });
+        return;
+      }
+      parsedMaxDocs = maxDocsCandidate;
     }
 
     setIsSubmitting(true);

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -18,9 +18,23 @@ type Notice = {
   href?: string;
 };
 
+const RAW_SECRET_PATTERNS = [
+  /\bghp_[A-Za-z0-9_]{20,}\b/i,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/i,
+  /\bAIza[A-Za-z0-9_-]{20,}\b/,
+  /\bATATT[A-Za-z0-9_-]{10,}\b/,
+  /\bAKIA[A-Z0-9]{16}\b/,
+  /-----BEGIN\s+(?:RSA|EC|DSA|OPENSSH)\s+PRIVATE\s+KEY-----/i,
+  /\b(?:token|password|secret)\s*[:=]\s*(?!\s*(?:\$\{|env:\/\/|vault:\/\/))[^\s'",}]+/i,
+];
+
 const ManifestsResponseSchema = z.object({
   items: z.array(ManifestRunSchema),
 });
+
+function hasRawSecretLikeValue(values: string[]): boolean {
+  return values.some((value) => RAW_SECRET_PATTERNS.some((pattern) => pattern.test(value)));
+}
 
 export function ManifestsPage({ payload }: { payload: BootPayload }) {
   const [manifestName, setManifestName] = useState('');
@@ -66,6 +80,24 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
       setNotice({ level: 'error', text: 'Manifest YAML is required.' });
       return;
     }
+    if (
+      hasRawSecretLikeValue([
+        trimmedManifestName,
+        trimmedRegistryName,
+        manifestContent,
+      ])
+    ) {
+      setNotice({
+        level: 'error',
+        text: 'Raw secret-like values are not allowed. Use env or Vault references instead.',
+      });
+      return;
+    }
+    const trimmedMaxDocs = maxDocs.trim();
+    if (trimmedMaxDocs && !/^[1-9]\d*$/.test(trimmedMaxDocs)) {
+      setNotice({ level: 'error', text: 'Max Docs must be a positive whole number.' });
+      return;
+    }
 
     setIsSubmitting(true);
     setNotice(null);
@@ -76,9 +108,8 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
     if (forceFull) {
       options.forceFull = true;
     }
-    const parsedMaxDocs = Number(maxDocs);
-    if (Number.isFinite(parsedMaxDocs) && parsedMaxDocs >= 1) {
-      options.maxDocs = parsedMaxDocs;
+    if (trimmedMaxDocs) {
+      options.maxDocs = Number(trimmedMaxDocs);
     }
 
     try {

--- a/specs/216-run-manifest-page-form/checklists/requirements.md
+++ b/specs/216-run-manifest-page-form/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Run Manifest Page Form
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Priority control is explicitly assumed out of scope unless a supported manifest-run backend field exists.

--- a/specs/216-run-manifest-page-form/contracts/ui-contract.md
+++ b/specs/216-run-manifest-page-form/contracts/ui-contract.md
@@ -1,0 +1,46 @@
+# UI Contract: Run Manifest Page Form
+
+## Surface
+
+Route: `/tasks/manifests`
+
+Primary user-visible regions:
+- `Manifests` page heading
+- `Run Manifest` form
+- `Recent Runs` list/table
+
+## Controls
+
+- `Source Kind`: select or equivalent accessible source-mode control with `Registry Manifest` and `Inline YAML`.
+- `Registry Manifest Name`: required in Registry Manifest mode.
+- `Manifest Name`: required in Inline YAML mode.
+- `Inline YAML`: required in Inline YAML mode.
+- `Action`: required supported action selector.
+- `Advanced options`: collapsed by default.
+- `Dry Run`, `Force Full`, `Max Docs`: supported advanced options.
+- `Run Manifest`: primary submit action, visible without opening advanced options.
+
+## Validation Contract
+
+Before any `PUT /api/manifests/{name}` or `POST /api/manifests/{name}/runs` request:
+- Registry mode rejects blank registry manifest names.
+- Inline mode rejects blank manifest names.
+- Inline mode rejects blank inline YAML.
+- Nonblank `Max Docs` rejects non-positive or non-integer values.
+- Raw secret-shaped values in manifest content or helper fields are rejected with guidance to use env/Vault references.
+
+## Submission Contract
+
+Registry mode:
+- Sends `POST /api/manifests/{registryName}/runs`.
+- Does not send `PUT /api/manifests/{registryName}`.
+
+Inline mode:
+- Sends `PUT /api/manifests/{manifestName}` with `{ "content": "<inline YAML>" }`.
+- Sends `POST /api/manifests/{manifestName}/runs`.
+
+Successful submit:
+- Keeps the user on `/tasks/manifests`.
+- Displays a success notice.
+- Exposes a run detail link when the response includes one.
+- Refreshes recent manifest runs.

--- a/specs/216-run-manifest-page-form/data-model.md
+++ b/specs/216-run-manifest-page-form/data-model.md
@@ -1,0 +1,39 @@
+# Data Model: Run Manifest Page Form
+
+## Entities
+
+### Manifest Run Draft
+
+Represents the transient form state for one in-browser `/tasks/manifests` session.
+
+Fields:
+- `sourceKind`: `registry` or `inline`.
+- `registryName`: registry-backed manifest name.
+- `manifestName`: inline manifest name.
+- `manifestContent`: inline YAML content.
+- `action`: supported manifest action, currently `run` or `plan`.
+- `dryRun`: optional boolean advanced option.
+- `forceFull`: optional boolean advanced option.
+- `maxDocs`: optional positive integer advanced option entered as text until validated.
+
+Validation rules:
+- Registry mode requires nonblank `registryName`.
+- Inline mode requires nonblank `manifestName` and nonblank `manifestContent`.
+- `maxDocs`, when provided, must be a positive integer.
+- Raw secret-shaped values in submitted content or helper fields are rejected unless they are represented as env/Vault references.
+
+### Manifest Run Submission
+
+Represents the request emitted after validation.
+
+Fields:
+- `action`: selected manifest action.
+- `title`: selected registry name or inline manifest name.
+- `options`: omitted when empty; may contain `dryRun`, `forceFull`, and `maxDocs`.
+
+State transitions:
+- Draft -> validation error: user remains on `/tasks/manifests`, draft values are preserved, no manifest API request is sent.
+- Draft -> inline upsert -> run request: inline mode saves content before creating the run.
+- Draft -> run request: registry mode creates a run without re-uploading manifest body.
+- Run request success -> recent runs refresh and success notice appears.
+- Run request failure -> error notice appears and draft values are preserved.

--- a/specs/216-run-manifest-page-form/plan.md
+++ b/specs/216-run-manifest-page-form/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Run Manifest Page Form
+
+**Branch**: `216-run-manifest-page-form` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/specs/216-run-manifest-page-form/spec.md`
+
+## Summary
+
+Deliver MM-419 by validating and hardening the existing Manifests-page Run Manifest form. Repo analysis shows the unified page, registry/inline modes, in-place refresh, accessible labels, and collapsed advanced options already exist from the related MM-418 work. The remaining runtime gaps were client-side rejection of invalid `max docs` values and raw secret-shaped values before manifest upsert or run requests; those gaps are now implemented in `frontend/src/entrypoints/manifests.tsx` and covered by focused frontend tests in `frontend/src/entrypoints/manifests.test.tsx`.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 / SCN-001 / DESIGN-REQ-001 | implemented_verified | `frontend/src/entrypoints/manifests.tsx`, `frontend/src/entrypoints/manifests.test.tsx` | preserve existing behavior | final validation |
+| FR-002 / SCN-002 | implemented_verified | registry mode field and test coverage in `frontend/src/entrypoints/manifests.test.tsx` | preserve existing behavior | final validation |
+| FR-003 / SCN-003 | implemented_verified | inline mode field and test coverage in `frontend/src/entrypoints/manifests.test.tsx` | preserve existing behavior | final validation |
+| FR-004 / SCN-004 / DESIGN-REQ-002 | implemented_verified | separate registry/inline state and mode-switch preservation test | preserve existing behavior | final validation |
+| FR-005 / SCN-005 / DESIGN-REQ-004 | implemented_verified | `frontend/src/entrypoints/manifests.tsx` rejects invalid max docs before side effects; `frontend/src/entrypoints/manifests.test.tsx` verifies no manifest API call is made | preserve existing behavior | final validation |
+| FR-006 / SCN-006 / DESIGN-REQ-004 | implemented_verified | `frontend/src/entrypoints/manifests.tsx` rejects raw secret-shaped values before side effects; `frontend/src/entrypoints/manifests.test.tsx` verifies rejection and allowed env-style references | preserve existing behavior | final validation |
+| FR-007 / DESIGN-REQ-005 | implemented_verified | valid submit tests assert API calls and in-place refresh | preserve existing behavior | final validation |
+| FR-008 / SCN-007 / DESIGN-REQ-006 | implemented_verified | controls are labels/selects/buttons reachable by role or label in tests | preserve existing behavior | final validation |
+| FR-009 / SCN-008 / DESIGN-REQ-007 | implemented_verified | Run Manifest button is outside collapsed advanced options | preserve existing behavior | final validation |
+| FR-010 | implemented_verified | MM-419 and the original preset brief are preserved in `spec.md`; implementation and tests remain tied to `specs/216-run-manifest-page-form/` | preserve in final report and any commit/PR metadata | final validation |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected for runtime changes
+**Primary Dependencies**: React, TanStack Query, existing manifest REST endpoints, Vitest, Testing Library
+**Storage**: Existing manifest registry and execution records only; no new persistent storage
+**Unit Testing**: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx`
+**Integration Testing**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` for runner-integrated frontend validation; full `./tools/test_unit.sh` before finalization when practical
+**Target Platform**: Mission Control web UI at `/tasks/manifests`
+**Project Type**: Web application frontend with existing FastAPI-backed runtime endpoints
+**Performance Goals**: Validation must run synchronously before submit without visible delay
+**Constraints**: Preserve existing manifest backend semantics; do not add raw secret entry; do not add unsupported priority fields; keep MM-419 traceability
+**Scale/Scope**: One existing React entrypoint and focused frontend tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. Uses existing manifest execution APIs and orchestration.
+- **II. One-Click Agent Deployment**: PASS. No new service or deployment dependency.
+- **III. Avoid Vendor Lock-In**: PASS. No vendor-specific coupling.
+- **IV. Own Your Data**: PASS. Manifest data remains in MoonMind-managed storage and execution records.
+- **V. Skills Are First-Class and Easy to Add**: PASS. No skill contract changes.
+- **VI. Evolving Scaffolds**: PASS. Hardens the existing UI without adding a parallel flow.
+- **VII. Runtime Configurability**: PASS. Uses existing runtime endpoint configuration.
+- **VIII. Modular Architecture**: PASS. Changes stay within the Manifests UI boundary.
+- **IX. Resilient by Default**: PASS. Invalid input fails before side effects.
+- **X. Continuous Improvement**: PASS. Adds regression tests for prior gaps.
+- **XI. Spec-Driven Development**: PASS. Spec, plan, tasks, and verification are maintained under `specs/216-run-manifest-page-form/`.
+- **XII. Canonical Documentation Separation**: PASS. Existing canonical UI doc remains desired-state; temporary orchestration artifacts stay under `docs/tmp`.
+- **XIII. Pre-Release Compatibility**: PASS. No compatibility shim or legacy duplicate behavior is introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/216-run-manifest-page-form/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── ui-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/entrypoints/
+├── manifests.tsx
+└── manifests.test.tsx
+
+docs/tmp/jira-orchestration-inputs/
+└── MM-419-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: This is a frontend validation hardening story for an existing page; production and test work remain in the existing Manifests entrypoint and its colocated Vitest suite.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/216-run-manifest-page-form/quickstart.md
+++ b/specs/216-run-manifest-page-form/quickstart.md
@@ -1,0 +1,38 @@
+# Quickstart: Run Manifest Page Form
+
+## Targeted Validation
+
+1. Run frontend tests:
+
+   ```bash
+   ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx
+   ```
+
+2. Run through the repository test wrapper:
+
+   ```bash
+   ./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx
+   ```
+
+3. Final validation:
+
+   ```bash
+   ./tools/test_unit.sh
+   ```
+
+4. Final MoonSpec verification:
+
+   ```text
+   /moonspec-verify
+   ```
+
+## Manual Scenario
+
+1. Open `/tasks/manifests`.
+2. Confirm the `Run Manifest` form appears above `Recent Runs`.
+3. Confirm `Advanced options` is collapsed and `Run Manifest` is visible.
+4. Submit Registry Manifest mode with a valid name and action; confirm no inline YAML is required.
+5. Submit Inline YAML mode with a valid name, YAML content, and action; confirm recent runs refresh in place.
+6. Enter `0`, `-1`, `1.5`, and `abc` in Max Docs; confirm each is rejected before submit.
+7. Enter a raw secret-shaped value such as a token assignment in Inline YAML; confirm it is rejected before submit and guidance points to env/Vault references.
+8. Enter an env/Vault-style reference in Inline YAML; confirm the UI does not reject it as a raw secret-shaped value.

--- a/specs/216-run-manifest-page-form/research.md
+++ b/specs/216-run-manifest-page-form/research.md
@@ -1,0 +1,73 @@
+# Research: Run Manifest Page Form
+
+## FR-001 / DESIGN-REQ-001
+
+Decision: implemented_verified.
+Evidence: `frontend/src/entrypoints/manifests.tsx` renders `Run Manifest` before `Recent Runs`; `frontend/src/entrypoints/manifests.test.tsx` verifies both headings on one page.
+Rationale: Existing MM-418 work already unified the page layout.
+Alternatives considered: Rebuilding the layout was rejected because behavior is already present.
+Test implications: final validation only.
+
+## FR-002 / FR-003
+
+Decision: implemented_verified.
+Evidence: `sourceKind` controls Registry Manifest and Inline YAML fields in `frontend/src/entrypoints/manifests.tsx`; existing tests submit registry and inline modes through existing APIs.
+Rationale: The source modes and action field already match MM-419.
+Alternatives considered: Adding a separate page or modal was rejected because `/tasks/manifests` is the canonical page.
+Test implications: final validation only.
+
+## FR-004 / DESIGN-REQ-002
+
+Decision: implemented_verified.
+Evidence: separate `manifestName`, `manifestContent`, and `registryName` state in `frontend/src/entrypoints/manifests.tsx`; existing test verifies registry title after editing inline fields.
+Rationale: Independent state preserves source-mode values during switching.
+Alternatives considered: Shared field state was rejected because it would lose mode-specific drafts.
+Test implications: final validation only.
+
+## FR-005 / DESIGN-REQ-004
+
+Decision: implemented_verified; validate before side effects.
+Evidence: `frontend/src/entrypoints/manifests.tsx` rejects nonblank `maxDocs` values unless they are positive whole numbers; `frontend/src/entrypoints/manifests.test.tsx` verifies invalid max docs produces an error and no manifest API call.
+Rationale: MM-419 requires non-positive and non-integer values to be rejected before submit.
+Alternatives considered: Relying on backend validation was rejected because the client previously omitted invalid values, preventing backend rejection.
+Test implications: focused frontend validation and runner-integrated UI validation.
+
+## FR-006 / DESIGN-REQ-004
+
+Decision: implemented_verified; use a small client-side raw secret-shaped value detector before side effects.
+Evidence: `frontend/src/entrypoints/manifests.tsx` scans source helper fields and inline YAML before submitting; `frontend/src/entrypoints/manifests.test.tsx` verifies raw secret-shaped values are rejected while env-style references remain allowed.
+Rationale: MM-419 requires UI rejection before submit or env/Vault references instead.
+Alternatives considered: Importing backend Python validation into frontend is impossible; adding a small frontend detector aligned with existing secret-like patterns is sufficient for client-side prevention.
+Test implications: focused frontend validation and runner-integrated UI validation.
+
+## FR-007 / DESIGN-REQ-005
+
+Decision: implemented_verified.
+Evidence: successful submit sets an in-page notice, exposes an `Open run` link, and calls `refetch`; existing tests assert in-place refresh.
+Rationale: Behavior already satisfies the success flow.
+Alternatives considered: Navigation to run details was rejected because the desired behavior is in-place context.
+Test implications: final validation only.
+
+## FR-008 / DESIGN-REQ-006
+
+Decision: implemented_verified.
+Evidence: tests locate controls by visible label or role (`Source Kind`, `Registry Manifest Name`, `Manifest Name`, `Inline YAML`, `Action`, `Run Manifest`).
+Rationale: Existing semantic form controls are accessible enough for this story.
+Alternatives considered: Custom segmented controls were rejected as unnecessary for this runtime gap.
+Test implications: final validation only.
+
+## FR-009 / DESIGN-REQ-007
+
+Decision: implemented_verified.
+Evidence: submit action is outside the collapsed `details` advanced-options region in `frontend/src/entrypoints/manifests.tsx`.
+Rationale: The primary action is visible in default form flow.
+Alternatives considered: Pinning the button was rejected as unnecessary for the current layout.
+Test implications: final validation only.
+
+## FR-010
+
+Decision: implemented_verified.
+Evidence: MM-419 appears in `docs/tmp/jira-orchestration-inputs/MM-419-moonspec-orchestration-input.md`; `specs/216-run-manifest-page-form/spec.md` preserves the original preset brief verbatim in `Input`.
+Rationale: Final verification must explicitly preserve issue-key traceability.
+Alternatives considered: Reusing MM-418 spec was rejected because it would lose MM-419 traceability.
+Test implications: final MoonSpec verification.

--- a/specs/216-run-manifest-page-form/spec.md
+++ b/specs/216-run-manifest-page-form/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: Run Manifest Page Form
+
+**Feature Branch**: `216-run-manifest-page-form`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: User description: the Jira preset brief for MM-419, preserved verbatim below.
+
+```text
+Jira issue: MM-419 from MM project
+Summary: Run registry or inline manifests from the Manifests page
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-419 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-419: Run registry or inline manifests from the Manifests page
+
+Source Reference
+- Source Document: docs/UI/ManifestsPage.md
+- Source Title: Manifests Page
+- Source Sections:
+  - Page structure
+  - Run Manifest card
+  - Source type toggle
+  - Fields
+  - Validation rules
+  - Responsive behavior
+  - Accessibility
+  - Why inline form is preferred over a drawer/modal
+- Coverage IDs:
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-006
+  - DESIGN-REQ-007
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-016
+  - DESIGN-REQ-018
+
+User Story
+As a dashboard user, I want a compact Run Manifest form on the Manifests page that supports registry names and inline YAML so I can start either kind of manifest run from the same context.
+
+Acceptance Criteria
+- Given /tasks/manifests loads, then a Run Manifest card is visible above Recent Runs and advanced options are collapsed by default.
+- Given Registry Manifest mode is active, then manifest name and action are required and inline YAML is not required.
+- Given Inline YAML mode is active, then non-empty YAML and action are required and registry manifest name is not required.
+- Given a user switches between source modes, then values entered in each mode are preserved independently for the current session.
+- Given max docs is provided, then non-positive or non-integer values are rejected before submit.
+- Given submitted content or helper fields contain raw secret-style entries, then the UI rejects them or requires env/Vault references instead.
+- Given the page is used with keyboard or assistive technology, then the source toggle, validation messages, YAML fallback, and primary action have accessible labels and field associations.
+- Given the viewport narrows, then form controls stack in a clear form-first flow without hiding the primary Run Manifest action behind advanced options.
+
+Requirements
+- The Run Manifest card must be available directly on /tasks/manifests.
+- Registry Manifest mode must accept a required manifest name and existing supported action values.
+- Inline YAML mode must accept required YAML content and existing supported action values.
+- Advanced options must include supported dry run, force full sync, max docs, and priority controls where those controls already exist or are backend-supported.
+- The primary action label must be Run Manifest and must disable while submission is in progress.
+- The implementation must not introduce raw secret entry into the UI.
+- Autocomplete from /api/manifests may be added only as progressive enhancement with free-text fallback.
+
+Implementation Notes
+- This story is about adding compact Manifests-page authoring for manifest runs, not replacing the existing manifest execution contract.
+- The UI must support both registry manifest names and inline YAML as separate source modes.
+- Mode switching must preserve the entered values independently for the current session.
+- Validation must happen before submit for required source fields, supported actions, max docs, and raw secret-style values.
+- Preserve MM-419 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-419 is blocked by MM-420, whose embedded status is Done.
+- Trusted Jira link metadata also shows MM-419 blocks MM-418, which is not a blocker for MM-419 and is ignored for dependency gating.
+```
+
+## User Story - Run Manifest From Manifests Page
+
+**Summary**: As a dashboard user, I want a compact Run Manifest form on the Manifests page that supports registry names and inline YAML so I can start either kind of manifest run from the same context.
+
+**Goal**: Users can launch supported manifest runs from `/tasks/manifests` without leaving the recent-runs context, while client-side validation prevents unsupported or unsafe submissions before any run request is sent.
+
+**Independent Test**: Open `/tasks/manifests`, exercise registry and inline source modes, submit valid runs through the existing manifest run flow, and verify invalid names, empty YAML, invalid max docs, and raw secret-shaped values are rejected before submission.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user opens `/tasks/manifests`, **When** the page renders, **Then** the Run Manifest card appears before Recent Runs and advanced options are collapsed by default.
+2. **Given** Registry Manifest mode is active, **When** a user submits without a registry manifest name, **Then** the page reports that the registry manifest name is required and does not require inline YAML.
+3. **Given** Inline YAML mode is active, **When** a user submits without inline YAML, **Then** the page reports that manifest YAML is required and does not require a registry manifest name.
+4. **Given** a user enters values in one source mode, **When** they switch to the other source mode and back, **Then** values entered for each mode are preserved independently for the current session.
+5. **Given** a user enters a non-positive or non-integer max docs value, **When** they submit, **Then** the page rejects the value before sending any manifest upsert or run request.
+6. **Given** submitted content or helper fields contain raw secret-style values, **When** the user submits, **Then** the page rejects the submission before sending any manifest upsert or run request and directs the user to env or Vault references.
+7. **Given** keyboard or assistive technology users interact with the form, **When** they navigate controls and validation messages, **Then** source selection, source-specific inputs, action, advanced options, and submit feedback have accessible names or associations.
+8. **Given** the viewport narrows, **When** form controls wrap or stack, **Then** the form remains first in the page flow and the Run Manifest action remains visible without opening advanced options.
+
+### Edge Cases
+
+- Blank or whitespace-only registry manifest names are rejected in registry mode.
+- Blank or whitespace-only inline YAML is rejected in inline mode.
+- `max docs` values such as `0`, negative numbers, decimals, and alphabetic text are rejected before submit.
+- Raw secret-shaped values in inline YAML, manifest names, or helper fields are rejected, while env/Vault reference-style values remain allowed.
+- Failed submission preserves entered data and leaves the user on `/tasks/manifests`.
+
+## Assumptions
+
+- Priority is not added to the UI unless a supported manifest-run backend field exists; the current manifest run options support dry run, force full sync, and max docs.
+- Registry autocomplete remains a progressive enhancement and free-text registry names are sufficient for this story.
+
+## Source Design Requirements
+
+The preserved Jira brief lists source coverage IDs `DESIGN-REQ-003`, `DESIGN-REQ-004`, `DESIGN-REQ-005`, `DESIGN-REQ-006`, `DESIGN-REQ-007`, `DESIGN-REQ-013`, `DESIGN-REQ-014`, `DESIGN-REQ-016`, and `DESIGN-REQ-018`. The mappings below are this single-story spec's extracted requirements from `docs/UI/ManifestsPage.md`; they keep the story traceable without requiring unrelated source sections to become in-scope work.
+
+- **DESIGN-REQ-001** (`docs/UI/ManifestsPage.md`, Page structure): The page has a Run Manifest section above Recent Runs. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-002** (`docs/UI/ManifestsPage.md`, Source type toggle): The run form distinguishes Registry Manifest and Inline YAML modes and preserves mode values during switching. Scope: in scope. Maps to FR-002, FR-003, FR-004.
+- **DESIGN-REQ-003** (`docs/UI/ManifestsPage.md`, Fields): The form includes required source fields, supported action values, and supported advanced options. Scope: in scope. Maps to FR-002, FR-003, FR-005.
+- **DESIGN-REQ-004** (`docs/UI/ManifestsPage.md`, Validation rules): The form rejects missing required inputs, invalid max docs values, and raw secret-shaped values. Scope: in scope. Maps to FR-005, FR-006.
+- **DESIGN-REQ-005** (`docs/UI/ManifestsPage.md`, Submission behavior): Successful submissions stay on the Manifests page, refresh recent runs, and expose a run detail affordance. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-006** (`docs/UI/ManifestsPage.md`, Accessibility): Controls and validation feedback are keyboard and assistive-technology accessible. Scope: in scope. Maps to FR-008.
+- **DESIGN-REQ-007** (`docs/UI/ManifestsPage.md`, Responsive behavior): Narrow layouts keep a clear form-first flow and visible primary action. Scope: in scope. Maps to FR-009.
+- **DESIGN-REQ-008** (`docs/UI/ManifestsPage.md`, Optional future section): Saved manifest registry browsing is optional and must not be required for this story. Scope: out of scope because MM-419 only requires free-text fallback and direct run submission.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST show a Run Manifest form directly on `/tasks/manifests` above Recent Runs, with advanced options collapsed by default.
+- **FR-002**: The system MUST support Registry Manifest mode with required manifest name and supported action values, without requiring inline YAML.
+- **FR-003**: The system MUST support Inline YAML mode with required YAML content and supported action values, without requiring a registry manifest name.
+- **FR-004**: The system MUST preserve entered values for Registry Manifest and Inline YAML modes independently during source-mode switching in the current session.
+- **FR-005**: The system MUST reject non-positive and non-integer max docs values before sending manifest upsert or run requests.
+- **FR-006**: The system MUST reject raw secret-style values in submitted manifest content or helper fields before sending manifest upsert or run requests, while allowing env/Vault reference-style values.
+- **FR-007**: Successful valid submissions MUST remain on `/tasks/manifests`, expose the started run, and refresh Recent Runs in place.
+- **FR-008**: Form controls and feedback MUST expose accessible names or associations for source mode, source-specific fields, action, advanced options, and submission status.
+- **FR-009**: The form MUST keep the Run Manifest action visible in the default form flow without requiring advanced options to be opened.
+- **FR-010**: The implementation MUST preserve Jira issue key MM-419 in Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend validation tests show invalid max docs and raw secret-shaped values are rejected before any manifest upsert or run request.
+- **SC-002**: Frontend tests show registry and inline submissions still call the existing manifest APIs and refresh recent runs in place.
+- **SC-003**: Accessibility-oriented tests can locate the source mode, source-specific inputs, action, advanced options, and Run Manifest action by accessible label or role.
+- **SC-004**: The final verification report traces implementation evidence back to MM-419 and all in-scope DESIGN-REQ mappings.

--- a/specs/216-run-manifest-page-form/tasks.md
+++ b/specs/216-run-manifest-page-form/tasks.md
@@ -1,0 +1,66 @@
+# Tasks: Run Manifest Page Form
+
+**Input**: Design documents from `/specs/216-run-manifest-page-form/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Test Commands**:
+
+- Unit tests: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx`
+- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+- [X] T001 Create Moon Spec artifacts for MM-419 in `specs/216-run-manifest-page-form/`.
+- [X] T002 Preserve canonical Jira brief for MM-419 in `docs/tmp/jira-orchestration-inputs/MM-419-moonspec-orchestration-input.md`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing manifest run backend options support dry run, force full, and max docs but no priority field in `api_service/api/schemas.py`.
+- [X] T004 Confirm existing Manifests page and tests cover unified layout, source modes, mode value preservation, and in-place refresh in `frontend/src/entrypoints/manifests.tsx` and `frontend/src/entrypoints/manifests.test.tsx`.
+
+## Phase 3: Story - Run Manifest From Manifests Page
+
+**Summary**: As a dashboard user, I want a compact Run Manifest form on the Manifests page that supports registry names and inline YAML so I can start either kind of manifest run from the same context.
+
+**Independent Test**: Open `/tasks/manifests`, exercise registry and inline source modes, submit valid runs through the existing manifest run flow, and verify invalid names, empty YAML, invalid max docs, and raw secret-shaped values are rejected before submission.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-001..007, SC-001..004
+
+### Unit Tests
+
+- [X] T005 Add failing frontend validation tests for invalid max docs and raw secret-shaped input in `frontend/src/entrypoints/manifests.test.tsx` (FR-005, FR-006, SC-001, DESIGN-REQ-004).
+- [X] T006 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx` and confirm T005 fails for the expected validation gaps.
+
+### Integration Tests
+
+- [X] T007 Add runner-integrated UI validation coverage for valid env/Vault-style references and existing valid submissions in `frontend/src/entrypoints/manifests.test.tsx` (FR-006, FR-007, SC-002).
+- [X] T008 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` and confirm new validation tests fail before implementation.
+
+### Implementation
+
+- [X] T009 Implement client-side max docs validation before manifest API calls in `frontend/src/entrypoints/manifests.tsx` (FR-005).
+- [X] T010 Implement client-side raw secret-shaped value rejection before manifest API calls in `frontend/src/entrypoints/manifests.tsx` (FR-006).
+
+### Story Validation
+
+- [X] T011 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx` and verify the story passes.
+- [X] T012 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` and verify runner-integrated UI validation passes.
+
+## Phase 4: Polish And Verification
+
+- [X] T013 Update `docs/UI/ManifestsPage.md` only if implementation behavior diverges from the desired-state document.
+- [X] T014 Run `./tools/test_unit.sh` for final unit validation or document the exact local blocker.
+- [X] T015 Run final `/moonspec-verify` and record the verdict for MM-419.
+
+## Dependencies & Execution Order
+
+- T005-T008 must run before T009-T010.
+- T009 and T010 both touch `frontend/src/entrypoints/manifests.tsx` and should be sequenced.
+- T011-T015 run after implementation.
+
+## Implementation Strategy
+
+Existing MM-418 work already implemented most MM-419 behavior. This story closes the remaining validation gaps with tests first, keeps backend contracts unchanged, and preserves MM-419 traceability through final verification.


### PR DESCRIPTION
## Summary
- Adds MM-419 MoonSpec artifacts for `specs/216-run-manifest-page-form`.
- Hardens the Manifests page Run Manifest form with client-side validation for invalid Max Docs values and raw secret-like input.
- Adds focused frontend coverage for invalid Max Docs, raw secret rejection, and env-style secret references.

## Jira
- Jira issue key: MM-419

## MoonSpec
- Active feature path: `specs/216-run-manifest-page-form`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx`
- `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/manifests.test.tsx`
- `./tools/test_unit.sh`

## Remaining risks
- Remaining risk is limited to browser/runtime differences not covered by the focused JSDOM test harness; no known functional gaps remain for MM-419.
