### PR TITLE
MM-426 standardize Mission Control layout and table composition

### DIFF
--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-421",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1644"
+  "jira_issue_key": "MM-426",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1650"
 }

--- a/docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md
@@ -1,19 +1,69 @@
 # MM-426 MoonSpec Orchestration Input
 
-Jira Orchestrate for MM-426.
+## Source
 
-Source story: STORY-003.  
-Source summary: Standardize Mission Control layout and table composition patterns.  
-Source Jira issue: unknown.  
-Original brief reference: not provided.
+- Jira issue: MM-426
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Standardize Mission Control layout and table composition patterns
+- Labels: `moonmind-workflow-mm-d6451203-b4c9-4ae4-92b2-2b618c958888`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
 
-## Canonical Brief
+## Canonical MoonSpec Feature Request
 
-Standardize Mission Control layout and table composition patterns.
+Jira issue: MM-426 from MM project
+Summary: Standardize Mission Control layout and table composition patterns
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
 
-## Runtime Constraints
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-426 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
 
-- Use the existing Jira Orchestrate / MoonSpec lifecycle.
-- Do not run implementation inline inside a breakdown task.
-- Treat this as a single-story runtime UI composition story.
-- Preserve MM-426 in spec artifacts, verification output, commit text, and PR metadata.
+MM-426: Standardize Mission Control layout and table composition patterns
+
+Source Reference
+- Source Document: docs/UI/MissionControlDesignSystem.md
+- Source Title: Mission Control Design System
+- Source Sections:
+  - 7. Layout system
+  - 10.1 Masthead and navigation
+  - 10.4 Control decks and filter clusters
+  - 10.5 Tables and dense list surfaces
+  - 10.6 Column economics
+  - 11.1 /tasks/list
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-019
+
+User Story
+As an operator scanning operational work, I want Mission Control layouts, mastheads, control decks, utility clusters, and data slabs to make comparison and route-level hierarchy fast and predictable.
+
+Acceptance Criteria
+- Mission Control shell supports constrained and data-wide modes with documented width ranges or equivalent responsive constraints.
+- Masthead uses left brand, viewport-centered nav pills, and right utility/telemetry zone rather than centering nav only in leftover space.
+- List/console pages separate primary filters and utilities from the matte table/data slab.
+- Upper-right desktop space is used for compact utilities such as live toggle, result counts, active filter summary, page size, or pagination where relevant.
+- The task list remains table-first on desktop and uses cards only for narrow/mobile layouts.
+- Sticky table headers support long-scroll scanning.
+- Pagination and page-size controls are visually attached to the table system, not treated as primary filters.
+
+Requirements
+- Implement shell width modes and spacing rhythm.
+- Align masthead architecture.
+- Create or apply control deck plus data slab primitives.
+- Preserve comparison-oriented desktop table economics.
+
+Implementation Notes
+- Preserve MM-426 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/UI/MissionControlDesignSystem.md` as the source design reference for Mission Control layout, masthead, control deck, table, and column-composition patterns.
+- Keep desktop Mission Control list and console pages comparison-oriented and table-first.
+- Use narrow/mobile cards only for constrained viewports where table economics no longer fit.
+- Keep compact utility controls visually associated with route-level state and table/data-slab systems rather than treating them as primary filters.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-426 is blocked by MM-427, whose embedded status is Backlog.
+- Trusted Jira link metadata also shows MM-426 blocks MM-425, which is not a blocker for MM-426 and is ignored for dependency gating.

--- a/docs/tmp/jira-orchestration-reports/MM-426-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-426-code-review-transition.md
@@ -1,0 +1,24 @@
+# MM-426 Code Review Transition
+
+## Source
+
+- Jira issue: `MM-426`
+- Pull request handoff artifact: `artifacts/jira-orchestrate-pr.json`
+- Pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1650
+- Trusted tool surface: `MOONMIND_URL` `/mcp/tools`
+
+## Actions
+
+- Verified `artifacts/jira-orchestrate-pr.json` contains `jira_issue_key = MM-426` and a non-empty GitHub pull request URL.
+- Fetched MM-426 through `jira.get_issue`; current status before transition was `In Progress`.
+- Added a Jira-visible comment through `jira.add_comment`:
+  `Pull request for MM-426 is ready for Code Review: https://github.com/MoonLadderStudios/MoonMind/pull/1650`
+- Fetched available transitions through `jira.get_transitions`.
+- Matched `Code Review` against transition name and target status.
+- Applied transition id `51` through `jira.transition_issue`.
+- Re-fetched MM-426 through `jira.get_issue`.
+
+## Result
+
+- Confirmed Jira status: `Code Review`
+- Comment id: `10846`

--- a/specs/214-mission-control-layout-table-composition/plan.md
+++ b/specs/214-mission-control-layout-table-composition/plan.md
@@ -19,7 +19,7 @@ Implement MM-426 by making Mission Control's task-list composition match the des
 | FR-006 | partial | `DataTable` uses standalone Tailwind utility classes | switch to shared Mission Control table classes | compile/UI unit |
 | FR-007 | implemented_unverified | existing task-list tests cover behavior | rerun focused and wrapper tests | UI unit |
 | FR-008 | missing | no MM-426-specific tests | add composition and filter-chip tests | UI unit |
-| FR-009 | implemented_unverified | `spec.md` preserves MM-426 and source summary | preserve through tasks, verification, and commit | final verify |
+| FR-009 | implemented_unverified | `spec.md` preserves MM-426, the trusted Jira preset brief, and source design coverage IDs | preserve through tasks, verification, and commit | final verify |
 
 ## Technical Context
 

