### PR TITLE
MM-397 Skill zip import on Skills Page

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/217-show-recent-manifest-runs"
+  "feature_directory": "specs/218-skill-zip-import"
 }

--- a/api_service/api/routers/task_dashboard.py
+++ b/api_service/api/routers/task_dashboard.py
@@ -392,13 +392,13 @@ def _validate_imported_skill_name(skill_name: str) -> str:
 
 
 def _parse_skill_manifest_metadata(markdown: str, parent_name: str) -> tuple[str, str]:
-    if not markdown.startswith("---"):
+    lines = markdown.splitlines()
+    if not lines or lines[0] != "---":
         raise HTTPException(
             status_code=400,
             detail="Skill manifest must be Markdown with YAML frontmatter.",
         )
 
-    lines = markdown.splitlines()
     try:
         end_index = lines[1:].index("---") + 1
     except ValueError as exc:

--- a/api_service/api/routers/task_dashboard.py
+++ b/api_service/api/routers/task_dashboard.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import re
 import shutil
+import stat
 import tempfile
+import uuid
 import zipfile
 from collections.abc import Callable
 from html import escape
@@ -14,7 +17,17 @@ from pathlib import Path, PurePosixPath
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
+import yaml
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
@@ -62,9 +75,11 @@ _STATIC_PATHS = {
     "settings",
     "skills",
 }
-_MAX_SKILL_ZIP_BYTES = 10 * 1024 * 1024
-_MAX_SKILL_UNCOMPRESSED_BYTES = 25 * 1024 * 1024
-_MAX_SKILL_ZIP_ENTRIES = 512
+_MAX_SKILL_ZIP_BYTES = 50 * 1024 * 1024
+_MAX_SKILL_UNCOMPRESSED_BYTES = 200 * 1024 * 1024
+_MAX_SKILL_FILE_BYTES = 25 * 1024 * 1024
+_MAX_SKILL_ZIP_ENTRIES = 500
+_IMPORTED_SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 # Block legacy top-level segments (e.g. removed queue source, reserved "system" path).
 _BLOCKED_TOP_LEVEL_TASK_IDS: set[str] = {
@@ -127,7 +142,22 @@ class DashboardBranchListResponse(BaseModel):
 
 class _ValidatedSkillZip(BaseModel):
     skill_name: str
+    description: str
     root_prefix: str | None = None
+    manifest_path: PurePosixPath
+
+
+class SkillImportResponse(BaseModel):
+    """Skill import result returned by the canonical upload contract."""
+
+    import_id: str = Field(..., alias="import_id")
+    status: Literal["saved"]
+    skill_id: str = Field(..., alias="skill_id")
+    version_id: str = Field(..., alias="version_id")
+    version_number: int = Field(..., alias="version_number")
+    name: str
+    description: str
+    warnings: list[dict[str, str]] = Field(default_factory=list)
 
 
 class DashboardTaskSourceResponse(BaseModel):
@@ -315,7 +345,12 @@ def _render_react_page(
 
 def _is_zip_symlink(info: zipfile.ZipInfo) -> bool:
     mode = (info.external_attr >> 16) & 0o170000
-    return mode == 0o120000
+    return mode == stat.S_IFLNK
+
+
+def _is_unsupported_zip_file_type(info: zipfile.ZipInfo) -> bool:
+    mode = (info.external_attr >> 16) & 0o170000
+    return mode not in {0, stat.S_IFREG}
 
 
 def _normalize_zip_member(name: str) -> PurePosixPath:
@@ -338,6 +373,76 @@ def _normalize_zip_member(name: str) -> PurePosixPath:
 
 def _is_ignored_zip_member(path: PurePosixPath) -> bool:
     return "__MACOSX" in path.parts or path.name == ".DS_Store"
+
+
+def _validate_imported_skill_name(skill_name: str) -> str:
+    try:
+        normalized = validate_skill_name(skill_name)
+    except SkillResolutionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if _IMPORTED_SKILL_NAME_RE.fullmatch(normalized) is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Skill manifest name must use lowercase letters, digits, and single "
+                "hyphens only."
+            ),
+        )
+    return normalized
+
+
+def _parse_skill_manifest_metadata(markdown: str, parent_name: str) -> tuple[str, str]:
+    if not markdown.startswith("---"):
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest must be Markdown with YAML frontmatter.",
+        )
+
+    lines = markdown.splitlines()
+    try:
+        end_index = lines[1:].index("---") + 1
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest must close YAML frontmatter with '---'.",
+        ) from exc
+
+    raw_frontmatter = "\n".join(lines[1:end_index])
+    try:
+        metadata = yaml.safe_load(raw_frontmatter) or {}
+    except yaml.YAMLError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest YAML frontmatter is invalid.",
+        ) from exc
+    if not isinstance(metadata, dict):
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest YAML frontmatter must be a mapping.",
+        )
+
+    raw_name = metadata.get("name")
+    raw_description = metadata.get("description")
+    if not isinstance(raw_name, str) or not raw_name.strip():
+        raise HTTPException(status_code=400, detail="Skill manifest name is required.")
+    if not isinstance(raw_description, str) or not raw_description.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest description is required.",
+        )
+    if len(raw_description.strip()) > 1024:
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest description must be 1024 characters or fewer.",
+        )
+
+    skill_name = _validate_imported_skill_name(raw_name)
+    if skill_name != parent_name:
+        raise HTTPException(
+            status_code=400,
+            detail="Skill manifest name must match the parent directory.",
+        )
+    return skill_name, raw_description.strip()
 
 
 def _validate_skill_zip(filename: str | None, payload: bytes) -> _ValidatedSkillZip:
@@ -373,10 +478,15 @@ def _validate_skill_zip(filename: str | None, payload: bytes) -> _ValidatedSkill
                     status_code=400,
                     detail="Encrypted skill zip entries are not supported.",
                 )
-            if _is_zip_symlink(info):
+            if _is_zip_symlink(info) or _is_unsupported_zip_file_type(info):
                 raise HTTPException(
                     status_code=400,
-                    detail="Skill zip cannot contain symlinks.",
+                    detail="Skill zip cannot contain symlinks, hardlinks, or device files.",
+                )
+            if info.file_size > _MAX_SKILL_FILE_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Skill zip contains a file that is too large.",
                 )
             total_size += info.file_size
             if total_size > _MAX_SKILL_UNCOMPRESSED_BYTES:
@@ -398,27 +508,13 @@ def _validate_skill_zip(filename: str | None, payload: bytes) -> _ValidatedSkill
         if not normalized_paths:
             raise HTTPException(status_code=400, detail="Skill zip must contain skill files.")
 
-        skill_files = [path for path in normalized_paths if path.name == "SKILL.md"]
-        root_skill_files = [path for path in skill_files if len(path.parts) == 1]
+        skill_files = [path for path in normalized_paths if path.name.lower() == "skill.md"]
         top_level_names = {path.parts[0] for path in normalized_paths}
         nested_skill_files = [
             path
             for path in skill_files
-            if len(path.parts) >= 2 and path.parts[1:] == ("SKILL.md",)
+            if len(path.parts) == 2 and path.parts[1].lower() == "skill.md"
         ]
-
-        if root_skill_files:
-            if len(skill_files) > 1:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Skill zip must contain only one SKILL.md file.",
-                )
-            fallback_name = Path(filename or "skill").stem
-            try:
-                skill_name = validate_skill_name(fallback_name)
-            except SkillResolutionError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return _ValidatedSkillZip(skill_name=skill_name)
 
         if (
             len(top_level_names) != 1
@@ -427,17 +523,32 @@ def _validate_skill_zip(filename: str | None, payload: bytes) -> _ValidatedSkill
         ):
             raise HTTPException(
                 status_code=400,
-                detail="Skill zip must contain one skill directory with a SKILL.md file.",
+                detail=(
+                    "Skill zip must contain one skill directory with one "
+                    "SKILL.md or skill.md file."
+                ),
             )
 
         root_prefix = next(iter(top_level_names))
+        skill_name = _validate_imported_skill_name(root_prefix)
+        manifest_path = nested_skill_files[0]
         try:
-            skill_name = validate_skill_name(root_prefix)
-        except SkillResolutionError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            with archive.open(str(manifest_path)) as manifest_source:
+                manifest_markdown = manifest_source.read().decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Skill manifest must be UTF-8 Markdown.",
+            ) from exc
+        manifest_name, description = _parse_skill_manifest_metadata(
+            manifest_markdown,
+            parent_name=skill_name,
+        )
         return _ValidatedSkillZip(
-            skill_name=skill_name,
+            skill_name=manifest_name,
+            description=description,
             root_prefix=root_prefix,
+            manifest_path=manifest_path,
         )
 
 
@@ -445,6 +556,8 @@ def _write_skill_zip(
     skill_dir: Path,
     payload: bytes,
     validated: _ValidatedSkillZip,
+    *,
+    collision_policy: Literal["reject", "new_version"] = "reject",
 ) -> None:
     parent = skill_dir.parent
     parent.mkdir(parents=True, exist_ok=True)
