### PR TITLE
[codex] Fix merge automation head adoption

### DIFF
--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,57 +1,17 @@
 [
   {
-    "id": 3120762036,
+    "id": 3121533585,
     "disposition": "addressed",
-    "rationale": "Replaced the protocol ellipsis body with an explicit NotImplementedError so the statement is no longer a no-op."
+    "rationale": "Changed pre-resolver head adoption to trigger on stale_revision alone and added a regression test for already-ready updated heads."
   },
   {
-    "id": 3120762042,
+    "id": 3121533589,
     "disposition": "addressed",
-    "rationale": "Replaced the protocol ellipsis body with an explicit NotImplementedError so the statement is no longer a no-op."
+    "rationale": "Updated PrMergeAutomation docs to state that pre-resolver adoption happens whenever the published head changes, including already-ready heads."
   },
   {
-    "id": 3120762046,
+    "id": 4152015530,
     "disposition": "addressed",
-    "rationale": "Added an explanatory comment to the tolerant maxTailLines parse fallback."
-  },
-  {
-    "id": 3120762392,
-    "disposition": "addressed",
-    "rationale": "Exported RemediationLiveFollower from remediation_tools.__all__."
-  },
-  {
-    "id": 3120762405,
-    "disposition": "addressed",
-    "rationale": "Changed maxTailLines parsing to preserve an explicit zero instead of replacing it with the default."
-  },
-  {
-    "id": 3120762409,
-    "disposition": "addressed",
-    "rationale": "Cached parsed remediation context payloads by workflow ID and context artifact ref within the service instance."
-  },
-  {
-    "id": 3120762414,
-    "disposition": "addressed",
-    "rationale": "Imported RemediationLiveFollower in moonmind.workflows.temporal.__init__."
-  },
-  {
-    "id": 3120762415,
-    "disposition": "addressed",
-    "rationale": "Added RemediationLiveFollower to the package root __all__ list."
-  },
-  {
-    "id": 4151239835,
-    "disposition": "not-applicable",
-    "rationale": "Top-level review summary; its actionable inline comments were handled individually."
-  },
-  {
-    "id": 3120768401,
-    "disposition": "addressed",
-    "rationale": "Updated _bounded_tail_lines so explicit tail_lines are clamped by both boundedness.maxTailLines and policies.evidencePolicy.tailLines."
-  },
-  {
-    "id": 4151247216,
-    "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper; its actionable inline comment was handled individually."
+    "rationale": "Addressed the review summary by updating both implementation and documentation for unrestricted pre-resolver head adoption."
   }
 ]

--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -542,6 +542,14 @@ This does **not** require the same runtime process or exact same Python module. 
 
 The merge gate and the resolver snapshot/finalize logic may use different implementations, but they MUST agree on contract semantics.
 
+Before any resolver child has launched, `MoonMind.MergeAutomation` MAY adopt the
+latest observed PR head SHA when the first readiness evaluation sees that the
+published head changed while retryable gate blockers, such as running checks,
+are still present. This keeps normal post-publish head updates from terminally
+failing the parent before the gate has opened. After a resolver child has
+launched, revision changes MUST use the resolver disposition and gate re-entry
+contract instead of silently advancing the tracked head.
+
 ---
 
 ## 16. Dependency Semantics

--- a/docs/Tasks/PrMergeAutomation.md
+++ b/docs/Tasks/PrMergeAutomation.md
@@ -543,12 +543,13 @@ This does **not** require the same runtime process or exact same Python module. 
 The merge gate and the resolver snapshot/finalize logic may use different implementations, but they MUST agree on contract semantics.
 
 Before any resolver child has launched, `MoonMind.MergeAutomation` MAY adopt the
-latest observed PR head SHA when the first readiness evaluation sees that the
-published head changed while retryable gate blockers, such as running checks,
-are still present. This keeps normal post-publish head updates from terminally
-failing the parent before the gate has opened. After a resolver child has
-launched, revision changes MUST use the resolver disposition and gate re-entry
-contract instead of silently advancing the tracked head.
+latest observed PR head SHA when a readiness evaluation sees that the published
+head changed before the first resolver launch. This keeps normal post-publish
+head updates from terminally failing the parent before the resolver has had a
+chance to act, including when the updated head is already ready to merge. After
+a resolver child has launched, revision changes MUST use the resolver
+disposition and gate re-entry contract instead of silently advancing the tracked
+head.
 
 ---
 

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -301,12 +301,7 @@ class MoonMindMergeAutomationWorkflow:
             return False
         if observed_head_sha == str(self._input.pull_request.head_sha or "").strip():
             return False
