### PR TITLE
[codex] Fix provider profile pending queue cleanup

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,12 +1,32 @@
 [
   {
-    "id": 4149445122,
-    "disposition": "not-applicable",
-    "rationale": "Bot review summary only; no separate requested change beyond inline comment 3119057531."
+    "id": 3119651338,
+    "disposition": "addressed",
+    "rationale": "Moved pending-request verification after the initial queue drain so best-effort cleanup activity delays cannot block healthy slot assignment."
   },
   {
-    "id": 3119057531,
+    "id": 3119651341,
     "disposition": "addressed",
-    "rationale": "cancel_execution now passes include_orphaned_projection=True for cancel-target authorization, with regression coverage for a projection-only nested parent fallback."
+    "rationale": "Added bounded workflow-status activity batches so large pending queues are not sent in one unbounded verification call."
+  },
+  {
+    "id": 4150084160,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary comment; the actionable inline feedback from the review was handled separately."
+  },
+  {
+    "id": 3119681735,
+    "disposition": "addressed",
+    "rationale": "Consolidated lease-holder and pending-requester verification in the main loop into one shared status pass."
+  },
+  {
+    "id": 3119681739,
+    "disposition": "addressed",
+    "rationale": "Refactored duplicate activity invocation and status-application logic into shared private helpers."
+  },
+  {
+    "id": 4150114952,
+    "disposition": "not-applicable",
+    "rationale": "Automated review summary comment; its consolidation and refactoring recommendations were addressed through the inline comments."
   }
 ]

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -39,6 +39,7 @@ REFRESH_RESTORED_PROFILES_PATCH = "provider-profile-manager-refresh-restored-pro
 DB_AUTHORITATIVE_PROFILE_SYNC_PATCH = (
     "provider-profile-manager-db-authoritative-profile-sync-v1"
 )
+VERIFY_PENDING_REQUESTS_PATCH = "provider-profile-manager-verify-pending-requests-v1"
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
@@ -483,6 +484,9 @@ class MoonMindProviderProfileManagerWorkflow:
                         continue
 
             # Drain pending requests against available profiles.
+            if workflow.patched(VERIFY_PENDING_REQUESTS_PATCH):
+                await self._verify_pending_requesters()
+
             await self._drain_queue()
 
             # Clear expired cooldowns.
@@ -957,6 +961,52 @@ class MoonMindProviderProfileManagerWorkflow:
 
         if reclaimed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
             await self._sync_leases_to_db()
+
+    async def _verify_pending_requesters(self) -> int:
+        """Remove pending slot requests whose requester workflows are terminal."""
+        workflow_ids = list(
+            dict.fromkeys(req.requester_workflow_id for req in self._pending_requests)
+        )
+        if not workflow_ids:
+            return 0
+
+        try:
+            result = await workflow.execute_activity(
+                "provider_profile.verify_lease_holders",
+                {"workflow_ids": workflow_ids},
+                task_queue=ACTIVITY_TASK_QUEUE,
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=2),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=30),
+                    maximum_attempts=3,
+                ),
+            )
+        except Exception:
+            self._get_logger().warning(
+                "verify_lease_holders activity failed, skipping pending request verification"
+            )
+            return 0
+
+        workflow_statuses: dict[str, dict[str, Any]] = result or {}
+        remaining: list[PendingRequest] = []
+        removed_count = 0
+        for request in self._pending_requests:
+            status_info = workflow_statuses.get(request.requester_workflow_id, {})
+            if status_info.get("running", True):
+                remaining.append(request)
+                continue
+            removed_count += 1
+            self._get_logger().warning(
+                "Pruned pending slot request for terminal workflow %s (status=%s)",
+                request.requester_workflow_id,
+                status_info.get("status", "UNKNOWN"),
+            )
+
+        if removed_count:
+            self._pending_requests = remaining
+        return removed_count
 
     def _clear_expired_cooldowns(self) -> None:
         """Remove cooldown markers that have expired."""

