### PR TITLE
MM-460 Report Artifact Contract

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/225-preserve-styling-invariants"
+  "feature_directory": "specs/226-report-artifact-contract"
 }

--- a/artifacts/jira-orchestrate-pr.json
+++ b/artifacts/jira-orchestrate-pr.json
@@ -1,4 +1,4 @@
 {
-  "jira_issue_key": "MM-430",
-  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1671"
+  "jira_issue_key": "MM-460",
+  "pull_request_url": "https://github.com/MoonLadderStudios/MoonMind/pull/1676"
 }

--- a/artifacts/pr_resolver_addressed_comments.json
+++ b/artifacts/pr_resolver_addressed_comments.json
@@ -1,32 +1,22 @@
 [
   {
-    "id": 3121885533,
+    "id": 3122397775,
     "disposition": "addressed",
-    "rationale": "Cached the parsed PostCSS root so cssRuleBlock and matching helpers no longer parse the full Mission Control stylesheet on every lookup."
+    "rationale": "Allowed known service-managed preview_artifact_id metadata during report link validation and added a regression for linking restricted report artifacts after preview creation."
   },
   {
-    "id": 3121885539,
-    "disposition": "addressed",
-    "rationale": "Expanded token-first color assertions to cover shorthand border, outline, and box-shadow declarations."
-  },
-  {
-    "id": 4152392996,
+    "id": 4152948692,
     "disposition": "not-applicable",
-    "rationale": "Top-level bot review summary; its actionable inline comments are tracked separately in this ledger."
+    "rationale": "Automated review summary without a distinct actionable request."
   },
   {
-    "id": 4152397163,
+    "id": 3122402310,
+    "disposition": "addressed",
+    "rationale": "Simplified top-level report metadata validation by removing the redundant post-whitelist secret-key check while preserving unsafe unknown-key rejection."
+  },
+  {
+    "id": 4152954022,
     "disposition": "not-applicable",
-    "rationale": "Top-level automated review wrapper with no separate actionable request."
-  },
-  {
-    "id": 3121889590,
-    "disposition": "addressed",
-    "rationale": "Normalized resolved paths to forward slashes before regex assertions so the boundary test is separator-agnostic."
-  },
-  {
-    "id": 3121889592,
-    "disposition": "addressed",
-    "rationale": "Added cssRuleBlocks and updated token-first validation to check every matching rule block for each semantic selector."
+    "rationale": "Automated review summary; its single actionable item is tracked by comment 3122402310."
   }
 ]

