### PR TITLE
Run Jira Orchestrate for MM-437: Show remediation creation, evidence, links, and approvals in Mission Control

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/223-accessibility-performance-fallbacks"
+  "feature_directory": "specs/224-remediation-mission-control"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,32 @@
 [
   {
-    "id": 3121241459,
+    "id": 3121722981,
     "disposition": "addressed",
-    "rationale": "Replaced the exact long primary-button selector assertion with a PostCSS-backed rule lookup based on selector shape and declarations."
+    "rationale": "Changed remediation read contract route parameters from camelCase {workflowId} to snake_case {workflow_id}."
   },
   {
-    "id": 3121241462,
+    "id": 3121722994,
     "disposition": "addressed",
-    "rationale": "Consolidated the adjacent prefers-reduced-motion blocks for the running icon and liquidGL surfaces."
+    "rationale": "Clarified that link identity/status fields come from the persisted link/read model, while lock/action/resolution/context fields are bounded derived summaries returned as null or omitted when unavailable without adding a new persistence table."
   },
   {
-    "id": 4151743717,
+    "id": 3121722997,
+    "disposition": "addressed",
+    "rationale": "Changed the approval decision route to scope by {remediation_workflow_id} and {request_id}, and documented that target-scoped screens must submit the selected remediation task workflow ID."
+  },
+  {
+    "id": 4152209722,
     "disposition": "not-applicable",
-    "rationale": "Review summary reported no direct code-change feedback; inline suggestions are tracked by their own comment ids."
+    "rationale": "Summary review body only; the three concrete child review comments were addressed individually."
   },
   {
-    "id": 3121245746,
+    "id": 3121729143,
     "disposition": "addressed",
-    "rationale": "Added .route-nav a:focus-visible to the forced-colors focus outline fallback."
+    "rationale": "Updated focused frontend test commands in tasks, plan, and quickstart to use --dashboard-only with --ui-args."
   },
   {
-    "id": 4151748283,
+    "id": 4152216624,
     "disposition": "not-applicable",
-    "rationale": "Automated review preamble with no standalone remediation request; inline suggestions are tracked by their own comment ids."
-  },
-  {
-    "id": 3121245749,
-    "disposition": "addressed",
-    "rationale": "Added .live-logs-artifact-link:focus-visible to the forced-colors focus outline fallback."
+    "rationale": "Automated review summary/header only; no separate actionable request beyond the inline comments."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-437-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-437-moonspec-orchestration-input.md
@@ -1,0 +1,61 @@
+# MM-437 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: unknown
+- Jira orchestration target: MM-437
+- Source story: STORY-007
+- Summary: Show remediation creation, evidence, links, and approvals in Mission Control.
+- Original brief reference: not provided.
+- Canonical source: task instruction supplied to the managed Jira Orchestrate run.
+
+## Canonical MoonSpec Feature Request
+
+Jira Orchestrate for MM-437.
+
+Source story: STORY-007.
+Source summary: Show remediation creation, evidence, links, and approvals in Mission Control.
+Source Jira issue: unknown.
+Original brief reference: not provided.
+
+Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
+
+## Source Reference
+
+- Source Document: `docs/Tasks/TaskRemediation.md`
+- Source Title: Task Remediation
+- Source Sections:
+  - 14.1 Required remediation artifacts
+  - 14.4 Target-side linkage summary
+  - 14.5 Control-plane audit events
+  - 15.1 Create flow
+  - 15.2 Target task detail
+  - 15.3 Remediation task detail
+  - 15.4 Evidence presentation
+  - 15.6 Operator handoff
+  - 16.3 Historical target has only merged logs
+  - 16.4 Missing or partial artifact refs
+  - 16.5 Live follow unavailable
+- Additional Source Document: `docs/UI/MissionControlDesignSystem.md`
+- Additional Source Section:
+  - 12. Accessibility and performance
+
+## User Story
+
+As a Mission Control operator, I want to create remediation tasks from target execution views and inspect remediation links, evidence, and approvals in task detail so I can understand and govern remediation work without leaving Mission Control.
+
+## Acceptance Criteria
+
+- Mission Control exposes Create remediation task from eligible target detail/problem surfaces and expands submissions into the canonical remediation create contract.
+- Target task detail shows inbound remediation task links, status, authority mode, latest action, resolution, active lock, and update metadata.
+- Remediation task detail shows target execution link, pinned target run ID, selected steps, current target state, evidence bundle, allowed actions, approval state, and lock state.
+- Remediation evidence artifacts are directly reachable through existing artifact presentation and never expose raw storage paths, presigned URLs, storage keys, local paths, or unbounded logs.
+- Approval-gated remediation shows proposed action, preconditions, expected blast radius, approve/reject controls when permitted, and audit-backed decision state.
+- Missing or partial remediation evidence degrades visibly without breaking task detail rendering.
+
+## Implementation Notes
+
+- Preserve MM-437, STORY-007, source summary, and unknown Jira issue status in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use existing remediation create, link, context artifact, evidence tool, artifact presentation, and Mission Control task-detail surfaces where possible.
+- Scope implementation to Mission Control visibility and narrow trusted API/read-model or approval handoff surfaces required by the UI.
+- Do not implement automatic self-healing, new raw admin action kinds, unbounded evidence import, or direct raw storage access.

--- a/specs/224-remediation-mission-control/checklists/requirements.md
+++ b/specs/224-remediation-mission-control/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Remediation Mission Control Surfaces
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details in the user-facing specification
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The source Jira issue is explicitly unknown in the task instruction; the spec preserves MM-437 and STORY-007 traceability without inventing a Jira issue key.
+- Implementation is intentionally not run in this breakdown/orchestration task.

--- a/specs/224-remediation-mission-control/contracts/remediation-mission-control.md
+++ b/specs/224-remediation-mission-control/contracts/remediation-mission-control.md
@@ -1,0 +1,122 @@
+# Contract: Remediation Mission Control Surfaces
+
+## Read Remediation Links
+
+Mission Control needs a bounded read surface for task detail.
+
+```http
+GET /api/executions/{workflowId}/remediations?direction=inbound
+GET /api/executions/{workflowId}/remediations?direction=outbound
+```
+
+`inbound` returns remediation tasks targeting `{workflowId}`. `outbound` returns the target execution for a remediation task.
+
+Response shape:
+
+```json
+{
+  "items": [
+    {
+      "remediationWorkflowId": "mm:remediation",
+      "remediationRunId": "run-remediation",
+      "targetWorkflowId": "mm:target",
+      "targetRunId": "run-target",
+      "mode": "snapshot_then_follow",
+      "authorityMode": "approval_gated",
+      "status": "awaiting_approval",
+      "activeLockScope": "target_execution",
+      "activeLockHolder": "mm:remediation",
+      "latestActionSummary": "Proposed session interrupt",
+      "resolution": null,
+      "contextArtifactRef": "art-context",
+      "createdAt": "2026-04-22T00:00:00Z",
+      "updatedAt": "2026-04-22T00:01:00Z"
+    }
+  ],
+  "direction": "inbound"
+}
+```
+
+Rules:
+- Response items are compact read-model data sourced from persisted remediation links and artifacts.
+- The route must not scan raw logs or artifact bodies during task-detail rendering.
+- Missing or unauthorized executions return existing task-detail authorization semantics.
+
+## Create Remediation From Target
+
+Existing route:
+
+```http
+POST /api/executions/{workflowId}/remediation
+```
+
+Mission Control sends target-scoped choices such as:
+
+```json
+{
+  "task": {
+    "instructions": "Investigate the target execution using bounded evidence.",
+    "runtime": { "mode": "codex" },
+    "remediation": {
+      "target": {
+        "runId": "run-target",
+        "stepSelectors": [{ "logicalStepId": "run-tests", "attempt": 1 }],
+        "taskRunIds": ["tr_123"]
+      },
+      "mode": "snapshot_then_follow",
+      "authorityMode": "observe_only",
+      "evidencePolicy": {
+        "includeStepLedger": true,
+        "includeDiagnostics": true,
+        "tailLines": 2000
+      },
+      "actionPolicyRef": "admin_healer_default",
+      "approvalPolicy": { "mode": "risk_gated" },
+      "trigger": { "type": "manual" }
+    }
+  }
+}
+```
+
+The server expands the path workflow ID into `task.remediation.target.workflowId` and normalizes to the canonical `initialParameters.task.remediation` payload.
+
+## Remediation Evidence Presentation
+
+Task detail groups artifact refs with remediation artifact types:
+
+- `remediation.context`
+- `remediation.plan`
+- `remediation.decision_log`
+- `remediation.action_request`
+- `remediation.action_result`
+- `remediation.verification`
+- `remediation.summary`
+
+The UI uses existing artifact preview/download routes. It must not render storage keys, local paths, presigned URLs, or raw log bodies as remediation evidence metadata.
+
+## Approval Decision
+
+If no existing control-event route can record decisions, add a narrow route:
+
+```http
+POST /api/executions/{workflowId}/remediation/approvals/{requestId}
+```
+
+Request:
+
+```json
+{
+  "decision": "approved",
+  "comment": "Preconditions and blast radius reviewed."
+}
+```
+
+Allowed decisions:
+- `approved`
+- `rejected`
+
+Rules:
+- The route requires current-operator approval permission.
+- The route writes an audit/control event before returning success.
+- Duplicate decisions must be idempotent or fail with a structured conflict.
+- The route never executes the remediation action directly; it records operator approval state for the remediation action boundary.

--- a/specs/224-remediation-mission-control/contracts/remediation-mission-control.md
+++ b/specs/224-remediation-mission-control/contracts/remediation-mission-control.md
@@ -5,11 +5,11 @@
 Mission Control needs a bounded read surface for task detail.
 
 ```http
-GET /api/executions/{workflowId}/remediations?direction=inbound
-GET /api/executions/{workflowId}/remediations?direction=outbound
+GET /api/executions/{workflow_id}/remediations?direction=inbound
+GET /api/executions/{workflow_id}/remediations?direction=outbound
 ```
 
-`inbound` returns remediation tasks targeting `{workflowId}`. `outbound` returns the target execution for a remediation task.
+`inbound` returns remediation tasks targeting `{workflow_id}`. `outbound` returns the target execution for a remediation task.
 
 Response shape:
 
@@ -39,6 +39,8 @@ Response shape:
 
 Rules:
 - Response items are compact read-model data sourced from persisted remediation links and artifacts.
+- `remediationWorkflowId`, `remediationRunId`, `targetWorkflowId`, `targetRunId`, `mode`, `authorityMode`, `status`, `createdAt`, and `updatedAt` come from the persisted remediation link/read model.
+- `activeLockScope`, `activeLockHolder`, `latestActionSummary`, `resolution`, and `contextArtifactRef` are derived from bounded remediation execution state, control/action-event metadata, and artifact metadata. If an existing bounded source is unavailable, the fields are returned as `null` or omitted; implementation must not add a persistent table solely for these summaries.
 - The route must not scan raw logs or artifact bodies during task-detail rendering.
 - Missing or unauthorized executions return existing task-detail authorization semantics.
 
@@ -47,7 +49,7 @@ Rules:
 Existing route:
 
 ```http
-POST /api/executions/{workflowId}/remediation
+POST /api/executions/{workflow_id}/remediation
 ```
 
 Mission Control sends target-scoped choices such as:
@@ -99,8 +101,10 @@ The UI uses existing artifact preview/download routes. It must not render storag
 If no existing control-event route can record decisions, add a narrow route:
 
 ```http
-POST /api/executions/{workflowId}/remediation/approvals/{requestId}
+POST /api/executions/{remediation_workflow_id}/remediation/approvals/{request_id}
 ```
+
+`{remediation_workflow_id}` identifies the remediation task execution that owns the action request. Target-scoped screens must submit the selected remediation task workflow ID rather than the target workflow ID, because one target execution can have multiple remediation tasks and pending requests.
 
 Request:
 

--- a/specs/224-remediation-mission-control/data-model.md
+++ b/specs/224-remediation-mission-control/data-model.md
@@ -1,0 +1,81 @@
+# Data Model: Remediation Mission Control Surfaces
+
+## Remediation Link Summary
+
+Compact API/read-model item for one remediation relationship.
+
+Fields:
+- `remediationWorkflowId`: logical workflow ID of the remediation task.
+- `remediationRunId`: current or pinned run ID of the remediation task.
+- `targetWorkflowId`: logical workflow ID of the target execution.
+- `targetRunId`: pinned target run ID.
+- `mode`: remediation mode such as `snapshot`, `live_follow`, or `snapshot_then_follow`.
+- `authorityMode`: remediation authority mode such as `observe_only`, `approval_gated`, or `admin_auto`.
+- `status`: compact remediation phase or task status.
+- `activeLockScope`: nullable current lock scope.
+- `activeLockHolder`: nullable current lock holder.
+- `latestActionSummary`: nullable compact latest action summary.
+- `resolution`: nullable final or current remediation resolution.
+- `contextArtifactRef`: nullable artifact ID for `reports/remediation_context.json`.
+- `createdAt`: creation timestamp.
+- `updatedAt`: latest link/update timestamp.
+
+Validation:
+- Workflow and run IDs are identifiers only; they are not presigned URLs or storage keys.
+- A read response may omit optional fields, but it must preserve enough identity to link both directions.
+- Lists are bounded for task-detail rendering.
+
+## Remediation Evidence Item
+
+Operator-facing metadata for one linked remediation evidence artifact.
+
+Fields:
+- `artifactId`: existing artifact identifier.
+- `artifactType`: one of `remediation.context`, `remediation.plan`, `remediation.decision_log`, `remediation.action_request`, `remediation.action_result`, `remediation.verification`, `remediation.summary`, or an unknown remediation-prefixed type.
+- `label`: human-readable label derived from artifact metadata or known remediation type.
+- `previewUrl` / `downloadUrl`: existing artifact presentation routes when authorized.
+- `createdAt`: artifact creation timestamp when available.
+- `degradedReason`: optional reason when the expected artifact is missing or unavailable.
+
+Validation:
+- Evidence items never include storage backend keys, local filesystem paths, presigned URLs, raw log bodies, or artifact byte content.
+- Unknown remediation artifact types render as evidence artifacts with safe generic labels.
+
+## Remediation Approval State
+
+Current operator handoff state for approval-gated remediation.
+
+Fields:
+- `requestId`: stable action request identifier or artifact ID.
+- `actionKind`: typed action kind.
+- `riskTier`: action risk tier.
+- `preconditions`: bounded text or structured summary.
+- `blastRadius`: bounded text or structured summary.
+- `decision`: `pending`, `approved`, `rejected`, `expired`, or `not_required`.
+- `decisionActor`: nullable user/principal that decided.
+- `decisionAt`: nullable decision timestamp.
+- `canDecide`: whether the current operator may approve/reject.
+- `auditRef`: nullable artifact or audit event reference.
+
+Validation:
+- Side-effecting decisions require a trusted server route.
+- Read-only users must receive `canDecide = false` and no enabled decision action.
+- Approval metadata is bounded and does not include raw credentials or raw command output.
+
+## Remediation Create Draft
+
+Mission Control state expanded into the canonical create route.
+
+Fields:
+- `targetWorkflowId`: target execution workflow ID from the current detail page.
+- `targetRunId`: pinned current run ID when known.
+- `selectedSteps`: selected logical step IDs, attempts, or task run IDs.
+- `authorityMode`: `observe_only`, `approval_gated`, or `admin_auto` when supported.
+- `mode`: `snapshot`, `live_follow`, or `snapshot_then_follow`.
+- `actionPolicyRef`: selected action policy reference.
+- `evidencePolicy`: bounded evidence classes and tail-line hints.
+
+Validation:
+- The submitted shape must normalize into `initialParameters.task.remediation`.
+- The target workflow ID is always taken from trusted page/API state, not free-form prompt text.
+- Evidence preview is descriptive and ref-based; it does not fetch raw artifact bodies during draft creation.

--- a/specs/224-remediation-mission-control/plan.md
+++ b/specs/224-remediation-mission-control/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Remediation Mission Control Surfaces
+
+**Branch**: `224-remediation-mission-control` | **Date**: 2026-04-22 | **Spec**: `specs/224-remediation-mission-control/spec.md`
+**Input**: Single-story Jira Orchestrate request for MM-437 / STORY-007.
+
+## Summary
+
+Implement MM-437 by layering Mission Control UI and narrow API read/decision surfaces over the existing remediation create/link/context/evidence foundations. Existing backend work already accepts remediation create requests, persists remediation links, builds bounded context artifacts, and exposes typed evidence tools at service boundaries. This story adds operator-visible task-detail panels and create/approval flows: target pages show remediation creation and inbound links, remediation pages show target/evidence/approval state, evidence artifact refs use the existing artifact presentation path, and approval decisions stay permission-aware and audit-backed. Tests are frontend-first with focused backend route coverage where Mission Control needs a read or decision contract that does not already exist.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | missing | Task detail has generic status and action regions, but no remediation create action | Add eligible-target create action in task detail | UI unit |
+| FR-002 | partial | `POST /api/executions/{workflow_id}/remediation` exists in `api_service/api/routers/executions.py`; no Mission Control prefill flow | Wire create action/form to canonical route with target context | UI unit + router unit |
+| FR-003 | missing | No remediation create UI policy/evidence preview found | Add troubleshooting/admin choices and evidence preview | UI unit |
+| FR-004 | partial | Service methods `list_remediations_for_target` exist; no API/UI read surface | Add/read inbound remediation link API and target panel | API unit + UI unit |
+| FR-005 | partial | Service methods `list_remediation_targets` and context builder exist; no task-detail panel | Add/read outbound target API and remediation target panel | API unit + UI unit |
+| FR-006 | partial | Remediation artifacts and context refs exist; task detail shows generic artifacts only | Add remediation evidence grouping and labels | UI unit |
+| FR-007 | implemented_unverified | Artifact authorization/preview path exists; no remediation-specific no-raw-storage test | Verify evidence links use artifact refs only | UI unit |
+| FR-008 | missing | Timeline can render approval rows; no remediation approval summary contract | Add approval-state read model and UI display | API unit + UI unit |
+| FR-009 | missing | No remediation approval decision controls found | Add permission-aware approve/reject flow or read-only fallback | API unit + UI unit |
+| FR-010 | missing | No remediation degraded/empty states | Add degraded states for missing links, context, evidence, live follow, approval | UI unit |
+| FR-011 | implemented_unverified | MM-429 accessibility/fallback CSS exists; remediation-specific panels not covered | Add remediation panel accessibility/fallback assertions | UI unit |
+| FR-012 | implemented_unverified | Existing task-detail/create/artifact tests pass in prior specs | Preserve and rerun route regression tests | UI unit |
+| FR-013 | missing | This artifact set did not exist before MM-437 | Preserve traceability in specs/tasks/verification | final verify |
+| DESIGN-REQ-001 | missing | Desired-state doc only for Mission Control create entrypoints | Implement create action entrypoints | UI unit |
+| DESIGN-REQ-002 | missing | Desired-state doc only for remediation create choices | Implement create form/prefill choices | UI unit |
+| DESIGN-REQ-003 | partial | Backend link table/service exists; no Mission Control panel | Implement inbound panel/API | API unit + UI unit |
+| DESIGN-REQ-004 | partial | Backend outbound link/context exists; no Mission Control panel | Implement outbound panel/API | API unit + UI unit |
+| DESIGN-REQ-005 | partial | Remediation artifacts exist as generic artifacts | Implement remediation evidence grouping | UI unit |
+| DESIGN-REQ-006 | missing | No remediation approval handoff UI/API found | Implement approval display and decision path | API unit + UI unit |
+| DESIGN-REQ-007 | missing | No remediation degraded UI states | Implement partial-evidence and missing-link states | UI unit |
+| DESIGN-REQ-008 | implemented_unverified | Mission Control design tests exist but not for new remediation surfaces | Add accessibility/fallback coverage for remediation panels | UI unit |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route/read-model tests.  
+**Primary Dependencies**: React, TanStack Query, existing Mission Control task-detail entrypoint, generated OpenAPI types, FastAPI, SQLAlchemy async ORM, existing Temporal execution/remediation services, pytest, Vitest and Testing Library.  
+**Storage**: Existing remediation link table, artifact tables, and any existing control/audit event storage; no new persistent table planned unless approval decisions lack a current audit surface.  
+**Unit Testing**: `./tools/test_unit.sh` for Python and `./tools/test_unit.sh --ui-args <paths>` for frontend-focused runs.  
+**Integration Testing**: Rendered React entrypoint tests plus focused API/router tests; no compose-backed integration expected unless the approval decision path crosses an existing integration boundary.  
+**Target Platform**: Browser Mission Control UI backed by FastAPI control-plane APIs.  
+**Project Type**: Frontend runtime behavior with narrow backend API/read-model support.  
+**Performance Goals**: Task detail loads remediation metadata with bounded list payloads and artifact refs only; no unbounded log or artifact body fetches during page render.  
+**Constraints**: Preserve canonical remediation create contract; do not expose raw storage identifiers; preserve non-remediation task detail behavior; keep dense evidence panels matte/readable; do not change Temporal workflow payload shapes.  
+**Scale/Scope**: One target execution may show a bounded list of remediation tasks; one remediation execution shows one target and grouped evidence/approval state.
+
+## Constitution Check
+
+- I. Orchestrate, Don't Recreate: PASS. The story surfaces existing remediation orchestration rather than changing agent cognition.
+- II. One-Click Agent Deployment: PASS. No new required service dependency is planned.
+- III. Avoid Vendor Lock-In: PASS. No provider-specific behavior is introduced.
+- IV. Own Your Data: PASS. Remediation links, evidence, and approvals remain MoonMind-owned data/artifacts.
+- V. Skills Are First-Class: PASS. No agent instruction bundle or executable skill contract change is needed.
+- VI. Replaceable Scaffolding / Tests Anchor: PASS. UI/API contracts are covered by focused tests before implementation.
+- VII. Runtime Configurability: PASS. Remediation authority and policies come from request/link data, not hardcoded provider behavior.
+- VIII. Modular Architecture: PASS. Work stays in task-detail UI, remediation API/read-model boundaries, and tests.
+- IX. Resilient by Default: PASS. Degraded states prevent missing evidence from breaking operator visibility.
+- X. Continuous Improvement: PASS. Remediation evidence and approvals make follow-up outcomes reviewable.
+- XI. Spec-Driven Development: PASS. This plan follows one MM-437 story with traceable requirements.
+- XII. Canonical Documentation Separation: PASS. Desired-state docs remain canonical; implementation work stays under specs and source/tests.
+- XIII. Pre-release Compatibility Policy: PASS. The story uses the canonical remediation contract and does not add compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/224-remediation-mission-control/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── remediation-mission-control.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+api_service/api/routers/executions.py
+api_service/db/models.py
+moonmind/workflows/temporal/service.py
+frontend/src/entrypoints/task-detail.tsx
+frontend/src/entrypoints/task-detail.test.tsx
+frontend/src/entrypoints/task-create.tsx
+frontend/src/entrypoints/task-create.test.tsx
+frontend/src/generated/openapi.ts
+frontend/src/styles/mission-control.css
+tests/unit/api/routers/test_executions.py
+tests/unit/workflows/temporal/test_temporal_service.py
+```
+
+**Structure Decision**: Implement the story in the existing task-detail and task-create Mission Control entrypoints, adding backend route/read-model support only where the frontend cannot consume existing remediation service data safely.
+
+## Complexity Tracking
+
+None.

--- a/specs/224-remediation-mission-control/plan.md
+++ b/specs/224-remediation-mission-control/plan.md
@@ -38,7 +38,7 @@ Implement MM-437 by layering Mission Control UI and narrow API read/decision sur
 **Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 for FastAPI route/read-model tests.  
 **Primary Dependencies**: React, TanStack Query, existing Mission Control task-detail entrypoint, generated OpenAPI types, FastAPI, SQLAlchemy async ORM, existing Temporal execution/remediation services, pytest, Vitest and Testing Library.  
 **Storage**: Existing remediation link table, artifact tables, and any existing control/audit event storage; no new persistent table planned unless approval decisions lack a current audit surface.  
-**Unit Testing**: `./tools/test_unit.sh` for Python and `./tools/test_unit.sh --ui-args <paths>` for frontend-focused runs.  
+**Unit Testing**: `./tools/test_unit.sh` for Python and `./tools/test_unit.sh --dashboard-only --ui-args <paths>` for frontend-focused runs.
 **Integration Testing**: Rendered React entrypoint tests plus focused API/router tests; no compose-backed integration expected unless the approval decision path crosses an existing integration boundary.  
 **Target Platform**: Browser Mission Control UI backed by FastAPI control-plane APIs.  
 **Project Type**: Frontend runtime behavior with narrow backend API/read-model support.  

--- a/specs/224-remediation-mission-control/quickstart.md
+++ b/specs/224-remediation-mission-control/quickstart.md
@@ -3,7 +3,7 @@
 ## Focused Frontend Tests
 
 ```bash
-./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
 ```
 
 Expected result:
@@ -35,7 +35,7 @@ Expected result:
 ## Final Verification
 
 ```bash
-MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
 MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py
 ```
 

--- a/specs/224-remediation-mission-control/quickstart.md
+++ b/specs/224-remediation-mission-control/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Remediation Mission Control Surfaces
+
+## Focused Frontend Tests
+
+```bash
+./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+```
+
+Expected result:
+- Target detail renders the Create remediation task action for eligible states.
+- Target detail renders inbound Remediation Tasks metadata.
+- Remediation detail renders target, evidence, lock, and approval panels.
+- Non-remediation task detail and create behavior remain unchanged.
+
+## Focused API Tests
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py
+```
+
+Expected result:
+- Remediation create route still expands into the canonical task remediation contract.
+- Inbound and outbound remediation link read surfaces return compact data.
+- Approval decision route, if added, enforces permission and audit semantics.
+
+## Traceability Check
+
+```bash
+rg -n "MM-437|STORY-007|Remediation Mission Control|DESIGN-REQ-00[1-8]" specs/224-remediation-mission-control
+```
+
+Expected result:
+- The orchestration target, story ID, source summary, and source design mappings are present in spec, plan, tasks, and verification artifacts.
+
+## Final Verification
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py
+```
+
+Then run `moonspec-verify` for `specs/224-remediation-mission-control` and record the result in `verification.md`.

--- a/specs/224-remediation-mission-control/research.md
+++ b/specs/224-remediation-mission-control/research.md
@@ -1,0 +1,57 @@
+# Research: Remediation Mission Control Surfaces
+
+## FR-001 / Create Remediation Entry Points
+
+Decision: Add the create action to task detail and eligible status/problem surfaces, starting with failed, attention-required, stuck, provider-slot, and session problem states already represented in task detail data.
+Evidence: `docs/Tasks/TaskRemediation.md` section 15.1 requires Mission Control create entrypoints; `frontend/src/entrypoints/task-detail.tsx` owns task detail action and evidence regions.
+Rationale: Task detail is the shared surface where the target workflow ID, current run state, steps, artifacts, and problem context are available without inventing a new route.
+Alternatives considered: A standalone remediation page was rejected because the source design calls for entrypoints from existing target surfaces.
+Test implications: UI test renders eligible and ineligible task states and asserts create action visibility.
+
+## FR-002 and FR-003 / Canonical Create Prefill
+
+Decision: Use the existing `POST /api/executions/{workflow_id}/remediation` convenience route when available and prefill its body from task detail state.
+Evidence: `api_service/api/routers/executions.py` already defines `create_remediation_execution`; `docs/Tasks/TaskRemediation.md` section 7.5 allows the route only as an expansion into canonical task-shaped creation.
+Rationale: Reusing the existing route avoids a second durable payload shape while giving Mission Control a simple target-scoped create flow.
+Alternatives considered: Directly constructing a full `POST /api/executions` payload in the frontend was rejected as higher duplication when the convenience route already exists.
+Test implications: Frontend submit test and router regression test for canonical target/policy/evidence payload shape.
+
+## FR-004 and FR-005 / Bidirectional Link Read Surface
+
+Decision: Add or expose a bounded execution remediations API that returns inbound and outbound remediation link summaries for task detail.
+Evidence: `TemporalExecutionService.list_remediations_for_target` and `list_remediation_targets` already exist, but no REST read route was found for Mission Control consumption.
+Rationale: The frontend should not infer remediation links by scanning artifacts or parsing task parameters; it needs a trusted read model sourced from persisted links.
+Alternatives considered: Embedding remediation link data into every task detail response was rejected unless the existing detail payload already has a natural extension point, because a separate route keeps payload growth bounded.
+Test implications: API unit tests for inbound/outbound direction, empty state, and bounded compact fields; UI tests for target and remediation panels.
+
+## FR-006 and FR-007 / Evidence Presentation
+
+Decision: Group remediation evidence artifacts by known remediation artifact types while still routing access through existing artifact preview/download links.
+Evidence: `docs/Tasks/TaskRemediation.md` section 14.1 defines required remediation artifacts; current task detail already renders artifacts and timeline artifact links.
+Rationale: Operators need remediation-specific labels and grouping, but authorization and content access must stay in the artifact subsystem.
+Alternatives considered: Reading context/log bodies directly into task detail was rejected because the source design requires artifact refs and bounded presentation.
+Test implications: UI tests assert grouped evidence labels and absence of raw storage identifiers in rendered state.
+
+## FR-008 and FR-009 / Approval Handoff
+
+Decision: Represent approval-gated remediation through a compact approval state in the remediation read model and add approve/reject controls only when permission and pending state are present.
+Evidence: `docs/Tasks/TaskRemediation.md` section 15.6 requires proposed action, preconditions, blast radius, approve/reject, and audit trail; task detail timeline already handles approval row types generically.
+Rationale: Approval controls must be explicit and permission-aware; read-only state is safer than showing disabled controls without context.
+Alternatives considered: Encoding approvals only as timeline events was rejected because operators need a stable current-state panel and decision controls.
+Test implications: API tests for permission/pending/read-only states and UI tests for approve, reject, and unauthorized read-only rendering.
+
+## FR-010 / Degraded States
+
+Decision: Treat missing links, missing context refs, unavailable live follow, partial artifact refs, and approval read failures as explicit degraded states inside the remediation panels.
+Evidence: `docs/Tasks/TaskRemediation.md` sections 16.3 through 16.5 require partial-evidence and live-follow fallback behavior.
+Rationale: Remediation is often used when systems are already failing; Mission Control must remain useful when evidence is incomplete.
+Alternatives considered: Hiding panels until complete data exists was rejected because it obscures troubleshooting state.
+Test implications: UI tests for empty/degraded copy and preserved task detail rendering.
+
+## FR-011 and FR-012 / Mission Control Integration
+
+Decision: Reuse existing Mission Control matte evidence region styling and add focused regression tests for remediation panels.
+Evidence: `specs/223-accessibility-performance-fallbacks` added contrast, focus, reduced-motion, fallback, and dense evidence-region posture; `frontend/src/styles/mission-control.css` contains task-detail evidence-region selectors.
+Rationale: Remediation panels are dense operational surfaces and should follow the existing task-detail composition rather than introducing new premium effects.
+Alternatives considered: Creating a visually distinct remediation page treatment was rejected as unnecessary scope and likely to regress dense evidence readability.
+Test implications: UI tests for focusable controls, containment, degraded states, and non-remediation route regressions.

--- a/specs/224-remediation-mission-control/spec.md
+++ b/specs/224-remediation-mission-control/spec.md
@@ -1,0 +1,96 @@
+# Feature Specification: Remediation Mission Control Surfaces
+
+**Feature Branch**: `224-remediation-mission-control`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**: Jira Orchestrate for MM-437.
+
+Source story: STORY-007.
+Source summary: Show remediation creation, evidence, links, and approvals in Mission Control.
+Source Jira issue: unknown.
+Original brief reference: not provided.
+
+Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
+
+## User Story - Remediation Mission Control Surfaces
+
+**Summary**: As a Mission Control operator, I want to create remediation tasks from target execution views and inspect remediation links, evidence, and approvals in task detail so I can understand and govern remediation work without leaving Mission Control.
+
+**Goal**: Mission Control exposes the remediation relationship as an operator-visible workflow: target executions can start remediation, target and remediation task detail pages show the relationship in both directions, remediation evidence artifacts are directly reachable, and approval-gated remediation actions show review state and decision affordances.
+
+**Independent Test**: Render a target execution with inbound remediation links and a remediation execution with outbound target metadata, context evidence, action artifacts, and approval events. The story passes when Mission Control shows create remediation entrypoints, bidirectional links, evidence artifact access, approval state, and safe degraded states without changing the underlying task execution contract.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator views a failed, attention-required, stuck, provider-slot, or session-problem execution, **When** the task detail page renders, **Then** Mission Control shows a Create remediation task action that starts the canonical remediation create flow for that target workflow.
+2. **Given** a target execution has remediation tasks, **When** the target task detail page renders, **Then** Mission Control shows a Remediation Tasks panel with links, status, authority mode, latest action, resolution, active lock state, and last-updated time for each remediation.
+3. **Given** a remediation execution targets another execution, **When** the remediation task detail page renders, **Then** Mission Control shows a Remediation Target panel with the target link, pinned run ID, selected steps, current target state, evidence bundle link, allowed actions summary, approval state, and lock state.
+4. **Given** remediation context, decision log, action request/result, verification, or summary artifacts are linked, **When** an operator reviews remediation evidence, **Then** Mission Control presents direct artifact links and labels them by remediation evidence type without exposing raw storage paths, presigned URLs, or unbounded log bodies.
+5. **Given** a remediation task is approval-gated or requests a high-risk action, **When** the task detail page renders, **Then** Mission Control shows the proposed action, preconditions, blast-radius summary, approval state, and approve/reject affordances backed by the existing audit trail.
+6. **Given** remediation link or evidence data is partial, missing, or degraded, **When** Mission Control renders the remediation surfaces, **Then** it shows bounded empty/degraded states without hiding the task detail page or implying approval/action success.
+
+### Edge Cases
+
+- Target executions without remediation links show an unobtrusive empty state and still expose the create remediation action when the target status supports remediation.
+- Remediation executions without a linked context artifact show the target relationship and a missing-evidence state rather than a broken artifact link.
+- Approval affordances are disabled or replaced with read-only status when the current operator lacks approval permission.
+- Inbound and outbound link fetch failures show retryable degraded states without losing existing task detail content.
+- Artifact links use existing artifact preview/download authorization and never surface raw storage identifiers.
+- Long workflow IDs, run IDs, action labels, and artifact names remain readable and contained on mobile and desktop.
+
+## Assumptions
+
+- This story implements Mission Control visibility and operator handoff surfaces only; it does not create a new remediation execution workflow type.
+- Existing remediation create, context artifact, and evidence-tool slices provide the canonical backend foundations where already implemented.
+- Approval decision persistence may reuse an existing audit/control-event surface if one is available; otherwise this story adds only the narrow API/UI contract needed for approval-gated remediation display and decision submission.
+- The source Jira issue key is unknown in the task instruction, so artifacts preserve MM-437 as the orchestration target while recording the issue field as unknown.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/Tasks/TaskRemediation.md` section 15.1): Mission Control should expose Create remediation task from task detail, failed task banners, attention-required surfaces, stuck task surfaces, and provider-slot or session problem surfaces. Scope: in scope, mapped to FR-001 and FR-002.
+- **DESIGN-REQ-002** (`docs/Tasks/TaskRemediation.md` section 15.1): The create UI should let operators choose the pinned target run, selected steps, authority mode, live-follow mode, action policy, and evidence preview. Scope: in scope, mapped to FR-002 and FR-003.
+- **DESIGN-REQ-003** (`docs/Tasks/TaskRemediation.md` sections 14.4 and 15.2): Target task detail should show inbound remediation metadata including links, status, authority mode, latest action, resolution, active lock, and last-updated information. Scope: in scope, mapped to FR-004.
+- **DESIGN-REQ-004** (`docs/Tasks/TaskRemediation.md` section 15.3): Remediation task detail should show the target link, pinned run ID, selected steps, current target state, evidence bundle, allowed actions, approval state, and lock state. Scope: in scope, mapped to FR-005.
+- **DESIGN-REQ-005** (`docs/Tasks/TaskRemediation.md` sections 14.1 and 15.4): Mission Control should provide direct operator access to remediation context, decision log, action request/result, verification, and summary artifacts while honoring artifact presentation safety. Scope: in scope, mapped to FR-006 and FR-007.
+- **DESIGN-REQ-006** (`docs/Tasks/TaskRemediation.md` sections 14.5 and 15.6): Approval-gated remediation should show proposed action, preconditions, expected blast radius, approve/reject controls, and audit-trail-backed decision state. Scope: in scope, mapped to FR-008 and FR-009.
+- **DESIGN-REQ-007** (`docs/Tasks/TaskRemediation.md` sections 16.3 through 16.5): Partial evidence, unavailable live follow, or missing artifact refs should degrade safely and visibly. Scope: in scope, mapped to FR-010.
+- **DESIGN-REQ-008** (`docs/UI/MissionControlDesignSystem.md` section 12): Remediation panels, evidence links, and approval controls must preserve readable contrast, visible focus, reduced-motion behavior, and fallback rendering. Scope: in scope, mapped to FR-011.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Mission Control task detail MUST expose a Create remediation task action for eligible target executions, including failed, attention-required, stuck, provider-slot, and session problem states.
+- **FR-002**: The Create remediation action MUST use the canonical remediation create route or task-shaped create contract and MUST prefill the target workflow ID, current run ID, selected-step context, authority mode, live-follow mode, action policy, and evidence preview where available.
+- **FR-003**: The create surface MUST distinguish troubleshooting-only remediation from admin remediation and show the evidence and policy choices before submission.
+- **FR-004**: Target execution detail MUST show inbound remediation tasks with remediation task links, status, authority mode, latest action, resolution, active lock state, and last-updated time.
+- **FR-005**: Remediation execution detail MUST show outbound target metadata including target execution link, pinned run ID, selected steps, current target state, evidence context link, allowed actions summary, approval state, and lock state.
+- **FR-006**: Remediation detail surfaces MUST show direct links to remediation context, decision log, action request, action result, verification, and summary artifacts when those refs are present.
+- **FR-007**: Remediation evidence links MUST use existing artifact authorization and preview behavior and MUST NOT expose raw storage paths, presigned URLs, storage keys, local filesystem paths, or unbounded raw logs in UI state.
+- **FR-008**: Approval-gated remediation surfaces MUST show proposed action kind, preconditions, expected blast radius, risk tier, current approval decision, and timestamps from the audit trail.
+- **FR-009**: Operators with approval permission MUST be able to approve or reject pending remediation action requests from Mission Control, and operators without permission MUST see read-only status without enabled decision controls.
+- **FR-010**: Missing remediation links, context artifacts, evidence refs, live-follow support, or approval audit rows MUST render explicit degraded or empty states without breaking task detail rendering.
+- **FR-011**: Remediation creation, link, evidence, and approval surfaces MUST retain Mission Control accessibility, reduced-motion, mobile containment, and fallback styling guarantees.
+- **FR-012**: Existing task-list, task-detail, artifact, timeline, live-log, and execution create behavior MUST remain unchanged for non-remediation executions.
+- **FR-013**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-437, STORY-007, the source summary, and the unknown Jira issue status from the orchestration input.
+
+### Key Entities
+
+- **Remediation Create Surface**: The task-detail action and modal or form state that expands operator choices into the canonical remediation create contract.
+- **Inbound Remediation Link**: A target-to-remediator relationship shown on target task detail.
+- **Outbound Remediation Target**: A remediation-to-target relationship shown on remediation task detail.
+- **Remediation Evidence Link**: An artifact-backed evidence reference shown through existing artifact authorization and preview behavior.
+- **Remediation Approval State**: The proposed action, decision state, permission state, and audit-trail metadata for approval-gated remediation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: UI tests prove eligible target detail states expose Create remediation task and submit the canonical remediation create payload with pinned target context.
+- **SC-002**: UI/API tests prove target task detail renders inbound remediation links with status, authority, latest action, resolution, lock, and update metadata.
+- **SC-003**: UI/API tests prove remediation task detail renders outbound target metadata, selected steps, context evidence link, allowed actions, approval state, and lock state.
+- **SC-004**: UI tests prove remediation evidence artifact links are labeled by evidence type and routed through existing artifact presentation behavior without raw storage identifiers.
+- **SC-005**: UI/API tests prove approval-gated remediation shows proposed action, preconditions, blast radius, risk tier, current decision, and permission-correct approve/reject controls.
+- **SC-006**: UI tests prove missing or degraded remediation data renders explicit empty/degraded states and does not break existing task detail rendering.
+- **SC-007**: Existing task-list, task-detail, artifact, live-log, and create-page tests continue to pass for non-remediation executions.
+- **SC-008**: Traceability verification confirms MM-437, STORY-007, source summary, and DESIGN-REQ-001 through DESIGN-REQ-008 are preserved in the MoonSpec artifacts.

--- a/specs/224-remediation-mission-control/speckit_analyze_report.md
+++ b/specs/224-remediation-mission-control/speckit_analyze_report.md
@@ -1,0 +1,31 @@
+# MoonSpec Alignment Report: Remediation Mission Control Surfaces
+
+**Feature**: `specs/224-remediation-mission-control`
+**Date**: 2026-04-22
+**Source**: Jira Orchestrate request for MM-437 / STORY-007
+
+## Result
+
+PASS. The generated MoonSpec artifacts are aligned for a single runtime story and implementation is intentionally deferred.
+
+## Checks
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| Single-story scope | PASS | One user story: Remediation Mission Control Surfaces. |
+| Original input preserved | PASS | `spec.md` preserves MM-437, STORY-007, source summary, unknown Jira issue, and no-implementation-inline instruction. |
+| Source design coverage | PASS | `DESIGN-REQ-001` through `DESIGN-REQ-008` map to `FR-*` requirements and tasks. |
+| Plan/test strategy | PASS | `plan.md`, `quickstart.md`, and `tasks.md` identify frontend UI and backend API test commands. |
+| TDD task order | PASS | `tasks.md` requires API/UI tests and red-first runs before implementation tasks. |
+| Implementation skipped | PASS | No production code was changed; implementation tasks remain unchecked. |
+
+## Key Decisions
+
+- Use the existing remediation create route as the create flow target rather than inventing a second durable payload.
+- Add a bounded remediation link read surface for Mission Control if task detail cannot already consume the service data.
+- Keep evidence display artifact-ref based and reuse existing artifact authorization/presentation.
+- Represent approval-gated remediation as a compact current-state panel plus permission-aware decision controls.
+
+## Remaining Risks
+
+- The exact approval audit/control-event storage surface must be confirmed during implementation. The artifacts allow a narrow route only if no existing trusted route fits.

--- a/specs/224-remediation-mission-control/tasks.md
+++ b/specs/224-remediation-mission-control/tasks.md
@@ -12,7 +12,7 @@
 **Test Commands**:
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py`
-- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
+- Integration tests: `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
 - Final verification: `/speckit.verify`
 
 ## Format: `[ID] [P?] Description`
@@ -77,7 +77,7 @@
 - [ ] T019 Add failing task-detail UI test for missing link, missing context artifact, missing evidence refs, unavailable live follow, and approval fetch failure degraded states in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-010, SC-006, DESIGN-REQ-007)
 - [ ] T020 Add failing CSS/accessibility assertions for remediation panel focus, contrast, mobile containment, reduced-motion/fallback posture in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/styles/mission-control.css` inspection helpers. (FR-011, DESIGN-REQ-008)
 - [ ] T021 Add or confirm non-remediation task-detail/create regression coverage in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx`. (FR-012, SC-007)