--- a/moonmind/workflows/temporal/workflows/provider_profile_manager.py
+++ b/moonmind/workflows/temporal/workflows/provider_profile_manager.py
@@ -43,6 +43,7 @@ VERIFY_PENDING_REQUESTS_PATCH = "provider-profile-manager-verify-pending-request
 
 # Continue-as-new threshold to bound history growth.
 _MAX_EVENTS_BEFORE_CONTINUE_AS_NEW = 2000
+_VERIFY_WORKFLOW_STATUS_BATCH_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
@@ -483,10 +484,8 @@ class MoonMindProviderProfileManagerWorkflow:
                             pass
                         continue
 
-            # Drain pending requests against available profiles.
-            if workflow.patched(VERIFY_PENDING_REQUESTS_PATCH):
-                await self._verify_pending_requesters()
-
+            # Drain pending requests against available profiles before any
+            # best-effort terminal-workflow verification activity.
             await self._drain_queue()
 
             # Clear expired cooldowns.
@@ -498,11 +497,15 @@ class MoonMindProviderProfileManagerWorkflow:
             if evicted_count > 0 and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
                 await self._sync_leases_to_db()
 
-            if workflow.patched(VERIFY_LEASE_HOLDERS_PATCH):
-                # Verify lease holders are still running, reclaiming slots from
-                # workflows in terminal states without waiting for lease timeout.
-                await self._verify_lease_holders()
+            verify_lease_holders = workflow.patched(VERIFY_LEASE_HOLDERS_PATCH)
+            verify_pending_requesters = workflow.patched(VERIFY_PENDING_REQUESTS_PATCH)
+            if verify_lease_holders or verify_pending_requesters:
+                await self._verify_active_workflows(
+                    verify_lease_holders=verify_lease_holders,
+                    verify_pending_requesters=verify_pending_requesters,
+                )
 
+            if verify_lease_holders:
                 # Immediately offer any reclaimed slots to waiting requests.
                 await self._drain_queue()
 
@@ -908,47 +911,66 @@ class MoonMindProviderProfileManagerWorkflow:
                 )
         return total_evicted
 
-    async def _verify_lease_holders(self) -> None:
-        """Remove leases held by workflows that are in a terminal state.
-
-        Uses the verify_lease_holders activity to check whether each lease-holding
-        workflow is still running. This allows faster reclaim of slots from
-        cancelled/terminated workflows without waiting for the lease duration timeout.
-        """
-        # Collect all workflow IDs that hold leases across all profiles.
+    def _lease_holder_workflow_ids(self) -> list[str]:
+        """Return unique workflow IDs that currently hold profile leases."""
         all_wf_ids: list[str] = []
         for profile in self._profiles.values():
             all_wf_ids.extend(profile.current_leases)
+        return list(dict.fromkeys(all_wf_ids))
 
-        if not all_wf_ids:
-            return
+    def _pending_requester_workflow_ids(self) -> list[str]:
+        """Return unique workflow IDs with pending slot requests."""
+        return list(
+            dict.fromkeys(req.requester_workflow_id for req in self._pending_requests)
+        )
 
-        try:
-            result = await workflow.execute_activity(
-                "provider_profile.verify_lease_holders",
-                {"workflow_ids": all_wf_ids},
-                task_queue=ACTIVITY_TASK_QUEUE,
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=2),
-                    backoff_coefficient=2.0,
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                ),
-            )
-        except Exception:
-            # If verification fails, skip this cycle rather than leaking slots.
-            self._get_logger().warning(
-                "verify_lease_holders activity failed, skipping verification cycle"
-            )
-            return
+    async def _verify_workflow_statuses(
+        self, workflow_ids: list[str]
+    ) -> dict[str, dict[str, Any]] | None:
+        """Fetch workflow running status in bounded batches."""
+        unique_workflow_ids = list(dict.fromkeys(workflow_ids))
+        if not unique_workflow_ids:
+            return {}
 