--- a/docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md
+++ b/docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md
@@ -1,0 +1,78 @@
+# MM-460 MoonSpec Orchestration Input
+
+## Source
+
+- Jira issue: MM-460
+- Jira project key: MM
+- Issue type: Story
+- Current status at fetch time: In Progress
+- Summary: Report Artifact Contract
+- Labels: `moonmind-workflow-mm-ba49b1c2-6312-465a-bf68-0d46b37886cf`
+- Trusted fetch tool: `jira.get_issue`
+- Canonical source: normalized Jira preset brief synthesized from trusted Jira tool response fields because the MCP issue response did not expose `recommendedImports.presetInstructions`, `normalizedPresetBrief`, `presetBrief`, or `presetInstructions`.
+
+## Canonical MoonSpec Feature Request
+
+Jira issue: MM-460 from MM project
+Summary: Report Artifact Contract
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-460 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-460: Report Artifact Contract
+
+Short Name
+report-artifact-contract
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 1. Purpose, 1.1 Related docs and ownership boundaries, 2. Scope / Non-goals, 3. Core decision, 5. Non-goals, 8. Recommended report artifact classes, 10. Metadata model for report artifacts, 11. Storage and linkage rules, 21. Bottom line
+- Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-009
+
+User Story
+As a workflow producer, I can publish report deliverables using explicit report artifact link types and bounded metadata in the existing artifact system, so reports become first-class without creating a separate storage plane.
+
+Acceptance Criteria
+- Given a report-producing workflow publishes a canonical report, when the artifact is linked, then it uses `link_type = report.primary` and remains stored in the existing artifact store.
+- Given summary, structured results, evidence, appendix, findings-index, or export artifacts are part of a report deliverable, then they use the corresponding `report.*` link type instead of generic output classes.
+- Given report metadata is stored, then only bounded display and classification fields such as `artifact_type`, `report_type`, `report_scope`, `title`, `producer`, `subject`, `render_hint`, `counts`, `step_id`, and `attempt` are accepted for control-plane use.
+- Given metadata contains secrets, raw access grants, cookies, session tokens, or large inline payloads, then publication rejects or redacts those fields according to the existing artifact boundary.
+- Generic `output.primary`, `output.summary`, and `output.agent_result` flows continue to work for non-report deliverables.
+
+Requirements
+- Define stable report link types for `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `report.appendix`, `report.findings_index`, and `report.export`.
+- Represent reports as artifact families in the existing artifact system, not as a new storage system.
+- Standardize bounded report metadata keys while keeping detailed findings and large content in artifacts.
+- Keep report bodies and large supporting evidence artifact-backed instead of embedding them in workflow history or control-plane metadata.
+- Keep report semantics explicit without breaking generic output flows.
+
+Relevant Implementation Notes
+- Layer report-specific behavior on top of `docs/Temporal/WorkflowArtifactSystemDesign.md` and `docs/Temporal/ArtifactPresentationContract.md`; do not redefine artifact identity, storage, authorization, lifecycle, generic preview behavior, or rendering rules.
+- Use `report.*` link types only when an artifact is explicitly part of a report deliverable.
+- Continue using `output.primary`, `output.summary`, and `output.agent_result` for generic non-report outputs.
+- Store report artifacts in the existing artifact store and index with immutable artifact IDs and ordinary execution linkage.
+- Link report artifacts to the producing execution using standard execution references and `link_type` values such as `report.primary`, `report.summary`, `report.structured`, and `report.evidence`.
+- Keep standardized metadata bounded and safe for control-plane display; detailed findings belong in `report.structured` or other linked artifacts.
+- Preserve separation between curated reports and observability surfaces such as stdout, stderr, merged logs, diagnostics, provider snapshots, and session continuity artifacts.
+
+Non-Goals
+- Introducing a separate report blob store or replacing generic artifact APIs with a report-specific storage system.
+- Treating every `output.primary` artifact as a report.
+- Storing evidence, logs, diagnostics, or large report bodies inline inside one payload by default.
+- Introducing mutable in-place report updates.
+- Requiring every report workflow to produce PDF output.
+- Making Mission Control parse provider-native raw payloads as canonical reports.
+- Implementing provider-specific report-generation prompts, PDF rendering, full-text indexing, legal/compliance review, or mutable report update workflows.
+
+Validation
+- Verify report-producing workflows can publish a canonical `report.primary` artifact stored in the existing artifact system.
+- Verify report bundle artifacts use explicit `report.*` link types for primary report, summary, structured results, evidence, appendix, findings index, and export outputs.
+- Verify bounded report metadata accepts only safe display and classification keys and rejects or redacts secrets, raw grants, cookies, session tokens, and large inline payloads.
+- Verify generic `output.primary`, `output.summary`, and `output.agent_result` flows continue to work for non-report deliverables.
+- Verify report artifacts remain linked through existing execution artifact references without creating a separate storage plane.
+
+Needs Clarification
+- None

--- a/docs/tmp/jira-orchestration-reports/MM-460-code-review-transition.md
+++ b/docs/tmp/jira-orchestration-reports/MM-460-code-review-transition.md
@@ -1,0 +1,27 @@
+# MM-460 Code Review Transition
+
+Date: 2026-04-22
+
+## Pull Request Gate
+
+- Handoff artifact: `artifacts/jira-orchestrate-pr.json`
+- Confirmed Jira issue key: `MM-460`
+- Confirmed pull request URL: https://github.com/MoonLadderStudios/MoonMind/pull/1676
+
+## Jira Tool Evidence
+
+- Trusted tool surface: `MOONMIND_URL` `/mcp/tools`
+- Trusted issue fetch tool: `jira.get_issue`
+- Initial status from trusted fetch: `In Progress`
+- Trusted transition discovery tool: `jira.get_transitions`
+- Matched requested status `Code Review` against available transition name and target status.
+- Selected transition ID from Jira response: `51`
+- Added Jira-visible pull request reference with `jira.add_comment`; comment ID `10952`.
+- Applied transition with trusted transition tool: `jira.transition_issue`
+- Re-fetched `MM-460` with `jira.get_issue`.
+- Confirmed final status: `Code Review`
+
+## Notes
+
+- No raw Jira credentials were used.
+- The issue was not transitioned until after the PR URL was confirmed in the local handoff artifact.

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -1757,6 +1757,7 @@ class TemporalArtifactService:
         validate_report_artifact_contract(
             link_type=coerced_execution_ref.link_type,
             metadata=artifact.metadata_json,
+            allow_internal_metadata=True,
         )
         link = await self._repository.add_link(
             artifact_id=artifact_id,

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -1246,6 +1246,15 @@ class TemporalArtifactService:
                 raise TemporalArtifactValidationError("size_bytes must be non-negative")
 
         execution_ref = self._coerce_execution_ref(link)
+        if execution_ref is not None:
+            from moonmind.workflows.temporal.report_artifacts import (
+                validate_report_artifact_contract,
+            )
+
+            validate_report_artifact_contract(
+                link_type=execution_ref.link_type,
+                metadata=metadata_json,
+            )
         derived_retention = _derive_retention(
             retention_class,
             execution_ref.link_type if execution_ref else None,
@@ -1740,9 +1749,18 @@ class TemporalArtifactService:
     ) -> db_models.TemporalArtifactLink:
         artifact = await self._repository.get_artifact(artifact_id)
         self._assert_mutation_access(artifact, principal=principal)
+        coerced_execution_ref = self._coerce_execution_ref(execution_ref)
+        from moonmind.workflows.temporal.report_artifacts import (
+            validate_report_artifact_contract,
+        )
+
+        validate_report_artifact_contract(
+            link_type=coerced_execution_ref.link_type,
+            metadata=artifact.metadata_json,
+        )
         link = await self._repository.add_link(
             artifact_id=artifact_id,
-            execution=self._coerce_execution_ref(execution_ref),
+            execution=coerced_execution_ref,
         )
         if (
             artifact.retention_class

--- a/moonmind/workflows/temporal/report_artifacts.py
+++ b/moonmind/workflows/temporal/report_artifacts.py
@@ -1,0 +1,150 @@
+"""Report artifact link-type and metadata contract helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from moonmind.workflows.temporal.artifacts import TemporalArtifactValidationError
+
+
+REPORT_ARTIFACT_LINK_TYPES = frozenset(
+    {
+        "report.primary",
+        "report.summary",
+        "report.structured",
+        "report.evidence",
+        "report.appendix",
+        "report.findings_index",
+        "report.export",
+    }
+)
+
+REPORT_METADATA_KEYS = frozenset(
+    {
+        "artifact_type",
+        "report_type",
+        "report_scope",
+        "title",
+        "description",
+        "producer",
+        "subject",
+        "render_hint",
+        "name",
+        "is_final_report",
+        "finding_counts",
+        "severity_counts",
+        "counts",
+        "step_id",
+        "attempt",
+    }
+)
+
+_MAX_REPORT_METADATA_STRING_CHARS = 2048
+_MAX_REPORT_METADATA_DEPTH = 4
+_MAX_REPORT_METADATA_ITEMS = 64
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(token|password|secret|cookie|session|credential|grant|authorization|api[_-]?key)"
+)
+_SECRET_VALUE_PATTERN = re.compile(
+    r"(?i)(ghp_|github_pat_|AIza|ATATT|AKIA|token\s*[=:]|password\s*[=:]|"
+    r"authorization\s*:|-----BEGIN [A-Z ]*PRIVATE KEY-----)"
+)
+
+
+def is_report_artifact_link_type(link_type: str | None) -> bool:
+    """Return whether the link type is one of the supported report classes."""
+
+    return str(link_type or "").strip() in REPORT_ARTIFACT_LINK_TYPES
+
+
+def validate_report_artifact_contract(
+    *,
+    link_type: str | None,
+    metadata: Mapping[str, Any] | None,
+) -> None:
+    """Validate report-specific link-type and metadata invariants.
+
+    Non-report link types are intentionally ignored so generic artifact flows retain
+    their existing metadata behavior.
+    """
+
+    normalized_link_type = str(link_type or "").strip()
+    if not normalized_link_type.startswith("report."):
+        return
+    if normalized_link_type not in REPORT_ARTIFACT_LINK_TYPES:
+        raise TemporalArtifactValidationError(
+            f"unsupported report artifact link_type '{normalized_link_type}'"
+        )
+
+    _validate_report_metadata(dict(metadata or {}))
+
+
+def _validate_report_metadata(metadata: Mapping[str, Any]) -> None:
+    for key, value in metadata.items():
+        normalized_key = str(key or "").strip()
+        if normalized_key not in REPORT_METADATA_KEYS:
+            if _SECRET_KEY_PATTERN.search(normalized_key):
+                raise TemporalArtifactValidationError(
+                    f"unsafe report metadata key '{normalized_key}'"
+                )
+            raise TemporalArtifactValidationError(
+                f"unsupported report metadata key '{normalized_key}'"
+            )
+        if _SECRET_KEY_PATTERN.search(normalized_key):
+            raise TemporalArtifactValidationError(
+                f"unsafe report metadata key '{normalized_key}'"
+            )
+        _validate_report_metadata_value(value, path=normalized_key, depth=0)
+
+
+def _validate_report_metadata_value(value: Any, *, path: str, depth: int) -> None:
+    if depth > _MAX_REPORT_METADATA_DEPTH:
+        raise TemporalArtifactValidationError(
+            f"report metadata value is too large or deeply nested at '{path}'"
+        )
+    if value is None or isinstance(value, (bool, int, float)):
+        return
+    if isinstance(value, str):
+        if len(value) > _MAX_REPORT_METADATA_STRING_CHARS:
+            raise TemporalArtifactValidationError(
+                f"report metadata value is too large at '{path}'"
+            )
+        if _SECRET_VALUE_PATTERN.search(value):
+            raise TemporalArtifactValidationError(
+                f"unsafe report metadata value at '{path}'"
+            )
+        return
+    if isinstance(value, Mapping):
+        if len(value) > _MAX_REPORT_METADATA_ITEMS:
+            raise TemporalArtifactValidationError(
+                f"report metadata value is too large at '{path}'"
+            )
+        for nested_key, nested_value in value.items():
+            nested_path = f"{path}.{nested_key}"
+            if _SECRET_KEY_PATTERN.search(str(nested_key or "")):
+                raise TemporalArtifactValidationError(
+                    f"unsafe report metadata key '{nested_path}'"
+                )
+            _validate_report_metadata_value(
+                nested_value,
+                path=nested_path,
+                depth=depth + 1,
+            )
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        if len(value) > _MAX_REPORT_METADATA_ITEMS:
+            raise TemporalArtifactValidationError(
+                f"report metadata value is too large at '{path}'"
+            )
+        for index, item in enumerate(value):
+            _validate_report_metadata_value(
+                item,
+                path=f"{path}[{index}]",
+                depth=depth + 1,
+            )
+        return
+    raise TemporalArtifactValidationError(
+        f"unsupported report metadata value at '{path}'"
+    )

--- a/moonmind/workflows/temporal/report_artifacts.py
+++ b/moonmind/workflows/temporal/report_artifacts.py
@@ -40,6 +40,11 @@ REPORT_METADATA_KEYS = frozenset(
         "attempt",
     }
 )
+REPORT_INTERNAL_METADATA_KEYS = frozenset(
+    {
+        "preview_artifact_id",
+    }
+)
 
 _MAX_REPORT_METADATA_STRING_CHARS = 2048
 _MAX_REPORT_METADATA_DEPTH = 4
@@ -63,6 +68,7 @@ def validate_report_artifact_contract(
     *,
     link_type: str | None,
     metadata: Mapping[str, Any] | None,
+    allow_internal_metadata: bool = False,
 ) -> None:
     """Validate report-specific link-type and metadata invariants.
 
@@ -78,12 +84,24 @@ def validate_report_artifact_contract(
             f"unsupported report artifact link_type '{normalized_link_type}'"
         )
 
-    _validate_report_metadata(dict(metadata or {}))
+    _validate_report_metadata(
+        dict(metadata or {}),
+        allow_internal_metadata=allow_internal_metadata,
+    )
 
 
-def _validate_report_metadata(metadata: Mapping[str, Any]) -> None:
+def _validate_report_metadata(
+    metadata: Mapping[str, Any],
+    *,
+    allow_internal_metadata: bool,
+) -> None:
     for key, value in metadata.items():
         normalized_key = str(key or "").strip()
+        if (
+            allow_internal_metadata
+            and normalized_key in REPORT_INTERNAL_METADATA_KEYS
+        ):
+            continue
         if normalized_key not in REPORT_METADATA_KEYS:
             if _SECRET_KEY_PATTERN.search(normalized_key):
                 raise TemporalArtifactValidationError(
@@ -91,10 +109,6 @@ def _validate_report_metadata(metadata: Mapping[str, Any]) -> None:
                 )
             raise TemporalArtifactValidationError(
                 f"unsupported report metadata key '{normalized_key}'"
-            )
-        if _SECRET_KEY_PATTERN.search(normalized_key):
-            raise TemporalArtifactValidationError(
-                f"unsafe report metadata key '{normalized_key}'"
             )
         _validate_report_metadata_value(value, path=normalized_key, depth=0)
 

--- a/specs/226-report-artifact-contract/checklists/requirements.md
+++ b/specs/226-report-artifact-contract/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Report Artifact Contract
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Exactly one user story is defined
+- [x] Requirements are testable and unambiguous
+- [x] Runtime intent describes system behavior rather than docs-only changes, unless docs-only was explicitly requested
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Independent Test describes how the story can be validated end-to-end
+- [x] Acceptance scenarios are concrete enough to derive unit and integration tests
+- [x] No in-scope source design requirements are unmapped from functional requirements
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] The single user story covers the primary flow
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Runtime intent selected from the MM-460 task instructions.
+- The Jira preset brief identifies one independently testable story: report artifact link types and bounded metadata in the existing artifact system.

--- a/specs/226-report-artifact-contract/contracts/report-artifact-contract.md
+++ b/specs/226-report-artifact-contract/contracts/report-artifact-contract.md
@@ -1,0 +1,42 @@
+# Contract: Report Artifact Contract
+
+## Artifact Create
+
+Report artifact creation uses the existing artifact create path.
+
+When `link.link_type` is one of the supported `report.*` values:
+
+- `metadata` must contain only allowed report metadata keys.
+- metadata values must be compact and safe for control-plane display.
+- unsupported `report.*` link types must fail validation.
+- unsafe keys or values must fail validation before persistence.
+
+## Artifact Link
+
+Existing artifacts may be linked as report artifacts through the existing link path.
+
+When `execution_ref.link_type` is one of the supported `report.*` values:
+
+- the target artifact's current metadata must satisfy the report metadata contract.
+- unsupported `report.*` link types must fail validation.
+- the link is stored in the existing artifact link table.
+
+## Latest Report Lookup
+
+Latest report lookup uses existing execution artifact listing semantics:
+
+```text
+namespace + workflow_id + run_id + link_type = report.primary + latest_only
+```
+
+No report-specific latest pointer or table is added.
+
+## Generic Output Compatibility
+
+The following generic output link types remain valid non-report link types:
+
+- `output.primary`
+- `output.summary`
+- `output.agent_result`
+
+They are not aliases for report artifacts and do not require report metadata.

--- a/specs/226-report-artifact-contract/data-model.md
+++ b/specs/226-report-artifact-contract/data-model.md
@@ -1,0 +1,60 @@
+# Data Model: Report Artifact Contract
+
+## Report Link Type
+
+Stable string values used in existing `TemporalArtifactLink.link_type` records:
+
+- `report.primary`
+- `report.summary`
+- `report.structured`
+- `report.evidence`
+- `report.appendix`
+- `report.findings_index`
+- `report.export`
+
+Validation rules:
+
+- Values beginning with `report.` must be one of the supported values.
+- Non-report link types remain governed by the existing artifact system.
+- `output.primary`, `output.summary`, and `output.agent_result` remain valid generic output link types and are not report aliases.
+
+## Report Metadata
+
+Report metadata is stored in the existing artifact `metadata_json` payload.
+
+Allowed report metadata keys:
+
+- `artifact_type`
+- `report_type`
+- `report_scope`
+- `title`
+- `description`
+- `producer`
+- `subject`
+- `render_hint`
+- `name`
+- `is_final_report`
+- `finding_counts`
+- `severity_counts`
+- `counts`
+- `step_id`
+- `attempt`
+
+Validation rules:
+
+- Unknown report metadata keys are rejected.
+- Secret-like keys and values are rejected.
+- Raw access grant, cookie, session token, and credential fields are rejected.
+- Large inline string values are rejected.
+- Nested lists and objects are accepted only when they remain compact and contain safe scalar values.
+
+## State Transitions
+
+Report artifact lifecycle uses existing artifact states:
+
+1. Create pending artifact with optional report link and bounded metadata.
+2. Complete upload through existing artifact completion.
+3. Link an existing artifact with a report link type after validating its current metadata.
+4. List or fetch latest report artifact through existing execution link queries.
+
+No new report-specific persistence state is introduced.

--- a/specs/226-report-artifact-contract/plan.md
+++ b/specs/226-report-artifact-contract/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Report Artifact Contract
+
+**Branch**: `226-report-artifact-contract` | **Date**: 2026-04-22 | **Spec**: [spec.md](spec.md)  
+**Input**: Single-story feature specification from `specs/226-report-artifact-contract/spec.md`
+
+**Note**: `.specify/scripts/bash/setup-plan.sh --json` is not used because the managed branch name is not guaranteed to match the numeric feature-branch pattern. This plan follows the same output contract manually using `.specify/feature.json`.
+
+## Summary
+
+MM-460 adds the runtime artifact boundary needed for report-producing workflows to publish explicit report deliverables in the existing artifact system. The repository already supports arbitrary execution artifact link types, metadata storage, latest-by-link lookup, and generic output link types, but it does not define the stable `report.*` contract or reject unsafe/unbounded report metadata. The implementation will add report link-type constants and metadata validation, wire validation into artifact creation and link operations, preserve generic outputs, and verify the behavior through unit and artifact-service integration-style tests.
+
+## Requirement Status
+
+| ID | Status | Evidence | Planned Work | Required Tests |
+| --- | --- | --- | --- | --- |
+| FR-001 | partial | `TemporalArtifactService.create()` and `link_artifact()` already store and link artifacts | add report-specific validation without adding storage | unit + service integration |
+| FR-002 | missing | no report link-type constants or validation exist | define supported report link types | unit |
+| FR-003 | missing | arbitrary `report.*` link types currently pass through | reject unsupported report link types | unit + service integration |
+| FR-004 | missing | artifact metadata is stored as arbitrary JSON | restrict report metadata keys and value shapes | unit + service integration |
+| FR-005 | missing | no secret-like or large inline report metadata guard exists | reject unsafe report metadata before storage/linking | unit + service integration |
+| FR-006 | implemented_unverified | generic output link types are used in tests and workload output declarations | add regression proving generic outputs remain accepted | service integration |
+| FR-007 | implemented_verified | artifact schema already stores metadata and links in existing tables | no new storage; confirm via diff/final verify | final verify |
+| FR-008 | implemented_unverified | `latest_for_execution_link()` already filters by namespace, workflow_id, run_id, link_type | add report-primary latest lookup regression | service integration |
+| FR-009 | implemented_verified | source scope excludes provider prompting, PDF, indexing, legal review, and mutable updates | no implementation work | final verify |
+| FR-010 | partial | MM-460 preserved in spec and input brief | preserve in plan, tasks, and verification | final verify |
+| DESIGN-REQ-001 | partial | existing artifact store is the runtime storage plane | validate reports in existing artifact service | service integration |
+| DESIGN-REQ-002 | implemented_unverified | execution artifact linkage and latest lookup exist | add report link tests against existing linkage | service integration |
+| DESIGN-REQ-003 | missing | no `report.*` constants | add constants and validation | unit |
+| DESIGN-REQ-004 | implemented_unverified | generic outputs exist; no regression specific to report validation | prove generic outputs unaffected | service integration |
+| DESIGN-REQ-005 | missing | no bounded report metadata contract | add validator and tests | unit + service integration |
+| DESIGN-REQ-009 | implemented_verified | no implementation planned for excluded areas | final verify only | final verify |
+
+## Technical Context
+
+**Language/Version**: Python 3.12  
+**Primary Dependencies**: Pydantic v2, SQLAlchemy async ORM, existing Temporal artifact service and artifact API schemas  
+**Storage**: Existing Temporal artifact and artifact link tables only; no new persistent storage  
+**Unit Testing**: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh <python test targets>`  
+**Integration Testing**: Artifact-service integration-style tests under `tests/unit/workflows/temporal/test_artifacts.py`; optional full hermetic integration via `./tools/test_integration.sh` when Docker is available  
+**Target Platform**: MoonMind backend/workers on Linux containers  
+**Project Type**: Backend artifact contract and validation feature  
+**Performance Goals**: Report metadata validation is bounded by a small allowlist and rejects large inline values before storage  
+**Constraints**: No raw secrets in metadata; no new storage plane; generic output flows must remain compatible; report semantics must be explicit; MM-460 traceability must be preserved  
+**Scale/Scope**: Seven report link types and one bounded metadata contract for existing artifact create/link paths
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Orchestrate, Don't Recreate**: PASS. The feature extends the artifact orchestration boundary without changing agent behavior.
+- **II. One-Click Agent Deployment**: PASS. No new infrastructure or required external service is added.
+- **III. Avoid Vendor Lock-In**: PASS. The report contract is provider-neutral.
+- **IV. Own Your Data**: PASS. Reports remain in operator-controlled artifacts.
+- **V. Skills Are First-Class and Easy to Add**: PASS. The feature does not alter skill registration.
+- **VI. Scientific Method Scaffold**: PASS. Tests are planned before implementation.
+- **VII. Runtime Configurability**: PASS. No hardcoded deployment-specific values are introduced.
+- **VIII. Modular and Extensible Architecture**: PASS. Validation is isolated behind artifact contract helpers.
+- **IX. Resilient by Default**: PASS. The contract fails closed for unsafe report metadata.
+- **X. Facilitate Continuous Improvement**: PASS. Explicit report metadata improves downstream observability.
+- **XI. Spec-Driven Development**: PASS. This plan follows `specs/226-report-artifact-contract/spec.md`.
+- **XII. Documentation Separation**: PASS. Runtime design remains in canonical docs; implementation artifacts stay in `specs/`.
+- **XIII. Pre-Release Compatibility Policy**: PASS. The story adds strict report validation without compatibility aliases.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/226-report-artifact-contract/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── report-artifact-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+moonmind/
+└── workflows/
+    └── temporal/
+        ├── artifacts.py
+        └── report_artifacts.py
+
+tests/
+└── unit/
+    └── workflows/
+        └── temporal/
+            └── test_artifacts.py
+```
+
+**Structure Decision**: Implement the report contract inside the backend Temporal artifact layer. Keep report validation separate from persistence code in `report_artifacts.py`, and call it from artifact create/link paths.
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/226-report-artifact-contract/quickstart.md
+++ b/specs/226-report-artifact-contract/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Report Artifact Contract
+
+## Targeted Validation
+
+Run the focused artifact service tests:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py
+```
+
+Expected coverage:
+
+- Supported `report.*` link types are accepted.
+- Unsupported `report.*` link types are rejected.
+- Report metadata allowlist and bounded value rules are enforced.
+- Secret-like report metadata is rejected before storage.
+- Generic output links still work with generic metadata.
+- Latest `report.primary` lookup uses existing execution linkage.
+
+## Full Unit Validation
+
+Run the full unit suite before final handoff:
+
+```bash
+MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh
+```
+
+## Optional Hermetic Integration
+
+When Docker is available, run:
+
+```bash
+./tools/test_integration.sh
+```
+
+This story does not require provider credentials.

