### PR TITLE
Fix merge gate head drift

### DIFF
--- a/api_service/data/task_step_templates/jira-orchestrate.yaml
+++ b/api_service/data/task_step_templates/jira-orchestrate.yaml
@@ -152,7 +152,9 @@ steps:
 
       This preset owns pull request creation before the Jira Code Review transition. It must be run with task.publish.mode=none so the pull request is created in this step, not by a later MoonMind publish stage. If the runtime instructions, task parameters, authentication, remote configuration, branch protection, or repository permissions prevent committing, pushing, or creating the pull request in this step, stop before changing Jira to Code Review and report the exact blocker.
 
-      First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a pull request with the available authenticated GitHub tooling.
+      First confirm the working tree contains only intentional changes for this issue and no raw credentials. Commit the work with a concise message that includes {{ inputs.jira_issue_key }}. Push the current non-protected work branch and create a non-draft pull request with the available authenticated GitHub tooling.
+
+      The pull request must be ready for review, not a draft. Do not pass draft flags when creating it. If the available tool or repository default creates a draft pull request, immediately mark it ready for review (for example, with the authenticated GitHub tooling's ready-for-review command) and verify the final pull request isDraft value is false before continuing.
 
       The pull request title must include {{ inputs.jira_issue_key }}. The pull request body must include:
       - the Jira issue key
@@ -161,7 +163,7 @@ steps:
       - tests run
       - remaining risks
 
-      After creation, record the confirmed pull request URL in the step result and in a local handoff artifact at artifacts/jira-orchestrate-pr.json with keys jira_issue_key and pull_request_url. Do not continue unless the pull_request_url is a GitHub pull request URL for the current work branch.
+      After creation and non-draft verification, record the confirmed pull request URL in the step result and in a local handoff artifact at artifacts/jira-orchestrate-pr.json with keys jira_issue_key and pull_request_url. Do not continue unless the pull_request_url is a GitHub pull request URL for the current work branch and the pull request is confirmed non-draft.
     skill:
       id: auto
       args: {}

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -285,6 +285,25 @@ class MoonMindMergeAutomationWorkflow:
         self._input.pull_request.head_sha = head_sha
         return True
 
+    def _should_refresh_pre_resolver_head(
+        self,
+        *,
+        evaluation: Any,
+        blockers: list[ReadinessBlockerModel],
+    ) -> bool:
+        if (
+            self._input is None
+            or self._resolver_child_workflow_ids
+            or not isinstance(evaluation, Mapping)
+        ):
+            return False
+        observed_head_sha = self._head_sha_from_mapping(evaluation)
+        if not observed_head_sha:
+            return False
+        if observed_head_sha == self._input.pull_request.head_sha:
+            return False
+        return any(blocker.kind == "stale_revision" for blocker in blockers)
+
     async def _failed_resolver_summary(
         self,
         *,
@@ -427,6 +446,17 @@ class MoonMindMergeAutomationWorkflow:
                         evaluation if isinstance(evaluation, Mapping) else {},
                         tracked_head_sha=self._input.pull_request.head_sha,
                     )
+            if workflow.patched(
+                "merge-automation-pre-resolver-head-refresh-v1"
+            ) and self._should_refresh_pre_resolver_head(
+                evaluation=evaluation,
+                blockers=list(evidence.blockers),
+            ):
+                self._refresh_tracked_head_sha(evaluation)
+                evidence = classify_readiness(
+                    evaluation if isinstance(evaluation, Mapping) else {},
+                    tracked_head_sha=self._input.pull_request.head_sha,
+                )
             self._blockers = list(evidence.blockers)
             await self._write_gate_snapshot(evidence_ready=evidence.ready)
             if evidence.pull_request_merged:

--- a/specs/219-merge-gate-head-drift/plan.md
+++ b/specs/219-merge-gate-head-drift/plan.md
@@ -1,0 +1,35 @@
+# Implementation Plan: Merge Gate Head Drift Resilience
+
+**Branch**: `219-merge-gate-head-drift` | **Date**: 2026-04-21 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Update `MoonMind.MergeAutomation` so a pull request head change observed before any resolver launch refreshes the tracked revision and reuses the existing readiness classifier for the new head. Update the Jira Orchestrate seed template so the pull request creation step explicitly creates a non-draft PR or marks it ready before Jira Code Review transition.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 and YAML seed templates
+**Dependencies**: Temporal Python SDK, Pydantic v2, pytest, existing task template expansion tests
+**Storage**: Existing Temporal history, memo, and artifact outputs only
+**Testing**: Focused pytest targets for merge automation workflow behavior and Jira Orchestrate template expansion
+
+## Constitution Check
+
+- **I. Orchestrate, Don't Recreate**: PASS. Uses existing workflow and GitHub/Jira tool paths.
+- **II. One-Click Agent Deployment**: PASS. No new services or setup.
+- **III. Avoid Vendor Lock-In**: PASS. GitHub-specific evidence remains in the adapter/activity boundary.
+- **IV. Own Your Data**: PASS. State remains in Temporal/artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. Jira Orchestrate remains a seed template using existing skills.
+- **VI. Design for Deletion / Scientific Method**: PASS. Narrow behavioral change with regression tests.
+- **VII. Powerful Runtime Configurability**: PASS. Existing merge automation policy remains authoritative.
+- **VIII. Modular and Extensible Architecture**: PASS. Workflow logic changes are confined to merge automation.
+- **IX. Resilient by Default**: PASS. Handles normal pre-resolver head drift without failing the parent run.
+- **X. Facilitate Continuous Improvement**: PASS. Operator-visible blockers still explain active gates.
+- **XI. Spec-Driven Development Is the Source of Truth**: PASS. This spec records the requested behavior.
+- **XII. Canonical Documentation Separates Desired State from Migration Backlog**: PASS. No canonical docs changed.
+- **XIII. Pre-Release Compatibility Policy**: PASS. No compatibility alias or fallback contract added.
+
+## Validation
+
+- Add a workflow unit test for pre-resolver head refresh and revision-scoped resolver launch.
+- Extend Jira Orchestrate template expansion coverage for non-draft PR instructions.

--- a/specs/219-merge-gate-head-drift/spec.md
+++ b/specs/219-merge-gate-head-drift/spec.md
@@ -1,0 +1,23 @@
+# Feature Specification: Merge Gate Head Drift Resilience
+
+**Feature Branch**: `219-merge-gate-head-drift`
+**Created**: 2026-04-21
+**Status**: Draft
+**Input**: Operator request after workflow `mm:f5f2911f-b35d-499e-88c2-c15e2d51ba4f` failed because Jira Orchestrate added a handoff commit after PR publication but before merge automation evaluated readiness.
+
+## User Story
+
+As a MoonMind operator running Jira Orchestrate with merge automation, I want the merge gate to tolerate pre-resolver pull request head changes and I want Jira Orchestrate pull requests to be ready for review, so automation does not fail on normal handoff commits or leave review-hidden draft PRs.
+
+## Requirements
+
+- **FR-001**: Merge automation MUST refresh the tracked pull request head when GitHub reports a new head before any resolver child has launched.
+- **FR-002**: After refreshing a pre-resolver head, merge automation MUST reclassify readiness for the current revision instead of returning a terminal `stale_revision` blocker.
+- **FR-003**: Merge automation MUST still apply configured readiness gates, including running checks and review blockers, to the refreshed current revision.
+- **FR-004**: Resolver child workflow IDs MUST remain revision-scoped to the refreshed head SHA.
+- **FR-005**: Jira Orchestrate PR creation instructions MUST require non-draft pull requests and must require verification or conversion to ready-for-review before Jira is moved to Code Review.
+
+## Success Criteria
+
+- **SC-001**: A merge automation run that sees `abc123` at start and `def456` before resolver launch waits or resolves against `def456` without failing on `stale_revision`.
+- **SC-002**: Jira Orchestrate seeded template expansion tells agents to create or convert the PR as non-draft before writing the handoff artifact.

--- a/specs/219-merge-gate-head-drift/tasks.md
+++ b/specs/219-merge-gate-head-drift/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Merge Gate Head Drift Resilience
+
+- [X] T001 Add workflow regression coverage for pre-resolver PR head refresh.
+- [X] T002 Implement merge automation pre-resolver head refresh and reclassification.
+- [X] T003 Update Jira Orchestrate PR creation instructions to require non-draft PRs.
+- [X] T004 Extend task template expansion tests for non-draft PR requirements.
+- [X] T005 Run focused unit tests.

--- a/tests/unit/api/test_task_step_templates_service.py
+++ b/tests/unit/api/test_task_step_templates_service.py
@@ -1225,6 +1225,9 @@ async def test_seed_catalog_includes_jira_orchestrate_preset(tmp_path):
                 "instructions"
             ]
             assert "task.publish.mode=none" in expanded["steps"][11]["instructions"]