-        lease_statuses: dict[str, dict[str, Any]] = result or {}
+        statuses: dict[str, dict[str, Any]] = {}
+        for start in range(
+            0,
+            len(unique_workflow_ids),
+            _VERIFY_WORKFLOW_STATUS_BATCH_SIZE,
+        ):
+            batch = unique_workflow_ids[
+                start : start + _VERIFY_WORKFLOW_STATUS_BATCH_SIZE
+            ]
+            try:
+                result = await workflow.execute_activity(
+                    "provider_profile.verify_lease_holders",
+                    {"workflow_ids": batch},
+                    task_queue=ACTIVITY_TASK_QUEUE,
+                    start_to_close_timeout=timedelta(seconds=30),
+                    retry_policy=RetryPolicy(
+                        initial_interval=timedelta(seconds=2),
+                        backoff_coefficient=2.0,
+                        maximum_interval=timedelta(seconds=30),
+                        maximum_attempts=3,
+                    ),
+                )
+            except Exception:
+                self._get_logger().warning(
+                    "verify_lease_holders activity failed, skipping verification cycle"
+                )
+                return None
+            statuses.update(result or {})
+        return statuses
+
+    def _reclaim_terminal_leases(
+        self, workflow_statuses: dict[str, dict[str, Any]]
+    ) -> bool:
+        """Remove leases held by workflows that are in a terminal state."""
         reclaimed = False
 
         for profile in list(self._profiles.values()):
             for wf_id in list(profile.current_leases):
-                status_info = lease_statuses.get(wf_id, {})
+                status_info = workflow_statuses.get(wf_id, {})
                 if not status_info.get("running", True):
                     profile.release(wf_id)
                     reclaimed = True
@@ -959,37 +981,12 @@ class MoonMindProviderProfileManagerWorkflow:
                         status_info.get("status", "UNKNOWN"),
                     )
 
-        if reclaimed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
-            await self._sync_leases_to_db()
+        return reclaimed
 
-    async def _verify_pending_requesters(self) -> int:
+    def _prune_terminal_pending_requesters(
+        self, workflow_statuses: dict[str, dict[str, Any]]
+    ) -> int:
         """Remove pending slot requests whose requester workflows are terminal."""
-        workflow_ids = list(
-            dict.fromkeys(req.requester_workflow_id for req in self._pending_requests)
-        )
-        if not workflow_ids:
-            return 0
-
-        try:
-            result = await workflow.execute_activity(
-                "provider_profile.verify_lease_holders",
-                {"workflow_ids": workflow_ids},
-                task_queue=ACTIVITY_TASK_QUEUE,
-                start_to_close_timeout=timedelta(seconds=30),
-                retry_policy=RetryPolicy(
-                    initial_interval=timedelta(seconds=2),
-                    backoff_coefficient=2.0,
-                    maximum_interval=timedelta(seconds=30),
-                    maximum_attempts=3,
-                ),
-            )
-        except Exception:
-            self._get_logger().warning(
-                "verify_lease_holders activity failed, skipping pending request verification"
-            )
-            return 0
-
-        workflow_statuses: dict[str, dict[str, Any]] = result or {}
         remaining: list[PendingRequest] = []
         removed_count = 0
         for request in self._pending_requests:
@@ -1007,6 +1004,59 @@ class MoonMindProviderProfileManagerWorkflow:
         if removed_count:
             self._pending_requests = remaining
         return removed_count