--- a/specs/214-mission-control-layout-table-composition/plan.md
+++ b/specs/214-mission-control-layout-table-composition/plan.md
@@ -21,7 +21,7 @@ Implement MM-426 by making Mission Control's task-list composition match the des
 | FR-008 | implemented_verified | `tasks-list.test.tsx` includes MM-426-focused composition, filter-chip, and sticky-header assertions. | no new implementation | UI unit |
 | FR-009 | implemented_verified | `spec.md`, `verification.md`, and `docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md` preserve MM-426, the trusted Jira preset brief, and source design coverage IDs. | no new implementation | final verify |
 | DESIGN-REQ-012 | implemented_verified | `spec.md` maps MM-426 to the Mission Control layout system; `tasks-list.tsx` uses control and data surfaces that support data-wide route composition. | no new implementation | UI unit |
-| DESIGN-REQ-013 | implemented_verified | Masthead/navigation architecture is out of direct task-list scope, and this story preserves route composition without changing masthead ownership. | no new implementation | final verify |
+| DESIGN-REQ-013 | implemented_verified | `frontend/src/styles/mission-control.css` uses a three-zone masthead grid, and `frontend/src/entrypoints/mission-control.test.tsx` verifies brand-left, nav-centered, version-right desktop alignment. | no new implementation | UI unit |
 | DESIGN-REQ-014 | implemented_verified | Control deck/filter cluster requirements are implemented by `.task-list-control-deck`, `.task-list-control-grid`, utility cluster, chips, and clear action. | no new implementation | UI unit |
 | DESIGN-REQ-019 | implemented_verified | `/tasks/list` uses the control deck + data slab structure, sticky table header, attached pagination/page-size controls, and table-first desktop posture. | no new implementation | UI unit |
 
@@ -30,7 +30,7 @@ Implement MM-426 by making Mission Control's task-list composition match the des
 **Language/Version**: TypeScript/React for Mission Control UI; CSS for shared Mission Control styling  
 **Primary Dependencies**: React, TanStack Query, Vite/Vitest, existing Mission Control shared stylesheet  
 **Storage**: No new persistent storage  
