### PR TITLE
MM-431 Accept remediation create requests and persist target links

### DIFF
--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3359,6 +3359,80 @@ async def _resolve_schedule_routing(
     return _ScheduleRouteResult()
 
 
+@router.post(
+    "/{workflow_id}/remediation",
+    response_model=ExecutionModel | ScheduleCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_remediation_execution(
+    workflow_id: str,
+    payload: dict[str, Any] = Body(default_factory=dict),
+    service: TemporalExecutionService = Depends(_get_service),
+    session: AsyncSession = Depends(get_async_session),
+    user: User = Depends(get_current_user()),
+    _submit_enabled: None = Depends(_ensure_submit_enabled),
+) -> ExecutionModel | ScheduleCreatedResponse:
+    body = payload if isinstance(payload, dict) else {}
+    task_payload = (
+        dict(body.get("task")) if isinstance(body.get("task"), Mapping) else {}
+    )
+
+    instructions = str(
+        task_payload.get("instructions") or body.get("instructions") or ""
+    ).strip()
+    if instructions:
+        task_payload["instructions"] = instructions
+
+    runtime_payload = body.get("runtime")
+    if isinstance(runtime_payload, Mapping) and "runtime" not in task_payload:
+        task_payload["runtime"] = dict(runtime_payload)
+
+    remediation_payload = body.get("remediation")
+    if not isinstance(remediation_payload, Mapping):
+        remediation_payload = task_payload.get("remediation")
+    remediation = (
+        dict(remediation_payload) if isinstance(remediation_payload, Mapping) else {}
+    )
+    target = (
+        dict(remediation.get("target"))
+        if isinstance(remediation.get("target"), Mapping)
+        else {}
+    )
+    target["workflowId"] = workflow_id
+    remediation["target"] = target
+    task_payload["remediation"] = remediation
+
+    request_payload: dict[str, Any] = {
+        "repository": body.get("repository"),
+        "integration": body.get("integration"),
+        "requiredCapabilities": body.get("requiredCapabilities"),
+        "task": task_payload,
+    }
+    for key in (
+        "dependsOn",
+        "inputArtifactRef",
+        "planArtifactRef",
+        "manifestArtifactRef",
+        "targetRuntime",
+        "profileId",
+        "providerProfile",
+        "idempotencyKey",
+        "schedule",
+    ):
+        if key in body:
+            request_payload[key] = body[key]
+
+    request = CreateJobRequest.model_validate(
+        {"type": "task", "payload": request_payload}
+    )
+    return await _create_execution_from_task_request(
+        request=request,
+        service=service,
+        user=user,
+        session=session,
+    )
+
+
 @router.post("", response_model=ExecutionModel | ScheduleCreatedResponse, status_code=status.HTTP_201_CREATED)
 async def create_execution(
     payload: dict[str, Any] = Body(...),

--- a/api_service/api/routers/executions.py
+++ b/api_service/api/routers/executions.py
@@ -3378,18 +3378,25 @@ async def create_remediation_execution(
     )
 
     instructions = str(
-        task_payload.get("instructions") or body.get("instructions") or ""
+        body.get("instructions") or task_payload.get("instructions") or ""
     ).strip()
     if instructions:
         task_payload["instructions"] = instructions
 
     runtime_payload = body.get("runtime")
-    if isinstance(runtime_payload, Mapping) and "runtime" not in task_payload:
+    if isinstance(runtime_payload, Mapping):
         task_payload["runtime"] = dict(runtime_payload)
 
-    remediation_payload = body.get("remediation")
-    if not isinstance(remediation_payload, Mapping):
+    if "remediation" in body:
+        remediation_payload = body.get("remediation")
+        if not isinstance(remediation_payload, Mapping):
+            raise _invalid_task_request("task.remediation must be an object")
+    else:
         remediation_payload = task_payload.get("remediation")
+        if remediation_payload is not None and not isinstance(
+            remediation_payload, Mapping
+        ):
+            raise _invalid_task_request("task.remediation must be an object")
     remediation = (
         dict(remediation_payload) if isinstance(remediation_payload, Mapping) else {}
     )
@@ -3422,9 +3429,16 @@ async def create_remediation_execution(
         if key in body:
             request_payload[key] = body[key]
 
-    request = CreateJobRequest.model_validate(
-        {"type": "task", "payload": request_payload}
-    )
+    request_data: dict[str, Any] = {"type": "task", "payload": request_payload}
+    if "priority" in body:
+        request_data["priority"] = body["priority"]
+    if "maxAttempts" in body:
+        request_data["maxAttempts"] = body["maxAttempts"]
+    elif "max_attempts" in body:
+        request_data["maxAttempts"] = body["max_attempts"]
+    if "schedule" in body:
+        request_data["schedule"] = body["schedule"]
+    request = CreateJobRequest.model_validate(request_data)
     return await _create_execution_from_task_request(
         request=request,
         service=service,

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1042,6 +1042,14 @@ class TemporalExecutionRemediationLink(Base):
         ForeignKey("temporal_artifacts.artifact_id", ondelete="SET NULL"),
         nullable=True,
     )
+    active_lock_scope: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    active_lock_holder: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )
+    latest_action_summary: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True
+    )
+    outcome: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api_service/migrations/versions/223_remediation_link_status_fields.py
+++ b/api_service/migrations/versions/223_remediation_link_status_fields.py
@@ -1,0 +1,54 @@
+"""add remediation link status fields
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
+
+
+def upgrade() -> None:
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("active_lock_scope", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("active_lock_holder", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("latest_action_summary", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "execution_remediation_links",
+        sa.Column("outcome", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("execution_remediation_links", "outcome")
+    op.drop_column("execution_remediation_links", "latest_action_summary")
+    op.drop_column("execution_remediation_links", "active_lock_holder")
+    op.drop_column("execution_remediation_links", "active_lock_scope")

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,57 +1,27 @@
 [
   {
-    "id": 3120762036,
+    "id": 4151732435,
     "disposition": "addressed",
-    "rationale": "Replaced the protocol ellipsis body with an explicit NotImplementedError so the statement is no longer a no-op."
+    "rationale": "Addressed the review summary by passing priority, maxAttempts, and schedule through the remediation convenience route and standardizing top-level field precedence."
   },
   {
-    "id": 3120762042,
+    "id": 3121231598,
     "disposition": "addressed",
-    "rationale": "Replaced the protocol ellipsis body with an explicit NotImplementedError so the statement is no longer a no-op."
+    "rationale": "The remediation route now includes priority, maxAttempts, snake-case max_attempts fallback, and schedule in the CreateJobRequest model validation input."
   },
   {
-    "id": 3120762046,
+    "id": 3121231606,
     "disposition": "addressed",
-    "rationale": "Added an explanatory comment to the tolerant maxTailLines parse fallback."
+    "rationale": "The remediation convenience route now consistently lets top-level instructions, runtime, and remediation override nested task defaults."
   },
   {
-    "id": 3120762392,
+    "id": 3121238803,
     "disposition": "addressed",
-    "rationale": "Exported RemediationLiveFollower from remediation_tools.__all__."
+    "rationale": "The convenience route now rejects non-object remediation values with a 422 invalid_execution_request response instead of coercing them to an empty object."
   },
   {
-    "id": 3120762405,
-    "disposition": "addressed",
-    "rationale": "Changed maxTailLines parsing to preserve an explicit zero instead of replacing it with the default."
-  },
-  {
-    "id": 3120762409,
-    "disposition": "addressed",
-    "rationale": "Cached parsed remediation context payloads by workflow ID and context artifact ref within the service instance."
-  },
-  {
-    "id": 3120762414,
-    "disposition": "addressed",
-    "rationale": "Imported RemediationLiveFollower in moonmind.workflows.temporal.__init__."
-  },
-  {
-    "id": 3120762415,
-    "disposition": "addressed",
-    "rationale": "Added RemediationLiveFollower to the package root __all__ list."
-  },
-  {
-    "id": 4151239835,
+    "id": 4151740844,
     "disposition": "not-applicable",
-    "rationale": "Top-level review summary; its actionable inline comments were handled individually."
-  },
-  {
-    "id": 3120768401,
-    "disposition": "addressed",
-    "rationale": "Updated _bounded_tail_lines so explicit tail_lines are clamped by both boundedness.maxTailLines and policies.evidencePolicy.tailLines."
-  },
-  {
-    "id": 4151247216,
-    "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper; its actionable inline comment was handled individually."
+    "rationale": "Automated Codex review metadata only; no actionable code request beyond the inline comments already handled."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-431-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-431-moonspec-orchestration-input.md
@@ -1,0 +1,66 @@
+# MM-431 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-431
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Accept remediation create requests and persist target links
+- Labels: `moonmind-workflow-mm-a59f3b1d-da4d-4600-86a8-1d582ee67fe8`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-431 from MM project
+Summary: Accept remediation create requests and persist target links
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-431 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-431: Accept remediation create requests and persist target links
+
+Source Reference
+- Source Document: docs/Tasks/TaskRemediation.md
+- Source Title: Task Remediation
+- Source Sections:
+  - 5.1 Remediation tasks remain MoonMind.Run
+  - 5.2 Remediation is a relationship, not a dependency
+  - 7. Submission contract
+  - 8. Identity, linkage, and read models
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-024
+
+User Story
+As an operator, I can create a remediation task that targets another execution so MoonMind records an explicit troubleshooting relationship without treating the target as a dependency gate.
+
+Acceptance Criteria
+- POST /api/executions accepts a task.remediation payload and stores it as initialParameters.task.remediation before MoonMind.Run starts.
+- target.workflowId is required and a concrete target.runId is resolved and persisted when omitted by the caller.
+- Malformed self-reference, unsupported target workflow types, invalid taskRunIds, unsupported authorityMode values, incompatible actionPolicyRef, and disallowed nested remediation are rejected with structured errors.
+- A remediation link record supports remediator-to-target and target-to-remediator lookup including mode, authorityMode, current status, pinned run identity, lock holder, latest action summary, and outcome fields.
+- The convenience route expands into the same canonical create contract and does not introduce a second durable payload shape.
+
+Requirements
+- Remediation tasks remain MoonMind.Run executions with additional nested task.remediation semantics.
+- Remediation links are relationships, not dependsOn gates, and start independently of target success.
+- The system exposes inbound and outbound remediation lookup APIs for execution detail surfaces.
+- Canonical source data remains upstream of any derived read model.
+
+Implementation Notes
+- Preserve MM-431 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation task semantics, submission contract, identity, linkage, and read model behavior.
+- Scope implementation to accepting remediation create requests, persisting the canonical task.remediation payload, resolving target run identity, validating unsupported or malformed remediation submissions, and exposing durable remediation link lookup data.
+- Keep remediation links as explicit troubleshooting relationships rather than dependency gates; target execution success must not be required for remediation task startup.
+- Keep the convenience route as an expansion into the canonical create contract, not a second durable payload shape.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-431 is blocked by MM-432, whose embedded status is Backlog.

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -938,6 +938,23 @@ export interface paths {
         patch: operations["proxy_pass_through_patch"];
         trace?: never;
     };
+    "/api/executions/{workflow_id}/remediation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Remediation Execution */
+        post: operations["create_remediation_execution_api_executions__workflow_id__remediation_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/executions": {
         parameters: {
             query?: never;
@@ -8421,6 +8438,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_remediation_execution_api_executions__workflow_id__remediation_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutionModel"] | components["schemas"]["ScheduleCreatedResponse"];
                 };
             };
             /** @description Validation Error */

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -70,6 +70,10 @@ TERMINAL_STATES: set[MoonMindWorkflowState] = {
     MoonMindWorkflowState.CANCELED,
 }
 CREATE_IDEMPOTENCY_KEY_MAX_LENGTH = 128
+ALLOWED_REMEDIATION_AUTHORITY_MODES = frozenset(
+    {"observe_only", "approval_gated", "admin_auto"}
+)
+ALLOWED_REMEDIATION_ACTION_POLICY_REFS = frozenset({"admin_healer_default"})
 
 import logging
 
@@ -408,17 +412,63 @@ class TemporalExecutionService:
                 f"Remediation target {target_workflow_id} is a {wf_type_value} "
                 "workflow, not a MoonMind.Run workflow."
             )
+        target_task = (
+            target_record.parameters.get("task")
+            if isinstance(target_record.parameters, Mapping)
+            else None
+        )
+        if (
+            isinstance(target_task, Mapping)
+            and target_task.get("remediation") is not None
+        ):
+            raise TemporalExecutionValidationError(
+                "Nested remediation targets are not supported."
+            )
 
         requested_run_id = str(target.get("runId") or target.get("run_id") or "").strip()
         if requested_run_id and requested_run_id != target_record.run_id:
             raise TemporalExecutionValidationError(
                 "task.remediation.target.runId must match the current target runId."
             )
+        task_run_ids = (
+            target.get("taskRunIds")
+            if "taskRunIds" in target
+            else target.get("task_run_ids")
+        )
+        if task_run_ids is not None:
+            if not isinstance(task_run_ids, list) or any(
+                not isinstance(item, str) or not item.strip()
+                for item in task_run_ids
+            ):
+                raise TemporalExecutionValidationError(
+                    "task.remediation.target.taskRunIds must be a list of strings."
+                )
 
         trigger = remediation.get("trigger")
         trigger_type = None
         if isinstance(trigger, Mapping):
             trigger_type = str(trigger.get("type") or "").strip() or None
+        authority_mode = str(
+            remediation.get("authorityMode")
+            or remediation.get("authority_mode")
+            or "observe_only"
+        ).strip() or "observe_only"
+        if authority_mode not in ALLOWED_REMEDIATION_AUTHORITY_MODES:
+            supported = ", ".join(sorted(ALLOWED_REMEDIATION_AUTHORITY_MODES))
+            raise TemporalExecutionValidationError(
+                "Unsupported task.remediation.authorityMode "
+                f"'{authority_mode}'. Supported values: {supported}."
+            )
+        action_policy_ref = str(remediation.get("actionPolicyRef") or "").strip()
+        if (
+            action_policy_ref
+            and action_policy_ref not in ALLOWED_REMEDIATION_ACTION_POLICY_REFS
+        ):
+            supported = ", ".join(sorted(ALLOWED_REMEDIATION_ACTION_POLICY_REFS))
+            raise TemporalExecutionValidationError(
+                "Unsupported task.remediation.actionPolicyRef "
+                f"'{action_policy_ref}'. Supported values: {supported}."
+            )
 
         return TemporalExecutionRemediationLink(
             remediation_workflow_id=new_workflow_id,
@@ -427,12 +477,7 @@ class TemporalExecutionService:
             target_run_id=target_record.run_id,
             mode=str(remediation.get("mode") or "snapshot_then_follow").strip()
             or "snapshot_then_follow",
-            authority_mode=str(
-                remediation.get("authorityMode")
-                or remediation.get("authority_mode")
-                or "observe_only"
-            ).strip()
-            or "observe_only",
+            authority_mode=authority_mode,
             status="created",
             trigger_type=trigger_type,
         )

--- a/specs/220-remediation-create-links/checklists/requirements.md
+++ b/specs/220-remediation-create-links/checklists/requirements.md
@@ -1,0 +1,11 @@
+# Requirements Checklist: Remediation Create Links
+
+- [X] One independently testable story.
+- [X] MM-431 traceability preserved.
+- [X] Original Jira preset brief preserved in `spec.md`.
+- [X] Requirements are testable and unambiguous.
+- [X] Runtime intent describes system behavior, not docs-only changes.
+- [X] Acceptance scenarios cover successful create, validation failures, relationship lookup, and convenience-route expansion.
+- [X] In-scope source design requirements map to functional requirements.
+- [X] Out-of-scope remediation context, action execution, and UI rendering are explicit.
+- [X] Unit verification evidence recorded.

--- a/specs/220-remediation-create-links/contracts/remediation-create-links.md
+++ b/specs/220-remediation-create-links/contracts/remediation-create-links.md
@@ -53,6 +53,44 @@ The service exposes:
 
 Both return durable link rows from `execution_remediation_links`.
 
+Link rows include nullable compact status/action fields for later read-model updates:
+
+- `active_lock_scope`
+- `active_lock_holder`
+- `latest_action_summary`
+- `outcome`
+
+## Convenience Route
+
+`POST /api/executions/{workflowId}/remediation` accepts a remediation request body and expands it into the same task-shaped create contract as `POST /api/executions`.
+
+The route sets:
+
+```json
+{
+  "task": {
+    "remediation": {
+      "target": {
+        "workflowId": "mm:target-workflow"
+      }
+    }
+  }
+}
+```
+
+from the path workflow ID. It must not introduce a second durable payload shape.
+
 ## Error Contract
 
 Invalid remediation create requests fail with `TemporalExecutionValidationError` before workflow start and before any remediation link is committed.
+
+Invalid requests include:
+
+- missing or malformed `target.workflowId`
+- target run IDs supplied as workflow IDs
+- missing, unauthorized, or non-`MoonMind.Run` targets
+- mismatched target `runId`
+- malformed `target.taskRunIds`
+- unsupported `authorityMode`
+- unsupported `actionPolicyRef`
+- nested remediation targets

--- a/specs/220-remediation-create-links/data-model.md
+++ b/specs/220-remediation-create-links/data-model.md
@@ -14,6 +14,10 @@ Fields:
 - `authority_mode`: Compact authority mode. Defaults to `observe_only` when omitted.
 - `status`: Link lifecycle status for the persistence slice. Initial value is `created`.
 - `trigger_type`: Optional trigger type copied from `task.remediation.trigger.type`.
+- `active_lock_scope`: Nullable compact lock scope for later action/lock updates.
+- `active_lock_holder`: Nullable compact lock holder identifier for later action/lock updates.
+- `latest_action_summary`: Nullable bounded summary of the latest remediation action.
+- `outcome`: Nullable final remediation outcome.
 - `created_at`: Create timestamp.
 - `updated_at`: Last update timestamp.
 
@@ -23,4 +27,8 @@ Validation rules:
 - The target must exist and be a `MoonMind.Run`.
 - The target must be visible to the creating owner.
 - `target.runId`, when supplied, must match the current target run ID in this slice.
+- `target.taskRunIds`, when supplied, must be a list of non-empty strings.
+- `authorityMode`, when supplied, must be one of `observe_only`, `approval_gated`, or `admin_auto`.
+- `actionPolicyRef`, when supplied, must be supported by the current trusted action policy catalog.
+- The target must not itself be a remediation execution in this slice.
 - Remediation links do not create dependency edges.

--- a/specs/220-remediation-create-links/plan.md
+++ b/specs/220-remediation-create-links/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement MM-431 by adding the create-time persistence slice for Task Remediation. The existing `MoonMind.Run` create path already validates and persists dependency edges; this story adds a separate remediation relationship that accepts `task.remediation`, validates the target execution, pins the current target run ID, writes a durable link table, and exposes service-level inbound/outbound lookup methods. Tests focus on the service boundary and task-shaped API normalization so behavior is proven before production changes.
+Implement MM-431 by adding the create-time persistence slice for Task Remediation. The existing `MoonMind.Run` create path already validates and persists dependency edges; this story adds a separate remediation relationship that accepts `task.remediation`, validates the target execution, pins the current target run ID, writes a durable link table, exposes service-level inbound/outbound lookup methods, and maps the remediation convenience route into the same canonical task-shaped create contract. Tests focus on the service boundary and task-shaped API normalization so behavior is proven before production changes.
 
 ## Requirement Status
 
@@ -18,10 +18,17 @@ Implement MM-431 by adding the create-time persistence slice for Task Remediatio
 | FR-005 | missing | No link persistence exists | Write link in same create transaction as canonical record | unit |
 | FR-006 | missing | No remediation lookup methods exist | Add inbound and outbound service lookup methods | unit |
 | FR-007 | implemented_unverified | Dependency logic is separate but no remediation regression coverage exists | Add test proving remediation does not write dependency edges | unit |
+| FR-008 | missing | No authority-mode allowlist exists | Reject unsupported `task.remediation.authorityMode` values | unit |
+| FR-009 | missing | No action-policy compatibility check exists | Reject unsupported `task.remediation.actionPolicyRef` values | unit |
+| FR-010 | missing | No `target.taskRunIds` shape validation exists | Reject malformed task run ID lists | unit |
+| FR-011 | missing | Nested remediation target policy is not enforced | Reject remediation tasks that target remediation executions | unit |
+| FR-012 | missing | No remediation convenience route exists | Add route that expands into canonical task create payload | unit |
 | DESIGN-REQ-001 | missing | `docs/Tasks/TaskRemediation.md` desired state only | Implement required target validation | unit |
 | DESIGN-REQ-002 | missing | `docs/Tasks/TaskRemediation.md` desired state only | Persist pinned target run ID | unit |
 | DESIGN-REQ-003 | missing | `docs/Tasks/TaskRemediation.md` desired state only | Persist relationship and lookup directions | unit |
-| DESIGN-REQ-004 | implemented_verified | Out-of-scope in `spec.md` | No implementation | final verify |
+| DESIGN-REQ-004 | missing | `docs/Tasks/TaskRemediation.md` desired state only | Implement bounded create-time validation for supported fields | unit |
+| DESIGN-REQ-005 | missing | `docs/Tasks/TaskRemediation.md` desired state only | Add convenience route expansion | unit |
+| DESIGN-REQ-024 | missing | Link table lacks compact action/outcome columns | Add nullable link metadata columns | unit |
 
 ## Technical Context
 

--- a/specs/220-remediation-create-links/research.md
+++ b/specs/220-remediation-create-links/research.md
@@ -39,3 +39,51 @@ Evidence: `docs/Tasks/TaskRemediation.md` section 5.2 says remediation is a rela
 Rationale: Remediation often starts because the target failed, so dependency wait semantics are inappropriate.
 Alternatives considered: Reusing `dependsOn` was rejected by the source design.
 Test implications: Unit test asserts remediation creation has no prerequisites.
+
+## FR-008 / Authority Mode Validation
+
+Decision: Validate `task.remediation.authorityMode` against the desired-state modes `observe_only`, `approval_gated`, and `admin_auto` during create-time service validation.
+Evidence: `docs/Tasks/TaskRemediation.md` section 7.3 defines the allowed authority modes, and `moonmind/workflows/temporal/service.py` owns remediation create validation before workflow start.
+Rationale: Unsupported authority modes affect privilege semantics and must fail before a remediation link or workflow starts.
+Alternatives considered: Deferring authority-mode validation to later action execution was rejected because the canonical create contract requires structured rejection at create time.
+Test implications: Service unit test for unsupported `authorityMode`.
+
+## FR-009 / Action Policy Compatibility
+
+Decision: Validate `task.remediation.actionPolicyRef` against the trusted action policy references available in this slice, currently `admin_healer_default`.
+Evidence: `docs/Tasks/TaskRemediation.md` section 7.4 requires action policy compatibility validation, while no broader persisted action policy catalog exists in this story.
+Rationale: A narrow allowlist keeps create-time behavior deterministic without inventing a new policy storage model.
+Alternatives considered: Accepting arbitrary policy refs was rejected because it would silently defer an incompatible privilege request; adding a full policy registry was rejected as broader action-execution scope.
+Test implications: Service unit test for unsupported `actionPolicyRef`.
+
+## FR-010 / Task Run ID Shape Validation
+
+Decision: Validate `task.remediation.target.taskRunIds` as a list of non-empty strings during create-time service validation.
+Evidence: `docs/Tasks/TaskRemediation.md` section 7.3 defines `target.taskRunIds[]`; `moonmind/workflows/temporal/remediation_context.py` later normalizes bounded task-run IDs for context artifacts.
+Rationale: This slice can enforce the durable payload shape without coupling create-time validation to later evidence lookup internals.
+Alternatives considered: Rejecting unknown task-run IDs by resolving managed-run records was rejected because not every target has a persisted managed-run binding at create time and later context tooling performs evidence scoping.
+Test implications: Service unit test for malformed `target.taskRunIds`.
+
+## FR-011 / Nested Remediation Guard
+
+Decision: Reject remediation tasks that target an execution whose canonical parameters already contain `task.remediation`.
+Evidence: `docs/Tasks/TaskRemediation.md` section 6 states nested remediation is off by default.
+Rationale: Disallowing nested remediation at create time prevents unbounded self-healing loops until policy explicitly supports them.
+Alternatives considered: Allowing nested remediation under `admin_auto` was rejected because no loop-prevention policy surface exists in this slice.
+Test implications: Service unit test for nested remediation target rejection.
+
+## FR-012 / Convenience Route Expansion
+
+Decision: Add `POST /api/executions/{workflowId}/remediation` as a control-plane convenience route that builds the same task-shaped create contract as `POST /api/executions`.
+Evidence: `docs/Tasks/TaskRemediation.md` section 7.5 allows a convenience route only when it expands into the canonical execution create contract.
+Rationale: The route improves submission ergonomics without adding a second durable payload shape.
+Alternatives considered: Persisting a route-specific remediation payload was rejected because `initialParameters.task.remediation` is the canonical durable contract.
+Test implications: Router unit test for expansion into `initial_parameters.task.remediation`.
+
+## DESIGN-REQ-024 / Compact Link Metadata
+
+Decision: Add nullable lock/action/outcome fields to the remediation link model so canonical link data remains upstream of later read models.
+Evidence: `docs/Tasks/TaskRemediation.md` sections 8.3 and 8.4 require durable linkage to support current status, lock holder, latest action summary, final outcome, and downstream rendering.
+Rationale: Nullable compact fields preserve the read-model foundation without implementing action execution, locks, or UI rendering in this story.
+Alternatives considered: Deferring all fields until a later UI/API slice was rejected because the MM-431 preset brief includes link support for lock/action/outcome metadata.
+Test implications: Service unit test verifies newly created links expose the compact metadata fields as unset until later lifecycle updates.

--- a/specs/220-remediation-create-links/spec.md
+++ b/specs/220-remediation-create-links/spec.md
@@ -3,12 +3,12 @@
 **Feature Branch**: `220-remediation-create-links`
 **Created**: 2026-04-21
 **Status**: Draft
-**Input**: Jira Orchestrate for MM-431.
+**Input**: Jira Orchestrate for MM-431 using `docs/tmp/jira-orchestration-inputs/MM-431-moonspec-orchestration-input.md` as the canonical MoonSpec orchestration input.
 
 Source story: STORY-001.
 Source summary: Accept remediation create requests and persist target links.
-Source Jira issue: unknown.
-Original brief reference: not provided.
+Source Jira issue: MM-431.
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-431-moonspec-orchestration-input.md`.
 
 Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
 
@@ -26,12 +26,16 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 2. **Given** the remediation request omits `target.runId`, **When** creation succeeds, **Then** the persisted link records the target execution's current run ID at create time.
 3. **Given** a malformed remediation request with no target workflow ID, **When** the task is submitted, **Then** creation fails before the workflow starts and no remediation link is written.
 4. **Given** a target workflow that does not exist or is not a `MoonMind.Run`, **When** the task is submitted, **Then** creation fails with a validation error and no remediation link is written.
+5. **Given** a remediation request with unsupported authority mode, incompatible action policy, malformed task run IDs, or a remediation target that is itself a remediation task, **When** the task is submitted, **Then** creation fails with a structured validation error before workflow start.
+6. **Given** a caller submits through the remediation convenience route, **When** the route expands the request, **Then** it produces the same canonical `POST /api/executions` task create contract with `task.remediation.target.workflowId` set to the target workflow.
 
 ### Edge Cases
 
 - A remediation request must not use a target run ID as the workflow target.
 - A caller-provided `target.runId` must match the current known target run because historical run lookup is not available in this slice.
 - Remediation links are relationships, not dependencies, so they must not add `dependsOn` gates or dependency fan-out behavior.
+- `target.taskRunIds` must be a list of non-empty strings when supplied.
+- Nested remediation targets are rejected in this slice because automatic remediation of remediation tasks is disabled by default.
 
 ## Assumptions
 
@@ -44,7 +48,9 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **DESIGN-REQ-001** (`docs/Tasks/TaskRemediation.md` section 7.4): Create-time validation must require `task.remediation.target.workflowId`. Scope: in scope, mapped to FR-001 and FR-004.
 - **DESIGN-REQ-002** (`docs/Tasks/TaskRemediation.md` sections 6 and 8.1): Create time must resolve and persist a concrete target run ID. Scope: in scope, mapped to FR-002.
 - **DESIGN-REQ-003** (`docs/Tasks/TaskRemediation.md` sections 5.2 and 8.2): Remediation is a directed relationship, not a dependency, and must support forward and reverse lookup. Scope: in scope, mapped to FR-003 and FR-006.
-- **DESIGN-REQ-004** (`docs/Tasks/TaskRemediation.md` sections 10 and 9): Evidence context, action execution, locks, and live follow are typed later-stage surfaces. Scope: out of scope for this persistence slice.
+- **DESIGN-REQ-004** (`docs/Tasks/TaskRemediation.md` sections 7.4 and 7.3): Create-time validation must reject unsupported target types, malformed task run IDs, unsupported authority modes, incompatible action policy references, and disallowed nested remediation. Scope: in scope, mapped to FR-004, FR-008, FR-009, FR-010, and FR-011.
+- **DESIGN-REQ-005** (`docs/Tasks/TaskRemediation.md` section 7.5): The remediation convenience route expands into the same canonical execution create contract as `POST /api/executions`. Scope: in scope, mapped to FR-012.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskRemediation.md` sections 8.3 and 8.4): Canonical remediation link data remains upstream of derived read models and includes compact status/action/outcome fields. Scope: in scope for durable link fields, mapped to FR-003.
 
 ## Requirements *(mandatory)*
 
@@ -57,6 +63,11 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **FR-005**: Remediation link persistence MUST occur in the same create transaction as the canonical execution source record so failed validation or persistence cannot leave orphan links.
 - **FR-006**: The service layer MUST provide forward lookup from remediation workflow to target and reverse lookup from target workflow to remediation workflows.
 - **FR-007**: Remediation create handling MUST NOT create dependency edges or alter dependency wait behavior.
+- **FR-008**: Remediation create validation MUST reject unsupported `authorityMode` values.
+- **FR-009**: Remediation create validation MUST reject unsupported or incompatible `actionPolicyRef` values.
+- **FR-010**: Remediation create validation MUST reject malformed `target.taskRunIds` values.
+- **FR-011**: Remediation create validation MUST reject nested remediation targets when the target execution is itself a remediation task.
+- **FR-012**: The convenience route `POST /api/executions/{workflowId}/remediation` MUST expand into the canonical task-shaped create contract without introducing a second durable payload shape.
 
 ### Key Entities
 
@@ -72,3 +83,5 @@ Use the existing Jira Orchestrate workflow for this Jira issue. Do not run imple
 - **SC-002**: Unit tests prove malformed, missing, run-ID, and non-run targets fail before workflow start.
 - **SC-003**: Unit tests prove remediation links are queryable in both outbound and inbound directions.
 - **SC-004**: Existing dependency create tests continue to pass, proving remediation links do not change dependency semantics.
+- **SC-005**: Unit tests prove unsupported authority modes, incompatible action policies, malformed task run IDs, and nested remediation targets fail before workflow start.
+- **SC-006**: Router unit tests prove the remediation convenience route expands into canonical task-shaped execution creation.

--- a/specs/220-remediation-create-links/spec.md
+++ b/specs/220-remediation-create-links/spec.md
@@ -12,6 +12,77 @@ Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-431-moonspec-or
 
 Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
 
+## Original Preset Brief
+
+```text
+# MM-431 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-431
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Accept remediation create requests and persist target links
+- Labels: `moonmind-workflow-mm-a59f3b1d-da4d-4600-86a8-1d582ee67fe8`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-431 from MM project
+Summary: Accept remediation create requests and persist target links
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-431 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-431: Accept remediation create requests and persist target links
+
+Source Reference
+- Source Document: docs/Tasks/TaskRemediation.md
+- Source Title: Task Remediation
+- Source Sections:
+  - 5.1 Remediation tasks remain MoonMind.Run
+  - 5.2 Remediation is a relationship, not a dependency
+  - 7. Submission contract
+  - 8. Identity, linkage, and read models
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-002
+  - DESIGN-REQ-003
+  - DESIGN-REQ-004
+  - DESIGN-REQ-005
+  - DESIGN-REQ-024
+
+User Story
+As an operator, I can create a remediation task that targets another execution so MoonMind records an explicit troubleshooting relationship without treating the target as a dependency gate.
+
+Acceptance Criteria
+- POST /api/executions accepts a task.remediation payload and stores it as initialParameters.task.remediation before MoonMind.Run starts.
+- target.workflowId is required and a concrete target.runId is resolved and persisted when omitted by the caller.
+- Malformed self-reference, unsupported target workflow types, invalid taskRunIds, unsupported authorityMode values, incompatible actionPolicyRef, and disallowed nested remediation are rejected with structured errors.
+- A remediation link record supports remediator-to-target and target-to-remediator lookup including mode, authorityMode, current status, pinned run identity, lock holder, latest action summary, and outcome fields.
+- The convenience route expands into the same canonical create contract and does not introduce a second durable payload shape.
+
+Requirements
+- Remediation tasks remain MoonMind.Run executions with additional nested task.remediation semantics.
+- Remediation links are relationships, not dependsOn gates, and start independently of target success.
+- The system exposes inbound and outbound remediation lookup APIs for execution detail surfaces.
+- Canonical source data remains upstream of any derived read model.
+
+Implementation Notes
+- Preserve MM-431 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation task semantics, submission contract, identity, linkage, and read model behavior.
+- Scope implementation to accepting remediation create requests, persisting the canonical task.remediation payload, resolving target run identity, validating unsupported or malformed remediation submissions, and exposing durable remediation link lookup data.
+- Keep remediation links as explicit troubleshooting relationships rather than dependency gates; target execution success must not be required for remediation task startup.
+- Keep the convenience route as an expansion into the canonical create contract, not a second durable payload shape.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-431 is blocked by MM-432, whose embedded status is Backlog.
+```
+
 ## User Story - Persist Remediation Targets
 
 **Summary**: As a MoonMind operator, I want task creation to accept a remediation target and persist the target relationship so remediation tasks can be inspected from either side.

--- a/specs/220-remediation-create-links/tasks.md
+++ b/specs/220-remediation-create-links/tasks.md
@@ -35,6 +35,12 @@
 - [X] T008 Implement remediation inbound and outbound lookup methods in `moonmind/workflows/temporal/service.py` for FR-006.
 - [X] T009 Preserve `payload.task.remediation` in task-shaped create normalization in `api_service/api/routers/executions.py` for FR-001.
 - [X] T010 Run focused unit tests and update implementation until they pass for SC-001, SC-002, SC-003, SC-004.
+- [X] T013 Add failing service validation tests for unsupported `authorityMode`, unsupported `actionPolicyRef`, malformed `target.taskRunIds`, and nested remediation targets in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-008, FR-009, FR-010, and FR-011.
+- [X] T014 Add failing router test for `POST /api/executions/{workflowId}/remediation` expanding into canonical task-shaped create in `tests/unit/api/routers/test_executions.py` for FR-012.
+- [X] T015 Add nullable remediation link action/outcome fields in `api_service/db/models.py` and `api_service/migrations/versions/223_remediation_link_status_fields.py` for FR-003 and DESIGN-REQ-024.
+- [X] T016 Implement bounded remediation validation in `moonmind/workflows/temporal/service.py` for FR-008, FR-009, FR-010, and FR-011.
+- [X] T017 Implement remediation convenience route expansion in `api_service/api/routers/executions.py` for FR-012.
+- [X] T018 Run focused unit tests and update implementation until they pass for SC-005 and SC-006.
 
 ## Final Phase: Polish And Verification
 

--- a/specs/220-remediation-create-links/tasks.md
+++ b/specs/220-remediation-create-links/tasks.md
@@ -9,7 +9,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py`
 - Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` covers the API/service boundary for this persistence slice; `./tools/test_integration.sh` is not required because no compose-backed boundary is introduced.
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Phase 1: Setup
 

--- a/specs/220-remediation-create-links/tasks.md
+++ b/specs/220-remediation-create-links/tasks.md
@@ -3,12 +3,12 @@
 **Input**: Design documents from `/specs/220-remediation-create-links/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
 
-**Tests**: Unit tests are required first. Integration coverage is represented by router/service boundary unit tests for this persistence slice.
+**Tests**: Unit tests are required first. Integration coverage is represented by FastAPI router and Temporal service boundary tests for this persistence slice; no compose-backed integration service is introduced.
 
 **Test Commands**:
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py`
-- Integration tests: Not required for this persistence slice; no compose-backed boundary is introduced.
+- Integration tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` covers the API/service boundary for this persistence slice; `./tools/test_integration.sh` is not required because no compose-backed boundary is introduced.
 - Final verification: `/speckit.verify`
 
 ## Phase 1: Setup
@@ -26,23 +26,27 @@
 
 **Independent Test**: Create a target execution, create a remediation execution pointing at it, then assert the normalized payload and persisted inbound/outbound link.
 
-**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003.
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-024.
+
+**Unit Test Plan**: Add red-first service tests for create-time validation, run ID pinning, persistence, lookup direction, dependency separation, authority/action policy validation, taskRunIds shape validation, nested remediation rejection, and compact link metadata.
+
+**Integration Test Plan**: Add red-first FastAPI router/API-boundary tests proving task-shaped create preserves `task.remediation` and the remediation convenience route expands into the same canonical create contract. No compose-backed integration test is required for this persistence-only slice.
 
 - [X] T004 Add failing service tests for valid remediation link creation, run ID pinning, inbound lookup, outbound lookup, and no dependency edges in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-002, FR-003, FR-005, FR-006, FR-007.
 - [X] T005 Add failing service validation tests for missing target workflow ID, run ID identifier, missing target, non-run target, and mismatched target run ID in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-004.
 - [X] T006 Add a failing task-shaped router test proving `payload.task.remediation` is preserved into `initial_parameters.task.remediation` in `tests/unit/api/routers/test_executions.py` for FR-001.
-- [X] T007 Implement remediation target validation, run ID resolution, and link persistence in `moonmind/workflows/temporal/service.py` for FR-002, FR-003, FR-004, FR-005.
-- [X] T008 Implement remediation inbound and outbound lookup methods in `moonmind/workflows/temporal/service.py` for FR-006.
-- [X] T009 Preserve `payload.task.remediation` in task-shaped create normalization in `api_service/api/routers/executions.py` for FR-001.
-- [X] T010 Run focused unit tests and update implementation until they pass for SC-001, SC-002, SC-003, SC-004.
-- [X] T013 Add failing service validation tests for unsupported `authorityMode`, unsupported `actionPolicyRef`, malformed `target.taskRunIds`, and nested remediation targets in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-008, FR-009, FR-010, and FR-011.
-- [X] T014 Add failing router test for `POST /api/executions/{workflowId}/remediation` expanding into canonical task-shaped create in `tests/unit/api/routers/test_executions.py` for FR-012.
-- [X] T015 Add nullable remediation link action/outcome fields in `api_service/db/models.py` and `api_service/migrations/versions/223_remediation_link_status_fields.py` for FR-003 and DESIGN-REQ-024.
-- [X] T016 Implement bounded remediation validation in `moonmind/workflows/temporal/service.py` for FR-008, FR-009, FR-010, and FR-011.
-- [X] T017 Implement remediation convenience route expansion in `api_service/api/routers/executions.py` for FR-012.
-- [X] T018 Run focused unit tests and update implementation until they pass for SC-005 and SC-006.
+- [X] T007 Add failing API-boundary integration-style router test proving `POST /api/executions/{workflowId}/remediation` expands into canonical task-shaped create in `tests/unit/api/routers/test_executions.py` for FR-012 and DESIGN-REQ-005.
+- [X] T008 Add failing service validation tests for unsupported `authorityMode`, unsupported `actionPolicyRef`, malformed `target.taskRunIds`, and nested remediation targets in `tests/unit/workflows/temporal/test_temporal_service.py` for FR-008, FR-009, FR-010, FR-011, and DESIGN-REQ-004.
+- [X] T009 Run focused tests and confirm red-first failures before production changes in `tests/unit/workflows/temporal/test_temporal_service.py` and `tests/unit/api/routers/test_executions.py` for SC-001, SC-002, SC-003, SC-004, SC-005, and SC-006.
+- [X] T010 Add nullable remediation link action/outcome fields in `api_service/db/models.py` and `api_service/migrations/versions/223_remediation_link_status_fields.py` for FR-003 and DESIGN-REQ-024.
+- [X] T011 Implement remediation target validation, run ID resolution, and link persistence in `moonmind/workflows/temporal/service.py` for FR-002, FR-003, FR-004, FR-005.
+- [X] T012 Implement bounded remediation validation in `moonmind/workflows/temporal/service.py` for FR-008, FR-009, FR-010, and FR-011.
+- [X] T013 Implement remediation inbound and outbound lookup methods in `moonmind/workflows/temporal/service.py` for FR-006.
+- [X] T014 Preserve `payload.task.remediation` in task-shaped create normalization in `api_service/api/routers/executions.py` for FR-001.
+- [X] T015 Implement remediation convenience route expansion in `api_service/api/routers/executions.py` for FR-012.
+- [X] T016 Run story validation with focused unit and API-boundary tests from `specs/220-remediation-create-links/quickstart.md` for SC-001, SC-002, SC-003, SC-004, SC-005, and SC-006.
 
 ## Final Phase: Polish And Verification
 
-- [X] T011 Run relevant unit verification from `specs/220-remediation-create-links/quickstart.md`.
-- [X] T012 Run `/speckit.verify` by auditing implementation against `specs/220-remediation-create-links/spec.md` and recording the result.
+- [X] T017 Run relevant unit and API-boundary verification from `specs/220-remediation-create-links/quickstart.md`.
+- [X] T018 Run `/moonspec-verify` by auditing implementation against `specs/220-remediation-create-links/spec.md` and recording the result in `specs/220-remediation-create-links/verification.md`.

--- a/specs/220-remediation-create-links/verification.md
+++ b/specs/220-remediation-create-links/verification.md
@@ -13,6 +13,11 @@
 | FR-005 | VERIFIED | Link insertion occurs before the create transaction commit with the canonical source record. |
 | FR-006 | VERIFIED | Inbound and outbound service lookup methods are covered by service unit tests. |
 | FR-007 | VERIFIED | Service unit test confirms remediation links do not create dependency prerequisites. |
+| FR-008 | VERIFIED | Unsupported `task.remediation.authorityMode` values are rejected by `TemporalExecutionService`; covered by `tests/unit/workflows/temporal/test_temporal_service.py`. |
+| FR-009 | VERIFIED | Unsupported `task.remediation.actionPolicyRef` values are rejected by `TemporalExecutionService`; covered by `tests/unit/workflows/temporal/test_temporal_service.py`. |
+| FR-010 | VERIFIED | Malformed `target.taskRunIds` values are rejected by `TemporalExecutionService`; covered by `tests/unit/workflows/temporal/test_temporal_service.py`. |
+| FR-011 | VERIFIED | Nested remediation targets are rejected by `TemporalExecutionService`; covered by `tests/unit/workflows/temporal/test_temporal_service.py`. |
+| FR-012 | VERIFIED | `POST /api/executions/{workflowId}/remediation` expands into canonical task-shaped execution creation; covered by `tests/unit/api/routers/test_executions.py`. |
 
 ## Test Evidence
 

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -876,6 +876,42 @@ def test_create_task_shaped_execution_preserves_malformed_remediation_for_servic
     assert kwargs["initial_parameters"]["task"]["remediation"] == "mm:target-workflow"
 
 
+def test_create_remediation_convenience_route_expands_to_task_create_contract(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    service.create_execution.return_value = _build_execution_record()
+
+    response = test_client.post(
+        "/api/executions/mm:target-workflow/remediation",
+        json={
+            "repository": "MoonLadderStudios/MoonMind",
+            "instructions": "Investigate the target execution.",
+            "runtime": {"mode": "codex"},
+            "remediation": {
+                "mode": "snapshot",
+                "authorityMode": "observe_only",
+                "trigger": {"type": "manual"},
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    service.create_execution.assert_awaited_once()
+    kwargs = service.create_execution.call_args.kwargs
+    assert kwargs["workflow_type"] == "MoonMind.Run"
+    assert kwargs["initial_parameters"]["task"]["instructions"] == (
+        "Investigate the target execution."
+    )
+    assert kwargs["initial_parameters"]["task"]["runtime"] == {"mode": "codex_cli"}
+    assert kwargs["initial_parameters"]["task"]["remediation"] == {
+        "target": {"workflowId": "mm:target-workflow"},
+        "mode": "snapshot",
+        "authorityMode": "observe_only",
+        "trigger": {"type": "manual"},
+    }
+
+
 def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/api/routers/test_executions.py
+++ b/tests/unit/api/routers/test_executions.py
@@ -912,6 +912,81 @@ def test_create_remediation_convenience_route_expands_to_task_create_contract(
     }
 
 
+def test_create_remediation_convenience_route_uses_top_level_overrides(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+    scheduled_for = datetime.now(UTC) + timedelta(minutes=5)
+    record = _build_execution_record(state=MoonMindWorkflowState.SCHEDULED)
+    record.scheduled_for = scheduled_for
+    service.create_execution.return_value = record
+
+    response = test_client.post(
+        "/api/executions/mm:target-workflow/remediation",
+        json={
+            "repository": "MoonLadderStudios/MoonMind",
+            "priority": 7,
+            "maxAttempts": 5,
+            "schedule": {
+                "mode": "once",
+                "scheduledFor": scheduled_for.isoformat(),
+            },
+            "instructions": "Top-level instructions",
+            "runtime": {"mode": "codex"},
+            "remediation": {
+                "mode": "snapshot",
+                "authorityMode": "observe_only",
+                "trigger": {"type": "manual"},
+            },
+            "task": {
+                "instructions": "Nested instructions",
+                "runtime": {"mode": "jules"},
+                "remediation": {
+                    "mode": "snapshot_then_follow",
+                    "authorityMode": "limited_write",
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    called_kwargs = service.create_execution.await_args.kwargs
+    initial_parameters = called_kwargs["initial_parameters"]
+    assert called_kwargs["scheduled_for"] == scheduled_for
+    assert initial_parameters["priority"] == 7
+    assert initial_parameters["maxAttempts"] == 5
+    assert initial_parameters["task"]["instructions"] == "Top-level instructions"
+    assert initial_parameters["task"]["runtime"] == {"mode": "codex_cli"}
+    assert initial_parameters["task"]["remediation"] == {
+        "target": {"workflowId": "mm:target-workflow"},
+        "mode": "snapshot",
+        "authorityMode": "observe_only",
+        "trigger": {"type": "manual"},
+    }
+
+
+def test_create_remediation_convenience_route_rejects_malformed_remediation(
+    client: tuple[TestClient, AsyncMock, SimpleNamespace],
+) -> None:
+    test_client, service, _user = client
+
+    response = test_client.post(
+        "/api/executions/mm:target-workflow/remediation",
+        json={
+            "repository": "MoonLadderStudios/MoonMind",
+            "instructions": "Investigate the target execution.",
+            "remediation": "mm:target-workflow",
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == {
+        "code": "invalid_execution_request",
+        "message": "task.remediation must be an object",
+    }
+    service.create_execution.assert_not_awaited()
+
+
 def test_create_task_shaped_execution_maps_instructions_and_tool_for_temporal(
     client: tuple[TestClient, AsyncMock, SimpleNamespace],
 ) -> None:

--- a/tests/unit/workflows/temporal/test_temporal_service.py
+++ b/tests/unit/workflows/temporal/test_temporal_service.py
@@ -589,6 +589,10 @@ async def test_create_execution_persists_remediation_link_and_supports_lookups(
         assert link.authority_mode == "approval_gated"
         assert link.status == "created"
         assert link.trigger_type == "manual"
+        assert link.active_lock_scope is None
+        assert link.active_lock_holder is None
+        assert link.latest_action_summary is None
+        assert link.outcome is None
 
         remediation_record = await session.get(
             TemporalExecutionCanonicalRecord, remediation.workflow_id
@@ -840,6 +844,192 @@ async def test_create_execution_rejects_mismatched_remediation_target_run_id(
                             "target": {
                                 "workflowId": target.workflow_id,
                                 "runId": "not-current-run",
+                            }
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_unsupported_remediation_authority_mode(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="Unsupported task.remediation.authorityMode",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                title="Remediate target",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "task": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "authorityMode": "root_shell",
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_incompatible_remediation_action_policy(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="Unsupported task.remediation.actionPolicyRef",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                title="Remediate target",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "task": {
+                        "remediation": {
+                            "target": {"workflowId": target.workflow_id},
+                            "actionPolicyRef": "unknown_policy",
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_nested_remediation_target(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+        first_remediation = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="First remediation",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={
+                "task": {"remediation": {"target": {"workflowId": target.workflow_id}}}
+            },
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="Nested remediation targets are not supported",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                title="Nested remediation",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "task": {
+                        "remediation": {
+                            "target": {"workflowId": first_remediation.workflow_id}
+                        }
+                    }
+                },
+                idempotency_key=None,
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_execution_rejects_malformed_remediation_task_run_ids(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        owner_id = uuid4()
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        target = await service.create_execution(
+            workflow_type="MoonMind.Run",
+            owner_id=owner_id,
+            title="Target",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            manifest_artifact_ref=None,
+            failure_policy=None,
+            initial_parameters={},
+            idempotency_key=None,
+        )
+
+        with pytest.raises(
+            TemporalExecutionValidationError,
+            match="task.remediation.target.taskRunIds must be a list of strings",
+        ):
+            await service.create_execution(
+                workflow_type="MoonMind.Run",
+                owner_id=owner_id,
+                title="Remediate target",
+                input_artifact_ref=None,
+                plan_artifact_ref=None,
+                manifest_artifact_ref=None,
+                failure_policy=None,
+                initial_parameters={
+                    "task": {
+                        "remediation": {
+                            "target": {
+                                "workflowId": target.workflow_id,
+                                "taskRunIds": ["tr_valid", ""],
                             }
                         }
                     }


### PR DESCRIPTION
Jira issue key: MM-431

Active MoonSpec feature path: `specs/220-remediation-create-links`

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_temporal_service.py tests/unit/api/routers/test_executions.py` - PASS (Python: 186 passed; UI: 345 passed)

Remaining risks:
- No UI read model is included in this story; service lookup methods provide the persistence foundation for a later UI/API slice.
