### PR TITLE
[codex] Fix merge automation stale head wait

### DIFF
--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -285,6 +285,44 @@ class MoonMindMergeAutomationWorkflow:
         self._input.pull_request.head_sha = head_sha
         return True
 
+    @staticmethod
+    def _stale_revision_can_track_current_head(evidence: Any) -> bool:
+        blockers = list(getattr(evidence, "blockers", []) or [])
+        stale_seen = False
+        for blocker in blockers:
+            kind = str(getattr(blocker, "kind", "") or "").strip()
+            if kind == "stale_revision":
+                stale_seen = True
+                continue
+            if kind in TERMINAL_BLOCKER_KINDS or not bool(
+                getattr(blocker, "retryable", False)
+            ):
+                return False
+        return stale_seen
+
+    def _refresh_current_head_for_stale_wait(
+        self,
+        *,
+        evaluation: Any,
+        evidence: Any,
+    ) -> Any:
+        if self._input is None or not isinstance(evaluation, Mapping):
+            return evidence
+        if getattr(evidence, "ready", False) or getattr(
+            evidence,
+            "pull_request_merged",
+            False,
+        ):
+            return evidence
+        if not self._stale_revision_can_track_current_head(evidence):
+            return evidence
+        if not self._refresh_tracked_head_sha(evaluation):
+            return evidence
+        return classify_readiness(
+            evaluation,
+            tracked_head_sha=self._input.pull_request.head_sha,
+        )
+
     async def _failed_resolver_summary(
         self,
         *,
@@ -427,6 +465,11 @@ class MoonMindMergeAutomationWorkflow:
                         evaluation if isinstance(evaluation, Mapping) else {},
                         tracked_head_sha=self._input.pull_request.head_sha,
                     )
+            if workflow.patched("merge-automation-refresh-stale-current-head"):
+                evidence = self._refresh_current_head_for_stale_wait(
+                    evaluation=evaluation,
+                    evidence=evidence,
+                )
             self._blockers = list(evidence.blockers)
             await self._write_gate_snapshot(evidence_ready=evidence.ready)
             if evidence.pull_request_merged:

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -220,8 +220,16 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         "execute_child_workflow",
         fake_execute_child_workflow,
     )
-    monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
-    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
     monkeypatch.setattr(
         merge_automation_module.workflow,
         "upsert_search_attributes",
@@ -258,6 +266,114 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         "name": "pr-resolver",
         "version": "1.0",
     }
+
+
+@pytest.mark.asyncio
+async def test_merge_automation_tracks_current_head_when_checks_are_still_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    child_workflow_ids: list[str] = []
+    child_payloads: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        if activity_type != "merge_automation.evaluate_readiness":
+            raise RuntimeError(activity_type)
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "def456",
+                "ready": False,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": False,
+                "checksPassing": False,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+                "blockers": [
+                    {
+                        "kind": "checks_running",
+                        "summary": "Required checks are still running.",
+                        "retryable": True,
+                        "source": "github",
+                    }
+                ],
+            }
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        child_payloads.append(payload)
+        child_workflow_ids.append(str(kwargs["id"]))
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    async def fake_wait_condition(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "wait_condition",
+        fake_wait_condition,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    expected_resolver_id = deterministic_resolver_idempotency_key(
+        parent_workflow_id="wf-parent",
+        repo="MoonLadderStudios/MoonMind",
+        pr_number=350,
+        head_sha="def456",
+    )
+    assert readiness_calls == 2
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+    assert result["blockers"] == []
+    assert child_workflow_ids == [f"{expected_resolver_id}:1"]
+    assert child_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Refresh merge automation tracking to the current PR head when GitHub reports a newer head with only retryable wait blockers, such as running checks.
- Keep true terminal blockers terminal, including closed PRs and policy denial.
- Add workflow-boundary regression coverage for stale tracked head plus running checks before resolver launch.

## Root Cause
Workflow `mm:bd4fd27f-d504-4f28-ab7e-48dd4bb3e334` started merge automation with tracked head `8bc810a...`, while GitHub reported current PR head `285786e...` and checks still running. The gate classified that as terminal `stale_revision`, returned `blocked`, and the parent failed.

## Validation
- `./tools/test_unit.sh` passed: Python `3720 passed, 1 xpassed`; frontend `345 passed`.
- `./tools/test_unit.sh --python-only tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py` passed: `24 passed`.
- `npm run ui:test -- entrypoints/mission-control.test.tsx` passed: `18 passed`.
- `git diff --check` passed.