### PR TITLE
Why is there blank space to the left of the github repo in the floating create page bar? There shouldn't be open space. We should use the available sp

### DIFF
--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5705,10 +5705,10 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)[^}]*justify-content:\s*stretch[^}]*justify-items:\s*stretch/s,
+      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)[^}]*justify-content:\s*stretch/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar-row\s*\{[^}]*width:\s*100%[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
+      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
     );
     expect(missionControlCss).toMatch(
       /@media \(max-width:\s*640px\)\s*\{[^}]*\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,

--- a/frontend/src/entrypoints/task-create.test.tsx
+++ b/frontend/src/entrypoints/task-create.test.tsx
@@ -5705,10 +5705,10 @@ describe("Task Create Entrypoint", () => {
     );
 
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)/s,
+      /\.queue-floating-bar\s*\{[^}]*width:\s*min\(100% - 1\.5rem,\s*72rem\)[^}]*justify-content:\s*stretch[^}]*justify-items:\s*stretch/s,
     );
     expect(missionControlCss).toMatch(
-      /\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
+      /\.queue-floating-bar-row\s*\{[^}]*width:\s*100%[^}]*grid-template-columns:\s*minmax\(0,\s*1\.35fr\)\s*minmax\(0,\s*1\.35fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,
     );
     expect(missionControlCss).toMatch(
       /@media \(max-width:\s*640px\)\s*\{[^}]*\.queue-floating-bar-row\s*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(9\.5rem,\s*0\.8fr\)\s*auto/s,

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2266,7 +2266,6 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   display: grid;
   gap: 0.4rem;
   justify-content: stretch;
-  justify-items: stretch;
   isolation: isolate;
 }
 
@@ -2286,7 +2285,6 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
 .queue-floating-bar-row {
   display: grid;
-  width: 100%;
   grid-template-columns:
     minmax(0, 1.35fr)
     minmax(0, 1.35fr)

--- a/frontend/src/styles/mission-control.css
+++ b/frontend/src/styles/mission-control.css
@@ -2265,6 +2265,8 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
   -webkit-backdrop-filter: blur(26px) saturate(1.65);
   display: grid;
   gap: 0.4rem;
+  justify-content: stretch;
+  justify-items: stretch;
   isolation: isolate;
 }
 
@@ -2284,6 +2286,7 @@ button:not(.secondary):not(.queue-action):not(.queue-submit-primary):not(.queue-
 
 .queue-floating-bar-row {
   display: grid;
+  width: 100%;
   grid-template-columns:
     minmax(0, 1.35fr)
     minmax(0, 1.35fr)


### PR DESCRIPTION
Why is there blank space to the left of the github repo in the floating create page bar? There shouldn't be open space. We should use the available space for the dropdowns.