### PR TITLE
Clean up Task Detail hero: inline instructions, move status pill to header

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,17 @@
 [
   {
-    "id": 3115891581,
+    "id": 3119218535,
     "disposition": "addressed",
-    "rationale": "Changed status capitalization to use charAt(0), which is safe for empty strings."
+    "rationale": "Excluded .td-instructions-toggle from the global primary button selectors so its lightweight hover/active styling is preserved."
   },
   {
-    "id": 4146021949,
+    "id": 4149618936,
     "disposition": "not-applicable",
-    "rationale": "Non-actionable bot review summary; the referenced status formatting concern is covered by comment 3115891581."
+    "rationale": "Automated review summary container; the actionable inline comment from this review is tracked separately."
   },
   {
-    "id": 3118644455,
-    "disposition": "addressed",
-    "rationale": "Added phase to the manifest run schema and stage derivation, with test coverage for /api/executions phase payloads."
-  },
-  {
-    "id": 4149013747,
+    "id": 4149627539,
     "disposition": "not-applicable",
-    "rationale": "Non-actionable automated review body; actionable Codex feedback is covered by comment 3118644455."
+    "rationale": "Review body explicitly states there is no feedback to address."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -270,7 +270,7 @@ describe('Mission Control shared entry', () => {
     const routineBlocks = [
       cssRuleBlock(
         missionControlCss,
-        'button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):hover',
+        'button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):hover',
       ),
       cssRuleBlock(missionControlCss, 'button.secondary:hover'),
       cssRuleBlock(
@@ -292,7 +292,7 @@ describe('Mission Control shared entry', () => {
     const pressedBlocks = [
       cssRuleBlock(
         missionControlCss,
-        'button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):active',
+        'button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):active',
       ),
       cssRuleBlock(
         missionControlCss,
@@ -326,7 +326,7 @@ describe('Mission Control shared entry', () => {
     expect(cssRuleBlock(missionControlCss, 'input:focus-visible,\nselect:focus-visible,\ntextarea:focus-visible')).toContain(
       'box-shadow: var(--mm-control-focus-ring)',
     );
-    expect(cssRuleBlock(missionControlCss, 'button:disabled,\nbutton:disabled:hover,\nbutton.secondary:disabled,\nbutton.secondary:disabled:hover,\nbutton:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):disabled,\nbutton:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):disabled:hover,\n.button[aria-disabled="true"],\n.button[aria-disabled="true"]:hover,\n.button.secondary[aria-disabled="true"],\n.button.secondary[aria-disabled="true"]:hover,\n.button:not(.secondary):not(.queue-action):not(.queue-submit-primary)[aria-disabled="true"],\n.button:not(.secondary):not(.queue-action):not(.queue-submit-primary)[aria-disabled="true"]:hover')).toMatch(
+    expect(cssRuleBlock(missionControlCss, 'button:disabled,\nbutton:disabled:hover,\nbutton.secondary:disabled,\nbutton.secondary:disabled:hover,\nbutton:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):disabled,\nbutton:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):disabled:hover,\n.button[aria-disabled="true"],\n.button[aria-disabled="true"]:hover,\n.button.secondary[aria-disabled="true"],\n.button.secondary[aria-disabled="true"]:hover,\n.button:not(.secondary):not(.queue-action):not(.queue-submit-primary)[aria-disabled="true"],\n.button:not(.secondary):not(.queue-action):not(.queue-submit-primary)[aria-disabled="true"]:hover')).toMatch(
       /opacity:\s*var\(--mm-control-disabled-opacity\);[^}]*transform:\s*none;[^}]*box-shadow:\s*none;/s,
     );
     expect(missionControlCss).toMatch(

--- a/frontend/src/entrypoints/task-detail.test.tsx
+++ b/frontend/src/entrypoints/task-detail.test.tsx
@@ -1374,8 +1374,8 @@ describe('Task Detail Entrypoint', () => {
     });
 
     expect(screen.queryByText('Inspect the repository.')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /Example task/ }));
-    expect(screen.getByText('Instructions')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Show instructions/ }));
+    expect(screen.getByRole('button', { name: /Hide instructions/ }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText(/Inspect the repository\./)).toBeTruthy();
     expect(screen.getByText(/Then run the focused UI tests\./)).toBeTruthy();
 

--- a/frontend/src/entrypoints/task-detail.tsx
+++ b/frontend/src/entrypoints/task-detail.tsx
@@ -3329,7 +3329,18 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       <div className="toolbar">
         <div>
           <h2 className="page-title">Temporal Task Detail</h2>
-          <p className="page-meta">Task {taskId || '—'}</p>
+          <div className="toolbar-identity-row">
+            <p className="page-meta">Task {taskId || '—'}</p>
+            {execution ? (
+              <span
+                className={executionStatusPillClasses(
+                  execution.rawState || execution.state || execution.status,
+                )}
+              >
+                {execution.rawState || execution.state || execution.status || '—'}
+              </span>
+            ) : null}
+          </div>
         </div>
         <div className="toolbar-controls">
           <label className="queue-inline-toggle toolbar-live-toggle">
@@ -3369,54 +3380,45 @@ export function TaskDetailPage({ payload }: { payload: BootPayload }) {
       ) : execution ? (
         <>
           <div className="td-hero">
-            <div>
+            <div className="td-hero-body">
+              <div className="td-hero-headline">
+                <h3 className="td-title-text">{execution.title}</h3>
+                <span className="meta-inline">
+                  Temporal
+                  {execution.workflowType ? (
+                    <>
+                      <span className="dot">·</span>
+                      {execution.workflowType}
+                    </>
+                  ) : null}
+                  {execution.entry ? (
+                    <>
+                      <span className="dot">·</span>
+                      {execution.entry}
+                    </>
+                  ) : null}
+                </span>
+              </div>
               <button
                 type="button"
-                className="td-title-toggle"
+                className="td-instructions-toggle"
                 aria-expanded={instructionsExpanded}
                 aria-controls="task-instructions-panel"
                 onClick={() => setInstructionsExpanded((current) => !current)}
               >
-                <span className="td-title-toggle-copy">
-                  <span className="td-title-text">{execution.title}</span>
-                  <span className="meta-inline">
-                    Temporal
-                    {execution.workflowType ? (
-                      <>
-                        <span className="dot">·</span>
-                        {execution.workflowType}
-                      </>
-                    ) : null}
-                    {execution.entry ? (
-                      <>
-                        <span className="dot">·</span>
-                        {execution.entry}
-                      </>
-                    ) : null}
-                  </span>
-                </span>
-                <span className="td-title-toggle-hint">
-                  {instructionsExpanded ? 'Hide instructions' : 'Show instructions'}
-                </span>
+                {instructionsExpanded ? 'Hide instructions' : 'Show instructions'}
               </button>
             </div>
-            <div className="td-hero-right">
-              <span className={executionStatusPillClasses(execution.rawState || execution.state || execution.status)}>
-                {execution.rawState || execution.state || execution.status || '—'}
-              </span>
-            </div>
+            {instructionsExpanded ? (
+              <div id="task-instructions-panel" className="td-instructions-panel">
+                {hasTaskInstructions ? (
+                  <pre>{taskInstructions}</pre>
+                ) : (
+                  <p className="small">Full instructions are not available for this task.</p>
+                )}
+              </div>
+            ) : null}
           </div>
-
-          {instructionsExpanded ? (
-            <div id="task-instructions-panel" className="td-instructions-panel">
-              <h4>Instructions</h4>
-              {hasTaskInstructions ? (
-                <pre>{taskInstructions}</pre>
-              ) : (
-                <p className="small">Full instructions are not available for this task.</p>
-              )}
-            </div>
-          ) : null}
 
           <div className="td-summary-block">
             <h4>Summary</h4>

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -452,6 +452,18 @@ h1 {
   font-size: 0.9rem;
 }
 
+.toolbar-identity-row {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+  margin: 0.2rem 0 0.8rem;
+}
+
+.toolbar-identity-row .page-meta {
+  margin: 0;
+}
+
 .toolbar {
   display: flex;
   align-items: center;
@@ -2805,63 +2817,63 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
 /* Task detail: grouped flat facts */
 .td-hero {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 1rem;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
   margin-bottom: 1.5rem;
 }
 
-.td-hero h3 {
-  font-size: 1.35rem;
-  margin: 0 0 0.3rem;
-  letter-spacing: 0;
-}
-
-.td-title-toggle {
-  width: 100%;
-  border: 1px solid rgb(var(--mm-border));
-  border-radius: 8px;
-  background: transparent;
-  color: inherit;
+.td-hero-body {
   display: flex;
-  gap: 1rem;
-  justify-content: space-between;
   align-items: flex-start;
-  padding: 0.75rem;
-  text-align: left;
-  cursor: pointer;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.td-title-toggle:hover {
-  border-color: rgb(var(--mm-accent));
-}
-
-.td-title-toggle-copy {
+.td-hero-headline {
   display: grid;
   gap: 0.3rem;
   min-width: 0;
 }
 
 .td-title-text {
-  font-size: 1.35rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  line-height: 1.25;
+  line-height: 1.2;
+  margin: 0;
   overflow-wrap: anywhere;
+  letter-spacing: 0;
 }
 
-.td-title-toggle-hint {
-  color: rgb(var(--mm-muted));
-  font-size: 0.78rem;
+.td-instructions-toggle {
+  flex-shrink: 0;
+  background: transparent;
+  border: 0;
+  color: rgb(var(--mm-accent));
+  font-size: 0.82rem;
+  font-weight: 500;
+  padding: 0.3rem 0.55rem;
+  margin: 0.25rem -0.55rem 0 0;
+  border-radius: 6px;
+  cursor: pointer;
   white-space: nowrap;
-  padding-top: 0.2rem;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.td-instructions-toggle:hover {
+  background: rgb(var(--mm-accent) / 0.1);
+}
+
+.td-instructions-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--mm-control-focus-ring);
 }
 
 .td-hero .meta-inline {
   color: rgb(var(--mm-muted));
   font-size: 0.82rem;
   font-family: var(--mm-font-mono);
-  margin: 0.1rem 0 0;
+  margin: 0;
 }
 
 .td-hero .meta-inline .dot {
@@ -2869,25 +2881,12 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   opacity: 0.4;
 }
 
-.td-hero-right {
-  display: grid;
-  gap: 0.4rem;
-  justify-items: end;
-}
-
 .td-instructions-panel {
-  border: 1px solid rgb(var(--mm-border));
-  border-radius: 8px;
-  padding: 1rem;
-  margin: -0.75rem 0 1.25rem;
-}
-
-.td-instructions-panel h4 {
-  margin: 0 0 0.75rem;
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0;
-  color: rgb(var(--mm-accent));
+  background: rgb(var(--mm-accent) / 0.06);
+  border-left: 2px solid rgb(var(--mm-accent) / 0.55);
+  border-radius: 0 6px 6px 0;
+  padding: 0.85rem 1rem;
+  margin: 0;
 }
 
 .td-instructions-panel pre {
@@ -2897,6 +2896,12 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   font-family: var(--mm-font-sans);
   font-size: 0.92rem;
   line-height: 1.5;
+  color: rgb(var(--mm-ink));
+}
+
+.td-instructions-panel p.small {
+  margin: 0;
+  color: rgb(var(--mm-muted));
 }
 
 .td-group {
@@ -2985,20 +2990,13 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 }
 
 @media (max-width: 820px) {
-  .td-hero {
-    grid-template-columns: 1fr;
+  .td-hero-body {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .td-hero-right {
-    justify-items: start;
-  }
-
-  .td-title-toggle {
-    display: grid;
-  }
-
-  .td-title-toggle-hint {
-    white-space: normal;
+  .td-instructions-toggle {
+    margin: 0;
   }
 
   .td-group dl {

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -1397,12 +1397,12 @@ button {
   transition: var(--mm-control-transition);
 }
 
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button) {
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle) {
   border-color: rgb(255 255 255 / 0.52);
   box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.2), 0 12px 24px -16px rgb(var(--mm-accent) / 0.82);
 }
 
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):hover {
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):hover {
   background: linear-gradient(
     160deg,
     rgb(var(--mm-accent) / 1) 0%,
@@ -1419,8 +1419,8 @@ button:focus-visible {
   box-shadow: var(--mm-control-focus-ring);
 }
 
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):active,
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button).is-clicked {
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):active,
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle).is-clicked {
   background: linear-gradient(
     160deg,
     rgb(var(--mm-accent) / 1) 0%,
@@ -1517,8 +1517,8 @@ button:disabled,
 button:disabled:hover,
 button.secondary:disabled,
 button.secondary:disabled:hover,
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):disabled,
-button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):disabled:hover,
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):disabled,
+button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-step-icon-button):not(.queue-step-attachment-add-button):not(.queue-step-extension-button):not(.table-sort-button):not(.td-instructions-toggle):disabled:hover,
 .button[aria-disabled="true"],
 .button[aria-disabled="true"]:hover,
 .button.secondary[aria-disabled="true"],


### PR DESCRIPTION
## Summary
- Moved the EXECUTING status pill into the top toolbar next to the task identity so state is visible independently of the hero layout.
- Replaced the dramatic 1px-bordered title button with a clean heading + meta line and a subtle accent-colored "Show/Hide instructions" text button.
- Expanded instructions now render inline inside the same hero container (soft accent-tinted background + 2px left stripe) instead of a second full-bordered panel below.

## Test plan
- [ ] Load a Temporal task detail page and confirm the status pill shows next to the `Task {id}` line in the header.
- [ ] Confirm the title/meta block no longer has a heavy surrounding border.
- [ ] Click "Show instructions" — the instructions should expand inline within the same section with the left-stripe treatment, with no second bordered box.
- [ ] Click "Hide instructions" and confirm the section collapses back.
- [ ] Verify layout on a narrow (<820px) viewport: toggle and title stack cleanly.
- [ ] Run `npm run ui:typecheck` (already passing locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)