--- a/specs/226-report-artifact-contract/research.md
+++ b/specs/226-report-artifact-contract/research.md
@@ -1,0 +1,49 @@
+# Research: Report Artifact Contract
+
+## FR-001 / DESIGN-REQ-001 Existing Artifact Storage
+
+Decision: Implement report publishing as validation around the existing artifact create/link paths.
+Evidence: `moonmind/workflows/temporal/artifacts.py` already creates artifacts, persists metadata, links execution refs, and lists artifacts by execution.
+Rationale: MM-460 explicitly requires reports to remain artifact families in the existing system.
+Alternatives considered: A report-specific table or store was rejected by the source brief and Constitution storage constraints.
+Test implications: Service integration-style tests should create and link report artifacts through `TemporalArtifactService`.
+
+## FR-002 / FR-003 Report Link Types
+
+Decision: Define the supported report link types as runtime constants and reject unsupported `report.*` values.
+Evidence: Current `ExecutionRef.link_type` is a free-form string, so `report.unknown` would currently be accepted.
+Rationale: Stable report semantics require a bounded vocabulary while allowing existing non-report types.
+Alternatives considered: Database enum migration was rejected because arbitrary non-report link types remain valid and no new storage is planned.
+Test implications: Unit tests cover supported/unsupported link types; service tests cover create/link failure paths.
+
+## FR-004 / FR-005 Bounded Metadata
+
+Decision: Validate report metadata with an allowlist, compact value limits, and secret-like key/value rejection.
+Evidence: `TemporalArtifactService.create()` currently stores `metadata_json` directly after image attachment reserved-key checks.
+Rationale: Control-plane metadata must be safe and bounded; detailed findings belong in artifacts.
+Alternatives considered: Redacting metadata in place was rejected for this story because fail-closed behavior is clearer and safer at the artifact boundary.
+Test implications: Unit tests cover allowed metadata, unknown keys, large strings, nested payloads, and secret-like keys/values.
+
+## FR-006 Generic Outputs
+
+Decision: Keep `output.primary`, `output.summary`, and `output.agent_result` outside report validation.
+Evidence: Existing workload code declares `output.primary` and `output.summary`; artifact service tests already create `output.primary` links.
+Rationale: Source requirements explicitly say generic output flows continue to work for non-report deliverables.
+Alternatives considered: Auto-reclassifying generic outputs as reports was rejected by source non-goals.
+Test implications: Add a regression that generic output metadata can still contain non-report keys.
+
+## FR-008 Latest Report Discovery
+
+Decision: Use existing latest-by-execution-link behavior for `report.primary`.
+Evidence: `TemporalArtifactRepository.latest_for_execution_link()` filters by namespace, workflow ID, run ID, and link type.
+Rationale: The source doc defines latest-report selection as server query behavior, not mutable state.
+Alternatives considered: A separate latest-report pointer was rejected because it adds storage and mutable state.
+Test implications: Create two `report.primary` artifacts and verify `latest_only=True` returns the newer artifact.
+
+## Test Tooling
+
+Decision: Use `tests/unit/workflows/temporal/test_artifacts.py` for artifact-service integration-style coverage and focused pure-unit tests for the new validator.
+Evidence: The test file already provides isolated async SQLite fixtures and local artifact store coverage.
+Rationale: This validates the real service boundary without Docker or external credentials.
+Alternatives considered: Compose-backed integration tests are useful but unnecessary for this narrow service contract.
+Test implications: Targeted command is `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py`.

