### PR TITLE
[codex] fix merge automation head sha

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,17 +1,27 @@
 [
   {
-    "id": 3119218535,
+    "id": 3120172516,
     "disposition": "addressed",
-    "rationale": "Excluded .td-instructions-toggle from the global primary button selectors so its lightweight hover/active styling is preserved."
+    "rationale": "Included the resolved push_head_sha in the no_commits result path and added focused unit coverage."
   },
   {
-    "id": 4149618936,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary container; the actionable inline comment from this review is tracked separately."
+    "id": 3120172519,
+    "disposition": "addressed",
+    "rationale": "Updated _resolve_workspace_head_sha to kill and reap the rev-parse subprocess on timeout and added focused unit coverage."
   },
   {
-    "id": 4149627539,
+    "id": 4150632918,
     "disposition": "not-applicable",
-    "rationale": "Review body explicitly states there is no feedback to address."
+    "rationale": "Review summary comment only; its two concrete findings are tracked and addressed by comments 3120172516 and 3120172519."
+  },
+  {
+    "id": 3120179522,
+    "disposition": "addressed",
+    "rationale": "Duplicate timeout-resource-leak finding; fixed by killing and awaiting the timed-out rev-parse subprocess."
+  },
+  {
+    "id": 4150640657,
+    "disposition": "not-applicable",
+    "rationale": "Automated review wrapper/informational comment; the concrete actionable suggestion is tracked separately as comment 3120179522."
   }
 ]

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4690,8 +4690,8 @@ class TemporalAgentRuntimeActivities:
         """Push the workspace branch to origin.
 
         Returns a dict with ``push_status``, ``push_branch``, and optionally
-        ``push_error``, ``push_base_ref``, and ``push_commit_count`` that the
-        caller merges into result metadata.
+        ``push_error``, ``push_base_ref``, ``push_head_sha``, and
+        ``push_commit_count`` that the caller merges into result metadata.
 
         Uses ``asyncio.create_subprocess_exec`` to avoid blocking the event
         loop.
@@ -4859,6 +4859,12 @@ class TemporalAgentRuntimeActivities:
                     "push_error": error_detail,
                 }
 
+            head_sha = await self._resolve_workspace_head_sha(
+                workspace=workspace,
+                run_id=run_id,
+                env=command_env,
+            )
+
             # Verify the branch actually has commits over the publish base.
             # git push succeeds as a no-op when the branch is already
             # up-to-date, which would cause repo.create_pr to fail
@@ -4900,6 +4906,8 @@ class TemporalAgentRuntimeActivities:
                 "push_base_ref": base_ref,
             }
             result.update(commit_info)
+            if head_sha:
+                result["push_head_sha"] = head_sha
             if commit_count >= 0:
                 result["push_commit_count"] = commit_count
             return result
@@ -4913,6 +4921,41 @@ class TemporalAgentRuntimeActivities:
                 "push_status": "failed",
                 "push_error": str(exc),
             }
+
+    async def _resolve_workspace_head_sha(
+        self,
+        *,
+        workspace: str,
+        run_id: str,
+        env: Mapping[str, str],
+    ) -> str | None:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *self._workspace_git_command(workspace, "rev-parse", "HEAD"),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=10,
+            )
+        except Exception:
+            logger.warning(
+                "Could not resolve pushed HEAD SHA for run %s",
+                run_id,
+                exc_info=True,
+            )
+            return None
+        if proc.returncode != 0:
+            detail = stderr_bytes.decode("utf-8", errors="replace").strip()
+            logger.warning(
+                "Could not resolve pushed HEAD SHA for run %s: %s",
+                run_id,
+                detail or f"git rev-parse exited with {proc.returncode}",
+            )
+            return None
+        head_sha = stdout_bytes.decode("utf-8", errors="replace").strip()
+        return head_sha or None
 
     async def _resolve_workspace_default_branch(
         self,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -4886,13 +4886,16 @@ class TemporalAgentRuntimeActivities:
                     current_branch,
                     base_ref,
                 )
-                return {
+                result = {
                     "push_status": "no_commits",
                     "push_branch": current_branch,
                     "push_base_branch": base_branch_name,
                     "push_base_ref": base_ref,
                     "push_commit_count": 0,
                 }
+                if head_sha:
+                    result["push_head_sha"] = head_sha
+                return result
 
             logger.info(
                 "Post-agent git push completed for run %s (branch=%s)",
@@ -4936,9 +4939,14 @@ class TemporalAgentRuntimeActivities:
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
             )
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(), timeout=10,
-            )
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=10,
+                )
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+                raise
         except Exception:
             logger.warning(
                 "Could not resolve pushed HEAD SHA for run %s",

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -513,8 +513,14 @@ class TestPushWorkspaceBranch:
             elif call_count == 2:  # status --porcelain
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
-            elif call_count == 3:  # push
+            elif call_count == 3:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 5:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"no-commit-head-sha\n", b""))
                 proc.returncode = 0
             else:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"0\n", b""))
@@ -527,7 +533,28 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "auto-abc123"
         assert result["push_base_ref"] == "origin/main"
         assert result["push_commit_count"] == 0
+        assert result["push_head_sha"] == "no-commit-head-sha"
         assert "push_error" not in result
+
+    @pytest.mark.asyncio
+    async def test_resolve_workspace_head_sha_timeout_kills_process(self):
+        store = _make_mock_store()
+        activities = TemporalAgentRuntimeActivities(run_store=store)
+        proc = MagicMock()
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await activities._resolve_workspace_head_sha(
+                workspace="/work/agent_jobs/run-1/repo",
+                run_id="run-1",
+                env={},
+            )
+
+        assert result is None
+        proc.kill.assert_called_once_with()
+        proc.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_push_with_commits(self):

--- a/tests/unit/services/temporal/test_fetch_result_push.py
+++ b/tests/unit/services/temporal/test_fetch_result_push.py
@@ -296,6 +296,9 @@ class TestPushWorkspaceBranch:
             elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
+            elif call_count == 5:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"abc123head\n", b""))
+                proc.returncode = 0
             else:
                 raise AssertionError(f"Unexpected subprocess call #{call_count}: {args!r}")
             return proc
@@ -311,6 +314,7 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "develop"
         assert result["push_base_ref"] == "origin/develop"
         assert result["push_commit_count"] == 1
+        assert result["push_head_sha"] == "abc123head"
 
     @pytest.mark.asyncio
     async def test_push_keeps_target_branch_protected_when_head_differs(self):
@@ -353,6 +357,9 @@ class TestPushWorkspaceBranch:
             elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
+            elif call_count == 5:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"pushed-head-sha\n", b""))
+                proc.returncode = 0
             else:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"2\n", b""))
                 proc.returncode = 0
@@ -364,6 +371,7 @@ class TestPushWorkspaceBranch:
         assert result["push_branch"] == "feature/delete-spec-048"
         assert result["push_base_branch"] == "trunk"
         assert result["push_base_ref"] == "origin/trunk"
+        assert result["push_head_sha"] == "pushed-head-sha"
         assert "push_error" not in result
 
     @pytest.mark.asyncio
@@ -415,6 +423,9 @@ class TestPushWorkspaceBranch:
             elif call_count == 4:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
+            elif call_count == 5:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"safe-head-sha\n", b""))
+                proc.returncode = 0
             else:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"1\n", b""))
                 proc.returncode = 0
@@ -424,7 +435,8 @@ class TestPushWorkspaceBranch:
             result = await activities._push_workspace_branch("run-1")
 
         assert result["push_status"] == "pushed"
-        assert len(recorded_calls) == 5
+        assert result["push_head_sha"] == "safe-head-sha"
+        assert len(recorded_calls) == 6
         for call in recorded_calls:
             command = list(call)
             assert command[:5] == [
@@ -579,8 +591,14 @@ class TestPushWorkspaceBranch:
             elif call_count == 5:  # commit
                 proc.communicate = AsyncMock(return_value=(b"[auto-dirty123 abc123] msg\n", b""))
                 proc.returncode = 0
-            elif call_count == 6:  # push
+            elif call_count == 6:  # remote default branch
+                proc.communicate = AsyncMock(return_value=(b"origin/main\n", b""))
+                proc.returncode = 0
+            elif call_count == 7:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 8:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"dirty-head-sha\n", b""))
                 proc.returncode = 0
             else:  # rev-list --count
                 proc.communicate = AsyncMock(return_value=(b"1\n", b""))
@@ -596,6 +614,7 @@ class TestPushWorkspaceBranch:
         assert result["push_status"] == "pushed"
         assert result["push_branch"] == "auto-dirty123"
         assert result["push_commit_count"] == 1
+        assert result["push_head_sha"] == "dirty-head-sha"
         assert result["push_commit_message"] == "Ship dirty workspace"
         add_call = recorded_calls[2]
         assert list(add_call[-3:]) == [
@@ -924,6 +943,9 @@ class TestPushWorkspaceBranch:
             elif call_count == 3:  # push
                 proc.communicate = AsyncMock(return_value=(b"", b""))
                 proc.returncode = 0
+            elif call_count == 4:  # rev-parse HEAD
+                proc.communicate = AsyncMock(return_value=(b"develop-head-sha\n", b""))
+                proc.returncode = 0
             else:  # rev-list --count
                 captured_revlist_args = args
                 proc.communicate = AsyncMock(return_value=(b"5\n", b""))
@@ -935,6 +957,7 @@ class TestPushWorkspaceBranch:
                 "run-1", target_branch="develop",
             )
         assert result["push_status"] == "pushed"
+        assert result["push_head_sha"] == "develop-head-sha"
         # Verify the rev-list range uses origin/develop, not origin/main
         assert captured_revlist_args is not None
         revlist_range = [a for a in captured_revlist_args if ".." in str(a)]

--- a/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
+++ b/tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py
@@ -133,6 +133,22 @@ def test_run_records_merge_automation_disposition_from_step_outputs() -> None:
     assert workflow._merge_automation_head_sha == "abc123"
 
 
+def test_run_records_pushed_head_sha_for_parent_owned_merge_automation() -> None:
+    workflow = MoonMindRunWorkflow()
+
+    workflow._record_execution_context(
+        node_id="publish",
+        execution_result={
+            "outputs": {
+                "push_status": "pushed",
+                "push_head_sha": "pushed-head-sha",
+            }
+        },
+    )
+
+    assert workflow._publish_context["headSha"] == "pushed-head-sha"
+
+
 def test_parent_run_summary_projects_merge_automation_visibility() -> None:
     workflow = MoonMindRunWorkflow()
     workflow._publish_context = {


### PR DESCRIPTION
## Summary

Fix merge automation startup for PR-publishing runs by returning the pushed branch HEAD SHA from workspace push metadata.

## Root Cause

Parent-owned merge automation requires both a pull request URL and a concrete PR head SHA. The push path returned the PR URL and branch metadata, but not the pushed HEAD SHA, so the parent could not build the merge automation payload and skipped starting the child workflow.

## Changes

- Resolve `git rev-parse HEAD` after successful workspace pushes.
- Include `push_head_sha` in successful push metadata.
- Add regression coverage for push metadata and parent publish-context recording.

## Validation

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/services/temporal/test_fetch_result_push.py tests/unit/workflows/temporal/test_run_parent_owned_merge_automation.py tests/unit/workflows/temporal/test_run_merge_gate_start.py`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
