### PR TITLE
[codex] Fix PR resolver mergeability transition

### DIFF
--- a/.agents/skills/pr-resolver/SKILL.md
+++ b/.agents/skills/pr-resolver/SKILL.md
@@ -80,6 +80,7 @@ Repeat this state machine until a terminal success or manual blocker:
   - `ci_signal_degraded`
   - `merge_not_ready` (limited grace retries)
 - If retries transition from transient CI states into actionable `ci_failures`, continue into `run_fix_ci_skill` instead of stopping at manual review.
+- If `merge_not_ready` resolves into an actionable blocker such as `merge_conflicts`, continue into the matching remediation skill instead of stopping at manual review.
 - Non-retryable stop reasons:
   - `comment_policy_not_enforced`
   - any unknown blocker

--- a/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
+++ b/.agents/skills/pr-resolver/bin/pr_resolve_orchestrate.py
@@ -80,6 +80,10 @@ def _is_safe_reason_transition(previous: str, current: str) -> bool:
         return True
     if prev in FINALIZE_ONLY_RETRY_REASONS and curr in FINALIZE_ONLY_RETRY_REASONS:
         return True
+    if prev == "merge_not_ready" and (
+        curr in FULL_REMEDIATION_REASONS or curr in FINALIZE_ONLY_RETRY_REASONS
+    ):
+        return True
     if curr == "merge_not_ready" and prev in FINALIZE_ONLY_RETRY_REASONS:
         return True
     return False

--- a/tests/unit/test_pr_resolver_tools.py
+++ b/tests/unit/test_pr_resolver_tools.py
@@ -793,6 +793,59 @@ def test_orchestrate_merge_conflicts_after_ci_running_escalates_fix_conflicts(
     assert sleeps == [15]
 
 
+def test_orchestrate_merge_conflicts_after_merge_not_ready_escalates_fix_conflicts(
+    pr_resolve_orchestrate_module: dict[str, Any],
+) -> None:
+    run_orchestration = pr_resolve_orchestrate_module["run_orchestration"]
+
+    finalize_results = iter(
+        [
+            {
+                "status": "blocked",
+                "merge_outcome": "blocked",
+                "reason": "merge_not_ready",
+            },
+            {
+                "status": "blocked",
+                "merge_outcome": "blocked",
+                "reason": "merge_conflicts",
+            },
+            {
+                "status": "merged",
+                "merge_outcome": "merged",
+                "reason": "ci_complete",
+            },
+        ]
+    )
+    full_calls: list[tuple[int, int, str]] = []
+    sleeps: list[int] = []
+
+    result, exit_code = run_orchestration(
+        finalize_runner=lambda _attempt: next(finalize_results),
+        full_runner=lambda attempt, escalation, reason: (
+            full_calls.append((attempt, escalation, reason))
+            or {
+                "status": "needs_remediation",
+                "merge_outcome": "blocked",
+                "reason": reason,
+            }
+        ),
+        sleep_fn=lambda seconds: sleeps.append(seconds),
+        monotonic_fn=lambda: 0.0,
+        finalize_max_retries=3,
+        fix_max_iterations=3,
+        base_sleep_seconds=15,
+        max_sleep_seconds=60,
+        max_elapsed_seconds=900,
+        merge_not_ready_grace_retries=1,
+    )
+
+    assert exit_code == 0
+    assert result["status"] == "merged"
+    assert full_calls == [(2, 1, "merge_conflicts")]
+    assert sleeps == [15]
+
+
 def test_orchestrate_main_uses_extended_finalize_wait_defaults(
     pr_resolve_orchestrate_module: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- allow `merge_not_ready` to resolve into actionable remediation states without forcing manual review
- document that actionable mergeability transitions should continue into the matching remediation skill
- add a regression test for `merge_not_ready` -> `merge_conflicts` invoking conflict remediation

## Validation
- `./tools/test_unit.sh tests/unit/test_pr_resolver_tools.py`
- `./tools/test_unit.sh`

## Root Cause
GitHub can initially report a PR as not ready while mergeability settles, then later report concrete conflicts. The resolver treated that reason change as unsafe and returned `manual_review` before it could run `fix-merge-conflicts`.