+            assert "non-draft pull request" in expanded["steps"][11]["instructions"]
+            assert "isDraft value is false" in expanded["steps"][11]["instructions"]
+            assert "confirmed non-draft" in expanded["steps"][11]["instructions"]
             assert "artifacts/jira-orchestrate-pr.json" in expanded["steps"][11][
                 "instructions"
             ]

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -261,6 +261,108 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
 
 
 @pytest.mark.asyncio
+async def test_merge_automation_refreshes_head_before_resolver_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    child_workflow_ids: list[str] = []
+    child_payloads: list[dict[str, Any]] = []
+    wait_calls = 0
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        assert activity_type == "merge_automation.evaluate_readiness"
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "def456",
+                "ready": False,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": False,
+                "checksPassing": False,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+                "blockers": [
+                    {
+                        "kind": "checks_running",
+                        "summary": "Required checks are still running.",
+                        "retryable": True,
+                        "source": "github",
+                    }
+                ],
+            }
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        child_payloads.append(payload)
+        child_workflow_ids.append(str(kwargs["id"]))
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    async def fake_wait_condition(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal wait_calls
+        wait_calls += 1
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "wait_condition",
+        fake_wait_condition,
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    expected_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="def456",
+    )
+    assert readiness_calls == 2
+    assert wait_calls == 1
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+    assert result["blockers"] == []
+    assert child_workflow_ids == [f"{expected_resolver_id}:1"]
+    assert child_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
+
+
+@pytest.mark.asyncio
 async def test_merge_automation_resolver_child_uses_try_cancel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Refresh merge automation tracking when a PR head changes before any resolver child launches, then reclassify readiness for the current revision.
- Require Jira Orchestrate-created pull requests to be non-draft and verified ready for review before Jira Code Review handoff.
- Add Moon Spec artifacts and regression tests for the new behavior.

## Root Cause

Merge automation treated any PR head change observed before the gate opened as a terminal stale revision. Jira Orchestrate can add a normal handoff commit after PR creation, which made the gate fail the parent run instead of continuing against the current PR head.

## Validation

- ./tools/test_unit.sh

## Notes

This PR is intentionally opened as ready for review, not draft.