### PR TITLE
MM-424 Align Mission Control visual token MoonSpec

### DIFF
--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,11 @@
 {
   "jira_issue_key": "MM-424",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1642"
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1642",
+  "code_review_transition": {
+    "previous_status": "In Progress",
+    "confirmed_status": "Code Review",
+    "transition_id": "51",
+    "transition_name": "Code Review",
+    "jira_comment_added": true
+  }
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "Use liquid-glass-studio to add a liquid glass blur and refraction to the panel that holds the github repo, branch, publish mode, and create task buttons at the bottom of the create page",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1593"
+  "jira_issue_key": "MM-424",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1642"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,27 +1,17 @@
 [
   {
-    "id": 3115399905,
-    "disposition": "addressed",
-    "rationale": "Secret validation now checks only fields submitted by the active source mode."
-  },
-  {
-    "id": 4145431398,
+    "id": 4145803972,
     "disposition": "not-applicable",
-    "rationale": "Review summary; its single actionable point is tracked by review comments 3115399905 and 3115404834."
+    "rationale": "Top-level review summary only; no separate requested code or documentation change beyond the inline comments."
   },
   {
-    "id": 3115404834,
+    "id": 3115693329,
     "disposition": "addressed",
-    "rationale": "Registry submissions now ignore stale inactive inline YAML while preserving validation for active registry input."
+    "rationale": "Updated T004 to include floating bar coverage plus FR-005 and DESIGN-REQ-027 traceability."
   },
   {
-    "id": 3115404837,
+    "id": 3115693346,
     "disposition": "addressed",
-    "rationale": "Max Docs validation now rejects non-safe or non-finite numeric conversions before request payload construction."
-  },
-  {
-    "id": 4145436869,
-    "disposition": "not-applicable",
-    "rationale": "Automated review wrapper with no separate actionable feedback beyond the inline comments already addressed."
+    "rationale": "Updated T012 to reflect that the completed MM-424 work was committed and a pull request was created."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md
@@ -2,14 +2,40 @@
 
 Jira Orchestrate for MM-424.
 
-Source story: STORY-001.  
-Source summary: Establish Mission Control visual tokens and atmosphere.  
-Source Jira issue: unknown.  
-Original brief reference: not provided.
+Trusted Jira issue: MM-424.
+Source document: `docs/UI/MissionControlDesignSystem.md`.
+Source title: Mission Control Design System.
+Source sections: 1. Purpose; 2. Product expression; 5. Color system and token contract; 6. Typography and iconography; 10.11 Background separators and horizon lines; 14. Summary.
 
 ## Canonical Brief
 
 Establish Mission Control visual tokens and atmosphere.
+
+As a Mission Control operator, I want the UI foundation to use the documented tokenized color, typography, atmosphere, and product-expression rules so every route feels coherent, readable, and unmistakably MoonMind.
+
+### Coverage IDs
+
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-027
+
+### Acceptance Criteria
+
+- All core `--mm-*` tokens from the design document are defined as RGB triplets for both light and dark modes.
+- Accent usage follows the documented semantic roles: purple/violet for identity, cyan for live/executing, amber/orange for warning, red/rose for failure/destructive, and green/teal for create/commit/complete.
+- Mission Control backgrounds use restrained layered atmosphere and remain content-dominant in light and dark themes.
+- IBM Plex Sans is the default UI typeface and IBM Plex Mono or tabular numerics are used for IDs, timestamps, runtime values, logs, versions, counts, durations, and compact telemetry.
+- The resulting style avoids novelty HUD framing and preserves professional operator readability.
+
+### Requirements
+
+- Implement token-first visual foundation.
+- Apply atmosphere and separator styling through reusable Mission Control CSS.
+- Align typography and telemetry styling with the design system.
+- Keep spectacle subordinate to readability and hierarchy.
 
 ## Runtime Constraints
 

--- a/specs/212-mission-control-visual-tokens/checklists/requirements.md
+++ b/specs/212-mission-control-visual-tokens/checklists/requirements.md
@@ -6,7 +6,7 @@
 - [X] Requirements are testable.
 - [X] Success criteria are measurable.
 - [X] Scope is bounded to one independently testable story.
-- [X] MM-424 and the supplied source summary are preserved.
+- [X] MM-424 and the trusted Jira preset brief are preserved.
 
 ## Requirement Completeness
 

--- a/specs/212-mission-control-visual-tokens/plan.md
+++ b/specs/212-mission-control-visual-tokens/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Establish MM-424 by promoting Mission Control's atmospheric and glass styling into explicit reusable CSS tokens, then consume those tokens in the shared application background and chrome. Repo inspection shows `docs/UI/MissionControlDesignSystem.md` already defines the desired product expression and core token table, while `frontend/src/styles/mission-control.css` currently has core `--mm-*` tokens plus direct gradient and glass values. The implementation keeps the work scoped to the shared stylesheet and shared entry tests: add token names for atmosphere layers, glass surfaces, input wells, and elevation, wire body, masthead, panel, and floating rail styling to those tokens, then add focused CSS contract tests without changing route/runtime behavior.
+Establish MM-424 by promoting Mission Control's atmospheric and glass styling into explicit reusable CSS tokens, then consume those tokens in the shared application background and chrome. The trusted Jira preset brief points at `docs/UI/MissionControlDesignSystem.md` sections 1, 2, 5, 6, 10.11, and 14 as runtime source requirements for tokenized color, typography, atmosphere, and product expression. Repo inspection shows the design document already defines the desired product expression and core token table, while `frontend/src/styles/mission-control.css` had core `--mm-*` tokens plus direct gradient and glass values. The implementation keeps the work scoped to the shared stylesheet and shared entry tests: add token names for atmosphere layers, glass surfaces, input wells, and elevation, wire body, masthead, panel, and floating rail styling to those tokens, then add focused CSS contract tests without changing route/runtime behavior.
 
 ## Requirement Status
 
@@ -18,7 +18,7 @@ Establish MM-424 by promoting Mission Control's atmospheric and glass styling in
 | FR-005 | implemented_unverified | existing text and border semantic tokens remain in use | preserve text/border token usage and add contract coverage | unit UI |
 | FR-006 | implemented_unverified | planned surface is CSS-only | rerun shared app-shell tests to prove behavior unchanged | unit UI |
 | FR-007 | missing | no MM-424-specific tests | add CSS contract tests in `mission-control.test.tsx` | unit UI |
-| FR-008 | implemented_unverified | `spec.md` preserves MM-424 and the supplied brief | preserve through tasks, verification, commit, and final report | final verify |
+| FR-008 | implemented_unverified | `spec.md` preserves MM-424 and the trusted Jira preset brief | preserve through tasks, verification, commit, and final report | final verify |
 
 ## Technical Context
 

--- a/specs/212-mission-control-visual-tokens/plan.md
+++ b/specs/212-mission-control-visual-tokens/plan.md
@@ -11,14 +11,14 @@ Establish MM-424 by promoting Mission Control's atmospheric and glass styling in
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | core tokens exist in `mission-control.css`; atmosphere/glass tokens are implicit | add explicit atmosphere, glass, input, and elevation tokens | unit UI |
-| FR-002 | partial | `.dark` overrides core tokens only | add matching dark overrides for new token names | unit UI |
-| FR-003 | partial | body has layered gradients with direct semantic-token alpha usage | route body gradient through atmosphere layer tokens | unit UI |
-| FR-004 | partial | masthead/panel/floating bar use a mix of semantic tokens and one-off alpha values | consume shared surface/elevation tokens for chrome posture | unit UI |
-| FR-005 | implemented_unverified | existing text and border semantic tokens remain in use | preserve text/border token usage and add contract coverage | unit UI |
-| FR-006 | implemented_unverified | planned surface is CSS-only | rerun shared app-shell tests to prove behavior unchanged | unit UI |
-| FR-007 | missing | no MM-424-specific tests | add CSS contract tests in `mission-control.test.tsx` | unit UI |
-| FR-008 | implemented_unverified | `spec.md` preserves MM-424 and the trusted Jira preset brief | preserve through tasks, verification, commit, and final report | final verify |
+| FR-001 | implemented_verified | `mission-control.css` defines `--mm-atmosphere-*`, `--mm-glass-*`, `--mm-input-well`, and `--mm-elevation-*`; `verification.md` records passing contract tests | no new implementation | final verify |
+| FR-002 | implemented_verified | `:root` and `.dark` define the same new visual token names with theme-specific values | no new implementation | final verify |
+| FR-003 | implemented_verified | `body` and `.dark body` consume the atmosphere token stack | no new implementation | final verify |
+| FR-004 | implemented_verified | `.masthead::before`, `.panel`, and the Create page floating rail consume shared glass/elevation tokens | no new implementation | final verify |
+| FR-005 | implemented_verified | semantic text, muted, border, and status token usage remains authoritative; verification records no task/runtime behavior change | no new implementation | final verify |
+| FR-006 | implemented_verified | shared app-shell rendering tests pass for route loading, alerts, constrained/data-wide shells, and unknown pages | no new implementation | final verify |
+| FR-007 | implemented_verified | `mission-control.test.tsx` covers token definitions and token consumption; targeted Vitest rerun passed with 14 tests | no new implementation | final verify |
+| FR-008 | implemented_verified | `spec.md`, `verification.md`, and `docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md` preserve MM-424 and the trusted Jira preset brief | no new implementation | final verify |
 
 ## Technical Context
 

--- a/specs/212-mission-control-visual-tokens/research.md
+++ b/specs/212-mission-control-visual-tokens/research.md
@@ -4,7 +4,7 @@
 
 Decision: Implement token and atmosphere changes in `frontend/src/styles/mission-control.css`, not as docs-only work.
 
-Rationale: The trusted Jira preset brief asks to establish visual tokens and atmosphere from `docs/UI/MissionControlDesignSystem.md`. The design document already describes the desired-state design direction, while the runtime stylesheet still embeds several atmospheric and glass values directly. A CSS token contract makes the design system operational.
+Rationale: The trusted Jira preset brief asks to establish visual tokens and atmosphere from `docs/UI/MissionControlDesignSystem.md`. The design document already describes the desired-state design direction. Before MM-424, the runtime stylesheet embedded several atmospheric and glass values directly; a CSS token contract makes the design system operational.
 
 Alternatives considered: Updating only canonical docs was rejected because the design-system doc is already present and the story needs runtime evidence. Adding a new token build system was rejected because CSS custom properties already exist and are sufficient.
 
@@ -12,7 +12,7 @@ Alternatives considered: Updating only canonical docs was rejected because the d
 
 Decision: Add named `--mm-atmosphere-*`, `--mm-glass-*`, `--mm-input-*`, and `--mm-elevation-*` tokens in both `:root` and `.dark`.
 
-Rationale: Current core tokens (`--mm-bg`, `--mm-panel`, `--mm-ink`, and status colors) are stable, but the body gradient and glass shells encode alpha/elevation choices inline. Named tokens let surfaces consume the same visual language while preserving flexible alpha composition.
+Rationale: Core tokens (`--mm-bg`, `--mm-panel`, `--mm-ink`, and status colors) are stable. Before MM-424, the body gradient and glass shells encoded alpha/elevation choices inline. Named tokens let surfaces consume the same visual language while preserving flexible alpha composition.
 
 Alternatives considered: Creating route-specific variables was rejected because MM-424 is a shared Mission Control foundation story. Replacing core semantic tokens was rejected because existing components already depend on them.
 

--- a/specs/212-mission-control-visual-tokens/research.md
+++ b/specs/212-mission-control-visual-tokens/research.md
@@ -4,7 +4,7 @@
 
 Decision: Implement token and atmosphere changes in `frontend/src/styles/mission-control.css`, not as docs-only work.
 
-Rationale: The supplied brief asks to establish visual tokens and atmosphere. `docs/UI/MissionControlDesignSystem.md` already describes the desired-state design direction, while the runtime stylesheet still embeds several atmospheric and glass values directly. A CSS token contract makes the design system operational.
+Rationale: The trusted Jira preset brief asks to establish visual tokens and atmosphere from `docs/UI/MissionControlDesignSystem.md`. The design document already describes the desired-state design direction, while the runtime stylesheet still embeds several atmospheric and glass values directly. A CSS token contract makes the design system operational.
 
 Alternatives considered: Updating only canonical docs was rejected because the design-system doc is already present and the story needs runtime evidence. Adding a new token build system was rejected because CSS custom properties already exist and are sufficient.
 

--- a/specs/212-mission-control-visual-tokens/spec.md
+++ b/specs/212-mission-control-visual-tokens/spec.md
@@ -3,13 +3,31 @@
 **Feature Branch**: `run-jira-orchestrate-for-mm-424-establis-342df6cf`  
 **Created**: 2026-04-20  
 **Status**: Draft  
-**Input**: Jira Orchestrate for MM-424. Source story: STORY-001. Source summary: "Establish Mission Control visual tokens and atmosphere." Source Jira issue: unknown. Original brief reference: not provided.
+**Input**: Trusted Jira preset brief for MM-424. Summary: "Establish Mission Control visual tokens and atmosphere." Source document: `docs/UI/MissionControlDesignSystem.md` sections 1, 2, 5, 6, 10.11, and 14. Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027.
 
 ## Original Jira Preset Brief
 
 Jira issue: MM-424
 
-Source story: STORY-001. Source summary: Establish Mission Control visual tokens and atmosphere. Source Jira issue: unknown. Original brief reference: not provided.
+Source document: `docs/UI/MissionControlDesignSystem.md`
+Source title: Mission Control Design System
+Source sections:
+- 1. Purpose
+- 2. Product expression
+- 5. Color system and token contract
+- 6. Typography and iconography
+- 10.11 Background separators and horizon lines
+- 14. Summary
+
+Coverage IDs:
+- DESIGN-REQ-001
+- DESIGN-REQ-002
+- DESIGN-REQ-009
+- DESIGN-REQ-010
+- DESIGN-REQ-011
+- DESIGN-REQ-027
+
+As a Mission Control operator, I want the UI foundation to use the documented tokenized color, typography, atmosphere, and product-expression rules so every route feels coherent, readable, and unmistakably MoonMind.
 
 Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve this Jira issue reference in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
 
@@ -45,7 +63,7 @@ Single-story runtime feature request. The brief contains one independently testa
 - "Mission Control visual tokens and atmosphere" refers to the shared browser UI styling layer and desired-state design-system contract.
 - Existing Create page liquid glass work remains separate; this story establishes the reusable foundation that elevated effects consume.
 - No backend persistence or API contract change is required.
-- The trusted Jira issue fetch is unavailable in this local managed runtime, so the supplied MM-424 task text is preserved as the canonical brief.
+- The trusted Jira issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`; the canonical brief is synthesized from the trusted MM-424 issue key, summary, description, acceptance criteria, coverage IDs, and implementation notes.
 
 ## Requirements *(mandatory)*
 
@@ -56,7 +74,7 @@ Single-story runtime feature request. The brief contains one independently testa
 - **FR-005**: The token contract MUST preserve readability by keeping primary text, muted text, borders, and focusable surfaces based on existing semantic tokens.
 - **FR-006**: The implementation MUST NOT change Mission Control route selection, task creation payloads, data fetching, or runtime behavior.
 - **FR-007**: Automated verification MUST cover the token contract, body atmosphere usage, shared chrome token usage, and unchanged app-shell behavior.
-- **FR-008**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-424 and the original supplied brief.
+- **FR-008**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-424 and the trusted Jira preset brief.
 
 ## Key Entities
 
@@ -70,4 +88,4 @@ Single-story runtime feature request. The brief contains one independently testa
 - **SC-002**: CSS verification confirms the body background consumes the named atmosphere tokens and preserves a violet, cyan, and warm layered atmosphere.
 - **SC-003**: CSS verification confirms shared masthead and panel chrome consume shared surface/elevation tokens.
 - **SC-004**: Existing shared Mission Control app-shell tests continue to pass.
-- **SC-005**: Traceability verification confirms MM-424 and the supplied source summary are preserved in MoonSpec artifacts and final evidence.
+- **SC-005**: Traceability verification confirms MM-424 and the trusted Jira preset brief are preserved in MoonSpec artifacts and final evidence.

--- a/specs/212-mission-control-visual-tokens/tasks.md
+++ b/specs/212-mission-control-visual-tokens/tasks.md
@@ -23,7 +23,7 @@ Integration-style app-shell rendering coverage stays in `frontend/src/entrypoint
 ## Phase 2: Red-First Tests
 
 - [X] T003 Add red-first unit CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` for shared atmosphere/glass/elevation tokens in `:root` and `.dark`. (FR-001, FR-002, SC-001, DESIGN-REQ-001, DESIGN-REQ-009)
-- [X] T004 Add red-first integration-style app-shell/CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` proving `body`, `.dark body`, `.masthead::before`, and `.panel` consume the shared tokens while existing shell behavior remains covered. (FR-003, FR-004, FR-006, SC-002, SC-003, SC-004, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011)
+- [X] T004 Add red-first integration-style app-shell/CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` proving body, .dark body, .masthead::before, .panel, and the floating bar consume the shared tokens while existing shell behavior remains covered. (FR-003, FR-004, FR-005, FR-006, SC-002, SC-003, SC-004, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027)
 - [X] T005 Run the focused Mission Control test and confirm the new contract tests fail before production CSS changes. (FR-007)
 
 ## Phase 3: Implementation
@@ -37,7 +37,7 @@ Integration-style app-shell rendering coverage stays in `frontend/src/entrypoint
 - [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/mission-control.test.tsx` or document the exact blocker. (FR-007)
 - [X] T010 Run traceability validation for MM-424, trusted Jira preset brief preservation, and DESIGN-REQ coverage across `specs/212-mission-control-visual-tokens/` and `docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md`. (FR-008, SC-005)
 - [X] T011 Run final `/moonspec-verify` work and write `specs/212-mission-control-visual-tokens/verification.md` with coverage, commands, and verdict. (FR-001 through FR-008, SC-001 through SC-005)
-- [X] T012 Commit the completed MM-424 work without pushing or creating a pull request.
+- [X] T012 Commit the completed MM-424 work and create the pull request.
 
 ## Dependencies And Order
 

--- a/specs/212-mission-control-visual-tokens/tasks.md
+++ b/specs/212-mission-control-visual-tokens/tasks.md
@@ -7,7 +7,7 @@
 ## Phase 1: Setup
 
 - [X] T001 Review `.specify/memory/constitution.md`, `README.md`, Jira Orchestrate preset behavior, and relevant Mission Control design docs.
-- [X] T002 Create MM-424 MoonSpec artifacts under `specs/212-mission-control-visual-tokens/` and preserve the supplied Jira brief under `docs/tmp/jira-orchestration-inputs/`.
+- [X] T002 Create MM-424 MoonSpec artifacts under `specs/212-mission-control-visual-tokens/` and preserve the trusted Jira preset brief under `docs/tmp/jira-orchestration-inputs/`.
 
 ## Phase 2: Tests First
 
@@ -25,4 +25,4 @@
 - [X] T008 Attempt `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`, then run the direct Vitest equivalent after the npm script cannot resolve `vitest` in this container. (FR-006, FR-007)
 - [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/mission-control.test.tsx` or document the exact blocker. (FR-007)
 - [X] T010 Write `specs/212-mission-control-visual-tokens/verification.md` with coverage, commands, and verdict. (FR-008, SC-005)
-- [ ] T011 Commit the completed MM-424 work without pushing or creating a pull request.
+- [X] T011 Commit the completed MM-424 work without pushing or creating a pull request.

--- a/specs/212-mission-control-visual-tokens/tasks.md
+++ b/specs/212-mission-control-visual-tokens/tasks.md
@@ -3,26 +3,45 @@
 **Input**: Design artifacts from `specs/212-mission-control-visual-tokens/`
 **Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/visual-token-contract.md`, `quickstart.md`
 **Tests**: Add focused UI/CSS contract tests before production CSS changes. Confirm they fail for the intended missing-token reason, then implement CSS until they pass.
+**Story**: One story only, "Visual Tokens and Atmosphere" from trusted Jira issue MM-424.
+**Independent Test**: Inspect `frontend/src/styles/mission-control.css` and render the shared Mission Control app shell. The story passes when the token contract exists in light and dark themes, body atmosphere uses tokenized violet/cyan/warm layers, shared chrome consumes glass/elevation tokens, and route behavior remains unchanged.
+**Traceability IDs**: FR-001 through FR-008, SC-001 through SC-005, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-009, DESIGN-REQ-010, DESIGN-REQ-011, DESIGN-REQ-027, MM-424.
+
+## Unit Test Plan
+
+Focused unit-style CSS contract assertions live in `frontend/src/entrypoints/mission-control.test.tsx`. They validate token definitions in `:root` and `.dark`, body atmosphere usage, and shared chrome token consumption.
+
+## Integration Test Plan
+
+Integration-style app-shell rendering coverage stays in `frontend/src/entrypoints/mission-control.test.tsx`. It verifies shared Mission Control route loading, dashboard alerts, shell width behavior, and unknown-page behavior while the token contract is active. No compose-backed integration suite is required for this CSS-only design-system story.
 
 ## Phase 1: Setup
 
 - [X] T001 Review `.specify/memory/constitution.md`, `README.md`, Jira Orchestrate preset behavior, and relevant Mission Control design docs.
 - [X] T002 Create MM-424 MoonSpec artifacts under `specs/212-mission-control-visual-tokens/` and preserve the trusted Jira preset brief under `docs/tmp/jira-orchestration-inputs/`.
 
-## Phase 2: Tests First
+## Phase 2: Red-First Tests
 
-- [X] T003 Add CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` for shared atmosphere/glass/elevation tokens in `:root` and `.dark`. (FR-001, FR-002, SC-001)
-- [X] T004 Add CSS contract tests proving `body`, `.dark body`, `.masthead::before`, and `.panel` consume the shared tokens. (FR-003, FR-004, SC-002, SC-003)
+- [X] T003 Add red-first unit CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` for shared atmosphere/glass/elevation tokens in `:root` and `.dark`. (FR-001, FR-002, SC-001, DESIGN-REQ-001, DESIGN-REQ-009)
+- [X] T004 Add red-first integration-style app-shell/CSS contract tests in `frontend/src/entrypoints/mission-control.test.tsx` proving `body`, `.dark body`, `.masthead::before`, and `.panel` consume the shared tokens while existing shell behavior remains covered. (FR-003, FR-004, FR-006, SC-002, SC-003, SC-004, DESIGN-REQ-002, DESIGN-REQ-010, DESIGN-REQ-011)
 - [X] T005 Run the focused Mission Control test and confirm the new contract tests fail before production CSS changes. (FR-007)
 
 ## Phase 3: Implementation
 
-- [X] T006 Add light and dark atmosphere/glass/input/elevation token definitions to `frontend/src/styles/mission-control.css`. (FR-001, FR-002)
-- [X] T007 Update body, dark body, masthead, panel, and floating bar styling to consume the new tokens while preserving existing layout and readable semantic text tokens. (FR-003, FR-004, FR-005)
+- [X] T006 Add light and dark atmosphere/glass/input/elevation token definitions to `frontend/src/styles/mission-control.css`. (FR-001, FR-002, SC-001)
+- [X] T007 Update body, dark body, masthead, panel, and floating bar styling in `frontend/src/styles/mission-control.css` to consume the new tokens while preserving existing layout and readable semantic text tokens. (FR-003, FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-027)
 
-## Phase 4: Verification
+## Phase 4: Story Validation And Final Verify
 
-- [X] T008 Attempt `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`, then run the direct Vitest equivalent after the npm script cannot resolve `vitest` in this container. (FR-006, FR-007)
+- [X] T008 Run story validation with `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`, then run the direct Vitest equivalent after the npm script cannot resolve `vitest` in this container. (FR-006, FR-007, SC-004)
 - [X] T009 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/mission-control.test.tsx` or document the exact blocker. (FR-007)
-- [X] T010 Write `specs/212-mission-control-visual-tokens/verification.md` with coverage, commands, and verdict. (FR-008, SC-005)
-- [X] T011 Commit the completed MM-424 work without pushing or creating a pull request.
+- [X] T010 Run traceability validation for MM-424, trusted Jira preset brief preservation, and DESIGN-REQ coverage across `specs/212-mission-control-visual-tokens/` and `docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md`. (FR-008, SC-005)
+- [X] T011 Run final `/moonspec-verify` work and write `specs/212-mission-control-visual-tokens/verification.md` with coverage, commands, and verdict. (FR-001 through FR-008, SC-001 through SC-005)
+- [X] T012 Commit the completed MM-424 work without pushing or creating a pull request.
+
+## Dependencies And Order
+
+- T001-T002 must complete before any test or implementation task.
+- T003-T005 must complete before T006-T007.
+- T006-T007 must complete before T008-T011.
+- T012 runs last after final verification evidence is recorded.

--- a/specs/212-mission-control-visual-tokens/verification.md
+++ b/specs/212-mission-control-visual-tokens/verification.md
@@ -15,13 +15,15 @@
 | FR-005 | Existing semantic text, muted, border, and status tokens remain authoritative; no task/runtime behavior changed. | VERIFIED |
 | FR-006 | Shared app-shell rendering tests still pass for route loading, alerts, constrained/data-wide shells, and unknown pages. | VERIFIED |
 | FR-007 | New `mission-control.test.tsx` CSS contract tests cover token definitions and token consumption. | VERIFIED |
-| FR-008 | MM-424 and the supplied source summary are preserved in `spec.md`, this verification file, and the orchestration input artifact. | VERIFIED |
+| FR-008 | MM-424 and the trusted Jira preset brief are preserved in `spec.md`, this verification file, and the orchestration input artifact. | VERIFIED |
 
 ## Test Evidence
 
 - `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`: BLOCKED in this container because the npm script shell could not resolve `vitest` even after `npm ci`; direct local binary invocation was used for the same test command.
 - `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx`: PASS, 9 tests.
 - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/mission-control.test.tsx`: PASS, 3635 Python tests, 1 xpassed, 16 subtests, and 9 targeted Mission Control UI tests.
+- 2026-04-21 source alignment rerun: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx`: PASS, 14 tests.
+- 2026-04-21 traceability rerun: `rg -n "MM-424|DESIGN-REQ-001|DESIGN-REQ-002|DESIGN-REQ-009|DESIGN-REQ-010|DESIGN-REQ-011|DESIGN-REQ-027|trusted Jira preset brief|docs/UI/MissionControlDesignSystem.md" specs/212-mission-control-visual-tokens docs/tmp/jira-orchestration-inputs/MM-424-moonspec-orchestration-input.md`: PASS.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Preserve the trusted Jira MM-424 preset brief in MoonSpec artifacts.
- Clarify MM-424 task coverage for red-first unit tests, integration-style app-shell tests, story validation, and final /moonspec-verify work.
- Align plan and research artifacts with the verified implementation state.
- Record the confirmed PR URL in artifacts/jira-orchestrate-pr.json.

## Jira Issue
- MM-424

## Active MoonSpec Feature Path
- specs/212-mission-control-visual-tokens

## Verification Verdict
- FULLY_IMPLEMENTED

## Tests Run
- ./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx: PASS, 14 tests
- Traceability search for MM-424, trusted Jira preset brief, and DESIGN-REQ coverage: PASS
- Secret-pattern scan over the MM-424 diff and handoff artifact: PASS

## Remaining Risks
- None identified for the scoped MM-424 story.
