### PR TITLE
Implement these improvements to fix the tasks list page: The good news is the page structure is **almost** the right one. The design doc says `/tasks/

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,12 @@
 [
   {
-    "id": 3115365887,
+    "id": 3115467916,
     "disposition": "addressed",
-    "rationale": "Refactored resolver child request construction to consume a single canonical resolverTemplate.executionProfileRef key and write only task.runtime.executionProfileRef for the child run."
+    "rationale": "Replaced the raw mission-control.css regex assertions with rendered DOM getComputedStyle assertions for the shell panel, control grid, data slab, and table wrapper."
   },
   {
-    "id": 3115365890,
+    "id": 4145523992,
     "disposition": "addressed",
-    "rationale": "Refactored merge automation resolver template construction to read the parent profile from the existing parameters.profileId source and emit only resolverTemplate.executionProfileRef."
-  },
-  {
-    "id": 4145395537,
-    "disposition": "addressed",
-    "rationale": "Removed redundant profile/model/effort alias propagation from the merge automation resolver template and child runtime payload."
-  },
-  {
-    "id": 3115378317,
-    "disposition": "addressed",
-    "rationale": "Removed the multiple-profile-field selection path so conflicting resolverTemplate aliases are no longer accepted or silently prioritized."
-  },
-  {
-    "id": 4145408425,
-    "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper with no actionable code feedback."
+    "rationale": "Addressed the review summary by removing the brittle CSS source-file test and verifying the applied task list layout styles through rendered output."
   }
 ]

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -222,24 +222,46 @@ describe('Tasks List Entrypoint', () => {
   });
 
   it('keeps the task list surfaces to one control deck and one data slab', async () => {
-    const { readFileSync } = await import('node:fs');
-    const missionControlCss = readFileSync(
-      `${process.cwd()}/frontend/src/styles/mission-control.css`,
-      'utf8',
+    renderWithClient(
+      <section className="panel" aria-live="polite">
+        <TasksListPage payload={mockPayload} />
+      </section>,
     );
 
-    expect(missionControlCss).toMatch(
-      /\.panel:has\(\.task-list-control-deck\)\s*\{[^}]*border:\s*0;[^}]*background:\s*transparent;[^}]*box-shadow:\s*none;[^}]*padding:\s*0;[^}]*min-height:\s*0;/s,
-    );
-    expect(missionControlCss).toMatch(
-      /\.task-list-control-grid\s*\{[^}]*width:\s*100%;[^}]*max-width:\s*none;[^}]*grid-template-columns:\s*repeat\(4,\s*minmax\(12rem,\s*1fr\)\)/s,
-    );
-    expect(missionControlCss).toMatch(
-      /\.task-list-data-slab\s*\{[^}]*gap:\s*0;[^}]*overflow:\s*hidden;[^}]*padding:\s*0;[^}]*background:\s*rgb\(var\(--mm-panel\) \/ 0\.96\)/s,
-    );
-    expect(missionControlCss).toMatch(
-      /\.task-list-data-slab \.queue-table-wrapper\s*\{[^}]*border:\s*0;[^}]*border-radius:\s*0;[^}]*background:\s*transparent/s,
-    );
+    await screen.findAllByText('Example task');
+
+    const shellPanel = document.querySelector<HTMLElement>('.panel');
+    const controlDecks = document.querySelectorAll<HTMLElement>('.task-list-control-deck.panel--controls');
+    const dataSlabs = document.querySelectorAll<HTMLElement>('.task-list-data-slab.panel--data');
+    const controlGrid = controlDecks[0]?.querySelector<HTMLElement>('.task-list-control-grid');
+    const tableWrapper = dataSlabs[0]?.querySelector<HTMLElement>('.queue-table-wrapper[data-layout="table"]');
+
+    expect(controlDecks).toHaveLength(1);
+    expect(dataSlabs).toHaveLength(1);
+    expect(controlGrid).toBeTruthy();
+    expect(tableWrapper).toBeTruthy();
+
+    const shellPanelStyles = getComputedStyle(shellPanel as HTMLElement);
+    expect(shellPanelStyles.borderTopWidth).toBe('0px');
+    expect(shellPanelStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(shellPanelStyles.boxShadow).toBe('none');
+    expect(shellPanelStyles.paddingTop).toBe('0px');
+    expect(shellPanelStyles.minHeight).toBe('0px');
+
+    const controlGridStyles = getComputedStyle(controlGrid as HTMLElement);
+    expect(controlGridStyles.width).toBe('100%');
+    expect(controlGridStyles.maxWidth).toBe('none');
+    expect(controlGridStyles.gridTemplateColumns).toBe('repeat(4, minmax(12rem, 1fr))');
+
+    const dataSlabStyles = getComputedStyle(dataSlabs[0]);
+    expect(dataSlabStyles.gap).toBe('0px');
+    expect(dataSlabStyles.overflow).toBe('hidden');
+    expect(dataSlabStyles.paddingTop).toBe('0px');
+
+    const tableWrapperStyles = getComputedStyle(tableWrapper as HTMLElement);
+    expect(tableWrapperStyles.borderTopWidth).toBe('0px');
+    expect(tableWrapperStyles.borderRadius).toBe('0px');
+    expect(tableWrapperStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
   });
 
   it('shows active filter chips and clears filters from the control deck', async () => {

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -221,6 +221,27 @@ describe('Tasks List Entrypoint', () => {
     expect(getComputedStyle(scheduledHeader as HTMLElement).position).toBe('sticky');
   });
 
+  it('keeps the task list surfaces to one control deck and one data slab', async () => {
+    const { readFileSync } = await import('node:fs');
+    const missionControlCss = readFileSync(
+      `${process.cwd()}/frontend/src/styles/mission-control.css`,
+      'utf8',
+    );
+
+    expect(missionControlCss).toMatch(
+      /\.panel:has\(\.task-list-control-deck\)\s*\{[^}]*border:\s*0;[^}]*background:\s*transparent;[^}]*box-shadow:\s*none;[^}]*padding:\s*0;[^}]*min-height:\s*0;/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.task-list-control-grid\s*\{[^}]*width:\s*100%;[^}]*max-width:\s*none;[^}]*grid-template-columns:\s*repeat\(4,\s*minmax\(12rem,\s*1fr\)\)/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.task-list-data-slab\s*\{[^}]*gap:\s*0;[^}]*overflow:\s*hidden;[^}]*padding:\s*0;[^}]*background:\s*rgb\(var\(--mm-panel\) \/ 0\.96\)/s,
+    );
+    expect(missionControlCss).toMatch(
+      /\.task-list-data-slab \.queue-table-wrapper\s*\{[^}]*border:\s*0;[^}]*border-radius:\s*0;[^}]*background:\s*transparent/s,
+    );
+  });
+
   it('shows active filter chips and clears filters from the control deck', async () => {
     renderWithClient(<TasksListPage payload={mockPayload} />);
 

--- a/frontend/src/entrypoints/tasks-list.test.tsx
+++ b/frontend/src/entrypoints/tasks-list.test.tsx
@@ -233,11 +233,15 @@ describe('Tasks List Entrypoint', () => {
     const shellPanel = document.querySelector<HTMLElement>('.panel');
     const controlDecks = document.querySelectorAll<HTMLElement>('.task-list-control-deck.panel--controls');
     const dataSlabs = document.querySelectorAll<HTMLElement>('.task-list-data-slab.panel--data');
-    const controlGrid = controlDecks[0]?.querySelector<HTMLElement>('.task-list-control-grid');
-    const tableWrapper = dataSlabs[0]?.querySelector<HTMLElement>('.queue-table-wrapper[data-layout="table"]');
 
     expect(controlDecks).toHaveLength(1);
     expect(dataSlabs).toHaveLength(1);
+
+    const controlDeck = controlDecks[0] as HTMLElement;
+    const dataSlab = dataSlabs[0] as HTMLElement;
+    const controlGrid = controlDeck.querySelector<HTMLElement>('.task-list-control-grid');
+    const tableWrapper = dataSlab.querySelector<HTMLElement>('.queue-table-wrapper[data-layout="table"]');
+
     expect(controlGrid).toBeTruthy();
     expect(tableWrapper).toBeTruthy();
 
@@ -253,7 +257,7 @@ describe('Tasks List Entrypoint', () => {
     expect(controlGridStyles.maxWidth).toBe('none');
     expect(controlGridStyles.gridTemplateColumns).toBe('repeat(4, minmax(12rem, 1fr))');
 
-    const dataSlabStyles = getComputedStyle(dataSlabs[0]);
+    const dataSlabStyles = getComputedStyle(dataSlab);
     expect(dataSlabStyles.gap).toBe('0px');
     expect(dataSlabStyles.overflow).toBe('hidden');
     expect(dataSlabStyles.paddingTop).toBe('0px');

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -413,6 +413,14 @@ h1 {
   margin-inline: auto;
 }
 
+.panel:has(.task-list-control-deck) {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  min-height: 0;
+}
+
 .panel.panel--data-wide {
   max-width: min(112rem, calc(100vw - 2rem));
 }
@@ -548,11 +556,15 @@ h1 {
 .task-list-control-deck {
   display: grid;
   gap: 0.85rem;
+  border-color: rgb(var(--mm-border) / 0.55);
+  box-shadow: 0 14px 34px -24px rgb(0 0 0 / 0.35);
 }
 
 .task-list-control-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(9rem, 1fr));
+  width: 100%;
+  max-width: none;
+  grid-template-columns: repeat(4, minmax(12rem, 1fr));
   gap: 0.8rem;
 }
 
@@ -659,12 +671,25 @@ tbody tr:hover {
   width: 100%;
 }
 
+.task-list-data-slab {
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+  border-color: rgb(var(--mm-border) / 0.45);
+  background: rgb(var(--mm-panel) / 0.96);
+}
+
 .queue-results-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.task-list-data-slab .queue-results-toolbar {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
 }
 
 .queue-pagination {
@@ -692,8 +717,16 @@ tbody tr:hover {
   background: rgb(var(--mm-panel) / 0.92);
 }
 
+.task-list-data-slab .queue-table-wrapper {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
 .queue-table-wrapper table {
   border: 0;
+  border-radius: 0;
+  background: transparent;
   table-layout: fixed;
   max-width: 100%;
   margin: 0;
@@ -1026,6 +1059,12 @@ tr[data-proposal-id].proposal-consuming td {
 @media (min-width: 768px) {
   .queue-card-list {
     display: none;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1080px) {
+  .task-list-control-grid {
+    grid-template-columns: repeat(2, minmax(14rem, 1fr));
   }
 }
 


### PR DESCRIPTION
Implement these improvements to fix the tasks list page: The good news is the page structure is **almost** the right one. The design doc says `/tasks/list` should be a **control deck + data slab** page: compact filters and utilities up top, then a distinct table slab below, with page-size grouped with pagination and the table staying table-first on desktop. It also says Mission Control should use **glass for controls** and **matte slabs for dense data**, with **one main hero treatment per page**, not repeated spectacle on every layer. 

That means this page should read visually as:

**background atmosphere** → **one control deck** → **one data slab**

not:

**outer panel** → **control card** → **data card** → **table wrapper** → **table**

From your screenshot, that second version is what happened: concentric rounded rectangles, repeated borders, repeated shadows, and too many “framed” layers.

The route code is directionally correct. It already renders a separate `.task-list-control-deck.panel--controls` and `.task-list-data-slab.panel--data`, which matches the intended composition. The problem is that the CSS also gives the generic `.panel`, `.panel--controls`, `.panel--data`, `.queue-table-wrapper`, and even `table` their own border/background/radius treatment, so the result stacks multiple surface shells on top of each other. The CSS also applies a generic `form { max-width: 760px; }`, which is why the filters stop early and leave that awkward dead zone to the right on a wide screen.  

So according to the design system, what’s wrong is not the **layout idea**. It is the **surface hierarchy** and **chrome density**.

What would make it cleaner:

1. **Remove the extra outer shell for this route.**
   The task list already has its own control deck and data slab. Wrapping both inside another bordered panel is what creates the “card inside card inside card” look. The outer route container should be spacing only, not another visible surface. This matches the doc’s idea that `/tasks/list` should be a control deck over a data slab, not one giant super-card. 

2. **Let the filter row actually use the available width.**
   The global `form` max-width is choking the control deck. On desktop, those four filters should stretch across the row or form a deliberate 2x2 block, not sit in a small left column while the rest of the deck is empty. The doc explicitly calls for disciplined use of wide space and says the upper-right should be used intentionally, not left blank.  

3. **Make the control deck the only glassy surface in the content area.**
   Keep one subtle glass deck for filters/utilities. Then make the results slab more matte and quieter. Right now the control deck, the results slab, and the table all have similar visual weight, so nothing feels primary. That violates the “matte for content, glass for controls” rule. 

4. **Make the data slab singular.**
   Either the slab owns the border/radius, or the table wrapper does. Not both. The cleanest version is: the data slab owns the outer shell, the toolbar sits at the top of it, and the table sits inside with just row dividers and a sticky header. The actual `<table>` should not look like another separate card.  

5. **Tone down border repetition.**
   The design doc prefers edge light and subtle separators over heavy repeated outlines. One quiet border per major surface is enough. The current page has too many similarly weighted outlines competing with each other. 

A strong first-pass cleanup would be something like this:

```css
/* 1) Don’t wrap the whole tasks page in another visible shell */
.panel:has(.task-list-control-deck) {
  background: transparent;
  border: 0;
  box-shadow: none;
  padding: 0;
  min-height: 0;
}

