### PR TITLE
[codex] Fix child workflow cancellation

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -4136,6 +4136,7 @@ async def cancel_execution(
         service=service,
         workflow_id=workflow_id,
         user=user,
+        include_orphaned_projection=True,
         use_cancel_target_fallback=True,
     )
 

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3143,12 +3143,16 @@ async def _get_owned_execution(
     workflow_id: str,
     user: User,
     include_orphaned_projection: bool = False,
+    use_cancel_target_fallback: bool = False,
 ):
     try:
-        record = await service.describe_execution(
-            workflow_id,
-            include_orphaned=include_orphaned_projection,
-        )
+        if use_cancel_target_fallback:
+            record = await service.describe_cancel_target_execution(workflow_id)
+        else:
+            record = await service.describe_execution(
+                workflow_id,
+                include_orphaned=include_orphaned_projection,
+            )
     except TemporalExecutionNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -4128,7 +4132,12 @@ async def cancel_execution(
     user: User = Depends(get_current_user()),
     _actions_enabled: None = Depends(_ensure_actions_enabled),
 ) -> ExecutionModel:
-    await _get_owned_execution(service=service, workflow_id=workflow_id, user=user)
+    await _get_owned_execution(
+        service=service,
+        workflow_id=workflow_id,
+        user=user,
+        use_cancel_target_fallback=True,
+    )
 
     request = payload or CancelExecutionRequest()
     record = await service.cancel_execution(

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,12 @@
 [
   {
-    "id": 3115713023,
-    "disposition": "addressed",
-    "rationale": "Removed the redundant .panel--controls background declaration so the shared glass-control group remains the single source for that fill."
-  },
-  {
-    "id": 3115713032,
-    "disposition": "addressed",
-    "rationale": "Aligned .panel--data to the matte data surface opacity of rgb(var(--mm-panel) / 0.92) and added a CSS contract assertion."
-  },
-  {
-    "id": 4145824587,
+    "id": 4149445122,
     "disposition": "not-applicable",
-    "rationale": "Summary review comment only; its two actionable findings are tracked and addressed by the linked inline review comments."
+    "rationale": "Bot review summary only; no separate requested change beyond inline comment 3119057531."
+  },
+  {
+    "id": 3119057531,
+    "disposition": "addressed",
+    "rationale": "cancel_execution now passes include_orphaned_projection=True for cancel-target authorization, with regression coverage for a projection-only nested parent fallback."
   }
 ]

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -1566,7 +1566,7 @@ class TemporalExecutionService:
         graceful: bool,
         action: str = "cancel",
     ) -> TemporalExecutionRecord | TemporalExecutionCanonicalRecord:
-        record = await self._require_source_execution(workflow_id)
+        record = await self._require_cancel_target_execution(workflow_id)
 
         action_name = "reject" if action == "reject" else "cancel"
         default_reason = (
@@ -1597,7 +1597,9 @@ class TemporalExecutionService:
             ) from exc
 
         if record.state in TERMINAL_STATES:
-            return await self._sync_projection_best_effort(record)
+            if isinstance(record, TemporalExecutionCanonicalRecord):
+                return await self._sync_projection_best_effort(record)
+            return record
 
         record.paused = False
         self._clear_waiting_metadata(record)
@@ -1626,7 +1628,9 @@ class TemporalExecutionService:
         await self._session.commit()
         await self._session.refresh(record)
         await self._fan_out_dependency_resolution(record)
