### PR TITLE
MM-445 Route Claude Settings auth actions

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/225-preserve-styling-invariants"
+  "feature_directory": "specs/226-route-claude-auth-actions"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,8 @@ Key diagnostics:
 - Existing agent skill tables and artifact-backed version content; no new persistent tables planned (206-agent-skill-catalog-source-policy)
 - TypeScript/React for Mission Control UI; CSS for shared Mission Control styling; Python 3.12 remains present but is not expected in this story + React, TanStack Query, existing Create page entrypoint, existing Mission Control stylesheet, Vitest and Testing Library (210-liquid-glass-panel)
 - No new persistent storage; existing task draft and submission payload state only (210-liquid-glass-panel)
+- TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected in this story + React, TanStack Query, existing Settings entrypoint, Vitest, Testing Library (226-route-claude-auth-actions)
+- No new persistent storage; uses existing provider profile row metadata and optional command/readiness data (226-route-claude-auth-actions)
 
 ## Recent Changes
 - 176-temporal-type-gates: Added Python 3.12 + Pydantic v2, Temporal Python SDK, pytest, existing MoonMind Temporal workflow test helpers

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-430",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1671"
+  "jira_issue_key": "MM-445",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1675"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3121885533,
+    "id": 3122381615,
     "disposition": "addressed",