-**Unit Testing**: `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`; direct `./node_modules/.bin/vitest` if the npm script cannot resolve `vitest` in the managed container; final wrapper via `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
+**Unit Testing**: `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx frontend/src/entrypoints/mission-control.test.tsx`; direct `./node_modules/.bin/vitest` if the npm script cannot resolve `vitest` in the managed container; final wrapper via `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`
 **Integration Testing**: Existing task-list UI render tests exercise API request shape, route links, and user-level filter/pagination flows in an integration-style browser component boundary; no compose-backed integration is required because backend contracts are unchanged
 **Target Platform**: Browser-hosted Mission Control UI served by FastAPI  
 **Project Type**: Web UI composition/design-system story  

--- a/specs/214-mission-control-layout-table-composition/plan.md
+++ b/specs/214-mission-control-layout-table-composition/plan.md
@@ -5,21 +5,25 @@
 
 ## Summary
 
-Implement MM-426 by making Mission Control's task-list composition match the desired control-deck plus data-slab pattern from `docs/UI/MissionControlDesignSystem.md`. Repo inspection shows the task list already has functional filters, sorting, pagination, constrained columns, and mobile cards, but its controls and table are one loose stack. The implementation keeps behavior intact while adding semantic control/data surfaces, active-filter chips, sticky table headers, and a tokenized shared `DataTable` slab for existing dense-table consumers.
+Implement MM-426 by making Mission Control's task-list composition match the desired control-deck plus data-slab pattern from `docs/UI/MissionControlDesignSystem.md`. Current repo inspection shows the implementation is present: task-list markup exposes semantic control/data surfaces, active-filter chips, sticky table headers, and shared `DataTable` slab classes while preserving existing request, sorting, pagination, and mobile-card behavior.
 
 ## Requirement Status
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | partial | task list has title, filters, and live updates but no named control deck | group them in `.task-list-control-deck.panel--controls` | UI unit |
-| FR-002 | partial | result toolbar and table exist in `.queue-layouts` | make `.task-list-data-slab.panel--data` the connected result surface | UI unit |
-| FR-003 | missing | filters update query/request state but active chips are absent | add active filter chips and clear action | UI unit |
-| FR-004 | partial | table has constrained columns but headers are not sticky | make table wrapper scrollable and headers sticky | UI unit / CSS |
-| FR-005 | implemented_unverified | existing constrained column tests cover long workflow IDs | preserve and rerun tests | UI unit |
-| FR-006 | partial | `DataTable` uses standalone Tailwind utility classes | switch to shared Mission Control table classes | compile/UI unit |
-| FR-007 | implemented_unverified | existing task-list tests cover behavior | rerun focused and wrapper tests | UI unit |
-| FR-008 | missing | no MM-426-specific tests | add composition and filter-chip tests | UI unit |
-| FR-009 | implemented_unverified | `spec.md` preserves MM-426, the trusted Jira preset brief, and source design coverage IDs | preserve through tasks, verification, and commit | final verify |
+| FR-001 | implemented_verified | `frontend/src/entrypoints/tasks-list.tsx` renders `.task-list-control-deck.panel--controls`; `tasks-list.test.tsx` asserts the control deck exists. | no new implementation | UI unit |
+| FR-002 | implemented_verified | `tasks-list.tsx` renders `.task-list-data-slab.panel--data`; `tasks-list.test.tsx` asserts the data slab and table wrapper exist. | no new implementation | UI unit |
+| FR-003 | implemented_verified | `tasks-list.tsx` renders `.task-list-filter-chip` entries and `Clear filters`; `tasks-list.test.tsx` covers chip rendering and clearing. | no new implementation | UI unit |
+| FR-004 | implemented_verified | `mission-control.css` sets `.queue-table-wrapper th { position: sticky; }`; `tasks-list.test.tsx` verifies computed sticky positioning. | no new implementation | UI unit / CSS |
+| FR-005 | implemented_verified | Existing task-list tests cover long workflow IDs, and `.queue-table-wrapper` / cell styles constrain dense table layout. | no new implementation | UI unit |
+| FR-006 | implemented_verified | `frontend/src/components/tables/DataTable.tsx` emits `.data-table-slab`, `.data-table`, and `.data-table-empty` classes. | no new implementation | compile/UI unit |
+| FR-007 | implemented_verified | Existing task-list tests continue to cover request behavior, sorting, pagination, dependency summaries, runtime labels, and mobile cards. | no new implementation | UI unit |
+| FR-008 | implemented_verified | `tasks-list.test.tsx` includes MM-426-focused composition, filter-chip, and sticky-header assertions. | no new implementation | UI unit |
+| FR-009 | implemented_verified | `spec.md`, `verification.md`, and `docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md` preserve MM-426, the trusted Jira preset brief, and source design coverage IDs. | no new implementation | final verify |
+| DESIGN-REQ-012 | implemented_verified | `spec.md` maps MM-426 to the Mission Control layout system; `tasks-list.tsx` uses control and data surfaces that support data-wide route composition. | no new implementation | UI unit |
+| DESIGN-REQ-013 | implemented_verified | Masthead/navigation architecture is out of direct task-list scope, and this story preserves route composition without changing masthead ownership. | no new implementation | final verify |
+| DESIGN-REQ-014 | implemented_verified | Control deck/filter cluster requirements are implemented by `.task-list-control-deck`, `.task-list-control-grid`, utility cluster, chips, and clear action. | no new implementation | UI unit |
+| DESIGN-REQ-019 | implemented_verified | `/tasks/list` uses the control deck + data slab structure, sticky table header, attached pagination/page-size controls, and table-first desktop posture. | no new implementation | UI unit |
 
 ## Technical Context
 
@@ -27,7 +31,7 @@ Implement MM-426 by making Mission Control's task-list composition match the des
 **Primary Dependencies**: React, TanStack Query, Vite/Vitest, existing Mission Control shared stylesheet  
 **Storage**: No new persistent storage  
 **Unit Testing**: `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`; direct `./node_modules/.bin/vitest` if the npm script cannot resolve `vitest` in the managed container; final wrapper via `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`  
-**Integration Testing**: Existing task-list UI test render exercises API request shape and routing links; no compose-backed integration is required because backend contracts are unchanged  
+**Integration Testing**: Existing task-list UI render tests exercise API request shape, route links, and user-level filter/pagination flows in an integration-style browser component boundary; no compose-backed integration is required because backend contracts are unchanged
 **Target Platform**: Browser-hosted Mission Control UI served by FastAPI  
 **Project Type**: Web UI composition/design-system story  
 **Performance Goals**: Avoid new network calls, runtime loops, or heavy visual effects; sticky headers are CSS-only  
@@ -72,6 +76,8 @@ frontend/src/
 docs/tmp/jira-orchestration-inputs/
 └── MM-426-moonspec-orchestration-input.md
 ```
+
+`data-model.md` is intentionally absent because MM-426 introduces no persisted entity, state machine, schema, or data contract.
 
 **Structure Decision**: Keep behavior in the existing task-list entrypoint and shared table component. Use CSS classes as the layout contract so other Mission Control table consumers can adopt the same slab posture without new runtime APIs.
 

--- a/specs/214-mission-control-layout-table-composition/quickstart.md
+++ b/specs/214-mission-control-layout-table-composition/quickstart.md
@@ -27,6 +27,10 @@ MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypo
 
 Expected result: Python unit suite and targeted UI tests pass through the canonical wrapper.
 
+## Integration Strategy
+
+No compose-backed integration test is required for MM-426 because backend contracts, persistence, and Temporal behavior are unchanged. The integration-style validation is the task-list browser component boundary in `frontend/src/entrypoints/tasks-list.test.tsx`, which exercises rendered filters, request/query shape, routing links, pagination, mobile cards, active-filter chips, and table structure together.
+
 ## Manual Inspection
 
 1. Open `/tasks/list`.

--- a/specs/214-mission-control-layout-table-composition/quickstart.md
+++ b/specs/214-mission-control-layout-table-composition/quickstart.md
@@ -19,6 +19,14 @@ Expected result:
 - table wrapper scroll and sticky header posture is covered,
 - existing task-list behavior tests still pass.
 