/* 2) Let filters fill the control deck */
.task-list-control-grid {
  max-width: none;
  grid-template-columns: repeat(4, minmax(12rem, 1fr));
}

/* 3) Keep one glass control deck */
.panel--controls {
  border-color: rgb(var(--mm-border) / 0.55);
  box-shadow: 0 14px 34px -24px rgb(0 0 0 / 0.35);
}

/* 4) Make the result area one matte slab */
.task-list-data-slab {
  padding: 0;
  background: rgb(var(--mm-panel) / 0.96);
  border-color: rgb(var(--mm-border) / 0.45);
  overflow: hidden;
}

.queue-results-toolbar {
  padding: 0.85rem 1rem;
  border-bottom: 1px solid rgb(var(--mm-border) / 0.28);
}

/* 5) Stop double-framing the table */
.queue-table-wrapper {
  border: 0;
  border-radius: 0;
  background: transparent;
}

.queue-table-wrapper table {
  border: 0;
  border-radius: 0;
  background: transparent;
}
```

Visually, the clean version should feel like this:

* one premium masthead
* one compact glass control deck
* one quiet matte results slab
* one embedded table with subtle separators

So the page reads as **two surfaces**, not **five**.

The single biggest fixes are: **remove the extra outer panel**, **override the 760px form cap on the filter row**, and **stop giving both the wrapper and the table their own full card styling**. Those three changes alone would make this look much closer to the design doc.