-        if not self._has_blocker(evidence, "stale_revision"):
-            return False
-        return any(
-            blocker.retryable and blocker.kind != "stale_revision"
-            for blocker in getattr(evidence, "blockers", [])
-        )
+        return self._has_blocker(evidence, "stale_revision")
 
     async def _failed_resolver_summary(
         self,

--- a/moonmind/workflows/temporal/workflows/merge_automation.py
+++ b/moonmind/workflows/temporal/workflows/merge_automation.py
@@ -285,6 +285,29 @@ class MoonMindMergeAutomationWorkflow:
         self._input.pull_request.head_sha = head_sha
         return True
 
+    @staticmethod
+    def _has_blocker(evidence: Any, kind: str) -> bool:
+        return any(
+            blocker.kind == kind for blocker in getattr(evidence, "blockers", [])
+        )
+
+    def _should_adopt_initial_waiting_head_sha(self, evidence: Any) -> bool:
+        if self._input is None:
+            return False
+        if self._resolver_child_workflow_ids:
+            return False
+        observed_head_sha = str(getattr(evidence, "head_sha", "") or "").strip()
+        if not observed_head_sha:
+            return False
+        if observed_head_sha == str(self._input.pull_request.head_sha or "").strip():
+            return False
+        if not self._has_blocker(evidence, "stale_revision"):
+            return False
+        return any(
+            blocker.retryable and blocker.kind != "stale_revision"
+            for blocker in getattr(evidence, "blockers", [])
+        )
+
     async def _failed_resolver_summary(
         self,
         *,
@@ -420,6 +443,12 @@ class MoonMindMergeAutomationWorkflow:
                 evaluation if isinstance(evaluation, Mapping) else {},
                 tracked_head_sha=self._input.pull_request.head_sha,
             )
+            if self._should_adopt_initial_waiting_head_sha(evidence):
+                self._refresh_tracked_head_sha(evaluation)
+                evidence = classify_readiness(
+                    evaluation if isinstance(evaluation, Mapping) else {},
+                    tracked_head_sha=self._input.pull_request.head_sha,
+                )
             if self._refresh_tracked_head_sha_on_next_evaluation:
                 self._refresh_tracked_head_sha_on_next_evaluation = False
                 if self._refresh_tracked_head_sha(evaluation):

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -221,7 +221,11 @@ async def test_merge_automation_reenters_gate_after_resolver_remediation(
         fake_execute_child_workflow,
     )
     monkeypatch.setattr(merge_automation_module.workflow, "now", lambda: datetime.now(timezone.utc))
-    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_memo",
+        lambda _memo: None,
+    )
     monkeypatch.setattr(
         merge_automation_module.workflow,
         "upsert_search_attributes",
@@ -466,6 +470,102 @@ async def test_merge_automation_launches_resolver_when_checks_are_failing_but_co
     assert child_calls == 1
     assert result["status"] == "merged"
     assert result["blockers"] == []
+
+
+@pytest.mark.asyncio
+async def test_merge_automation_adopts_initial_waiting_head_sha_before_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    readiness_calls = 0
+    resolver_payloads: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        nonlocal readiness_calls
+        assert activity_type == "merge_automation.evaluate_readiness"
+        readiness_calls += 1
+        if readiness_calls == 1:
+            return {
+                "headSha": "def456",
+                "ready": False,
+                "pullRequestOpen": True,
+                "policyAllowed": True,
+                "checksComplete": False,
+                "checksPassing": False,
+                "automatedReviewComplete": True,
+                "jiraStatusAllowed": True,
+                "blockers": [
+                    {
+                        "kind": "checks_running",
+                        "summary": "Required checks are still running.",
+                        "retryable": True,
+                        "source": "github",
+                    }
+                ],
+            }
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        resolver_payloads.append(payload)
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    async def fake_wait_condition(*_args: Any, **_kwargs: Any) -> None:
+        raise TimeoutError
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "wait_condition",
+        fake_wait_condition,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert readiness_calls == 2
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+    assert result["blockers"] == []
+    assert (
+        resolver_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
+++ b/tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py
@@ -569,6 +569,71 @@ async def test_merge_automation_adopts_initial_waiting_head_sha_before_resolver(
 
 
 @pytest.mark.asyncio
+async def test_merge_automation_adopts_initial_ready_head_sha_before_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow = MoonMindMergeAutomationWorkflow()
+    resolver_payloads: list[dict[str, Any]] = []
+
+    async def fake_execute_activity(
+        activity_type: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert activity_type == "merge_automation.evaluate_readiness"
+        return {
+            "headSha": "def456",
+            "ready": True,
+            "pullRequestOpen": True,
+            "policyAllowed": True,
+            "checksComplete": True,
+            "checksPassing": True,
+            "automatedReviewComplete": True,
+            "jiraStatusAllowed": True,
+        }
+
+    async def fake_execute_child_workflow(
+        workflow_type: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        assert workflow_type == "MoonMind.Run"
+        resolver_payloads.append(payload)
+        return {"status": "success", "mergeAutomationDisposition": "merged"}
+
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_activity",
+        fake_execute_activity,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "execute_child_workflow",
+        fake_execute_child_workflow,
+    )
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "now",
+        lambda: datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(merge_automation_module.workflow, "upsert_memo", lambda _memo: None)
+    monkeypatch.setattr(
+        merge_automation_module.workflow,
+        "upsert_search_attributes",
+        lambda _attrs: None,
+    )
+
+    result = await workflow.run(_payload())
+
+    assert result["status"] == "merged"
+    assert result["latestHeadSha"] == "def456"
+    assert result["blockers"] == []
+    assert (
+        resolver_payloads[0]["initial_parameters"]["mergeGate"]["headSha"] == "def456"
+    )
+
+
+@pytest.mark.asyncio
 async def test_merge_automation_finishes_already_merged_without_resolver(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- adopt a newer observed PR head during the initial merge-automation waiting phase when retryable gate blockers are still present
- keep post-resolver revision changes on the existing resolver disposition and gate re-entry path
- add regression coverage and document the pre-resolver head adoption rule

## Root Cause
A merge-automation child could start with the published head SHA, then immediately observe a newer GitHub PR head while checks were still running. The gate classified that as terminal `stale_revision` before any resolver child launched, causing the parent run to fail instead of waiting on the current PR head.

## Validation
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/workflows/test_merge_automation_temporal.py`

## Notes
- `tools/auth-codex-volume.sh` has unrelated local changes and is intentionally excluded from this PR.