+For masthead source-design coverage, run:
+
+```bash
+./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx
+```
+
+Expected result: the desktop masthead keeps brand content left, navigation visually centered, and version/utility metadata aligned right.
+
 ## Final Unit Wrapper
 
 ```bash

--- a/specs/214-mission-control-layout-table-composition/research.md
+++ b/specs/214-mission-control-layout-table-composition/research.md
@@ -6,16 +6,36 @@ Rationale: `docs/UI/MissionControlDesignSystem.md` names `/tasks/list` as the ro
 
 Alternatives considered: Redesigning manifests, schedules, settings, or detail pages was rejected as broader than the supplied single-story brief. Those pages can consume the shared `DataTable` improvements without a route redesign.
 
+Test implications: Unit coverage comes from focused Vitest task-list tests. Integration-style coverage stays at the browser component boundary because the route behavior is exercised through rendered filters, request shape, routing links, and pagination without changing backend contracts.
+
 ## Decision: Use semantic CSS classes as the composition contract
 
 Rationale: Mission Control already relies on stable semantic classes such as `panel`, `toolbar`, and `queue-table-wrapper`. Adding `panel--controls`, `panel--data`, `task-list-control-deck`, and `task-list-data-slab` keeps the pattern inspectable and testable without introducing a component framework migration.
 
 Alternatives considered: Introducing a new React layout component was rejected because the current page is small and the first useful contract is the rendered surface structure.
 
+Test implications: Unit tests assert the semantic class contract directly, and computed-style checks verify sticky table posture.
+
 ## Decision: Keep table behavior and request semantics unchanged
 
 Rationale: The story is about composition and table posture, not data fetching. Existing tests already cover request parameters, sorting, pagination, dependency summaries, runtime labels, mobile cards, and long ID wrapping. New tests should add coverage around surface structure and active filter chips while preserving existing assertions.
 
+Test implications: Unit tests cover the new UI structure while existing render tests continue to serve as integration-style guardrails for query/request behavior.
+
 ## Decision: Standardize `DataTable` markup on Mission Control classes
 
 Rationale: `frontend/src/components/tables/DataTable.tsx` used standalone Tailwind table wrappers that did not express the shared matte data slab pattern. Switching its wrapper/table/empty-state classes to Mission Control classes lets existing consumers inherit the same table foundation.
+
+Test implications: No backend or compose-backed integration test is required; build/type checks and existing component render coverage validate the shared class contract.
+
+## Source Design Coverage
+
+Decision: Treat DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, and DESIGN-REQ-019 from the trusted MM-426 preset brief as in-scope runtime requirements.
+
+Evidence: `specs/214-mission-control-layout-table-composition/spec.md` preserves the source design coverage IDs; `frontend/src/entrypoints/tasks-list.tsx` renders the control deck, utility cluster, active chips, clear action, and data slab; `frontend/src/styles/mission-control.css` defines sticky table headers and dense table slab styles; `frontend/src/components/tables/DataTable.tsx` emits shared data-table classes.
+
+Rationale: The Jira brief points at `docs/UI/MissionControlDesignSystem.md` as source requirements. The scoped story implements the `/tasks/list` layout/table composition portions while keeping masthead ownership outside the task-list route.
+
+Alternatives considered: Regenerating broad design breakdown output was rejected because MM-426 is already a single-story preset brief. Adding a data model was rejected because the story adds no persisted data, schema, or state machine.
+
+Test implications: Unit tests cover the rendered UI class contract and sticky header posture. Integration strategy remains the existing task-list browser component boundary because backend API contracts are unchanged.

--- a/specs/214-mission-control-layout-table-composition/research.md
+++ b/specs/214-mission-control-layout-table-composition/research.md
@@ -32,10 +32,10 @@ Test implications: No backend or compose-backed integration test is required; bu
 
 Decision: Treat DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, and DESIGN-REQ-019 from the trusted MM-426 preset brief as in-scope runtime requirements.
 
-Evidence: `specs/214-mission-control-layout-table-composition/spec.md` preserves the source design coverage IDs; `frontend/src/entrypoints/tasks-list.tsx` renders the control deck, utility cluster, active chips, clear action, and data slab; `frontend/src/styles/mission-control.css` defines sticky table headers and dense table slab styles; `frontend/src/components/tables/DataTable.tsx` emits shared data-table classes.
+Evidence: `specs/214-mission-control-layout-table-composition/spec.md` preserves the source design coverage IDs; `frontend/src/entrypoints/tasks-list.tsx` renders the control deck, utility cluster, active chips, clear action, and data slab; `frontend/src/styles/mission-control.css` defines sticky table headers, dense table slab styles, and the three-zone masthead grid; `frontend/src/entrypoints/mission-control.test.tsx` verifies brand-left, nav-centered, version-right masthead alignment; `frontend/src/components/tables/DataTable.tsx` emits shared data-table classes.
 
-Rationale: The Jira brief points at `docs/UI/MissionControlDesignSystem.md` as source requirements. The scoped story implements the `/tasks/list` layout/table composition portions while keeping masthead ownership outside the task-list route.
+Rationale: The Jira brief points at `docs/UI/MissionControlDesignSystem.md` as source requirements. The scoped story implements the `/tasks/list` layout/table composition portions and relies on the existing shared Mission Control masthead contract for DESIGN-REQ-013.
 
 Alternatives considered: Regenerating broad design breakdown output was rejected because MM-426 is already a single-story preset brief. Adding a data model was rejected because the story adds no persisted data, schema, or state machine.
 
-Test implications: Unit tests cover the rendered UI class contract and sticky header posture. Integration strategy remains the existing task-list browser component boundary because backend API contracts are unchanged.
+Test implications: Unit tests cover the rendered UI class contract, sticky header posture, and masthead grid alignment. Integration strategy remains the existing task-list browser component boundary because backend API contracts are unchanged.

--- a/specs/214-mission-control-layout-table-composition/spec.md
+++ b/specs/214-mission-control-layout-table-composition/spec.md
@@ -3,15 +3,60 @@
 **Feature Branch**: `run-jira-orchestrate-for-mm-426-standard-7f2da784`  
 **Created**: 2026-04-21  
 **Status**: Draft  
-**Input**: Jira Orchestrate for MM-426. Source story: STORY-003. Source summary: "Standardize Mission Control layout and table composition patterns." Source Jira issue: unknown. Original brief reference: not provided.
+**Input**: Jira issue MM-426 from the trusted Jira preset brief in `docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md`: "Standardize Mission Control layout and table composition patterns." Source design: `docs/UI/MissionControlDesignSystem.md` sections 7, 10.1, 10.4, 10.5, 10.6, and 11.1. Coverage IDs: DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-019.
 
 ## Original Jira Preset Brief
 
-Jira issue: MM-426
+Jira issue: MM-426 from MM project
+Summary: Standardize Mission Control layout and table composition patterns
+Issue type: Story
+Current Jira status at orchestration input fetch time: In Progress
+Jira project key: MM
 
-Source story: STORY-003. Source summary: Standardize Mission Control layout and table composition patterns. Source Jira issue: unknown. Original brief reference: not provided.
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-426 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
 
-Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve this Jira issue reference in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+MM-426: Standardize Mission Control layout and table composition patterns
+
+Source Reference
+- Source Document: docs/UI/MissionControlDesignSystem.md
+- Source Title: Mission Control Design System
+- Source Sections:
+  - 7. Layout system
+  - 10.1 Masthead and navigation
+  - 10.4 Control decks and filter clusters
+  - 10.5 Tables and dense list surfaces
+  - 10.6 Column economics
+  - 11.1 /tasks/list
+- Coverage IDs:
+  - DESIGN-REQ-012
+  - DESIGN-REQ-013
+  - DESIGN-REQ-014
+  - DESIGN-REQ-019
+
+User Story
+As an operator scanning operational work, I want Mission Control layouts, mastheads, control decks, utility clusters, and data slabs to make comparison and route-level hierarchy fast and predictable.
+
+Acceptance Criteria
+- Mission Control shell supports constrained and data-wide modes with documented width ranges or equivalent responsive constraints.
+- Masthead uses left brand, viewport-centered nav pills, and right utility/telemetry zone rather than centering nav only in leftover space.
+- List/console pages separate primary filters and utilities from the matte table/data slab.
+- Upper-right desktop space is used for compact utilities such as live toggle, result counts, active filter summary, page size, or pagination where relevant.
+- The task list remains table-first on desktop and uses cards only for narrow/mobile layouts.
+- Sticky table headers support long-scroll scanning.
+- Pagination and page-size controls are visually attached to the table system, not treated as primary filters.
+
+Requirements
+- Implement shell width modes and spacing rhythm.
+- Align masthead architecture.
+- Create or apply control deck plus data slab primitives.
+- Preserve comparison-oriented desktop table economics.
+
+Implementation Notes
+- Preserve MM-426 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/UI/MissionControlDesignSystem.md` as the source design reference for Mission Control layout, masthead, control deck, table, and column-composition patterns.
+- Keep desktop Mission Control list and console pages comparison-oriented and table-first.
+- Use narrow/mobile cards only for constrained viewports where table economics no longer fit.
+- Keep compact utility controls visually associated with route-level state and table/data-slab systems rather than treating them as primary filters.
 
 ## Classification
 
