### PR TITLE
[codex] Enable OAuth terminal right-click copy

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,22 @@
 [
   {
-    "id": 3119218535,
+    "id": 3119672179,
     "disposition": "addressed",
-    "rationale": "Excluded .td-instructions-toggle from the global primary button selectors so its lightweight hover/active styling is preserved."
+    "rationale": "Added a capture-phase window contextmenu listener so stale OAuth terminal copy menus close before external right-clicks or replacement terminal menus are handled."
   },
   {
-    "id": 4149618936,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary container; the actionable inline comment from this review is tracked separately."
+    "id": 3119672181,
+    "disposition": "addressed",
+    "rationale": "Added coordinate fallback for zero/invalid contextmenu client coordinates using the terminal element bounds."
   },
   {
-    "id": 4149627539,
+    "id": 4150105434,
     "disposition": "not-applicable",
-    "rationale": "Review body explicitly states there is no feedback to address."
+    "rationale": "Bot review summary only; the specific actionable child review comments were addressed separately."
+  },
+  {
+    "id": 3119672189,
+    "disposition": "addressed",
+    "rationale": "Focused the copy menu item when the context menu opens to support keyboard and assistive-technology navigation."
   }
 ]

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -495,11 +495,44 @@ describe('Mission Control shared entry', () => {
 
       expect(await screen.findByText('Provider Login Terminal')).toBeTruthy();
       expect(await screen.findByText('Ready for login')).toBeTruthy();
-      fireEvent.contextMenu(screen.getByTestId('oauth-xterm'), {
+      const terminalElement = screen.getByTestId('oauth-xterm');
+      vi.spyOn(terminalElement, 'getBoundingClientRect').mockReturnValue({
+        x: 10,
+        y: 20,
+        left: 10,
+        top: 20,
+        right: 90,
+        bottom: 60,
+        width: 80,
+        height: 40,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+      fireEvent.contextMenu(terminalElement, {
         clientX: 24,
         clientY: 32,
       });
-      fireEvent.click(screen.getByRole('menuitem', { name: 'Copy selection' }));
+      const copyMenuItem = screen.getByRole('menuitem', { name: 'Copy selection' });
+      await waitFor(() => {
+        expect(document.activeElement).toBe(copyMenuItem);
+      });
+      fireEvent.contextMenu(document.body, {
+        clientX: 200,
+        clientY: 220,
+      });
+      expect(screen.queryByRole('menuitem', { name: 'Copy selection' })).toBeNull();
+
+      fireEvent.contextMenu(terminalElement, {
+        clientX: 0,
+        clientY: 0,
+      });
+      const fallbackMenuItem = screen.getByRole('menuitem', { name: 'Copy selection' });
+      const fallbackMenu = fallbackMenuItem.closest('.oauth-terminal-context-menu');
+      expect(fallbackMenu).toBeInstanceOf(HTMLElement);
+      expect((fallbackMenu as HTMLElement).style.left).toBe('34px');
+      expect((fallbackMenu as HTMLElement).style.top).toBe('40px');
+
+      fireEvent.click(fallbackMenuItem);
       expect(clipboardMock.writeText).toHaveBeenCalledWith('Ready for login');
       fireEvent.click(screen.getByRole('button', { name: 'Copy selection' }));
       expect(clipboardMock.writeText).toHaveBeenCalledWith('Ready for login');

--- a/frontend/src/entrypoints/mission-control.test.tsx
+++ b/frontend/src/entrypoints/mission-control.test.tsx
@@ -495,6 +495,12 @@ describe('Mission Control shared entry', () => {
 
       expect(await screen.findByText('Provider Login Terminal')).toBeTruthy();
       expect(await screen.findByText('Ready for login')).toBeTruthy();
+      fireEvent.contextMenu(screen.getByTestId('oauth-xterm'), {
+        clientX: 24,
+        clientY: 32,
+      });
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Copy selection' }));
+      expect(clipboardMock.writeText).toHaveBeenCalledWith('Ready for login');
       fireEvent.click(screen.getByRole('button', { name: 'Copy selection' }));
       expect(clipboardMock.writeText).toHaveBeenCalledWith('Ready for login');
       await waitFor(() => {

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -128,6 +128,23 @@ function isTerminalAttachable(session: OAuthSessionResponse): boolean {
   );
 }
 
+function contextMenuPositionForEvent(
+  event: MouseEvent,
+  fallbackElement: HTMLElement,
+): Pick<TerminalContextMenuState, 'x' | 'y'> {
+  if (Number.isFinite(event.clientX) && Number.isFinite(event.clientY)) {
+    if (event.clientX !== 0 || event.clientY !== 0) {
+      return { x: event.clientX, y: event.clientY };
+    }
+  }
+
+  const rect = fallbackElement.getBoundingClientRect();
+  return {
+    x: rect.left + Math.min(24, Math.max(rect.width / 2, 0)),
+    y: rect.top + Math.min(24, Math.max(rect.height / 2, 0)),
+  };
+}
+
 async function readErrorDetail(response: Response, fallback: string): Promise<string> {
   const payload = (await response.json().catch(() => null)) as { detail?: unknown } | null;
   return typeof payload?.detail === 'string' ? payload.detail : fallback;
@@ -138,6 +155,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
   const [status, setStatus] = useState('Preparing terminal');
   const [contextMenu, setContextMenu] = useState<TerminalContextMenuState | null>(null);
   const terminalElementRef = useRef<HTMLDivElement | null>(null);
+  const contextMenuItemRef = useRef<HTMLButtonElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const socketRef = useRef<WebSocket | null>(null);
@@ -161,11 +179,14 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
         closeContextMenu();
       }
     };
+    contextMenuItemRef.current?.focus({ preventScroll: true });
     window.addEventListener('click', closeContextMenu);
+    window.addEventListener('contextmenu', closeContextMenu, true);
     window.addEventListener('keydown', closeContextMenuOnEscape);
     window.addEventListener('resize', closeContextMenu);
     return () => {
       window.removeEventListener('click', closeContextMenu);
+      window.removeEventListener('contextmenu', closeContextMenu, true);
       window.removeEventListener('keydown', closeContextMenuOnEscape);
       window.removeEventListener('resize', closeContextMenu);
     };
@@ -211,10 +232,11 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
         return;
       }
       event.preventDefault();
+      const position = contextMenuPositionForEvent(event, terminalElement);
       setContextMenu({
         selectedText,
-        x: event.clientX,
-        y: event.clientY,
+        x: position.x,
+        y: position.y,
       });
     };
     terminalElement.addEventListener('contextmenu', contextMenuListener);
@@ -381,6 +403,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
           onMouseDown={(event) => event.preventDefault()}
         >
           <button
+            ref={contextMenuItemRef}
             type="button"
             role="menuitem"
             onClick={() => {

--- a/frontend/src/entrypoints/oauth-terminal.tsx
+++ b/frontend/src/entrypoints/oauth-terminal.tsx
@@ -37,6 +37,12 @@ type OAuthSessionResponse = {
   failure_reason?: string | null;
 };
 
+type TerminalContextMenuState = {
+  selectedText: string;
+  x: number;
+  y: number;
+};
+
 const TERMINAL_ATTACHABLE_STATUSES: readonly OAuthSessionStatus[] = [
   'bridge_ready',
   'awaiting_user',
@@ -50,21 +56,44 @@ const TERMINAL_FINAL_STATUSES: readonly OAuthSessionStatus[] = [
 ];
 const TERMINAL_READY_POLL_MS = 1000;
 
+function copyTextWithLegacyCommand(text: string): void {
+  if (typeof document === 'undefined' || !document.body) {
+    return;
+  }
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.setAttribute('readonly', '');
+  textArea.style.left = '-9999px';
+  textArea.style.position = 'fixed';
+  textArea.style.top = '0';
+  document.body.appendChild(textArea);
+  textArea.select();
+  try {
+    document.execCommand('copy');
+  } catch {
+    // Some browsers block programmatic copy; the visible selection remains intact.
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
 function copyTextToClipboard(text: string): void {
   if (
     typeof navigator === 'undefined' ||
     !navigator.clipboard ||
     typeof navigator.clipboard.writeText !== 'function'
   ) {
+    copyTextWithLegacyCommand(text);
     return;
   }
   try {
     const maybePromise = navigator.clipboard.writeText(text);
     if (typeof maybePromise?.catch === 'function') {
-      maybePromise.catch(() => undefined);
+      maybePromise.catch(() => copyTextWithLegacyCommand(text));
     }
   } catch {
     // Clipboard permissions can vary by browser/context; keep terminal input stable.
+    copyTextWithLegacyCommand(text);
   }
 }
 
@@ -107,6 +136,7 @@ async function readErrorDetail(response: Response, fallback: string): Promise<st
 export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
   const sessionId = useMemo(() => readSessionId(payload), [payload]);
   const [status, setStatus] = useState('Preparing terminal');
+  const [contextMenu, setContextMenu] = useState<TerminalContextMenuState | null>(null);
   const terminalElementRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -118,6 +148,28 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       copyTextToClipboard(selectedText);
     }
   };
+
+  useEffect(() => {
+    if (!contextMenu) {
+      return undefined;
+    }
+    const closeContextMenu = () => {
+      setContextMenu(null);
+    };
+    const closeContextMenuOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeContextMenu();
+      }
+    };
+    window.addEventListener('click', closeContextMenu);
+    window.addEventListener('keydown', closeContextMenuOnEscape);
+    window.addEventListener('resize', closeContextMenu);
+    return () => {
+      window.removeEventListener('click', closeContextMenu);
+      window.removeEventListener('keydown', closeContextMenuOnEscape);
+      window.removeEventListener('resize', closeContextMenu);
+    };
+  }, [contextMenu]);
 
   useEffect(() => {
     const terminalElement = terminalElementRef.current;
@@ -152,6 +204,20 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       event.clipboardData.setData('text/plain', selectedText);
     };
     terminalElement.addEventListener('copy', copySelectionListener);
+    const contextMenuListener = (event: MouseEvent) => {
+      const selectedText = terminal.getSelection();
+      if (!selectedText) {
+        setContextMenu(null);
+        return;
+      }
+      event.preventDefault();
+      setContextMenu({
+        selectedText,
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
+    terminalElement.addEventListener('contextmenu', contextMenuListener);
 
     const sendResize = () => {
       const socket = socketRef.current;
@@ -173,6 +239,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       return () => {
         window.removeEventListener('resize', resizeListener);
         terminalElement.removeEventListener('copy', copySelectionListener);
+        terminalElement.removeEventListener('contextmenu', contextMenuListener);
         terminal.dispose();
         terminalRef.current = null;
         fitAddonRef.current = null;
@@ -279,6 +346,7 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       closed = true;
       window.removeEventListener('resize', resizeListener);
       terminalElement.removeEventListener('copy', copySelectionListener);
+      terminalElement.removeEventListener('contextmenu', contextMenuListener);
       inputDisposable.dispose();
       socketRef.current?.close();
       socketRef.current = null;
@@ -305,6 +373,25 @@ export function OAuthTerminalPage({ payload }: { payload: BootPayload }) {
       <section className="oauth-terminal-surface" aria-label="OAuth terminal output">
         <div ref={terminalElementRef} className="oauth-terminal-xterm" />
       </section>
+      {contextMenu ? (
+        <div
+          className="oauth-terminal-context-menu"
+          role="menu"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+          onMouseDown={(event) => event.preventDefault()}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              copyTextToClipboard(contextMenu.selectedText);
+              setContextMenu(null);
+            }}
+          >
+            Copy selection
+          </button>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2397,6 +2397,36 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   height: 100%;
 }
 
+.oauth-terminal-context-menu {
+  background: rgb(var(--mm-panel, 255 255 255));
+  border: 1px solid rgb(var(--mm-border, 203 213 225));
+  border-radius: 8px;
+  box-shadow: 0 16px 32px rgb(15 23 42 / 0.18);
+  min-width: 144px;
+  padding: 4px;
+  position: fixed;
+  z-index: 80;
+}
+
+.oauth-terminal-context-menu button {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: rgb(var(--mm-text, 15 23 42));
+  cursor: pointer;
+  display: block;
+  font: inherit;
+  padding: 8px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.oauth-terminal-context-menu button:hover,
+.oauth-terminal-context-menu button:focus-visible {
+  background: rgb(var(--mm-hover, 241 245 249));
+  outline: none;
+}
+
 .jira-provenance-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Add a terminal-scoped right-click context menu for copying selected OAuth terminal output.
- Preserve the existing Copy selection button and add a legacy clipboard fallback.
- Cover the right-click copy path in the Mission Control UI test.

## Root Cause
The OAuth terminal renders through xterm.js, so browser-native context menu copy was not reliably available for xterm's virtual terminal selection.

## Validation
- `npm run ui:test -- frontend/src/entrypoints/mission-control.test.tsx`
- `npm run ui:typecheck`
- `./tools/test_unit.sh`