-    "rationale": "Cached the parsed PostCSS root so cssRuleBlock and matching helpers no longer parse the full Mission Control stylesheet on every lookup."
+    "rationale": "Updated Claude manual auth classification to require the canonical claude_code runtime and covered it in ProviderProfilesManager tests."
   },
   {
-    "id": 3121885539,
-    "disposition": "addressed",
-    "rationale": "Expanded token-first color assertions to cover shorthand border, outline, and box-shadow declarations."
-  },
-  {
-    "id": 4152392996,
+    "id": 4152931396,
     "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary; its actionable inline comments are tracked separately in this ledger."
+    "rationale": "Automated review summary with no separate actionable request."
   },
   {
-    "id": 4152397163,
+    "id": 3122381622,
+    "disposition": "addressed",
+    "rationale": "Preserved Claude manual auth status rendering even when no lifecycle actions are currently exposed, with a status-only test case."
+  },
+  {
+    "id": 4152938547,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper with no separate actionable request."
-  },
-  {
-    "id": 3121889590,
-    "disposition": "addressed",
-    "rationale": "Normalized resolved paths to forward slashes before regex assertions so the boundary test is separator-agnostic."
-  },
-  {
-    "id": 3121889592,
-    "disposition": "addressed",
-    "rationale": "Added cssRuleBlocks and updated token-first validation to check every matching rule block for each semantic selector."
+    "rationale": "Review summary only; it did not request a code change."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-445-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-445-moonspec-orchestration-input.md
@@ -1,0 +1,62 @@
+# MM-445 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-445
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Route claude_anthropic Settings auth actions to a Claude enrollment flow
+- Labels: `moonmind-workflow-mm-ee47cb53-4263-419f-aecd-fe52ac23f51c`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-445 from MM project
+Summary: Route claude_anthropic Settings auth actions to a Claude enrollment flow
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-445 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-445: Route claude_anthropic Settings auth actions to a Claude enrollment flow
+
+Source Reference
+- Source Document: docs/ManagedAgents/ClaudeAnthropicOAuth.md
+- Source Title: MoonMind Design: claude_anthropic Settings Authentication (Repo-Backed)
+- Source Sections:
+  - 2.1 Settings surface
+  - 2.3 Current Settings UI implementation
+  - 5.1 Placement
+  - 5.2 Row-level action model
+  - 10.1 Frontend
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-003
+  - DESIGN-REQ-007
+
+User Story
+As an operator configuring provider profiles, I can start Claude Anthropic authentication from the existing Providers & Secrets table and see Claude-specific actions instead of a Codex-shaped Auth control.
+
+Acceptance Criteria
+- `claude_anthropic` exposes a Connect Claude action when not connected.
+- Connected `claude_anthropic` rows expose Replace token, Validate, and Disconnect actions where supported by returned capability/readiness metadata.
+- Codex OAuth behavior remains available for `codex_default` without reusing Codex labels for Claude.
+- No new standalone Claude auth page or specs directory is created by this story.
+
+Requirements
+- Auth capability is derived from profile metadata or explicit strategy, not hardcoded to `profile.runtime_id === codex_cli`.
+- The provider profile row remains the entry point for Claude enrollment.
+- Action labels distinguish manual Claude enrollment from terminal OAuth.
+
+Implementation Notes
+- Preserve MM-445 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the source design reference for the Settings provider row placement, action model, and frontend behavior.
+- Scope implementation to routing `claude_anthropic` Settings authentication actions from the existing Providers & Secrets table into the Claude enrollment flow.
+- Keep Codex OAuth behavior available for `codex_default` and avoid reusing Codex OAuth labels for Claude-specific manual token enrollment.
+- Do not create a new standalone Claude auth page or a separate specs directory for this story.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-445 is blocked by MM-446, whose embedded status is Backlog.

--- a/docs/tmp/jira-orchestration-reports/MM-445-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-445-code-review-transition.md
@@ -1,0 +1,8 @@
+# MM-445 Code Review Transition
+
+- Jira issue: MM-445
+- Pull request: https://github.com/MoonLadderStudios/MoonMind/pull/1675
+- Confirmed Jira status: Code Review
+- Transition used: Code Review (`51`)
+- Jira-visible PR reference: added comment `10951`; Jira development metadata also reports a GitHub pull request.
+- Confirmed at: 2026-04-22T00:52:54.183-0700

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -306,6 +306,34 @@ describe('ProviderProfilesManager form controls', () => {
     account_label: 'Codex account',
   };
 
+  const claudeManualProfile: ProviderProfile = {
+    ...profile,
+    profile_id: 'claude-anthropic',
+    runtime_id: 'claude_cli',
+    provider_id: 'anthropic',
+    credential_source: 'secret_ref',
+    runtime_materialization_mode: 'api_key_env',
+    secret_refs: {},
+    command_behavior: {
+      auth_strategy: 'claude_manual_token',
+      auth_state: 'not_connected',
+      auth_actions: ['connect'],
+      auth_status_label: 'Claude token not connected',
+    },
+  };
+
+  const connectedClaudeManualProfile: ProviderProfile = {
+    ...claudeManualProfile,
+    profile_id: 'claude-anthropic-connected',
+    secret_refs: { ANTHROPIC_AUTH_TOKEN: 'db://claude-token' },
+    command_behavior: {
+      auth_strategy: 'claude_manual_token',
+      auth_state: 'connected',
+      auth_actions: ['replace_token', 'validate', 'disconnect'],
+      auth_status_label: 'Claude token ready',
+    },
+  };
+
   it('labels secret refs and resets create-form values', () => {
     renderProviderProfilesManager();
 
@@ -549,5 +577,40 @@ describe('ProviderProfilesManager form controls', () => {
         expect.objectContaining({ method: 'POST' }),
       );
     });
+  });
+
+  it('shows a Claude-specific connect action for disconnected claude_anthropic rows', () => {
+    renderProviderProfilesManager([claudeManualProfile]);
+
+    expect(screen.getByRole('button', { name: 'Connect Claude claude-anthropic' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Auth claude-anthropic' })).toBeNull();
+    expect(screen.getByText('Claude token not connected')).toBeTruthy();
+  });
+
+  it('shows supported Claude lifecycle actions for connected claude_anthropic rows', () => {
+    renderProviderProfilesManager([connectedClaudeManualProfile]);
+
+    expect(
+      screen.getByRole('button', { name: 'Replace token claude-anthropic-connected' }),
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Validate claude-anthropic-connected' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Disconnect claude-anthropic-connected' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Auth claude-anthropic-connected' })).toBeNull();
+    expect(screen.getByText('Claude token ready')).toBeTruthy();
+  });
+
+  it('does not show Claude auth actions without trusted Claude metadata', () => {
+    renderProviderProfilesManager([
+      {
+        ...claudeManualProfile,
+        profile_id: 'claude-without-metadata',
+        command_behavior: {},
+      },
+    ]);
+
+    expect(screen.queryByRole('button', { name: /Connect Claude/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Replace token/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Validate/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Disconnect/ })).toBeNull();
   });
 });

--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -309,7 +309,7 @@ describe('ProviderProfilesManager form controls', () => {
   const claudeManualProfile: ProviderProfile = {
     ...profile,
     profile_id: 'claude-anthropic',
-    runtime_id: 'claude_cli',
+    runtime_id: 'claude_code',
     provider_id: 'anthropic',
     credential_source: 'secret_ref',
     runtime_materialization_mode: 'api_key_env',
@@ -608,6 +608,27 @@ describe('ProviderProfilesManager form controls', () => {
       },
     ]);
 
+    expect(screen.queryByRole('button', { name: /Connect Claude/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Replace token/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Validate/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Disconnect/ })).toBeNull();
+  });
+
+  it('shows Claude status without lifecycle actions when metadata has no actions', () => {
+    renderProviderProfilesManager([
+      {
+        ...claudeManualProfile,
+        profile_id: 'claude-status-only',
+        command_behavior: {
+          auth_strategy: 'claude_manual_token',
+          auth_state: 'enrollment_pending',
+          auth_actions: [],
+          auth_status_label: 'Claude enrollment pending',
+        },
+      },
+    ]);
+
+    expect(screen.getByText('Claude enrollment pending')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Connect Claude/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /Replace token/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /Validate/ })).toBeNull();

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -224,8 +224,86 @@ function summarizeSecretRefs(secretRefs: Record<string, string>): string {
   return entries.map(([key, value]) => `${key}: ${value}`).join(', ');
 }
 
-function isCodexOAuthCapable(profile: ProviderProfile): boolean {
-  return profile.runtime_id === 'codex_cli';
+type ProviderAuthActionLabel = 'Connect Claude' | 'Replace token' | 'Validate' | 'Disconnect';
+
+interface ClaudeAuthAction {
+  id: string;
+  label: ProviderAuthActionLabel;
+}
+
+type ProviderAuthModel =
+  | { kind: 'codex_oauth' }
+  | { kind: 'claude_manual'; statusLabel: string | null; actions: ClaudeAuthAction[] }
+  | { kind: 'none' };
+
+const CLAUDE_AUTH_ACTION_LABELS: Record<string, ProviderAuthActionLabel> = {
+  connect: 'Connect Claude',
+  replace_token: 'Replace token',
+  validate: 'Validate',
+  disconnect: 'Disconnect',
+};
+
+function commandBehaviorValue(profile: ProviderProfile, key: string): unknown {
+  const commandBehavior = profile.command_behavior;
+  if (!commandBehavior || typeof commandBehavior !== 'object' || Array.isArray(commandBehavior)) {
+    return undefined;
+  }
+  return commandBehavior[key];
+}
+
+function commandBehaviorString(profile: ProviderProfile, key: string): string | null {
+  const value = commandBehaviorValue(profile, key);
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function commandBehaviorStringArray(profile: ProviderProfile, key: string): string[] {
+  const value = commandBehaviorValue(profile, key);
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.trim() !== '');
+}
+
+function isCodexOAuthProfile(profile: ProviderProfile): boolean {
+  return (
+    profile.runtime_id === 'codex_cli' &&
+    (profile.credential_source === 'oauth_volume' ||
+      profile.runtime_materialization_mode === 'oauth_home' ||
+      Boolean(profile.volume_ref || profile.volume_mount_path))
+  );
+}
+
+function isClaudeManualAuthProfile(profile: ProviderProfile): boolean {
+  return (
+    profile.runtime_id === 'claude_cli' &&
+    profile.provider_id === 'anthropic' &&
+    commandBehaviorString(profile, 'auth_strategy') === 'claude_manual_token'
+  );
+}
+
+function providerAuthModel(profile: ProviderProfile): ProviderAuthModel {
+  if (isCodexOAuthProfile(profile)) {
+    return { kind: 'codex_oauth' };
+  }
+
+  if (!isClaudeManualAuthProfile(profile)) {
+    return { kind: 'none' };
+  }
+
+  const actions = commandBehaviorStringArray(profile, 'auth_actions')
+    .map((actionId) => {
+      const label = CLAUDE_AUTH_ACTION_LABELS[actionId];
+      return label ? { id: actionId, label } : null;
+    })
+    .filter((action): action is ClaudeAuthAction => action !== null);
+
+  if (actions.length === 0) {
+    return { kind: 'none' };
+  }
+
+  return {
+    kind: 'claude_manual',
+    statusLabel: commandBehaviorString(profile, 'auth_status_label'),
+    actions,
+  };
 }
 
 function oauthStatusLabel(status: OAuthSessionStatus): string {
@@ -738,7 +816,8 @@ export function ProviderProfilesManager({
             ) : (
               profiles.map((profile) => {
                 const oauthSession = oauthSessions[profile.profile_id];
-                const canStartOAuth = isCodexOAuthCapable(profile);
+                const authModel = providerAuthModel(profile);
+                const canStartOAuth = authModel.kind === 'codex_oauth';
                 return (
                 <tr key={profile.profile_id} role="row">
                   <td
@@ -828,6 +907,11 @@ export function ProviderProfilesManager({
                         {oauthSession.failureReason}
                       </div>
                     ) : null}
+                    {authModel.kind === 'claude_manual' && authModel.statusLabel ? (
+                      <div className="mt-2 text-xs font-medium text-slate-600 dark:text-slate-400">
+                        {authModel.statusLabel}
+                      </div>
+                    ) : null}
                   </td>
                   <td
                     className="px-3 py-4"
@@ -847,6 +931,24 @@ export function ProviderProfilesManager({
                           Auth
                         </button>
                       ) : null}
+                      {authModel.kind === 'claude_manual'
+                        ? authModel.actions.map((action) => (
+                            <button
+                              key={action.id}
+                              type="button"
+                              className="rounded-full border border-emerald-300 dark:border-emerald-700 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 transition hover:border-emerald-500 dark:hover:border-emerald-500"
+                              onClick={() =>
+                                onNotice({
+                                  level: 'ok',
+                                  text: `${action.label} selected for "${profile.profile_id}".`,
+                                })
+                              }
+                              aria-label={`${action.label} ${profile.profile_id}`}
+                            >
+                              {action.label}
+                            </button>
+                          ))
+                        : null}
                       {oauthSession && isActiveOAuthStatus(oauthSession.status) ? (
                         <button
                           type="button"

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -273,7 +273,7 @@ function isCodexOAuthProfile(profile: ProviderProfile): boolean {
 
 function isClaudeManualAuthProfile(profile: ProviderProfile): boolean {
   return (
-    profile.runtime_id === 'claude_cli' &&
+    profile.runtime_id === 'claude_code' &&
     profile.provider_id === 'anthropic' &&
     commandBehaviorString(profile, 'auth_strategy') === 'claude_manual_token'
   );
@@ -294,10 +294,6 @@ function providerAuthModel(profile: ProviderProfile): ProviderAuthModel {
       return label ? { id: actionId, label } : null;
     })
     .filter((action): action is ClaudeAuthAction => action !== null);
-
-  if (actions.length === 0) {
-    return { kind: 'none' };
-  }
 
   return {
     kind: 'claude_manual',

--- a/specs/226-route-claude-auth-actions/checklists/requirements.md
+++ b/specs/226-route-claude-auth-actions/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Route Claude Auth Actions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The specification records trusted Jira dependency metadata for MM-446 while preserving MM-445 as the selected single-story feature request.

--- a/specs/226-route-claude-auth-actions/contracts/provider-profile-auth-actions.md
+++ b/specs/226-route-claude-auth-actions/contracts/provider-profile-auth-actions.md
@@ -1,0 +1,59 @@
+# Contract: Provider Profile Auth Actions
+
+## Scope
+
+This contract defines the Settings row-level behavior for provider profile auth actions. It is a UI interaction contract, not a new HTTP API contract.
+
+## Inputs
+
+`ProviderProfilesManager` receives `ProviderProfile[]`.
+
+Relevant profile fields:
+
+```ts
+type ProviderProfile = {
+  profile_id: string;
+  runtime_id: string;
+  provider_id: string;
+  credential_source: string;
+  runtime_materialization_mode: string;
+  secret_refs: Record<string, string>;
+  command_behavior?: Record<string, unknown> | null;
+  enabled: boolean;
+};
+```
+
+Optional Claude metadata in `command_behavior`:
+
+```json
+{
+  "auth_strategy": "claude_manual_token",
+  "auth_state": "connected",
+  "auth_actions": ["replace_token", "validate", "disconnect"],
+  "auth_status_label": "Claude token ready"
+}
+```
+
+## Required Rendering
+
+- Codex OAuth-capable rows keep the existing `Auth`, `Cancel OAuth`, `Finalize`, and `Retry` behavior tied to OAuth session state.
+- Disconnected Claude Anthropic rows with supported metadata render a row action labeled `Connect Claude`.
+- Connected Claude Anthropic rows render only supported lifecycle labels:
+  - `Replace token`
+  - `Validate`
+  - `Disconnect`
+- Claude rows must not render the generic Codex `Auth` label.
+- Unsupported rows render no Claude auth action.
+- Optional Claude auth status text renders in the Status cell when metadata provides a secret-free `auth_status_label`.
+
+## Non-Goals
+
+- No standalone Claude auth page.
+- No raw token handling in this story.
+- No new provider profile persistence schema.
+- No changes to Codex OAuth request payloads or endpoints.
+
+## Verification
+
+- UI tests assert labels, omitted unsupported labels, status text, and preserved Codex OAuth behavior.
+- Final verification confirms MM-445 and source design mappings are preserved.

--- a/specs/226-route-claude-auth-actions/data-model.md
+++ b/specs/226-route-claude-auth-actions/data-model.md
@@ -1,0 +1,56 @@
+# Data Model: Route Claude Auth Actions
+
+## Provider Profile Row
+
+Represents one Settings table row for a configured runtime/provider profile.
+
+Fields used by this story:
+
+- `profile_id`: stable profile identifier shown in the row and used for action aria labels.
+- `runtime_id`: runtime identifier, retained for Codex OAuth compatibility but not sufficient by itself for Claude capability.
+- `provider_id`: provider identifier; `anthropic` identifies Claude Anthropic provider intent when paired with Claude metadata.
+- `credential_source`: credential source such as `oauth_volume`, `secret_ref`, or `none`.
+- `runtime_materialization_mode`: materialization mode such as `oauth_home` or `api_key_env`.
+- `secret_refs`: existing secret reference map; presence may indicate a connected secret-backed Claude profile.
+- `command_behavior`: optional trusted metadata for action/capability/readiness hints.
+- `enabled`: existing row enabled state.
+
+Validation rules:
+
+- Codex OAuth remains available for rows classified as Codex OAuth-capable by the existing credential/materialization shape.
+- Claude actions require a Claude Anthropic provider profile identity plus trusted strategy, capability, or readiness metadata.
+- Missing or unsupported metadata fails closed by omitting Claude lifecycle actions.
+
+## Auth Action Classification
+
+Derived row state used only by the frontend render path.
+
+Fields:
+
+- `kind`: `codex_oauth`, `claude_manual`, or `none`.
+- `status_label`: optional row-visible auth/readiness text.
+- `actions`: ordered row actions with display label and aria label.
+
+State transitions:
+
+- Disconnected Claude metadata -> `Connect Claude`.
+- Connected Claude metadata -> supported lifecycle actions (`Replace token`, `Validate`, `Disconnect`).
+- Failed or degraded Claude metadata -> status label plus supported recovery actions when metadata allows them.
+- Unsupported or missing metadata -> no Claude auth action.
+
+## Claude Auth Metadata
+
+Trusted profile metadata shape interpreted from `command_behavior` or existing readiness fields.
+
+Recommended keys:
+
+- `auth_strategy`: expected value `claude_manual_token` for this story.
+- `auth_state`: `not_connected`, `connected`, `failed`, or `degraded`.
+- `auth_actions`: array containing supported action identifiers: `connect`, `replace_token`, `validate`, `disconnect`.
+- `auth_status_label`: optional secret-free operator-readable status.
+
+Validation rules:
+
+- Raw tokens or secret values must never be present in metadata.
+- Unknown action identifiers are ignored.
+- Lifecycle labels are rendered only for supported action identifiers.

--- a/specs/226-route-claude-auth-actions/plan.md
+++ b/specs/226-route-claude-auth-actions/plan.md
@@ -11,25 +11,25 @@ Route `claude_anthropic` provider profile rows in Settings to Claude-specific au
 
 | ID | Status | Evidence | Planned Work | Required Tests |
 | --- | --- | --- | --- | --- |
-| FR-001 | implemented_unverified | `frontend/src/components/settings/ProviderProfilesManager.tsx` renders provider rows inside Settings Provider Profiles | preserve row-level placement and add Claude action assertions | unit UI |
-| FR-002 | missing | no Claude action classification exists | add disconnected Claude `Connect Claude` action | unit UI |
-| FR-003 | partial | `isCodexOAuthCapable(profile)` hardcodes `runtime_id === 'codex_cli'` | replace with metadata/strategy-based action classification | unit UI |
-| FR-004 | implemented_unverified | Codex OAuth tests cover Auth start/finalize/retry | keep Codex path unchanged and rerun targeted tests | unit UI |
-| FR-005 | missing | no connected Claude lifecycle action rendering exists | add supported `Replace token`, `Validate`, and `Disconnect` labels from trusted metadata/readiness | unit UI |
-| FR-006 | missing | Claude-specific labels are absent | render Claude labels and avoid Codex OAuth text for Claude rows | unit UI |
-| FR-007 | implemented_unverified | actions render in provider row; no standalone Claude route exists | keep Claude entrypoint in row and do not add route/page | unit UI + final verify |
-| FR-008 | missing | no fail-closed Claude capability logic exists | suppress Claude actions when metadata is absent or unsupported | unit UI |
-| FR-009 | partial | row status shows enabled/disabled and OAuth state only | surface concise Claude readiness/validation state where available | unit UI |
-| FR-010 | implemented_unverified | `spec.md` preserves MM-445 and design mappings | carry traceability through artifacts, tasks, verification, commit, and PR metadata | final verify |
-| SC-001 | missing | no disconnected Claude row assertion exists | add focused UI test for `Connect Claude` and omitted generic `Auth` | unit UI |
-| SC-002 | missing | no connected Claude lifecycle assertion exists | add focused UI test for supported lifecycle actions | unit UI |
-| SC-003 | implemented_unverified | existing Codex OAuth tests cover current behavior | rerun/update Codex regression tests after classifier change | unit UI |
-| SC-004 | missing | no assertion proves classifier avoids runtime-only Claude decisions | add unsupported/missing metadata fail-closed test | unit UI |
-| SC-005 | implemented_unverified | no standalone Claude page exists today | preserve row-local flow and verify no new route/page is added | unit UI + final verify |
-| SC-006 | implemented_unverified | `spec.md` and task artifacts preserve MM-445 and source mappings | carry traceability through verification | final verify |
-| DESIGN-REQ-001 | implemented_unverified | provider rows are already in Settings Provider Profiles | preserve placement and readiness/status visibility | unit UI |
-| DESIGN-REQ-003 | partial | Codex-only hardcoded helper is present | replace with profile metadata action classifier | unit UI |
-| DESIGN-REQ-007 | missing | Claude row-level labels are absent | add Claude-specific labels and no standalone page | unit UI |
+| FR-001 | verified | `ProviderProfilesManager.tsx` continues rendering actions inside Settings Provider Profiles; T018-T020 passed | preserve row-level placement | unit UI |
+| FR-002 | verified | disconnected Claude fixture renders `Connect Claude`; T004 and T017 passed | maintain disconnected Claude action | unit UI |
+| FR-003 | verified | provider-profile auth classifier derives actions from metadata/strategy instead of a Codex-only helper; T006 and T011 passed | maintain metadata/strategy-based action classification | unit UI |
+| FR-004 | verified | Codex OAuth regression assertions remained passing through T009, T016, T017, and T020 | keep Codex path unchanged | unit UI |
+| FR-005 | verified | connected Claude fixture renders supported `Replace token`, `Validate`, and `Disconnect` actions; T005 and T017 passed | maintain supported lifecycle labels | unit UI |
+| FR-006 | verified | Claude rows omit generic Codex `Auth` while rendering Claude labels; T004-T005 and T017 passed | maintain Claude-specific labels | unit UI |
+| FR-007 | verified | Claude actions remain row-local and no standalone Claude auth route/page was added; T012, T018, and T019 passed | keep Claude entrypoint in row | unit UI + final verify |
+| FR-008 | verified | unsupported or missing Claude metadata hides lifecycle actions; T006 and T014 passed | maintain fail-closed unsupported metadata behavior | unit UI |
+| FR-009 | verified | Claude metadata-backed status labels render in the Status cell; T007 and T015 passed | maintain secret-free status label rendering | unit UI |
+| FR-010 | verified | `spec.md`, `plan.md`, `tasks.md`, and verification artifacts preserve MM-445 and source mappings | carry traceability through verification, commit, and PR metadata | final verify |
+| SC-001 | verified | disconnected Claude row assertion covers `Connect Claude` and omitted generic `Auth`; T004 and T017 passed | maintain focused UI test | unit UI |
+| SC-002 | verified | connected Claude lifecycle assertion covers supported actions; T005 and T017 passed | maintain focused UI test | unit UI |
+| SC-003 | verified | Codex OAuth behavior remains covered by existing regression assertions; T009, T016, and T017 passed | maintain Codex regression tests | unit UI |
+| SC-004 | verified | unsupported metadata assertion proves action decisions are not runtime-only; T006 and T011 passed | maintain fail-closed test | unit UI |
+| SC-005 | verified | row-local flow and absence of standalone Claude auth route/page are covered by T018-T019 | maintain row-local verification | unit UI + final verify |
+| SC-006 | verified | MM-445 and DESIGN-REQ-001/003/007 remain present in spec, plan, tasks, and final verification work | maintain traceability | final verify |
+| DESIGN-REQ-001 | verified | provider rows remain in Settings Provider Profiles with readiness/status visibility; T015 and T018 passed | maintain placement and status visibility | unit UI |
+| DESIGN-REQ-003 | verified | Codex-only hardcoded helper was replaced by provider metadata action classification; T011 passed | maintain metadata classifier | unit UI |
+| DESIGN-REQ-007 | verified | Claude row-level labels render without a standalone page; T012-T019 passed | maintain Claude labels and row-local flow | unit UI |
 
 ## Technical Context
 

--- a/specs/226-route-claude-auth-actions/plan.md
+++ b/specs/226-route-claude-auth-actions/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: Route Claude Auth Actions
+
+**Branch**: `226-route-claude-auth-actions` | **Date**: 2026-04-22 | **Spec**: `specs/226-route-claude-auth-actions/spec.md`
+**Input**: Single-story feature specification from `specs/226-route-claude-auth-actions/spec.md`
+
+## Summary
+
+Route `claude_anthropic` provider profile rows in Settings to Claude-specific auth actions while preserving existing Codex OAuth behavior. Repo inspection shows the action surface already lives in `frontend/src/components/settings/ProviderProfilesManager.tsx`, but auth capability is currently hardcoded to `profile.runtime_id === 'codex_cli'`. The planned slice extracts provider-profile auth action classification from trusted row metadata, renders Claude-specific labels for supported Claude profiles, keeps Codex OAuth session wiring unchanged, and adds focused Vitest coverage in `frontend/src/components/settings/ProviderProfilesManager.test.tsx`.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | implemented_unverified | `frontend/src/components/settings/ProviderProfilesManager.tsx` renders provider rows inside Settings Provider Profiles | preserve row-level placement and add Claude action assertions | unit UI |
+| FR-002 | missing | no Claude action classification exists | add disconnected Claude `Connect Claude` action | unit UI |
+| FR-003 | partial | `isCodexOAuthCapable(profile)` hardcodes `runtime_id === 'codex_cli'` | replace with metadata/strategy-based action classification | unit UI |
+| FR-004 | implemented_unverified | Codex OAuth tests cover Auth start/finalize/retry | keep Codex path unchanged and rerun targeted tests | unit UI |
+| FR-005 | missing | no connected Claude lifecycle action rendering exists | add supported `Replace token`, `Validate`, and `Disconnect` labels from trusted metadata/readiness | unit UI |
+| FR-006 | missing | Claude-specific labels are absent | render Claude labels and avoid Codex OAuth text for Claude rows | unit UI |
+| FR-007 | implemented_unverified | actions render in provider row; no standalone Claude route exists | keep Claude entrypoint in row and do not add route/page | unit UI + final verify |
+| FR-008 | missing | no fail-closed Claude capability logic exists | suppress Claude actions when metadata is absent or unsupported | unit UI |
+| FR-009 | partial | row status shows enabled/disabled and OAuth state only | surface concise Claude readiness/validation state where available | unit UI |
+| FR-010 | implemented_unverified | `spec.md` preserves MM-445 and design mappings | carry traceability through artifacts, tasks, verification, commit, and PR metadata | final verify |
+| SC-001 | missing | no disconnected Claude row assertion exists | add focused UI test for `Connect Claude` and omitted generic `Auth` | unit UI |
+| SC-002 | missing | no connected Claude lifecycle assertion exists | add focused UI test for supported lifecycle actions | unit UI |
+| SC-003 | implemented_unverified | existing Codex OAuth tests cover current behavior | rerun/update Codex regression tests after classifier change | unit UI |
+| SC-004 | missing | no assertion proves classifier avoids runtime-only Claude decisions | add unsupported/missing metadata fail-closed test | unit UI |
+| SC-005 | implemented_unverified | no standalone Claude page exists today | preserve row-local flow and verify no new route/page is added | unit UI + final verify |
+| SC-006 | implemented_unverified | `spec.md` and task artifacts preserve MM-445 and source mappings | carry traceability through verification | final verify |
+| DESIGN-REQ-001 | implemented_unverified | provider rows are already in Settings Provider Profiles | preserve placement and readiness/status visibility | unit UI |
+| DESIGN-REQ-003 | partial | Codex-only hardcoded helper is present | replace with profile metadata action classifier | unit UI |
+| DESIGN-REQ-007 | missing | Claude row-level labels are absent | add Claude-specific labels and no standalone page | unit UI |
+
+## Technical Context
+
+**Language/Version**: TypeScript/React for Mission Control UI; Python 3.12 remains present but is not expected in this story  
+**Primary Dependencies**: React, TanStack Query, existing Settings entrypoint, Vitest, Testing Library  
+**Storage**: No new persistent storage; uses existing provider profile row metadata and optional command/readiness data  
+**Unit Testing**: `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx` for focused iteration; final unit verification through `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`  
+**Integration Testing**: UI integration-style coverage in `ProviderProfilesManager.test.tsx` for row rendering and Codex OAuth request behavior; no compose-backed service integration is required for this frontend-only row-action slice  
+**Target Platform**: Mission Control browser UI served by FastAPI  
+**Project Type**: Web UI  
+**Performance Goals**: Provider profile rows continue to render immediately without extra network calls for action classification  
+**Constraints**: Do not create a standalone Claude auth page; do not change Codex OAuth session API calls; do not expose raw secrets; preserve responsive table/card layout  
+**Scale/Scope**: One Settings provider profile table component and focused tests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- I. Orchestrate, Don't Recreate: PASS. The story uses the existing Settings provider profile orchestration surface.
+- II. One-Click Agent Deployment: PASS. No new services, secrets, or deployment prerequisites.
+- III. Avoid Vendor Lock-In: PASS. Claude-specific behavior is isolated to provider-profile action classification and does not alter core orchestration.
+- IV. Own Your Data: PASS. Existing provider profile metadata remains the source; no external SaaS storage is added.
+- V. Skills Are First-Class and Easy to Add: PASS. No changes to executable or agent skill contracts.
+- VI. Replaceable Scaffolding: PASS. Work is a narrow UI classifier and row rendering slice.
+- VII. Runtime Configurability: PASS. Action availability is driven by row metadata/strategy rather than hidden constants.
+- VIII. Modular Architecture: PASS. Changes stay in the Settings component and tests.
+- IX. Resilient by Default: PASS. Unsupported or absent Claude metadata fails closed by hiding misleading actions.
+- X. Continuous Improvement: PASS. Verification evidence is captured in MoonSpec artifacts.
+- XI. Spec-Driven Development: PASS. Work proceeds from this single-story spec.
+- XII. Canonical Documentation Separation: PASS. Implementation evidence stays under `specs/`; no canonical docs migration notes are added.
+- XIII. Pre-Release Velocity: PASS. No compatibility aliases or old/new translation layer are introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/226-route-claude-auth-actions/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── provider-profile-auth-actions.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/components/settings/
+├── ProviderProfilesManager.tsx
+└── ProviderProfilesManager.test.tsx
+
+docs/tmp/jira-orchestration-inputs/
+└── MM-445-moonspec-orchestration-input.md
+```
+
+**Structure Decision**: Preserve the existing Settings component boundary. Use `ProviderProfilesManager.test.tsx` for both pure row-action assertions and integration-style Codex OAuth regression coverage.
+
+## Complexity Tracking
+
+No constitution violations.

--- a/specs/226-route-claude-auth-actions/quickstart.md
+++ b/specs/226-route-claude-auth-actions/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: Route Claude Auth Actions
+
+## Focused Test-First Workflow
+
+1. Prepare frontend dependencies if needed:
+
+   ```bash
+   npm ci --no-fund --no-audit
+   ```
+
+2. Add failing UI tests in `frontend/src/components/settings/ProviderProfilesManager.test.tsx`:
+
+   ```bash
+   npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx
+   ```
+
+   Expected before implementation: tests for Claude-specific row actions fail because only Codex `Auth` is currently implemented.
+
+3. Implement row action classification in `frontend/src/components/settings/ProviderProfilesManager.tsx`.
+
+4. Re-run focused UI tests:
+
+   ```bash
+   npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx
+   ```
+
+5. Run final required unit verification:
+
+   ```bash
+   MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+   ```
+
+## End-To-End Story Check
+
+Render Settings with:
+
+- a disconnected `claude_anthropic` row carrying trusted Claude manual-token capability metadata,
+- a connected `claude_anthropic` row carrying supported lifecycle actions,
+- a `codex_default` or equivalent Codex OAuth-capable row,
+- an unsupported row with missing Claude metadata.
+
+The story passes when:
+
+- disconnected Claude shows `Connect Claude`;
+- connected Claude shows only supported `Replace token`, `Validate`, and `Disconnect` actions;
+- Claude rows do not show generic Codex `Auth`;
+- Codex OAuth still starts, finalizes, and retries through the existing OAuth session APIs;
+- unsupported rows show no misleading Claude auth action;
+- MM-445 and DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007 remain traceable in final verification.

--- a/specs/226-route-claude-auth-actions/research.md
+++ b/specs/226-route-claude-auth-actions/research.md
@@ -2,7 +2,7 @@
 
 ## FR-001 / DESIGN-REQ-001 - Provider Row Placement
 
-Decision: implemented_unverified; preserve existing Provider Profiles table placement.
+Decision: preserve existing Provider Profiles table placement.
 Evidence: `frontend/src/components/settings/ProviderProfilesManager.tsx` renders provider rows and action buttons in the Settings Provider Profiles table; tests already cover row/card labels in `frontend/src/components/settings/ProviderProfilesManager.test.tsx`.
 Rationale: The requested entrypoint already lives in the correct UI surface, so the story should extend row actions rather than add a page or route.
 Alternatives considered: A standalone Claude page was rejected because the Jira brief and source design explicitly forbid it.
@@ -10,7 +10,7 @@ Test implications: Unit UI assertions should prove Claude actions render in the 
 
 ## FR-002 / FR-005 / FR-006 / DESIGN-REQ-007 - Claude Labels And Lifecycle Actions
 
-Decision: missing; add a Claude action classifier that emits `Connect Claude` for disconnected rows and supported lifecycle labels for connected rows.
+Decision: add a Claude action classifier that emits `Connect Claude` for disconnected rows and supported lifecycle labels for connected rows.
 Evidence: Current action rendering only derives `canStartOAuth` from `isCodexOAuthCapable(profile)` and renders a generic `Auth` button.
 Rationale: The story is label and routing focused; lifecycle labels can be derived from trusted row metadata without implementing token persistence in this slice.
 Alternatives considered: Reusing the Codex OAuth button was rejected because the source design requires Claude-specific labels and action semantics.
@@ -18,7 +18,7 @@ Test implications: Unit UI tests must cover disconnected Claude, connected Claud
 
 ## FR-003 / DESIGN-REQ-003 - Metadata-Based Capability
 
-Decision: partial; replace the Codex-only auth helper with a classifier that considers runtime, provider, credential strategy, and explicit command/readiness metadata.
+Decision: replace the Codex-only auth helper with a classifier that considers runtime, provider, credential strategy, and explicit command/readiness metadata.
 Evidence: `isCodexOAuthCapable(profile)` currently returns true only when `profile.runtime_id === 'codex_cli'`; `ProviderProfile` already carries `provider_id`, `credential_source`, `runtime_materialization_mode`, `command_behavior`, and `secret_refs`.
 Rationale: The requirement forbids deciding capability solely from the Codex runtime check. A classifier can keep Codex OAuth support while enabling Claude only when the row identifies the Claude Anthropic provider and trusted metadata supports it.
 Alternatives considered: Adding backend schema fields first was rejected for this slice because the UI can consume existing row metadata and fail closed when metadata is absent.
@@ -26,7 +26,7 @@ Test implications: Tests should include a Claude row with explicit supported act
 
 ## FR-004 - Codex OAuth Regression
 
-Decision: implemented_unverified; preserve the existing Codex OAuth request path.
+Decision: preserve the existing Codex OAuth request path.
 Evidence: Tests named `starts a Codex OAuth session from the profile Auth action`, `supports OAuth finalize without offering reconnect after success`, and `supports OAuth retry actions for failed Settings sessions` cover the Codex path.
 Rationale: Claude action classification must not change the existing Codex OAuth session endpoints, payload, terminal launch, or labels.
 Alternatives considered: Renaming Codex `Auth` was rejected as unrelated scope.
@@ -34,7 +34,7 @@ Test implications: Existing Codex OAuth tests should continue passing; update on
 
 ## FR-008 - Fail-Closed Unsupported Metadata
 
-Decision: missing; unsupported Claude or missing metadata should show no Claude lifecycle actions.
+Decision: unsupported Claude or missing metadata should show no Claude lifecycle actions.
 Evidence: No current Claude auth logic exists.
 Rationale: Hiding actions is safer than presenting a misleading enrollment flow when the row does not expose trusted capability/readiness metadata.
 Alternatives considered: Showing `Connect Claude` for every `claude_cli` runtime was rejected because the spec requires metadata, provider, or credential strategy rather than runtime-only checks.
@@ -42,7 +42,7 @@ Test implications: Add a Claude-looking row without supported metadata and asser
 
 ## FR-009 - Readiness And Validation State
 
-Decision: partial; expose a concise Claude auth status line from trusted metadata when available.
+Decision: expose a concise Claude auth status line from trusted metadata when available.
 Evidence: Current status cell shows enabled/disabled and OAuth session status only.
 Rationale: Operators need to distinguish connected, disconnected, failed, and degraded Claude row states without leaving Settings.
 Alternatives considered: Adding a new backend readiness endpoint was rejected for this story to keep scope row-local.
@@ -54,4 +54,4 @@ Decision: preserve MM-445 and source mappings through all artifacts and final ve
 Evidence: `docs/tmp/jira-orchestration-inputs/MM-445-moonspec-orchestration-input.md` and `spec.md` include MM-445, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007.
 Rationale: Final verification and PR metadata need stable Jira/source references.
 Alternatives considered: None.
-Test implications: Final `/speckit.verify` should confirm traceability.
+Test implications: Final `/moonspec-verify` should confirm traceability.

--- a/specs/226-route-claude-auth-actions/research.md
+++ b/specs/226-route-claude-auth-actions/research.md
@@ -1,0 +1,57 @@
+# Research: Route Claude Auth Actions
+
+## FR-001 / DESIGN-REQ-001 - Provider Row Placement
+
+Decision: implemented_unverified; preserve existing Provider Profiles table placement.
+Evidence: `frontend/src/components/settings/ProviderProfilesManager.tsx` renders provider rows and action buttons in the Settings Provider Profiles table; tests already cover row/card labels in `frontend/src/components/settings/ProviderProfilesManager.test.tsx`.
+Rationale: The requested entrypoint already lives in the correct UI surface, so the story should extend row actions rather than add a page or route.
+Alternatives considered: A standalone Claude page was rejected because the Jira brief and source design explicitly forbid it.
+Test implications: Unit UI assertions should prove Claude actions render in the row and no standalone navigation is introduced.
+
+## FR-002 / FR-005 / FR-006 / DESIGN-REQ-007 - Claude Labels And Lifecycle Actions
+
+Decision: missing; add a Claude action classifier that emits `Connect Claude` for disconnected rows and supported lifecycle labels for connected rows.
+Evidence: Current action rendering only derives `canStartOAuth` from `isCodexOAuthCapable(profile)` and renders a generic `Auth` button.
+Rationale: The story is label and routing focused; lifecycle labels can be derived from trusted row metadata without implementing token persistence in this slice.
+Alternatives considered: Reusing the Codex OAuth button was rejected because the source design requires Claude-specific labels and action semantics.
+Test implications: Unit UI tests must cover disconnected Claude, connected Claude with supported actions, unsupported actions omitted, and absence of Codex labels.
+
+## FR-003 / DESIGN-REQ-003 - Metadata-Based Capability
+
+Decision: partial; replace the Codex-only auth helper with a classifier that considers runtime, provider, credential strategy, and explicit command/readiness metadata.
+Evidence: `isCodexOAuthCapable(profile)` currently returns true only when `profile.runtime_id === 'codex_cli'`; `ProviderProfile` already carries `provider_id`, `credential_source`, `runtime_materialization_mode`, `command_behavior`, and `secret_refs`.
+Rationale: The requirement forbids deciding capability solely from the Codex runtime check. A classifier can keep Codex OAuth support while enabling Claude only when the row identifies the Claude Anthropic provider and trusted metadata supports it.
+Alternatives considered: Adding backend schema fields first was rejected for this slice because the UI can consume existing row metadata and fail closed when metadata is absent.
+Test implications: Tests should include a Claude row with explicit supported actions and a non-Claude or unsupported row with no Claude action.
+
+## FR-004 - Codex OAuth Regression
+
+Decision: implemented_unverified; preserve the existing Codex OAuth request path.
+Evidence: Tests named `starts a Codex OAuth session from the profile Auth action`, `supports OAuth finalize without offering reconnect after success`, and `supports OAuth retry actions for failed Settings sessions` cover the Codex path.
+Rationale: Claude action classification must not change the existing Codex OAuth session endpoints, payload, terminal launch, or labels.
+Alternatives considered: Renaming Codex `Auth` was rejected as unrelated scope.
+Test implications: Existing Codex OAuth tests should continue passing; update only if aria labels need to distinguish action kind.
+
+## FR-008 - Fail-Closed Unsupported Metadata
+
+Decision: missing; unsupported Claude or missing metadata should show no Claude lifecycle actions.
+Evidence: No current Claude auth logic exists.
+Rationale: Hiding actions is safer than presenting a misleading enrollment flow when the row does not expose trusted capability/readiness metadata.
+Alternatives considered: Showing `Connect Claude` for every `claude_cli` runtime was rejected because the spec requires metadata, provider, or credential strategy rather than runtime-only checks.
+Test implications: Add a Claude-looking row without supported metadata and assert `Connect Claude` is absent.
+
+## FR-009 - Readiness And Validation State
+
+Decision: partial; expose a concise Claude auth status line from trusted metadata when available.
+Evidence: Current status cell shows enabled/disabled and OAuth session status only.
+Rationale: Operators need to distinguish connected, disconnected, failed, and degraded Claude row states without leaving Settings.
+Alternatives considered: Adding a new backend readiness endpoint was rejected for this story to keep scope row-local.
+Test implications: Add a UI assertion for a metadata-backed Claude readiness label when provided.
+
+## SC-* / Traceability
+
+Decision: preserve MM-445 and source mappings through all artifacts and final verification.
+Evidence: `docs/tmp/jira-orchestration-inputs/MM-445-moonspec-orchestration-input.md` and `spec.md` include MM-445, DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007.
+Rationale: Final verification and PR metadata need stable Jira/source references.
+Alternatives considered: None.
+Test implications: Final `/speckit.verify` should confirm traceability.

--- a/specs/226-route-claude-auth-actions/spec.md
+++ b/specs/226-route-claude-auth-actions/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Route Claude Auth Actions
+
+**Feature Branch**: `226-route-claude-auth-actions`
+**Created**: 2026-04-22
+**Status**: Draft
+**Input**:
+
+```text
+Jira issue: MM-445 from MM project
+Summary: Route claude_anthropic Settings auth actions to a Claude enrollment flow
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-445 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-445: Route claude_anthropic Settings auth actions to a Claude enrollment flow
+
+Source Reference
+- Source Document: docs/ManagedAgents/ClaudeAnthropicOAuth.md
+- Source Title: MoonMind Design: claude_anthropic Settings Authentication (Repo-Backed)
+- Source Sections:
+  - 2.1 Settings surface
+  - 2.3 Current Settings UI implementation
+  - 5.1 Placement
+  - 5.2 Row-level action model
+  - 10.1 Frontend
+- Coverage IDs:
+  - DESIGN-REQ-001
+  - DESIGN-REQ-003
+  - DESIGN-REQ-007
+
+User Story
+As an operator configuring provider profiles, I can start Claude Anthropic authentication from the existing Providers & Secrets table and see Claude-specific actions instead of a Codex-shaped Auth control.
+
+Acceptance Criteria
+- `claude_anthropic` exposes a Connect Claude action when not connected.
+- Connected `claude_anthropic` rows expose Replace token, Validate, and Disconnect actions where supported by returned capability/readiness metadata.
+- Codex OAuth behavior remains available for `codex_default` without reusing Codex labels for Claude.
+- No new standalone Claude auth page or specs directory is created by this story.
+
+Requirements
+- Auth capability is derived from profile metadata or explicit strategy, not hardcoded to `profile.runtime_id === codex_cli`.
+- The provider profile row remains the entry point for Claude enrollment.
+- Action labels distinguish manual Claude enrollment from terminal OAuth.
+
+Implementation Notes
+- Preserve MM-445 in MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+- Use `docs/ManagedAgents/ClaudeAnthropicOAuth.md` as the source design reference for the Settings provider row placement, action model, and frontend behavior.
+- Scope implementation to routing `claude_anthropic` Settings authentication actions from the existing Providers & Secrets table into the Claude enrollment flow.
+- Keep Codex OAuth behavior available for `codex_default` and avoid reusing Codex OAuth labels for Claude-specific manual token enrollment.
+- Do not create a new standalone Claude auth page or a separate specs directory for this story.
+
+Dependencies
+- Trusted Jira link metadata at fetch time shows MM-445 is blocked by MM-446, whose embedded status is Backlog.
+```
+
+## Classification
+
+Single-story runtime feature request. The brief contains one independently testable Settings behavior change: `claude_anthropic` provider profile rows must route authentication actions to Claude-specific enrollment controls while preserving existing Codex OAuth behavior.
+
+## User Story - Claude Settings Auth Actions
+
+**Summary**: As an operator configuring provider profiles, I want `claude_anthropic` rows in Providers & Secrets to show Claude-specific authentication actions so I can start or manage Claude enrollment without seeing Codex-shaped OAuth controls.
+
+**Goal**: Operators can manage Claude Anthropic authentication from the existing Provider Profiles table with labels and action availability that match Claude enrollment state, while Codex OAuth rows continue to behave as they do today.
+
+**Independent Test**: Render the Settings Providers & Secrets table with a disconnected `claude_anthropic` profile, a connected `claude_anthropic` profile, and `codex_default`. The story passes when Claude rows expose only Claude-specific actions appropriate to their state, the action entrypoint remains in the provider row, Codex still exposes its OAuth behavior, and no standalone Claude auth page is needed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `claude_anthropic` provider profile has no connected credential state, **When** the Providers & Secrets table renders, **Then** the row exposes a `Connect Claude` action instead of a generic `Auth` or Codex OAuth action.
+2. **Given** a `claude_anthropic` provider profile is connected and capability metadata supports lifecycle actions, **When** the row renders, **Then** it exposes Claude-specific `Replace token`, `Validate`, and `Disconnect` actions according to the supported capabilities.
+3. **Given** a `codex_default` provider profile is OAuth capable, **When** the Providers & Secrets table renders, **Then** the existing Codex OAuth action behavior and labels remain available.
+4. **Given** Claude authentication is started from Settings, **When** the operator activates the Claude action, **Then** the interaction stays anchored to the existing provider profile row and does not route to a new standalone Claude auth page.
+5. **Given** profile metadata is missing or does not indicate Claude auth support, **When** the Providers & Secrets table renders, **Then** the system avoids showing misleading Claude lifecycle actions.
+
+### Edge Cases
+
+- A `claude_anthropic` row has readiness data but no explicit lifecycle capability metadata.
+- A connected `claude_anthropic` row supports validation but not disconnect.
+- A `claude_anthropic` row is in a failed or degraded readiness state.
+- A non-Claude, non-Codex profile has the same runtime but a different provider or credential strategy.
+- Long profile names, provider names, and action labels render in narrow Settings layouts.
+
+## Assumptions
+
+- "Connected" means the provider row exposes trusted readiness, credential, or capability metadata indicating Claude enrollment is present.
+- The first slice may open an existing or newly added in-row modal or drawer entrypoint, but it must not create a separate Claude auth page.
+- The story is limited to Settings row action routing and visible action labels; backend token persistence may be represented by existing readiness or capability metadata if already available.
+- MM-446 is recorded as a Jira dependency, but this specification preserves the selected MM-445 story for downstream orchestration.
+
+## Source Design Requirements
+
+- **DESIGN-REQ-001** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 2.1): Claude Anthropic authentication should live in Settings > Providers & Secrets > Provider Profiles, using the existing provider profile surface for credential health, readiness, validation feedback, and lifecycle entrypoints. Scope: in scope, mapped to FR-001, FR-002, and FR-006.
+- **DESIGN-REQ-003** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` section 2.3): The current Settings UI gap is that auth capability is treated as Codex-only; Claude must become auth-capable without relying on the Codex-only runtime check. Scope: in scope, mapped to FR-003, FR-004, and FR-008.
+- **DESIGN-REQ-007** (`docs/ManagedAgents/ClaudeAnthropicOAuth.md` sections 5.1, 5.2, and 10.1): Claude rows should use row-level Claude-specific actions such as `Connect Claude`, `Replace token`, `Validate`, and `Disconnect`, should not reuse Codex labels, and should not create a separate Claude auth page. Scope: in scope, mapped to FR-002, FR-005, FR-006, and FR-007.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Settings MUST keep `claude_anthropic` authentication entrypoints inside Providers & Secrets > Provider Profiles.
+- **FR-002**: A disconnected `claude_anthropic` provider row MUST expose a `Connect Claude` action when trusted profile metadata indicates Claude enrollment is supported.
+- **FR-003**: Claude auth action availability MUST be derived from provider profile metadata, credential strategy, readiness, or explicit capability data rather than a Codex-only runtime check.
+- **FR-004**: `codex_default` and other Codex OAuth-capable profiles MUST retain their existing OAuth action behavior.
+- **FR-005**: Connected `claude_anthropic` rows MUST expose `Replace token`, `Validate`, and `Disconnect` actions only when trusted capability or readiness metadata supports those actions.
+- **FR-006**: Claude row actions MUST use Claude-specific labels and MUST NOT show Codex OAuth labels for Claude enrollment.
+- **FR-007**: Activating a Claude auth action MUST keep the operator in the existing Settings provider-profile flow and MUST NOT require or create a standalone Claude auth page.
+- **FR-008**: Profiles without trusted Claude auth capability metadata MUST NOT show misleading Claude enrollment actions.
+- **FR-009**: The provider row MUST continue to surface readiness, validation, failure, or degraded state in a way operators can distinguish from connected and disconnected states.
+- **FR-010**: MoonSpec artifacts, implementation notes, verification output, commit text, and pull request metadata MUST preserve MM-445 and the source design mappings.
+
+### Key Entities
+
+- **Provider Profile Row**: The Settings table row representing a runtime/provider credential configuration and its readiness state.
+- **Auth Capability Metadata**: Trusted profile, credential strategy, readiness, or lifecycle metadata that determines which auth actions are available.
+- **Claude Auth Action Set**: The Claude-specific row actions for starting, replacing, validating, or disconnecting Claude enrollment.
+- **Codex OAuth Action Set**: The existing Codex OAuth row behavior that must remain unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: UI tests confirm disconnected `claude_anthropic` rows show `Connect Claude` and do not show generic `Auth` or Codex-specific OAuth labels.
+- **SC-002**: UI tests confirm connected `claude_anthropic` rows show supported Claude lifecycle actions and omit unsupported actions.
+- **SC-003**: UI tests confirm `codex_default` keeps existing Codex OAuth behavior.
+- **SC-004**: Tests or verification confirm auth capability decisions are not hardcoded solely to `profile.runtime_id === codex_cli`.
+- **SC-005**: UI tests confirm Claude auth actions remain within the Providers & Secrets table flow and no standalone Claude auth page is introduced.
+- **SC-006**: Traceability verification confirms MM-445 and DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007 are preserved in MoonSpec artifacts and final verification evidence.

--- a/specs/226-route-claude-auth-actions/tasks.md
+++ b/specs/226-route-claude-auth-actions/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: Route Claude Auth Actions
+
+**Input**: Design documents from `/specs/226-route-claude-auth-actions/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Unit tests and integration-style UI tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: Tasks are grouped by phase around the single Claude Settings auth action story so the work stays focused, traceable, and independently testable.
+
+**Source Traceability**: MM-445; DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007; FR-001 through FR-010; SC-001 through SC-006.
+
+**Test Commands**:
+
+- Unit tests: `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+- Integration tests: `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+- Final verification: `/speckit.verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- Include exact file paths in descriptions
+- Include requirement, scenario, or source IDs when the task implements or validates behavior
+
+## Path Conventions
+
+- **Web app**: `frontend/src/components/settings/` for Settings UI and tests
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the existing Settings test harness is ready for this story.
+
+- [X] T001 Confirm `frontend/src/components/settings/ProviderProfilesManager.test.tsx` can run with `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the row-action classification boundary before story implementation.
+
+**CRITICAL**: No story implementation work can begin until this phase is complete.
+
+- [X] T002 Identify the current Codex OAuth action path and row status rendering in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-004 and DESIGN-REQ-003
+- [X] T003 Define the test fixture shape for trusted Claude auth metadata in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-003, FR-005, and FR-008
+
+**Checkpoint**: Foundation ready - story test and implementation work can now begin.
+
+---
+
+## Phase 3: Story - Claude Settings Auth Actions
+
+**Summary**: As an operator configuring provider profiles, I want `claude_anthropic` rows in Providers & Secrets to show Claude-specific authentication actions so I can start or manage Claude enrollment without seeing Codex-shaped OAuth controls.
+
+**Independent Test**: Render disconnected Claude, connected Claude, unsupported Claude, and Codex OAuth provider profile rows. The story passes when Claude rows show only trusted Claude-specific actions and status, unsupported rows fail closed, and Codex OAuth behavior remains unchanged.
+
+**Traceability**: MM-445, FR-001, FR-002, FR-003, FR-004, FR-005, FR-006, FR-007, FR-008, FR-009, FR-010, SC-001, SC-002, SC-003, SC-004, SC-005, SC-006, DESIGN-REQ-001, DESIGN-REQ-003, DESIGN-REQ-007
+
+**Test Plan**:
+
+- Unit: auth action classification from provider profile metadata, Claude label selection, unsupported metadata fail-closed behavior
+- Integration-style UI: rendered row actions/status and preserved Codex OAuth request behavior in the existing component test harness
+
+### Unit Tests (write first)
+
+> **NOTE**: Write these tests FIRST. Run them, confirm they FAIL for the expected reason, then implement only enough code to make them pass.
+
+- [X] T004 [P] Add failing UI test for disconnected `claude_anthropic` showing `Connect Claude` and no generic `Auth` in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-002, FR-006, SC-001, DESIGN-REQ-007
+- [X] T005 [P] Add failing UI test for connected `claude_anthropic` showing supported `Replace token`, `Validate`, and `Disconnect` actions in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-005, SC-002, DESIGN-REQ-007
+- [X] T006 [P] Add failing UI test for unsupported or missing Claude metadata hiding Claude lifecycle actions in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-003, FR-008
+- [X] T007 [P] Add failing UI test for Claude auth status text from trusted metadata in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-009, DESIGN-REQ-001
+- [X] T008 Run `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx` and confirm T004-T007 fail for the expected missing Claude action behavior
+
+### Integration Tests (write first)
+
+- [X] T009 [P] Preserve or update Codex OAuth regression assertions in `frontend/src/components/settings/ProviderProfilesManager.test.tsx` for FR-004 and SC-003
+- [X] T010 Run `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx` and confirm only the new Claude tests fail while existing Codex OAuth assertions remain meaningful
+
+### Implementation
+
+- [X] T011 Replace `isCodexOAuthCapable` with a provider-profile auth action classifier in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-003 and DESIGN-REQ-003
+- [X] T012 Render disconnected Claude `Connect Claude` row action without invoking the Codex OAuth mutation in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-002, FR-006, and FR-007
+- [X] T013 Render connected Claude lifecycle actions from supported trusted metadata in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-005 and DESIGN-REQ-007
+- [X] T014 Suppress Claude lifecycle actions when provider identity or trusted metadata is absent in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-008
+- [X] T015 Render optional Claude auth status text in the Status cell without exposing secrets in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-009
+- [X] T016 Preserve Codex OAuth session start/finalize/retry/cancel rendering and request behavior in `frontend/src/components/settings/ProviderProfilesManager.tsx` for FR-004
+- [X] T017 Run `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx` and fix failures until the focused Settings suite passes
+
+**Checkpoint**: The story is fully functional, covered by focused UI tests, and testable independently.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Strengthen the completed story without adding hidden scope.
+
+- [X] T018 [P] Review `frontend/src/components/settings/ProviderProfilesManager.tsx` for readable labels, accessible aria labels, and narrow row layout containment for SC-005
+- [X] T019 [P] Confirm no standalone Claude auth route, page, or specs directory was created outside `specs/226-route-claude-auth-actions` for FR-007 and SC-005
+- [X] T020 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification
+- [X] T021 Run `/speckit.verify` to validate the final implementation against MM-445 and DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks story work
+- **Story (Phase 3)**: Depends on Foundational phase completion
+- **Polish (Phase 4)**: Depends on the story being functionally complete and tests passing
+
+### Within The Story
+
+- Unit tests T004-T007 MUST be written and fail before implementation tasks T011-T016
+- Integration-style Codex regression check T009-T010 MUST remain meaningful before implementation
+- T011 classifier work must precede Claude rendering tasks T012-T015
+- T016 preserves Codex OAuth behavior and must be checked before final story validation T017
+- Final verification T021 runs only after focused and full unit tests pass or are explicitly blocked
+
+### Parallel Opportunities
+
+- T004-T007 can be authored together because they add independent assertions in the same test file but should be merged carefully
+- T012-T015 can be reasoned about together after T011, but implementation touches the same component and should be applied serially
+- T018 and T019 can run in parallel after story tests pass
+
+---
+
+## Parallel Example: Story Phase
+
+```bash
+# Launch conceptual test authoring together, then merge in one file:
+Task: "Add disconnected Claude action assertion in frontend/src/components/settings/ProviderProfilesManager.test.tsx"
+Task: "Add connected Claude lifecycle assertion in frontend/src/components/settings/ProviderProfilesManager.test.tsx"
+Task: "Add unsupported Claude fail-closed assertion in frontend/src/components/settings/ProviderProfilesManager.test.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### Test-Driven Story Delivery
+
+1. Complete setup and foundation checks.
+2. Add focused failing tests for Claude row actions/status and unsupported metadata.
+3. Confirm the focused test suite fails for the intended missing Claude behavior.
+4. Implement a small auth action classifier in `ProviderProfilesManager.tsx`.
+5. Render Claude-specific actions and status while preserving Codex OAuth mutations.
+6. Pass focused UI tests.
+7. Run full required unit verification.
+8. Run `/speckit.verify` and preserve MM-445 in the final report.
+
+---
+
+## Notes
+
+- MM-445 and the Jira preset brief are the canonical source for this story.
+- MM-446 is recorded as a Jira blocker dependency in the orchestration input; implementation should not broaden scope to MM-446.
+- Do not add token paste persistence, new backend endpoints, or standalone Claude auth pages in this story.

--- a/specs/226-route-claude-auth-actions/tasks.md
+++ b/specs/226-route-claude-auth-actions/tasks.md
@@ -13,7 +13,7 @@
 
 - Unit tests: `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
 - Integration tests: `npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx`
-- Final verification: `/speckit.verify`
+- Final verification: `/moonspec-verify`
 
 ## Format: `[ID] [P?] Description`
 
@@ -95,7 +95,7 @@
 - [X] T018 [P] Review `frontend/src/components/settings/ProviderProfilesManager.tsx` for readable labels, accessible aria labels, and narrow row layout containment for SC-005
 - [X] T019 [P] Confirm no standalone Claude auth route, page, or specs directory was created outside `specs/226-route-claude-auth-actions` for FR-007 and SC-005
 - [X] T020 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for final unit verification
-- [X] T021 Run `/speckit.verify` to validate the final implementation against MM-445 and DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007
+- [X] T021 Run `/moonspec-verify` to validate the final implementation against MM-445 and DESIGN-REQ-001, DESIGN-REQ-003, and DESIGN-REQ-007
 
 ---
 
@@ -146,7 +146,7 @@ Task: "Add unsupported Claude fail-closed assertion in frontend/src/components/s
 5. Render Claude-specific actions and status while preserving Codex OAuth mutations.
 6. Pass focused UI tests.
 7. Run full required unit verification.
-8. Run `/speckit.verify` and preserve MM-445 in the final report.
+8. Run `/moonspec-verify` and preserve MM-445 in the final report.
 
 ---
 


### PR DESCRIPTION
Jira issue key: MM-445

Active MoonSpec feature path: specs/226-route-claude-auth-actions

Verification verdict: FULLY_IMPLEMENTED

Tests run:
- node node_modules/vitest/vitest.mjs run --config frontend/vite.config.ts frontend/src/components/settings/ProviderProfilesManager.test.tsx: PASS (34 tests)
- MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh: PASS (3733 Python tests, 364 frontend tests)
- node node_modules/typescript/bin/tsc --noEmit -p frontend/tsconfig.json: PASS

Remaining risks:
- Non-blocking managed-container npm shim issue: npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx failed with vitest not found, while direct local Vitest and the canonical full unit runner passed.
- Jira dependency metadata recorded MM-446 as a blocker in Backlog at orchestration time; MM-445 implementation scope was preserved as requested.