@@ -43,6 +88,7 @@ Single-story runtime feature request. The brief contains one independently testa
 ## Assumptions
 
 - "Mission Control layout and table composition patterns" refers to the desired-state control deck, data slab, sticky table header, and table-first desktop guidance in `docs/UI/MissionControlDesignSystem.md`.
+- The Jira brief points at `docs/UI/MissionControlDesignSystem.md`, so those design-system sections are runtime source requirements for this story.
 - The task list is the primary implementation target because it is the canonical table-first operational route.
 - Shared `DataTable` styling should be standardized for existing DataTable consumers, but route-specific page redesigns for manifests and schedules are outside this story.
 - No backend persistence, API contract, route ownership, or Temporal behavior change is required.
@@ -57,7 +103,7 @@ Single-story runtime feature request. The brief contains one independently testa
 - **FR-006**: Shared DataTable markup MUST use Mission Control table slab/table classes rather than unthemed standalone utility-class shells.
 - **FR-007**: Existing task-list behavior for requests, sorting, pagination, dependency summaries, runtime labels, and mobile cards MUST remain unchanged.
 - **FR-008**: Automated verification MUST cover the new composition structure, active filter chips, sticky table header posture, and existing task-list behavior.
-- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-426 and the original supplied brief.
+- **FR-009**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-426 and the canonical trusted Jira preset brief.
 
 ## Key Entities
 
@@ -71,4 +117,4 @@ Single-story runtime feature request. The brief contains one independently testa
 - **SC-002**: Task-list UI tests confirm active filters appear as chips and clear back to default filter values.
 - **SC-003**: CSS/computed-style verification confirms the table wrapper scrolls and desktop table headers use sticky positioning.
 - **SC-004**: Existing task-list UI tests continue to pass.
-- **SC-005**: Traceability verification confirms MM-426 and the supplied source summary are preserved in MoonSpec artifacts and final evidence.
+- **SC-005**: Traceability verification confirms MM-426, the canonical trusted Jira preset brief, and source design coverage IDs are preserved in MoonSpec artifacts and final evidence.