-        return await self._sync_projection_best_effort(record)
+        if isinstance(record, TemporalExecutionCanonicalRecord):
+            return await self._sync_projection_best_effort(record)
+        return record
 
     async def mark_execution_succeeded(
         self,
@@ -1665,6 +1669,19 @@ class TemporalExecutionService:
         await self._session.commit()
         await self._session.refresh(record)
         return await self._sync_projection_best_effort(record)
+
+    async def describe_cancel_target_execution(
+        self,
+        workflow_id: str,
+    ) -> TemporalExecutionRecord | TemporalExecutionCanonicalRecord:
+        """Return the record that would be used for a cancel operation.
+
+        Canonical source rows remain authoritative. Projection-only rows are
+        accepted for child workflows that were discovered from Temporal but do
+        not have source rows of their own.
+        """
+
+        return await self._require_cancel_target_execution(workflow_id)
 
     async def mark_execution_executing(
         self,
@@ -2805,6 +2822,25 @@ class TemporalExecutionService:
                 f"Workflow execution {workflow_id} was not found"
             )
         return record
+
+    async def _require_cancel_target_execution(
+        self,
+        workflow_id: str,
+    ) -> TemporalExecutionCanonicalRecord | TemporalExecutionRecord:
+        canonical_workflow_id = self.canonicalize_workflow_id(workflow_id)
+        source = await self._load_source_execution(canonical_workflow_id)
+        if source is not None:
+            return source
+
+        projection = await self._load_projection_execution(
+            canonical_workflow_id,
+            include_orphaned=False,
+        )
+        if projection is None:
+            raise TemporalExecutionNotFoundError(
+                f"Workflow execution {canonical_workflow_id} was not found"
+            )
+        return projection
 
     async def _load_projection_execution(
         self,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2032,6 +2032,34 @@ def test_cancel_execution_passes_reject_action_to_service() -> None:
         assert response.json()["interventionAudit"][0]["action"] == "reject"
 
 
+def test_cancel_execution_authorizes_projection_only_child_target() -> None:
+    for test_client, service in _client_with_service():
+        child = _build_execution_record(state=MoonMindWorkflowState.AWAITING_SLOT)
+        child.workflow_id = (
+            "resolver:mm:parent:pr:1634:head:"
+            "5ed0c032789b901b99da93eaa4877de6609fdf35:1"
+        )
+        canceled = _build_execution_record(state=MoonMindWorkflowState.CANCELED)
+        canceled.workflow_id = child.workflow_id
+        canceled.close_status = "canceled"
+        service.describe_cancel_target_execution.return_value = child
+        service.cancel_execution.return_value = canceled
+
+        response = test_client.post(
+            f"/api/executions/{child.workflow_id}/cancel",
+            json={"graceful": True, "reason": "stop child"},
+        )
+
+        assert response.status_code == 202
+        service.describe_cancel_target_execution.assert_awaited_once_with(
+            child.workflow_id
+        )
+        called = service.cancel_execution.await_args.kwargs
+        assert called["workflow_id"] == child.workflow_id
+        assert called["reason"] == "stop child"
+        assert called["graceful"] is True
+
+
 def test_serialize_execution_treats_system_owner_id_as_system_owner_type() -> None:
     record = SimpleNamespace(
         close_status=None,

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -2060,6 +2060,44 @@ def test_cancel_execution_authorizes_projection_only_child_target() -> None:
         assert called["graceful"] is True
 
 
+def test_cancel_execution_authorizes_projection_only_nested_parent(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, user = client
+    child = _build_execution_record(
+        state=MoonMindWorkflowState.AWAITING_SLOT,
+        owner_id="",
+    )
+    child.workflow_id = "mm:parent:agent:child-1"
+    child.search_attributes = {}
+    child.owner_type = None
+
+    parent = _build_execution_record(owner_id=str(user.id))
+    parent.workflow_id = "mm:parent"
+
+    canceled = _build_execution_record(state=MoonMindWorkflowState.CANCELED)
+    canceled.workflow_id = child.workflow_id
+    canceled.close_status = "canceled"
+
+    service.describe_cancel_target_execution.return_value = child
+    service.describe_execution.return_value = parent
+    service.cancel_execution.return_value = canceled
+
+    response = test_client.post(
+        f"/api/executions/{child.workflow_id}/cancel",
+        json={"graceful": True, "reason": "stop nested child"},
+    )
+
+    assert response.status_code == 202
+    service.describe_execution.assert_awaited_once_with(
+        "mm:parent",
+        include_orphaned=True,
+    )
+    called = service.cancel_execution.await_args.kwargs
+    assert called["workflow_id"] == child.workflow_id
+    assert called["reason"] == "stop nested child"
+
+
 def test_serialize_execution_treats_system_owner_id_as_system_owner_type() -> None:
     record = SimpleNamespace(
         close_status=None,

--- a/tests/unit/api/test_execution_service.py
+++ b/tests/unit/api/test_execution_service.py
@@ -113,7 +113,7 @@ async def test_cancel_action_routes_to_temporal(
         state=MoonMindWorkflowState.EXECUTING,
         entry="run",
     )
-    service._require_source_execution = AsyncMock(return_value=record)
+    service._require_cancel_target_execution = AsyncMock(return_value=record)
     service._sync_projection_best_effort = AsyncMock(return_value=record)
 
     await service.cancel_execution(
@@ -136,7 +136,7 @@ async def test_force_terminate_routes_to_temporal_terminate(
         state=MoonMindWorkflowState.EXECUTING,
         entry="run",
     )
-    service._require_source_execution = AsyncMock(return_value=record)
+    service._require_cancel_target_execution = AsyncMock(return_value=record)
     service._sync_projection_best_effort = AsyncMock(return_value=record)
 
     await service.cancel_execution(

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -1727,6 +1727,124 @@ async def test_cancel_execution_records_reject_audit_action(
 
 
 @pytest.mark.asyncio
+async def test_cancel_execution_accepts_projection_only_child_workflow(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+        owner_id = str(uuid4())
+        workflow_id = (
+            "resolver:mm:parent:pr:1634:head:"
+            "5ed0c032789b901b99da93eaa4877de6609fdf35:1"
+        )
+        now = datetime.now(UTC)
+        projection = TemporalExecutionRecord(
+            workflow_id=workflow_id,
+            run_id=str(uuid4()),
+            namespace="default",
+            workflow_type=TemporalWorkflowType.RUN,
+            owner_id=owner_id,
+            owner_type=TemporalExecutionOwnerType.USER,
+            state=MoonMindWorkflowState.AWAITING_SLOT,
+            close_status=None,
+            entry="run",
+            search_attributes={
+                "mm_owner_type": "user",
+                "mm_owner_id": owner_id,
+                "mm_state": "awaiting_slot",
+                "mm_updated_at": now.isoformat(),
+                "mm_entry": "run",
+            },
+            memo={"title": "Resolve PR #1634", "summary": "Waiting for slot."},
+            artifact_refs=[],
+            parameters={},
+            paused=False,
+            awaiting_external=True,
+            waiting_reason="provider_profile_slot",
+            attention_required=False,
+            projection_version=1,
+            last_synced_at=now,
+            sync_state=TemporalExecutionProjectionSyncState.FRESH,
+            sync_error=None,
+            source_mode=TemporalExecutionProjectionSourceMode.PROJECTION_ONLY,
+            created_at=now,
+            started_at=now,
+            updated_at=now,
+            closed_at=None,
+        )
+        session.add(projection)
+        await session.commit()
+
+        canceled = await service.cancel_execution(
+            workflow_id=workflow_id,
+            reason="stop child",
+            graceful=True,
+        )
+
+        assert canceled.workflow_id == workflow_id
+        assert canceled.state is MoonMindWorkflowState.CANCELED
+        assert canceled.close_status is TemporalExecutionCloseStatus.CANCELED
+        assert canceled.waiting_reason is None
+        assert canceled.memo["summary"] == "stop child"
+        assert canceled.memo["intervention_audit"][-1]["action"] == "cancel"
+        assert canceled.search_attributes["mm_state"] == "canceled"
+        mock_client_adapter.cancel_workflow.assert_called_once_with(workflow_id)
+
+
+@pytest.mark.asyncio
+async def test_cancel_execution_rejects_orphaned_projection_only_workflow(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session)
+        service._client_adapter = mock_client_adapter
+        owner_id = str(uuid4())
+        now = datetime.now(UTC)
+        projection = TemporalExecutionRecord(
+            workflow_id="resolver:mm:orphaned:pr:1634:head:abc:1",
+            run_id=str(uuid4()),
+            namespace="default",
+            workflow_type=TemporalWorkflowType.RUN,
+            owner_id=owner_id,
+            owner_type=TemporalExecutionOwnerType.USER,
+            state=MoonMindWorkflowState.AWAITING_SLOT,
+            close_status=None,
+            entry="run",
+            search_attributes={
+                "mm_owner_type": "user",
+                "mm_owner_id": owner_id,
+                "mm_state": "awaiting_slot",
+                "mm_updated_at": now.isoformat(),
+                "mm_entry": "run",
+            },
+            memo={"title": "Resolve PR #1634", "summary": "Waiting for slot."},
+            artifact_refs=[],
+            parameters={},
+            projection_version=1,
+            last_synced_at=now,
+            sync_state=TemporalExecutionProjectionSyncState.ORPHANED,
+            sync_error="temporal execution missing",
+            source_mode=TemporalExecutionProjectionSourceMode.PROJECTION_ONLY,
+            created_at=now,
+            started_at=now,
+            updated_at=now,
+            closed_at=None,
+        )
+        session.add(projection)
+        await session.commit()
+
+        with pytest.raises(TemporalExecutionNotFoundError):
+            await service.cancel_execution(
+                workflow_id=projection.workflow_id,
+                reason="stop child",
+                graceful=True,
+            )
+
+        mock_client_adapter.cancel_workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_cancel_execution_best_effort_terminates_task_scoped_codex_session(
     tmp_path, mock_client_adapter, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- allow cancellation to target non-orphan projection-only child workflows such as PR resolver runs
- keep canonical execution rows authoritative while preserving orphan rejection
- route cancel authorization through the same cancel-target lookup used by the service

## Root Cause
Resolver child workflows can be visible through Temporal/projection fallback without a corresponding canonical `temporal_execution_sources` row. The cancel endpoint authorized only through the canonical-source path, so those child IDs returned 404 and never reached Temporal cancellation.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py -k 'cancel_execution_accepts_projection_only_child_workflow or cancel_execution_rejects_orphaned_projection_only_workflow or cancel_execution_records_reject_audit_action or cancel_execution_authorizes_projection_only_child_target or cancel_execution_passes_reject_action_to_service'`\n- Focused Python tests: 5 passed\n- Shared frontend suite from test runner: 11 files / 342 tests passed