--- a/specs/226-report-artifact-contract/spec.md
+++ b/specs/226-report-artifact-contract/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Report Artifact Contract
+
+**Feature Branch**: `226-report-artifact-contract`  
+**Created**: 2026-04-22  
+**Status**: Draft  
+**Input**:
+
+```text
+Use the Jira preset brief for MM-460 as the canonical Moon Spec orchestration input.
+
+Additional constraints:
+
+
+Selected mode: runtime.
+Default to runtime mode and only use docs mode when explicitly requested.
+If the brief points at an implementation document, treat it as runtime source requirements.
+Source design path (optional): .
+
+Classify the input as a single-story feature request, broad technical or declarative design, or existing feature directory.
+Inspect existing Moon Spec artifacts and resume from the first incomplete stage instead of regenerating valid later-stage artifacts.
+```
+
+**Canonical Jira Brief**: `docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md`
+
+## Original Jira Preset Brief
+
+Jira issue: MM-460 from MM project
+Summary: Report Artifact Contract
+Issue type: Story
+Current Jira status: In Progress
+Jira project key: MM
+
+Use this Jira preset brief as the canonical MoonSpec orchestration input. Preserve the Jira issue key MM-460 in spec artifacts, implementation notes, verification output, commit text, and pull request metadata.
+
+MM-460: Report Artifact Contract
+
+Short Name
+report-artifact-contract
+
+Source Reference
+- Source document: `docs/Artifacts/ReportArtifacts.md`
+- Source title: Report Artifacts
+- Source sections: 1. Purpose, 1.1 Related docs and ownership boundaries, 2. Scope / Non-goals, 3. Core decision, 5. Non-goals, 8. Recommended report artifact classes, 10. Metadata model for report artifacts, 11. Storage and linkage rules, 21. Bottom line
+- Coverage IDs: DESIGN-REQ-001, DESIGN-REQ-002, DESIGN-REQ-003, DESIGN-REQ-004, DESIGN-REQ-005, DESIGN-REQ-009
+
+User Story
+As a workflow producer, I can publish report deliverables using explicit report artifact link types and bounded metadata in the existing artifact system, so reports become first-class without creating a separate storage plane.
+
+Acceptance Criteria
+- Given a report-producing workflow publishes a canonical report, when the artifact is linked, then it uses `link_type = report.primary` and remains stored in the existing artifact store.
+- Given summary, structured results, evidence, appendix, findings-index, or export artifacts are part of a report deliverable, then they use the corresponding `report.*` link type instead of generic output classes.
+- Given report metadata is stored, then only bounded display and classification fields such as `artifact_type`, `report_type`, `report_scope`, `title`, `producer`, `subject`, `render_hint`, `counts`, `step_id`, and `attempt` are accepted for control-plane use.
+- Given metadata contains secrets, raw access grants, cookies, session tokens, or large inline payloads, then publication rejects or redacts those fields according to the existing artifact boundary.
+- Generic `output.primary`, `output.summary`, and `output.agent_result` flows continue to work for non-report deliverables.
+
+Requirements
+- Define stable report link types for `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `report.appendix`, `report.findings_index`, and `report.export`.
+- Represent reports as artifact families in the existing artifact system, not as a new storage system.
+- Standardize bounded report metadata keys while keeping detailed findings and large content in artifacts.
+- Keep report bodies and large supporting evidence artifact-backed instead of embedding them in workflow history or control-plane metadata.
+- Keep report semantics explicit without breaking generic output flows.
+
+Relevant Implementation Notes
+- Layer report-specific behavior on top of `docs/Temporal/WorkflowArtifactSystemDesign.md` and `docs/Temporal/ArtifactPresentationContract.md`; do not redefine artifact identity, storage, authorization, lifecycle, generic preview behavior, or rendering rules.
+- Use `report.*` link types only when an artifact is explicitly part of a report deliverable.
+- Continue using `output.primary`, `output.summary`, and `output.agent_result` for generic non-report outputs.
+- Store report artifacts in the existing artifact store and index with immutable artifact IDs and ordinary execution linkage.
+- Link report artifacts to the producing execution using standard execution references and `link_type` values such as `report.primary`, `report.summary`, `report.structured`, and `report.evidence`.
+- Keep standardized metadata bounded and safe for control-plane display; detailed findings belong in `report.structured` or other linked artifacts.
+- Preserve separation between curated reports and observability surfaces such as stdout, stderr, merged logs, diagnostics, provider snapshots, and session continuity artifacts.
+
+Non-Goals
+- Introducing a separate report blob store or replacing generic artifact APIs with a report-specific storage system.
+- Treating every `output.primary` artifact as a report.
+- Storing evidence, logs, diagnostics, or large report bodies inline inside one payload by default.
+- Introducing mutable in-place report updates.
+- Requiring every report workflow to produce PDF output.
+- Making Mission Control parse provider-native raw payloads as canonical reports.
+- Implementing provider-specific report-generation prompts, PDF rendering, full-text indexing, legal/compliance review, or mutable report update workflows.
+
+Validation
+- Verify report-producing workflows can publish a canonical `report.primary` artifact stored in the existing artifact system.
+- Verify report bundle artifacts use explicit `report.*` link types for primary report, summary, structured results, evidence, appendix, findings index, and export outputs.
+- Verify bounded report metadata accepts only safe display and classification keys and rejects or redacts secrets, raw grants, cookies, session tokens, and large inline payloads.
+- Verify generic `output.primary`, `output.summary`, and `output.agent_result` flows continue to work for non-report deliverables.
+- Verify report artifacts remain linked through existing execution artifact references without creating a separate storage plane.
+
+Needs Clarification
+- None
+
+## User Story - Publish Report Artifacts
+
+**Summary**: As a workflow producer, I want to publish report deliverables using explicit report artifact link types and bounded metadata so consumers can distinguish reports from generic outputs without a separate storage plane.
+
+**Goal**: Report-producing workflows can identify primary reports, summaries, structured report data, evidence, appendices, findings indexes, and exports through stable artifact linkage while preserving existing generic output behavior for non-report deliverables.
+
+**Independent Test**: Create artifacts through the existing artifact service using report-specific and generic link types, then verify report link types and bounded metadata are accepted, unsafe report metadata is rejected, latest-report lookup works through existing execution linkage, and generic output links remain accepted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a report-producing workflow creates a final human-facing report artifact, **When** it links that artifact to an execution, **Then** it uses `report.primary` and the artifact remains stored in the existing artifact system.
+2. **Given** a report-producing workflow creates related summary, structured results, evidence, appendix, findings-index, or export artifacts, **When** those artifacts are linked, **Then** each artifact uses the matching `report.*` link type.
+3. **Given** a report artifact is created with display/classification metadata, **When** the metadata only contains bounded allowed keys, **Then** the artifact is accepted for control-plane use.
+4. **Given** a report artifact metadata payload contains raw secrets, access grants, cookies, session tokens, or large inline values, **When** publication is attempted, **Then** the artifact boundary rejects the metadata before storing it.
+5. **Given** a workflow publishes generic non-report output, **When** it uses `output.primary`, `output.summary`, or `output.agent_result`, **Then** the existing generic output flow continues to work and is not reclassified as a report.
+
+### Edge Cases
+
+- Report metadata uses unknown keys that could cause clients to infer unsupported semantics.
+- Report metadata includes nested objects or lists with large inline payloads.
+- Report metadata uses a secret-like key or secret-like value in nested content.
+- A completed artifact is later linked with a report link type.
+- Existing generic output artifacts are created with non-report link types.
+
+## Assumptions
+
+- The existing artifact store, execution linkage tables, authorization rules, lifecycle behavior, and preview/download model remain the storage and access boundary for reports.
+- Runtime producers will use the existing artifact service or activity boundary to create and link report artifacts.
+- The initial runtime slice validates link types and metadata at the artifact boundary; richer report-first UI presentation can build on the same contract later.
+
+## Source Design Requirements
+
+| ID | Source | Requirement | Scope | Mapped Requirements |
+| --- | --- | --- | --- | --- |
+| DESIGN-REQ-001 | `docs/Artifacts/ReportArtifacts.md` §1, §3 | Reports are first-class artifact families in the existing artifact system, not a separate storage plane. | In scope | FR-001, FR-007 |
+| DESIGN-REQ-002 | `docs/Artifacts/ReportArtifacts.md` §3, §11 | Report artifacts remain artifact-backed and linked to executions through the standard artifact link model. | In scope | FR-001, FR-008 |
+| DESIGN-REQ-003 | `docs/Artifacts/ReportArtifacts.md` §8 | Report-producing workflows use stable `report.*` link types for primary, summary, structured, evidence, appendix, findings-index, and export artifacts. | In scope | FR-002, FR-003 |
+| DESIGN-REQ-004 | `docs/Artifacts/ReportArtifacts.md` §8.3 | Generic `output.primary`, `output.summary`, and `output.agent_result` continue to work for non-report outputs. | In scope | FR-006 |
+| DESIGN-REQ-005 | `docs/Artifacts/ReportArtifacts.md` §10 | Report metadata is bounded to safe display and classification keys; detailed findings and large content stay in artifacts. | In scope | FR-004, FR-005 |
+| DESIGN-REQ-009 | `docs/Artifacts/ReportArtifacts.md` §2, §5 | PDF conversion, provider prompting, full-text indexing, legal review, mutable report updates, and treating all generic outputs as reports remain out of scope. | In scope as exclusions | FR-009 |
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow report-producing workflows to store report artifacts in the existing artifact store and link them to executions without creating a separate report storage mechanism.
+- **FR-002**: The system MUST define and accept the stable report link types `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `report.appendix`, `report.findings_index`, and `report.export`.
+- **FR-003**: The system MUST reject unsupported `report.*` link types so producers cannot create unregistered report semantics.
+- **FR-004**: The system MUST restrict report artifact metadata to bounded display and classification fields for control-plane use.
+- **FR-005**: The system MUST reject report metadata that contains secret-like keys, raw access grant fields, cookies, session token fields, or large inline payload values.
+- **FR-006**: The system MUST preserve existing generic output link types including `output.primary`, `output.summary`, and `output.agent_result` for non-report deliverables.
+- **FR-007**: The system MUST avoid creating any report-specific database table, blob store, or storage backend.
+- **FR-008**: The system MUST keep latest-report discovery compatible with existing execution artifact linkage by filtering on `(namespace, workflow_id, run_id, link_type)`.
+- **FR-009**: The system MUST keep provider-specific report prompting, PDF rendering, full-text indexing, legal review, mutable report updates, and automatic reclassification of generic outputs out of scope.
+- **FR-010**: Moon Spec artifacts, verification evidence, commit text, and pull request metadata for this work MUST preserve Jira issue key MM-460.
+
+### Key Entities
+
+- **Report Link Type**: A stable execution artifact link classification for report deliverables, including `report.primary`, `report.summary`, `report.structured`, `report.evidence`, `report.appendix`, `report.findings_index`, and `report.export`.
+- **Report Metadata**: Bounded artifact metadata for control-plane display and filtering, limited to approved display/classification keys and safe scalar or compact count values.
+- **Report Artifact Family**: A set of existing artifacts linked to one execution through `report.*` link types.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of accepted `report.*` artifact links use one of the seven supported report link types.
+- **SC-002**: 100% of report metadata payloads containing unsupported keys, secret-like keys/values, or inline string values over the configured report metadata limit are rejected before storage.
+- **SC-003**: Existing generic output link tests for `output.primary`, `output.summary`, and `output.agent_result` continue to pass without report-specific metadata requirements.
+- **SC-004**: Latest artifact lookup for `report.primary` returns the most recent primary report through the existing execution linkage query without any report-specific storage table.
+- **SC-005**: MM-460 appears in the spec, plan, tasks, verification evidence, and publish metadata for traceability.