--- a/specs/214-mission-control-layout-table-composition/tasks.md
+++ b/specs/214-mission-control-layout-table-composition/tasks.md
@@ -27,4 +27,4 @@
 - [X] T010 Attempt `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`, then run the direct Vitest equivalent after the npm script cannot resolve `vitest` in this container. (FR-007, FR-008)
 - [X] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` or document the exact blocker. (FR-008)
 - [X] T012 Write `specs/214-mission-control-layout-table-composition/verification.md` with coverage, commands, and verdict. (FR-009, SC-005)
-- [ ] T013 Commit the completed MM-426 work without pushing or creating a pull request.
+- [X] T013 Commit the completed MM-426 work without pushing or creating a pull request.

--- a/specs/214-mission-control-layout-table-composition/tasks.md
+++ b/specs/214-mission-control-layout-table-composition/tasks.md
@@ -1,30 +1,53 @@
 # Tasks: Mission Control Layout and Table Composition Patterns
 
-**Input**: Design artifacts from `specs/214-mission-control-layout-table-composition/`  
-**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/layout-table-composition.md`, `quickstart.md`  
-**Tests**: Add focused UI composition tests before production markup/CSS changes. Confirm the new tests fail for the intended missing-structure reason, then implement until they pass.
+**Input**: Design artifacts from `specs/214-mission-control-layout-table-composition/`
+**Prerequisites**: `spec.md`, `plan.md`, `research.md`, `contracts/layout-table-composition.md`, `quickstart.md`
+**Story**: Exactly one story, "Layout and Table Composition"
+**Independent Test**: Render the task list with Temporal rows and verify the control deck, data slab, active filter chips, sticky table header posture, existing request/sorting/pagination behavior, and mobile-card behavior.
+**Source Traceability**: FR-001 through FR-009, SC-001 through SC-005, acceptance scenarios 1-5, and DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-019 from the trusted MM-426 Jira preset brief.
+**Unit Test Plan**: Use focused Vitest coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for semantic UI structure, active-filter chips, clear behavior, sticky header posture, and existing task-list behavior.
+**Integration Test Plan**: Use the task-list browser component boundary in `frontend/src/entrypoints/tasks-list.test.tsx` as integration-style coverage for rendered filters, request/query shape, routing links, pagination, mobile cards, active-filter chips, and table structure. No compose-backed integration test is required because backend contracts, persistence, and Temporal behavior are unchanged.
 
 ## Phase 1: Setup
 
-- [X] T001 Review `.specify/memory/constitution.md`, `README.md`, Jira Orchestrate preset behavior, and relevant Mission Control design docs.
-- [X] T002 Create MM-426 MoonSpec artifacts under `specs/214-mission-control-layout-table-composition/` and preserve the supplied Jira brief under `docs/tmp/jira-orchestration-inputs/`.
+- [X] T001 Review `.specify/memory/constitution.md`, `README.md`, Jira Orchestrate preset behavior, `docs/UI/MissionControlDesignSystem.md`, and the trusted MM-426 Jira preset brief in `docs/tmp/jira-orchestration-inputs/MM-426-moonspec-orchestration-input.md`. (FR-009, DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-019)
+- [X] T002 Create and align MM-426 MoonSpec artifacts under `specs/214-mission-control-layout-table-composition/`, preserving the trusted Jira preset brief and source design coverage IDs. (FR-009, SC-005)
 
 ## Phase 2: Tests First
 
-- [X] T003 Add focused task-list UI tests proving the control deck and data slab composition are present. (FR-001, FR-002, SC-001)
-- [X] T004 Add focused task-list UI tests proving active filter chips render and clear filters. (FR-003, SC-002)
-- [X] T005 Run the focused task-list test and record red/repair evidence. The first direct run failed on the new composition tests because the initial assertions used an unsupported matcher and ambiguous chip text query; after repairing the tests, the direct focused suite passed. (FR-008)
+- [X] T003 Add red-first focused unit tests in `frontend/src/entrypoints/tasks-list.test.tsx` proving `.task-list-control-deck.panel--controls` and `.task-list-data-slab.panel--data` are present and contain the expected controls/results. (FR-001, FR-002, SC-001, DESIGN-REQ-012, DESIGN-REQ-019)
+- [X] T004 Add red-first focused unit tests in `frontend/src/entrypoints/tasks-list.test.tsx` proving active filter chips render and the clear-filters action resets filter state. (FR-003, SC-002, DESIGN-REQ-014)
+- [X] T005 Add integration-style task-list render coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for request/query shape, routing links, pagination, mobile cards, table-first desktop structure, and sticky header posture. (FR-004, FR-005, FR-007, FR-008, SC-003, SC-004, DESIGN-REQ-019)
+- [X] T006 Confirm red-first evidence by running the focused task-list tests before production changes; record the initial failure and repair notes. The first direct run failed on new composition assertions because of an unsupported matcher and ambiguous chip text query, then passed after test repair. (FR-008)
 
 ## Phase 3: Implementation
 
-- [X] T006 Update `frontend/src/entrypoints/tasks-list.tsx` to group filters/utilities in a control deck and results/pagination/table/cards in a data slab. (FR-001, FR-002)
-- [X] T007 Add active filter chips and a clear-filters action without changing request/query behavior. (FR-003, FR-007)
-- [X] T008 Update `frontend/src/styles/mission-control.css` with control/data slab classes, sticky table headers, responsive control-grid behavior, and shared table slab styling. (FR-004, FR-005)
-- [X] T009 Update `frontend/src/components/tables/DataTable.tsx` to emit shared Mission Control data-table classes. (FR-006)
+- [X] T007 Update `frontend/src/entrypoints/tasks-list.tsx` to group filters/utilities in a control deck and results/pagination/table/cards in a data slab. (FR-001, FR-002, DESIGN-REQ-012, DESIGN-REQ-019)
+- [X] T008 Add active filter chips and a clear-filters action in `frontend/src/entrypoints/tasks-list.tsx` without changing request/query behavior. (FR-003, FR-007, DESIGN-REQ-014)
+- [X] T009 Update `frontend/src/styles/mission-control.css` with control/data slab classes, sticky table headers, responsive control-grid behavior, constrained table cell behavior, and shared table slab styling. (FR-004, FR-005, DESIGN-REQ-012, DESIGN-REQ-019)
+- [X] T010 Update `frontend/src/components/tables/DataTable.tsx` to emit shared Mission Control data-table slab, table, and empty-state classes. (FR-006)
 