-- [ ] T022 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and capture expected red-first failures for T013-T021.
+- [ ] T022 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and capture expected red-first failures for T013-T021.
 
 ### Implementation
 
@@ -89,7 +89,7 @@
 - [ ] T028 Implement approval-gated remediation display and approve/reject controls in `frontend/src/entrypoints/task-detail.tsx`, wired to the trusted backend route from T010 when required. (FR-008, FR-009, DESIGN-REQ-006)
 - [ ] T029 Implement degraded and empty states for missing remediation links, context artifacts, evidence refs, live follow, and approval metadata in `frontend/src/entrypoints/task-detail.tsx`. (FR-010, DESIGN-REQ-007)
 - [ ] T030 Update remediation panel styling in `frontend/src/styles/mission-control.css` using existing Mission Control evidence-region patterns. (FR-011, DESIGN-REQ-008)
-- [ ] T031 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
+- [ ] T031 Run `./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
 - [ ] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
 
 **Checkpoint**: The story is fully functional, covered by API and integration-style UI tests, and independently testable.
@@ -103,7 +103,7 @@
 - [ ] T033 [P] Review MM-437 traceability in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `tasks.md`, and `contracts/remediation-mission-control.md`. (FR-013, SC-008)
 - [ ] T034 [P] Review rendered remediation panels for long workflow IDs, run IDs, action labels, artifact labels, and mobile containment in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-011)
 - [ ] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
-- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
+- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --dashboard-only --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
 - [ ] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
 - [ ] T038 Run `/speckit.verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
 