--- a/specs/226-report-artifact-contract/tasks.md
+++ b/specs/226-report-artifact-contract/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Report Artifact Contract
+
+**Input**: Design documents from `/specs/226-report-artifact-contract/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/report-artifact-contract.md`, `quickstart.md`
+
+**Tests**: Unit tests and integration-style artifact service tests are REQUIRED. Write tests first, confirm they fail for the intended reason, then implement the production code until they pass.
+
+**Organization**: This task list covers exactly one user story: `Publish Report Artifacts`.
+
+**Source Traceability**: Original Jira issue `MM-460` and the original Jira preset brief are preserved in `spec.md` and `docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md`.
+
+**Test Commands**:
+
+- Unit and artifact service tests: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py`
+- Full unit verification: `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh`
+- Optional hermetic integration verification: `./tools/test_integration.sh`
+- Final verification: `/moonspec-verify`
+
+## Format: `[ID] [P?] Description`
+
+- **[P]**: Can run in parallel when the task touches different files and does not depend on incomplete tasks.
+- Include exact file paths in task descriptions.
+- Include requirement, scenario, success criterion, or source IDs when the task implements or validates behavior.
+
+## Path Conventions
+
+- Backend artifact code lives under `moonmind/workflows/temporal/`.
+- Unit and service integration-style tests live under `tests/unit/workflows/temporal/`.
+- Moon Spec artifacts live under `specs/226-report-artifact-contract/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the active feature context and artifact service surfaces.
+
+- [X] T001 Confirm `.specify/feature.json` points at `specs/226-report-artifact-contract` and preserve MM-460 traceability in `specs/226-report-artifact-contract/spec.md` (FR-010)
+- [X] T002 [P] Inspect artifact create/link/list behavior in `moonmind/workflows/temporal/artifacts.py` (FR-001, FR-008, DESIGN-REQ-001)
+- [X] T003 [P] Inspect existing artifact service tests in `tests/unit/workflows/temporal/test_artifacts.py` (FR-006, DESIGN-REQ-004)
+- [X] T004 [P] Inspect source report requirements in `docs/Artifacts/ReportArtifacts.md` (DESIGN-REQ-001 through DESIGN-REQ-005, DESIGN-REQ-009)
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add the focused validation surface before story behavior.
+
+- [X] T005 Create Moon Spec planning artifacts in `specs/226-report-artifact-contract/plan.md`, `research.md`, `data-model.md`, `contracts/report-artifact-contract.md`, and `quickstart.md` (FR-010)
+
+---
+
+## Phase 3: Story - Publish Report Artifacts
+
+**Summary**: As a workflow producer, I want to publish report deliverables using explicit report artifact link types and bounded metadata so consumers can distinguish reports from generic outputs without a separate storage plane.
+
+**Independent Test**: Create artifacts through the existing artifact service using report-specific and generic link types, then verify report link types and bounded metadata are accepted, unsafe report metadata is rejected, latest-report lookup works through existing execution linkage, and generic output links remain accepted.
+
+**Traceability**: FR-001 through FR-010, SC-001 through SC-005, DESIGN-REQ-001 through DESIGN-REQ-005, DESIGN-REQ-009.
+
+**Unit Test Plan**: Cover pure validation for supported report link types, unsupported report link types, allowed report metadata, unknown metadata keys, secret-like metadata, and large inline metadata.
+
+**Integration Test Plan**: Cover real `TemporalArtifactService.create()`, `link_artifact()`, and `list_for_execution(latest_only=True)` behavior using the existing isolated SQLite/local store test fixture.
+
+### Unit Tests
+
+- [X] T006 [P] Add failing pure validation tests for supported and unsupported report link types in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-002, FR-003, and DESIGN-REQ-003
+- [X] T007 [P] Add failing pure validation tests for bounded report metadata, unknown keys, secret-like values, and large inline values in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-004, FR-005, and DESIGN-REQ-005
+
+### Integration Tests
+
+- [X] T008 [P] Add failing artifact service test proving `report.primary` create/link succeeds with bounded metadata in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-001, FR-002, and DESIGN-REQ-001
+- [X] T009 [P] Add failing artifact service tests proving unsupported `report.*` link types and unsafe report metadata are rejected before storage/linking in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-003, FR-004, FR-005, SC-001, and SC-002
+- [X] T010 [P] Add failing artifact service test proving generic `output.primary`, `output.summary`, and `output.agent_result` links remain accepted with generic metadata in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-006 and DESIGN-REQ-004
+- [X] T011 [P] Add failing artifact service test proving latest `report.primary` lookup uses existing execution linkage in `tests/unit/workflows/temporal/test_artifacts.py` covering FR-008 and SC-004
+
+### Red-First Confirmation
+
+- [X] T012 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py` and confirm T006 through T011 fail for missing report artifact contract behavior
+
+### Implementation
+
+- [X] T013 Add report link-type constants and metadata validation helpers in `moonmind/workflows/temporal/report_artifacts.py` covering FR-002 through FR-005
+- [X] T014 Wire report link and metadata validation into `TemporalArtifactService.create()` in `moonmind/workflows/temporal/artifacts.py` covering FR-001 through FR-005
+- [X] T015 Wire report link and metadata validation into `TemporalArtifactService.link_artifact()` in `moonmind/workflows/temporal/artifacts.py` covering FR-003 through FR-005
+- [X] T016 Preserve generic output behavior without report metadata requirements in `moonmind/workflows/temporal/artifacts.py` covering FR-006 and DESIGN-REQ-004
+
+### Story Validation
+
+- [X] T017 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py` and fix failures until the story passes independently
+- [X] T018 Run `rg -n "MM-460|report.primary|report.findings_index|Report Artifact Contract" specs/226-report-artifact-contract docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md moonmind/workflows/temporal tests/unit/workflows/temporal/test_artifacts.py` and confirm traceability evidence exists
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+- [X] T019 Run `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` for full unit verification after targeted tests pass
+- [X] T020 Run `./tools/test_integration.sh` when Docker is available, or record Docker unavailability in final verification notes
+- [X] T021 Run a secret-pattern scan on changed files before final handoff
+- [X] T022 Review `git diff -- specs/226-report-artifact-contract docs/tmp/jira-orchestration-inputs/MM-460-moonspec-orchestration-input.md moonmind/workflows/temporal tests/unit/workflows/temporal/test_artifacts.py .specify/feature.json`
+- [X] T023 Run `/moonspec-verify` for `specs/226-report-artifact-contract` and preserve verification evidence for MM-460
+
+---
+
+## Dependencies & Execution Order
+
+- Phase 1 and Phase 2 must complete before story implementation.
+- T006 through T011 must be written before T012.
+- T012 must confirm red-first failures before T013 through T016.
+- T013 precedes T014 and T015.
+- T017 and T018 validate the completed story before Phase 4.
+- T019 through T023 are final verification and handoff tasks.
+
+## Parallel Opportunities
+
+- T002 through T004 can run in parallel.
+- T006 through T011 can be authored in parallel because they are focused test additions.
+- T014 and T015 can be implemented after T013 and affect separate service paths.
+
+## Implementation Strategy
+
+1. Complete Moon Spec setup and planning.
+2. Add red-first validator and artifact service tests.
+3. Confirm the targeted tests fail for missing report contract behavior.
+4. Add report contract helpers.
+5. Wire validation into existing artifact create/link paths.
+6. Run targeted tests, full unit verification, optional integration verification, secret scan, diff review, and final MoonSpec verification.
+
+## Notes
+
+- `MM-460` must remain visible in Moon Spec artifacts, verification output, commit text, and pull request metadata.
+- Do not add a report-specific database table, storage backend, or mutable latest-report pointer.
+- Do not reclassify generic `output.*` links as report artifacts.
+- Verification note: `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` cannot run in this managed branch because `run-jira-orchestrate-for-mm-460-report-a-a0795596` does not match the numeric feature branch pattern; artifact paths were resolved manually from `.specify/feature.json`.
+- Verification note: Docker is unavailable in this managed container (`/var/run/docker.sock` missing), so `./tools/test_integration.sh` was not run.
+- Verification note: the secret-pattern scan only matched deliberate redaction test fixtures and regex literals in `tests/unit/workflows/temporal/test_artifacts.py` and `moonmind/workflows/temporal/report_artifacts.py`.

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -30,6 +30,10 @@ from moonmind.workflows.temporal.artifacts import (
     generate_artifact_id,
 )
 from moonmind.workflows.temporal import artifacts as artifact_module
