### PR TITLE
MM-421 Show recent manifest runs below the run form

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/216-run-manifest-page-form"
+  "feature_directory": "specs/217-show-recent-manifest-runs"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "Use liquid-glass-studio to add a liquid glass blur and refraction to the panel that holds the github repo, branch, publish mode, and create task buttons at the bottom of the create page",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1593"
+  "jira_issue_key": "MM-421",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1644"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,22 @@
 [
   {
-    "id": 3115467916,
+    "id": 3115891581,
     "disposition": "addressed",
-    "rationale": "Replaced the raw mission-control.css regex assertions with rendered DOM getComputedStyle assertions for the shell panel, control grid, data slab, and table wrapper."
+    "rationale": "Changed status capitalization to use charAt(0), which is safe for empty strings."
   },
   {
-    "id": 4145523992,
+    "id": 4146021949,
+    "disposition": "not-applicable",
+    "rationale": "Non-actionable bot review summary; the referenced status formatting concern is covered by comment 3115891581."
+  },
+  {
+    "id": 3118644455,
     "disposition": "addressed",
-    "rationale": "Addressed the review summary by removing the brittle CSS source-file test and verifying the applied task list layout styles through rendered output."
+    "rationale": "Added phase to the manifest run schema and stage derivation, with test coverage for /api/executions phase payloads."
+  },
+  {
+    "id": 4149013747,
+    "disposition": "not-applicable",
+    "rationale": "Non-actionable automated review body; actionable Codex feedback is covered by comment 3118644455."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-421-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-421-moonspec-orchestration-input.md
@@ -1,0 +1,73 @@
+# MM-421 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-421
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Show recent manifest runs below the run form
+- Labels: moonmind-workflow-mm-f78d0769-fb1e-4712-a140-47c34e83cc3f
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-421 from MM project
+Summary: Show recent manifest runs below the run form
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-421 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-421: Show recent manifest runs below the run form
+
+Source Reference
+- Source Document: docs/UI/ManifestsPage.md
+- Source Title: Manifests Page
+- Source Sections:
+  - Recent Runs section
+  - Data source
+  - Table purpose
+  - Recommended columns
+  - Manifest-specific status detail
+  - Filters
+  - Empty state
+  - Responsive behavior
+  - Accessibility
+- Coverage IDs:
+  - DESIGN-REQ-002
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-017
+
+User Story
+As a dashboard user, I want recent manifest runs visible below the Run Manifest card so I can immediately check start state, current stage, result, timing, and details for manifest executions.
+
+Acceptance Criteria
+- Given /tasks/manifests loads, then Recent Runs requests /api/executions?entry=manifest&limit=200.
+- Given manifest runs exist, then the history surface shows run ID/details link, manifest label, action, status, current stage when available, started time, duration when available, and supported row actions.
+- Given a run is active and stage data is available, then the status display includes manifest-specific stage detail such as Running · fetch.
+- Given status, manifest name, or free-text filters are used, then the visible run list updates without a heavy filter-builder flow.
+- Given no manifest runs exist, then the empty state says no manifest runs exist and points users to run a registry manifest or submit inline YAML above.
+- Given the viewport is narrow, then recent runs remain readable as compact cards or stacked rows with clear action labels.
+- Given row actions are icon-based in implementation, then they include accessible names.
+
+Requirements
+- Recent Runs must appear below the Run Manifest card on the same page.
+- The history request must use the existing manifest execution endpoint for phase 1.
+- The history view must help answer whether the run started, whether it is still running, what stage it is in, whether it succeeded or failed, and how to open details/logs.
+- Filters must remain lightweight and bounded to status, manifest name, search, and optional action support.
+- The implementation must not require a backend redesign or new manifest-centric history API for phase 1.
+
+Implementation Notes
+- This story is about showing recent manifest execution history below the existing Run Manifest card, not replacing the existing manifest execution contract.
+- Use the existing manifest execution endpoint for the initial history request: /api/executions?entry=manifest&limit=200.
+- The UI should make recent runs scannable by exposing run identity/details, manifest label, action, status, current stage, timing, and available row actions.
+- Active runs should show manifest-specific stage detail when stage data exists.
+- Filters should remain lightweight and focused on status, manifest name, search, and optional action support.
+- Preserve MM-421 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.

--- a/frontend/src/entrypoints/manifests.test.tsx
+++ b/frontend/src/entrypoints/manifests.test.tsx
@@ -42,7 +42,7 @@ describe('Manifests Entrypoint', () => {
                 manifestName: 'registry-refresh',
                 action: 'plan',
                 status: 'running',
-                currentStage: 'fetch',
+                phase: 'fetch',
                 startedAt: '2026-04-21T12:05:00Z',
                 detailHref: '/tasks/mm:running-manifest?source=temporal',
               },

--- a/frontend/src/entrypoints/manifests.test.tsx
+++ b/frontend/src/entrypoints/manifests.test.tsx
@@ -26,7 +26,25 @@ describe('Manifests Entrypoint', () => {
                 taskId: 'mm:existing-manifest',
                 source: 'temporal',
                 sourceLabel: 'Temporal',
+                title: 'Nightly Docs Manifest',
+                manifestName: 'nightly-docs',
+                action: 'run',
                 status: 'completed',
+                startedAt: '2026-04-21T12:00:00Z',
+                durationSeconds: 42,
+                detailHref: '/tasks/mm:existing-manifest?source=temporal',
+              },
+              {
+                taskId: 'mm:running-manifest',
+                source: 'temporal',
+                sourceLabel: 'Temporal',
+                title: 'Registry Refresh',
+                manifestName: 'registry-refresh',
+                action: 'plan',
+                status: 'running',
+                currentStage: 'fetch',
+                startedAt: '2026-04-21T12:05:00Z',
+                detailHref: '/tasks/mm:running-manifest?source=temporal',
               },
             ],
           }),
@@ -75,6 +93,54 @@ describe('Manifests Entrypoint', () => {
     await waitFor(() => {
       expect(screen.getByText('mm:existing-manifest')).toBeTruthy();
     });
+  });
+
+  it('shows manifest run details, stage-aware status, timing, and accessible row actions', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Open run mm:existing-manifest' })).toBeTruthy();
+      expect(screen.getByRole('link', { name: 'View details for mm:running-manifest' })).toBeTruthy();
+    });
+
+    expect(screen.getByText('nightly-docs')).toBeTruthy();
+    expect(screen.getByText('registry-refresh')).toBeTruthy();
+    expect(screen.getAllByText('run').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('plan').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Running · fetch')).toBeTruthy();
+    expect(screen.getByText('42s')).toBeTruthy();
+  });
+
+  it('filters recent manifest runs by status, manifest name, and free-text search', async () => {
+    renderWithClient(<ManifestsPage payload={mockPayload} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('nightly-docs')).toBeTruthy();
+      expect(screen.getByText('registry-refresh')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'running' },
+    });
+    expect(screen.queryByText('nightly-docs')).toBeNull();
+    expect(screen.getByText('registry-refresh')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Filter by status'), {
+      target: { value: 'all' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter by manifest'), {
+      target: { value: 'nightly' },
+    });
+    expect(screen.getByText('nightly-docs')).toBeTruthy();
+    expect(screen.queryByText('registry-refresh')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Filter by manifest'), {
+      target: { value: '' },
+    });
+    fireEvent.change(screen.getByLabelText('Search recent runs'), {
+      target: { value: 'missing-run' },
+    });
+    expect(screen.getByText('No manifest runs exist yet. Run a registry manifest or submit inline YAML above.')).toBeTruthy();
   });
 
   it('upserts inline manifests through the supported manifest API and refreshes recent runs in place', async () => {

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -18,6 +18,7 @@ const ManifestRunSchema = z
     temporalStatus: z.string().nullable().optional(),
     currentStage: z.string().nullable().optional(),
     manifestStage: z.string().nullable().optional(),
+    phase: z.string().nullable().optional(),
     stage: z.string().nullable().optional(),
     startedAt: z.string().nullable().optional(),
     createdAt: z.string().nullable().optional(),
@@ -66,7 +67,7 @@ function runAction(run: ManifestRun): string {
 }
 
 function runStage(run: ManifestRun): string {
-  return String(run.currentStage || run.manifestStage || run.stage || '').trim();
+  return String(run.currentStage || run.manifestStage || run.phase || run.stage || '').trim();
 }
 
 function statusLabel(run: ManifestRun): string {
@@ -76,7 +77,7 @@ function statusLabel(run: ManifestRun): string {
     return status;
   }
   const activeStatuses = new Set(['running', 'executing', 'in progress', 'processing']);
-  return activeStatuses.has(status.toLowerCase()) ? `${status[0].toUpperCase()}${status.slice(1)} · ${stage}` : status;
+  return activeStatuses.has(status.toLowerCase()) ? `${status.charAt(0).toUpperCase()}${status.slice(1)} · ${stage}` : status;
 }
 
 function detailHref(run: ManifestRun): string {

--- a/frontend/src/entrypoints/manifests.tsx
+++ b/frontend/src/entrypoints/manifests.tsx
@@ -2,14 +2,30 @@ import { DataTable } from '../components/tables/DataTable';
 import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import { BootPayload } from '../boot/parseBootPayload';
-import { useState, type FormEvent } from 'react';
+import { useMemo, useState, type FormEvent } from 'react';
 
-const ManifestRunSchema = z.object({
-  taskId: z.string(),
-  source: z.string(),
-  sourceLabel: z.string().optional(),
-  status: z.string(),
-});
+const ManifestRunSchema = z
+  .object({
+    taskId: z.string(),
+    source: z.string(),
+    sourceLabel: z.string().optional(),
+    title: z.string().nullable().optional(),
+    manifestName: z.string().nullable().optional(),
+    action: z.string().nullable().optional(),
+    status: z.string(),
+    state: z.string().nullable().optional(),
+    rawState: z.string().nullable().optional(),
+    temporalStatus: z.string().nullable().optional(),
+    currentStage: z.string().nullable().optional(),
+    manifestStage: z.string().nullable().optional(),
+    stage: z.string().nullable().optional(),
+    startedAt: z.string().nullable().optional(),
+    createdAt: z.string().nullable().optional(),
+    durationSeconds: z.number().nullable().optional(),
+    detailHref: z.string().nullable().optional(),
+    link: z.string().nullable().optional(),
+  })
+  .passthrough();
 type ManifestRun = z.infer<typeof ManifestRunSchema>;
 type SourceKind = 'inline' | 'registry';
 type Notice = {
@@ -36,6 +52,70 @@ function hasRawSecretLikeValue(values: string[]): boolean {
   return values.some((value) => RAW_SECRET_PATTERNS.some((pattern) => pattern.test(value)));
 }
 
+function displayValue(value: string | null | undefined): string {
+  const normalized = String(value || '').trim();
+  return normalized || '-';
+}
+
+function manifestLabel(run: ManifestRun): string {
+  return displayValue(run.manifestName || run.sourceLabel || run.title || run.source || run.taskId);
+}
+
+function runAction(run: ManifestRun): string {
+  return displayValue(run.action);
+}
+
+function runStage(run: ManifestRun): string {
+  return String(run.currentStage || run.manifestStage || run.stage || '').trim();
+}
+
+function statusLabel(run: ManifestRun): string {
+  const status = displayValue(run.status || run.rawState || run.state || run.temporalStatus);
+  const stage = runStage(run);
+  if (!stage) {
+    return status;
+  }
+  const activeStatuses = new Set(['running', 'executing', 'in progress', 'processing']);
+  return activeStatuses.has(status.toLowerCase()) ? `${status[0].toUpperCase()}${status.slice(1)} · ${stage}` : status;
+}
+
+function detailHref(run: ManifestRun): string {
+  const direct = String(run.detailHref || run.link || '').trim();
+  return direct || `/tasks/${encodeURIComponent(run.taskId)}?source=temporal`;
+}
+
+function formatWhen(value: string | null | undefined): string {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return '-';
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return raw;
+  }
+  return date.toLocaleString();
+}
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) {
+    return '-';
+  }
+  if (seconds < 60) {
+    return `${Math.round(seconds)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.round(seconds % 60);
+  return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+}
+
+function matchesText(haystack: string[], needle: string): boolean {
+  const normalized = needle.trim().toLowerCase();
+  if (!normalized) {
+    return true;
+  }
+  return haystack.some((value) => value.toLowerCase().includes(normalized));
+}
+
 export function ManifestsPage({ payload }: { payload: BootPayload }) {
   const [manifestName, setManifestName] = useState('');
   const [action, setAction] = useState('run');
@@ -47,6 +127,9 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
   const [maxDocs, setMaxDocs] = useState('');
   const [notice, setNotice] = useState<Notice | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [manifestFilter, setManifestFilter] = useState('');
+  const [searchFilter, setSearchFilter] = useState('');
 
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['manifests'],
@@ -58,6 +141,27 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
       return ManifestsResponseSchema.parse(await response.json());
     },
   });
+
+  const runs = data?.items || [];
+  const statusOptions = useMemo(() => {
+    return Array.from(new Set(runs.map((run) => run.status).filter(Boolean))).sort((left, right) =>
+      left.localeCompare(right),
+    );
+  }, [runs]);
+  const filteredRuns = useMemo(() => {
+    return runs.filter((run) => {
+      if (statusFilter !== 'all' && run.status !== statusFilter) {
+        return false;
+      }
+      if (!matchesText([manifestLabel(run)], manifestFilter)) {
+        return false;
+      }
+      return matchesText(
+        [run.taskId, manifestLabel(run), runAction(run), statusLabel(run), runStage(run)],
+        searchFilter,
+      );
+    });
+  }, [manifestFilter, runs, searchFilter, statusFilter]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -303,16 +407,76 @@ export function ManifestsPage({ payload }: { payload: BootPayload }) {
         ) : isError ? (
           <div className="p-4 rounded-md bg-red-50 text-red-700 border border-red-200 mb-4">{(error as Error).message}</div>
         ) : (
-          <DataTable
-            data={data?.items || []}
-            columns={[
-              { key: 'taskId', header: 'Task ID' },
-              { key: 'sourceLabel', header: 'Source Label', render: (item: ManifestRun) => item.sourceLabel || item.source },
-              { key: 'status', header: 'Status' },
-            ]}
-            emptyMessage="No manifest runs found."
-            getRowKey={(item) => item.taskId}
-          />
+          <>
+            <div className="grid gap-4 md:grid-cols-3 mb-4">
+              <label>
+                Filter by status
+                <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+                  <option value="all">All statuses</option>
+                  {statusOptions.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Filter by manifest
+                <input
+                  value={manifestFilter}
+                  onChange={(event) => setManifestFilter(event.target.value)}
+                  placeholder="Manifest name"
+                />
+              </label>
+              <label>
+                Search recent runs
+                <input
+                  value={searchFilter}
+                  onChange={(event) => setSearchFilter(event.target.value)}
+                  placeholder="Run ID, action, status, or stage"
+                />
+              </label>
+            </div>
+            <DataTable
+              ariaLabel="Recent manifest runs"
+              data={filteredRuns}
+              columns={[
+                {
+                  key: 'taskId',
+                  header: 'Run ID',
+                  render: (item: ManifestRun) => (
+                    <a href={detailHref(item)} aria-label={`Open run ${item.taskId}`}>
+                      <code>{item.taskId}</code>
+                    </a>
+                  ),
+                },
+                { key: 'manifestName', header: 'Manifest', render: manifestLabel },
+                { key: 'action', header: 'Action', render: runAction },
+                { key: 'status', header: 'Status', render: statusLabel },
+                {
+                  key: 'startedAt',
+                  header: 'Started',
+                  render: (item: ManifestRun) => formatWhen(item.startedAt || item.createdAt),
+                },
+                {
+                  key: 'durationSeconds',
+                  header: 'Duration',
+                  render: (item: ManifestRun) => formatDuration(item.durationSeconds),
+                },
+                {
+                  key: 'actions',
+                  header: 'Actions',
+                  render: (item: ManifestRun) => (
+                    <a href={detailHref(item)} aria-label={`View details for ${item.taskId}`}>
+                      View details
+                    </a>
+                  ),
+                },
+              ]}
+              emptyMessage="No manifest runs exist yet. Run a registry manifest or submit inline YAML above."
+              getRowKey={(item) => item.taskId}
+            />
+          </>
         )}
       </div>
     </div>

--- a/specs/217-show-recent-manifest-runs/checklists/requirements.md
+++ b/specs/217-show-recent-manifest-runs/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Show Recent Manifest Runs
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- The endpoint path is included because it is an explicit source requirement from the Jira brief and design document.

--- a/specs/217-show-recent-manifest-runs/contracts/ui-contract.md
+++ b/specs/217-show-recent-manifest-runs/contracts/ui-contract.md
@@ -1,0 +1,61 @@
+# UI Contract: Show Recent Manifest Runs
+
+## Route
+
+- `GET /tasks/manifests`
+
+## Data Boundary
+
+The Manifests page must request recent manifest runs through:
+
+```text
+GET {apiBase}/executions?entry=manifest&limit=200
+```
+
+The frontend accepts the existing execution-list response shape:
+
+```json
+{
+  "items": [
+    {
+      "taskId": "mm:manifest-123",
+      "source": "temporal",
+      "sourceLabel": "Temporal",
+      "title": "Nightly docs",
+      "manifestName": "nightly-docs",
+      "action": "run",
+      "status": "running",
+      "currentStage": "fetch",
+      "startedAt": "2026-04-21T12:00:00Z",
+      "durationSeconds": 42,
+      "detailHref": "/tasks/mm:manifest-123?source=temporal"
+    }
+  ]
+}
+```
+
+Optional fields may be absent. The UI must render fallback values rather than failing parsing or hiding the row.
+
+## Required UI Surface
+
+- Run Manifest card appears before Recent Runs.
+- Recent Runs includes lightweight filters:
+  - Status
+  - Manifest
+  - Search
+- Recent Runs displays:
+  - Run ID/details link
+  - Manifest label
+  - Action
+  - Status with stage detail when available
+  - Started
+  - Duration
+  - View details action
+- Empty state text:
+  - `No manifest runs exist yet. Run a registry manifest or submit inline YAML above.`
+
+## Accessibility Contract
+
+- Filters have visible labels.
+- Run ID and View details links have accessible names that include the run ID.
+- Row action links remain keyboard reachable.

--- a/specs/217-show-recent-manifest-runs/data-model.md
+++ b/specs/217-show-recent-manifest-runs/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: Show Recent Manifest Runs
+
+## ManifestRunRow
+
+Represents one row returned by the existing execution history endpoint for `entry=manifest`.
+
+Fields:
+
+- `taskId` (required string): stable run/workflow identifier and row key.
+- `source` (required string): backend source label fallback.
+- `sourceLabel` (optional string): human-readable source fallback.
+- `title` (optional string): run title fallback for manifest label.
+- `manifestName` (optional string): registry or inline manifest label when present.
+- `action` (optional string): submitted manifest action, such as `run` or `plan`.
+- `status` (required string): current run status.
+- `state`, `rawState`, `temporalStatus` (optional strings): alternate status fields from execution history.
+- `currentStage`, `manifestStage`, `stage` (optional strings): current manifest stage when available.
+- `startedAt`, `createdAt` (optional strings): timestamp sources for started time.
+- `durationSeconds` (optional number): elapsed or total duration in seconds when available.
+- `detailHref`, `link` (optional strings): direct detail URL when returned by the API.
+
+Validation rules:
+
+- Missing optional display fields render as `-`.
+- Manifest label fallback order is `manifestName`, `sourceLabel`, `title`, `source`, `taskId`.
+- Detail link fallback is `/tasks/{taskId}?source=temporal`.
+- Stage detail is appended only when status is active and stage is non-empty.
+
+## RecentRunFilters
+
+Client-side filter state for the returned manifest rows.
+
+Fields:
+
+- `status` (string): `all` or exact status value.
+- `manifest` (string): case-insensitive substring match against manifest label.
+- `search` (string): case-insensitive substring match across run ID, manifest label, action, status, and stage.
+
+Validation rules:
+
+- Empty filter values do not remove rows.
+- Filtering is local to the already-fetched 200-row result set.

--- a/specs/217-show-recent-manifest-runs/plan.md
+++ b/specs/217-show-recent-manifest-runs/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: Show Recent Manifest Runs
+
+**Branch**: `217-show-recent-manifest-runs` | **Date**: 2026-04-21 | **Spec**: `specs/217-show-recent-manifest-runs/spec.md`
+**Input**: `specs/217-show-recent-manifest-runs/spec.md`
+
+## Summary
+
+MM-421 extends the existing unified Manifests page by making Recent Runs a useful manifest execution history surface below the Run Manifest form. Existing code already requests `/api/executions?entry=manifest&limit=200` and places Recent Runs below the form, but it only renders task ID, source label, and status. The implementation will add UI-only normalization, display columns, filters, fallback values, and accessible row actions in `frontend/src/entrypoints/manifests.tsx`, with Vitest/Testing Library coverage in `frontend/src/entrypoints/manifests.test.tsx`.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/manifests.tsx` renders Recent Runs after Run Manifest; existing test checks both headings | Preserve behavior | final validation |
+| FR-002 | implemented_verified | `frontend/src/entrypoints/manifests.tsx` fetches `/executions?entry=manifest&limit=200`; existing tests mock `/api/executions?entry=manifest&limit=200` | Preserve behavior | final validation |
+| FR-003 | partial | Current table lacks manifest/action/start/duration/detail action columns | Add row normalization and columns | frontend unit + runner-integrated UI |
+| FR-004 | missing | Current status column does not combine active status with stage | Add stage-aware status display | frontend unit + runner-integrated UI |
+| FR-005 | partial | Current Zod schema tolerates only limited fields; optional display fallbacks are not comprehensive | Add optional field parsing and fallback formatters | frontend unit |
+| FR-006 | missing | No status, manifest, or search filters exist | Add lightweight filters | frontend unit + runner-integrated UI |
+| FR-007 | partial | Current empty message says `No manifest runs found.` but does not point to the form above | Update empty state | frontend unit |
+| FR-008 | implemented_unverified | Existing DataTable supports table layout; no story-specific narrow viewport assertion | Keep table readable and avoid hiding identity/status/action | final validation |
+| FR-009 | partial | Existing form labels are accessible; Recent Runs filters do not exist yet and row action labels are absent | Add labeled filters and named actions | frontend unit + runner-integrated UI |
+| FR-010 | implemented_verified | `spec.md` and Jira input preserve MM-421 | Preserve in artifacts and final report | final verification |
+| DESIGN-REQ-001 | implemented_verified | Existing page order in `frontend/src/entrypoints/manifests.tsx` | Preserve behavior | final validation |
+| DESIGN-REQ-002 | implemented_verified | Existing query path | Preserve behavior | final validation |
+| DESIGN-REQ-003 | partial | Existing table cannot answer stage, action, timing, and details questions | Add history columns and detail action | frontend unit + runner-integrated UI |
+| DESIGN-REQ-004 | partial | Existing table lacks recommended columns | Add available columns and fallbacks | frontend unit + runner-integrated UI |
+| DESIGN-REQ-005 | missing | No stage-aware status detail | Add status-stage formatter | frontend unit |
+| DESIGN-REQ-006 | missing | No filters | Add status/manifest/search filters | frontend unit + runner-integrated UI |
+| DESIGN-REQ-007 | partial | Empty message lacks guidance | Update empty message | frontend unit |
+| DESIGN-REQ-008 | implemented_unverified | Existing table uses shared responsive styling; story does not require new custom layout | Preserve readable columns and action link | final validation |
+| DESIGN-REQ-009 | partial | New filters/actions need accessible labels | Add accessible labels/names | frontend unit + runner-integrated UI |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but no backend code is expected.
+**Primary Dependencies**: React, TanStack Query, Zod, existing `DataTable`, Vitest, Testing Library.
+**Storage**: No new persistent storage.
+**Unit Testing Tool**: Vitest through `frontend/vite.config.ts`.
+**Integration Testing Tool**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` runner-integrated UI test path.
+**Target Platform**: Mission Control browser UI.
+**Project Type**: Frontend entrypoint within existing FastAPI-served dashboard.
+**Performance Goals**: Filtering 200 returned rows happens locally without expensive UI constructs.
+**Constraints**: Use the existing `/api/executions?entry=manifest&limit=200` endpoint; do not redesign backend history APIs; preserve MM-421 traceability.
+**Scale/Scope**: One `/tasks/manifests` story; no saved manifest registry or run detail redesign.
+
+## Constitution Check
+
+- Orchestrate, don't recreate: PASS. Reuses existing execution history endpoint and dashboard components.
+- One-click deployment: PASS. No new service dependency.
+- Runtime configurability: PASS. No hardcoded service URL beyond the explicit existing endpoint suffix joined with `payload.apiBase`.
+- Modular/extensible architecture: PASS. Changes stay inside the manifests entrypoint and tests.
+- Resilient by default: PASS. Optional fields degrade to placeholders instead of crashing.
+- Testing discipline: PASS. Unit and runner-integrated UI tests are required before final verification.
+- Documentation separation: PASS. Canonical design remains in `docs/UI/ManifestsPage.md`; this implementation plan stays in `specs/`.
+
+## Project Structure
+
+```text
+frontend/src/entrypoints/manifests.tsx
+frontend/src/entrypoints/manifests.test.tsx
+frontend/src/components/tables/DataTable.tsx
+docs/UI/ManifestsPage.md
+specs/217-show-recent-manifest-runs/
+```
+
+## Complexity Tracking
+
+No constitution violations or additional complexity are required.

--- a/specs/217-show-recent-manifest-runs/quickstart.md
+++ b/specs/217-show-recent-manifest-runs/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Show Recent Manifest Runs
+
+## Focused UI Validation
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx
+```
+
+Expected result:
+
+- The Manifests page requests `/api/executions?entry=manifest&limit=200`.
+- Recent Runs renders below Run Manifest.
+- Manifest rows show run ID/details link, manifest label, action, status with stage detail, started time, duration, and View details action.
+- Status, manifest, and search filters update visible rows.
+- Empty states point users to the Run Manifest form above.
+
+## Runner-Integrated UI Validation
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx
+```
+
+## Full Unit Validation
+
+```bash
+./tools/test_unit.sh
+```

--- a/specs/217-show-recent-manifest-runs/research.md
+++ b/specs/217-show-recent-manifest-runs/research.md
@@ -1,0 +1,73 @@
+# Research: Show Recent Manifest Runs
+
+## FR-001 / DESIGN-REQ-001 Page Placement
+
+Decision: `implemented_verified`; preserve existing page order.
+Evidence: `frontend/src/entrypoints/manifests.tsx` renders the Run Manifest card before the Recent Runs card, and `frontend/src/entrypoints/manifests.test.tsx` verifies both headings.
+Rationale: The story depends on the existing unified page layout from MM-419.
+Alternatives considered: Reworking layout was rejected as out of scope.
+Test implications: Covered by existing frontend test and final validation.
+
+## FR-002 / DESIGN-REQ-002 Data Source
+
+Decision: `implemented_verified`; preserve existing query path.
+Evidence: `frontend/src/entrypoints/manifests.tsx` fetches `${payload.apiBase}/executions?entry=manifest&limit=200`.
+Rationale: The Jira brief explicitly requires this endpoint for phase 1.
+Alternatives considered: A manifest-specific history API was rejected by source requirements.
+Test implications: Existing test setup already mocks `/api/executions?entry=manifest&limit=200`; final validation keeps it covered.
+
+## FR-003 / DESIGN-REQ-003 / DESIGN-REQ-004 History Columns
+
+Decision: `partial`; add manifest label, action, started, duration, and View details action while retaining run identity and status.
+Evidence: Current table columns are Task ID, Source Label, and Status only.
+Rationale: Users cannot answer manifest action, timing, duration, or how to open details from the current table.
+Alternatives considered: Backend changes were rejected because the existing endpoint can provide optional fields and the UI can tolerate missing values.
+Test implications: Add frontend tests that fail before implementation and pass after columns are added.
+
+## FR-004 / DESIGN-REQ-005 Stage-Aware Status
+
+Decision: `missing`; add a formatter that displays `Running · fetch` when status is active and a current stage is available.
+Evidence: Current status column renders only `status`.
+Rationale: Source design requires manifest-specific stage detail inline.
+Alternatives considered: A separate Stage-only display was insufficient because the story names inline status detail.
+Test implications: Add frontend test with a running row and stage data.
+
+## FR-005 Fallbacks
+
+Decision: `partial`; extend row schema with optional fields and fallback formatters.
+Evidence: Current schema only accepts `taskId`, `source`, optional `sourceLabel`, and `status`.
+Rationale: Real execution rows may omit manifest label, action, timestamps, or duration, and the UI should not break or hide the row.
+Alternatives considered: Strictly requiring all fields was rejected because the source explicitly says optional values should appear when available.
+Test implications: Add frontend assertions for placeholders.
+
+## FR-006 / DESIGN-REQ-006 Filters
+
+Decision: `missing`; add status, manifest, and free-text search controls.
+Evidence: Current Recent Runs section has no filter controls.
+Rationale: The Jira brief requires lightweight bounded filters without a heavy builder.
+Alternatives considered: Server-side filtering was rejected for phase 1 because the endpoint requirement is fixed.
+Test implications: Add tests for status and search filtering.
+
+## FR-007 / DESIGN-REQ-007 Empty State
+
+Decision: `partial`; replace the generic empty message with manifest-specific guidance.
+Evidence: Current table message is `No manifest runs found.`
+Rationale: Source design asks users to run a registry manifest or submit inline YAML above.
+Alternatives considered: Separate empty-state card was unnecessary for this story.
+Test implications: Add test for filtered empty state.
+
+## FR-008 / DESIGN-REQ-008 Responsive Readability
+
+Decision: `implemented_unverified`; preserve shared table container and avoid hiding identity, status, or action.
+Evidence: `DataTable` uses shared table styling; no story-specific viewport test exists.
+Rationale: This story can satisfy phase 1 with the shared responsive table surface.
+Alternatives considered: A separate mobile card layout was rejected as extra scope.
+Test implications: Final validation checks that core columns remain present.
+
+## FR-009 / DESIGN-REQ-009 Accessibility
+
+Decision: `partial`; add labels for filter controls and accessible names for row actions.
+Evidence: Form controls are labeled, but new filters/actions do not exist.
+Rationale: Row actions and filters must be accessible by role or label.
+Alternatives considered: Icon-only unlabeled actions were rejected.
+Test implications: Use Testing Library role/label queries.

--- a/specs/217-show-recent-manifest-runs/spec.md
+++ b/specs/217-show-recent-manifest-runs/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Show Recent Manifest Runs
+
+**Feature Branch**: `217-show-recent-manifest-runs`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: User description: the Jira preset brief for MM-421, preserved verbatim below.
+
+```text
+Jira issue: MM-421 from MM project
+Summary: Show recent manifest runs below the run form
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-421 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-421: Show recent manifest runs below the run form
+
+Source Reference
+- Source Document: docs/UI/ManifestsPage.md
+- Source Title: Manifests Page
+- Source Sections:
+  - Recent Runs section
+  - Data source
+  - Table purpose
+  - Recommended columns
+  - Manifest-specific status detail
+  - Filters
+  - Empty state
+  - Responsive behavior
+  - Accessibility
+- Coverage IDs:
+  - DESIGN-REQ-002
+  - DESIGN-REQ-010
+  - DESIGN-REQ-011
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-017
+
+User Story
+As a dashboard user, I want recent manifest runs visible below the Run Manifest card so I can immediately check start state, current stage, result, timing, and details for manifest executions.
+
+Acceptance Criteria
+- Given /tasks/manifests loads, then Recent Runs requests /api/executions?entry=manifest&limit=200.
+- Given manifest runs exist, then the history surface shows run ID/details link, manifest label, action, status, current stage when available, started time, duration when available, and supported row actions.
+- Given a run is active and stage data is available, then the status display includes manifest-specific stage detail such as Running · fetch.
+- Given status, manifest name, or free-text filters are used, then the visible run list updates without a heavy filter-builder flow.
+- Given no manifest runs exist, then the empty state says no manifest runs exist and points users to run a registry manifest or submit inline YAML above.
+- Given the viewport is narrow, then recent runs remain readable as compact cards or stacked rows with clear action labels.
+- Given row actions are icon-based in implementation, then they include accessible names.
+
+Requirements
+- Recent Runs must appear below the Run Manifest card on the same page.
+- The history request must use the existing manifest execution endpoint for phase 1.
+- The history view must help answer whether the run started, whether it is still running, what stage it is in, whether it succeeded or failed, and how to open details/logs.
+- Filters must remain lightweight and bounded to status, manifest name, search, and optional action support.
+- The implementation must not require a backend redesign or new manifest-centric history API for phase 1.
+
+Implementation Notes
+- This story is about showing recent manifest execution history below the existing Run Manifest card, not replacing the existing manifest execution contract.
+- Use the existing manifest execution endpoint for the initial history request: /api/executions?entry=manifest&limit=200.
+- The UI should make recent runs scannable by exposing run identity/details, manifest label, action, status, current stage, timing, and available row actions.
+- Active runs should show manifest-specific stage detail when stage data exists.
+- Filters should remain lightweight and focused on status, manifest name, search, and optional action support.
+- Preserve MM-421 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+```
+
+## User Story - Monitor Recent Manifest Runs
+
+**Summary**: As a dashboard user, I want recent manifest runs visible below the Run Manifest card so I can immediately check start state, current stage, result, timing, and details for manifest executions.
+
+**Goal**: Users can open `/tasks/manifests`, scan recent manifest executions directly below the run form, filter the visible history lightly, and open run details without leaving the unified manifest workflow context.
+
+**Independent Test**: Open `/tasks/manifests` with manifest execution history returned by `/api/executions?entry=manifest&limit=200`, verify the Run Manifest form appears before Recent Runs, verify the Recent Runs surface shows run identity/detail link, manifest label, action, status with current stage when present, started time, duration, and row actions, then filter by status, manifest name, and search text and verify the visible list updates.
+
+**Acceptance Scenarios**:
+
+1. **Given** `/tasks/manifests` loads, **When** recent runs are requested, **Then** the page calls `/api/executions?entry=manifest&limit=200` and renders Recent Runs below the Run Manifest card.
+2. **Given** manifest runs exist, **When** the Recent Runs surface renders, **Then** each row exposes a run ID/details link, manifest label, action, status, current stage when available, started time, duration when available, and a supported View details action.
+3. **Given** a manifest run is active and stage data is available, **When** the status is displayed, **Then** the page includes manifest-specific stage detail such as `Running · fetch`.
+4. **Given** a user filters by status, manifest name, or free-text search, **When** filter values change, **Then** the visible run list updates without requiring a complex filter-builder flow.
+5. **Given** no manifest runs match the current data or filters, **When** the Recent Runs surface renders, **Then** the empty state says no manifest runs exist and points users to run a registry manifest or submit inline YAML above.
+6. **Given** row actions are link-based or icon-based, **When** keyboard or assistive technology users inspect them, **Then** each action has an accessible name.
+
+### Edge Cases
+
+- Runs without manifest labels fall back to available title, source label, or run ID.
+- Runs without explicit action values display a neutral placeholder instead of hiding the column.
+- Running statuses with no stage display status only.
+- Invalid or absent timestamps and durations display a neutral placeholder.
+- Filters that remove all rows show the same manifest-specific empty state.
+
+## Assumptions
+
+- The existing `/api/executions?entry=manifest&limit=200` response can carry optional execution fields such as title, status, current stage, created or started time, duration, and detail links; the UI should tolerate absent optional fields.
+- Phase 1 uses the existing execution history endpoint and does not require a backend redesign or new manifest-specific history API.
+
+## Source Design Requirements
+
+The preserved Jira brief lists source coverage IDs `DESIGN-REQ-002`, `DESIGN-REQ-010`, `DESIGN-REQ-011`, `DESIGN-REQ-012`, `DESIGN-REQ-013`, `DESIGN-REQ-014`, and `DESIGN-REQ-017`. The mappings below are this single-story spec's extracted requirements from `docs/UI/ManifestsPage.md`; they keep the story traceable without requiring unrelated source sections to become in-scope work.
+
+- **DESIGN-REQ-001** (`docs/UI/ManifestsPage.md`, Page structure): Recent Runs appears below the Run Manifest card in the unified Manifests page. Scope: in scope. Maps to FR-001.
+- **DESIGN-REQ-002** (`docs/UI/ManifestsPage.md`, Recent Runs data source): Recent Runs uses `/api/executions?entry=manifest&limit=200`. Scope: in scope. Maps to FR-002.
+- **DESIGN-REQ-003** (`docs/UI/ManifestsPage.md`, Table purpose): The history surface helps users identify whether a run started, whether it is running, what stage it is in, whether it succeeded or failed, and how to open details or logs. Scope: in scope. Maps to FR-003, FR-004, FR-005.
+- **DESIGN-REQ-004** (`docs/UI/ManifestsPage.md`, Recommended columns): Recent Runs exposes run ID, manifest, action, status, stage, started time, duration, and actions when those values are available. Scope: in scope. Maps to FR-003, FR-004, FR-005.
+- **DESIGN-REQ-005** (`docs/UI/ManifestsPage.md`, Manifest-specific status detail): Running manifest jobs show current stage detail inline when available. Scope: in scope. Maps to FR-004.
+- **DESIGN-REQ-006** (`docs/UI/ManifestsPage.md`, Filters): Filters remain lightweight and bounded to status, manifest name, search, and optional action support. Scope: in scope. Maps to FR-006.
+- **DESIGN-REQ-007** (`docs/UI/ManifestsPage.md`, Empty state): Empty Recent Runs states tell users there are no manifest runs and point them to run a registry manifest or submit inline YAML above. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-008** (`docs/UI/ManifestsPage.md`, Responsive behavior): Recent runs remain readable on narrow viewports as compact cards or stacked rows. Scope: in scope. Maps to FR-008.
+- **DESIGN-REQ-009** (`docs/UI/ManifestsPage.md`, Accessibility): Row actions and filter controls have accessible names or labels. Scope: in scope. Maps to FR-009.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST show Recent Runs below the Run Manifest form on `/tasks/manifests`.
+- **FR-002**: The system MUST request recent manifest runs from `/api/executions?entry=manifest&limit=200`.
+- **FR-003**: The Recent Runs surface MUST expose a run ID/details link, manifest label, action, status, started time, duration, and a View details action for each manifest run when source data is available.
+- **FR-004**: The Recent Runs surface MUST include current manifest stage detail inline with status for active runs when stage data is available.
+- **FR-005**: The Recent Runs surface MUST tolerate missing optional manifest label, action, stage, timestamp, duration, or detail-link fields with clear fallback values.
+- **FR-006**: The system MUST provide lightweight client-side filters for status, manifest name, and free-text search that update the visible run list.
+- **FR-007**: The Recent Runs empty state MUST say no manifest runs exist and direct users to run a registry manifest or submit inline YAML above.
+- **FR-008**: The Recent Runs surface MUST remain readable on narrow viewports without hiding run identity, status, or the detail action.
+- **FR-009**: Recent Runs filters and row actions MUST expose accessible labels or names.
+- **FR-010**: The implementation MUST preserve Jira issue key MM-421 in Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Frontend tests show the page requests `/api/executions?entry=manifest&limit=200` and renders Recent Runs below Run Manifest.
+- **SC-002**: Frontend tests show manifest run rows expose run detail link, manifest label, action, status with stage detail, started time, duration, and View details action.
+- **SC-003**: Frontend tests show status, manifest name, and search filters update the visible list and preserve a manifest-specific empty state.
+- **SC-004**: Accessibility-oriented tests can locate filters and row actions by accessible label or role.
+- **SC-005**: The final verification report traces implementation evidence back to MM-421 and all in-scope DESIGN-REQ mappings.

--- a/specs/217-show-recent-manifest-runs/tasks.md
+++ b/specs/217-show-recent-manifest-runs/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: Show Recent Manifest Runs
+
+**Input**: Design documents from `/specs/217-show-recent-manifest-runs/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Test Commands**:
+
+- Unit tests: `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx`
+- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+- [X] T001 Create Moon Spec artifacts for MM-421 in `specs/217-show-recent-manifest-runs/`.
+- [X] T002 Preserve canonical Jira brief for MM-421 in `docs/tmp/jira-orchestration-inputs/MM-421-moonspec-orchestration-input.md`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing Manifests page requests `/api/executions?entry=manifest&limit=200` and renders Recent Runs below Run Manifest in `frontend/src/entrypoints/manifests.tsx` and `frontend/src/entrypoints/manifests.test.tsx`.
+- [X] T004 Confirm existing Recent Runs table lacks MM-421 display columns and filters in `frontend/src/entrypoints/manifests.tsx`.
+
+## Phase 3: Story - Monitor Recent Manifest Runs
+
+**Summary**: As a dashboard user, I want recent manifest runs visible below the Run Manifest card so I can immediately check start state, current stage, result, timing, and details for manifest executions.
+
+**Independent Test**: Open `/tasks/manifests` with manifest execution history returned by `/api/executions?entry=manifest&limit=200`, verify the Run Manifest form appears before Recent Runs, verify the Recent Runs surface shows run identity/detail link, manifest label, action, status with current stage when present, started time, duration, and row actions, then filter by status, manifest name, and search text and verify the visible list updates.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, DESIGN-REQ-001..009, SC-001..005
+
+### Unit Tests
+
+- [X] T005 Add failing frontend row-display tests for run details, manifest label, action, status-stage detail, started time, duration, and View details action in `frontend/src/entrypoints/manifests.test.tsx` (FR-003, FR-004, FR-005, FR-009, SC-002, SC-004, DESIGN-REQ-003..005, DESIGN-REQ-009).
+- [X] T006 Add failing frontend filter and empty-state tests for status, manifest, and free-text search in `frontend/src/entrypoints/manifests.test.tsx` (FR-006, FR-007, SC-003, DESIGN-REQ-006, DESIGN-REQ-007).
+- [X] T007 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx` and confirm T005-T006 fail for the expected Recent Runs gaps.
+
+### Integration Tests
+
+- [X] T008 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` and confirm the new UI tests fail before implementation.
+
+### Implementation
+
+- [X] T009 Extend manifest execution row schema and display formatters in `frontend/src/entrypoints/manifests.tsx` (FR-003, FR-004, FR-005).
+- [X] T010 Add status, manifest, and search filters to Recent Runs in `frontend/src/entrypoints/manifests.tsx` (FR-006, FR-009).
+- [X] T011 Update Recent Runs table columns, detail links, status-stage display, fallback values, and manifest-specific empty state in `frontend/src/entrypoints/manifests.tsx` (FR-003, FR-004, FR-005, FR-007, FR-008, FR-009).
+
+### Story Validation
+
+- [X] T012 Run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx` and verify the story passes.
+- [X] T013 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` and verify runner-integrated UI validation passes.
+
+## Phase 4: Polish And Verification
+
+- [X] T014 Update `docs/UI/ManifestsPage.md` only if implementation behavior diverges from the desired-state document.
+- [X] T015 Run `./tools/test_unit.sh` for final unit validation or document the exact local blocker.
+- [X] T016 Run final `/moonspec-verify` and record the verdict for MM-421.
+
+## Dependencies & Execution Order
+
+- T005-T008 must run before T009-T011.
+- T009-T011 all touch `frontend/src/entrypoints/manifests.tsx` and should be sequenced.
+- T012-T016 run after implementation.
+
+## Implementation Strategy
+
+Existing MM-419 work already unified the Manifests page and added the Run Manifest form. MM-421 closes the Recent Runs observability gap with frontend tests first, then UI-only changes that keep the backend contract unchanged and preserve MM-421 traceability through final verification.


### PR DESCRIPTION
## Summary

Implements Jira issue MM-421 by expanding the Manifests page Recent Runs section below the Run Manifest form. The UI now shows manifest run identity/details, manifest label, action, status with current stage when available, timing, duration, and detail actions, plus lightweight status, manifest, and free-text filters.

## Jira

- Jira issue key: MM-421

## MoonSpec

- Active feature path: `specs/217-show-recent-manifest-runs`
- Verification verdict: `FULLY_IMPLEMENTED`

## Tests run

- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/manifests.test.tsx` - passed, 12 tests
- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/manifests.test.tsx` - passed, 3673 Python tests, 16 subtests, and targeted UI suite 12 tests
- `./tools/test_unit.sh` - passed earlier in the same MM-421 implementation sequence, including full frontend suite

## Remaining risks

- No known remaining implementation gaps.
- Recent Runs still relies on the existing phase 1 `/api/executions?entry=manifest&limit=200` response shape; optional fields fall back when absent.