### PR TITLE
[codex] Fix long Temporal workflow IDs

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3720,6 +3720,7 @@ async def describe_execution(
             use_projection_read = True
         except RPCError as exc:
             temporal_sync_unavailable = True
+            await session.rollback()
             logger.warning(
                 "Failed to sync execution %s from Temporal: %s",
                 canonical_workflow_id,
@@ -3727,6 +3728,7 @@ async def describe_execution(
                 exc_info=True,
             )
         except Exception as exc:
+            await session.rollback()
             logger.warning(
                 "Failed to sync execution %s from Temporal: %s",
                 canonical_workflow_id,

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -868,7 +868,7 @@ class TemporalExecutionCanonicalRecord(Base):
         ),
     )
 
-    workflow_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_id: Mapped[str] = mapped_column(String(255), primary_key=True)
     run_id: Mapped[str] = mapped_column(String(64), nullable=False)
     namespace: Mapped[str] = mapped_column(
         String(128), nullable=False, default="moonmind"
@@ -993,12 +993,12 @@ class TemporalExecutionDependency(Base):
     )
 
     dependent_workflow_id: Mapped[str] = mapped_column(
-        String(64),
+        String(255),
         ForeignKey("temporal_execution_sources.workflow_id", ondelete="CASCADE"),
         primary_key=True,
     )
     prerequisite_workflow_id: Mapped[str] = mapped_column(
-        String(64),
+        String(255),
         ForeignKey("temporal_execution_sources.workflow_id", ondelete="CASCADE"),
         primary_key=True,
     )
@@ -1037,7 +1037,7 @@ class TemporalExecutionRecord(Base):
         ),
     )
 
-    workflow_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_id: Mapped[str] = mapped_column(String(255), primary_key=True)
     run_id: Mapped[str] = mapped_column(String(64), nullable=False)
     namespace: Mapped[str] = mapped_column(
         String(128), nullable=False, default="moonmind"
@@ -1225,7 +1225,7 @@ class TemporalIntegrationCorrelationRecord(Base):
         String(255), nullable=True
     )
     workflow_id: Mapped[str] = mapped_column(
-        String(64),
+        String(255),
         ForeignKey("temporal_executions.workflow_id", ondelete="CASCADE"),
         nullable=False,
     )