+from moonmind.workflows.temporal.report_artifacts import (
+    REPORT_ARTIFACT_LINK_TYPES,
+    validate_report_artifact_contract,
+)
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -264,6 +268,274 @@ async def test_create_write_read_and_list_for_execution(tmp_path: Path) -> None:
                 principal="user-1",
             )
             assert [item.artifact_id for item in listed] == [artifact.artifact_id]
+
+
+async def test_report_artifact_contract_accepts_supported_link_types() -> None:
+    """MM-460: Report artifact link types should be explicit and stable."""
+
+    assert REPORT_ARTIFACT_LINK_TYPES == frozenset(
+        {
+            "report.primary",
+            "report.summary",
+            "report.structured",
+            "report.evidence",
+            "report.appendix",
+            "report.findings_index",
+            "report.export",
+        }
+    )
+
+    for link_type in REPORT_ARTIFACT_LINK_TYPES:
+        validate_report_artifact_contract(
+            link_type=link_type,
+            metadata={
+                "artifact_type": "unit_test_report",
+                "report_type": "unit_test",
+                "report_scope": "final",
+                "title": "Unit test report",
+                "producer": "pytest",
+                "subject": "tests/unit",
+                "render_hint": "json",
+                "counts": {"total": 3, "failed": 0},
+                "step_id": "test",
+                "attempt": 1,
+            },
+        )
+
+
+async def test_report_artifact_contract_rejects_unsupported_report_link_type() -> None:
+    """MM-460: Unknown report link types must not create implicit semantics."""
+
+    with pytest.raises(
+        TemporalArtifactValidationError,
+        match="unsupported report artifact link_type",
+    ):
+        validate_report_artifact_contract(
+            link_type="report.raw_dump",
+            metadata={"title": "Raw dump"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        ({"title": "Report", "unexpected": "value"}, "unsupported report metadata key"),
+        ({"title": "x" * 2049}, "report metadata value is too large"),
+        ({"token": "abc123"}, "unsafe report metadata key"),
+        ({"title": "token=abc123"}, "unsafe report metadata value"),
+        ({"counts": {"raw_payload": "x" * 2049}}, "report metadata value is too large"),
+    ],
+)
+async def test_report_artifact_contract_rejects_unsafe_metadata(
+    metadata: dict[str, object],
+    message: str,
+) -> None:
+    """MM-460: Report metadata should stay bounded and safe for display."""
+
+    with pytest.raises(TemporalArtifactValidationError, match=message):
+        validate_report_artifact_contract(
+            link_type="report.primary",
+            metadata=metadata,
+        )
+
+
+async def test_create_accepts_report_primary_with_bounded_metadata(
+    tmp_path: Path,
+) -> None:
+    """MM-460: Report artifacts should use the existing artifact store."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            artifact, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="text/markdown",
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                    "label": "Final report",
+                },
+                metadata_json={
+                    "artifact_type": "unit_test_report",
+                    "report_type": "unit_test",
+                    "report_scope": "final",
+                    "title": "Final unit test report",
+                    "producer": "pytest",
+                    "subject": "tests/unit",
+                    "render_hint": "text",
+                    "is_final_report": True,
+                },
+            )
+
+            links = await repo.list_links(artifact.artifact_id)
+            assert artifact.metadata_json["report_type"] == "unit_test"
+            assert links[0].link_type == "report.primary"
+
+
+async def test_create_rejects_bad_report_link_and_metadata(tmp_path: Path) -> None:
+    """MM-460: Report publication should fail before unsafe data is stored."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="unsupported report artifact link_type",
+            ):
+                await service.create(
+                    principal="workflow-producer",
+                    content_type="application/json",
+                    link={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-report",
+                        "run_id": "run-report",
+                        "link_type": "report.raw_dump",
+                    },
+                    metadata_json={"title": "Raw dump"},
+                )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="unsafe report metadata",
+            ):
+                await service.create(
+                    principal="workflow-producer",
+                    content_type="application/json",
+                    link={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-report",
+                        "run_id": "run-report",
+                        "link_type": "report.primary",
+                    },
+                    metadata_json={"title": "token=abc123"},
+                )
+
+
+async def test_link_artifact_rejects_unsafe_report_metadata(tmp_path: Path) -> None:
+    """MM-460: Existing artifacts must satisfy report metadata before report linking."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            artifact, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="application/json",
+                metadata_json={"title": "token=abc123"},
+            )
+
+            with pytest.raises(
+                TemporalArtifactValidationError,
+                match="unsafe report metadata",
+            ):
+                await service.link_artifact(
+                    artifact_id=artifact.artifact_id,
+                    principal="workflow-producer",
+                    execution_ref={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-report",
+                        "run_id": "run-report",
+                        "link_type": "report.primary",
+                    },
+                )
+
+
+async def test_generic_output_links_remain_accepted_with_generic_metadata(
+    tmp_path: Path,
+) -> None:
+    """MM-460: Generic output flows must not require report metadata."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            for link_type in ("output.primary", "output.summary", "output.agent_result"):
+                artifact, _upload = await service.create(
+                    principal="workflow-producer",
+                    content_type="application/json",
+                    link={
+                        "namespace": "moonmind",
+                        "workflow_id": "wf-output",
+                        "run_id": "run-output",
+                        "link_type": link_type,
+                    },
+                    metadata_json={
+                        "integration_name": "jules",
+                        "raw_result_shape": {"status": "completed"},
+                    },
+                )
+                links = await repo.list_links(artifact.artifact_id)
+                assert links[0].link_type == link_type
+
+
+async def test_latest_report_primary_uses_existing_execution_linkage(
+    tmp_path: Path,
+) -> None:
+    """MM-460: Latest report lookup should use existing execution link filters."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+
+            first, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="text/markdown",
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                },
+                metadata_json={"title": "First report"},
+            )
+            second, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="text/markdown",
+                link={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                },
+                metadata_json={"title": "Second report"},
+            )
+
+            latest = await service.list_for_execution(
+                namespace="moonmind",
+                workflow_id="wf-report",
+                run_id="run-report",
+                principal="workflow-producer",
+                link_type="report.primary",
+                latest_only=True,
+            )
+
+            assert [artifact.artifact_id for artifact in latest] == [
+                second.artifact_id
+            ]
+            assert first.artifact_id != second.artifact_id
 
 
 async def test_write_complete_rejects_invalid_task_image_signature(

--- a/tests/unit/workflows/temporal/test_artifacts.py
+++ b/tests/unit/workflows/temporal/test_artifacts.py
@@ -455,6 +455,47 @@ async def test_link_artifact_rejects_unsafe_report_metadata(tmp_path: Path) -> N
                 )
 
 
+async def test_link_artifact_allows_internal_preview_metadata_for_reports(
+    tmp_path: Path,
+) -> None:
+    """MM-460: System-added preview metadata must not block report linking."""
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            repo = TemporalArtifactRepository(session)
+            service = TemporalArtifactService(
+                repo,
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            artifact, _upload = await service.create(
+                principal="workflow-producer",
+                content_type="text/markdown",
+                metadata_json={"title": "Restricted report"},
+                redaction_level=TemporalArtifactRedactionLevel.RESTRICTED,
+            )
+            completed = await service.write_complete(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+                payload=b"# Report\nsafe display content",
+                content_type="text/markdown",
+            )
+
+            assert completed.metadata_json["preview_artifact_id"].startswith("art_")
+
+            link = await service.link_artifact(
+                artifact_id=artifact.artifact_id,
+                principal="workflow-producer",
+                execution_ref={
+                    "namespace": "moonmind",
+                    "workflow_id": "wf-report",
+                    "run_id": "run-report",
+                    "link_type": "report.primary",
+                },
+            )
+
+            assert link.link_type == "report.primary"
+
+
 async def test_generic_output_links_remain_accepted_with_generic_metadata(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Jira Issue

MM-460

## Active MoonSpec Feature Path

`specs/226-report-artifact-contract`

## Summary

Implements the MM-460 Report Artifact Contract for runtime report deliverables.

- Adds stable `report.*` link type constants and bounded report metadata validation.
- Wires report validation into existing Temporal artifact create and link paths without adding a separate storage plane.
- Preserves generic `output.primary`, `output.summary`, and `output.agent_result` behavior for non-report outputs.
- Adds MoonSpec artifacts under `specs/226-report-artifact-contract/` and preserves the canonical Jira preset brief for MM-460.

## Verification Verdict

`FULLY_IMPLEMENTED`

## Tests Run

- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh tests/unit/workflows/temporal/test_artifacts.py` - PASS (`35 passed`; frontend runner also completed `11` files / `361` tests)
- `MOONMIND_FORCE_LOCAL_TESTS=1 ./tools/test_unit.sh` - PASS in post-implementation verification (`3745 passed, 1 xpassed, 16 subtests passed`; frontend `11` files / `361` tests)
- `git diff --check` - PASS
- `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` - NOT RUN to completion: managed branch name does not match numeric feature branch convention; active feature resolved manually from `.specify/feature.json`
- `./tools/test_integration.sh` - NOT RUN: Docker socket unavailable in managed container

## Remaining Risks

- Branch is one commit behind `main` according to compare metadata, so it may need a rebase or merge update before landing.
- Hermetic Docker-backed integration verification was not run in this managed container because `/var/run/docker.sock` was unavailable.