+
+    async def _verify_active_workflows(
+        self,
+        *,
+        verify_lease_holders: bool,
+        verify_pending_requesters: bool,
+    ) -> None:
+        """Verify lease holders and pending requesters with one status pass."""
+        workflow_ids: list[str] = []
+        if verify_lease_holders:
+            workflow_ids.extend(self._lease_holder_workflow_ids())
+        if verify_pending_requesters:
+            workflow_ids.extend(self._pending_requester_workflow_ids())
+
+        workflow_statuses = await self._verify_workflow_statuses(workflow_ids)
+        if workflow_statuses is None:
+            return
+
+        reclaimed = False
+        if verify_lease_holders:
+            reclaimed = self._reclaim_terminal_leases(workflow_statuses)
+        if verify_pending_requesters:
+            self._prune_terminal_pending_requesters(workflow_statuses)
+
+        if reclaimed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+            await self._sync_leases_to_db()
+
+    async def _verify_lease_holders(self) -> None:
+        """Remove leases held by workflows that are in a terminal state.
+
+        Uses the verify_lease_holders activity to check whether each lease-holding
+        workflow is still running. This allows faster reclaim of slots from
+        cancelled/terminated workflows without waiting for the lease duration timeout.
+        """
+        workflow_statuses = await self._verify_workflow_statuses(
+            self._lease_holder_workflow_ids()
+        )
+        if workflow_statuses is None:
+            return
+
+        reclaimed = self._reclaim_terminal_leases(workflow_statuses)
+        if reclaimed and workflow.patched(DB_LEASE_PERSISTENCE_PATCH):
+            await self._sync_leases_to_db()
+
+    async def _verify_pending_requesters(self) -> int:
+        """Remove pending slot requests whose requester workflows are terminal."""
+        workflow_statuses = await self._verify_workflow_statuses(
+            self._pending_requester_workflow_ids()
+        )
+        if workflow_statuses is None:
+            return 0
+
+        return self._prune_terminal_pending_requesters(workflow_statuses)
 
     def _clear_expired_cooldowns(self) -> None:
         """Remove cooldown markers that have expired."""

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -13,6 +13,7 @@ from moonmind.workflows.temporal.workflows.provider_profile_manager import (
     HandoffReservation,
     PendingRequest,
     SLOT_HANDOFF_RESERVATION_PATCH,
+    VERIFY_PENDING_REQUESTS_PATCH,
     WORKFLOW_NAME,
     MoonMindProviderProfileManagerWorkflow,
     ProfileSlotState,
@@ -825,6 +826,82 @@ class TestProviderProfileManagerHelpers:
         ]
         assert "run-1" not in wf._handoff_reservations
 