--- a/api_service/migrations/versions/f8a9b0c1d2e3_widen_temporal_workflow_ids.py
+++ b/api_service/migrations/versions/f8a9b0c1d2e3_widen_temporal_workflow_ids.py
@@ -1,0 +1,97 @@
+"""widen temporal workflow ids
+
+Revision ID: f8a9b0c1d2e3
+Revises: e6f7a8b9c0d1
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "f8a9b0c1d2e3"
+down_revision: Union[str, None] = "e6f7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "temporal_execution_sources",
+        "workflow_id",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "temporal_executions",
+        "workflow_id",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "execution_dependencies",
+        "dependent_workflow_id",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "execution_dependencies",
+        "prerequisite_workflow_id",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "temporal_integration_correlations",
+        "workflow_id",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=255),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "temporal_integration_correlations",
+        "workflow_id",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "execution_dependencies",
+        "prerequisite_workflow_id",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "execution_dependencies",
+        "dependent_workflow_id",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "temporal_executions",
+        "workflow_id",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "temporal_execution_sources",
+        "workflow_id",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=64),
+        existing_nullable=False,
+    )

--- a/api_service/migrations/versions/f8a9b0c1d2e3_widen_temporal_workflow_ids.py
+++ b/api_service/migrations/versions/f8a9b0c1d2e3_widen_temporal_workflow_ids.py
@@ -18,7 +18,14 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
 
 
 def upgrade() -> None:

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,27 @@
 [
   {
-    "id": 3115365887,
+    "id": 3115612665,
     "disposition": "addressed",
-    "rationale": "Refactored resolver child request construction to consume a single canonical resolverTemplate.executionProfileRef key and write only task.runtime.executionProfileRef for the child run."
+    "rationale": "Added branch_labels to the migration module __all__ export so the Alembic global is intentionally exposed."
   },
   {
-    "id": 3115365890,
+    "id": 3115612672,
     "disposition": "addressed",
-    "rationale": "Refactored merge automation resolver template construction to read the parent profile from the existing parameters.profileId source and emit only resolverTemplate.executionProfileRef."
+    "rationale": "Added depends_on to the migration module __all__ export so the Alembic global is intentionally exposed."
   },
   {
-    "id": 4145395537,
+    "id": 3115615569,
     "disposition": "addressed",
-    "rationale": "Removed redundant profile/model/effort alias propagation from the merge automation resolver template and child runtime payload."
+    "rationale": "Gated the hashed resolver child workflow ID with Temporal workflow.patched and preserved the legacy child ID format for pre-patch replay histories."
   },
   {
-    "id": 3115378317,
-    "disposition": "addressed",
-    "rationale": "Removed the multiple-profile-field selection path so conflicting resolverTemplate aliases are no longer accepted or silently prioritized."
-  },
-  {
-    "id": 4145408425,
+    "id": 4145722830,
     "disposition": "not-applicable",
-    "rationale": "Informational Codex review wrapper with no actionable code feedback."
+    "rationale": "Automated review wrapper comment only; actionable inline review comments are tracked separately."
+  },
+  {
+    "id": 4145733313,
+    "disposition": "not-applicable",
+    "rationale": "Review summary explicitly states there is no feedback to provide."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -31,6 +31,7 @@ with workflow.unsafe.imports_passed_through():
         build_resolver_run_request,
         classify_readiness,
         deterministic_resolver_idempotency_key,
+        legacy_resolver_idempotency_key,
     )
 
 
@@ -447,7 +448,12 @@ class MoonMindMergeAutomationWorkflow:
                     merge_method=self._input.config.resolver.merge_method,
                     resolver_template=self._input.resolver_template,
                 )
-                resolver_workflow_id = deterministic_resolver_idempotency_key(
+                resolver_workflow_id_factory = (
+                    deterministic_resolver_idempotency_key
+                    if workflow.patched("merge-automation-hashed-resolver-child-id")
+                    else legacy_resolver_idempotency_key
+                )
+                resolver_workflow_id = resolver_workflow_id_factory(
                     parent_workflow_id=self._input.parent_workflow_id,
                     repo=self._input.pull_request.repo,
                     pr_number=self._input.pull_request.number,

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from typing import Any
 
 from temporalio import workflow
@@ -221,9 +222,22 @@ def deterministic_resolver_idempotency_key(
     pr_number: int,
     head_sha: str,
 ) -> str:
-    # Keep repository identity in payload/search attributes, not workflow ids.
-    # Raw repo names contain "/" and make API/UI routing fragile.
-    return f"resolver:{parent_workflow_id}:pr:{pr_number}:head:{head_sha}"
+    # Keep full parent/repo/SHA identity in payload/search attributes and use a
+    # bounded digest in the workflow id to avoid projection and UI path limits.
+    identity = "\x1f".join(
+        [
+            str(parent_workflow_id).strip(),
+            str(repo).strip(),
+            str(pr_number).strip(),
+            str(head_sha).strip(),
+        ]
+    )
+    digest = sha256(identity.encode("utf-8")).hexdigest()[:16]
+    pr_prefix = re.sub(r"[^a-zA-Z0-9_.-]", "-", str(pr_number).strip())[:12] or "pr"
+    head_prefix = (
+        re.sub(r"[^a-zA-Z0-9_.-]", "-", str(head_sha).strip())[:12] or "head"
+    )
+    return f"resolver:pr:{pr_prefix}:head:{head_prefix}:h:{digest}"
 
 
 def build_resolver_run_request(

--- a/moonmind/workflows/temporal/workflows/merge_gate.py
+++ b/moonmind/workflows/temporal/workflows/merge_gate.py
@@ -240,6 +240,17 @@ def deterministic_resolver_idempotency_key(
     return f"resolver:pr:{pr_prefix}:head:{head_prefix}:h:{digest}"
 
 
+def legacy_resolver_idempotency_key(
+    *,
+    parent_workflow_id: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+) -> str:
+    # Preserve the exact pre-hash child workflow id for workflow replay.
+    return f"resolver:{parent_workflow_id}:pr:{pr_number}:head:{head_sha}"
+
+
 def build_resolver_run_request(
     *,
     parent_workflow_id: str,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -1817,6 +1817,46 @@ def test_describe_execution_source_temporal_uses_projection_fallback_when_sync_f
     assert service.describe_execution.await_args.kwargs["include_orphaned"] is True
 
 
+def test_describe_execution_rolls_back_session_when_temporal_sync_commit_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    service = AsyncMock()
+    user = _override_user_dependencies(app, is_superuser=False)
+    service.describe_execution.return_value = _build_execution_record(
+        owner_id=str(user.id)
+    )
+    service.list_dependents.return_value = []
+    service.enrich_dependency_summaries.return_value = []
+    app.dependency_overrides[_get_service] = lambda: service
+    _override_query_client(app, progress={"total": 0})
+
+    session = AsyncMock()
+    session.commit.side_effect = RuntimeError("db flush failed")
+
+    async def _override_session():
+        yield session
+
+    async def _sync_success(*_args, **_kwargs):
+        return None
+
+    app.dependency_overrides[get_async_session] = _override_session
+    monkeypatch.setattr(
+        "api_service.core.sync.fetch_and_sync_execution",
+        _sync_success,
+    )
+
+    with TestClient(app) as test_client:
+        response = test_client.get(
+            "/api/executions/mm:wf-1", params={"source": "temporal"}
+        )
+
+    assert response.status_code == 200
+    session.rollback.assert_awaited_once()
+    assert service.describe_execution.await_args.kwargs["include_orphaned"] is True
+
+
 def test_describe_execution_source_temporal_returns_503_when_no_fallback_record(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -3198,7 +3198,8 @@ def test_describe_execution_hydrates_provider_profile_metadata() -> None:
                 provider_id="google",
                 provider_label="Google",
             )
-        )
+        ),
+        rollback=AsyncMock(),
     )
     _override_temporal_client(app)
     _override_user_dependencies(app, is_superuser=True)

--- a/tests/unit/api_service/test_temporal_workflow_id_width.py
+++ b/tests/unit/api_service/test_temporal_workflow_id_width.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from api_service.db.models import (
+    TemporalExecutionCanonicalRecord,
+    TemporalExecutionDependency,
+    TemporalExecutionRecord,
+    TemporalIntegrationCorrelationRecord,
+)
+
+
+def test_temporal_projection_workflow_ids_accept_child_workflow_ids() -> None:
+    assert TemporalExecutionCanonicalRecord.__table__.c.workflow_id.type.length == 255
+    assert TemporalExecutionRecord.__table__.c.workflow_id.type.length == 255
+    assert (
+        TemporalExecutionDependency.__table__.c.dependent_workflow_id.type.length == 255
+    )
+    assert (
+        TemporalExecutionDependency.__table__.c.prerequisite_workflow_id.type.length
+        == 255
+    )
+    assert (
+        TemporalIntegrationCorrelationRecord.__table__.c.workflow_id.type.length == 255
+    )

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -163,7 +163,10 @@ def test_deterministic_resolver_idempotency_key_is_revision_scoped() -> None:
     )
 
     assert first != second
-    assert first == "resolver:mm:parent:pr:341:head:abc123"
+    assert first.startswith("resolver:pr:341:head:abc123:h:")
+    assert len(first) <= 64
+    assert "mm:parent" not in first
+    assert "MoonLadderStudios" not in first
     assert "/" not in first
 
 

--- a/tests/unit/workflows/temporal/test_merge_gate_workflow.py
+++ b/tests/unit/workflows/temporal/test_merge_gate_workflow.py
@@ -8,6 +8,7 @@ from moonmind.workflows.temporal.workflows.merge_gate import (
     classify_readiness,
     deterministic_resolver_idempotency_key,
     build_continue_as_new_input,
+    legacy_resolver_idempotency_key,
 )
 
 
@@ -168,6 +169,17 @@ def test_deterministic_resolver_idempotency_key_is_revision_scoped() -> None:
     assert "mm:parent" not in first
     assert "MoonLadderStudios" not in first
     assert "/" not in first
+
+
+def test_legacy_resolver_idempotency_key_preserves_replay_format() -> None:
+    legacy = legacy_resolver_idempotency_key(
+        parent_workflow_id="mm:parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=341,
+        head_sha="abc123",
+    )
+
+    assert legacy == "resolver:mm:parent:pr:341:head:abc123"
 
 
 def test_build_resolver_run_request_uses_pr_resolver_and_publish_none() -> None:

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -12,6 +12,9 @@ from moonmind.workflows.temporal.workflows import merge_automation as merge_auto
 from moonmind.workflows.temporal.workflows.merge_automation import (
     MoonMindMergeAutomationWorkflow,
 )
+from moonmind.workflows.temporal.workflows.merge_gate import (
+    deterministic_resolver_idempotency_key,
+)
 
 
 def _payload() -> dict[str, Any]:
@@ -220,9 +223,21 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
     assert readiness_calls == 2
     assert result["status"] == "merged"
     assert result["cycles"] == 2
+    first_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="abc123",
+    )
+    second_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="def456",
+    )
     assert child_workflow_ids == [
-        "resolver:wf-parent:pr:350:head:abc123:1",
-        "resolver:wf-parent:pr:350:head:def456:2",
+        f"{first_resolver_id}:1",
+        f"{second_resolver_id}:2",
     ]
     assert child_payloads[0]["workflow_type"] == "MoonMind.Run"
     assert child_payloads[0]["initial_parameters"]["publishMode"] == "none"

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -14,6 +14,7 @@ from moonmind.workflows.temporal.workflows.merge_automation import (
 )
 from moonmind.workflows.temporal.workflows.merge_gate import (
     deterministic_resolver_idempotency_key,
+    legacy_resolver_idempotency_key,
 )
 
 
@@ -56,6 +57,15 @@ def _payload_with_post_merge_jira(**post_merge_overrides: Any) -> dict[str, Any]
         **post_merge_overrides,
     }
     return payload
+
+
+@pytest.fixture(autouse=True)
+def _default_temporal_patch_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda _patch_id: True,
+    )
 
 
 def test_merge_automation_extracts_artifact_id_from_ref_shapes() -> None:
@@ -309,6 +319,82 @@ async def test_merge_automation_resolver_child_uses_try_cancel(
     assert search_attributes["mm_owner_type"] == ["user"]
     assert search_attributes["mm_owner_id"] == ["wf-parent"]
     assert search_attributes["mm_repo"] == ["MoonLadderStudios/MoonMind"]
+
+
+@pytest.mark.asyncio
+async def test_merge_automation_resolver_child_uses_legacy_id_before_patch_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    child_workflow_ids: list[str] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert activity_type == "merge_automation.evaluate_readiness"
+        return {
+            "headSha": "abc123",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        _payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        child_workflow_ids.append(str(kwargs["id"]))
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "patched",
+        lambda _patch_id: False,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert result["status"] == "merged"
+    legacy_resolver_id = legacy_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="abc123",
+    )
+    assert child_workflow_ids == [f"{legacy_resolver_id}:1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- widen Temporal execution workflow ID columns to handle long child workflow IDs already present in Temporal
- roll back the API database session after failed Temporal sync so fallback reads do not hit PendingRollbackError
- shorten future merge resolver child workflow IDs with a bounded hash-backed format while keeping full identity in payload/search metadata

## Root Cause

Resolver child workflow IDs included the full parent workflow ID plus PR/head SHA data. Existing projection tables capped workflow IDs at 64 characters, so task-detail sync failed with StringDataRightTruncationError, then the poisoned SQLAlchemy session caused a fallback read to fail with PendingRollbackError.

## Validation

- ./tools/test_unit.sh --python-only tests/unit/workflows/temporal/test_merge_gate_workflow.py::test_deterministic_resolver_idempotency_key_is_revision_scoped tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py::test_merge_automation_reenters_gate_after_resolver_remediation tests/unit/api/routers/test_executions.py::test_describe_execution_rolls_back_session_when_temporal_sync_commit_fails tests/unit/api_service/test_temporal_workflow_id_width.py
- git diff --check
- Applied the migration locally and confirmed the original long workflow detail endpoint now returns 200

## Notes

- Running the default test wrapper without --python-only also executed frontend tests and hit an unrelated existing Mission Control OAuth terminal test failure where the page stayed on Loading Mission Control while looking for Provider Login Terminal.
