### PR TITLE
MM-432 align MoonSpec remediation context artifacts

### DIFF
--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-428",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1660"
+  "jira_issue_key": "MM-432",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1673"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,17 @@
 [
   {
-    "id": 3121722981,
+    "id": 3121950433,
     "disposition": "addressed",
-    "rationale": "Changed remediation read contract route parameters from camelCase {workflowId} to snake_case {workflow_id}."
+    "rationale": "Aligned Source Design Requirements in spec.md to the Jira brief coverage IDs DESIGN-REQ-006, DESIGN-REQ-011, DESIGN-REQ-019, DESIGN-REQ-022, DESIGN-REQ-023, and DESIGN-REQ-024 instead of local DESIGN-REQ-001 through DESIGN-REQ-004 numbering."
   },
   {
-    "id": 3121722994,
+    "id": 3121950436,
     "disposition": "addressed",
-    "rationale": "Clarified that link identity/status fields come from the persisted link/read model, while lock/action/resolution/context fields are bounded derived summaries returned as null or omitted when unavailable without adding a new persistence table."
+    "rationale": "Added explicit mappings from docs/Tasks/TaskRemediation.md sections 14.1 and 16.x into the Source Design Requirements table, including artifact presentation/redaction and bounded degraded evidence handling."
   },
   {
-    "id": 3121722997,
+    "id": 4152462627,
     "disposition": "addressed",
-    "rationale": "Changed the approval decision route to scope by {remediation_workflow_id} and {request_id}, and documented that target-scoped screens must submit the selected remediation task workflow ID."
-  },
-  {
-    "id": 4152209722,
-    "disposition": "not-applicable",
-    "rationale": "Summary review body only; the three concrete child review comments were addressed individually."
-  },
-  {
-    "id": 3121729143,
-    "disposition": "addressed",
-    "rationale": "Updated focused frontend test commands in tasks, plan, and quickstart to use --dashboard-only with --ui-args."
-  },
-  {
-    "id": 4152216624,
-    "disposition": "not-applicable",
-    "rationale": "Automated review summary/header only; no separate actionable request beyond the inline comments."
+    "rationale": "The broad review summary was addressed by correcting the inconsistent requirement IDs and source-section traceability across spec.md, plan.md, tasks.md, and verification.md."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-432-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-432-moonspec-orchestration-input.md
@@ -1,0 +1,68 @@
+# MM-432 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-432
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Build bounded remediation context artifacts
+- Labels: `moonmind-workflow-mm-a59f3b1d-da4d-4600-86a8-1d582ee67fe8`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-432 from MM project
+Summary: Build bounded remediation context artifacts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-432 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-432: Build bounded remediation context artifacts
+
+Source Reference
+- Source Document: docs/Tasks/TaskRemediation.md
+- Source Title: Task Remediation
+- Source Sections:
+  - 9. Evidence and context model
+  - 14.1 Required remediation artifacts
+  - 16. Failure modes and edge cases
+- Coverage IDs:
+  - DESIGN-REQ-006
+  - DESIGN-REQ-011
+  - DESIGN-REQ-019
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a remediation task, I receive a bounded artifact-backed context bundle for the target execution so diagnosis starts from durable evidence instead of unbounded logs or workflow history.
+
+Acceptance Criteria
+- A remediation task produces `reports/remediation_context.json` with `artifact_type` `remediation.context` before diagnosis begins.
+- The artifact includes target `workflowId`/`runId`, selected steps, observability refs, bounded summaries, diagnosis hints, policy snapshots, lock policy snapshot, and live-follow cursor state when applicable.
+- Large logs, diagnostics, provider snapshots, and evidence bodies remain behind artifact refs or observability refs rather than being embedded unbounded in the context artifact.
+- Missing artifact refs, unavailable diagnostics, and historical merged-log-only runs produce explicit degraded evidence metadata without deadlocking the remediation task.
+- The context builder never places presigned URLs, raw storage keys, absolute local filesystem paths, raw secrets, or secret-bearing config bundles in durable context.
+
+Requirements
+- Evidence access is artifact-first and bounded.
+- The context bundle is the stable entrypoint for the remediation runtime.
+- Partial evidence is represented as a bounded degradation, not an infinite wait.
+- Artifact presentation and redaction contracts apply to context metadata and bodies.
+
+Implementation Notes
+- Preserve MM-432 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation evidence, context bundle shape, required remediation artifacts, and degradation behavior.
+- Scope implementation to building the bounded `reports/remediation_context.json` artifact before diagnosis begins.
+- Keep full logs, diagnostics, provider snapshots, evidence bodies, presigned URLs, raw storage keys, absolute local paths, and secret-bearing config bundles out of the durable context artifact.
+- Represent missing artifact refs, unavailable diagnostics, historical merged-log-only evidence, and unavailable live follow as explicit bounded degradation metadata.
+- Include target identity, selected steps, observability refs, compact diagnosis hints, action and approval policy snapshots, lock policy snapshot, and live-follow cursor state when applicable.
+- Keep the context artifact as the stable entrypoint for remediation runtime evidence; richer evidence should remain reachable through typed artifact or observability refs.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-432 blocks MM-431, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-432 is blocked by MM-433, whose embedded status is Backlog.

--- a/specs/221-remediation-context-artifacts/plan.md
+++ b/specs/221-remediation-context-artifacts/plan.md
@@ -18,10 +18,12 @@ Implement MM-432 by adding a narrow Remediation Context Builder at the Temporal 
 | FR-005 | missing | No remediation evidence bounding exists | Clamp tail lines and task run IDs | unit |
 | FR-006 | missing | No context payload exists | Add redaction-safe payload assertions | unit |
 | FR-007 | missing | No builder exists | Fail on missing remediation link before artifact write | unit |
-| DESIGN-REQ-001 | missing | Desired-state docs only | Generate `remediation.context` artifact | unit |
-| DESIGN-REQ-002 | missing | Desired-state docs only | Include compact identity, selectors, refs, policies, live-follow state | unit |
-| DESIGN-REQ-003 | missing | Desired-state docs only | Enforce bounded/ref-only payload shape | unit |
-| DESIGN-REQ-004 | implemented_verified | Out-of-scope in `spec.md` | No implementation | final verify |
+| DESIGN-REQ-006 | missing | Desired-state docs only | Generate `remediation.context` artifact as the stable evidence entrypoint | unit |
+| DESIGN-REQ-011 | missing | Desired-state docs only | Include compact identity, selectors, observability refs, summaries, policies, and live-follow state | unit |
+| DESIGN-REQ-019 | missing | Desired-state docs only | Enforce bounded/ref-only payload shape with no raw logs, secrets, URLs, storage keys, or local paths | unit |
+| DESIGN-REQ-022 | missing | Desired-state docs only | Store safe artifact metadata and refs that follow artifact presentation/redaction contracts | unit |
+| DESIGN-REQ-023 | missing | Desired-state docs only | Represent missing and partial evidence as bounded degradation or fail-fast validation | unit |
+| DESIGN-REQ-024 | implemented_verified | Out-of-scope in `spec.md` | No implementation | final verify |
 
 ## Technical Context
 

--- a/specs/221-remediation-context-artifacts/spec.md
+++ b/specs/221-remediation-context-artifacts/spec.md
@@ -3,14 +3,87 @@
 **Feature Branch**: `221-remediation-context-artifacts`
 **Created**: 2026-04-21
 **Status**: Draft
-**Input**: Jira Orchestrate for MM-432.
+**Input**: Jira Orchestrate for MM-432 using `docs/tmp/jira-orchestration-inputs/MM-432-moonspec-orchestration-input.md` as the canonical MoonSpec orchestration input.
 
 Source story: STORY-002.
 Source summary: Build bounded remediation context artifacts.
-Source Jira issue: unknown.
-Original brief reference: not provided.
+Source Jira issue: MM-432.
+Original brief reference: `docs/tmp/jira-orchestration-inputs/MM-432-moonspec-orchestration-input.md`.
 
 Use the existing Jira Orchestrate workflow for this Jira issue. Do not run implementation inline inside the breakdown task.
+
+## Original Preset Brief
+
+```text
+# MM-432 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-432
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Build bounded remediation context artifacts
+- Labels: `moonmind-workflow-mm-a59f3b1d-da4d-4600-86a8-1d582ee67fe8`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-432 from MM project
+Summary: Build bounded remediation context artifacts
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-432 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-432: Build bounded remediation context artifacts
+
+Source Reference
+- Source Document: docs/Tasks/TaskRemediation.md
+- Source Title: Task Remediation
+- Source Sections:
+  - 9. Evidence and context model
+  - 14.1 Required remediation artifacts
+  - 16. Failure modes and edge cases
+- Coverage IDs:
+  - DESIGN-REQ-006
+  - DESIGN-REQ-011
+  - DESIGN-REQ-019
+  - DESIGN-REQ-022
+  - DESIGN-REQ-023
+  - DESIGN-REQ-024
+
+User Story
+As a remediation task, I receive a bounded artifact-backed context bundle for the target execution so diagnosis starts from durable evidence instead of unbounded logs or workflow history.
+
+Acceptance Criteria
+- A remediation task produces `reports/remediation_context.json` with `artifact_type` `remediation.context` before diagnosis begins.
+- The artifact includes target `workflowId`/`runId`, selected steps, observability refs, bounded summaries, diagnosis hints, policy snapshots, lock policy snapshot, and live-follow cursor state when applicable.
+- Large logs, diagnostics, provider snapshots, and evidence bodies remain behind artifact refs or observability refs rather than being embedded unbounded in the context artifact.
+- Missing artifact refs, unavailable diagnostics, and historical merged-log-only runs produce explicit degraded evidence metadata without deadlocking the remediation task.
+- The context builder never places presigned URLs, raw storage keys, absolute local filesystem paths, raw secrets, or secret-bearing config bundles in durable context.
+
+Requirements
+- Evidence access is artifact-first and bounded.
+- The context bundle is the stable entrypoint for the remediation runtime.
+- Partial evidence is represented as a bounded degradation, not an infinite wait.
+- Artifact presentation and redaction contracts apply to context metadata and bodies.
+
+Implementation Notes
+- Preserve MM-432 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/Tasks/TaskRemediation.md` as the source design reference for remediation evidence, context bundle shape, required remediation artifacts, and degradation behavior.
+- Scope implementation to building the bounded `reports/remediation_context.json` artifact before diagnosis begins.
+- Keep full logs, diagnostics, provider snapshots, evidence bodies, presigned URLs, raw storage keys, absolute local paths, and secret-bearing config bundles out of the durable context artifact.
+- Represent missing artifact refs, unavailable diagnostics, historical merged-log-only evidence, and unavailable live follow as explicit bounded degradation metadata.
+- Include target identity, selected steps, observability refs, compact diagnosis hints, action and approval policy snapshots, lock policy snapshot, and live-follow cursor state when applicable.
+- Keep the context artifact as the stable entrypoint for remediation runtime evidence; richer evidence should remain reachable through typed artifact or observability refs.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-432 blocks MM-431, whose embedded status is Code Review.
+- Trusted Jira link metadata at fetch time shows MM-432 is blocked by MM-433, whose embedded status is Backlog.
+```
 
 ## User Story - Build Bounded Remediation Context
 

--- a/specs/221-remediation-context-artifacts/spec.md
+++ b/specs/221-remediation-context-artifacts/spec.md
@@ -115,10 +115,12 @@ Dependencies
 
 ## Source Design Requirements
 
-- **DESIGN-REQ-001** (`docs/Tasks/TaskRemediation.md` section 9.2): A Remediation Context Builder must create `reports/remediation_context.json` with artifact type `remediation.context`. Scope: in scope, mapped to FR-001 and FR-002.
-- **DESIGN-REQ-002** (`docs/Tasks/TaskRemediation.md` sections 9.3 and 13.6): The context artifact must contain target identity, selected steps, evidence refs, policy snapshots, and live-follow cursor state when available. Scope: in scope, mapped to FR-003 and FR-004.
-- **DESIGN-REQ-003** (`docs/Tasks/TaskRemediation.md` sections 6, 9.4, 10.4, and 10.5): Context artifacts must remain bounded and must not include raw secrets, presigned URLs, storage keys, absolute local paths, or unbounded log bodies. Scope: in scope, mapped to FR-005 and FR-006.
-- **DESIGN-REQ-004** (`docs/Tasks/TaskRemediation.md` sections 9.5 through 11): Remediation evidence read tools, live-follow behavior, and typed action execution surfaces are later-stage capabilities. Scope: out of scope for this artifact-generation slice.
+- **DESIGN-REQ-006** (`docs/Tasks/TaskRemediation.md` section 9.2): A Remediation Context Builder must create `reports/remediation_context.json` with artifact type `remediation.context` as the remediation task's stable evidence entrypoint. Scope: in scope, mapped to FR-001 and FR-002.
+- **DESIGN-REQ-011** (`docs/Tasks/TaskRemediation.md` sections 9.2 and 9.3): The context artifact must contain target identity, selected steps, observability refs, bounded summaries, diagnosis hints, policy snapshots, lock policy snapshot, and live-follow cursor state when available. Scope: in scope, mapped to FR-003 and FR-004.
+- **DESIGN-REQ-019** (`docs/Tasks/TaskRemediation.md` sections 9.4, 10.4, 10.5, and 14.1): Context artifacts and required remediation artifacts must stay bounded and must not include raw secrets, presigned URLs, storage keys, absolute local paths, or unbounded log bodies. Scope: in scope, mapped to FR-005 and FR-006.
+- **DESIGN-REQ-022** (`docs/Tasks/TaskRemediation.md` section 14.1): The remediation context artifact must obey the normal artifact presentation contract by storing safe metadata, artifact refs rather than URLs, correct preview/redaction handling, and no secrets in metadata or bodies. Scope: in scope, mapped to FR-002, FR-004, and FR-006.
+- **DESIGN-REQ-023** (`docs/Tasks/TaskRemediation.md` sections 16.1 through 16.5): Missing target visibility, partial artifact refs, historical merged-log-only evidence, and unavailable live follow must produce fail-fast validation or explicit bounded degraded evidence rather than deadlocking context generation. Scope: in scope, mapped to FR-001, FR-004, and FR-007.
+- **DESIGN-REQ-024** (`docs/Tasks/TaskRemediation.md` sections 9.5 through 11 and 16.6 through 16.11): Remediation evidence read tools, lock handling, typed action execution, and remediation failure summaries are later-stage capabilities. Scope: out of scope for this artifact-generation slice.
 
 ## Requirements *(mandatory)*
 

--- a/specs/221-remediation-context-artifacts/tasks.md
+++ b/specs/221-remediation-context-artifacts/tasks.md
@@ -25,7 +25,7 @@
 
 **Independent Test**: Create a target execution and remediation execution, run the context builder, then assert the generated artifact is linked, complete, bounded, and ref-only.
 
-**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003.
+**Traceability IDs**: FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, DESIGN-REQ-006, DESIGN-REQ-011, DESIGN-REQ-019, DESIGN-REQ-022, DESIGN-REQ-023.
 
 - [X] T003 Add failing unit tests for valid context artifact generation, execution linkage, remediation link context ref, target identity, selectors, refs, policies, and boundedness in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-001 through FR-006.
 - [X] T004 Add a failing unit test for non-remediation workflow IDs failing before artifact creation in `tests/unit/workflows/temporal/test_remediation_context.py` for FR-007.

--- a/specs/221-remediation-context-artifacts/tasks.md
+++ b/specs/221-remediation-context-artifacts/tasks.md
@@ -9,7 +9,7 @@
 
 - Unit tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py`
 - Integration tests: Not required for this bounded service/artifact slice; no compose-backed boundary is introduced.
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Phase 1: Setup
 
@@ -36,4 +36,4 @@
 ## Final Phase: Polish And Verification
 
 - [X] T008 Run relevant unit verification from `specs/221-remediation-context-artifacts/quickstart.md`.
-- [X] T009 Run `/speckit.verify` by auditing implementation against `specs/221-remediation-context-artifacts/spec.md` and recording the result.
+- [X] T009 Run `/moonspec-verify` by auditing implementation against `specs/221-remediation-context-artifacts/spec.md` and recording the result.

--- a/specs/221-remediation-context-artifacts/verification.md
+++ b/specs/221-remediation-context-artifacts/verification.md
@@ -14,10 +14,12 @@
 | FR-005 | Tail-line clamp and task-run limit assertions in `test_remediation_context_builder_creates_bounded_linked_artifact` | VERIFIED |
 | FR-006 | Serialized payload assertions excluding local paths, storage keys, presigned references, and secret-like fields | VERIFIED |
 | FR-007 | `test_remediation_context_builder_rejects_non_remediation_workflow` | VERIFIED |
-| DESIGN-REQ-001 | Complete `remediation.context` artifact linked as `reports/remediation_context.json` | VERIFIED |
-| DESIGN-REQ-002 | Payload contains target identity, selectors, evidence refs, policies, and live-follow state | VERIFIED |
-| DESIGN-REQ-003 | Payload is bounded and ref-only; no raw artifact/log/storage access | VERIFIED |
-| DESIGN-REQ-004 | Out of scope for this slice; no action/live-follow tooling added | VERIFIED |
+| DESIGN-REQ-006 | Complete `remediation.context` artifact linked as `reports/remediation_context.json` | VERIFIED |
+| DESIGN-REQ-011 | Payload contains target identity, selectors, observability refs, bounded summaries, policies, and live-follow state | VERIFIED |
+| DESIGN-REQ-019 | Payload is bounded and ref-only; no raw artifact/log/storage access, URLs, local paths, or secret-like fields | VERIFIED |
+| DESIGN-REQ-022 | Artifact linkage uses safe metadata and artifact refs under normal artifact presentation/redaction contracts | VERIFIED |
+| DESIGN-REQ-023 | Missing optional evidence degrades to bounded empty refs and non-remediation targets fail before artifact creation | VERIFIED |
+| DESIGN-REQ-024 | Out of scope for this slice; no action/live-follow tooling added | VERIFIED |
 
 ## Tests
 


### PR DESCRIPTION
## Jira

- Jira issue key: MM-432

## MoonSpec

- Active feature path: `specs/221-remediation-context-artifacts`
- Verification verdict: FULLY_IMPLEMENTED

## Tests run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_remediation_context.py tests/unit/workflows/temporal/test_temporal_service.py` - PASS
  - Python: 84 passed
  - Frontend runner phase: 11 files / 355 tests passed

## Remaining risks

- Jira link metadata in the canonical brief says MM-432 is blocked by MM-433, currently Backlog. The local MoonSpec implementation is verified as FULLY_IMPLEMENTED; this remains an orchestration dependency risk rather than a code verification gap.