--- a/specs/224-remediation-mission-control/tasks.md
+++ b/specs/224-remediation-mission-control/tasks.md
@@ -1,0 +1,149 @@
+# Tasks: Remediation Mission Control Surfaces
+
+**Input**: Design documents from `specs/224-remediation-mission-control/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration-style UI tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped around the single MM-437 / STORY-007 user story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: This task list maps FR-001 through FR-013, SC-001 through SC-008, and DESIGN-REQ-001 through DESIGN-REQ-008 from `spec.md` to concrete test, implementation, and verification work.
+
+**Test Commands**:
+
+- Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py`
+- Integration tests: `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel because the task touches different files and has no dependency on incomplete tasks.
+- Include exact file paths in descriptions.
+- Include requirement, scenario, success criterion, or source design IDs when the task implements or validates behavior.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm existing remediation and Mission Control foundations before adding UI surfaces.
+
+- [ ] T001 Confirm active MM-437 artifacts exist in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md`, and `quickstart.md`. (FR-013, SC-008)
+- [ ] T002 Review existing remediation create/link/context/evidence behavior in `api_service/api/routers/executions.py`, `moonmind/workflows/temporal/service.py`, `moonmind/workflows/temporal/remediation_context.py`, and `moonmind/workflows/temporal/remediation_tools.py`. (FR-002, FR-004, FR-005, FR-006)
+- [ ] T003 Review current task detail action, timeline, artifact, live-log, and evidence-region rendering in `frontend/src/entrypoints/task-detail.tsx` and `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, FR-006, FR-011, FR-012)
+- [ ] T004 [P] Review task-create remediation route usage and generated OpenAPI paths in `frontend/src/generated/openapi.ts` and `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish compact remediation read and approval contracts required by the Mission Control panels.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [ ] T005 Add failing API unit tests for inbound and outbound remediation link read responses in `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005, SC-002, SC-003, DESIGN-REQ-003, DESIGN-REQ-004)
+- [ ] T006 Add failing service or router unit tests for bounded remediation link summary fields in `tests/unit/workflows/temporal/test_temporal_service.py` or `tests/unit/api/routers/test_executions.py`. (FR-004, FR-005)
+- [ ] T007 Add failing API unit tests for remediation approval-state read and permission-aware decision behavior in `tests/unit/api/routers/test_executions.py`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
+- [ ] T008 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and capture expected red-first failures for T005-T007.
+- [ ] T009 Implement inbound/outbound remediation link read route or task-detail payload extension in `api_service/api/routers/executions.py`, backed by existing `TemporalExecutionService` link methods. (FR-004, FR-005, DESIGN-REQ-003, DESIGN-REQ-004)
+- [ ] T010 Implement compact remediation approval read/decision route in `api_service/api/routers/executions.py` only if no existing control-event route can satisfy T007. (FR-008, FR-009, DESIGN-REQ-006)
+- [ ] T011 Update OpenAPI generation artifacts in `frontend/src/generated/openapi.ts` if backend route changes require generated frontend types. (FR-004, FR-005, FR-008, FR-009)
+- [ ] T012 Rerun the focused API tests from T008 and fix backend failures until the remediation read/approval contract passes.
+
+**Checkpoint**: Backend/read-model foundation ready - story UI work can now begin.
+
+---
+
+## Phase 3: Story - Remediation Mission Control Surfaces
+
+**Summary**: As a Mission Control operator, I want to create remediation tasks from target execution views and inspect remediation links, evidence, and approvals in task detail so I can understand and govern remediation work without leaving Mission Control.
+
+**Independent Test**: Render a target execution with inbound remediation links and a remediation execution with outbound target metadata, context evidence, action artifacts, and approval events. The story passes when Mission Control shows create remediation entrypoints, bidirectional links, evidence artifact access, approval state, and safe degraded states without changing the underlying task execution contract.
+
+**Traceability**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, FR-011, FR-012, FR-013, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, SC-007, SC-008, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-006, DESIGN-REQ-007, DESIGN-REQ-008
+
+**Test Plan**:
+
+- Unit: API/read-model tests for link direction, compact evidence, approval state, permission handling, and canonical create route preservation.
+- Integration-style UI: rendered task-detail/create tests for create actions, inbound/outbound panels, evidence grouping, approval controls, degraded states, accessibility/fallback posture, and non-remediation regressions.
+
+### Unit and UI Tests (write first)
+
+> NOTE: Write these tests FIRST. Run them, confirm they FAIL for the expected reason when they expose a gap, then implement only enough code to make them pass.
+
+- [ ] T013 Add failing task-detail UI test for eligible target states exposing Create remediation task and ineligible states hiding or disabling it in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-001, SC-001, DESIGN-REQ-001)
+- [ ] T014 Add failing task-detail UI test for remediation create prefill and canonical route submission in `frontend/src/entrypoints/task-detail.test.tsx` or `frontend/src/entrypoints/task-create.test.tsx`. (FR-002, FR-003, SC-001, DESIGN-REQ-002)
+- [ ] T015 Add failing task-detail UI test for inbound Remediation Tasks panel on a target execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-004, SC-002, DESIGN-REQ-003)
+- [ ] T016 Add failing task-detail UI test for outbound Remediation Target panel on a remediation execution in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-005, SC-003, DESIGN-REQ-004)
+- [ ] T017 Add failing task-detail UI test for grouped remediation evidence artifact links and absence of raw storage/path/presigned URL data in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-006, FR-007, SC-004, DESIGN-REQ-005)
+- [ ] T018 Add failing task-detail UI test for approval-gated remediation state, approve/reject controls, and read-only unauthorized state in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-008, FR-009, SC-005, DESIGN-REQ-006)
+- [ ] T019 Add failing task-detail UI test for missing link, missing context artifact, missing evidence refs, unavailable live follow, and approval fetch failure degraded states in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-010, SC-006, DESIGN-REQ-007)
+- [ ] T020 Add failing CSS/accessibility assertions for remediation panel focus, contrast, mobile containment, reduced-motion/fallback posture in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/styles/mission-control.css` inspection helpers. (FR-011, DESIGN-REQ-008)
+- [ ] T021 Add or confirm non-remediation task-detail/create regression coverage in `frontend/src/entrypoints/task-detail.test.tsx` and `frontend/src/entrypoints/task-create.test.tsx`. (FR-012, SC-007)
+- [ ] T022 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and capture expected red-first failures for T013-T021.
+
+### Implementation
+
+- [ ] T023 Implement remediation create action visibility and target-state eligibility in `frontend/src/entrypoints/task-detail.tsx`. (FR-001, DESIGN-REQ-001)
+- [ ] T024 Implement remediation create draft/prefill and canonical route submission from task detail in `frontend/src/entrypoints/task-detail.tsx` or shared create helpers in `frontend/src/entrypoints/task-create.tsx`. (FR-002, FR-003, DESIGN-REQ-002)
+- [ ] T025 Implement inbound Remediation Tasks panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-004, DESIGN-REQ-003)
+- [ ] T026 Implement outbound Remediation Target panel in `frontend/src/entrypoints/task-detail.tsx`. (FR-005, DESIGN-REQ-004)
+- [ ] T027 Implement remediation evidence grouping and safe artifact link rendering in `frontend/src/entrypoints/task-detail.tsx`. (FR-006, FR-007, DESIGN-REQ-005)
+- [ ] T028 Implement approval-gated remediation display and approve/reject controls in `frontend/src/entrypoints/task-detail.tsx`, wired to the trusted backend route from T010 when required. (FR-008, FR-009, DESIGN-REQ-006)
+- [ ] T029 Implement degraded and empty states for missing remediation links, context artifacts, evidence refs, live follow, and approval metadata in `frontend/src/entrypoints/task-detail.tsx`. (FR-010, DESIGN-REQ-007)
+- [ ] T030 Update remediation panel styling in `frontend/src/styles/mission-control.css` using existing Mission Control evidence-region patterns. (FR-011, DESIGN-REQ-008)
+- [ ] T031 Run `./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` and fix UI failures.
+- [ ] T032 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` and fix backend regressions.
+
+**Checkpoint**: The story is fully functional, covered by API and integration-style UI tests, and independently testable.
+
+---
+
+## Phase 4: Polish & Verification
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [ ] T033 [P] Review MM-437 traceability in `specs/224-remediation-mission-control/spec.md`, `plan.md`, `tasks.md`, and `contracts/remediation-mission-control.md`. (FR-013, SC-008)
+- [ ] T034 [P] Review rendered remediation panels for long workflow IDs, run IDs, action labels, artifact labels, and mobile containment in `frontend/src/entrypoints/task-detail.test.tsx`. (FR-011)
+- [ ] T035 Run quickstart validation commands from `specs/224-remediation-mission-control/quickstart.md`.
+- [ ] T036 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh --ui-args frontend/src/entrypoints/task-detail.test.tsx frontend/src/entrypoints/task-create.test.tsx` for final focused frontend evidence.
+- [ ] T037 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/api/routers/test_executions.py tests/unit/workflows/temporal/test_temporal_service.py` for final focused backend evidence.
+- [ ] T038 Run `/speckit.verify` final verification and write the result to `specs/224-remediation-mission-control/verification.md`. (SC-008)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1): no dependencies.
+- Foundational (Phase 2): depends on Setup and blocks UI story work.
+- Story (Phase 3): depends on backend/read-model foundation where needed.
+- Polish (Phase 4): depends on story tests and implementation passing.
+
+### Within The Story
+
+- API/read-model tests must be authored before backend route changes.
+- UI tests must be authored before task-detail implementation.
+- Create action and data-fetch wiring should land before panels that consume remediation data.
+- Evidence grouping and approval controls depend on remediation panel data shape.
+- Final `/speckit.verify` runs only after tests pass and tasks are marked complete.
+
+### Parallel Opportunities
+
+- T004 can run in parallel with T002 and T003.
+- T005 and T006 can be written together; T007 is separate if approval uses a different route.
+- T013 through T021 are in the same frontend test file family and should be edited in one ordered batch.
+- T033 and T034 can run in parallel after implementation and tests pass.
+
+## Implementation Strategy
+
+1. Lock the backend remediation read/approval contract with failing tests.
+2. Implement the smallest trusted API/read-model surface Mission Control needs.
+3. Add task-detail and create-page UI tests for every visible operator state.
+4. Implement the UI panels using existing Mission Control evidence-region styling.
+5. Run focused frontend and backend verification.
+6. Run `/speckit.verify` and record final evidence.
+
+## Notes
+
+- This task list covers one story only: MM-437 / STORY-007.
+- Do not implement automatic self-healing, new action registry kinds, raw log embedding, or direct raw storage access.
+- Preserve the canonical `task.remediation` create contract and existing non-remediation task behavior.

--- a/specs/224-remediation-mission-control/verification.md
+++ b/specs/224-remediation-mission-control/verification.md
@@ -1,0 +1,32 @@
+# Verification: Remediation Mission Control Surfaces
+
+**Feature**: `specs/224-remediation-mission-control`
+**Date**: 2026-04-22
+**Verdict**: IMPLEMENTATION_NOT_RUN
+
+## Summary
+
+Jira Orchestrate artifact generation for MM-437 / STORY-007 is complete through specify, plan, tasks, and alignment. Production implementation was intentionally not run because the task instruction says: "Do not run implementation inline inside the breakdown task."
+
+## Artifact Coverage
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| MM-437 and STORY-007 input preserved | VERIFIED | `spec.md`, `tasks.md`, and this verification file |
+| One-story spec | VERIFIED | `spec.md` defines one user story |
+| Source design mappings | VERIFIED | `DESIGN-REQ-001` through `DESIGN-REQ-008` in `spec.md` |
+| Plan and research | VERIFIED | `plan.md`, `research.md`, `data-model.md`, `contracts/remediation-mission-control.md` |
+| TDD tasks | VERIFIED | `tasks.md` includes API/UI tests before implementation tasks |
+| Implementation | NOT RUN | Deferred to the generated implementation task list |
+
+## Validation Commands
+
+```bash
+rg -n "MM-437|STORY-007|DESIGN-REQ-00[1-8]|FR-01[0-3]|SC-00[1-8]" specs/224-remediation-mission-control
+```
+
+Result: PASS during artifact generation.
+
+## Remaining Work
+
+Run the implementation tasks in `specs/224-remediation-mission-control/tasks.md`, then execute the focused frontend and backend test commands from `quickstart.md` and update this file with final implementation evidence.


### PR DESCRIPTION
Run Jira Orchestrate for MM-437.

Source story: STORY-007.
Source summary: Show remediation creation, evidence, links, and approvals in Mission Control.
Source Jira issue: unknown.
Original brief reference: not provided.

Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.