+    @pytest.mark.asyncio
+    async def test_verify_pending_requesters_prunes_terminal_workflows(self):
+        wf = self._make_workflow()
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="wf-canceled",
+                runtime_id="gemini_cli",
+            ),
+            PendingRequest(
+                requester_workflow_id="wf-running",
+                runtime_id="gemini_cli",
+            ),
+            PendingRequest(
+                requester_workflow_id="wf-missing-from-result",
+                runtime_id="gemini_cli",
+            ),
+        ]
+        captured_payloads: list[dict] = []
+
+        async def fake_execute_activity(
+            activity_name: str,
+            payload: dict,
+            **_: object,
+        ) -> dict:
+            captured_payloads.append(payload)
+            assert activity_name == "provider_profile.verify_lease_holders"
+            return {
+                "wf-canceled": {"running": False, "status": "CANCELED"},
+                "wf-running": {"running": True, "status": "RUNNING"},
+            }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            removed_count = await wf._verify_pending_requesters()
+
+        assert removed_count == 1
+        assert captured_payloads == [
+            {
+                "workflow_ids": [
+                    "wf-canceled",
+                    "wf-running",
+                    "wf-missing-from-result",
+                ]
+            }
+        ]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-running",
+            "wf-missing-from-result",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_verify_pending_requesters_keeps_queue_on_activity_failure(self):
+        wf = self._make_workflow()
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="wf-unknown",
+                runtime_id="gemini_cli",
+            )
+        ]
+
+        async def fake_execute_activity(*_: object, **__: object) -> dict:
+            raise RuntimeError("temporal unavailable")
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            removed_count = await wf._verify_pending_requesters()
+
+        assert removed_count == 0
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-unknown"
+        ]
+
     def test_handoff_reservation_blocks_only_one_slot(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(
@@ -922,6 +999,13 @@ class TestProviderProfileManagerHelpers:
 
 def test_workflow_name():
     assert WORKFLOW_NAME == "MoonMind.ProviderProfileManager"
+
+
+def test_verify_pending_requests_patch_id():
+    assert (
+        VERIFY_PENDING_REQUESTS_PATCH
+        == "provider-profile-manager-verify-pending-requests-v1"
+    )
 
 
 def test_registered_workflow_types():

--- a/tests/unit/workflows/temporal/test_provider_profile_manager.py
+++ b/tests/unit/workflows/temporal/test_provider_profile_manager.py
@@ -902,6 +902,102 @@ class TestProviderProfileManagerHelpers:
             "wf-unknown"
         ]
 
+    @pytest.mark.asyncio
+    async def test_verify_workflow_statuses_batches_large_workflow_id_sets(self):
+        wf = self._make_workflow()
+        workflow_ids = [f"wf-{idx}" for idx in range(205)]
+        captured_batches: list[list[str]] = []
+
+        async def fake_execute_activity(
+            activity_name: str,
+            payload: dict,
+            **_: object,
+        ) -> dict:
+            assert activity_name == "provider_profile.verify_lease_holders"
+            batch = payload["workflow_ids"]
+            captured_batches.append(batch)
+            return {workflow_id: {"running": True} for workflow_id in batch}
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            statuses = await wf._verify_workflow_statuses(workflow_ids)
+
+        assert statuses is not None
+        assert len(statuses) == 205
+        assert [len(batch) for batch in captured_batches] == [100, 100, 5]
+
+    @pytest.mark.asyncio
+    async def test_verify_active_workflows_consolidates_pending_and_lease_checks(self):
+        wf = self._make_workflow()
+        wf._profiles["p1"] = ProfileSlotState(
+            profile_id="p1",
+            max_parallel_runs=2,
+            cooldown_after_429_seconds=300,
+            rate_limit_policy="backoff",
+            enabled=True,
+            is_default=True,
+            current_leases=["wf-lease-terminal", "wf-shared"],
+        )
+        wf._pending_requests = [
+            PendingRequest(
+                requester_workflow_id="wf-pending-terminal",
+                runtime_id="gemini_cli",
+            ),
+            PendingRequest(
+                requester_workflow_id="wf-shared",
+                runtime_id="gemini_cli",
+            ),
+        ]
+        captured_payloads: list[dict] = []
+
+        async def fake_execute_activity(
+            activity_name: str,
+            payload: dict,
+            **_: object,
+        ) -> dict:
+            captured_payloads.append(payload)
+            assert activity_name == "provider_profile.verify_lease_holders"
+            return {
+                "wf-lease-terminal": {"running": False, "status": "CANCELED"},
+                "wf-pending-terminal": {"running": False, "status": "TERMINATED"},
+                "wf-shared": {"running": True, "status": "RUNNING"},
+            }
+
+        with patch(
+            "moonmind.workflows.temporal.workflows.provider_profile_manager.workflow"
+        ) as mock_wf:
+            mock_wf.execute_activity.side_effect = fake_execute_activity
+            mock_wf.patched.return_value = False
+            await wf._verify_active_workflows(
+                verify_lease_holders=True,
+                verify_pending_requesters=True,
+            )
+
+        assert captured_payloads == [
+            {
+                "workflow_ids": [
+                    "wf-lease-terminal",
+                    "wf-shared",
+                    "wf-pending-terminal",
+                ]
+            }
+        ]
+        assert wf._profiles["p1"].current_leases == ["wf-shared"]
+        assert [req.requester_workflow_id for req in wf._pending_requests] == [
+            "wf-shared"
+        ]
+
+    def test_run_drains_queue_before_best_effort_pending_verification(self):
+        import inspect
+
+        source = inspect.getsource(MoonMindProviderProfileManagerWorkflow.run)
+        drain_index = source.index("await self._drain_queue()")
+        verify_index = source.index("await self._verify_active_workflows(")
+
+        assert drain_index < verify_index
+
     def test_handoff_reservation_blocks_only_one_slot(self):
         wf = self._make_workflow()
         wf._profiles["p1"] = ProfileSlotState(


### PR DESCRIPTION
## Summary
- Add provider-profile manager cleanup for terminal workflows that are still waiting in the pending slot queue.
- Reuse the existing Temporal workflow status activity before queue draining so canceled/not-found pending requesters do not block later requests.
- Add unit coverage for pruning terminal pending requests and preserving the queue when verification fails.

## Root Cause
The manager only verified active lease holders. If an AgentRun was canceled while still pending, it could remain at the head of `_pending_requests` without a lease, preventing later requests from receiving available slots.

## Validation
- `./tools/test_unit.sh tests/unit/workflows/temporal/test_provider_profile_manager.py`
- `./tools/test_unit.sh`
- `python3 -m py_compile moonmind/workflows/temporal/workflows/provider_profile_manager.py tests/unit/workflows/temporal/test_provider_profile_manager.py`
- `git diff --check`