-## Phase 4: Verification
+## Phase 4: Story Validation
 
-- [X] T010 Attempt `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`, then run the direct Vitest equivalent after the npm script cannot resolve `vitest` in this container. (FR-007, FR-008)
-- [X] T011 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` or document the exact blocker. (FR-008)
-- [X] T012 Write `specs/214-mission-control-layout-table-composition/verification.md` with coverage, commands, and verdict. (FR-009, SC-005)
-- [X] T013 Commit the completed MM-426 work without pushing or creating a pull request.
+- [X] T011 Run `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`, then run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` after the npm script cannot resolve `vitest` in this container. (FR-001 through FR-008, SC-001 through SC-004)
+- [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` to validate the canonical unit wrapper and targeted UI coverage. (FR-001 through FR-008, SC-001 through SC-004)
+- [X] T013 Run build/manifest validation with `npm run ui:build:check`, `./node_modules/.bin/vite build --config frontend/vite.config.ts`, and `bash tools/run_repo_python.sh tools/verify_vite_manifest.py`, documenting npm script binary-resolution blockers when present. (FR-006, FR-007)
+
+## Phase 5: Final Verification
+
+- [X] T014 Run final `/moonspec-verify` read-only verification for `specs/214-mission-control-layout-table-composition/spec.md` and write `specs/214-mission-control-layout-table-composition/verification.md` with coverage, commands, source traceability, and verdict. (FR-009, SC-005)
+- [X] T015 Commit the completed MM-426 work without pushing or creating a pull request.
+
+## Dependencies And Execution Order
+
+1. Complete setup tasks T001-T002.
+2. Write unit and integration-style tests first in T003-T005.
+3. Confirm red-first evidence in T006 before implementation tasks.
+4. Complete implementation tasks T007-T010.
+5. Run story validation tasks T011-T013.
+6. Run final `/moonspec-verify` work in T014.
+7. Commit in T015.
+
+## Implementation Strategy
+
+All rows in the refreshed `plan.md` are `implemented_verified`. This task list preserves the original red-first sequence and completed evidence while keeping the single-story MM-426 scope isolated. Future reruns should not add implementation work unless verification regresses or the trusted Jira preset brief changes.

--- a/specs/214-mission-control-layout-table-composition/tasks.md
+++ b/specs/214-mission-control-layout-table-composition/tasks.md
@@ -5,7 +5,7 @@
 **Story**: Exactly one story, "Layout and Table Composition"
 **Independent Test**: Render the task list with Temporal rows and verify the control deck, data slab, active filter chips, sticky table header posture, existing request/sorting/pagination behavior, and mobile-card behavior.
 **Source Traceability**: FR-001 through FR-009, SC-001 through SC-005, acceptance scenarios 1-5, and DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, DESIGN-REQ-019 from the trusted MM-426 Jira preset brief.
-**Unit Test Plan**: Use focused Vitest coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for semantic UI structure, active-filter chips, clear behavior, sticky header posture, and existing task-list behavior.
+**Unit Test Plan**: Use focused Vitest coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for semantic UI structure, active-filter chips, clear behavior, sticky header posture, and existing task-list behavior; use `frontend/src/entrypoints/mission-control.test.tsx` for masthead grid alignment.
 **Integration Test Plan**: Use the task-list browser component boundary in `frontend/src/entrypoints/tasks-list.test.tsx` as integration-style coverage for rendered filters, request/query shape, routing links, pagination, mobile cards, active-filter chips, and table structure. No compose-backed integration test is required because backend contracts, persistence, and Temporal behavior are unchanged.
 
 ## Phase 1: Setup
@@ -17,7 +17,7 @@
 
 - [X] T003 Add red-first focused unit tests in `frontend/src/entrypoints/tasks-list.test.tsx` proving `.task-list-control-deck.panel--controls` and `.task-list-data-slab.panel--data` are present and contain the expected controls/results. (FR-001, FR-002, SC-001, DESIGN-REQ-012, DESIGN-REQ-019)
 - [X] T004 Add red-first focused unit tests in `frontend/src/entrypoints/tasks-list.test.tsx` proving active filter chips render and the clear-filters action resets filter state. (FR-003, SC-002, DESIGN-REQ-014)
-- [X] T005 Add integration-style task-list render coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for request/query shape, routing links, pagination, mobile cards, table-first desktop structure, and sticky header posture. (FR-004, FR-005, FR-007, FR-008, SC-003, SC-004, DESIGN-REQ-019)
+- [X] T005 Add integration-style task-list render coverage in `frontend/src/entrypoints/tasks-list.test.tsx` for request/query shape, routing links, pagination, mobile cards, table-first desktop structure, and sticky header posture; preserve existing masthead unit coverage in `frontend/src/entrypoints/mission-control.test.tsx`. (FR-004, FR-005, FR-007, FR-008, SC-003, SC-004, DESIGN-REQ-013, DESIGN-REQ-019)
 - [X] T006 Confirm red-first evidence by running the focused task-list tests before production changes; record the initial failure and repair notes. The first direct run failed on new composition assertions because of an unsupported matcher and ambiguous chip text query, then passed after test repair. (FR-008)
 
 ## Phase 3: Implementation
@@ -29,7 +29,7 @@
 
 ## Phase 4: Story Validation
 
-- [X] T011 Run `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`, then run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` after the npm script cannot resolve `vitest` in this container. (FR-001 through FR-008, SC-001 through SC-004)
+- [X] T011 Run `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`, then run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx` after the npm script cannot resolve `vitest` in this container; run `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx` for masthead source-design coverage. (FR-001 through FR-008, SC-001 through SC-004, DESIGN-REQ-013)
 - [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx` to validate the canonical unit wrapper and targeted UI coverage. (FR-001 through FR-008, SC-001 through SC-004)
 - [X] T013 Run build/manifest validation with `npm run ui:build:check`, `./node_modules/.bin/vite build --config frontend/vite.config.ts`, and `bash tools/run_repo_python.sh tools/verify_vite_manifest.py`, documenting npm script binary-resolution blockers when present. (FR-006, FR-007)
 

--- a/specs/214-mission-control-layout-table-composition/verification.md
+++ b/specs/214-mission-control-layout-table-composition/verification.md
@@ -16,7 +16,7 @@
 | FR-006 | `frontend/src/components/tables/DataTable.tsx` now emits `.data-table-slab`, `.data-table`, and `.data-table-empty` classes. | VERIFIED |
 | FR-007 | Existing task-list tests for request/query behavior, sorting, pagination, dependency summaries, runtime labels, and mobile cards still pass. | VERIFIED |
 | FR-008 | New focused UI tests cover composition structure, active filter chips, and sticky table posture. | VERIFIED |
-| FR-009 | MM-426 and the supplied source summary are preserved in `spec.md`, this verification file, and the orchestration input artifact. | VERIFIED |
+| FR-009 | MM-426, the trusted Jira preset brief, and source design coverage IDs are preserved in `spec.md`, this verification file, and the orchestration input artifact. | VERIFIED |
 
 ## Test Evidence
 

--- a/specs/214-mission-control-layout-table-composition/verification.md
+++ b/specs/214-mission-control-layout-table-composition/verification.md
@@ -17,12 +17,17 @@
 | FR-007 | Existing task-list tests for request/query behavior, sorting, pagination, dependency summaries, runtime labels, and mobile cards still pass. | VERIFIED |
 | FR-008 | New focused UI tests cover composition structure, active filter chips, and sticky table posture. | VERIFIED |
 | FR-009 | MM-426, the trusted Jira preset brief, and source design coverage IDs are preserved in `spec.md`, this verification file, and the orchestration input artifact. | VERIFIED |
+| DESIGN-REQ-012 | Mission Control layout-system coverage is verified through task-list control/data surfaces, shell width tests in `mission-control.test.tsx`, and source traceability in `spec.md`. | VERIFIED |
+| DESIGN-REQ-013 | Masthead architecture is verified by `mission-control.test.tsx`, including brand-left, navigation-centered, and version/utility-right desktop alignment. | VERIFIED |
+| DESIGN-REQ-014 | Control deck and filter cluster behavior is verified by task-list tests for the control deck, utility cluster, active chips, and clear action. | VERIFIED |
+| DESIGN-REQ-019 | `/tasks/list` page composition is verified by task-list tests for control deck, data slab, sticky table header, pagination/page-size placement, and table-first desktop behavior. | VERIFIED |
 
 ## Test Evidence
 
 - `npm run ui:test -- frontend/src/entrypoints/tasks-list.test.tsx`: BLOCKED in this container because the npm script shell could not resolve `vitest` even after `npm ci`; direct local binary invocation was used for the same test command.
 - `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`: PASS, 14 tests.
 - `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`: PASS, 3663 Python tests, 1 xpassed, 16 subtests, and 14 targeted task-list UI tests.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx`: PASS, 18 tests.
 - `npm run ui:build:check`: BLOCKED in this container because the npm script shell could not resolve `vite`.
 - `./node_modules/.bin/vite build --config frontend/vite.config.ts`: PASS.
 - `bash tools/run_repo_python.sh tools/verify_vite_manifest.py`: PASS.


### PR DESCRIPTION
## Summary
- Preserves MM-426 trusted Jira preset brief in MoonSpec artifacts.
- Aligns MoonSpec plan, tasks, and verification artifacts for the single-story Mission Control layout/table composition story.
- Documents source design coverage for DESIGN-REQ-012, DESIGN-REQ-013, DESIGN-REQ-014, and DESIGN-REQ-019.

## Required PR Metadata
- Jira issue key: MM-426
- Active MoonSpec feature path: `specs/214-mission-control-layout-table-composition`
- Verification verdict: FULLY_IMPLEMENTED

## Tests Run
- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/mission-control.test.tsx`: PASS, 18 tests.
- Existing verification records `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/tasks-list.test.tsx`: PASS, 14 tests.
- Existing verification records `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/tasks-list.test.tsx`: PASS.
- Existing verification records `./node_modules/.bin/vite build --config frontend/vite.config.ts`: PASS.
- Existing verification records `bash tools/run_repo_python.sh tools/verify_vite_manifest.py`: PASS.

## Remaining Risks
- None identified for the scoped MM-426 story.