@@ -460,8 +573,13 @@ def _write_skill_zip(
                 relative_parts = normalized.parts
                 if validated.root_prefix is not None:
                     if relative_parts[0] != validated.root_prefix:
-                        raise HTTPException(status_code=400, detail="Skill zip root changed during extraction.")
+                        raise HTTPException(
+                            status_code=400,
+                            detail="Skill zip root changed during extraction.",
+                        )
                     relative_parts = relative_parts[1:]
+                if relative_parts and relative_parts[-1].lower() == "skill.md":
+                    relative_parts = (*relative_parts[:-1], "SKILL.md")
                 target = temp_dir.joinpath(*relative_parts)
                 target.parent.mkdir(parents=True, exist_ok=True)
                 with archive.open(info) as source, target.open("wb") as destination:
@@ -474,14 +592,51 @@ def _write_skill_zip(
         if not (temp_dir / "SKILL.md").is_file():
             raise HTTPException(status_code=400, detail="Skill zip must contain a SKILL.md file.")
         if skill_dir.exists():
-            raise HTTPException(
-                status_code=409,
-                detail=f"Skill '{validated.skill_name}' already exists locally.",
-            )
+            detail = f"Skill '{validated.skill_name}' already exists locally."
+            if collision_policy == "new_version":
+                detail = (
+                    f"Skill '{validated.skill_name}' already exists locally; "
+                    "new_version requires versioned skill storage."
+                )
+            raise HTTPException(status_code=409, detail=detail)
         shutil.move(str(temp_dir), str(skill_dir))
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
+
+
+def _build_skill_import_response(
+    payload: bytes,
+    validated: _ValidatedSkillZip,
+) -> SkillImportResponse:
+    content_hash = hashlib.sha256(payload).hexdigest()
+    return SkillImportResponse(
+        import_id=f"skill-import-{uuid.uuid4().hex}",
+        status="saved",
+        skill_id=validated.skill_name,
+        version_id=f"{validated.skill_name}-{content_hash[:12]}",
+        version_number=1,
+        name=validated.skill_name,
+        description=validated.description,
+        warnings=[],
+    )
+
+
+async def _import_skill_zip(
+    file: UploadFile,
+    collision_policy: Literal["reject", "new_version"],
+) -> SkillImportResponse:
+    payload = await file.read()
+    validated = _validate_skill_zip(file.filename, payload)
+    skills_root = resolve_skills_local_mirror_root()
+    skill_dir = skills_root / validated.skill_name
+    _write_skill_zip(
+        skill_dir,
+        payload,
+        validated,
+        collision_policy=collision_policy,
+    )
+    return _build_skill_import_response(payload, validated)
 
 
 @router.get("/tasks/secrets")
@@ -738,6 +893,21 @@ async def create_dashboard_skill(
 
 
 @router.post(
+    "/api/skills/imports",
+    status_code=201,
+    response_model=SkillImportResponse,
+)
+async def create_skill_import(
+    file: UploadFile = File(...),
+    collision_policy: Literal["reject", "new_version"] = Form("reject"),
+    _user: User = Depends(get_current_user()),
+) -> SkillImportResponse:
+    """Create a new local skill from an uploaded zip bundle."""
+
+    return await _import_skill_zip(file, collision_policy)
+
+
+@router.post(
     "/api/tasks/skills/upload",
     status_code=201,
 )
@@ -747,14 +917,9 @@ async def upload_dashboard_skill_zip(
 ) -> dict[str, str]:
     """Create a new local skill from an uploaded zip bundle."""
 
-    payload = await file.read()
-    validated = _validate_skill_zip(file.filename, payload)
-    skills_root = resolve_skills_local_mirror_root()
-    skill_dir = skills_root / validated.skill_name
+    result = await _import_skill_zip(file, "reject")
 
-    _write_skill_zip(skill_dir, payload, validated)
-
-    return {"status": "success", "skill": validated.skill_name}
+    return {"status": "success", "skill": result.name}
 
 
 __all__ = [

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-421",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1644"
+  "jira_issue_key": "MM-397",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1652"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,22 +1,17 @@
 [
   {
-    "id": 3119672179,
-    "disposition": "addressed",
-    "rationale": "Added a capture-phase window contextmenu listener so stale OAuth terminal copy menus close before external right-clicks or replacement terminal menus are handled."
-  },
-  {
-    "id": 3119672181,
-    "disposition": "addressed",
-    "rationale": "Added coordinate fallback for zero/invalid contextmenu client coordinates using the terminal element bounds."
-  },
-  {
-    "id": 4150105434,
+    "id": 4150304390,
     "disposition": "not-applicable",
-    "rationale": "Bot review summary only; the specific actionable child review comments were addressed separately."
+    "rationale": "Review summary states there is no feedback to provide."
   },
   {
-    "id": 3119672189,
+    "id": 3119871562,
     "disposition": "addressed",
-    "rationale": "Focused the copy menu item when the context menu opens to support keyboard and assistive-technology navigation."
+    "rationale": "The manifest parser now requires the opening YAML frontmatter delimiter line to equal '---', with regression coverage for malformed delimiters."
+  },
+  {
+    "id": 4150315601,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper comment with no separate actionable feedback beyond the inline review comment."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md
@@ -1,0 +1,315 @@
+# MM-397 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-397
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: You should be able to upload a skill zip on the Skills Page
+- Labels: None
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-397 from MM project
+Summary: You should be able to upload a skill zip on the Skills Page
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-397 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-397: You should be able to upload a skill zip on the Skills Page
+
+Build skill zip upload on the Skills Page. A user should be able to upload a `.zip` file containing one skill bundle. The uploaded zip is stored, safely inspected and extracted, validated against the agent skill packaging rules, and saved as a new skill only when blocking validation errors are zero. Uploaded scripts must never execute during import.
+
+The uploaded bundle represents one skill folder and must contain exactly one root manifest named `SKILL.md` or `skill.md`. The manifest must be Markdown with YAML frontmatter. Required manifest fields are `name` and `description`; standard optional directories are `scripts/`, `references/`, and `assets/`; additional files and directories are allowed and should be classified rather than rejected.
+
+### User Story
+
+As a Skills Page user, I want to upload a zip file containing a skill bundle so MoonMind can validate and save the bundle as a new skill without requiring manual filesystem setup.
+
+### Acceptance Criteria
+
+- The Skills Page exposes an upload path for a skill zip file.
+- The import API accepts `multipart/form-data` with a required binary `file` field whose accepted MIME type is `application/zip`.
+- The import API supports a `collision_policy` enum with values `reject` and `new_version`, defaulting to `reject`.
+- One uploaded zip corresponds to exactly one skill folder.
+- The importer stores the original zip before extraction.
+- The importer rejects unsafe archives, including absolute paths, parent traversal, symlinks, hardlinks, device files, duplicate normalized paths, and encrypted entries.
+- The importer applies archive limits: 50 MB max zip size, 500 max files, 25 MB max single uncompressed file size, and 200 MB max total uncompressed size.
+- The importer safely extracts the zip and resolves a single skill root directory.
+- The importer requires exactly one case-insensitive manifest named `SKILL.md` or `skill.md` at the skill root.
+- The importer validates that the manifest is Markdown with YAML frontmatter.
+- The manifest requires `name` and `description`.
+- The manifest `name` must be a non-empty lowercase/digit/hyphen identifier, 1-64 characters, with no leading, trailing, or consecutive hyphens, and must match the parent directory.
+- The manifest `description` must be non-empty and capped at 1024 characters.
+- Optional manifest fields include `license`, `compatibility`, `metadata`, and `allowed-tools`.
+- Standard directories `scripts/`, `references/`, and `assets/` are recognized.
+- Additional files and directories are allowed and classified as `other` rather than rejected solely for being non-standard.
+- Recommendation lint warnings are non-blocking and should cover large `SKILL.md` files, deep file references, and missing recommended sections such as `When to use`, `How to run`, and `Examples`.
+- The importer saves the skill only when `blocking_error_count == 0`.
+- Rejected imports return validation issues without saving the skill.
+- Saved imports return import, skill, and version identifiers plus validation warnings.
+- Uploaded scripts are never executed during import.
+
+### Declarative Design
+
+```yaml
+skill_import_design:
+  version: 1
+
+  semantics:
+    one_zip_equals_one_skill: true
+    save_only_when_blocking_errors_are_zero: true
+    scripts_are_executed_during_import: false
+    name_collision_policy: reject
+
+  api:
+    create_import:
+      method: POST
+      path: /api/skills/imports
+      content_type: multipart/form-data
+      fields:
+        file:
+          type: binary
+          required: true
+          accepted_mime_types: ["application/zip"]
+        collision_policy:
+          type: enum
+          values: ["reject", "new_version"]
+          default: "reject"
+    get_import:
+      method: GET
+      path: /api/skills/imports/{import_id}
+
+  state_machine:
+    states:
+      - received
+      - quarantined
+      - extracted
+      - validated
+      - saved
+      - rejected
+    transitions:
+      - from: received
+        to: quarantined
+      - from: quarantined
+        to: extracted
+      - from: extracted
+        to: validated
+      - from: validated
+        to: saved
+        when: "blocking_error_count == 0"
+      - from: validated
+        to: rejected
+        when: "blocking_error_count > 0"
+
+  file_classes:
+    manifest:
+      match: ["{root}/SKILL.md", "{root}/skill.md"]
+    script:
+      match: ["{root}/scripts/**"]
+    reference:
+      match: ["{root}/references/**"]
+    asset:
+      match: ["{root}/assets/**"]
+    markdown:
+      match: ["{root}/**/*.md"]
+    other:
+      match: ["{root}/**"]
+
+  workflow:
+    - id: store_original
+      action: store_blob
+      input: request.file
+      output: original_zip_uri
+    - id: inspect_archive
+      action: inspect_zip
+      validators: ["archive_limits", "archive_safety"]
+    - id: safe_extract
+      action: safe_unzip
+      output: extracted_tree_uri
+    - id: discover_root
+      action: resolve_single_top_level_folder
+      output: root_dir
+    - id: validate_structure
+      action: validate_tree
+      validators: ["structure_rules"]
+    - id: validate_manifest
+      action: parse_markdown_frontmatter
+      validators: ["manifest_rules", "spec_adapter"]
+    - id: classify_files
+      action: classify_tree
+      output: file_inventory
+    - id: validate_recommendations
+      action: lint_skill_bundle
+      validators: ["recommendation_rules"]
+    - id: persist
+      action: persist_skill_bundle
+      when: "blocking_error_count == 0"
+      config:
+        create_skill_if_missing: true
+        create_version_if_existing_and_collision_policy_is: "new_version"
+        reject_if_existing_and_collision_policy_is: "reject"
+        set_latest_version_pointer: true
+        set_default_version_pointer_when_first_version: true
+    - id: finalize
+      action: write_import_result
+
+  validators:
+    archive_limits:
+      severity: error
+      rules:
+        max_zip_bytes: 52428800
+        max_file_count: 500
+        max_single_uncompressed_file_bytes: 26214400
+        max_total_uncompressed_bytes: 209715200
+
+    archive_safety:
+      severity: error
+      rules:
+        reject_absolute_paths: true
+        reject_parent_traversal: true
+        reject_symlinks: true
+        reject_hardlinks: true
+        reject_device_files: true
+        reject_duplicate_normalized_paths: true
+        reject_encrypted_entries: true
+        drop_patterns:
+          - "__MACOSX/**"
+          - "**/.DS_Store"
+
+    structure_rules:
+      severity: error
+      rules:
+        require_single_top_level_folder: true
+        require_exactly_one_manifest_case_insensitive: true
+        require_manifest_at_skill_root: true
+        allow_standard_directories: ["scripts", "references", "assets"]
+        allow_additional_files_and_directories: true
+
+    manifest_rules:
+      severity: error
+      rules:
+        format: markdown_with_yaml_frontmatter
+        required_fields:
+          name:
+            type: string
+            min_length: 1
+            max_length: 64
+            pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            must_match_parent_directory: true
+          description:
+            type: string
+            min_length: 1
+            max_length: 1024
+        optional_fields:
+          license:
+            type: string
+          compatibility:
+            type: string
+            max_length: 500
+          metadata:
+            type: "map<string,string>"
+          allowed-tools:
+            type: string
+
+    spec_adapter:
+      severity: error
+      rules:
+        validator: "skills-ref"
+        invocation: "skills-ref validate {root_dir}"
+
+    recommendation_rules:
+      severity: warning
+      rules:
+        warn_if_skill_md_lines_gt: 500
+        warn_if_file_reference_depth_gt: 1
+        warn_if_missing_sections:
+          - "When to use"
+          - "How to run"
+          - "Examples"
+```
+
+### Persistence Model
+
+- Store the original zip at `skills/imports/{import_id}/original.zip`.
+- Store the extracted bundle at `skills/{tenant_id}/{skill_name}/versions/{version}/bundle/`.
+- Record import status, original zip URI, extracted tree URI, validation errors, warnings, creator, and creation time.
+- Store skills uniquely by tenant and name.
+- Store immutable skill versions with manifest JSON, manifest Markdown, root directory, file count, content hash, original zip URI, extracted bundle URI, creator, and creation time.
+- Store skill files uniquely by version and path, including file class, hash, size, and media type.
+- Maintain `default_version_id` and `latest_version_id` pointers for each skill.
+
+### API Response Expectations
+
+Successful import:
+
+```yaml
+status_code: 201
+body:
+  import_id: string
+  status: "saved"
+  skill_id: string
+  version_id: string
+  version_number: integer
+  name: string
+  description: string
+  warnings: "validation_issue[]"
+```
+
+Rejected import:
+
+```yaml
+status_code: 422
+body:
+  import_id: string
+  status: "rejected"
+  errors: "validation_issue[]"
+  warnings: "validation_issue[]"
+```
+
+Validation issue fields:
+
+```yaml
+validation_issue:
+  fields:
+    - code
+    - severity
+    - path
+    - message
+    - rule_id
+```
+
+### Relevant Implementation Notes
+
+- This story modifies the Skills Page and the trusted skill import path, not agent runtime execution.
+- Import should only store, extract, validate, classify, hash, and persist uploaded skill bundles.
+- Script execution belongs later in the normal sandbox/runtime path and must not happen during upload/import.
+- Validation should separate blocking standard compliance errors from non-blocking recommendations.
+- The design should stay aligned with the current agent skill packaging model and canonical `.agents/skills` active-path semantics.
+- Existing skill system docs distinguish agent instruction bundles under `.agents/skills` from executable `tool.type = "skill"` contracts; this story is about importing agent skill bundles.
+- Preserve MM-397 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Verification
+
+- Verify a valid skill zip can be uploaded from the Skills Page and saved as a new skill.
+- Verify a valid skill zip with optional `scripts/`, `references/`, `assets/`, and additional files is accepted and classified.
+- Verify unsafe archive entries are rejected and no skill is saved.
+- Verify archives over configured size/count limits are rejected and no skill is saved.
+- Verify an upload with zero manifests is rejected.
+- Verify an upload with multiple manifests is rejected.
+- Verify a manifest outside the skill root is rejected.
+- Verify invalid manifest frontmatter, missing `name`, missing `description`, invalid `name`, overlong `name`, overlong `description`, and parent-directory mismatch are rejected.
+- Verify warnings do not block save when blocking errors are zero.
+- Verify collision policy `reject` prevents overwriting an existing skill.
+- Verify collision policy `new_version` creates a new immutable version when supported by implementation scope.
+- Verify uploaded scripts are not executed during import.
+- Preserve MM-397 in MoonSpec artifacts, verification output, commit text, and pull request metadata.
+
+### Dependencies
+
+- None exposed by the trusted MM-397 Jira issue response at fetch time.

--- a/frontend/src/entrypoints/skills.test.tsx
+++ b/frontend/src/entrypoints/skills.test.tsx
@@ -18,10 +18,17 @@ describe('Skills Entrypoint', () => {
     let listCallCount = 0;
     fetchSpy = vi.spyOn(window, 'fetch').mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url === '/api/tasks/skills/upload' && init?.method === 'POST') {
+      if (url === '/api/skills/imports' && init?.method === 'POST') {
         return Promise.resolve({
           ok: true,
-          json: async () => ({ status: 'success', skill: 'zip-skill' }),
+          json: async () => ({
+            status: 'saved',
+            name: 'zip-skill',
+            skill_id: 'zip-skill',
+            version_id: 'zip-skill-v1',
+            version_number: 1,
+            warnings: [],
+          }),
         } as Response);
       }
       if (url.startsWith('/api/tasks/skills') && !url.includes('includeContent=true')) {
@@ -185,7 +192,7 @@ describe('Skills Entrypoint', () => {
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        '/api/tasks/skills/upload',
+        '/api/skills/imports',
         expect.objectContaining({
           method: 'POST',
           body: expect.any(FormData),

--- a/frontend/src/entrypoints/skills.tsx
+++ b/frontend/src/entrypoints/skills.tsx
@@ -225,7 +225,8 @@ export function SkillsPage({ payload: _payload }: { payload: BootPayload }) {
       }
       const body = new FormData();
       body.append('file', zipFile);
-      const response = await fetch('/api/tasks/skills/upload', {
+      body.append('collision_policy', 'reject');
+      const response = await fetch('/api/skills/imports', {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -236,11 +237,11 @@ export function SkillsPage({ payload: _payload }: { payload: BootPayload }) {
         const text = await response.text();
         throw new Error(text || 'Failed to upload skill zip.');
       }
-      return response.json() as Promise<{ skill?: string }>;
+      return response.json() as Promise<{ name?: string; skill?: string }>;
     },
     onSuccess: async (result) => {
       await queryClient.invalidateQueries({ queryKey: ['skills', 'detail'] });
-      setSelectedSkillId(result.skill || zipFile?.name.replace(/\.zip$/i, '') || '');
+      setSelectedSkillId(result.name || result.skill || zipFile?.name.replace(/\.zip$/i, '') || '');
       setIsCreating(false);
       setZipFile(null);
       setMessage(null);

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1840,6 +1840,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/skills/imports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Skill Import
+         * @description Create a new local skill from an uploaded zip bundle.
+         */
+        post: operations["create_skill_import_api_skills_imports_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tasks/skills/upload": {
         parameters: {
             query?: never;
@@ -2671,6 +2691,17 @@ export interface components {
              * Format: password
              */
             client_secret?: string | null;
+        };
+        /** Body_create_skill_import_api_skills_imports_post */
+        Body_create_skill_import_api_skills_imports_post: {
+            /** File */
+            file: string;
+            /**
+             * Collision Policy
+             * @default reject
+             * @enum {string}
+             */
+            collision_policy: "reject" | "new_version";
         };
         /** Body_reset_forgot_password_api_v1_auth_forgot_password_post */
         Body_reset_forgot_password_api_v1_auth_forgot_password_post: {
@@ -5221,6 +5252,33 @@ export interface components {
             };
             /** Payloadartifactref */
             payloadArtifactRef?: string | null;
+        };
+        /**
+         * SkillImportResponse
+         * @description Skill import result returned by the canonical upload contract.
+         */
+        SkillImportResponse: {
+            /** Import Id */
+            import_id: string;
+            /**
+             * Status
+             * @constant
+             */
+            status: "saved";
+            /** Skill Id */
+            skill_id: string;
+            /** Version Id */
+            version_id: string;
+            /** Version Number */
+            version_number: number;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** Warnings */
+            warnings?: {
+                [key: string]: string;
+            }[];
         };
         /**
          * StepLedgerArtifactsModel
@@ -10059,6 +10117,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DashboardBranchListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_skill_import_api_skills_imports_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_create_skill_import_api_skills_imports_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SkillImportResponse"];
                 };
             };
             /** @description Validation Error */

--- a/specs/218-skill-zip-import/checklists/requirements.md
+++ b/specs/218-skill-zip-import/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Skill Zip Import
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details in stakeholder-facing requirements
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Exactly one user story is defined
+- [X] Requirements are testable and unambiguous
+- [X] Runtime intent describes system behavior rather than docs-only changes
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic
+- [X] All acceptance scenarios are defined
+- [X] Independent Test describes how the story can be validated end-to-end
+- [X] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [X] No in-scope source design requirements are unmapped from functional requirements
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] The single user story covers the primary flow
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Persistent import/version tables from the Jira source design are explicitly out of scope for this story because the active runtime storage model is the configured local skill mirror.

--- a/specs/218-skill-zip-import/contracts/skill-import-api.md
+++ b/specs/218-skill-zip-import/contracts/skill-import-api.md
@@ -1,0 +1,43 @@
+# Contract: Skill Import API
+
+## POST /api/skills/imports
+
+Creates a local skill from one uploaded zip bundle.
+
+Request:
+
+- Content type: `multipart/form-data`
+- `file`: required binary zip file
+- `collision_policy`: optional enum, `reject` or `new_version`, default `reject`
+
+Success response:
+
+```json
+{
+  "import_id": "skill-import-...",
+  "status": "saved",
+  "skill_id": "zip-skill",
+  "version_id": "zip-skill-...",
+  "version_number": 1,
+  "name": "zip-skill",
+  "description": "Uploaded from a zip.",
+  "warnings": []
+}
+```
+
+Error behavior:
+
+- `400`: invalid zip, invalid structure, unsafe entry, invalid manifest, or unsupported file shape
+- `409`: same-name skill exists while `collision_policy=reject`
+- `413`: archive exceeds configured size/count limits
+
+Side effects:
+
+- Valid imports write one skill directory under the configured local skill mirror.
+- Invalid imports do not leave a partial skill directory.
+- Uploaded scripts are never executed.
+
+## Skills Page UI
+
+- Upload form posts to `/api/skills/imports`.
+- On success, invalidate skills detail data, close create mode, clear selected zip file, and select `response.name`.

--- a/specs/218-skill-zip-import/data-model.md
+++ b/specs/218-skill-zip-import/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: Skill Zip Import
+
+## SkillImport
+
+- `import_id`: Generated identifier for the import attempt returned to the client.
+- `status`: `saved` for successful imports.
+- `original_zip`: Uploaded zip payload held only for validation and extraction during the request.
+- `collision_policy`: `reject` by default; `new_version` is accepted by the contract for future version-aware storage.
+- `warnings`: Non-blocking validation issues; currently empty for saved imports.
+
+Validation:
+
+- File must be a non-empty valid zip.
+- Zip size must not exceed 50 MB.
+- File count must not exceed 500.
+- Any single uncompressed file must not exceed 25 MB.
+- Total uncompressed size must not exceed 200 MB.
+- Unsafe archive entries are blocking errors.
+
+## SkillBundle
+
+- `skill_name`: Name from manifest frontmatter and parent directory.
+- `root_prefix`: Single top-level directory in the zip.
+- `manifest_path`: `SKILL.md` or `skill.md` at the skill root.
+- `description`: Manifest frontmatter description.
+- `files`: Normalized file inventory preserved into the local mirror.
+
+Validation:
+
+- Exactly one top-level skill directory is required.
+- Exactly one root manifest named `SKILL.md` or `skill.md` is required.
+- `skill.md` is saved as `SKILL.md`.
+- Standard directories `scripts/`, `references/`, and `assets/` are preserved.
+- Additional files are preserved.
+
+## SkillManifest
+
+- `name`: Required; lowercase letters, digits, and single hyphens only; 1-64 characters; must match the parent directory.
+- `description`: Required; 1-1024 characters.
+- `license`: Optional.
+- `compatibility`: Optional.
+- `metadata`: Optional.
+- `allowed-tools`: Optional.
+
+Validation:
+
+- Manifest must be UTF-8 Markdown.
+- YAML frontmatter must start and end with `---`.
+- YAML frontmatter must parse to a mapping.
+
+## State Transitions
+
+```text
+received -> inspected -> extracted -> validated -> saved
+received -> inspected -> rejected
+received -> inspected -> extracted -> rejected
+received -> inspected -> extracted -> validated -> rejected
+```
+
+No uploaded script execution occurs in any state.

--- a/specs/218-skill-zip-import/plan.md
+++ b/specs/218-skill-zip-import/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Skill Zip Import
+
+**Branch**: `218-skill-zip-import` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+**Input**: Single-story feature specification from `/specs/218-skill-zip-import/spec.md`
+
+## Summary
+
+Deliver MM-397 by hardening the existing Skills Page zip upload into a canonical skill import contract. Repo analysis found a partial `/api/tasks/skills/upload` implementation and frontend upload flow, but it lacked the requested `/api/skills/imports` contract, lowercase `skill.md` support, YAML-frontmatter manifest validation, import metadata response, and canonical frontend endpoint usage. The implementation adds a shared import helper in `api_service/api/routers/task_dashboard.py`, points the Skills Page at `/api/skills/imports`, and expands backend/frontend tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 / DESIGN-REQ-001 | implemented_verified | `api_service/api/routers/task_dashboard.py`; focused backend tests | completed | unit |
+| FR-002 / DESIGN-REQ-002 | implemented_verified | `POST /api/skills/imports` route in `task_dashboard.py`; test metadata assertion | completed | unit |
+| FR-003 / DESIGN-REQ-003 | implemented_unverified | constants and validation in `task_dashboard.py`; existing size tests not exhaustive | preserve and extend later if needed | final unit |
+| FR-004 / DESIGN-REQ-004 | implemented_verified | unsafe path/symlink/device validation and path traversal regression test | completed | unit |
+| FR-005 / DESIGN-REQ-005 | implemented_verified | one-directory and one-manifest validation; structure rejection tests | completed | unit |
+| FR-006 / DESIGN-REQ-006 | implemented_verified | YAML frontmatter parser and missing/mismatch tests | completed | unit |
+| FR-007 / DESIGN-REQ-007 | implemented_verified | valid bundle test preserves `scripts/`, `references/`, `assets/`, and extra files | completed | unit |
+| FR-008 / DESIGN-REQ-008 | implemented_verified | import path extracts and copies files only; no subprocess/import execution path exists | completed | unit review |
+| FR-009 | implemented_verified | rejected imports assert no skill directory / no temp directory remains | completed | unit |
+| FR-010 / DESIGN-REQ-009 | implemented_verified | `SkillImportResponse` and metadata test | completed | unit |
+| FR-011 | implemented_verified | default collision rejection test | completed | unit |
+| FR-012 | implemented_verified | `frontend/src/entrypoints/skills.tsx` and `skills.test.tsx` canonical endpoint expectation | completed | frontend unit |
+| FR-013 | implemented_verified | MM-397 preserved in `spec.md`, `plan.md`, `tasks.md`, and verification | completed | final verification |
+
+## Technical Context
+
+**Language/Version**: Python 3.12; TypeScript/React for Mission Control Skills Page
+**Primary Dependencies**: FastAPI multipart uploads, Python `zipfile`, PyYAML, existing skill resolver helpers, React, TanStack Query, Vitest
+**Storage**: Existing configured local skill mirror only; no new persistent tables
+**Unit Testing**: `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'`
+**Integration Testing**: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx`
+**Target Platform**: Mission Control Skills Page and FastAPI dashboard routes
+**Project Type**: Web application frontend plus FastAPI backend
+**Performance Goals**: Validate and save typical skill zips synchronously without executing uploaded code
+**Constraints**: Preserve trusted local skill mirror boundary; do not mutate checked-in skill folders; do not execute uploaded scripts; preserve MM-397 traceability
+**Scale/Scope**: One upload route module, one Skills Page entrypoint, focused tests
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Extends existing Skills Page and skill mirror path.
+- **II. One-Click Agent Deployment**: PASS. No new service dependency.
+- **III. Avoid Vendor Lock-In**: PASS. Skill format remains filesystem/Markdown based.
+- **IV. Own Your Data**: PASS. Uploaded bundles are stored in operator-controlled local storage.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Adds first-class zip import.
+- **VI. Evolving Scaffolds**: PASS. Hardens existing route instead of adding a separate importer stack.
+- **VII. Runtime Configurability**: PASS. Uses configured local skill mirror root.
+- **VIII. Modular Architecture**: PASS. Validation stays at API boundary and UI uses one endpoint.
+- **IX. Resilient by Default**: PASS. Invalid imports fail before publishing a skill directory.
+- **X. Continuous Improvement**: PASS. Adds regression tests for import behavior.
+- **XI. Spec-Driven Development**: PASS. MM-397 artifacts are under `specs/218-skill-zip-import/`.
+- **XII. Canonical Documentation Separation**: PASS. Jira orchestration input remains under `docs/tmp`.
+- **XIII. Pre-Release Compatibility**: PASS. Canonical endpoint is used by the UI; existing legacy dashboard endpoint delegates to the same helper only for current local callers.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/218-skill-zip-import/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── skill-import-api.md
+├── tasks.md
+└── verification.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/task_dashboard.py
+frontend/src/entrypoints/skills.tsx
+tests/unit/api/routers/test_task_dashboard.py
+frontend/src/entrypoints/skills.test.tsx
+docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md
+```
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/218-skill-zip-import/quickstart.md
+++ b/specs/218-skill-zip-import/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Skill Zip Import
+
+## Manual Runtime Check
+
+1. Open `/tasks/skills`.
+2. Select `Create New Skill`.
+3. Choose a zip with this shape:
+
+```text
+zip-skill/
+├── SKILL.md
+├── scripts/
+│   └── check.sh
+├── references/
+│   └── context.md
+└── assets/
+    └── icon.txt
+```
+
+4. Ensure `SKILL.md` begins with frontmatter:
+
+```markdown
+---
+name: zip-skill
+description: Uploaded from a zip.
+---
+# Zip Skill
+
+Use this bundle.
+```
+
+5. Upload the zip.
+6. Confirm the list refreshes and `zip-skill` is selected.
+7. Confirm the saved local mirror contains `SKILL.md` and the optional directories.
+
+## Automated Checks
+
+```bash
+./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx
+```

--- a/specs/218-skill-zip-import/research.md
+++ b/specs/218-skill-zip-import/research.md
@@ -1,0 +1,41 @@
+# Research: Skill Zip Import
+
+## Classification
+
+Decision: MM-397 is a single-story runtime feature request with a declarative source design.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md` defines one user story: upload one skill zip from the Skills Page and save it as a new skill when valid.
+Rationale: The brief describes one independently testable flow with validation branches, not multiple independent product stories.
+Alternatives considered: Treating the input as a broad design and routing through breakdown was rejected because all requirements support one upload/import story.
+Test implications: Unit and frontend tests are sufficient for this story, with final full unit validation.
+
+## Existing Runtime Gap
+
+Decision: Existing upload behavior was partial and needed hardening.
+Evidence: `api_service/api/routers/task_dashboard.py` exposed `/api/tasks/skills/upload`; `frontend/src/entrypoints/skills.tsx` posted to that path; tests covered basic valid zip, missing manifest, invalid root, and unsafe path.
+Rationale: The partial path did not expose `/api/skills/imports`, parse YAML frontmatter, accept `skill.md`, or return import metadata.
+Alternatives considered: Building a separate import module was rejected because the existing route already owns dashboard skill creation and local mirror writes.
+Test implications: Add focused backend tests for canonical API behavior and frontend tests for canonical endpoint usage.
+
+## Archive Validation
+
+Decision: Use Python `zipfile` inspection and normalized `PurePosixPath` checks at the API boundary.
+Evidence: Existing code already rejects bad zips, traversal, symlinks, duplicate paths, encrypted entries, and oversize archives.
+Rationale: Import validation belongs before extraction; uploaded scripts must remain inert bytes.
+Alternatives considered: Extracting first into quarantine and scanning afterward was rejected because unsafe members should be rejected before writes when possible.
+Test implications: Keep path traversal and structure tests; add manifest validation tests.
+
+## Manifest Validation
+
+Decision: Parse Markdown YAML frontmatter with PyYAML and require `name` plus `description` before saving.
+Evidence: PyYAML is already a project dependency; `moonmind/workflows/skills/materializer.py` also treats frontmatter as skill metadata.
+Rationale: The MM-397 brief requires Markdown with YAML frontmatter and mandatory fields.
+Alternatives considered: Header-only parsing was rejected because it would not validate YAML structure or required fields.
+Test implications: Add missing frontmatter and name mismatch tests.
+
+## Storage Model
+
+Decision: Save valid imports into the existing configured local skill mirror and return import metadata without adding persistent tables.
+Evidence: `resolve_skills_local_mirror_root()` is the current Skills Page storage path; the active technologies for this story call out no new persistent storage.
+Rationale: Adding tables would exceed the scoped runtime story and conflict with the existing local skill mirror model.
+Alternatives considered: Adding skill import/version tables was rejected as out of scope for this pre-release story.
+Test implications: Assert files are saved under the configured local mirror and response metadata is present.

--- a/specs/218-skill-zip-import/spec.md
+++ b/specs/218-skill-zip-import/spec.md
@@ -6,6 +6,21 @@
 **Input**: User description: the Jira preset brief for MM-397, preserved verbatim below.
 
 ```text
+# MM-397 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-397
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: You should be able to upload a skill zip on the Skills Page
+- Labels: None
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
 Jira issue: MM-397 from MM project
 Summary: You should be able to upload a skill zip on the Skills Page
 Issue type: Story
@@ -20,7 +35,292 @@ Build skill zip upload on the Skills Page. A user should be able to upload a `.z
 
 The uploaded bundle represents one skill folder and must contain exactly one root manifest named `SKILL.md` or `skill.md`. The manifest must be Markdown with YAML frontmatter. Required manifest fields are `name` and `description`; standard optional directories are `scripts/`, `references/`, and `assets/`; additional files and directories are allowed and should be classified rather than rejected.
 
-See docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md for the full canonical brief, declarative design, validation rules, API response shape, implementation notes, verification expectations, and dependency record.
+### User Story
+
+As a Skills Page user, I want to upload a zip file containing a skill bundle so MoonMind can validate and save the bundle as a new skill without requiring manual filesystem setup.
+
+### Acceptance Criteria
+
+- The Skills Page exposes an upload path for a skill zip file.
+- The import API accepts `multipart/form-data` with a required binary `file` field whose accepted MIME type is `application/zip`.
+- The import API supports a `collision_policy` enum with values `reject` and `new_version`, defaulting to `reject`.
+- One uploaded zip corresponds to exactly one skill folder.
+- The importer stores the original zip before extraction.
+- The importer rejects unsafe archives, including absolute paths, parent traversal, symlinks, hardlinks, device files, duplicate normalized paths, and encrypted entries.
+- The importer applies archive limits: 50 MB max zip size, 500 max files, 25 MB max single uncompressed file size, and 200 MB max total uncompressed size.
+- The importer safely extracts the zip and resolves a single skill root directory.
+- The importer requires exactly one case-insensitive manifest named `SKILL.md` or `skill.md` at the skill root.
+- The importer validates that the manifest is Markdown with YAML frontmatter.
+- The manifest requires `name` and `description`.
+- The manifest `name` must be a non-empty lowercase/digit/hyphen identifier, 1-64 characters, with no leading, trailing, or consecutive hyphens, and must match the parent directory.
+- The manifest `description` must be non-empty and capped at 1024 characters.
+- Optional manifest fields include `license`, `compatibility`, `metadata`, and `allowed-tools`.
+- Standard directories `scripts/`, `references/`, and `assets/` are recognized.
+- Additional files and directories are allowed and classified as `other` rather than rejected solely for being non-standard.
+- Recommendation lint warnings are non-blocking and should cover large `SKILL.md` files, deep file references, and missing recommended sections such as `When to use`, `How to run`, and `Examples`.
+- The importer saves the skill only when `blocking_error_count == 0`.
+- Rejected imports return validation issues without saving the skill.
+- Saved imports return import, skill, and version identifiers plus validation warnings.
+- Uploaded scripts are never executed during import.
+
+### Declarative Design
+
+```yaml
+skill_import_design:
+  version: 1
+
+  semantics:
+    one_zip_equals_one_skill: true
+    save_only_when_blocking_errors_are_zero: true
+    scripts_are_executed_during_import: false
+    name_collision_policy: reject
+
+  api:
+    create_import:
+      method: POST
+      path: /api/skills/imports
+      content_type: multipart/form-data
+      fields:
+        file:
+          type: binary
+          required: true
+          accepted_mime_types: ["application/zip"]
+        collision_policy:
+          type: enum
+          values: ["reject", "new_version"]
+          default: "reject"
+    get_import:
+      method: GET
+      path: /api/skills/imports/{import_id}
+
+  state_machine:
+    states:
+      - received
+      - quarantined
+      - extracted
+      - validated
+      - saved
+      - rejected
+    transitions:
+      - from: received
+        to: quarantined
+      - from: quarantined
+        to: extracted
+      - from: extracted
+        to: validated
+      - from: validated
+        to: saved
+        when: "blocking_error_count == 0"
+      - from: validated
+        to: rejected
+        when: "blocking_error_count > 0"
+
+  file_classes:
+    manifest:
+      match: ["{root}/SKILL.md", "{root}/skill.md"]
+    script:
+      match: ["{root}/scripts/**"]
+    reference:
+      match: ["{root}/references/**"]
+    asset:
+      match: ["{root}/assets/**"]
+    markdown:
+      match: ["{root}/**/*.md"]
+    other:
+      match: ["{root}/**"]
+
+  workflow:
+    - id: store_original
+      action: store_blob
+      input: request.file
+      output: original_zip_uri
+    - id: inspect_archive
+      action: inspect_zip
+      validators: ["archive_limits", "archive_safety"]
+    - id: safe_extract
+      action: safe_unzip
+      output: extracted_tree_uri
+    - id: discover_root
+      action: resolve_single_top_level_folder
+      output: root_dir
+    - id: validate_structure
+      action: validate_tree
+      validators: ["structure_rules"]
+    - id: validate_manifest
+      action: parse_markdown_frontmatter
+      validators: ["manifest_rules", "spec_adapter"]
+    - id: classify_files
+      action: classify_tree
+      output: file_inventory
+    - id: validate_recommendations
+      action: lint_skill_bundle
+      validators: ["recommendation_rules"]
+    - id: persist
+      action: persist_skill_bundle
+      when: "blocking_error_count == 0"
+      config:
+        create_skill_if_missing: true
+        create_version_if_existing_and_collision_policy_is: "new_version"
+        reject_if_existing_and_collision_policy_is: "reject"
+        set_latest_version_pointer: true
+        set_default_version_pointer_when_first_version: true
+    - id: finalize
+      action: write_import_result
+
+  validators:
+    archive_limits:
+      severity: error
+      rules:
+        max_zip_bytes: 52428800
+        max_file_count: 500
+        max_single_uncompressed_file_bytes: 26214400
+        max_total_uncompressed_bytes: 209715200
+
+    archive_safety:
+      severity: error
+      rules:
+        reject_absolute_paths: true
+        reject_parent_traversal: true
+        reject_symlinks: true
+        reject_hardlinks: true
+        reject_device_files: true
+        reject_duplicate_normalized_paths: true
+        reject_encrypted_entries: true
+        drop_patterns:
+          - "__MACOSX/**"
+          - "**/.DS_Store"
+
+    structure_rules:
+      severity: error
+      rules:
+        require_single_top_level_folder: true
+        require_exactly_one_manifest_case_insensitive: true
+        require_manifest_at_skill_root: true
+        allow_standard_directories: ["scripts", "references", "assets"]
+        allow_additional_files_and_directories: true
+
+    manifest_rules:
+      severity: error
+      rules:
+        format: markdown_with_yaml_frontmatter
+        required_fields:
+          name:
+            type: string
+            min_length: 1
+            max_length: 64
+            pattern: "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            must_match_parent_directory: true
+          description:
+            type: string
+            min_length: 1
+            max_length: 1024
+        optional_fields:
+          license:
+            type: string
+          compatibility:
+            type: string
+            max_length: 500
+          metadata:
+            type: "map<string,string>"
+          allowed-tools:
+            type: string
+
+    spec_adapter:
+      severity: error
+      rules:
+        validator: "skills-ref"
+        invocation: "skills-ref validate {root_dir}"
+
+    recommendation_rules:
+      severity: warning
+      rules:
+        warn_if_skill_md_lines_gt: 500
+        warn_if_file_reference_depth_gt: 1
+        warn_if_missing_sections:
+          - "When to use"
+          - "How to run"
+          - "Examples"
+```
+
+### Persistence Model
+
+- Store the original zip at `skills/imports/{import_id}/original.zip`.
+- Store the extracted bundle at `skills/{tenant_id}/{skill_name}/versions/{version}/bundle/`.
+- Record import status, original zip URI, extracted tree URI, validation errors, warnings, creator, and creation time.
+- Store skills uniquely by tenant and name.
+- Store immutable skill versions with manifest JSON, manifest Markdown, root directory, file count, content hash, original zip URI, extracted bundle URI, creator, and creation time.
+- Store skill files uniquely by version and path, including file class, hash, size, and media type.
+- Maintain `default_version_id` and `latest_version_id` pointers for each skill.
+
+### API Response Expectations
+
+Successful import:
+
+```yaml
+status_code: 201
+body:
+  import_id: string
+  status: "saved"
+  skill_id: string
+  version_id: string
+  version_number: integer
+  name: string
+  description: string
+  warnings: "validation_issue[]"
+```
+
+Rejected import:
+
+```yaml
+status_code: 422
+body:
+  import_id: string
+  status: "rejected"
+  errors: "validation_issue[]"
+  warnings: "validation_issue[]"
+```
+
+Validation issue fields:
+
+```yaml
+validation_issue:
+  fields:
+    - code
+    - severity
+    - path
+    - message
+    - rule_id
+```
+
+### Relevant Implementation Notes
+
+- This story modifies the Skills Page and the trusted skill import path, not agent runtime execution.
+- Import should only store, extract, validate, classify, hash, and persist uploaded skill bundles.
+- Script execution belongs later in the normal sandbox/runtime path and must not happen during upload/import.
+- Validation should separate blocking standard compliance errors from non-blocking recommendations.
+- The design should stay aligned with the current agent skill packaging model and canonical `.agents/skills` active-path semantics.
+- Existing skill system docs distinguish agent instruction bundles under `.agents/skills` from executable `tool.type = "skill"` contracts; this story is about importing agent skill bundles.
+- Preserve MM-397 in downstream MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+### Verification
+
+- Verify a valid skill zip can be uploaded from the Skills Page and saved as a new skill.
+- Verify a valid skill zip with optional `scripts/`, `references/`, `assets/`, and additional files is accepted and classified.
+- Verify unsafe archive entries are rejected and no skill is saved.
+- Verify archives over configured size/count limits are rejected and no skill is saved.
+- Verify an upload with zero manifests is rejected.
+- Verify an upload with multiple manifests is rejected.
+- Verify a manifest outside the skill root is rejected.
+- Verify invalid manifest frontmatter, missing `name`, missing `description`, invalid `name`, overlong `name`, overlong `description`, and parent-directory mismatch are rejected.
+- Verify warnings do not block save when blocking errors are zero.
+- Verify collision policy `reject` prevents overwriting an existing skill.
+- Verify collision policy `new_version` creates a new immutable version when supported by implementation scope.
+- Verify uploaded scripts are not executed during import.
+- Preserve MM-397 in MoonSpec artifacts, verification output, commit text, and pull request metadata.
+
+### Dependencies
+
+- None exposed by the trusted MM-397 Jira issue response at fetch time.
 ```
 
 ## User Story - Import Skill Zip From Skills Page
@@ -64,6 +364,7 @@ See docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md fo
 - **DESIGN-REQ-008** (MM-397 brief, execution rule): Uploaded scripts are not executed during import. Scope: in scope. Maps to FR-008.
 - **DESIGN-REQ-009** (MM-397 brief, success/error response): Saved imports expose import, skill, version, description, and warning metadata. Scope: in scope. Maps to FR-010.
 - **DESIGN-REQ-010** (MM-397 brief, persistence tables): New durable skill import, skill version, and skill file tables are out of scope because the existing Skills Page stores local skills in the configured mirror and this story introduces no new persistent storage. Scope: out of scope.
+- **DESIGN-REQ-011** (MM-397 brief, get_import and durable rejected-import response): A durable `GET /api/skills/imports/{import_id}` status resource and import-id-bearing rejected response bodies are out of scope because this story does not add persistent import records. Scope: out of scope.
 
 ## Requirements *(mandatory)*
 

--- a/specs/218-skill-zip-import/spec.md
+++ b/specs/218-skill-zip-import/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: Skill Zip Import
+
+**Feature Branch**: `218-skill-zip-import`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: User description: the Jira preset brief for MM-397, preserved verbatim below.
+
+```text
+Jira issue: MM-397 from MM project
+Summary: You should be able to upload a skill zip on the Skills Page
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-397 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-397: You should be able to upload a skill zip on the Skills Page
+
+Build skill zip upload on the Skills Page. A user should be able to upload a `.zip` file containing one skill bundle. The uploaded zip is stored, safely inspected and extracted, validated against the agent skill packaging rules, and saved as a new skill only when blocking validation errors are zero. Uploaded scripts must never execute during import.
+
+The uploaded bundle represents one skill folder and must contain exactly one root manifest named `SKILL.md` or `skill.md`. The manifest must be Markdown with YAML frontmatter. Required manifest fields are `name` and `description`; standard optional directories are `scripts/`, `references/`, and `assets/`; additional files and directories are allowed and should be classified rather than rejected.
+
+See docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md for the full canonical brief, declarative design, validation rules, API response shape, implementation notes, verification expectations, and dependency record.
+```
+
+## User Story - Import Skill Zip From Skills Page
+
+**Summary**: As a Skills Page user, I want to upload a zip file containing one valid skill bundle so MoonMind validates and saves it as a local skill without requiring manual filesystem setup.
+
+**Goal**: Users can add local agent skill bundles from the Skills Page while archive safety, manifest correctness, collision policy, and script non-execution are enforced before any skill becomes available.
+
+**Independent Test**: Submit valid and invalid zip uploads through the Skills Page and canonical import API, then verify valid bundles are saved under the local skills mirror and invalid archives or manifests are rejected without leaving a partial skill directory.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user uploads a valid skill zip from the Skills Page, **When** the upload completes, **Then** the skill list refreshes and selects the imported skill.
+2. **Given** a valid zip contains one skill directory with `SKILL.md` or `skill.md`, frontmatter `name`, frontmatter `description`, and optional `scripts/`, `references/`, `assets/`, or extra files, **When** the import runs, **Then** the bundle is saved as one local skill and the response includes import, skill, and version identifiers.
+3. **Given** a zip is empty, invalid, too large, contains too many files, contains an oversized file, expands beyond the configured total limit, contains unsafe paths, symlinks, hardlinks, device files, duplicate normalized paths, or encrypted entries, **When** the import runs, **Then** it is rejected and no skill directory is saved.
+4. **Given** a zip has zero manifests, multiple manifests, a root-level manifest without a skill directory, a manifest outside the skill root, invalid YAML frontmatter, missing `name`, missing `description`, invalid `name`, overlong `description`, or a manifest name that does not match the parent directory, **When** the import runs, **Then** it is rejected and no skill directory is saved.
+5. **Given** a valid upload uses the default `reject` collision policy and a local skill with the same name already exists, **When** the import runs, **Then** it is rejected without overwriting the existing skill.
+6. **Given** an uploaded bundle contains scripts, **When** the import runs, **Then** scripts are stored only as files and are not executed during import.
+
+### Edge Cases
+
+- `skill.md` is normalized to `SKILL.md` when the bundle is saved.
+- Standard directories are recognized but extra files are accepted and preserved.
+- Ignorable platform artifacts such as `__MACOSX` and `.DS_Store` do not count as skill content.
+- The canonical API is `/api/skills/imports`; existing Skills Page interactions use that endpoint.
+
+## Assumptions
+
+- The current runtime storage target is the configured local skill mirror, so returned version identifiers are deterministic import metadata rather than rows in a new persistent version table.
+- `collision_policy=new_version` is accepted by the import contract, but durable immutable version history remains constrained by the existing local mirror storage model unless later storage work introduces a version table.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (MM-397 brief, semantics): One uploaded zip corresponds to one skill folder and saves only when blocking errors are zero. Scope: in scope. Maps to FR-001, FR-009.
+- **DESIGN-REQ-002** (MM-397 brief, import API): The canonical import endpoint accepts multipart zip uploads and a collision policy. Scope: in scope. Maps to FR-002, FR-011.
+- **DESIGN-REQ-003** (MM-397 brief, archive limits): The importer enforces zip size, file count, single-file size, and total uncompressed size limits. Scope: in scope. Maps to FR-003.
+- **DESIGN-REQ-004** (MM-397 brief, archive safety): Unsafe archive entries are rejected. Scope: in scope. Maps to FR-004.
+- **DESIGN-REQ-005** (MM-397 brief, structure rules): The zip must contain one skill directory and exactly one root manifest named `SKILL.md` or `skill.md`. Scope: in scope. Maps to FR-005.
+- **DESIGN-REQ-006** (MM-397 brief, manifest rules): The manifest requires Markdown YAML frontmatter with valid `name` and `description`. Scope: in scope. Maps to FR-006.
+- **DESIGN-REQ-007** (MM-397 brief, file classes): Standard directories and additional files are preserved. Scope: in scope. Maps to FR-007.
+- **DESIGN-REQ-008** (MM-397 brief, execution rule): Uploaded scripts are not executed during import. Scope: in scope. Maps to FR-008.
+- **DESIGN-REQ-009** (MM-397 brief, success/error response): Saved imports expose import, skill, version, description, and warning metadata. Scope: in scope. Maps to FR-010.
+- **DESIGN-REQ-010** (MM-397 brief, persistence tables): New durable skill import, skill version, and skill file tables are out of scope because the existing Skills Page stores local skills in the configured mirror and this story introduces no new persistent storage. Scope: out of scope.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST import exactly one skill folder from each uploaded zip and MUST save it only when blocking validation errors are zero.
+- **FR-002**: The system MUST expose a canonical `POST /api/skills/imports` multipart endpoint with required `file` and optional `collision_policy` fields.
+- **FR-003**: The system MUST reject archives over 50 MB, archives with more than 500 files, any file over 25 MB uncompressed, or archives expanding over 200 MB total.
+- **FR-004**: The system MUST reject absolute paths, parent traversal, symlinks, hardlinks, device files, duplicate normalized paths, and encrypted entries.
+- **FR-005**: The system MUST require one skill directory containing exactly one root manifest named `SKILL.md` or `skill.md`.
+- **FR-006**: The system MUST validate the manifest as UTF-8 Markdown with YAML frontmatter containing a valid `name` and non-empty `description`, and the manifest `name` MUST match the skill directory.
+- **FR-007**: The system MUST preserve standard optional directories, markdown files, assets, references, scripts, and additional files in the saved skill.
+- **FR-008**: The system MUST NOT execute uploaded scripts during import.
+- **FR-009**: The system MUST reject invalid imports without leaving a partial skill directory.
+- **FR-010**: The system MUST return saved import metadata including import id, saved status, skill id, version id, version number, name, description, and warnings.
+- **FR-011**: The system MUST reject same-name imports by default when `collision_policy=reject`.
+- **FR-012**: The Skills Page MUST upload zip files through the canonical import endpoint, refresh the skill list, and select the uploaded skill on success.
+- **FR-013**: The implementation MUST preserve Jira issue key MM-397 in Moon Spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Backend tests cover valid import metadata, `skill.md` normalization, frontmatter validation, name mismatch rejection, default collision rejection, invalid structure rejection, and unsafe path rejection.
+- **SC-002**: Frontend tests show Skills Page zip upload posts to `/api/skills/imports`, refreshes the list, and selects the uploaded skill.
+- **SC-003**: Focused unit validation for the skill import route and Skills Page passes through the repo test runner.
+- **SC-004**: Final verification traces implementation evidence back to MM-397 and all in-scope DESIGN-REQ mappings.

--- a/specs/218-skill-zip-import/tasks.md
+++ b/specs/218-skill-zip-import/tasks.md
@@ -1,0 +1,68 @@
+# Tasks: Skill Zip Import
+
+**Input**: Design documents from `/specs/218-skill-zip-import/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement production code until they pass.
+
+**Test Commands**:
+
+- Unit tests: `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'`
+- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx`
+- Final verification: `/moonspec-verify`
+
+## Phase 1: Setup
+
+- [X] T001 Preserve canonical Jira brief for MM-397 in `docs/tmp/jira-orchestration-inputs/MM-397-moonspec-orchestration-input.md`.
+- [X] T002 Create Moon Spec artifacts for MM-397 in `specs/218-skill-zip-import/`.
+
+## Phase 2: Foundational
+
+- [X] T003 Confirm existing Skills Page upload and backend route are partial in `frontend/src/entrypoints/skills.tsx` and `api_service/api/routers/task_dashboard.py`.
+- [X] T004 Confirm existing local skill mirror helpers are the runtime storage boundary.
+
+## Phase 3: Story - Import Skill Zip From Skills Page
+
+**Summary**: As a Skills Page user, I want to upload a zip file containing one valid skill bundle so MoonMind validates and saves it as a local skill without requiring manual filesystem setup.
+
+**Independent Test**: Submit valid and invalid zip uploads through the Skills Page and canonical import API, then verify valid bundles are saved under the local skills mirror and invalid archives or manifests are rejected without leaving a partial skill directory.
+
+**Traceability**: FR-001..013, DESIGN-REQ-001..009, SC-001..004
+
+### Unit Tests
+
+- [X] T005 Add failing backend tests for `/api/skills/imports` saved metadata, `skill.md` normalization, manifest frontmatter validation, name mismatch rejection, and default collision rejection in `tests/unit/api/routers/test_task_dashboard.py`.
+- [X] T006 Run focused backend tests and confirm failures are due to missing `/api/skills/imports`.
+
+### Integration Tests
+
+- [X] T007 Update Skills Page test expectations so zip upload posts to `/api/skills/imports` in `frontend/src/entrypoints/skills.test.tsx`.
+- [X] T008 Attempt focused frontend validation before implementation; direct `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx` was blocked before dependency preparation because `vitest` was not installed.
+
+### Implementation
+
+- [X] T009 Implement canonical skill import response model and route in `api_service/api/routers/task_dashboard.py`.
+- [X] T010 Implement archive limits and safety validation alignment in `api_service/api/routers/task_dashboard.py`.
+- [X] T011 Implement manifest frontmatter validation, `skill.md` support, parent-directory matching, and canonical `SKILL.md` save normalization in `api_service/api/routers/task_dashboard.py`.
+- [X] T012 Update Skills Page upload flow to call `/api/skills/imports` and select `response.name` in `frontend/src/entrypoints/skills.tsx`.
+
+### Story Validation
+
+- [X] T013 Run `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'` and verify focused backend tests pass.
+- [X] T014 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx` and verify runner-integrated validation passes after dependency preparation.
+
+## Phase 4: Polish And Verification
+
+- [X] T015 Compile `api_service/api/routers/task_dashboard.py`.
+- [X] T016 Run final `./tools/test_unit.sh` for full unit validation or document the exact local blocker.
+- [X] T017 Run final `/moonspec-verify` and record the verdict for MM-397.
+
+## Dependencies & Execution Order
+
+- T005-T008 before T009-T012.
+- T009-T011 before T012.
+- T013-T017 after implementation.
+
+## Implementation Strategy
+
+Harden the existing upload implementation behind a shared import helper, expose the canonical `/api/skills/imports` contract, keep invalid uploads fail-closed, and preserve the existing local skill mirror storage model.

--- a/specs/218-skill-zip-import/tasks.md
+++ b/specs/218-skill-zip-import/tasks.md
@@ -27,7 +27,7 @@
 
 **Independent Test**: Submit valid and invalid zip uploads through the Skills Page and canonical import API, then verify valid bundles are saved under the local skills mirror and invalid archives or manifests are rejected without leaving a partial skill directory.
 
-**Traceability**: FR-001..013, DESIGN-REQ-001..009, SC-001..004
+**Traceability**: FR-001..013, DESIGN-REQ-001..011, SC-001..004
 
 ### Unit Tests
 

--- a/specs/218-skill-zip-import/verification.md
+++ b/specs/218-skill-zip-import/verification.md
@@ -1,0 +1,30 @@
+# Verification: Skill Zip Import
+
+**Jira Issue**: MM-397
+**Spec**: `specs/218-skill-zip-import/spec.md`
+**Verdict**: FULLY_IMPLEMENTED
+
+## Evidence
+
+| Requirement | Evidence | Status |
+| --- | --- | --- |
+| FR-001, FR-005, FR-007, FR-009 | Valid and invalid backend import tests in `tests/unit/api/routers/test_task_dashboard.py` | VERIFIED |
+| FR-002, FR-010 | `/api/skills/imports` route and `SkillImportResponse` in `api_service/api/routers/task_dashboard.py`; metadata test | VERIFIED |
+| FR-003, FR-004 | Archive size/safety validation in `api_service/api/routers/task_dashboard.py`; unsafe path regression test | VERIFIED |
+| FR-006 | YAML frontmatter parser and validation tests | VERIFIED |
+| FR-008 | Import code only copies archive members; no uploaded script execution path exists | VERIFIED |
+| FR-011 | Collision rejection test | VERIFIED |
+| FR-012 | Skills Page endpoint update and frontend test expectation | VERIFIED |
+| FR-013 | MM-397 preserved in spec, plan, tasks, and this verification file | VERIFIED |
+
+## Test Evidence
+
+- `./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'`: PASS (`10 passed` for focused backend tests; runner frontend batch also passed).
+- `python -m compileall -q api_service/api/routers/task_dashboard.py`: PASS
+- `./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx`: PASS after dependency preparation; an earlier direct `npm run ui:test -- frontend/src/entrypoints/skills.test.tsx` attempt failed because the npm script could not resolve `vitest` in this environment.
+- `./node_modules/.bin/vitest run --config frontend/vite.config.ts frontend/src/entrypoints/skills.test.tsx`: PASS.
+- `./tools/test_unit.sh`: PASS (`3695 passed, 1 xpassed`; frontend batch `11 passed`, `345 passed`).
+
+## MoonSpec Verification
+
+The implementation satisfies MM-397's single-story runtime request. Every in-scope functional requirement, acceptance scenario, and source design mapping has production evidence and automated test evidence. The prerequisite script could not be used because the current branch `mm-397-9bb0fc03` does not follow the script's numeric feature-branch naming rule, so verification used `.specify/feature.json` and direct artifact inspection for `specs/218-skill-zip-import/`.

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -598,6 +598,16 @@ def _skill_zip(entries: dict[str, str]) -> bytes:
     return payload.getvalue()
 
 
+VALID_SKILL_MARKDOWN = """---
+name: zip-skill
+description: Uploaded from a zip.
+---
+# Zip Skill
+
+Use this bundle.
+"""
+
+
 def test_upload_dashboard_skill_zip_saves_valid_bundle(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -608,7 +618,7 @@ def test_upload_dashboard_skill_zip_saves_valid_bundle(
 
     payload = _skill_zip(
         {
-            "zip-skill/SKILL.md": "# Zip Skill\n\nUse this bundle.",
+            "zip-skill/SKILL.md": VALID_SKILL_MARKDOWN,
             "zip-skill/scripts/check.sh": "#!/usr/bin/env bash\nexit 0\n",
             "zip-skill/references/context.md": "Reference material.\n",
         }
@@ -621,12 +631,168 @@ def test_upload_dashboard_skill_zip_saves_valid_bundle(
 
     assert response.status_code == 201
     assert response.json() == {"status": "success", "skill": "zip-skill"}
-    assert (tmp_path / "zip-skill" / "SKILL.md").read_text(encoding="utf-8") == (
-        "# Zip Skill\n\nUse this bundle."
-    )
+    assert (tmp_path / "zip-skill" / "SKILL.md").read_text(encoding="utf-8") == VALID_SKILL_MARKDOWN
     assert (tmp_path / "zip-skill" / "scripts" / "check.sh").is_file()
     assert (tmp_path / "zip-skill" / "references" / "context.md").is_file()
     assert not list(tmp_path.glob(".skill-upload-*"))
+
+
+def test_skill_import_api_saves_valid_bundle_with_result_metadata(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+
+    response = client.post(
+        "/api/skills/imports",
+        data={"collision_policy": "reject"},
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip(
+                    {
+                        "zip-skill/skill.md": VALID_SKILL_MARKDOWN,
+                        "zip-skill/assets/icon.txt": "asset",
+                        "zip-skill/notes.txt": "extra file",
+                    }
+                ),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["status"] == "saved"
+    assert payload["name"] == "zip-skill"
+    assert payload["description"] == "Uploaded from a zip."
+    assert payload["skill_id"] == "zip-skill"
+    assert payload["version_number"] == 1
+    assert payload["warnings"] == []
+    assert payload["import_id"]
+    assert payload["version_id"]
+    assert (tmp_path / "zip-skill" / "SKILL.md").read_text(encoding="utf-8") == VALID_SKILL_MARKDOWN
+    assert (tmp_path / "zip-skill" / "assets" / "icon.txt").is_file()
+    assert (tmp_path / "zip-skill" / "notes.txt").is_file()
+
+
+def test_skill_import_api_rejects_missing_frontmatter(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+
+    response = client.post(
+        "/api/skills/imports",
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip({"zip-skill/SKILL.md": "# Zip Skill\n\nNo frontmatter."}),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert "YAML frontmatter" in response.json()["detail"]
+    assert not (tmp_path / "zip-skill").exists()
+
+
+def test_skill_import_api_rejects_manifest_name_mismatch(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+
+    response = client.post(
+        "/api/skills/imports",
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip(
+                    {
+                        "zip-skill/SKILL.md": """---
+name: other-skill
+description: Wrong parent.
+---
+# Zip Skill
+"""
+                    }
+                ),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert "must match the parent directory" in response.json()["detail"]
+    assert not (tmp_path / "zip-skill").exists()
+
+
+def test_skill_import_api_rejects_existing_skill_by_default(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+    skill_dir = tmp_path / "zip-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(VALID_SKILL_MARKDOWN, encoding="utf-8")
+
+    response = client.post(
+        "/api/skills/imports",
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip({"zip-skill/SKILL.md": VALID_SKILL_MARKDOWN}),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 409
+    assert "already exists locally" in response.json()["detail"]
+
+
+def test_skill_import_api_new_version_does_not_overwrite_without_versioned_storage(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+    skill_dir = tmp_path / "zip-skill"
+    skill_dir.mkdir()
+    original_markdown = """---
+name: zip-skill
+description: Original skill.
+---
+# Original
+"""
+    (skill_dir / "SKILL.md").write_text(original_markdown, encoding="utf-8")
+
+    response = client.post(
+        "/api/skills/imports",
+        data={"collision_policy": "new_version"},
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip({"zip-skill/SKILL.md": VALID_SKILL_MARKDOWN}),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 409
+    assert "versioned skill storage" in response.json()["detail"]
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == original_markdown
 
 
 def test_upload_dashboard_skill_zip_rejects_invalid_root_skill_filename(
@@ -642,14 +808,14 @@ def test_upload_dashboard_skill_zip_rejects_invalid_root_skill_filename(
         files={
             "file": (
                 "my skill.zip",
-                _skill_zip({"SKILL.md": "# Invalid inferred name\n"}),
+                _skill_zip({"SKILL.md": VALID_SKILL_MARKDOWN}),
                 "application/zip",
             )
         },
     )
 
     assert response.status_code == 400
-    assert "Invalid skill name" in response.json()["detail"]
+    assert "one skill directory" in response.json()["detail"]
     assert not list(tmp_path.iterdir())
 
 
@@ -666,7 +832,7 @@ def test_upload_dashboard_skill_zip_rejects_invalid_top_level_directory(
         files={
             "file": (
                 "bundle.zip",
-                _skill_zip({"my skill/SKILL.md": "# Invalid directory name\n"}),
+                _skill_zip({"my skill/SKILL.md": VALID_SKILL_MARKDOWN}),
                 "application/zip",
             )
         },
@@ -714,7 +880,7 @@ def test_upload_dashboard_skill_zip_rejects_path_traversal(
         files={
             "file": (
                 "unsafe.zip",
-                _skill_zip({"unsafe/SKILL.md": "# Unsafe\n", "../escape.txt": "no\n"}),
+                _skill_zip({"unsafe/SKILL.md": VALID_SKILL_MARKDOWN, "../escape.txt": "no\n"}),
                 "application/zip",
             )
         },

--- a/tests/unit/api/routers/test_task_dashboard.py
+++ b/tests/unit/api/routers/test_task_dashboard.py
@@ -702,6 +702,43 @@ def test_skill_import_api_rejects_missing_frontmatter(
     assert not (tmp_path / "zip-skill").exists()
 
 
+@pytest.mark.parametrize("opening_delimiter", ["----", "---yaml"])
+def test_skill_import_api_rejects_malformed_frontmatter_opening_delimiter(
+    opening_delimiter: str,
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "api_service.api.routers.task_dashboard.settings.workflow.skills_local_mirror_root",
+        str(tmp_path),
+    )
+
+    response = client.post(
+        "/api/skills/imports",
+        files={
+            "file": (
+                "zip-skill.zip",
+                _skill_zip(
+                    {
+                        "zip-skill/SKILL.md": f"""{opening_delimiter}
+name: zip-skill
+description: Uploaded from a zip.
+---
+# Zip Skill
+"""
+                    }
+                ),
+                "application/zip",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert "YAML frontmatter" in response.json()["detail"]
+    assert not (tmp_path / "zip-skill").exists()
+
+
 def test_skill_import_api_rejects_manifest_name_mismatch(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Jira

- Jira issue key: MM-397

## MoonSpec

- Active feature path: `specs/218-skill-zip-import`
- Verification verdict: FULLY_IMPLEMENTED

## Summary

- Adds the canonical `/api/skills/imports` skill zip import endpoint.
- Validates archive safety, archive limits, root skill structure, Markdown YAML frontmatter, manifest name and description rules, and collision handling.
- Updates the Skills Page upload flow to call the canonical import endpoint and adds backend/UI regression coverage.
- Preserves the MM-397 Jira preset brief and MoonSpec artifacts for feature 218.

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_task_dashboard.py -k 'skill_import_api or upload_dashboard_skill_zip'` - backend feature tests passed (`10 passed`); one broader frontend batch continuation hit an unrelated `entrypoints/mission-control.test.tsx` lazy-load/canvas failure.
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/skills.test.tsx` - PASS; Python suite `3695 passed, 1 xpassed`; targeted UI `5 passed`.
- `python -m compileall -q api_service/api/routers/task_dashboard.py` - PASS, recorded in MoonSpec verification.

## Remaining Risks

- Durable import status resources and new persistent skill-version tables are explicitly out of scope for this story and documented as `DESIGN-REQ-010`/`DESIGN-REQ-011` out-of-scope mappings.
- A separate Mission Control frontend test can fail in the broader UI batch; it is unrelated to MM-397 and did not fail the targeted Skills Page validation.