### PR TITLE
[codex] Fix OAuth terminal readiness attach race

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,12 @@
 [
   {
-    "id": 3115713023,
+    "id": 3119379489,
     "disposition": "addressed",
-    "rationale": "Removed the redundant .panel--controls background declaration so the shared glass-control group remains the single source for that fill."
+    "rationale": "Replaced the exhausted session status fallback with an explicit stable awaiting_user terminal status in the Mission Control OAuth terminal wait test mock."
   },
   {
-    "id": 3115713032,
-    "disposition": "addressed",
-    "rationale": "Aligned .panel--data to the matte data surface opacity of rgb(var(--mm-panel) / 0.92) and added a CSS contract assertion."
-  },
-  {
-    "id": 4145824587,
+    "id": 4149792433,
     "disposition": "not-applicable",
-    "rationale": "Summary review comment only; its two actionable findings are tracked and addressed by the linked inline review comments."
+    "rationale": "Review summary comment only; the underlying actionable inline feedback is tracked and addressed separately."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -550,7 +550,11 @@ describe('Mission Control shared entry', () => {
     fetchSpy.mockImplementation((input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/v1/oauth-sessions/oas_terminal_wait') {
-        const nextStatus = sessionStatuses.shift() ?? sessionStatuses[sessionStatuses.length - 1];
+        const nextStatus = sessionStatuses.shift() ?? {
+          status: 'awaiting_user',
+          terminal_session_id: 'term_oas_terminal_wait',
+          terminal_bridge_id: 'br_oas_terminal_wait',
+        };
         return Promise.resolve({
           ok: true,
           json: async () => ({

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -445,6 +445,17 @@ describe('Mission Control shared entry', () => {
       window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
       fetchSpy.mockImplementation((input: RequestInfo | URL) => {
         const url = String(input);
+        if (url === '/api/v1/oauth-sessions/oas_terminal_ui') {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              session_id: 'oas_terminal_ui',
+              status: 'awaiting_user',
+              terminal_session_id: 'term_oas_terminal_ui',
+              terminal_bridge_id: 'br_oas_terminal_ui',
+            }),
+          } as Response);
+        }
         if (url === '/api/v1/oauth-sessions/oas_terminal_ui/terminal/attach') {
           return Promise.resolve({
             ok: true,
@@ -497,5 +508,106 @@ describe('Mission Control shared entry', () => {
         Reflect.deleteProperty(navigator, 'clipboard');
       }
     }
+  });
+
+  it('waits for OAuth terminal readiness before requesting an attach token', async () => {
+    const sentFrames: string[] = [];
+    const attachCalls: string[] = [];
+    const sessionStatuses = [
+      { status: 'pending' },
+      { status: 'starting' },
+      {
+        status: 'awaiting_user',
+        terminal_session_id: 'term_oas_terminal_wait',
+        terminal_bridge_id: 'br_oas_terminal_wait',
+      },
+    ];
+
+    class MockWebSocket extends EventTarget {
+      static readonly OPEN = 1;
+      readonly OPEN = 1;
+      readyState = 1;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      constructor(readonly url: string) {
+        super();
+        setTimeout(() => {
+          this.onopen?.(new Event('open'));
+          this.onmessage?.(new MessageEvent('message', { data: 'Ready after wait' }));
+        }, 0);
+      }
+      send(frame: string) {
+        sentFrames.push(frame);
+      }
+      close() {
+        this.onclose?.(new CloseEvent('close'));
+      }
+    }
+    window.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+    fetchSpy.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/v1/oauth-sessions/oas_terminal_wait') {
+        const nextStatus = sessionStatuses.shift() ?? sessionStatuses[sessionStatuses.length - 1];
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: 'oas_terminal_wait',
+            ...nextStatus,
+          }),
+        } as Response);
+      }
+      if (url === '/api/v1/oauth-sessions/oas_terminal_wait/terminal/attach') {
+        attachCalls.push(url);
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: 'oas_terminal_wait',
+            terminal_session_id: 'term_oas_terminal_wait',
+            terminal_bridge_id: 'br_oas_terminal_wait',
+            websocket_url: '/api/v1/oauth-sessions/oas_terminal_wait/terminal/ws?token=once',
+            attach_token: 'once',
+          }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({ detail: 'Unhandled fetch' }),
+      } as Response);
+    });
+
+    renderWithClient(
+      <MissionControlApp
+        payload={{
+          page: 'oauth-terminal',
+          apiBase: '/api',
+          initialData: { sessionId: 'oas_terminal_wait' },
+        }}
+      />,
+    );
+
+    expect(await screen.findByText('Provider Login Terminal')).toBeTruthy();
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/v1/oauth-sessions/oas_terminal_wait',
+        expect.objectContaining({ headers: { Accept: 'application/json' } }),
+      );
+    });
+    expect(attachCalls).toEqual([]);
+
+    await waitFor(
+      () => {
+        expect(attachCalls).toEqual([
+          '/api/v1/oauth-sessions/oas_terminal_wait/terminal/attach',
+        ]);
+      },
+      { timeout: 3500 },
+    );
+    expect(await screen.findByText('Ready after wait')).toBeTruthy();
+    expect(sentFrames.some((frame) => frame.includes('"heartbeat"'))).toBe(true);
   });
 });

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -17,6 +17,39 @@ type AttachResponse = {
   attach_token: string;
 };
 
+type OAuthSessionStatus =
+  | 'pending'
+  | 'starting'
+  | 'bridge_ready'
+  | 'awaiting_user'
+  | 'verifying'
+  | 'registering_profile'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'expired';
+
+type OAuthSessionResponse = {
+  session_id: string;
+  status: OAuthSessionStatus;
+  terminal_session_id?: string | null;
+  terminal_bridge_id?: string | null;
+  failure_reason?: string | null;
+};
+
+const TERMINAL_ATTACHABLE_STATUSES: readonly OAuthSessionStatus[] = [
+  'bridge_ready',
+  'awaiting_user',
+  'verifying',
+];
+const TERMINAL_FINAL_STATUSES: readonly OAuthSessionStatus[] = [
+  'succeeded',
+  'failed',
+  'cancelled',
+  'expired',
+];
+const TERMINAL_READY_POLL_MS = 1000;
+
 function copyTextToClipboard(text: string): void {
   if (
     typeof navigator === 'undefined' ||
@@ -49,6 +82,26 @@ function websocketUrlFromAttach(websocketUrl: string): string {
     return websocketUrl;
   }
   return `${base}${websocketUrl}`;
+}
+
+function oauthStatusLabel(status: OAuthSessionStatus): string {
+  return status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function isTerminalAttachable(session: OAuthSessionResponse): boolean {
+  return (
+    TERMINAL_ATTACHABLE_STATUSES.includes(session.status) &&
+    Boolean(session.terminal_session_id) &&
+    Boolean(session.terminal_bridge_id)
+  );
+}
+
+async function readErrorDetail(response: Response, fallback: string): Promise<string> {
+  const payload = (await response.json().catch(() => null)) as { detail?: unknown } | null;
+  return typeof payload?.detail === 'string' ? payload.detail : fallback;
 }
 
 export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
@@ -158,12 +211,45 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
 
     async function attach() {
       try {
-        const response = await fetch(
-          `/api/v1/oauth-sessions/${encodeURIComponent(sessionId)}/terminal/attach`,
-          { method: 'POST' },
-        );
+        const sessionEndpoint = `/api/v1/oauth-sessions/${encodeURIComponent(sessionId)}`;
+        const waitForTerminalReadiness = async (): Promise<void> => {
+          while (!closed) {
+            const sessionResponse = await fetch(sessionEndpoint, {
+              headers: { Accept: 'application/json' },
+            });
+            if (!sessionResponse.ok) {
+              const detail = await readErrorDetail(
+                sessionResponse,
+                `Session lookup failed: ${sessionResponse.status}`,
+              );
+              throw new Error(detail);
+            }
+            const session = (await sessionResponse.json()) as OAuthSessionResponse;
+            if (isTerminalAttachable(session)) {
+              return;
+            }
+            if (TERMINAL_FINAL_STATUSES.includes(session.status)) {
+              const reason = session.failure_reason ? `: ${session.failure_reason}` : '';
+              throw new Error(`OAuth session ${oauthStatusLabel(session.status)}${reason}`);
+            }
+            setStatus(
+              TERMINAL_ATTACHABLE_STATUSES.includes(session.status)
+                ? 'Preparing terminal bridge'
+                : `OAuth ${oauthStatusLabel(session.status)}`,
+            );
+            await new Promise((resolve) => window.setTimeout(resolve, TERMINAL_READY_POLL_MS));
+          }
+        };
+
+        await waitForTerminalReadiness();
+        if (closed) {
+          return;
+        }
+        setStatus('Connecting terminal');
+        const response = await fetch(`${sessionEndpoint}/terminal/attach`, { method: 'POST' });
         if (!response.ok) {
-          throw new Error(`Attach failed: ${response.status}`);
+          const detail = await readErrorDetail(response, `Attach failed: ${response.status}`);
+          throw new Error(detail);
         }
         const attachPayload = (await response.json()) as AttachResponse;
         if (closed) {


### PR DESCRIPTION
## Summary

Fixes the Mission Control OAuth terminal launch race for Codex provider profile authentication. The terminal page now polls the OAuth session projection until the backend has reached an attachable state and published terminal bridge refs before requesting the one-time WebSocket attach token.

## Root Cause

Settings opens `/oauth-terminal` immediately after creating the OAuth session. The terminal page previously posted to `/terminal/attach` once, while the session was often still `pending` or `starting`. The backend correctly returned 400 because attach is only valid after the runner reaches `bridge_ready`, `awaiting_user`, or `verifying` with terminal refs.

## Changes

- Add OAuth session polling in the terminal entrypoint before requesting attach credentials.
- Surface terminal session terminal/failure states instead of a generic attach status code.
- Add regression coverage for `pending -> starting -> awaiting_user` to prove attach is not requested prematurely.

## Validation

- `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`
- `npm run ui:typecheck`
- `npm run ui:lint -- frontend/src/entrypoints/oauth-terminal.tsx frontend/src/entrypoints/mission-control.test.tsx`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`